### PR TITLE
Allow setting KeyUsage, ExtKeyUsage on CAs

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -763,6 +763,18 @@ func generateCert(sc *storageContext,
 		data.Params.IsCA = isCA
 		data.Params.PermittedDNSDomains = input.apiData.Get("permitted_dns_domains").([]string)
 
+		if rawKeyUsageValue, ok := input.apiData.GetOk("key_usage"); ok {
+			data.Params.KeyUsage = x509.KeyUsage(parseKeyUsages(rawKeyUsageValue.([]string)))
+		}
+
+		if rawExtKeyUsagesValue, ok := input.apiData.GetOk("ext_key_usage"); ok {
+			data.Params.ExtKeyUsage = parseExtKeyUsagesValue(0, rawExtKeyUsagesValue.([]string))
+		}
+
+		if rawExtKeyUsageOidsValue, ok := input.apiData.GetOk("ext_key_usage_oids"); ok {
+			data.Params.ExtKeyUsage = parseExtKeyUsagesValue(0, rawExtKeyUsageOidsValue.([]string))
+		}
+
 		if data.SigningBundle == nil {
 			// Generating a self-signed root certificate. Since we have no
 			// issuer entry yet, we default to the global URLs.
@@ -1021,6 +1033,18 @@ func signCert(b *backend,
 
 	if isCA {
 		creation.Params.PermittedDNSDomains = data.apiData.Get("permitted_dns_domains").([]string)
+
+		if rawKeyUsageValue, ok := data.apiData.GetOk("key_usage"); ok {
+			creation.Params.KeyUsage = x509.KeyUsage(parseKeyUsages(rawKeyUsageValue.([]string)))
+		}
+
+		if rawExtKeyUsagesValue, ok := data.apiData.GetOk("ext_key_usage"); ok {
+			creation.Params.ExtKeyUsage = parseExtKeyUsagesValue(0, rawExtKeyUsagesValue.([]string))
+		}
+
+		if rawExtKeyUsageOidsValue, ok := data.apiData.GetOk("ext_key_usage_oids"); ok {
+			creation.Params.ExtKeyUsage = parseExtKeyUsagesValue(0, rawExtKeyUsageOidsValue.([]string))
+		}
 	} else {
 		for _, ext := range csr.Extensions {
 			if ext.Id.Equal(certutil.ExtensionBasicConstraintsOID) {

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -593,9 +593,7 @@ basic constraints.`,
 	return fields
 }
 
-// addSignVerbatimRoleFields provides the fields and defaults to be used by anything that is building up the fields
-// and their corresponding default values when generating/using a sign-verbatim type role such as buildSignVerbatimRole.
-func addSignVerbatimRoleFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+func addKeyUsageRoleFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
 	fields["key_usage"] = &framework.FieldSchema{
 		Type:    framework.TypeCommaStringSlice,
 		Default: []string{"DigitalSignature", "KeyAgreement", "KeyEncipherment"},
@@ -621,6 +619,14 @@ this value to an empty list.`,
 		Type:        framework.TypeCommaStringSlice,
 		Description: `A comma-separated string or list of extended key usage oids.`,
 	}
+
+	return fields
+}
+
+// addSignVerbatimRoleFields provides the fields and defaults to be used by anything that is building up the fields
+// and their corresponding default values when generating/using a sign-verbatim type role such as buildSignVerbatimRole.
+func addSignVerbatimRoleFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields = addKeyUsageRoleFields(fields)
 
 	fields["signature_bits"] = &framework.FieldSchema{
 		Type:    framework.TypeInt,

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -113,6 +113,7 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 	}
 
 	ret.Fields = addCACommonFields(map[string]*framework.FieldSchema{})
+	ret.Fields = addKeyUsageRoleFields(ret.Fields)
 	ret.Fields = addCAKeyGenerationFields(ret.Fields)
 	ret.Fields = addCAIssueFields(ret.Fields)
 	return ret

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -1422,7 +1422,11 @@ func parseExtKeyUsages(role *roleEntry) certutil.CertExtKeyUsage {
 		parsedKeyUsages |= certutil.EmailProtectionExtKeyUsage
 	}
 
-	for _, k := range role.ExtKeyUsage {
+	return parseExtKeyUsagesValue(parsedKeyUsages, role.ExtKeyUsage)
+}
+
+func parseExtKeyUsagesValue(parsedKeyUsages certutil.CertExtKeyUsage, extKeyUsages []string) certutil.CertExtKeyUsage {
+	for _, k := range extKeyUsages {
 		switch strings.ToLower(strings.TrimSpace(k)) {
 		case "any":
 			parsedKeyUsages |= certutil.AnyExtKeyUsage

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -83,6 +83,7 @@ func buildPathIssuerSignIntermediateRaw(b *backend, pattern string, displayAttrs
 	}
 
 	path.Fields = addCACommonFields(path.Fields)
+	path.Fields = addKeyUsageRoleFields(path.Fields)
 	path.Fields = addCAIssueFields(path.Fields)
 
 	path.Fields["csr"] = &framework.FieldSchema{

--- a/changelog/76.txt
+++ b/changelog/76.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add support for KeyUsage, ExtKeyUsage when issuing CA certificates, allowing compliance with CA/BF guidelines (e.g., with GCP Load Balancers).
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -956,6 +956,30 @@ when signing an externally-owned intermediate.
   over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
   ECDSA/Ed25519 issuers.
 
+- `key_usage` `(list: ["KeyAgreement", "KeyEncipherment"])` -
+  Specifies the default key usage constraint on the issued certificate. Valid
+  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
+  drop the `KeyUsage` part of the value. Values are not case-sensitive. 
+
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `KeyUsage` extension is missing
+   from the CSR.
+
+- `ext_key_usage` `(list: [])` -
+  Specifies the default extended key usage constraint on the issued certificate. Valid
+  values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply
+  drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
+  specify no key default usage constraints, set this to an empty list.
+
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `ExtendedKeyUsage` extension is
+   missing from the CSR.
+
+- `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
+
+~> Note: This value is only used as a default when the `ExtendedKeyUsage`
+   extension is missing from the CSR.
+
 #### Sample payload
 
 ```json
@@ -2026,6 +2050,30 @@ use the values set via `config/urls`.
   specified date value. The value format should be given in UTC format
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
   standard devices, `9999-12-31T23:59:59Z`.
+
+- `key_usage` `(list: ["KeyAgreement", "KeyEncipherment"])` -
+  Specifies the default key usage constraint on the issued certificate. Valid
+  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
+  drop the `KeyUsage` part of the value. Values are not case-sensitive. 
+
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `KeyUsage` extension is missing
+   from the CSR.
+
+- `ext_key_usage` `(list: [])` -
+  Specifies the default extended key usage constraint on the issued certificate. Valid
+  values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply
+  drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
+  specify no key default usage constraints, set this to an empty list.
+
+~> Note: previous versions of this document incorrectly called this a constraint;
+   this value is only used as a default when the `ExtendedKeyUsage` extension is
+   missing from the CSR.
+
+- `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
+
+~> Note: This value is only used as a default when the `ExtendedKeyUsage`
+   extension is missing from the CSR.
 
 * ~> Note: Keys of type `rsa` currently only support PKCS#1 v1.5 signatures.
 


### PR DESCRIPTION
This adds the ability to set KeyUsage and ExtKeyUsage on roots and intermediates created in OpenBao. This does not add the ability to add KeyUsage or ExtKeyUsage extensions to intermediate CA CSRs as that can be added by the signing CA conditionally.

This allows interoperability with GCP Load Balancers and compiles with CA/BF guidelines. Only DigitalSignature may (optionally) be added to KeyUsage, but no restrictions are placed on ExtKeyUsage or its OIDs.

Resolves: https://github.com/openbao/openbao/issues/60