### PR TITLE
Adding Basic SBOM Support

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -6,8 +6,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,10 +26,10 @@ jobs:
 
     steps:
       - name: 'Repository Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Setup Golang'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ">=1.20.0"
 

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: 'Submit Dependencies To GitHub'
         uses: actions/go-dependency-submission@v2.0.0
-        with:
+        #with:
           # GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner
           # token: # optional, default is ${{ github.token }}
           # User provided map of max key/value pairs of metadata to include with the snapshot e.g. {"lastModified": "12-31-2022"}

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -1,0 +1,48 @@
+# .github/workflows/go-dependency-submission.yml
+name: Go Dependency Submission
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Environment variables to configure Go and Go modules. Customize as necessary
+env:
+  GOPROXY: '' # A Go Proxy server to be used
+  GOPRIVATE: '' # A list of modules are considered private and not requested from GOPROXY
+
+# The API requires write permission on the repository to submit dependencies
+permissions:
+  contents: write
+
+jobs:
+  go-dependency-submission:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Repository Checkout'
+        uses: actions/checkout@v3
+
+      - name: 'Setup Golang'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.20.0"
+
+      - name: 'Submit Dependencies To GitHub'
+        uses: actions/go-dependency-submission@v2.0.0
+        with:
+          # GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner
+          # token: # optional, default is ${{ github.token }}
+          # User provided map of max key/value pairs of metadata to include with the snapshot e.g. {"lastModified": "12-31-2022"}
+          # metadata: # optional
+          # Repo path to the go.mod file used to detect dependencies for the Go build target. Defaults to go.mod in the root of the repository.
+          # go-mod-path: # default is go.mod
+          # Build target to detect build dependencies. If unspecified, will use "all", with will detect all dependencies used in all build targets (including tests and tools).
+          # go-build-target: # default is all


### PR DESCRIPTION
References: #94

Changes:
- Adding a basic GitHub workflow for Golang dependency submission. This will enable basic SBOM generation via GitHub.