### PR TITLE
pki: Preserve ordering of submitted SAN names

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2963,9 +2963,9 @@ func TestBackend_OID_SANs(t *testing.T) {
 		t.Fatalf("unexpected IP SAN %q", cert.IPAddresses[0].String())
 	}
 	if len(cert.DNSNames) != 3 ||
-		cert.DNSNames[0] != "bar.foobar.com" ||
+		cert.DNSNames[0] != "foobar.com" ||
 		cert.DNSNames[1] != "foo.foobar.com" ||
-		cert.DNSNames[2] != "foobar.com" {
+		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
 
@@ -3051,9 +3051,9 @@ func TestBackend_OID_SANs(t *testing.T) {
 		t.Fatalf("unexpected IP SAN %q", cert.IPAddresses[0].String())
 	}
 	if len(cert.DNSNames) != 3 ||
-		cert.DNSNames[0] != "bar.foobar.com" ||
+		cert.DNSNames[0] != "foobar.com" ||
 		cert.DNSNames[1] != "foo.foobar.com" ||
-		cert.DNSNames[2] != "foobar.com" {
+		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
 	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
@@ -3081,9 +3081,9 @@ func TestBackend_OID_SANs(t *testing.T) {
 		t.Fatalf("unexpected IP SAN %q", cert.IPAddresses[0].String())
 	}
 	if len(cert.DNSNames) != 3 ||
-		cert.DNSNames[0] != "bar.foobar.com" ||
+		cert.DNSNames[0] != "foobar.com" ||
 		cert.DNSNames[1] != "foo.foobar.com" ||
-		cert.DNSNames[2] != "foobar.com" {
+		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
 	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
@@ -3117,9 +3117,9 @@ func TestBackend_OID_SANs(t *testing.T) {
 		t.Fatalf("unexpected IP SAN %q", cert.IPAddresses[0].String())
 	}
 	if len(cert.DNSNames) != 3 ||
-		cert.DNSNames[0] != "bar.foobar.com" ||
+		cert.DNSNames[0] != "foobar.com" ||
 		cert.DNSNames[1] != "foo.foobar.com" ||
-		cert.DNSNames[2] != "foobar.com" {
+		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
 	expectedOtherNames := []otherNameUtf8{{oid1, val1}, {oid2, val2}}

--- a/changelog/50.txt
+++ b/changelog/50.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secret/pki: Use user-submitted ordering for SANs, fixing issues where automatic ordering causes parse failures in some browsers.
+```


### PR DESCRIPTION
As discussed upstream, this preserves ordering of the DNS SANs submitted by the caller, giving them control over the ordering on the final certificate. Previously, these were sorted: this resulted in stable ordering (independent of request ordering), but can sometimes result in unexpected behavior if a SAN is unsupported by the browser.

While this is a breaking change (insofar as this can change SAN ordering, which in turn means that there is a potential for newly issued leaf certificates to behave differently when reissued via the same API call), this change also gives more control to the caller to resolve any issues they may currently be running into due to the automated re-ordering.

Thus, on balance, this change is a net benefit to users.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1757758
See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1196364

Resolves: https://github.com/openbao/openbao/issues/49