### PR TITLE
Fix running API, SDK tests & vetting

### DIFF
--- a/sdk/framework/testdata/legacy.json
+++ b/sdk/framework/testdata/legacy.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "title": "HashiCorp Vault API",
-    "description": "HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.",
+    "title": "OpenBao API",
+    "description": "HTTP API that gives you full access to OpenBao. All API routes are prefixed with `/v1/`.",
     "version": "<vault_version>",
     "license": {
       "name": "Mozilla Public License 2.0",

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "title": "HashiCorp Vault API",
-    "description": "HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.",
+    "title": "OpenBao API",
+    "description": "HTTP API that gives you full access to OpenBao. All API routes are prefixed with `/v1/`.",
     "version": "<vault_version>",
     "license": {
       "name": "Mozilla Public License 2.0",

--- a/sdk/framework/testdata/operations_list.json
+++ b/sdk/framework/testdata/operations_list.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "title": "HashiCorp Vault API",
-    "description": "HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.",
+    "title": "OpenBao API",
+    "description": "HTTP API that gives you full access to OpenBao. All API routes are prefixed with `/v1/`.",
     "version": "<vault_version>",
     "license": {
       "name": "Mozilla Public License 2.0",

--- a/sdk/framework/testdata/responses.json
+++ b/sdk/framework/testdata/responses.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "title": "HashiCorp Vault API",
-    "description": "HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.",
+    "title": "OpenBao API",
+    "description": "HTTP API that gives you full access to OpenBao. All API routes are prefixed with `/v1/`.",
     "version": "<vault_version>",
     "license": {
       "name": "Mozilla Public License 2.0",


### PR DESCRIPTION
As noted in #61, the tests for the `api/` and `sdk/` subpackages were not run; this fixes the failing tests and adds them to the Makefile so this should be prevented in the future. 

Resolves: #61