### PR TITLE
fork: Rename Environment Variables

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -33,26 +32,26 @@ import (
 )
 
 const (
-	EnvVaultAddress          = "VAULT_ADDR"
-	EnvVaultAgentAddr        = "VAULT_AGENT_ADDR"
-	EnvVaultCACert           = "VAULT_CACERT"
-	EnvVaultCACertBytes      = "VAULT_CACERT_BYTES"
-	EnvVaultCAPath           = "VAULT_CAPATH"
-	EnvVaultClientCert       = "VAULT_CLIENT_CERT"
-	EnvVaultClientKey        = "VAULT_CLIENT_KEY"
-	EnvVaultClientTimeout    = "VAULT_CLIENT_TIMEOUT"
-	EnvVaultSRVLookup        = "VAULT_SRV_LOOKUP"
-	EnvVaultSkipVerify       = "VAULT_SKIP_VERIFY"
-	EnvVaultNamespace        = "VAULT_NAMESPACE"
-	EnvVaultTLSServerName    = "VAULT_TLS_SERVER_NAME"
-	EnvVaultWrapTTL          = "VAULT_WRAP_TTL"
-	EnvVaultMaxRetries       = "VAULT_MAX_RETRIES"
-	EnvVaultToken            = "VAULT_TOKEN"
-	EnvVaultMFA              = "VAULT_MFA"
-	EnvRateLimit             = "VAULT_RATE_LIMIT"
-	EnvHTTPProxy             = "VAULT_HTTP_PROXY"
-	EnvVaultProxyAddr        = "VAULT_PROXY_ADDR"
-	EnvVaultDisableRedirects = "VAULT_DISABLE_REDIRECTS"
+	EnvVaultAddress          = "BAO_ADDR"
+	EnvVaultAgentAddr        = "BAO_AGENT_ADDR"
+	EnvVaultCACert           = "BAO_CACERT"
+	EnvVaultCACertBytes      = "BAO_CACERT_BYTES"
+	EnvVaultCAPath           = "BAO_CAPATH"
+	EnvVaultClientCert       = "BAO_CLIENT_CERT"
+	EnvVaultClientKey        = "BAO_CLIENT_KEY"
+	EnvVaultClientTimeout    = "BAO_CLIENT_TIMEOUT"
+	EnvVaultSRVLookup        = "BAO_SRV_LOOKUP"
+	EnvVaultSkipVerify       = "BAO_SKIP_VERIFY"
+	EnvVaultNamespace        = "BAO_NAMESPACE"
+	EnvVaultTLSServerName    = "BAO_TLS_SERVER_NAME"
+	EnvVaultWrapTTL          = "BAO_WRAP_TTL"
+	EnvVaultMaxRetries       = "BAO_MAX_RETRIES"
+	EnvVaultToken            = "BAO_TOKEN"
+	EnvVaultMFA              = "BAO_MFA"
+	EnvRateLimit             = "BAO_RATE_LIMIT"
+	EnvHTTPProxy             = "BAO_HTTP_PROXY"
+	EnvVaultProxyAddr        = "BAO_PROXY_ADDR"
+	EnvVaultDisableRedirects = "BAO_DISABLE_REDIRECTS"
 	HeaderIndex              = "X-Vault-Index"
 	HeaderForward            = "X-Vault-Forward"
 	HeaderInconsistent       = "X-Vault-Inconsistent"
@@ -73,15 +72,15 @@ const (
 		"on the server or run the client with -address set to an address\n" +
 		"that uses the http protocol:\n\n" +
 		"    vault <command> -address http://<address>\n\n" +
-		"You can also set the VAULT_ADDR environment variable:\n\n\n" +
-		"    VAULT_ADDR=http://<address> vault <command>\n\n" +
+		"You can also set the BAO_ADDR environment variable:\n\n\n" +
+		"    BAO_ADDR=http://<address> vault <command>\n\n" +
 		"where <address> is replaced by the actual address to the server."
 )
 
 // Deprecated values
 const (
-	EnvVaultAgentAddress = "VAULT_AGENT_ADDR"
-	EnvVaultInsecure     = "VAULT_SKIP_VERIFY"
+	EnvVaultAgentAddress = "BAO_AGENT_ADDR"
+	EnvVaultInsecure     = "BAO_SKIP_VERIFY"
 )
 
 // WrappingLookupFunc is a function that, given an HTTP verb and a path,
@@ -240,7 +239,7 @@ type TLSConfig struct {
 // safe to modify the return value of this function.
 //
 // The default Address is https://127.0.0.1:8200, but this can be overridden by
-// setting the `VAULT_ADDR` environment variable.
+// setting the `BAO_ADDR` environment variable.
 //
 // If an error is encountered, the Error field on the returned *Config will be populated with the specific error.
 func DefaultConfig() *Config {
@@ -378,56 +377,56 @@ func (c *Config) ReadEnvironment() error {
 	var envVaultDisableRedirects bool
 
 	// Parse the environment variables
-	if v := os.Getenv(EnvVaultAddress); v != "" {
+	if v := ReadBaoVariable(EnvVaultAddress); v != "" {
 		envAddress = v
 	}
-	if v := os.Getenv(EnvVaultAgentAddr); v != "" {
+	if v := ReadBaoVariable(EnvVaultAgentAddr); v != "" {
 		envAgentAddress = v
 	}
-	if v := os.Getenv(EnvVaultMaxRetries); v != "" {
+	if v := ReadBaoVariable(EnvVaultMaxRetries); v != "" {
 		maxRetries, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			return err
 		}
 		envMaxRetries = &maxRetries
 	}
-	if v := os.Getenv(EnvVaultCACert); v != "" {
+	if v := ReadBaoVariable(EnvVaultCACert); v != "" {
 		envCACert = v
 	}
-	if v := os.Getenv(EnvVaultCACertBytes); v != "" {
+	if v := ReadBaoVariable(EnvVaultCACertBytes); v != "" {
 		envCACertBytes = []byte(v)
 	}
-	if v := os.Getenv(EnvVaultCAPath); v != "" {
+	if v := ReadBaoVariable(EnvVaultCAPath); v != "" {
 		envCAPath = v
 	}
-	if v := os.Getenv(EnvVaultClientCert); v != "" {
+	if v := ReadBaoVariable(EnvVaultClientCert); v != "" {
 		envClientCert = v
 	}
-	if v := os.Getenv(EnvVaultClientKey); v != "" {
+	if v := ReadBaoVariable(EnvVaultClientKey); v != "" {
 		envClientKey = v
 	}
-	if v := os.Getenv(EnvRateLimit); v != "" {
+	if v := ReadBaoVariable(EnvRateLimit); v != "" {
 		rateLimit, burstLimit, err := parseRateLimit(v)
 		if err != nil {
 			return err
 		}
 		limit = rate.NewLimiter(rate.Limit(rateLimit), burstLimit)
 	}
-	if t := os.Getenv(EnvVaultClientTimeout); t != "" {
+	if t := ReadBaoVariable(EnvVaultClientTimeout); t != "" {
 		clientTimeout, err := parseutil.ParseDurationSecond(t)
 		if err != nil {
 			return fmt.Errorf("could not parse %q", EnvVaultClientTimeout)
 		}
 		envClientTimeout = clientTimeout
 	}
-	if v := os.Getenv(EnvVaultSkipVerify); v != "" {
+	if v := ReadBaoVariable(EnvVaultSkipVerify); v != "" {
 		var err error
 		envInsecure, err = strconv.ParseBool(v)
 		if err != nil {
 			return fmt.Errorf("could not parse %s", EnvVaultSkipVerify)
 		}
 	}
-	if v := os.Getenv(EnvVaultSRVLookup); v != "" {
+	if v := ReadBaoVariable(EnvVaultSRVLookup); v != "" {
 		var err error
 		envSRVLookup, err = strconv.ParseBool(v)
 		if err != nil {
@@ -435,20 +434,20 @@ func (c *Config) ReadEnvironment() error {
 		}
 	}
 
-	if v := os.Getenv(EnvVaultTLSServerName); v != "" {
+	if v := ReadBaoVariable(EnvVaultTLSServerName); v != "" {
 		envTLSServerName = v
 	}
 
-	if v := os.Getenv(EnvHTTPProxy); v != "" {
+	if v := ReadBaoVariable(EnvHTTPProxy); v != "" {
 		envVaultProxy = v
 	}
 
-	// VAULT_PROXY_ADDR supersedes VAULT_HTTP_PROXY
-	if v := os.Getenv(EnvVaultProxyAddr); v != "" {
+	// BAO_PROXY_ADDR supersedes BAO_HTTP_PROXY
+	if v := ReadBaoVariable(EnvVaultProxyAddr); v != "" {
 		envVaultProxy = v
 	}
 
-	if v := os.Getenv(EnvVaultDisableRedirects); v != "" {
+	if v := ReadBaoVariable(EnvVaultDisableRedirects); v != "" {
 		var err error
 		envVaultDisableRedirects, err = strconv.ParseBool(v)
 		if err != nil {
@@ -586,7 +585,7 @@ type Client struct {
 // If the configuration is nil, Vault will use configuration from
 // DefaultConfig(), which is the recommended starting configuration.
 //
-// If the environment variable `VAULT_TOKEN` is present, the token will be
+// If the environment variable `BAO_TOKEN` is present, the token will be
 // automatically added to the client. Otherwise, you must manually call
 // `SetToken()`.
 func NewClient(c *Config) (*Client, error) {
@@ -643,11 +642,11 @@ func NewClient(c *Config) (*Client, error) {
 	// Add the VaultRequest SSRF protection header
 	client.headers[RequestHeaderName] = []string{"true"}
 
-	if token := os.Getenv(EnvVaultToken); token != "" {
+	if token := ReadBaoVariable(EnvVaultToken); token != "" {
 		client.token = token
 	}
 
-	if namespace := os.Getenv(EnvVaultNamespace); namespace != "" {
+	if namespace := ReadBaoVariable(EnvVaultNamespace); namespace != "" {
 		client.setNamespace(namespace)
 	}
 
@@ -684,7 +683,7 @@ func (c *Client) CloneConfig() *Config {
 
 // SetAddress sets the address of Vault in the client. The format of address should be
 // "<Scheme>://<Host>:<Port>". Setting this on a client will override the
-// value of VAULT_ADDR environment variable.
+// value of BAO_ADDR environment variable.
 func (c *Client) SetAddress(addr string) error {
 	c.modifyLock.Lock()
 	defer c.modifyLock.Unlock()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -26,21 +26,21 @@ import (
 
 func init() {
 	// Ensure our special envvars are not present
-	os.Setenv("VAULT_ADDR", "")
-	os.Setenv("VAULT_TOKEN", "")
+	os.Setenv("BAO_ADDR", "")
+	os.Setenv("BAO_TOKEN", "")
 }
 
 func TestDefaultConfig_envvar(t *testing.T) {
-	os.Setenv("VAULT_ADDR", "https://vault.mycompany.com")
-	defer os.Setenv("VAULT_ADDR", "")
+	os.Setenv("BAO_ADDR", "https://vault.mycompany.com")
+	defer os.Setenv("BAO_ADDR", "")
 
 	config := DefaultConfig()
 	if config.Address != "https://vault.mycompany.com" {
 		t.Fatalf("bad: %s", config.Address)
 	}
 
-	os.Setenv("VAULT_TOKEN", "testing")
-	defer os.Setenv("VAULT_TOKEN", "")
+	os.Setenv("BAO_TOKEN", "testing")
+	defer os.Setenv("BAO_TOKEN", "")
 
 	client, err := NewClient(config)
 	if err != nil {
@@ -72,8 +72,8 @@ func TestClientNilConfig(t *testing.T) {
 }
 
 func TestClientDefaultHttpClient_unixSocket(t *testing.T) {
-	os.Setenv("VAULT_AGENT_ADDR", "unix:///var/run/vault.sock")
-	defer os.Setenv("VAULT_AGENT_ADDR", "")
+	os.Setenv("BAO_AGENT_ADDR", "unix:///var/run/vault.sock")
+	defer os.Setenv("BAO_AGENT_ADDR", "")
 
 	client, err := NewClient(nil)
 	if err != nil {
@@ -689,7 +689,7 @@ func TestClone(t *testing.T) {
 					t.Fatalf("tokens do not match: %v vs %v", parent.token, clone.token)
 				}
 			} else {
-				// assumes `VAULT_TOKEN` is unset or has an empty value.
+				// assumes `BAO_TOKEN` is unset or has an empty value.
 				expected := ""
 				if clone.token != expected {
 					t.Fatalf("expected clone's token %q, actual %q", expected, clone.token)
@@ -1342,31 +1342,31 @@ func TestVaultProxy(t *testing.T) {
 		requestUrl               string
 		expectedResolvedProxyUrl string
 	}{
-		"VAULT_HTTP_PROXY used when NO_PROXY env var doesn't include request host": {
+		"BAO_HTTP_PROXY used when NO_PROXY env var doesn't include request host": {
 			vaultHttpProxy: "https://hashicorp.com",
 			vaultProxyAddr: "",
 			noProxy:        "terraform.io",
 			requestUrl:     "https://vaultproject.io",
 		},
-		"VAULT_HTTP_PROXY used when NO_PROXY env var includes request host": {
+		"BAO_HTTP_PROXY used when NO_PROXY env var includes request host": {
 			vaultHttpProxy: "https://hashicorp.com",
 			vaultProxyAddr: "",
 			noProxy:        "terraform.io,vaultproject.io",
 			requestUrl:     "https://vaultproject.io",
 		},
-		"VAULT_PROXY_ADDR used when NO_PROXY env var doesn't include request host": {
+		"BAO_PROXY_ADDR used when NO_PROXY env var doesn't include request host": {
 			vaultHttpProxy: "",
 			vaultProxyAddr: "https://hashicorp.com",
 			noProxy:        "terraform.io",
 			requestUrl:     "https://vaultproject.io",
 		},
-		"VAULT_PROXY_ADDR used when NO_PROXY env var includes request host": {
+		"BAO_PROXY_ADDR used when NO_PROXY env var includes request host": {
 			vaultHttpProxy: "",
 			vaultProxyAddr: "https://hashicorp.com",
 			noProxy:        "terraform.io,vaultproject.io",
 			requestUrl:     "https://vaultproject.io",
 		},
-		"VAULT_PROXY_ADDR used when VAULT_HTTP_PROXY env var also supplied": {
+		"BAO_PROXY_ADDR used when BAO_HTTP_PROXY env var also supplied": {
 			vaultHttpProxy:           "https://hashicorp.com",
 			vaultProxyAddr:           "https://terraform.io",
 			noProxy:                  "",

--- a/api/env.go
+++ b/api/env.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"os"
+	"strings"
+)
+
+func ReadBaoVariable(name string) string {
+	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
+	prefixes := [2]string{"BAO_", "VAULT_"}
+	for _, prefix := range prefixes {
+		searchName := prefix + nonPrefixedName
+		result := os.Getenv(searchName)
+		if result != "" {
+			return result
+		}
+	}
+	return ""
+}

--- a/api/env_test.go
+++ b/api/env_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadBaoVariable_Vault(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("VAULT_TEST", actual)
+	expected := ReadBaoVariable("BAO_TEST")
+	if actual != expected {
+		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+	}
+}
+
+func TestReadBaoVariable_Bao(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("BAO_TEST", actual)
+	expected := ReadBaoVariable("BAO_TEST")
+	if actual != expected {
+		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+	}
+}
+
+func TestReadBaoVariable_BothSame(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("VAULT_TEST", actual)
+	os.Setenv("BAO_TEST", actual)
+	expected := ReadBaoVariable("BAO_TEST")
+	if actual != expected {
+		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+	}
+}
+
+func TestReadBaoVariable_BoaWins(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("VAULT_TEST", actual+"not_valid")
+	os.Setenv("BAO_TEST", actual)
+	expected := ReadBaoVariable("BAO_TEST")
+	if actual != expected {
+		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+	}
+}

--- a/api/logical.go
+++ b/api/logical.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/errwrap"
@@ -30,8 +29,8 @@ var (
 	// var to set the wrap TTL. The default wrap TTL will apply when when writing
 	// to `sys/wrapping/wrap` when the env var is not set.
 	DefaultWrappingLookupFunc = func(operation, path string) string {
-		if os.Getenv(EnvVaultWrapTTL) != "" {
-			return os.Getenv(EnvVaultWrapTTL)
+		if ReadBaoVariable(EnvVaultWrapTTL) != "" {
+			return ReadBaoVariable(EnvVaultWrapTTL)
 		}
 
 		if (operation == http.MethodPut || operation == http.MethodPost) && path == "sys/wrapping/wrap" {

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -22,15 +22,15 @@ import (
 const (
 	// PluginAutoMTLSEnv is used to ensure AutoMTLS is used. This will override
 	// setting a TLSProviderFunc for a plugin.
-	PluginAutoMTLSEnv = "VAULT_PLUGIN_AUTOMTLS_ENABLED"
+	PluginAutoMTLSEnv = "BAO_PLUGIN_AUTOMTLS_ENABLED"
 
 	// PluginMetadataModeEnv is an ENV name used to disable TLS communication
 	// to bootstrap mounting plugins.
-	PluginMetadataModeEnv = "VAULT_PLUGIN_METADATA_MODE"
+	PluginMetadataModeEnv = "BAO_PLUGIN_METADATA_MODE"
 
 	// PluginUnwrapTokenEnv is the ENV name used to pass unwrap tokens to the
 	// plugin.
-	PluginUnwrapTokenEnv = "VAULT_UNWRAP_TOKEN"
+	PluginUnwrapTokenEnv = "BAO_UNWRAP_TOKEN"
 )
 
 // sudoPaths is a map containing the paths that require a token's policy

--- a/helper/forwarding/util.go
+++ b/helper/forwarding/util.go
@@ -35,7 +35,7 @@ func GenerateForwardedHTTPRequest(req *http.Request, addr string) (*http.Request
 	}
 
 	var newBody []byte
-	switch os.Getenv("VAULT_MESSAGE_TYPE") {
+	switch os.Getenv("BAO_MESSAGE_TYPE") {
 	case "json":
 		newBody, err = jsonutil.EncodeJSON(fq)
 	case "json_compress":


### PR DESCRIPTION
This PR will allow users to configure OpenBAO with both `VAULT_` and `BAO_` prefixes for environment variables. 

Resolves #66

## Target Release
GA
