### PR TITLE
Fix API & SDK failing tests

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -85,7 +85,7 @@ func TestClientDefaultHttpClient_unixSocket(t *testing.T) {
 	if client.addr.Scheme != "http" {
 		t.Fatalf("bad: %s", client.addr.Scheme)
 	}
-	if client.addr.Host != "/var/run/vault.sock" {
+	if client.addr.Host != "localhost" {
 		t.Fatalf("bad: %s", client.addr.Host)
 	}
 }
@@ -109,8 +109,8 @@ func TestClientSetAddress(t *testing.T) {
 	if client.addr.Scheme != "http" {
 		t.Fatalf("bad: expected: 'http' actual: %q", client.addr.Scheme)
 	}
-	if client.addr.Host != "/var/run/vault.sock" {
-		t.Fatalf("bad: expected: '/var/run/vault.sock' actual: %q", client.addr.Host)
+	if client.addr.Host != "localhost" {
+		t.Fatalf("bad: expected: 'localhost' actual: %q", client.addr.Host)
 	}
 	if client.addr.Path != "" {
 		t.Fatalf("bad: expected '' actual: %q", client.addr.Path)
@@ -1426,7 +1426,7 @@ func TestParseAddressWithUnixSocket(t *testing.T) {
 	if u.Scheme != "http" {
 		t.Fatal("Scheme not changed to http")
 	}
-	if u.Host != "/var/run/vault.sock" {
+	if u.Host != "localhost" {
 		t.Fatal("Host not changed to socket name")
 	}
 	if u.Path != "" {

--- a/sdk/helper/testcluster/replication.go
+++ b/sdk/helper/testcluster/replication.go
@@ -255,7 +255,7 @@ func WaitForPerfReplicationWorking(ctx context.Context, pri, sec VaultCluster) e
 		"bar": 1,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to write KV on primary", "path", path)
+		return fmt.Errorf("unable to write KV on primary: path=%v", path)
 	}
 
 	for ctx.Err() == nil {


### PR DESCRIPTION
These can be run manually with:

```
$ cd api && go test ./...
$ cd sdk && go test ./...
```

Note that, for some reason I haven't yet figured out, the former can be run from the root with `go test github.com/openbao/openbao/api`. but the SDK doesn't run similarly.

Related: #61 