### PR TITLE
Forbid v1 & v2 convergent keys in Transit

### DIFF
--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -1026,11 +1026,6 @@ func testDerivedKeyUpgrade(t *testing.T, keyType keysutil.KeyType) {
 }
 
 func TestConvergentEncryption(t *testing.T) {
-	testConvergentEncryptionCommon(t, 0, keysutil.KeyType_AES256_GCM96)
-	testConvergentEncryptionCommon(t, 2, keysutil.KeyType_AES128_GCM96)
-	testConvergentEncryptionCommon(t, 2, keysutil.KeyType_AES256_GCM96)
-	testConvergentEncryptionCommon(t, 2, keysutil.KeyType_ChaCha20_Poly1305)
-	testConvergentEncryptionCommon(t, 2, keysutil.KeyType_XChaCha20_Poly1305)
 	testConvergentEncryptionCommon(t, 3, keysutil.KeyType_AES128_GCM96)
 	testConvergentEncryptionCommon(t, 3, keysutil.KeyType_AES256_GCM96)
 	testConvergentEncryptionCommon(t, 3, keysutil.KeyType_ChaCha20_Poly1305)

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/openbao/openbao/helper/constants"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/helper/errutil"
 	"github.com/openbao/openbao/sdk/helper/keysutil"
@@ -42,11 +41,6 @@ ciphertext; "wrapped" will return the ciphertext only.`,
 			"context": {
 				Type:        framework.TypeString,
 				Description: "Context for key derivation. Required for derived keys.",
-			},
-
-			"nonce": {
-				Type:        framework.TypeString,
-				Description: "Nonce for when convergent encryption v1 is used (only in Vault 0.6.1 before OpenBao's fork)",
 			},
 
 			"bits": {
@@ -100,16 +94,6 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	// Decode the nonce if any
-	nonceRaw := d.Get("nonce").(string)
-	var nonce []byte
-	if len(nonceRaw) != 0 {
-		nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
-		}
-	}
-
 	// Get the policy
 	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
@@ -158,7 +142,7 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	ciphertext, err := p.EncryptWithFactory(ver, context, nonce, base64.StdEncoding.EncodeToString(newKey), nil, managedKeyFactory)
+	ciphertext, err := p.EncryptWithFactory(ver, context, nil, base64.StdEncoding.EncodeToString(newKey), nil, managedKeyFactory)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:
@@ -185,14 +169,6 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 			"ciphertext":  ciphertext,
 			"key_version": keyVersion,
 		},
-	}
-
-	if len(nonce) > 0 && !nonceAllowed(p) {
-		return nil, ErrNonceNotAllowed
-	}
-
-	if constants.IsFIPS() && shouldWarnAboutNonceUsage(p, nonce) {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 
 	if plaintextAllowed {

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -57,15 +57,6 @@ Base64 encoded context for key derivation. Required if key derivation is
 enabled.`,
 			},
 
-			"nonce": {
-				Type: framework.TypeString,
-				Description: `
-Base64 encoded nonce value used during encryption. Must be provided if
-convergent encryption is enabled for this key and the key was generated with
-Vault 0.6.1 (prior to OpenBao's fork). Not required for keys created in
-Vault 0.6.2+.`,
-			},
-
 			"partial_failure_response_code": {
 				Type: framework.TypeInt,
 				Description: `
@@ -90,7 +81,7 @@ data are attested not to have been tampered with.
 				Type: framework.TypeSlice,
 				Description: `
 Specifies a list of items to be decrypted in a single batch. When this
-parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
+parameter is set, if the parameters 'ciphertext' and 'context' are
 also set, they will be ignored. Any batch output will preserve the order
 of the batch input.`,
 			},
@@ -128,7 +119,6 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		batchInputItems[0] = BatchRequestItem{
 			Ciphertext:     ciphertext,
 			Context:        d.Get("context").(string),
-			Nonce:          d.Get("nonce").(string),
 			AssociatedData: d.Get("associated_data").(string),
 		}
 	}
@@ -153,16 +143,6 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		// Decode the context
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
-			if err != nil {
-				userErrorInBatch = true
-				batchResponseItems[i].Error = err.Error()
-				continue
-			}
-		}
-
-		// Decode the nonce
-		if len(item.Nonce) != 0 {
-			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
 				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
@@ -218,7 +198,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 			}
 		}
 
-		plaintext, err := p.DecryptWithFactory(item.DecodedContext, item.DecodedNonce, item.Ciphertext, factory, managedKeyFactory)
+		plaintext, err := p.DecryptWithFactory(item.DecodedContext, nil, item.Ciphertext, factory, managedKeyFactory)
 		if err != nil {
 			switch err.(type) {
 			case errutil.InternalError:

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -12,8 +12,6 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/openbao/openbao/helper/constants"
-
 	"github.com/mitchellh/mapstructure"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/helper/errutil"
@@ -35,14 +33,8 @@ type BatchRequestItem struct {
 	// Ciphertext for decryption
 	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
 
-	// Nonce to be used when v1 convergent encryption is used
-	Nonce string `json:"nonce" structs:"nonce" mapstructure:"nonce"`
-
 	// The key version to be used for encryption
 	KeyVersion int `json:"key_version" structs:"key_version" mapstructure:"key_version"`
-
-	// DecodedNonce is the base64 decoded version of Nonce
-	DecodedNonce []byte
 
 	// Associated Data for AEAD ciphers
 	AssociatedData string `json:"associated_data" struct:"associated_data" mapstructure:"associated_data"`
@@ -111,18 +103,6 @@ func (b *backend) pathEncrypt() *framework.Path {
 				Description: "Base64 encoded context for key derivation. Required if key derivation is enabled",
 			},
 
-			"nonce": {
-				Type: framework.TypeString,
-				Description: `
-Base64 encoded nonce value. Must be provided if convergent encryption is
-enabled for this key and the key was generated with Vault 0.6.1 (prior to
-OpenBao's fork). Not required for keys created in 0.6.2+. The value must be
-exactly 96 bits (12 bytes) long and the user must ensure that for any given
-context (and thus, any given encryption key) this nonce value is **never
-reused**.
-`,
-			},
-
 			"type": {
 				Type:    framework.TypeString,
 				Default: "aes256-gcm96",
@@ -176,7 +156,7 @@ data are attested not to have been tampered with.
 				Type: framework.TypeSlice,
 				Description: `
 Specifies a list of items to be encrypted in a single batch. When this parameter
-is set, if the parameters 'plaintext', 'context' and 'nonce' are also set, they
+is set, if the parameters 'plaintext' and 'context' are also set, they
 will be ignored. Any batch output will preserve the order of the batch input.`,
 			},
 		},
@@ -260,15 +240,6 @@ func decodeBatchRequestItems(src interface{}, requirePlaintext bool, requireCiph
 			}
 		} else if requirePlaintext {
 			errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].plaintext' missing plaintext to encrypt", i))
-		}
-
-		if v, has := item["nonce"]; has {
-			if !reflect.ValueOf(v).IsValid() {
-			} else if casted, ok := v.(string); ok {
-				(*dst)[i].Nonce = casted
-			} else {
-				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].nonce' expected type 'string', got unconvertible type '%T'", i, item["nonce"]))
-			}
 		}
 
 		if v, has := item["key_version"]; has {
@@ -356,7 +327,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		batchInputItems[0] = BatchRequestItem{
 			Plaintext:      valueRaw.(string),
 			Context:        d.Get("context").(string),
-			Nonce:          d.Get("nonce").(string),
 			KeyVersion:     d.Get("key_version").(int),
 			AssociatedData: d.Get("associated_data").(string),
 		}
@@ -387,16 +357,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		// Decode the context
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
-			if err != nil {
-				userErrorInBatch = true
-				batchResponseItems[i].Error = err.Error()
-				continue
-			}
-		}
-
-		// Decode the nonce
-		if len(item.Nonce) != 0 {
-			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
 				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
@@ -467,22 +427,11 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	// Process batch request items. If encryption of any request
 	// item fails, respectively mark the error in the response
 	// collection and continue to process other items.
-	warnAboutNonceUsage := false
 	successesInBatch := false
 	for i, item := range batchInputItems {
 		if batchResponseItems[i].Error != "" {
 			userErrorInBatch = true
 			continue
-		}
-
-		if item.Nonce != "" && !nonceAllowed(p) {
-			userErrorInBatch = true
-			batchResponseItems[i].Error = ErrNonceNotAllowed.Error()
-			continue
-		}
-
-		if !warnAboutNonceUsage && shouldWarnAboutNonceUsage(p, item.DecodedNonce) {
-			warnAboutNonceUsage = true
 		}
 
 		var factory interface{}
@@ -511,7 +460,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 			}
 		}
 
-		ciphertext, err := p.EncryptWithFactory(item.KeyVersion, item.DecodedContext, item.DecodedNonce, item.Plaintext, factory, managedKeyFactory)
+		ciphertext, err := p.EncryptWithFactory(item.KeyVersion, item.DecodedContext, nil, item.Plaintext, factory, managedKeyFactory)
 		if err != nil {
 			switch err.(type) {
 			case errutil.InternalError:
@@ -565,10 +514,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	if constants.IsFIPS() && warnAboutNonceUsage {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
-	}
-
 	if req.Operation == logical.CreateOperation && !upserted {
 		resp.AddWarning("Attempted creation of the key during the encrypt operation, but it was created beforehand")
 	}
@@ -576,25 +521,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	p.Unlock()
 
 	return batchRequestResponse(d, resp, req, successesInBatch, userErrorInBatch, internalErrorInBatch)
-}
-
-func nonceAllowed(p *keysutil.Policy) bool {
-	var supportedKeyType bool
-	switch p.Type {
-	case keysutil.KeyType_MANAGED_KEY:
-		return true
-	case keysutil.KeyType_AES128_GCM96, keysutil.KeyType_AES256_GCM96, keysutil.KeyType_ChaCha20_Poly1305, keysutil.KeyType_XChaCha20_Poly1305:
-		supportedKeyType = true
-	default:
-		supportedKeyType = false
-	}
-
-	if supportedKeyType && p.ConvergentEncryption && p.ConvergentVersion == 1 {
-		// We only use the user supplied nonce for v1 convergent encryption keys
-		return true
-	}
-
-	return false
 }
 
 // Depending on the errors in the batch, different status codes should be returned. User errors
@@ -622,34 +548,6 @@ func batchRequestResponse(d *framework.FieldData, resp *logical.Response, req *l
 	}
 
 	return resp, nil
-}
-
-// shouldWarnAboutNonceUsage attempts to determine if we will use a provided nonce or not. Ideally this
-// would be information returned through p.Encrypt but that would require an SDK api change and this is
-// transit specific
-func shouldWarnAboutNonceUsage(p *keysutil.Policy, userSuppliedNonce []byte) bool {
-	if len(userSuppliedNonce) == 0 {
-		return false
-	}
-
-	var supportedKeyType bool
-	switch p.Type {
-	case keysutil.KeyType_AES128_GCM96, keysutil.KeyType_AES256_GCM96, keysutil.KeyType_ChaCha20_Poly1305, keysutil.KeyType_XChaCha20_Poly1305:
-		supportedKeyType = true
-	default:
-		supportedKeyType = false
-	}
-
-	if supportedKeyType && p.ConvergentEncryption && p.ConvergentVersion == 1 {
-		// We only use the user supplied nonce for v1 convergent encryption keys
-		return true
-	}
-
-	if supportedKeyType && !p.ConvergentEncryption {
-		return true
-	}
-
-	return false
 }
 
 const pathEncryptHelpSyn = `Encrypt a plaintext value or a batch of plaintext

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -6,18 +6,14 @@ package transit
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/openbao/openbao/helper/constants"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/helper/errutil"
 	"github.com/openbao/openbao/sdk/helper/keysutil"
 	"github.com/openbao/openbao/sdk/logical"
 )
-
-var ErrNonceNotAllowed = errors.New("provided nonce not allowed for this key")
 
 func (b *backend) pathRewrap() *framework.Path {
 	return &framework.Path{
@@ -44,11 +40,6 @@ func (b *backend) pathRewrap() *framework.Path {
 				Description: "Base64 encoded context for key derivation. Required for derived keys.",
 			},
 
-			"nonce": {
-				Type:        framework.TypeString,
-				Description: "Nonce for when convergent encryption is used",
-			},
-
 			"key_version": {
 				Type: framework.TypeInt,
 				Description: `The version of the key to use for encryption.
@@ -60,7 +51,7 @@ to the min_encryption_version configured on the key.`,
 				Type: framework.TypeSlice,
 				Description: `
 Specifies a list of items to be re-encrypted in a single batch. When this parameter is set,
-if the parameters 'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
+if the parameters 'ciphertext' and 'context' are also set, they will be ignored.
 Any batch output will preserve the order of the batch input.`,
 			},
 		},
@@ -97,7 +88,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		batchInputItems[0] = BatchRequestItem{
 			Ciphertext: ciphertext,
 			Context:    d.Get("context").(string),
-			Nonce:      d.Get("nonce").(string),
 			KeyVersion: d.Get("key_version").(int),
 		}
 	}
@@ -123,15 +113,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 				continue
 			}
 		}
-
-		// Decode the nonce
-		if len(item.Nonce) != 0 {
-			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
-			if err != nil {
-				batchResponseItems[i].Error = err.Error()
-				continue
-			}
-		}
 	}
 
 	// Get the policy
@@ -149,18 +130,12 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		p.Lock(false)
 	}
 
-	warnAboutNonceUsage := false
 	for i, item := range batchInputItems {
 		if batchResponseItems[i].Error != "" {
 			continue
 		}
 
-		if item.Nonce != "" && !nonceAllowed(p) {
-			batchResponseItems[i].Error = ErrNonceNotAllowed.Error()
-			continue
-		}
-
-		plaintext, err := p.Decrypt(item.DecodedContext, item.DecodedNonce, item.Ciphertext)
+		plaintext, err := p.Decrypt(item.DecodedContext, nil, item.Ciphertext)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:
@@ -172,11 +147,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 			}
 		}
 
-		if !warnAboutNonceUsage && shouldWarnAboutNonceUsage(p, item.DecodedNonce) {
-			warnAboutNonceUsage = true
-		}
-
-		ciphertext, err := p.Encrypt(item.KeyVersion, item.DecodedContext, item.DecodedNonce, plaintext)
+		ciphertext, err := p.Encrypt(item.KeyVersion, item.DecodedContext, nil, plaintext)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:
@@ -223,10 +194,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 			"ciphertext":  batchResponseItems[0].Ciphertext,
 			"key_version": batchResponseItems[0].KeyVersion,
 		}
-	}
-
-	if constants.IsFIPS() && warnAboutNonceUsage {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 
 	p.Unlock()

--- a/changelog/85.txt
+++ b/changelog/85.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secret/transit: Remove ability to use v1 and v2 Transit convergent encryption keys migrated from Vault v0.6.2 or earlier.
+```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -31,7 +31,7 @@ values set here cannot be changed after key creation.
 - `convergent_encryption` `(bool: false)` – If enabled, the key will support
   convergent encryption, where the same plaintext creates the same ciphertext.
   This requires _derived_ to be set to `true`. When enabled, each
-  encryption(/decryption/rewrap/datakey) operation will derive a `nonce` value
+  encryption(/decryption/rewrap/datakey) operation will derive a nonce value
   rather than randomly generate it.
 
 - `derived` `(bool: false)` – Specifies if key derivation is to be used. If
@@ -712,14 +712,6 @@ will be returned.
   encryption. If not set, uses the latest version. Must be greater than or
   equal to the key's `min_encryption_version`, if set.
 
-- `nonce` `(string: "")` – Specifies the **base64 encoded** nonce value. This
-  must be provided if convergent encryption is enabled for this key and the key
-  was generated with Vault 0.6.1. Not required for keys created in 0.6.2+. The
-  value must be exactly 96 bits (12 bytes) long for AES and ChaCha20 or 192
-  bits (24 bytes) long for XChaCha20 and the user must ensure that for any
-  given context (and thus, any given encryption key) this nonce value is
-  **never reused**.
-
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
   corresponding `batch_results` item in the response, to assist in understanding
@@ -728,7 +720,7 @@ will be returned.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   encrypted in a single batch. When this parameter is set, if the parameters
-  'plaintext', 'context' and 'nonce' are also set, they will be ignored.
+  'plaintext' and 'context' are also set, they will be ignored.
   Any batch output will preserve the order of the batch input. The
   format for the input is:
 
@@ -835,11 +827,6 @@ This endpoint decrypts the provided ciphertext using the named key.
 - `context` `(string: "")` – Specifies the **base64 encoded** context for key
   derivation. This is required if key derivation is enabled.
 
-- `nonce` `(string: "")` – Specifies a base64 encoded nonce value used during
-  encryption. Must be provided if convergent encryption is enabled for this key
-  and the key was generated with Vault 0.6.1. Not required for keys created in
-  0.6.2+.
-
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
   corresponding `batch_results` item in the response, to assist in understanding
@@ -848,7 +835,7 @@ This endpoint decrypts the provided ciphertext using the named key.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   decrypted in a single batch. When this parameter is set, if the parameters
-  'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
+  'ciphertext' and 'context' are also set, they will be ignored.
   Any batch output will preserve the order of the batch input. Format
   for the input goes like this:
 
@@ -925,11 +912,6 @@ functionality to untrusted users or scripts.
   operation. If not set, uses the latest version. Must be greater than or equal
   to the key's `min_encryption_version`, if set.
 
-- `nonce` `(string: "")` – Specifies a base64 encoded nonce value used during
-  encryption. Must be provided if convergent encryption is enabled for this key
-  and the key was generated with Vault 0.6.1. Not required for keys created in
-  0.6.2+.
-
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
   corresponding `batch_results` item in the response, to assist in understanding
@@ -938,7 +920,7 @@ functionality to untrusted users or scripts.
 
 - `batch_input` `(array<object>: nil)` – Specifies a list of items to be
   re-encrypted in a single batch. When this parameter is set, if the parameters
-  'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
+  'ciphertext' and 'context' are also set, they will be ignored.
   Any batch output will preserve the order of the batch input. Format
   for the input goes like this:
 
@@ -1008,13 +990,6 @@ then made available to trusted users.
 
 - `context` `(string: "")` – Specifies the key derivation context, provided as a
   base64-encoded string. This must be provided if derivation is enabled.
-
-- `nonce` `(string: "")` – Specifies a nonce value, provided as base64 encoded.
-  Must be provided if convergent encryption is enabled for this key and the key
-  was generated with Vault 0.6.1. Not required for keys created in 0.6.2+. The
-  value must be exactly 96 bits (12 bytes) long for AES and ChaCha20 or 192 bits
-  (24 bytes) for XChaCha20 and the user must ensure that for any given context
-  (and thus, any given encryption key) this nonce value is **never reused**.
 
 - `bits` `(int: 256)` – Specifies the number of bits in the desired key. Can be
   128, 256, or 512.


### PR DESCRIPTION
This prohibits the usage of the nonce field entirely, removing it as an API option from Transit. Similarly in the keysutil backend, v1 & v2 keys are forbidden.

Because this completely removes nonce from the APIs, this results in OpenBao issuing a warning about the unknown parameter via the CLI, but does not fail requests. A nil value for nonce will be passed into the SDK, which will then generate a fresh value (for encryption) or use the value inferred from the ciphertext (for decryption).

---

Resolves: #37 