### PR TITLE
 Transit: Fix bug where locks were not being freed on specific operations - with tests

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -165,6 +165,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	successesInBatch := false
 	for i, item := range batchInputItems {
@@ -224,8 +225,6 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	} else {
 		if batchResponseItems[0].Error != "" {
-			p.Unlock()
-
 			if internalErrorInBatch {
 				return nil, errutil.InternalError{Err: batchResponseItems[0].Error}
 			}
@@ -236,8 +235,6 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 			"plaintext": batchResponseItems[0].Plaintext,
 		}
 	}
-
-	p.Unlock()
 
 	return batchRequestResponse(d, resp, req, successesInBatch, userErrorInBatch, internalErrorInBatch)
 }

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -423,6 +423,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	// Process batch request items. If encryption of any request
 	// item fails, respectively mark the error in the response
@@ -499,8 +500,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	} else {
 		if batchResponseItems[0].Error != "" {
-			p.Unlock()
-
 			if internalErrorInBatch {
 				return nil, errutil.InternalError{Err: batchResponseItems[0].Error}
 			}
@@ -517,8 +516,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	if req.Operation == logical.CreateOperation && !upserted {
 		resp.AddWarning("Attempted creation of the key during the encrypt operation, but it was created beforehand")
 	}
-
-	p.Unlock()
 
 	return batchRequestResponse(d, resp, req, successesInBatch, userErrorInBatch, internalErrorInBatch)
 }

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -136,6 +136,7 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	switch {
 	case ver == 0:
@@ -145,23 +146,19 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 	case ver == p.LatestVersion:
 		// Allowed
 	case p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion:
-		p.Unlock()
 		return logical.ErrorResponse("cannot generate HMAC: version is too old (disallowed by policy)"), logical.ErrInvalidRequest
 	}
 
 	key, err := p.HMACKey(ver)
 	if err != nil {
-		p.Unlock()
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 	if key == nil && p.Type != keysutil.KeyType_MANAGED_KEY {
-		p.Unlock()
 		return nil, fmt.Errorf("HMAC key value could not be computed")
 	}
 
 	hashAlgorithm, ok := keysutil.HashTypeMap[algorithm]
 	if !ok {
-		p.Unlock()
 		return logical.ErrorResponse("unsupported algorithm %q", hashAlgorithm), nil
 	}
 
@@ -172,18 +169,15 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 	if batchInputRaw != nil {
 		err = mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
-			p.Unlock()
 			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {
-			p.Unlock()
 			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
 		valueRaw, ok := d.GetOk("input")
 		if !ok {
-			p.Unlock()
 			return logical.ErrorResponse("missing input for HMAC"), logical.ErrInvalidRequest
 		}
 
@@ -233,8 +227,6 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 		response[i].HMAC = retStr
 	}
 
-	p.Unlock()
-
 	// Generate the response
 	resp := &logical.Response{}
 	if batchInputRaw != nil {
@@ -282,10 +274,10 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	hashAlgorithm, ok := keysutil.HashTypeMap[algorithm]
 	if !ok {
-		p.Unlock()
 		return logical.ErrorResponse("unsupported algorithm %q", hashAlgorithm), nil
 	}
 
@@ -296,12 +288,10 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 	if batchInputRaw != nil {
 		err := mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
-			p.Unlock()
 			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {
-			p.Unlock()
 			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
@@ -397,8 +387,6 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 		retBytes := hf.Sum(nil)
 		response[i].Valid = hmac.Equal(retBytes, verBytes)
 	}
-
-	p.Unlock()
 
 	// Generate the response
 	resp := &logical.Response{}

--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -232,6 +232,8 @@ func (b *backend) pathImportWrite(ctx context.Context, req *logical.Request, d *
 		return nil, errors.New("the import path cannot be used with an existing key; use import-version to rotate an existing imported key")
 	}
 
+	// Otherwise, p was nil, so there is no lock that needs to be released.
+
 	key, resp, err := b.extractKeyFromFields(ctx, req, d, polReq.KeyType, isCiphertextSet)
 	if err != nil {
 		return resp, err

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -252,9 +252,10 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	if p == nil {
 		return nil, fmt.Errorf("error generating key: returned policy was nil")
 	}
-	if b.System().CachingDisabled() {
-		p.Unlock()
+	if !b.System().CachingDisabled() {
+		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	resp, err := b.formatKeyPolicy(p, nil)
 	if err != nil {

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -129,6 +129,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
 	}
+	defer p.Unlock()
 
 	for i, item := range batchInputItems {
 		if batchResponseItems[i].Error != "" {
@@ -142,7 +143,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 				batchResponseItems[i].Error = err.Error()
 				continue
 			default:
-				p.Unlock()
 				return nil, err
 			}
 		}
@@ -154,16 +154,13 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 				batchResponseItems[i].Error = err.Error()
 				continue
 			case errutil.InternalError:
-				p.Unlock()
 				return nil, err
 			default:
-				p.Unlock()
 				return nil, err
 			}
 		}
 
 		if ciphertext == "" {
-			p.Unlock()
 			return nil, fmt.Errorf("empty ciphertext returned for input item %d", i)
 		}
 
@@ -187,7 +184,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		}
 	} else {
 		if batchResponseItems[0].Error != "" {
-			p.Unlock()
 			return logical.ErrorResponse(batchResponseItems[0].Error), logical.ErrInvalidRequest
 		}
 		resp.Data = map[string]interface{}{
@@ -196,7 +192,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		}
 	}
 
-	p.Unlock()
 	return resp, nil
 }
 

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -70,7 +70,6 @@ func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *
 		var keyId string
 		keyId, err = GetManagedKeyUUID(ctx, b, managedKeyName, managedKeyId)
 		if err != nil {
-			p.Unlock()
 			return nil, err
 		}
 		err = p.RotateManagedKey(ctx, req.Storage, keyId)

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -366,8 +366,8 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 	}
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
-		defer p.Unlock()
 	}
+	defer p.Unlock()
 
 	if !p.Type.SigningSupported() {
 		return logical.ErrorResponse(fmt.Sprintf("key type %v does not support signing", p.Type)), logical.ErrInvalidRequest
@@ -620,8 +620,8 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 	}
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
-		defer p.Unlock()
 	}
+	defer p.Unlock()
 
 	if !p.Type.SigningSupported() {
 		return logical.ErrorResponse(fmt.Sprintf("key type %v does not support verification", p.Type)), logical.ErrInvalidRequest

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -366,10 +366,10 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 	}
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
+		defer p.Unlock()
 	}
 
 	if !p.Type.SigningSupported() {
-		p.Unlock()
 		return logical.ErrorResponse(fmt.Sprintf("key type %v does not support signing", p.Type)), logical.ErrInvalidRequest
 	}
 
@@ -385,12 +385,10 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 	if batchInputRaw != nil {
 		err = mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
-			p.Unlock()
 			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {
-			p.Unlock()
 			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
@@ -491,7 +489,6 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	} else {
 		if response[0].Error != "" || response[0].err != nil {
-			p.Unlock()
 			if response[0].Error != "" {
 				return logical.ErrorResponse(response[0].Error), response[0].err
 			}
@@ -509,7 +506,6 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}
 
-	p.Unlock()
 	return resp, nil
 }
 
@@ -624,10 +620,10 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 	}
 	if !b.System().CachingDisabled() {
 		p.Lock(false)
+		defer p.Unlock()
 	}
 
 	if !p.Type.SigningSupported() {
-		p.Unlock()
 		return logical.ErrorResponse(fmt.Sprintf("key type %v does not support verification", p.Type)), logical.ErrInvalidRequest
 	}
 
@@ -732,7 +728,6 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		}
 	} else {
 		if response[0].Error != "" || response[0].err != nil {
-			p.Unlock()
 			if response[0].Error != "" {
 				return logical.ErrorResponse(response[0].Error), response[0].err
 			}
@@ -743,7 +738,6 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		}
 	}
 
-	p.Unlock()
 	return resp, nil
 }
 

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -10,8 +10,13 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/constants"
+	vaulthttp "github.com/openbao/openbao/http"
+	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 
 	"golang.org/x/crypto/ed25519"
 
@@ -32,13 +37,17 @@ type signOutcome struct {
 }
 
 func TestTransit_SignVerify_ECDSA(t *testing.T) {
+	t.Parallel()
 	t.Run("256", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_ECDSA(t, 256)
 	})
 	t.Run("384", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_ECDSA(t, 384)
 	})
 	t.Run("521", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_ECDSA(t, 521)
 	})
 }
@@ -371,6 +380,7 @@ func validatePublicKey(t *testing.T, in string, sig string, pubKeyRaw []byte, ex
 }
 
 func TestTransit_SignVerify_ED25519(t *testing.T) {
+	t.Parallel()
 	b, storage := createBackendWithSysView(t)
 
 	// First create a key
@@ -715,13 +725,17 @@ func TestTransit_SignVerify_ED25519(t *testing.T) {
 }
 
 func TestTransit_SignVerify_RSA_PSS(t *testing.T) {
+	t.Parallel()
 	t.Run("2048", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_RSA_PSS(t, 2048)
 	})
 	t.Run("3072", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_RSA_PSS(t, 3072)
 	})
 	t.Run("4096", func(t *testing.T) {
+		t.Parallel()
 		testTransit_SignVerify_RSA_PSS(t, 4096)
 	})
 }
@@ -978,4 +992,93 @@ func testTransit_SignVerify_RSA_PSS(t *testing.T, bits int) {
 			})
 		}
 	}
+}
+
+func TestTransit_NoDeadlock_SignVerify(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rsa-2048/cached", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-2048", false)
+	})
+	t.Run("rsa-3072/cached", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-3072", false)
+	})
+	t.Run("rsa-4096/cached", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-4096", false)
+	})
+
+	t.Run("rsa-2048/direct", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-2048", true)
+	})
+	t.Run("rsa-3072/direct", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-3072", true)
+	})
+	t.Run("rsa-4096/direct", func(t *testing.T) {
+		t.Parallel()
+		testTransit_NoDeadlock_SignVerify(t, "rsa-4096", true)
+	})
+}
+
+func testTransit_NoDeadlock_SignVerify(t *testing.T, keyType string, cachingDisabled bool) {
+	// This test detects a deadlock caused by certain code paths not releasing
+	// the implicit read lock that is fetched; when a subsequent write lock
+	// is attempted, it will stall indefinitely, causing future reads and writes
+	// to also fail.
+	coreConfig := &vault.CoreConfig{
+		DisableCache: cachingDisabled,
+		LogicalBackends: map[string]logical.Factory{
+			"transit": Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	core := cores[0]
+
+	core.StopAutomaticRollbacks()
+
+	vault.TestWaitActive(t, core.Core)
+	client := core.Client
+	err := client.Sys().Mount("transit", &api.MountInput{
+		Type: "transit",
+	})
+	require.NoError(t, err)
+
+	_, err = client.Logical().Write("transit/keys/broken_transit_key", map[string]interface{}{
+		"type": keyType,
+	})
+	require.NoError(t, err)
+
+	// This error case triggered a leaked read lock.
+	_, err = client.Logical().Write("transit/sign/broken_transit_key", map[string]interface{}{
+		"input":          "aGVsbG8gd29ybGQuCg==",
+		"prehashed":      "false",
+		"hash_algorithm": "none",
+	})
+	require.Error(t, err, "hash_algorithm=none requires both prehashed=true and signature_algorithm=pkcs1v15")
+
+	// The tidy operation aggressively grabs a write lock over the keys
+	// to see if auto-rotation needs to occur. By triggering this manually,
+	// we avoid needing to wait for it to occur to detect if it causes a
+	// deadlock due to leaking read locks.
+	core.TriggerRollbacks()
+	time.Sleep(2 * time.Second)
+
+	// If we've leaked a read lock, the above write lock grab will not block,
+	// causing future read locks calls to also block until the write lock is
+	// able to succeed. Setting a timeout should let us return and fail the
+	// test (as the context should be cancelled).
+	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
+	_, err = client.Logical().ReadWithContext(ctx, "transit/keys/broken_transit_key")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
@Gabrielopesantos started this one in #136 (thank you!!!), but I got a little excited with the tests, so I'll take over from here... :-)

> This PR includes the fix to a bug happening in certain transit operations, sign and verify, where locks weren't being freed as expected which lead to goroutine deadlocks (operations hitting their timeout).
> 
> The deferred call of `Unlock` has been included in the `if` block so that it is only called if `Lock` has been initially called.
>
>EDIT: After doing some additional tests (on other files), it seems there are cases where makes difference between leaving the deferred `Unlock` call to be in the `if` block or outside. Are there any known cases where `Unlock` calls are expected even if `Lock` isn't called?
> 
> Resolves `https://github.com/hashicorp/vault/issues/25325`.

---

This moves all of Transit and the `keysutil.LockManager.GetPolicy(...)` helper to a consistent pattern: acquire lock and defer, or, if given an implicit lock and we don't need one, unlock it.

This imposes a slight performance penalty on mixed read/write workload: by holding the lock longer during templating (in the batch encrypt/decrypt or HMAC cases), we can prevent a write from occurring sooner. This is an OK trade off for 

---

Notably, this catches a panic caused by concurrent access to an unlocked pointer: when I introduced d52d3076616d5bd79bfd1edbdb389bb88576803d, I had forgotten to adjust the locking mechanism for `keyPolicyWrite`: previously it didn't need any values in the returned policy and so could unlock in the one case it held the lock. After that commit, it read that policy, which (when caching is in use and rotation was occurring) could cause a concurrent read/write to the same map:

```
fatal error: concurrent map iteration and map write

goroutine 12681 [running]:github.com/openbao/openbao/builtin/logical/transit.(*backend).formatKeyPolicy(0x479ecb0?, 0xc00094dd40, {0x0, 0x0, 0x0})
      /home/cipherboy/GitHub/openbao/openbao/builtin/logical/transit/path_keys.go:364 +0x186cgithub.com/openbao/openbao/builtin/logical/transit.(*backend).pathPolicyWrite(0xc00065b500, {0x479e428, 0xc0031a7f20}, 0xc0037a4fc0, 0xc0014f6b10)
      /home/cipherboy/GitHub/openbao/openbao/builtin/logical/transit/path_keys.go:257 +0xd25github.com/openbao/openbao/sdk/framework.(*Backend).HandleRequest(0xc000f141e0, {0x479e428, 0xc0031a7f20}, 0xc0037a4fc0)
      /home/cipherboy/GitHub/openbao/openbao/sdk/framework/backend.go:300 +0xac8github.com/openbao/openbao/builtin/plugin/v5.(*backend).HandleRequest(0xc0010526c0, {0x479e428, 0xc0031a7f20}, 0xc0037a4fc0)
```