### PR TITLE
Part 16/n - Use kv plugin for tests

### DIFF
--- a/builtin/logical/kv/passthrough.go
+++ b/builtin/logical/kv/passthrough.go
@@ -41,8 +41,10 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 	}
 
 	backend := &framework.Backend{
-		BackendType: logical.TypeLogical,
-		Help:        strings.TrimSpace(passthroughHelp),
+		BackendType:    logical.TypeLogical,
+		RunningVersion: ReportedVersion,
+
+		Help: strings.TrimSpace(passthroughHelp),
 
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -87,8 +87,8 @@ func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 				PluginType:        consts.PluginTypeCredential,
 				DeprecationStatus: consts.PendingRemoval,
 			},
-			"aws":    {PluginType: consts.PluginTypeCredential},
-			"consul": {PluginType: consts.PluginTypeSecrets},
+			"cert": {PluginType: consts.PluginTypeCredential},
+			"kv":   {PluginType: consts.PluginTypeSecrets},
 		},
 	}
 }
@@ -121,7 +121,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 	switch name {
 	case "approle", "pending-removal-test-plugin":
 		return toFunc(approle.Factory), true
-	case "aws":
+	case "cert":
 		return toFunc(func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 			b := new(framework.Backend)
 			b.Setup(ctx, config)
@@ -137,7 +137,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 		}), true
 	case "mysql-database-plugin":
 		return mysql.New(mysql.DefaultUserNameTemplate), true
-	case "consul":
+	case "kv":
 		return toFunc(func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 			b := new(framework.Backend)
 			b.Setup(ctx, config)

--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -45,7 +45,7 @@ func GetPlugin(t testing.T, typ consts.PluginType) (string, string, string, stri
 		pluginMain = filepath.Join("builtin", "credential", pluginType, "cmd", pluginType, "main.go")
 		pluginVersionLocation = fmt.Sprintf("github.com/openbao/openbao/builtin/credential/%s.ReportedVersion", pluginType)
 	case consts.PluginTypeSecrets:
-		pluginType = "consul"
+		pluginType = "kv"
 		pluginName = "vault-plugin-secrets-" + pluginType
 		pluginMain = filepath.Join("builtin", "logical", pluginType, "cmd", pluginType, "main.go")
 		pluginVersionLocation = fmt.Sprintf("github.com/openbao/openbao/builtin/logical/%s.ReportedVersion", pluginType)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -424,6 +424,7 @@ func TestSysMounts_headerAuth(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -491,6 +492,7 @@ func TestSysMounts_headerAuth(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -50,6 +50,7 @@ func TestSysMounts(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -117,6 +118,7 @@ func TestSysMounts(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",
@@ -231,6 +233,7 @@ func TestSysMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"secret/": map[string]interface{}{
 				"description":             "key/value secret storage",
@@ -247,6 +250,7 @@ func TestSysMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -314,6 +318,7 @@ func TestSysMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"secret/": map[string]interface{}{
 			"description":             "key/value secret storage",
@@ -330,6 +335,7 @@ func TestSysMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",
@@ -545,6 +551,7 @@ func TestSysRemount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"secret/": map[string]interface{}{
 				"description":             "key/value secret storage",
@@ -561,6 +568,7 @@ func TestSysRemount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -628,6 +636,7 @@ func TestSysRemount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"secret/": map[string]interface{}{
 			"description":             "key/value secret storage",
@@ -644,6 +653,7 @@ func TestSysRemount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",
@@ -758,6 +768,7 @@ func TestSysUnmount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -825,6 +836,7 @@ func TestSysUnmount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",
@@ -1025,6 +1037,7 @@ func TestSysTuneMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"secret/": map[string]interface{}{
 				"description":             "key/value secret storage",
@@ -1041,6 +1054,7 @@ func TestSysTuneMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -1108,6 +1122,7 @@ func TestSysTuneMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"secret/": map[string]interface{}{
 			"description":             "key/value secret storage",
@@ -1124,6 +1139,7 @@ func TestSysTuneMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",
@@ -1264,6 +1280,7 @@ func TestSysTuneMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"secret/": map[string]interface{}{
 				"description":             "key/value secret storage",
@@ -1280,6 +1297,7 @@ func TestSysTuneMount(t *testing.T) {
 				"plugin_version":         "",
 				"running_sha256":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"description":             "system endpoints used for control, policy and debugging",
@@ -1347,6 +1365,7 @@ func TestSysTuneMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"secret/": map[string]interface{}{
 			"description":             "key/value secret storage",
@@ -1363,6 +1382,7 @@ func TestSysTuneMount(t *testing.T) {
 			"plugin_version":         "",
 			"running_sha256":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"description":             "system endpoints used for control, policy and debugging",

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openbao/openbao/api/auth/approle"
 	"github.com/openbao/openbao/builtin/logical/database"
 	"github.com/openbao/openbao/helper/namespace"
-	"github.com/openbao/openbao/helper/testhelpers/consul"
 	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/helper/testhelpers/pluginhelpers"
 	postgreshelper "github.com/openbao/openbao/helper/testhelpers/postgresql"
@@ -521,27 +520,15 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 				}
 
 				// Configure
-				cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-				defer cleanupConsul()
-
-				_, err := client.Logical().Write(pluginPath+"/config/access", map[string]interface{}{
-					"address": consulConfig.Address(),
-					"token":   consulConfig.Token,
+				_, err := client.Logical().Write(pluginPath+"/data/creds", map[string]interface{}{
+					"address": "localhost:8300",
+					"token":   "devcreds",
 				})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				_, err = client.Logical().Write(pluginPath+"/roles/test", map[string]interface{}{
-					"consul_policies": []string{"test"},
-					"ttl":             "6h",
-					"local":           false,
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				resp, err := client.Logical().Read(pluginPath + "/creds/test")
+				resp, err := client.Logical().Read(pluginPath + "/data/creds")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -574,28 +561,15 @@ func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
 
 	testRegisterAndEnable(t, client, plugin)
 
-	// Configure
-	cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-	defer cleanupConsul()
-
-	_, err := client.Logical().Write(plugin.Name+"/config/access", map[string]interface{}{
-		"address": consulConfig.Address(),
-		"token":   consulConfig.Token,
+	_, err := client.Logical().Write(plugin.Name+"/data/creds", map[string]interface{}{
+		"address": "localhost:8300",
+		"token":   "testtoken",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = client.Logical().Write(plugin.Name+"/roles/test", map[string]interface{}{
-		"consul_policies": []string{"test"},
-		"ttl":             "6h",
-		"local":           false,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	resp, err := client.Logical().Read(plugin.Name + "/creds/test")
+	resp, err := client.Logical().Read(plugin.Name + "/data/creds")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,7 +584,7 @@ func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err = client.Logical().Read(plugin.Name + "/creds/test")
+	resp, err = client.Logical().Read(plugin.Name + "/data/creds")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -978,11 +952,9 @@ func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T
 	}
 
 	// Configure
-	cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-	defer cleanupConsul()
-	_, err = client.Logical().Write(plugin.Name+"/config/access", map[string]interface{}{
-		"address": consulConfig.Address(),
-		"token":   consulConfig.Token,
+	_, err = client.Logical().Write(plugin.Name+"/data/creds", map[string]interface{}{
+		"address": "localhost:8300",
+		"token":   "devcreds",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -995,7 +967,7 @@ func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T
 		auditRequest := map[string]interface{}{}
 		if req, ok := auditRecord["request"]; ok {
 			auditRequest = req.(map[string]interface{})
-			if auditRequest["path"] != plugin.Name+"/config/access" {
+			if auditRequest["path"] != plugin.Name+"/data/creds" {
 				continue
 			}
 		}
@@ -1004,7 +976,7 @@ func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T
 		auditResponse := map[string]interface{}{}
 		if req, ok := auditRecord["response"]; ok {
 			auditRequest = req.(map[string]interface{})
-			if auditResponse["path"] != plugin.Name+"/config/access" {
+			if auditResponse["path"] != plugin.Name+"/data/creds" {
 				continue
 			}
 		}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -2323,6 +2323,8 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 						http.StatusOK: {{
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
+								// XXX: additional fields in SystemBackend.mountInfo are
+								// missing from this schema declaration.
 								"type": {
 									Type:     framework.TypeString,
 									Required: true,
@@ -2374,6 +2376,10 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 								"config": {
 									Type:     framework.TypeMap,
 									Required: true,
+								},
+								"deprecation_status": {
+									Type:     framework.TypeString,
+									Required: false,
 								},
 							},
 						}},

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5861,7 +5861,7 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 		pluginType consts.PluginType
 		mountTable string
 	}{
-		{"consul", consts.PluginTypeSecrets, "mounts"},
+		{"kv", consts.PluginTypeSecrets, "mounts"},
 		{"approle", consts.PluginTypeCredential, "auth"},
 	}
 	readMountConfig := func(pluginName, mountTable string) map[string]interface{} {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -212,6 +212,7 @@ func TestSystemBackend_mounts(t *testing.T) {
 			"plugin_version":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
 			"running_sha256":         "",
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"type":                    "system",
@@ -350,6 +351,7 @@ func TestSystemBackend_mount(t *testing.T) {
 			"plugin_version":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
 			"running_sha256":         "",
+			"deprecation_status":     "supported",
 		},
 		"sys/": map[string]interface{}{
 			"type":                    "system",
@@ -426,6 +428,7 @@ func TestSystemBackend_mount(t *testing.T) {
 			"plugin_version":         "",
 			"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
 			"running_sha256":         "",
+			"deprecation_status":     "supported",
 		},
 	}
 	if diff := deep.Equal(resp.Data, exp); len(diff) > 0 {
@@ -3796,6 +3799,7 @@ func TestSystemBackend_InternalUIMounts(t *testing.T) {
 				"plugin_version":         "",
 				"running_plugin_version": versions.GetBuiltinVersion(consts.PluginTypeSecrets, "kv"),
 				"running_sha256":         "",
+				"deprecation_status":     "supported",
 			},
 			"sys/": map[string]interface{}{
 				"type":                    "system",


### PR DESCRIPTION
This switches to the K/V plugin for testing, replacing Consul tests in a lot of places. 

---

Note that this is waiting on #109 to merge as it currently includes that branch in this one. Part of #68; broken up for reviewability. 