### PR TITLE
Part 17/17 - Move testIdentityStore to use AppRole instead of GitHub

### DIFF
--- a/vault/external_tests/identity/aliases_test.go
+++ b/vault/external_tests/identity/aliases_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openbao/openbao/api"
 	auth "github.com/openbao/openbao/api/auth/userpass"
+	"github.com/openbao/openbao/builtin/credential/approle"
 	"github.com/openbao/openbao/builtin/credential/userpass"
 	"github.com/openbao/openbao/helper/testhelpers"
 	vaulthttp "github.com/openbao/openbao/http"
@@ -20,8 +21,7 @@ import (
 	"github.com/openbao/openbao/vault"
 )
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin.
+// TODO: rewrite test to not rely on AppRole plugin.
 func TestIdentityStore_ListAlias(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -179,7 +179,6 @@ func TestIdentityStore_ListAlias(t *testing.T) {
 		}
 	}
 }
-*/
 
 // TestIdentityStore_RenameAlias_CannotMergeEntity verifies that an error is
 // returned on an attempt to rename an alias to match another alias with the
@@ -347,8 +346,7 @@ func TestIdentityStore_MergeEntities_FailsDueToClash(t *testing.T) {
 	}
 }
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin
+// TODO: rewrite test to not rely on AppRole plugin
 func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -565,7 +563,6 @@ func TestIdentityStore_MergeEntities_FailsDueToDoubleClash(t *testing.T) {
 		t.Fatalf("Did not identify mount accessor %s as being reason for conflict. Error: %v", mountAccessorAppRole, err)
 	}
 }
-*/
 
 func TestIdentityStore_MergeEntities_FailsDueToClashInFromEntities_CheckRawRequest(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
@@ -848,8 +845,7 @@ func TestIdentityStore_MergeEntities_SameMountAccessor_ThenUseAlias(t *testing.T
 	}
 }
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin.
+// TODO: rewrite test to not rely on AppRole plugin.
 func TestIdentityStore_MergeEntities_FailsDueToMultipleClashMergesAttempted(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
 		CredentialBackends: map[string]logical.Factory{
@@ -959,4 +955,3 @@ func TestIdentityStore_MergeEntities_FailsDueToMultipleClashMergesAttempted(t *t
 		t.Fatalf("did not error for the right reason. Error: %v", err)
 	}
 }
-*/

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -9,13 +9,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/require"
 
 	"github.com/armon/go-metrics"
 	"github.com/go-test/deep"
 	uuid "github.com/hashicorp/go-uuid"
+	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
+	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/storagepacker"
 	"github.com/openbao/openbao/sdk/logical"
 )
 
@@ -74,8 +78,6 @@ func TestIdentityStore_DeleteEntityAlias(t *testing.T) {
 	require.Len(t, entity.Aliases, 0)
 }
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin
 func TestIdentityStore_UnsealingWhenConflictingAliasNames(t *testing.T) {
 	err := AddTestCredentialBackend("approle", credAppRole.Factory)
 	if err != nil {
@@ -172,7 +174,6 @@ func TestIdentityStore_UnsealingWhenConflictingAliasNames(t *testing.T) {
 		t.Fatal("still sealed")
 	}
 }
-*/
 
 func TestIdentityStore_EntityIDPassthrough(t *testing.T) {
 	// Enable AppRole auth and initialize
@@ -535,8 +536,6 @@ func TestIdentityStore_TokenEntityInheritance(t *testing.T) {
 	}
 }
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin
 func TestIdentityStore_MergeConflictingAliases(t *testing.T) {
 	err := AddTestCredentialBackend("approle", credAppRole.Factory)
 	if err != nil {
@@ -724,7 +723,6 @@ func testIdentityStoreWithAppRoleUserpassAuth(ctx context.Context, t *testing.T)
 
 	return c.identityStore, githubMe.Accessor, userpassMe.Accessor, c
 }
-*/
 
 func TestIdentityStore_MetadataKeyRegex(t *testing.T) {
 	key := "validVALID012_-=+/"
@@ -769,8 +767,6 @@ func expectSingleCount(t *testing.T, sink *metrics.InmemSink, keyPrefix string) 
 	}
 }
 
-/*
-// TODO: rewrite test to not rely on GitHub plugin
 func TestIdentityStore_NewEntityCounter(t *testing.T) {
 	// Add github credential factory to core config
 	err := AddTestCredentialBackend("approle", credAppRole.Factory)
@@ -820,7 +816,6 @@ func TestIdentityStore_NewEntityCounter(t *testing.T) {
 
 	expectSingleCount(t, sink, "identity.entity.creation")
 }
-*/
 
 func TestIdentityStore_UpdateAliasMetadataPerAccessor(t *testing.T) {
 	entity := &identity.Entity{


### PR DESCRIPTION
As GitHub auth has been removed, we switch to relying on AppRole for various sanity checks.

---

Part of #68; broken up for reviewability. 