### PR TITLE
Use api.ReadBaoVariable everywhere

### DIFF
--- a/api/auth/approle/approle_test.go
+++ b/api/auth/approle/approle_test.go
@@ -36,6 +36,7 @@ func testHTTPServer(
 }
 
 func init() {
+	os.Setenv("BAO_TOKEN", "")
 	os.Setenv("VAULT_TOKEN", "")
 }
 

--- a/api/auth/ldap/ldap_test.go
+++ b/api/auth/ldap/ldap_test.go
@@ -36,6 +36,7 @@ func testHTTPServer(
 }
 
 func init() {
+	os.Setenv("BAO_TOKEN", "")
 	os.Setenv("VAULT_TOKEN", "")
 }
 

--- a/api/auth/userpass/userpass_test.go
+++ b/api/auth/userpass/userpass_test.go
@@ -36,6 +36,7 @@ func testHTTPServer(
 }
 
 func init() {
+	os.Setenv("BAO_TOKEN", "")
 	os.Setenv("VAULT_TOKEN", "")
 }
 

--- a/api/env.go
+++ b/api/env.go
@@ -6,14 +6,29 @@ import (
 )
 
 func ReadBaoVariable(name string) string {
-	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
-	prefixes := [2]string{"BAO_", "VAULT_"}
-	for _, prefix := range prefixes {
-		searchName := prefix + nonPrefixedName
-		result := os.Getenv(searchName)
-		if result != "" {
-			return result
-		}
+	if !strings.HasPrefix(name, "BAO_") {
+		return os.Getenv(name)
 	}
-	return ""
+
+	// If the BAO_ version is present but set to the empty string, still
+	// prefer that over the VAULT_ prefixed version.
+	if baoValue, baoPresent := os.LookupEnv(name); baoPresent {
+		return baoValue
+	}
+
+	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
+	return os.Getenv("VAULT_" + nonPrefixedName)
+}
+
+func LookupBaoVariable(name string) (string, bool) {
+	if !strings.HasPrefix(name, "BAO_") {
+		return os.LookupEnv(name)
+	}
+
+	if baoValue, baoPresent := os.LookupEnv(name); baoPresent {
+		return baoValue, baoPresent
+	}
+
+	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
+	return os.LookupEnv("VAULT_" + nonPrefixedName)
 }

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"flag"
 	"net/url"
-	"os"
 	"regexp"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -130,12 +129,12 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 // VaultPluginTLSProviderContext is run inside a plugin and retrieves the response
 // wrapped TLS certificate from vault. It returns a configured TLS Config.
 func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig) func() (*tls.Config, error) {
-	if os.Getenv(PluginAutoMTLSEnv) == "true" || os.Getenv(PluginMetadataModeEnv) == "true" {
+	if ReadBaoVariable(PluginAutoMTLSEnv) == "true" || ReadBaoVariable(PluginMetadataModeEnv) == "true" {
 		return nil
 	}
 
 	return func() (*tls.Config, error) {
-		unwrapToken := os.Getenv(PluginUnwrapTokenEnv)
+		unwrapToken := ReadBaoVariable(PluginUnwrapTokenEnv)
 
 		parsedJWT, err := jwt.ParseSigned(unwrapToken)
 		if err != nil {

--- a/builtin/credential/kerberos/cmd/login-kerb/main.go
+++ b/builtin/credential/kerberos/cmd/login-kerb/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/jcmturner/gokrb5/v8/spnego"
+	"github.com/openbao/openbao/api"
 	kerberos "github.com/openbao/openbao/builtin/credential/kerberos"
 )
 
@@ -77,7 +78,7 @@ func main() {
 		os.Exit(1)
 	}
 	if vaultAddr == "" {
-		vaultAddr = os.Getenv("VAULT_ADDR")
+		vaultAddr = api.ReadBaoVariable("BAO_ADDR")
 		if vaultAddr == "" {
 			fmt.Println(`"vault_addr" is required`)
 			os.Exit(1)

--- a/builtin/credential/kubernetes/integrationtest/integration_test.go
+++ b/builtin/credential/kubernetes/integrationtest/integration_test.go
@@ -51,8 +51,8 @@ func run(m *testing.M) int {
 	}
 	defer close()
 
-	os.Setenv("VAULT_ADDR", fmt.Sprintf("http://127.0.0.1:%d", localPort))
-	os.Setenv("VAULT_TOKEN", "root")
+	os.Setenv("BAO_ADDR", fmt.Sprintf("http://127.0.0.1:%d", localPort))
+	os.Setenv("BAO_TOKEN", "root")
 
 	return m.Run()
 }

--- a/builtin/credential/ldap/cli.go
+++ b/builtin/credential/ldap/cli.go
@@ -98,5 +98,5 @@ func usernameFromEnv() string {
 }
 
 func passwordFromEnv() string {
-	return os.Getenv("VAULT_LDAP_PASSWORD")
+	return api.ReadBaoVariable("BAO_LDAP_PASSWORD")
 }

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	_ "github.com/jackc/pgx/v4"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/builtinplugins"
 	"github.com/openbao/openbao/helper/namespace"
 	postgreshelper "github.com/openbao/openbao/helper/testhelpers/postgresql"
@@ -59,7 +60,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 }
 
 func TestBackend_PluginMain_Postgres(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -72,7 +73,7 @@ func TestBackend_PluginMain_Postgres(t *testing.T) {
 }
 
 func TestBackend_PluginMain_PostgresMultiplexed(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -1455,7 +1456,7 @@ func (h hangingPlugin) Close() error {
 var _ v5.Database = (*hangingPlugin)(nil)
 
 func TestBackend_PluginMain_Hanging(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 	v5.Serve(&hangingPlugin{})

--- a/builtin/logical/database/dbplugin/plugin_test.go
+++ b/builtin/logical/database/dbplugin/plugin_test.go
@@ -6,7 +6,6 @@ package dbplugin_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -121,7 +120,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 // This is not an actual test case, it's a helper function that will be executed
 // by the go-plugin client via an exec call.
 func TestPlugin_GRPC_Main(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv) == "" && api.ReadBaoVariable(pluginutil.PluginMetadataModeEnv) != "true" {
 		return
 	}
 

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/namespace"
 	postgreshelper "github.com/openbao/openbao/helper/testhelpers/postgresql"
 	v5 "github.com/openbao/openbao/sdk/database/dbplugin/v5"
@@ -705,7 +706,7 @@ func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
 
 func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts map[string]interface{}) {
 	// We need to set this value for the plugin to run, but it doesn't matter what we set it to.
-	oldToken := os.Getenv(pluginutil.PluginUnwrapTokenEnv)
+	oldToken := api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv)
 	os.Setenv(pluginutil.PluginUnwrapTokenEnv, "...")
 	defer func() {
 		if oldToken != "" {

--- a/builtin/logical/database/versioning_large_test.go
+++ b/builtin/logical/database/versioning_large_test.go
@@ -8,7 +8,6 @@ package database
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -449,11 +448,11 @@ func cleanup(t *testing.T, b *databaseBackend, reqs []*logical.Request) {
 }
 
 func TestBackend_PluginMain_MockV4(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -468,7 +467,7 @@ func TestBackend_PluginMain_MockV4(t *testing.T) {
 }
 
 func TestBackend_PluginMain_MockV5(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -476,7 +475,7 @@ func TestBackend_PluginMain_MockV5(t *testing.T) {
 }
 
 func TestBackend_PluginMain_MockV6Multiplexed(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 

--- a/builtin/logical/kubernetes/integrationtest/integration_test.go
+++ b/builtin/logical/kubernetes/integrationtest/integration_test.go
@@ -30,8 +30,8 @@ import (
 func TestMain(m *testing.M) {
 	if os.Getenv("INTEGRATION_TESTS") != "" {
 		checkKubectlVersion()
-		os.Setenv("VAULT_ADDR", "http://127.0.0.1:38300")
-		os.Setenv("VAULT_TOKEN", "root")
+		os.Setenv("BAO_ADDR", "http://127.0.0.1:38300")
+		os.Setenv("BAO_TOKEN", "root")
 		os.Setenv("KUBERNETES_CA", getK8sCA())
 		os.Setenv("KUBE_HOST", getKubeHost(os.Getenv("KIND_CLUSTER_NAME")))
 		os.Setenv("SUPER_JWT", getSuperJWT())

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -24,7 +24,6 @@ import (
 	mathrand "math/rand"
 	"net"
 	"net/url"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -350,7 +349,7 @@ func TestBackend_Roles(t *testing.T) {
 			}
 
 			testCase.Steps = append(testCase.Steps, generateRoleSteps(t, tc.useCSR)...)
-			if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+			if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 				for i, v := range testCase.Steps {
 					data := map[string]interface{}{}
 					var keys []string
@@ -925,7 +924,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		// testing we use a randomized time for maximum fuzziness.
 	*/
 	var seed int64 = 1
-	fixedSeed := os.Getenv("VAULT_PKITESTS_FIXED_SEED")
+	fixedSeed := api.ReadBaoVariable("BAO_PKITESTS_FIXED_SEED")
 	if len(fixedSeed) == 0 {
 		seed = time.Now().UnixNano()
 	} else {
@@ -1290,7 +1289,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		default:
 			panic("invalid key type: " + keyType)
 		}
-		if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+		if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 			t.Logf("roleKeyBits=%d testBitSize=%d errorOk=%v", plan.roleKeyBits, testBitSize, plan.errorOk)
 		}
 
@@ -1427,7 +1426,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		getOrganizationCheck, getOuCheck, getPostalCodeCheck, getRandCsr, getStreetAddressCheck,
 		getProvinceCheck,
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("funcs=%d", len(funcs))
 	}
 
@@ -3102,7 +3101,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("certificate 1 to check:\n%s", certStr)
 	}
 
@@ -3132,7 +3131,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 		cert.DNSNames[2] != "bar.foobar.com" {
 		t.Fatalf("unexpected DNS SANs %v", cert.DNSNames)
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("certificate 2 to check:\n%s", certStr)
 	}
 
@@ -3176,7 +3175,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 	if diff := deep.Equal(expectedOtherNames, foundOtherNames); len(diff) != 0 {
 		t.Errorf("unexpected otherNames: %v", diff)
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("certificate 3 to check:\n%s", certStr)
 	}
 }
@@ -3262,7 +3261,7 @@ func TestBackend_AllowedSerialNumbers(t *testing.T) {
 	if cert.Subject.SerialNumber != "f00bar" {
 		t.Fatalf("unexpected Subject SerialNumber %s", cert.Subject.SerialNumber)
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("certificate 1 to check:\n%s", certStr)
 	}
 
@@ -3283,7 +3282,7 @@ func TestBackend_AllowedSerialNumbers(t *testing.T) {
 	if cert.Subject.SerialNumber != "b4rf00" {
 		t.Fatalf("unexpected Subject SerialNumber %s", cert.Subject.SerialNumber)
 	}
-	if len(os.Getenv("VAULT_VERBOSE_PKITESTS")) > 0 {
+	if len(api.ReadBaoVariable("BAO_VERBOSE_PKITESTS")) > 0 {
 		t.Logf("certificate 2 to check:\n%s", certStr)
 	}
 }

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/helper/errutil"
 	"github.com/openbao/openbao/sdk/logical"
@@ -20,7 +20,7 @@ const (
 	storageAcmeConfig      = "config/acme"
 	pathConfigAcmeHelpSyn  = "Configuration of ACME Endpoints"
 	pathConfigAcmeHelpDesc = "Here we configure:\n\nenabled=false, whether ACME is enabled, defaults to false meaning that clusters will by default not get ACME support,\nallowed_issuers=\"default\", which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer,\nallowed_roles=\"*\", which roles are allowed for use with ACME; by default these will be all roles matching our selection criteria,\ndefault_directory_policy=\"\", either \"forbid\", preventing the default directory from being used at all, \"role:<role_name>\" which is the role to be used for non-role-qualified ACME requests; or \"sign-verbatim\", the default meaning ACME issuance will be equivalent to sign-verbatim.,\ndns_resolver=\"\", which specifies a custom DNS resolver to use for all ACME-related DNS lookups"
-	disableAcmeEnvVar      = "VAULT_DISABLE_PUBLIC_ACME"
+	disableAcmeEnvVar      = "BAO_DISABLE_PUBLIC_ACME"
 )
 
 type acmeConfigEntry struct {
@@ -336,7 +336,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 }
 
 func isPublicACMEDisabledByEnv() (bool, error) {
-	disableAcmeRaw, ok := os.LookupEnv(disableAcmeEnvVar)
+	disableAcmeRaw, ok := api.LookupBaoVariable(disableAcmeEnvVar)
 	if !ok {
 		return false, nil
 	}

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -6,7 +6,6 @@ package pkiext_binary
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -23,9 +22,9 @@ type VaultPkiCluster struct {
 }
 
 func NewVaultPkiCluster(t *testing.T) *VaultPkiCluster {
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running docker test when $VAULT_BINARY present")
+		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
 	opts := &docker.DockerClusterOptions{

--- a/builtin/plugin/backend_test.go
+++ b/builtin/plugin/backend_test.go
@@ -60,11 +60,11 @@ func TestBackend_Factory(t *testing.T) {
 
 func TestBackend_PluginMain(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv) == "" && api.ReadBaoVariable(pluginutil.PluginMetadataModeEnv) != "true" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -88,11 +88,11 @@ func TestBackend_PluginMain(t *testing.T) {
 
 func TestBackend_PluginMain_Multiplexed(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv) == "" && api.ReadBaoVariable(pluginutil.PluginMetadataModeEnv) != "true" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}

--- a/command/agent.go
+++ b/command/agent.go
@@ -249,7 +249,7 @@ func (c *AgentCommand) Run(args []string) int {
 	// Tests might not want to start a vault server and just want to verify
 	// the configuration.
 	if c.flagTestVerifyOnly {
-		if os.Getenv("VAULT_TEST_VERIFY_ONLY_DUMP_CONFIG") != "" {
+		if api.ReadBaoVariable("BAO_TEST_VERIFY_ONLY_DUMP_CONFIG") != "" {
 			c.UI.Output(fmt.Sprintf(
 				"\nConfiguration:\n%s\n",
 				pretty.Sprint(*c.config)))
@@ -374,7 +374,7 @@ func (c *AgentCommand) Run(args []string) int {
 	// We do this after auto-auth has been configured, because we don't want to
 	// confuse the issue of retries for auth failures which have their own
 	// config and are handled a bit differently.
-	if os.Getenv(api.EnvVaultMaxRetries) == "" {
+	if api.ReadBaoVariable(api.EnvVaultMaxRetries) == "" {
 		client.SetMaxRetries(ctconfig.DefaultRetryAttempts)
 		if config.Vault != nil {
 			if config.Vault.Retry != nil {

--- a/command/agent.go
+++ b/command/agent.go
@@ -975,7 +975,7 @@ func (c *AgentCommand) setStringFlag(f *FlagSets, configVal string, fVar *String
 		}
 	})
 
-	flagEnvValue, flagEnvSet := os.LookupEnv(fVar.EnvVar)
+	flagEnvValue, flagEnvSet := api.LookupBaoVariable(fVar.EnvVar)
 	switch {
 	case isFlagSet:
 		// Don't do anything as the flag is already set from the command line
@@ -999,7 +999,7 @@ func (c *AgentCommand) setBoolFlag(f *FlagSets, configVal bool, fVar *BoolVar) {
 		}
 	})
 
-	flagEnvValue, flagEnvSet := os.LookupEnv(fVar.EnvVar)
+	flagEnvValue, flagEnvSet := api.LookupBaoVariable(fVar.EnvVar)
 	switch {
 	case isFlagSet:
 		// Don't do anything as the flag is already set from the command line

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/command/agentproxyshared"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/internalshared/configutil"
@@ -54,8 +55,8 @@ type Config struct {
 }
 
 const (
-	DisableIdleConnsEnv  = "VAULT_AGENT_DISABLE_IDLE_CONNECTIONS"
-	DisableKeepAlivesEnv = "VAULT_AGENT_DISABLE_KEEP_ALIVES"
+	DisableIdleConnsEnv  = "BAO_AGENT_DISABLE_IDLE_CONNECTIONS"
+	DisableKeepAlivesEnv = "BAO_AGENT_DISABLE_KEEP_ALIVES"
 )
 
 func (c *Config) Prune() {
@@ -671,7 +672,7 @@ func LoadConfigFile(path string) (*Config, error) {
 		}
 	}
 
-	if disableIdleConnsEnv := os.Getenv(DisableIdleConnsEnv); disableIdleConnsEnv != "" {
+	if disableIdleConnsEnv := api.ReadBaoVariable(DisableIdleConnsEnv); disableIdleConnsEnv != "" {
 		result.DisableIdleConns, err = parseutil.ParseCommaStringSlice(strings.ToLower(disableIdleConnsEnv))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing environment variable %s: %v", DisableIdleConnsEnv, err)
@@ -693,7 +694,7 @@ func LoadConfigFile(path string) (*Config, error) {
 		}
 	}
 
-	if disableKeepAlivesEnv := os.Getenv(DisableKeepAlivesEnv); disableKeepAlivesEnv != "" {
+	if disableKeepAlivesEnv := api.ReadBaoVariable(DisableKeepAlivesEnv); disableKeepAlivesEnv != "" {
 		result.DisableKeepAlives, err = parseutil.ParseCommaStringSlice(strings.ToLower(disableKeepAlivesEnv))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing environment variable %s: %v", DisableKeepAlivesEnv, err)

--- a/command/agent/testing.go
+++ b/command/agent/testing.go
@@ -16,12 +16,13 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/logical"
 )
 
-const envVarRunAccTests = "VAULT_ACC"
+const envVarRunAccTests = "BAO_ACC"
 
-var runAcceptanceTests = os.Getenv(envVarRunAccTests) == "1"
+var runAcceptanceTests = api.ReadBaoVariable(envVarRunAccTests) == "1"
 
 func GetTestJWT(t *testing.T) (string, *ecdsa.PrivateKey) {
 	t.Helper()

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1016,13 +1016,13 @@ func TestAgent_Template_VaultClientFromEnv(t *testing.T) {
 	testCases := map[string]struct {
 		env map[string]string
 	}{
-		"VAULT_ADDR and VAULT_CACERT": {
+		"BAO_ADDR and BAO_CACERT": {
 			env: map[string]string{
 				api.EnvVaultAddress: vaultAddr,
 				api.EnvVaultCACert:  cluster.CACertPEMFile,
 			},
 		},
-		"VAULT_ADDR and VAULT_CACERT_BYTES": {
+		"BAO_ADDR and BAO_CACERT_BYTES": {
 			env: map[string]string{
 				api.EnvVaultAddress:     vaultAddr,
 				api.EnvVaultCACertBytes: string(cluster.CACertPEM),

--- a/command/base.go
+++ b/command/base.go
@@ -126,7 +126,7 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 	}
 
 	// Turn off retries on the CLI
-	if os.Getenv(api.EnvVaultMaxRetries) == "" {
+	if api.ReadBaoVariable(api.EnvVaultMaxRetries) == "" {
 		client.SetMaxRetries(0)
 	}
 

--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -8,13 +8,13 @@ import (
 	"flag"
 	"fmt"
 	"math"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/openbao/openbao/api"
 	"github.com/posener/complete"
 )
 
@@ -118,7 +118,7 @@ type BoolPtrVar struct {
 
 func (f *FlagSet) BoolPtrVar(i *BoolPtrVar) {
 	def := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if b, err := strconv.ParseBool(v); err == nil {
 			if def == nil {
 				def = new(bool)
@@ -150,7 +150,7 @@ type BoolVar struct {
 
 func (f *FlagSet) BoolVar(i *BoolVar) {
 	def := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if b, err := strconv.ParseBool(v); err == nil {
 			def = b
 		}
@@ -211,7 +211,7 @@ type IntVar struct {
 
 func (f *FlagSet) IntVar(i *IntVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if i, err := parseutil.SafeParseInt(v); err == nil {
 			initial = i
 		}
@@ -277,7 +277,7 @@ type Int64Var struct {
 
 func (f *FlagSet) Int64Var(i *Int64Var) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if i, err := strconv.ParseInt(v, 0, 64); err == nil {
 			initial = i
 		}
@@ -341,7 +341,7 @@ type UintVar struct {
 
 func (f *FlagSet) UintVar(i *UintVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if i, err := strconv.ParseUint(v, 0, 64); err == nil {
 			initial = uint(i)
 		}
@@ -408,7 +408,7 @@ type Uint64Var struct {
 
 func (f *FlagSet) Uint64Var(i *Uint64Var) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if i, err := strconv.ParseUint(v, 0, 64); err == nil {
 			initial = i
 		}
@@ -472,7 +472,7 @@ type StringVar struct {
 
 func (f *FlagSet) StringVar(i *StringVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		initial = v
 	}
 
@@ -529,7 +529,7 @@ type Float64Var struct {
 
 func (f *FlagSet) Float64Var(i *Float64Var) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if i, err := strconv.ParseFloat(v, 64); err == nil {
 			initial = i
 		}
@@ -593,7 +593,7 @@ type DurationVar struct {
 
 func (f *FlagSet) DurationVar(i *DurationVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if d, err := parseutil.ParseDurationSecond(v); err == nil {
 			initial = d
 		}
@@ -670,7 +670,7 @@ type StringSliceVar struct {
 
 func (f *FlagSet) StringSliceVar(i *StringSliceVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		parts := strings.Split(v, ",")
 		for i := range parts {
 			parts[i] = strings.TrimSpace(parts[i])
@@ -939,7 +939,7 @@ func parseTimeAlternatives(input string, allowedFormats TimeFormat) (time.Time, 
 
 func (f *FlagSet) TimeVar(i *TimeVar) {
 	initial := i.Default
-	if v, exist := os.LookupEnv(i.EnvVar); exist {
+	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
 		if d, err := parseTimeAlternatives(v, i.Formats); err == nil {
 			initial = d
 		}

--- a/command/base_predict.go
+++ b/command/base_predict.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -40,7 +39,7 @@ func (p *Predict) Client() *api.Client {
 			}
 
 			// Turn off retries for prediction
-			if os.Getenv(api.EnvVaultMaxRetries) == "" {
+			if api.ReadBaoVariable(api.EnvVaultMaxRetries) == "" {
 				client.SetMaxRetries(0)
 			}
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -47,27 +47,27 @@ import (
 
 const (
 	// EnvVaultCLINoColor is an env var that toggles colored UI output.
-	EnvVaultCLINoColor = `VAULT_CLI_NO_COLOR`
+	EnvVaultCLINoColor = `BAO_CLI_NO_COLOR`
 	// EnvVaultFormat is the output format
-	EnvVaultFormat = `VAULT_FORMAT`
+	EnvVaultFormat = `BAO_FORMAT`
 	// EnvVaultLicense is an env var used in Vault Enterprise to provide a license blob
-	EnvVaultLicense = "VAULT_LICENSE"
+	EnvVaultLicense = "BAO_LICENSE"
 	// EnvVaultLicensePath is an env var used in Vault Enterprise to provide a
 	// path to a license file on disk
-	EnvVaultLicensePath = "VAULT_LICENSE_PATH"
+	EnvVaultLicensePath = "BAO_LICENSE_PATH"
 	// EnvVaultDetailed is to output detailed information (e.g., ListResponseWithInfo).
-	EnvVaultDetailed = `VAULT_DETAILED`
+	EnvVaultDetailed = `BAO_DETAILED`
 	// EnvVaultLogFormat is used to specify the log format. Supported values are "standard" and "json"
-	EnvVaultLogFormat = "VAULT_LOG_FORMAT"
+	EnvVaultLogFormat = "BAO_LOG_FORMAT"
 	// EnvVaultLogLevel is used to specify the log level applied to logging
 	// Supported log levels: Trace, Debug, Error, Warn, Info
-	EnvVaultLogLevel = "VAULT_LOG_LEVEL"
+	EnvVaultLogLevel = "BAO_LOG_LEVEL"
 	// EnvVaultExperiments defines the experiments to enable for a server as a
 	// comma separated list. See experiments.ValidExperiments() for the list of
 	// valid experiments. Not mutable or persisted in storage, only read and
 	// logged at startup _per node_. This was initially introduced for the events
 	// system being developed over multiple release cycles.
-	EnvVaultExperiments = "VAULT_EXPERIMENTS"
+	EnvVaultExperiments = "BAO_EXPERIMENTS"
 
 	// flagNameAddress is the flag used in the base command to read in the
 	// address of the Vault server.

--- a/command/config.go
+++ b/command/config.go
@@ -9,11 +9,11 @@ import (
 
 const (
 	// DefaultConfigPath is the default path to the configuration file
-	DefaultConfigPath = "~/.vault"
+	DefaultConfigPath = "~/.bao"
 
 	// ConfigPathEnv is the environment variable that can be used to
 	// override where the Vault configuration is.
-	ConfigPathEnv = "VAULT_CONFIG_PATH"
+	ConfigPathEnv = "BAO_CONFIG_PATH"
 )
 
 // Config is the CLI configuration for Vault that can be specified via

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -11,16 +11,17 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/hclutil"
 )
 
 const (
 	// DefaultConfigPath is the default path to the configuration file
-	DefaultConfigPath = "~/.vault"
+	DefaultConfigPath = "~/.bao"
 
 	// ConfigPathEnv is the environment variable that can be used to
 	// override where the Vault configuration is.
-	ConfigPathEnv = "VAULT_CONFIG_PATH"
+	ConfigPathEnv = "BAO_CONFIG_PATH"
 )
 
 // Config is the CLI configuration for Vault that can be specified via
@@ -52,7 +53,7 @@ func LoadConfig(path string) (*DefaultConfig, error) {
 	if path == "" {
 		path = DefaultConfigPath
 	}
-	if v := os.Getenv(ConfigPathEnv); v != "" {
+	if v := api.ReadBaoVariable(ConfigPathEnv); v != "" {
 		path = v
 	}
 

--- a/command/format.go
+++ b/command/format.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -82,7 +81,7 @@ func Format(ui cli.Ui) string {
 		return ui.format
 	}
 
-	format := os.Getenv(EnvVaultFormat)
+	format := api.ReadBaoVariable(EnvVaultFormat)
 	if format == "" {
 		format = "table"
 	}

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -5,9 +5,9 @@ package command
 
 import (
 	"flag"
-	"os"
 	"strconv"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/internalshared/configutil"
 	"github.com/posener/complete"
 )
@@ -102,7 +102,7 @@ func envVarValue(key string) (string, bool) {
 	if key == "" {
 		return "", false
 	}
-	return os.LookupEnv(key)
+	return api.LookupBaoVariable(key)
 }
 
 // flagValue attempts to find the named flag in a set of FlagSets.

--- a/command/login.go
+++ b/command/login.go
@@ -319,7 +319,7 @@ func (c *LoginCommand) Run(args []string) int {
 	} else if !c.flagTokenOnly {
 		// If token-only the user knows it won't be stored, so don't warn
 		c.UI.Warn(wrapAtLength(
-			"The token was not stored in token helper. Set the VAULT_TOKEN "+
+			"The token was not stored in token helper. Set the BAO_TOKEN "+
 				"environment variable or pass the token below with each request to "+
 				"Vault.") + "\n")
 	}
@@ -378,13 +378,13 @@ func (c *LoginCommand) extractToken(client *api.Client, secret *api.Secret, unwr
 	}
 }
 
-// Warn if the VAULT_TOKEN environment variable is set, as that will take
+// Warn if the BAO_TOKEN environment variable is set, as that will take
 // precedence. We output as a warning, so piping should still work since it
 // will be on a different stream.
 func (c *LoginCommand) checkForAndWarnAboutLoginToken() {
-	if os.Getenv("VAULT_TOKEN") != "" {
-		c.UI.Warn(wrapAtLength("WARNING! The VAULT_TOKEN environment variable "+
+	if api.ReadBaoVariable("BAO_TOKEN") != "" {
+		c.UI.Warn(wrapAtLength("WARNING! The BAO_TOKEN environment variable "+
 			"is set! The value of this variable will take precedence; if this is unwanted "+
-			"please unset VAULT_TOKEN or update its value accordingly.") + "\n")
+			"please unset BAO_TOKEN or update its value accordingly.") + "\n")
 	}
 }

--- a/command/main.go
+++ b/command/main.go
@@ -96,7 +96,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		}
 	}
 
-	envVaultFormat := os.Getenv(EnvVaultFormat)
+	envVaultFormat := api.ReadBaoVariable(EnvVaultFormat)
 	// If we did not parse a value, fetch the env var
 	if format == "" && envVaultFormat != "" {
 		format = envVaultFormat
@@ -107,7 +107,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		format = "table"
 	}
 
-	envVaultDetailed := os.Getenv(EnvVaultDetailed)
+	envVaultDetailed := api.ReadBaoVariable(EnvVaultDetailed)
 	// If we did not parse a value, fetch the env var
 	if !haveDetailed && envVaultDetailed != "" {
 		detailed, err = strconv.ParseBool(envVaultDetailed)
@@ -160,7 +160,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 
 	// Don't use color if disabled
 	useColor := true
-	if os.Getenv(EnvVaultCLINoColor) != "" || color.NoColor {
+	if api.ReadBaoVariable(EnvVaultCLINoColor) != "" || color.NoColor {
 		useColor = false
 	}
 

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -31,7 +31,7 @@ func (c *NamespaceCreateCommand) Help() string {
 Usage: bao namespace create [options] PATH
 
   Create a child namespace. The namespace created will be relative to the
-  namespace provided in either the VAULT_NAMESPACE environment variable or
+  namespace provided in either the BAO_NAMESPACE environment variable or
   -namespace CLI flag.
 
   Create a child namespace (e.g. ns1/):

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -29,7 +29,7 @@ func (c *NamespaceDeleteCommand) Help() string {
 Usage: bao namespace delete [options] PATH
 
   Delete an existing namespace. The namespace deleted will be relative to the
-  namespace provided in either the VAULT_NAMESPACE environment variable or
+  namespace provided in either the BAO_NAMESPACE environment variable or
   -namespace CLI flag.
 
   Delete a namespace (e.g. ns1/):

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -35,7 +35,7 @@ func (c *NamespacePatchCommand) Help() string {
 Usage: bao namespace patch [options] PATH
 
   Patch an existing namespace. The namespace patched will be relative to the
-  namespace provided in either the VAULT_NAMESPACE environment variable or
+  namespace provided in either the BAO_NAMESPACE environment variable or
   -namespace CLI flag.
 
   Patch an existing child namespace by adding and removing custom-metadata (e.g. ns1/):

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
+
+	bApi "github.com/openbao/openbao/api"
 	cserver "github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/constants"
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -317,7 +319,7 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 
 		// Check for raft quorum status
 		if config.Storage.Type == storageTypeRaft {
-			path := os.Getenv(raft.EnvVaultRaftPath)
+			path := bApi.ReadBaoVariable(raft.EnvVaultRaftPath)
 			if path == "" {
 				path, ok := config.Storage.Config["path"]
 				if !ok {
@@ -592,10 +594,10 @@ SEALFAIL:
 	} else {
 		// Load License from environment variables. These take precedence over the
 		// configured license.
-		if envLicensePath := os.Getenv(EnvVaultLicensePath); envLicensePath != "" {
+		if envLicensePath := bApi.ReadBaoVariable(EnvVaultLicensePath); envLicensePath != "" {
 			coreConfig.LicensePath = envLicensePath
 		}
-		if envLicense := os.Getenv(EnvVaultLicense); envLicense != "" {
+		if envLicense := bApi.ReadBaoVariable(EnvVaultLicense); envLicense != "" {
 			coreConfig.License = envLicense
 		}
 		vault.DiagnoseCheckLicense(licenseCtx, vaultCore, coreConfig, false)

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -375,7 +375,7 @@ func (c *OperatorInitCommand) consulAuto(client *api.Client, req *api.InitReques
 				"Vault server:",
 			vaultURL.String(), c.flagConsulService)))
 		c.UI.Output("")
-		c.UI.Output(fmt.Sprintf("    $ %s VAULT_ADDR=%s%s%s", export, quote, vaultAddr, quote))
+		c.UI.Output(fmt.Sprintf("    $ %s BAO_ADDR=%s%s%s", export, quote, vaultAddr, quote))
 		c.UI.Output("")
 		return 0
 	}
@@ -405,7 +405,7 @@ func (c *OperatorInitCommand) consulAuto(client *api.Client, req *api.InitReques
 				"Vault server:",
 			vaultURL.String(), c.flagConsulService)))
 		c.UI.Output("")
-		c.UI.Output(fmt.Sprintf("    $ %s VAULT_ADDR=%s%s%s", export, quote, vaultAddr, quote))
+		c.UI.Output(fmt.Sprintf("    $ %s BAO_ADDR=%s%s%s", export, quote, vaultAddr, quote))
 		c.UI.Output("")
 		c.UI.Output("Attempting to initialize it...")
 		c.UI.Output("")
@@ -414,7 +414,7 @@ func (c *OperatorInitCommand) consulAuto(client *api.Client, req *api.InitReques
 		return c.init(client, req)
 	default:
 		// If more than one Vault node were discovered, print out all of them,
-		// requiring the client to update VAULT_ADDR and to run init again.
+		// requiring the client to update BAO_ADDR and to run init again.
 		c.UI.Output(wrapAtLength(fmt.Sprintf(
 			"Discovered %d uninitialized Vault servers with Consul service name "+
 				"%q. To initialize these Vaults, set any one of the following "+
@@ -431,7 +431,7 @@ func (c *OperatorInitCommand) consulAuto(client *api.Client, req *api.InitReques
 			}
 			vaultAddr := vaultURL.String()
 
-			c.UI.Output(fmt.Sprintf("    $ %s VAULT_ADDR=%s%s%s", export, quote, vaultAddr, quote))
+			c.UI.Output(fmt.Sprintf("    $ %s BAO_ADDR=%s%s%s", export, quote, vaultAddr, quote))
 		}
 
 		c.UI.Output("")

--- a/command/operator_migrate.go
+++ b/command/operator_migrate.go
@@ -116,7 +116,7 @@ func (c *OperatorMigrateCommand) Flags() *FlagSets {
 		Name:       "log-level",
 		Target:     &c.flagLogLevel,
 		Default:    "info",
-		EnvVar:     "VAULT_LOG_LEVEL",
+		EnvVar:     "BAO_LOG_LEVEL",
 		Completion: complete.PredictSet("trace", "debug", "info", "warn", "error"),
 		Usage: "Log verbosity level. Supported values (in order of detail) are " +
 			"\"trace\", \"debug\", \"info\", \"warn\", and \"error\". These are not case sensitive.",

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -236,7 +236,7 @@ func (c *ProxyCommand) Run(args []string) int {
 	// Tests might not want to start a vault server and just want to verify
 	// the configuration.
 	if c.flagTestVerifyOnly {
-		if os.Getenv("VAULT_TEST_VERIFY_ONLY_DUMP_CONFIG") != "" {
+		if api.ReadBaoVariable("BAO_TEST_VERIFY_ONLY_DUMP_CONFIG") != "" {
 			c.UI.Output(fmt.Sprintf(
 				"\nConfiguration:\n%s\n",
 				pretty.Sprint(*c.config)))
@@ -346,7 +346,7 @@ func (c *ProxyCommand) Run(args []string) int {
 	// We do this after auto-auth has been configured, because we don't want to
 	// confuse the issue of retries for auth failures which have their own
 	// config and are handled a bit differently.
-	if os.Getenv(api.EnvVaultMaxRetries) == "" {
+	if api.ReadBaoVariable(api.EnvVaultMaxRetries) == "" {
 		client.SetMaxRetries(ctconfig.DefaultRetryAttempts)
 		if config.Vault != nil {
 			if config.Vault.Retry != nil {

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -835,7 +835,7 @@ func (c *ProxyCommand) setStringFlag(f *FlagSets, configVal string, fVar *String
 		}
 	})
 
-	flagEnvValue, flagEnvSet := os.LookupEnv(fVar.EnvVar)
+	flagEnvValue, flagEnvSet := api.LookupBaoVariable(fVar.EnvVar)
 	switch {
 	case isFlagSet:
 		// Don't do anything as the flag is already set from the command line
@@ -859,7 +859,7 @@ func (c *ProxyCommand) setBoolFlag(f *FlagSets, configVal bool, fVar *BoolVar) {
 		}
 	})
 
-	flagEnvValue, flagEnvSet := os.LookupEnv(fVar.EnvVar)
+	flagEnvValue, flagEnvSet := api.LookupBaoVariable(fVar.EnvVar)
 	switch {
 	case isFlagSet:
 		// Don't do anything as the flag is already set from the command line

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/command/agentproxyshared"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/internalshared/configutil"
@@ -42,8 +43,8 @@ type Config struct {
 }
 
 const (
-	DisableIdleConnsEnv  = "VAULT_PROXY_DISABLE_IDLE_CONNECTIONS"
-	DisableKeepAlivesEnv = "VAULT_PROXY_DISABLE_KEEP_ALIVES"
+	DisableIdleConnsEnv  = "BAO_PROXY_DISABLE_IDLE_CONNECTIONS"
+	DisableKeepAlivesEnv = "BAO_PROXY_DISABLE_KEEP_ALIVES"
 )
 
 func (c *Config) Prune() {
@@ -431,7 +432,7 @@ func LoadConfigFile(path string) (*Config, error) {
 		}
 	}
 
-	if disableIdleConnsEnv := os.Getenv(DisableIdleConnsEnv); disableIdleConnsEnv != "" {
+	if disableIdleConnsEnv := api.ReadBaoVariable(DisableIdleConnsEnv); disableIdleConnsEnv != "" {
 		result.DisableIdleConns, err = parseutil.ParseCommaStringSlice(strings.ToLower(disableIdleConnsEnv))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing environment variable %s: %v", DisableIdleConnsEnv, err)
@@ -451,7 +452,7 @@ func LoadConfigFile(path string) (*Config, error) {
 		}
 	}
 
-	if disableKeepAlivesEnv := os.Getenv(DisableKeepAlivesEnv); disableKeepAlivesEnv != "" {
+	if disableKeepAlivesEnv := api.ReadBaoVariable(DisableKeepAlivesEnv); disableKeepAlivesEnv != "" {
 		result.DisableKeepAlives, err = parseutil.ParseCommaStringSlice(strings.ToLower(disableKeepAlivesEnv))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing environment variable %s: %v", DisableKeepAlivesEnv, err)

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/experiments"
 	"github.com/openbao/openbao/helper/osutil"
 	"github.com/openbao/openbao/internalshared/configutil"
@@ -477,11 +478,11 @@ func LoadConfig(path string) (*Config, error) {
 	if fi.IsDir() {
 		// check permissions on the config directory
 		var enableFilePermissionsCheck bool
-		if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+		if enableFilePermissionsCheckEnv := api.ReadBaoVariable(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
 			var err error
 			enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
 			if err != nil {
-				return nil, errors.New("Error parsing the environment variable VAULT_ENABLE_FILE_PERMISSIONS_CHECK")
+				return nil, errors.New("Error parsing the environment variable BAO_ENABLE_FILE_PERMISSIONS_CHECK")
 			}
 		}
 		f, err := os.Open(path)
@@ -538,11 +539,11 @@ func LoadConfigFile(path string) (*Config, error) {
 	}
 
 	var enableFilePermissionsCheck bool
-	if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+	if enableFilePermissionsCheckEnv := api.ReadBaoVariable(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
 		var err error
 		enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
 		if err != nil {
-			return nil, errors.New("Error parsing the environment variable VAULT_ENABLE_FILE_PERMISSIONS_CHECK")
+			return nil, errors.New("Error parsing the environment variable BAO_ENABLE_FILE_PERMISSIONS_CHECK")
 		}
 	}
 
@@ -761,7 +762,7 @@ func ParseConfig(d, source string) (*Config, error) {
 }
 
 func ExperimentsFromEnvAndCLI(config *Config, envKey string, flagExperiments []string) error {
-	if envExperimentsRaw := os.Getenv(envKey); envExperimentsRaw != "" {
+	if envExperimentsRaw := api.ReadBaoVariable(envKey); envExperimentsRaw != "" {
 		envExperiments := strings.Split(envExperimentsRaw, ",")
 		err := validateExperiments(envExperiments)
 		if err != nil {

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -87,7 +87,7 @@ func TestUnknownFieldValidationListenerAndStorage(t *testing.T) {
 }
 
 func TestExperimentsConfigParsing(t *testing.T) {
-	const envKey = "VAULT_EXPERIMENTS"
+	const envKey = "BAO_EXPERIMENTS"
 	originalValue := validExperiments
 	validExperiments = []string{"foo", "bar", "baz"}
 	t.Cleanup(func() {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -27,12 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	if signed := os.Getenv("VAULT_LICENSE_CI"); signed != "" {
-		os.Setenv(EnvVaultLicense, signed)
-	}
-}
-
 func testBaseHCL(tb testing.TB, listenerExtras string) string {
 	tb.Helper()
 

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -134,7 +134,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Name:       "strict-host-key-checking",
 		Target:     &c.flagStrictHostKeyChecking,
 		Default:    "ask",
-		EnvVar:     "VAULT_SSH_STRICT_HOST_KEY_CHECKING",
+		EnvVar:     "BAO_SSH_STRICT_HOST_KEY_CHECKING",
 		Completion: complete.PredictSet("ask", "no", "yes"),
 		Usage: "Value to use for the SSH configuration option " +
 			"\"StrictHostKeyChecking\".",
@@ -144,7 +144,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Name:       "user-known-hosts-file",
 		Target:     &c.flagUserKnownHostsFile,
 		Default:    "",
-		EnvVar:     "VAULT_SSH_USER_KNOWN_HOSTS_FILE",
+		EnvVar:     "BAO_SSH_USER_KNOWN_HOSTS_FILE",
 		Completion: complete.PredictFiles("*"),
 		Usage: "Value to use for the SSH configuration option " +
 			"\"UserKnownHostsFile\".",
@@ -176,7 +176,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Name:       "host-key-mount-point",
 		Target:     &c.flagHostKeyMountPoint,
 		Default:    "",
-		EnvVar:     "VAULT_SSH_HOST_KEY_MOUNT_POINT",
+		EnvVar:     "BAO_SSH_HOST_KEY_MOUNT_POINT",
 		Completion: complete.PredictAnything,
 		Usage: "Mount point to the SSH secrets engine where host keys are signed. " +
 			"When given a value, OpenBao will generate a custom \"known_hosts\" file " +
@@ -191,7 +191,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Name:       "host-key-hostnames",
 		Target:     &c.flagHostKeyHostnames,
 		Default:    "*",
-		EnvVar:     "VAULT_SSH_HOST_KEY_HOSTNAMES",
+		EnvVar:     "BAO_SSH_HOST_KEY_HOSTNAMES",
 		Completion: complete.PredictAnything,
 		Usage: "List of hostnames to delegate for the CA. The default value " +
 			"allows all domains and IPs. This is specified as a comma-separated " +
@@ -212,7 +212,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Name:       "ssh-executable",
 		Target:     &c.flagSSHExecutable,
 		Default:    "ssh",
-		EnvVar:     "VAULT_SSH_EXECUTABLE",
+		EnvVar:     "BAO_SSH_EXECUTABLE",
 		Completion: complete.PredictAnything,
 		Usage:      "Path to the SSH executable to use when connecting to the host",
 	})

--- a/helper/forwarding/util.go
+++ b/helper/forwarding/util.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/compressutil"
 	"github.com/openbao/openbao/sdk/helper/jsonutil"
 )
@@ -35,7 +35,7 @@ func GenerateForwardedHTTPRequest(req *http.Request, addr string) (*http.Request
 	}
 
 	var newBody []byte
-	switch os.Getenv("BAO_MESSAGE_TYPE") {
+	switch api.ReadBaoVariable("BAO_MESSAGE_TYPE") {
 	case "json":
 		newBody, err = jsonutil.EncodeJSON(fq)
 	case "json_compress":
@@ -112,7 +112,7 @@ func ParseForwardedHTTPRequest(req *http.Request) (*http.Request, error) {
 	}
 
 	fq := new(Request)
-	switch os.Getenv("VAULT_MESSAGE_TYPE") {
+	switch api.ReadBaoVariable("BAO_MESSAGE_TYPE") {
 	case "json", "json_compress":
 		err = jsonutil.DecodeJSON(buf.Bytes(), fq)
 	default:

--- a/helper/forwarding/util_test.go
+++ b/helper/forwarding/util_test.go
@@ -17,7 +17,7 @@ func Test_ForwardedRequest_GenerateParse(t *testing.T) {
 }
 
 func Benchmark_ForwardedRequest_GenerateParse_JSON(b *testing.B) {
-	os.Setenv("VAULT_MESSAGE_TYPE", "json")
+	os.Setenv("BAO_MESSAGE_TYPE", "json")
 	var totalSize int64
 	var numRuns int64
 	for i := 0; i < b.N; i++ {
@@ -28,7 +28,7 @@ func Benchmark_ForwardedRequest_GenerateParse_JSON(b *testing.B) {
 }
 
 func Benchmark_ForwardedRequest_GenerateParse_JSON_Compressed(b *testing.B) {
-	os.Setenv("VAULT_MESSAGE_TYPE", "json_compress")
+	os.Setenv("BAO_MESSAGE_TYPE", "json_compress")
 	var totalSize int64
 	var numRuns int64
 	for i := 0; i < b.N; i++ {
@@ -39,7 +39,7 @@ func Benchmark_ForwardedRequest_GenerateParse_JSON_Compressed(b *testing.B) {
 }
 
 func Benchmark_ForwardedRequest_GenerateParse_Proto3(b *testing.B) {
-	os.Setenv("VAULT_MESSAGE_TYPE", "proto3")
+	os.Setenv("BAO_MESSAGE_TYPE", "proto3")
 	var totalSize int64
 	var numRuns int64
 	for i := 0; i < b.N; i++ {

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/go-testing-interface"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/builtin/credential/approle"
 	"github.com/openbao/openbao/plugins/database/mysql"
@@ -388,7 +389,7 @@ func NewTestLogger(t testing.T) *TestLogger {
 	var logPath string
 	output := os.Stderr
 
-	logDir := os.Getenv("VAULT_TEST_LOG_DIR")
+	logDir := api.ReadBaoVariable("BAO_TEST_LOG_DIR")
 	if logDir != "" {
 		logPath = filepath.Join(logDir, t.Name()+".log")
 		// t.Name may include slashes.

--- a/helper/testhelpers/logical/testing.go
+++ b/helper/testhelpers/logical/testing.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -25,7 +24,7 @@ import (
 )
 
 // TestEnvVar must be set to a non-empty value for acceptance tests to run.
-const TestEnvVar = "VAULT_ACC"
+const TestEnvVar = "BAO_ACC"
 
 // TestCase is a single set of tests to run for a backend. A TestCase
 // should generally map 1:1 to each test method for your acceptance
@@ -121,7 +120,7 @@ type TestTeardownFunc func() error
 func Test(tt TestT, c TestCase) {
 	// We only run acceptance tests if an env var is set because they're
 	// slow and generally require some outside configuration.
-	if c.AcceptanceTest && os.Getenv(TestEnvVar) == "" {
+	if c.AcceptanceTest && api.ReadBaoVariable(TestEnvVar) == "" {
 		tt.Skip(fmt.Sprintf(
 			"Acceptance tests skipped unless env %q set",
 			TestEnvVar))

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -1049,7 +1049,7 @@ func WaitForNodesExcludingSelectedStandbys(t testing.T, cluster *vault.TestClust
 }
 
 // IsLocalOrRegressionTests returns true when the tests are running locally (not in CI), or when
-// the regression test env var (VAULT_REGRESSION_TESTS) is provided.
+// the regression test env var (BAO_REGRESSION_TESTS) is provided.
 func IsLocalOrRegressionTests() bool {
-	return os.Getenv("CI") == "" || os.Getenv("VAULT_REGRESSION_TESTS") == "true"
+	return os.Getenv("CI") == "" || api.ReadBaoVariable("BAO_REGRESSION_TESTS") == "true"
 }

--- a/http/plugin_test.go
+++ b/http/plugin_test.go
@@ -69,11 +69,11 @@ func getPluginClusterAndCore(t testing.TB, logger log.Logger) (*vault.TestCluste
 }
 
 func TestPlugin_PluginMain(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}

--- a/http/sys_feature_flags.go
+++ b/http/sys_feature_flags.go
@@ -6,8 +6,8 @@ package http
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/vault"
 )
 
@@ -16,11 +16,11 @@ type FeatureFlagsResponse struct {
 }
 
 var FeatureFlag_EnvVariables = [...]string{
-	"VAULT_CLOUD_ADMIN_NAMESPACE",
+	"BAO_CLOUD_ADMIN_NAMESPACE",
 }
 
 func featureFlagIsSet(name string) bool {
-	switch os.Getenv(name) {
+	switch api.ReadBaoVariable(name) {
 	case "", "0":
 		return false
 	default:

--- a/physical/raft/bolt_linux.go
+++ b/physical/raft/bolt_linux.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/openbao/openbao/api"
 	"github.com/shirou/gopsutil/v3/mem"
 	"golang.org/x/sys/unix"
 )
@@ -16,7 +17,7 @@ func init() {
 }
 
 func getMmapFlagsLinux(dbPath string) int {
-	if os.Getenv("VAULT_RAFT_DISABLE_MAP_POPULATE") != "" {
+	if api.ReadBaoVariable("BAO_RAFT_DISABLE_MAP_POPULATE") != "" {
 		return 0
 	}
 	stat, err := os.Stat(dbPath)

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbao/openbao/api"
 	"go.uber.org/atomic"
 )
 
@@ -812,7 +812,7 @@ func (b *RaftBackend) DisableAutopilot() {
 // it. If autopilot is disabled, this function does nothing.
 func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *AutopilotConfig, followerStates *FollowerStates, disable bool) {
 	b.l.Lock()
-	if disable || os.Getenv("VAULT_RAFT_AUTOPILOT_DISABLE") != "" {
+	if disable || api.ReadBaoVariable("BAO_RAFT_AUTOPILOT_DISABLE") != "" {
 		b.disableAutopilot = true
 	}
 

--- a/plugins/database/redis/redis_test.go
+++ b/plugins/database/redis/redis_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mediocregopher/radix/v4"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/database/dbplugin/v5"
 	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
@@ -214,7 +215,7 @@ func testRedisDBInitialize_TLS(t *testing.T, host string, port int) {
 }
 
 func testRedisDBCreateUser(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -286,7 +287,7 @@ func testRedisDBCreateUser(t *testing.T, address string, port int) {
 }
 
 func checkCredsExist(t *testing.T, username, password, address string, port int) error {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -330,7 +331,7 @@ func checkCredsExist(t *testing.T, username, password, address string, port int)
 }
 
 func checkRuleAllowed(t *testing.T, username, password, address string, port int, cmd string, rules []string) error {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -376,7 +377,7 @@ func checkRuleAllowed(t *testing.T, username, password, address string, port int
 }
 
 func revokeUser(t *testing.T, username, address string, port int) error {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -426,7 +427,7 @@ func revokeUser(t *testing.T, username, address string, port int) error {
 }
 
 func testRedisDBCreateUser_DefaultRule(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -508,7 +509,7 @@ func testRedisDBCreateUser_DefaultRule(t *testing.T, address string, port int) {
 }
 
 func testRedisDBCreateUser_plusRole(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -582,7 +583,7 @@ func testRedisDBCreateUser_plusRole(t *testing.T, address string, port int) {
 
 // g1 & g2 must exist in the database.
 func testRedisDBCreateUser_groupOnly(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -659,7 +660,7 @@ func testRedisDBCreateUser_groupOnly(t *testing.T, address string, port int) {
 }
 
 func testRedisDBCreateUser_roleAndGroup(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -736,7 +737,7 @@ func testRedisDBCreateUser_roleAndGroup(t *testing.T, address string, port int) 
 }
 
 func testRedisDBRotateRootCredentials(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 
@@ -870,7 +871,7 @@ func doRedisDBSetCredentials(t *testing.T, username, password, address string, p
 }
 
 func testRedisDBSetCredentials(t *testing.T, address string, port int) {
-	if os.Getenv("VAULT_ACC") == "" {
+	if api.ReadBaoVariable("BAO_ACC") == "" {
 		t.SkipNow()
 	}
 

--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -5,16 +5,16 @@ package dbtesting
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/database/dbplugin/v5"
 )
 
 func getRequestTimeout(t *testing.T) time.Duration {
-	rawDur := os.Getenv("VAULT_TEST_DATABASE_REQUEST_TIMEOUT")
+	rawDur := api.ReadBaoVariable("BAO_TEST_DATABASE_REQUEST_TIMEOUT")
 	if rawDur == "" {
 		// Note: we incremented the default timeout from 5 to 10 seconds in a bid
 		// to fix sporadic failures of mssql_test.go tests TestInitialize() and

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -36,9 +36,9 @@ const (
 	// resolving replicaiton addresses
 	ReplicationResolverALPN = "replication_resolver_v1"
 
-	VaultEnableFilePermissionsCheckEnv = "VAULT_ENABLE_FILE_PERMISSIONS_CHECK"
+	VaultEnableFilePermissionsCheckEnv = "BAO_ENABLE_FILE_PERMISSIONS_CHECK"
 
-	VaultDisableUserLockout = "VAULT_DISABLE_USER_LOCKOUT"
+	VaultDisableUserLockout = "BAO_DISABLE_USER_LOCKOUT"
 
 	PerformanceReplicationPathTarget = "performance"
 

--- a/sdk/helper/logging/logging.go
+++ b/sdk/helper/logging/logging.go
@@ -6,10 +6,10 @@ package logging
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 )
 
 type LogFormat int
@@ -69,7 +69,7 @@ func ParseLogFormat(format string) (LogFormat, error) {
 
 // ParseEnvLogFormat parses the log format from an environment variable.
 func ParseEnvLogFormat() LogFormat {
-	logFormat := os.Getenv("VAULT_LOG_FORMAT")
+	logFormat := api.ReadBaoVariable("BAO_LOG_FORMAT")
 	switch strings.ToLower(logFormat) {
 	case "json", "vault_json", "vault-json", "vaultjson":
 		return JSONFormat

--- a/sdk/helper/logging/logging_test.go
+++ b/sdk/helper/logging/logging_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/openbao/openbao/api"
 )
 
 func Test_ParseLogFormat(t *testing.T) {
@@ -39,10 +41,10 @@ func Test_ParseLogFormat(t *testing.T) {
 }
 
 func Test_ParseEnv_VAULT_LOG_FORMAT(t *testing.T) {
-	oldVLF := os.Getenv("VAULT_LOG_FORMAT")
-	defer os.Setenv("VAULT_LOG_FORMAT", oldVLF)
+	oldVLF := api.ReadBaoVariable("BAO_LOG_FORMAT")
+	defer os.Setenv("BAO_LOG_FORMAT", oldVLF)
 
-	testParseEnvLogFormat(t, "VAULT_LOG_FORMAT")
+	testParseEnvLogFormat(t, "BAO_LOG_FORMAT")
 }
 
 func testParseEnvLogFormat(t *testing.T, name string) {

--- a/sdk/helper/pluginutil/env.go
+++ b/sdk/helper/pluginutil/env.go
@@ -4,46 +4,45 @@
 package pluginutil
 
 import (
-	"os"
-
 	"github.com/hashicorp/go-secure-stdlib/mlock"
 	version "github.com/hashicorp/go-version"
+	"github.com/openbao/openbao/api"
 )
 
 const (
 	// PluginAutoMTLSEnv is used to ensure AutoMTLS is used. This will override
 	// setting a TLSProviderFunc for a plugin.
-	PluginAutoMTLSEnv = "VAULT_PLUGIN_AUTOMTLS_ENABLED"
+	PluginAutoMTLSEnv = "BAO_PLUGIN_AUTOMTLS_ENABLED"
 
 	// PluginMlockEnabled is the ENV name used to pass the configuration for
 	// enabling mlock
-	PluginMlockEnabled = "VAULT_PLUGIN_MLOCK_ENABLED"
+	PluginMlockEnabled = "BAO_PLUGIN_MLOCK_ENABLED"
 
 	// PluginVaultVersionEnv is the ENV name used to pass the version of the
 	// vault server to the plugin
-	PluginVaultVersionEnv = "VAULT_VERSION"
+	PluginVaultVersionEnv = "BAO_VERSION"
 
 	// PluginMetadataModeEnv is an ENV name used to disable TLS communication
 	// to bootstrap mounting plugins.
-	PluginMetadataModeEnv = "VAULT_PLUGIN_METADATA_MODE"
+	PluginMetadataModeEnv = "BAO_PLUGIN_METADATA_MODE"
 
 	// PluginUnwrapTokenEnv is the ENV name used to pass unwrap tokens to the
 	// plugin.
-	PluginUnwrapTokenEnv = "VAULT_UNWRAP_TOKEN"
+	PluginUnwrapTokenEnv = "BAO_UNWRAP_TOKEN"
 
 	// PluginCACertPEMEnv is an ENV name used for holding a CA PEM-encoded
 	// string. Used for testing.
-	PluginCACertPEMEnv = "VAULT_TESTING_PLUGIN_CA_PEM"
+	PluginCACertPEMEnv = "BAO_TESTING_PLUGIN_CA_PEM"
 
 	// PluginMultiplexingOptOut is an ENV name used to define a comma separated list of plugin names
 	// opted-out of the multiplexing feature; for emergencies if multiplexing ever causes issues
-	PluginMultiplexingOptOut = "VAULT_PLUGIN_MULTIPLEXING_OPT_OUT"
+	PluginMultiplexingOptOut = "BAO_PLUGIN_MULTIPLEXING_OPT_OUT"
 )
 
 // OptionallyEnableMlock determines if mlock should be called, and if so enables
 // mlock.
 func OptionallyEnableMlock() error {
-	if os.Getenv(PluginMlockEnabled) == "true" {
+	if api.ReadBaoVariable(PluginMlockEnabled) == "true" {
 		return mlock.LockMemory()
 	}
 
@@ -53,7 +52,7 @@ func OptionallyEnableMlock() error {
 // GRPCSupport defaults to returning true, unless VAULT_VERSION is missing or
 // it fails to meet the version constraint.
 func GRPCSupport() bool {
-	verString := os.Getenv(PluginVaultVersionEnv)
+	verString := api.ReadBaoVariable(PluginVaultVersionEnv)
 	// If the env var is empty, we fall back to netrpc for backward compatibility.
 	if verString == "" {
 		return false
@@ -76,5 +75,5 @@ func GRPCSupport() bool {
 
 // InMetadataMode returns true if the plugin calling this function is running in metadata mode.
 func InMetadataMode() bool {
-	return os.Getenv(PluginMetadataModeEnv) == "true"
+	return api.ReadBaoVariable(PluginMetadataModeEnv) == "true"
 }

--- a/sdk/helper/pluginutil/multiplexing.go
+++ b/sdk/helper/pluginutil/multiplexing.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/openbao/openbao/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -36,7 +36,7 @@ func MultiplexingSupported(ctx context.Context, cc grpc.ClientConnInterface, nam
 		return false, fmt.Errorf("client connection is nil")
 	}
 
-	out := strings.Split(os.Getenv(PluginMultiplexingOptOut), ",")
+	out := strings.Split(api.ReadBaoVariable(PluginMultiplexingOptOut), ",")
 	if strutil.StrListContains(out, name) {
 		return false, nil
 	}

--- a/sdk/helper/stepwise/stepwise.go
+++ b/sdk/helper/stepwise/stepwise.go
@@ -6,7 +6,6 @@ package stepwise
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
@@ -15,7 +14,7 @@ import (
 )
 
 // TestEnvVar must be set to a non-empty value for acceptance tests to run.
-const TestEnvVar = "VAULT_ACC"
+const TestEnvVar = "BAO_ACC"
 
 // Operation defines operations each step could perform. These are
 // intentionally redefined from the logical package in the SDK, so users
@@ -296,7 +295,7 @@ func makeRequest(tt TestT, env Environment, step Step) (*api.Secret, error) {
 
 func checkShouldRun(tt TestT) {
 	tt.Helper()
-	if os.Getenv(TestEnvVar) == "" {
+	if api.ReadBaoVariable(TestEnvVar) == "" {
 		tt.Skip(fmt.Sprintf(
 			"Acceptance tests skipped unless env '%s' set",
 			TestEnvVar))

--- a/sdk/helper/testcluster/consts.go
+++ b/sdk/helper/testcluster/consts.go
@@ -1,11 +1,6 @@
 package testcluster
 
 const (
-	// EnvVaultLicenseCI is the name of an environment variable that contains
-	// a signed license string used for Vault Enterprise binary-based tests.
-	// The binary will be run with the env var VAULT_LICENSE set to this value.
-	EnvVaultLicenseCI = "VAULT_LICENSE_CI"
-
 	// DefaultCAFile is the path to the CA file. This is a docker-specific
 	// constant. TODO: needs to be moved to a more relevant place
 	DefaultCAFile = "/vault/config/ca.pem"

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -432,9 +432,6 @@ func NewDockerCluster(ctx context.Context, opts *DockerClusterOptions) (*DockerC
 	if opts.Logger == nil {
 		opts.Logger = log.NewNullLogger()
 	}
-	if opts.VaultLicense == "" {
-		opts.VaultLicense = os.Getenv(testcluster.EnvVaultLicenseCI)
-	}
 
 	dc := &DockerCluster{
 		DockerAPI:   api,

--- a/sdk/helper/testcluster/docker/replication.go
+++ b/sdk/helper/testcluster/docker/replication.go
@@ -6,11 +6,11 @@ package docker
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/logging"
 	"github.com/openbao/openbao/sdk/helper/testcluster"
 )
@@ -19,7 +19,7 @@ func DefaultOptions(t *testing.T) *DockerClusterOptions {
 	return &DockerClusterOptions{
 		ImageRepo:   "hashicorp/vault",
 		ImageTag:    "latest",
-		VaultBinary: os.Getenv("VAULT_BINARY"),
+		VaultBinary: api.ReadBaoVariable("BAO_BINARY"),
 		ClusterOptions: testcluster.ClusterOptions{
 			NumCores:    3,
 			ClusterName: strings.ReplaceAll(t.Name(), "/", "-"),
@@ -31,9 +31,9 @@ func DefaultOptions(t *testing.T) *DockerClusterOptions {
 }
 
 func NewReplicationSetDocker(t *testing.T, opts *DockerClusterOptions) (*testcluster.ReplicationSet, error) {
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running docker test when $VAULT_BINARY present")
+		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
 	r := &testcluster.ReplicationSet{

--- a/sdk/helper/testcluster/exec.go
+++ b/sdk/helper/testcluster/exec.go
@@ -63,9 +63,6 @@ func NewTestExecDevCluster(t *testing.T, opts *ExecDevClusterOptions) *ExecDevCl
 	if opts.Logger == nil {
 		opts.Logger = logging.NewVaultLogger(log.Trace).Named(t.Name()) // .Named("container")
 	}
-	if opts.VaultLicense == "" {
-		opts.VaultLicense = os.Getenv(EnvVaultLicenseCI)
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)

--- a/sdk/physical/inmem/inmem.go
+++ b/sdk/physical/inmem/inmem.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/armon/go-radix"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/physical"
 )
 
@@ -78,7 +78,7 @@ func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, erro
 		failDelete:   new(uint32),
 		failList:     new(uint32),
 		failGetInTxn: new(uint32),
-		logOps:       os.Getenv("VAULT_INMEM_LOG_ALL_OPS") != "",
+		logOps:       api.ReadBaoVariable("BAO_INMEM_LOG_ALL_OPS") != "",
 		maxValueSize: maxValueSize,
 	}, nil
 }
@@ -106,7 +106,7 @@ func NewTransactionalInmem(conf map[string]string, logger log.Logger) (physical.
 			failDelete:   new(uint32),
 			failList:     new(uint32),
 			failGetInTxn: new(uint32),
-			logOps:       os.Getenv("VAULT_INMEM_LOG_ALL_OPS") != "",
+			logOps:       api.ReadBaoVariable("BAO_INMEM_LOG_ALL_OPS") != "",
 			maxValueSize: maxValueSize,
 		},
 	}, nil

--- a/sdk/plugin/mock/backend.go
+++ b/sdk/plugin/mock/backend.go
@@ -5,8 +5,8 @@ package mock
 
 import (
 	"context"
-	"os"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/logical"
 )
@@ -66,7 +66,7 @@ func Backend() *backend {
 	}
 	b.internal = "bar"
 	b.RunningVersion = "v0.0.0+mock"
-	if version := os.Getenv(MockPluginVersionEnv); version != "" {
+	if version := api.ReadBaoVariable(MockPluginVersionEnv); version != "" {
 		b.RunningVersion = version
 	}
 	return &b

--- a/serviceregistration/kubernetes/client/config.go
+++ b/serviceregistration/kubernetes/client/config.go
@@ -8,8 +8,8 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 	"net"
-	"os"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/certutil"
 )
 
@@ -24,8 +24,8 @@ const (
 	// We generally recommend preferring environmental settings over configured
 	// ones, allowing settings from the Downward API to override hard-coded
 	// ones.
-	EnvVarKubernetesNamespace = "VAULT_K8S_NAMESPACE"
-	EnvVarKubernetesPodName   = "VAULT_K8S_POD_NAME"
+	EnvVarKubernetesNamespace = "BAO_K8S_NAMESPACE"
+	EnvVarKubernetesPodName   = "BAO_K8S_POD_NAME"
 
 	// The service host and port environment variables are
 	// set by default inside a Kubernetes environment.
@@ -49,7 +49,7 @@ var (
 // inClusterConfig is based on this:
 // https://github.com/kubernetes/client-go/blob/a56922badea0f2a91771411eaa1173c9e9243908/rest/config.go#L451
 func inClusterConfig() (*Config, error) {
-	host, port := os.Getenv(EnvVarKubernetesServiceHost), os.Getenv(EnvVarKubernetesServicePort)
+	host, port := api.ReadBaoVariable(EnvVarKubernetesServiceHost), api.ReadBaoVariable(EnvVarKubernetesServicePort)
 	if len(host) == 0 || len(port) == 0 {
 		return nil, ErrNotInCluster
 	}

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	sr "github.com/openbao/openbao/serviceregistration"
 	"github.com/openbao/openbao/serviceregistration/kubernetes/client"
 )
@@ -109,7 +110,7 @@ func (r *serviceRegistration) NotifyInitializedStateChange(isInitialized bool) e
 func getRequiredField(logger hclog.Logger, config map[string]string, envVar, configParam string) (string, error) {
 	value := ""
 	switch {
-	case os.Getenv(envVar) != "":
+	case api.ReadBaoVariable(envVar) != "":
 		value = os.Getenv(envVar)
 	case config[configParam] != "":
 		value = config[configParam]

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -22,6 +22,7 @@ import (
 	"github.com/axiomhq/hyperloglog"
 	"github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/timeutil"
@@ -1103,7 +1104,7 @@ func (c *Core) setupActivityLogLocked(ctx context.Context, wg *sync.WaitGroup) e
 	logger := c.baseLogger.Named("activity")
 	c.AddLogger(logger)
 
-	if os.Getenv("VAULT_DISABLE_ACTIVITY_LOG") != "" {
+	if api.ReadBaoVariable("BAO_DISABLE_ACTIVITY_LOG") != "" {
 		if c.CensusLicensingEnabled() {
 			logger.Warn("activity log disabled via environment variable while reporting is enabled. " +
 				"Reporting will override, and the activity log will be enabled")

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -12,12 +12,12 @@ import (
 	"math"
 	"net"
 	"net/url"
-	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/certutil"
 	"github.com/openbao/openbao/sdk/helper/tlsutil"
 
@@ -79,7 +79,7 @@ type Listener struct {
 
 func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Logger, idleTimeout time.Duration) *Listener {
 	var maxStreams uint32 = math.MaxUint32
-	if override := os.Getenv("VAULT_GRPC_MAX_STREAMS"); override != "" {
+	if override := api.ReadBaoVariable("BAO_GRPC_MAX_STREAMS"); override != "" {
 		i, err := strconv.ParseUint(override, 10, 32)
 		if err != nil {
 			logger.Warn("vault grpc max streams override must be an uint32 integer", "value", override)
@@ -113,7 +113,7 @@ func NewListener(networkLayer NetworkLayer, cipherSuites []uint16, logger log.Lo
 		networkLayer:              networkLayer,
 		cipherSuites:              cipherSuites,
 		logger:                    logger,
-		tlsConnectionLoggingLevel: log.LevelFromString(os.Getenv("VAULT_CLUSTER_TLS_SESSION_LOG_LEVEL")),
+		tlsConnectionLoggingLevel: log.LevelFromString(api.ReadBaoVariable("BAO_CLUSTER_TLS_SESSION_LOG_LEVEL")),
 	}
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -2572,7 +2572,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	//
 	// Use a small temporary worker pool to run postUnsealFuncs in parallel
 	postUnsealFuncConcurrency := runtime.NumCPU() * 2
-	if v := os.Getenv("VAULT_POSTUNSEAL_FUNC_CONCURRENCY"); v != "" {
+	if v := api.ReadBaoVariable("BAO_POSTUNSEAL_FUNC_CONCURRENCY"); v != "" {
 		pv, err := strconv.Atoi(v)
 		if err != nil || pv < 1 {
 			c.logger.Warn("invalid value for VAULT_POSTUNSEAL_FUNC_CURRENCY, must be a positive integer", "error", err, "value", pv)
@@ -2610,7 +2610,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 		}
 	}
 
-	if os.Getenv(EnvVaultDisableLocalAuthMountEntities) != "" {
+	if api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
 		c.logger.Warn("disabling entities for local auth mounts through env var", "env", EnvVaultDisableLocalAuthMountEntities)
 	}
 	c.loginMFABackend.usedCodes = cache.New(0, 30*time.Second)
@@ -3581,7 +3581,7 @@ func (c *Core) updateLockedUserEntries() {
 func (c *Core) runLockedUserEntryUpdates(ctx context.Context) error {
 	// check environment variable to see if user lockout workflow is disabled
 	var disableUserLockout bool
-	if disableUserLockoutEnv := os.Getenv(consts.VaultDisableUserLockout); disableUserLockoutEnv != "" {
+	if disableUserLockoutEnv := api.ReadBaoVariable(consts.VaultDisableUserLockout); disableUserLockoutEnv != "" {
 		var err error
 		disableUserLockout, err = strconv.ParseBool(disableUserLockoutEnv)
 		if err != nil {
@@ -3859,7 +3859,7 @@ func (c *Core) GetHAPeerNodesCached() []PeerNode {
 
 func (c *Core) CheckPluginPerms(pluginName string) (err error) {
 	var enableFilePermissionsCheck bool
-	if enableFilePermissionsCheckEnv := os.Getenv(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
+	if enableFilePermissionsCheckEnv := api.ReadBaoVariable(consts.VaultEnableFilePermissionsCheckEnv); enableFilePermissionsCheckEnv != "" {
 		var err error
 		enableFilePermissionsCheck, err = strconv.ParseBool(enableFilePermissionsCheckEnv)
 		if err != nil {

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -6,11 +6,11 @@ package vault
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/physical/raft"
@@ -281,7 +281,7 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 			[]string{"secret", "kv", "count"},
 			[]metrics.Label{{"gauge", "kv_secrets_by_mountpoint"}},
 			c.kvSecretGaugeCollector,
-			"VAULT_DISABLE_KV_GAUGE",
+			"BAO_DISABLE_KV_GAUGE",
 		},
 		{
 			[]string{"identity", "entity", "count"},
@@ -310,7 +310,7 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 	} else if standby, _ := c.Standby(); !standby && !c.IsDRSecondary() {
 		for _, init := range metricsInit {
 			if init.DisableEnvVar != "" {
-				if os.Getenv(init.DisableEnvVar) != "" {
+				if api.ReadBaoVariable(init.DisableEnvVar) != "" {
 					c.logger.Info("usage gauge collection is disabled for",
 						"metric", init.MetricName)
 					continue

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -23,6 +22,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/base62"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/fairshare"
 	"github.com/openbao/openbao/helper/locking"
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -68,7 +68,7 @@ const (
 	// number of workers to use for general purpose testing
 	numExpirationWorkersTest = 10
 
-	fairshareWorkersOverrideVar = "VAULT_LEASE_REVOCATION_WORKERS"
+	fairshareWorkersOverrideVar = "BAO_LEASE_REVOCATION_WORKERS"
 
 	// limit irrevocable error messages to 240 characters to be respectful of
 	// storage/memory
@@ -310,7 +310,7 @@ func (r *revocationJob) revokeExponentialBackoff(attempt uint8) time.Duration {
 func getNumExpirationWorkers(c *Core, l log.Logger) int {
 	numWorkers := c.numExpirationWorkers
 
-	workerOverride := os.Getenv(fairshareWorkersOverrideVar)
+	workerOverride := api.ReadBaoVariable(fairshareWorkersOverrideVar)
 	if workerOverride != "" {
 		i, err := strconv.Atoi(workerOverride)
 		if err != nil {
@@ -362,7 +362,7 @@ func NewExpirationManager(c *Core, view *BarrierView, e ExpireLeaseStrategy, log
 		quitContext:       c.activeContext,
 		leaseCheckCounter: new(uint32),
 
-		logLeaseExpirations: os.Getenv("VAULT_SKIP_LOGGING_LEASE_EXPIRATIONS") == "",
+		logLeaseExpirations: api.ReadBaoVariable("BAO_SKIP_LOGGING_LEASE_EXPIRATIONS") == "",
 
 		jobManager:      jobManager,
 		revokeRetryBase: c.expirationRevokeRetryBase,

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/helper/testhelpers/pluginhelpers"
@@ -27,7 +28,7 @@ import (
 	"github.com/openbao/openbao/version"
 )
 
-const vaultTestingMockPluginEnv = "VAULT_TESTING_MOCK_PLUGIN"
+const vaultTestingMockPluginEnv = "BAO_TESTING_MOCK_PLUGIN"
 
 // version is used to override the plugin's self-reported version
 func testCoreWithPlugins(t *testing.T, typ consts.PluginType, versions ...string) (*Core, []pluginhelpers.TestPlugin) {
@@ -851,7 +852,7 @@ func TestExternalPlugin_DifferentEnv_AreNotMultiplexed(t *testing.T) {
 
 // Used to run a mock multiplexed secrets plugin
 func TestBackend_PluginMain_Multiplexed_Logical_v123(t *testing.T) {
-	if os.Getenv(vaultTestingMockPluginEnv) == "" {
+	if api.ReadBaoVariable(vaultTestingMockPluginEnv) == "" {
 		return
 	}
 
@@ -867,7 +868,7 @@ func TestBackend_PluginMain_Multiplexed_Logical_v123(t *testing.T) {
 
 // Used to run a mock multiplexed secrets plugin
 func TestBackend_PluginMain_Multiplexed_Logical_v124(t *testing.T) {
-	if os.Getenv(vaultTestingMockPluginEnv) == "" {
+	if api.ReadBaoVariable(vaultTestingMockPluginEnv) == "" {
 		return
 	}
 
@@ -883,7 +884,7 @@ func TestBackend_PluginMain_Multiplexed_Logical_v124(t *testing.T) {
 
 // Used to run a mock multiplexed auth plugin
 func TestBackend_PluginMain_Multiplexed_Credential_v123(t *testing.T) {
-	if os.Getenv(vaultTestingMockPluginEnv) == "" {
+	if api.ReadBaoVariable(vaultTestingMockPluginEnv) == "" {
 		return
 	}
 

--- a/vault/external_tests/api/feature_flag_ext_test.go
+++ b/vault/external_tests/api/feature_flag_ext_test.go
@@ -78,7 +78,7 @@ func TestFeatureFlags(t *testing.T) {
 	}
 
 	// Now try with the environment variable temporarily set
-	envVar := "VAULT_CLOUD_ADMIN_NAMESPACE"
+	envVar := "BAO_CLOUD_ADMIN_NAMESPACE"
 	os.Setenv(envVar, "1")
 	defer os.Unsetenv(envVar)
 

--- a/vault/external_tests/misc/misc_binary/recovery_test.go
+++ b/vault/external_tests/misc/misc_binary/recovery_test.go
@@ -5,7 +5,6 @@ package misc
 
 import (
 	"context"
-	"os"
 	"path"
 	"testing"
 
@@ -27,7 +26,7 @@ func TestRecovery_Docker(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Parallel()
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}

--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -709,16 +709,16 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 func TestBackend_PluginMain_V4_Logical(t *testing.T) {
 	args := []string{}
 	// don't run as a standalone unit test
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
 	// don't run as a V5 plugin
-	if os.Getenv(pluginutil.PluginAutoMTLSEnv) == "true" {
+	if api.ReadBaoVariable(pluginutil.PluginAutoMTLSEnv) == "true" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -745,11 +745,11 @@ func TestBackend_PluginMain_V4_Logical(t *testing.T) {
 
 func TestBackend_PluginMain_Multiplexed_Logical(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -771,11 +771,11 @@ func TestBackend_PluginMain_Multiplexed_Logical(t *testing.T) {
 
 func TestBackend_PluginMainLogical(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -798,16 +798,16 @@ func TestBackend_PluginMainLogical(t *testing.T) {
 func TestBackend_PluginMain_V4_Credentials(t *testing.T) {
 	args := []string{}
 	// don't run as a standalone unit test
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
 	// don't run as a V5 plugin
-	if os.Getenv(pluginutil.PluginAutoMTLSEnv) == "true" {
+	if api.ReadBaoVariable(pluginutil.PluginAutoMTLSEnv) == "true" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -834,11 +834,11 @@ func TestBackend_PluginMain_V4_Credentials(t *testing.T) {
 
 func TestBackend_PluginMain_Multiplexed_Credentials(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -860,11 +860,11 @@ func TestBackend_PluginMain_Multiplexed_Credentials(t *testing.T) {
 
 func TestBackend_PluginMainCredentials(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}
@@ -887,7 +887,7 @@ func TestBackend_PluginMainCredentials(t *testing.T) {
 // TestBackend_PluginMainEnv is a mock plugin that simply checks for the existence of FOO env var.
 func TestBackend_PluginMainEnv(t *testing.T) {
 	args := []string{}
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
+	if api.ReadBaoVariable(pluginutil.PluginUnwrapTokenEnv) == "" && api.ReadBaoVariable(pluginutil.PluginMetadataModeEnv) != "true" {
 		return
 	}
 
@@ -897,7 +897,7 @@ func TestBackend_PluginMainEnv(t *testing.T) {
 		t.Fatalf("expected: %q, got: %q", expectedEnvValue, actual)
 	}
 
-	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	caPEM := api.ReadBaoVariable(pluginutil.PluginCACertPEMEnv)
 	if caPEM == "" {
 		t.Fatal("CA cert not passed in")
 	}

--- a/vault/external_tests/pprof/pprof_binary/pprof_test.go
+++ b/vault/external_tests/pprof/pprof_binary/pprof_test.go
@@ -4,9 +4,9 @@
 package pprof_binary
 
 import (
-	"os"
 	"testing"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/testcluster"
 	"github.com/openbao/openbao/vault/external_tests/pprof"
 )
@@ -17,7 +17,7 @@ import (
 // other than that it was fast and simple.
 func TestSysPprof_Exec(t *testing.T) {
 	t.Parallel()
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("only running exec test when $VAULT_BINARY present")
 	}
@@ -39,7 +39,7 @@ func TestSysPprof_Exec(t *testing.T) {
 // other than that it was fast and simple.
 func TestSysPprof_Standby_Exec(t *testing.T) {
 	t.Parallel()
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("only running exec test when $VAULT_BINARY present")
 	}

--- a/vault/external_tests/raft/raft_binary/raft_test.go
+++ b/vault/external_tests/raft/raft_binary/raft_test.go
@@ -2,9 +2,9 @@ package raft_binary
 
 import (
 	"context"
-	"os"
 	"testing"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/testcluster"
 	"github.com/openbao/openbao/sdk/helper/testcluster/docker"
 	rafttest "github.com/openbao/openbao/vault/external_tests/raft"
@@ -14,7 +14,7 @@ import (
 // uses docker containers for the vault nodes.
 func TestRaft_Configuration_Docker(t *testing.T) {
 	t.Parallel()
-	binary := os.Getenv("VAULT_BINARY")
+	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/timeutil"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/logical"
@@ -222,7 +222,7 @@ func (b *SystemBackend) handleClientExport(ctx context.Context, req *logical.Req
 
 	// This is to avoid the default 90s context timeout.
 	timeout := 10 * time.Minute
-	if durationRaw := os.Getenv("VAULT_ACTIVITY_EXPORT_DURATION"); durationRaw != "" {
+	if durationRaw := api.ReadBaoVariable("BAO_ACTIVITY_EXPORT_DURATION"); durationRaw != "" {
 		d, err := parseutil.ParseDurationSecond(durationRaw)
 		if err == nil {
 			timeout = d

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/copystructure"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/builtin/plugin"
 	"github.com/openbao/openbao/helper/experiments"
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -1750,7 +1750,7 @@ func (c *Core) defaultMountTable() *MountTable {
 	}
 	table.Entries = append(table.Entries, c.requiredMountTable().Entries...)
 
-	if os.Getenv("VAULT_INTERACTIVE_DEMO_SERVER") != "" {
+	if api.ReadBaoVariable("BAO_INTERACTIVE_DEMO_SERVER") != "" {
 		mountUUID, err := uuid.GenerateUUID()
 		if err != nil {
 			panic(fmt.Sprintf("could not create default secret mount UUID: %v", err))

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -611,7 +611,7 @@ func TestPluginCatalog_MakeExternalPluginsKey_Comparable(t *testing.T) {
 }
 
 func TestPluginCatalog_PluginMain_Userpass(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -634,7 +634,7 @@ func TestPluginCatalog_PluginMain_Userpass(t *testing.T) {
 }
 
 func TestPluginCatalog_PluginMain_UserpassMultiplexed(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -657,7 +657,7 @@ func TestPluginCatalog_PluginMain_UserpassMultiplexed(t *testing.T) {
 }
 
 func TestPluginCatalog_PluginMain_Postgres(t *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 
@@ -670,7 +670,7 @@ func TestPluginCatalog_PluginMain_Postgres(t *testing.T) {
 }
 
 func TestPluginCatalog_PluginMain_PostgresMultiplexed(_ *testing.T) {
-	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
+	if api.ReadBaoVariable(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +22,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	uberAtomic "go.uber.org/atomic"
 
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/identity/mfa"
@@ -42,7 +42,7 @@ import (
 
 const (
 	replTimeout                           = 1 * time.Second
-	EnvVaultDisableLocalAuthMountEntities = "VAULT_DISABLE_LOCAL_AUTH_MOUNT_ENTITIES"
+	EnvVaultDisableLocalAuthMountEntities = "BAO_DISABLE_LOCAL_AUTH_MOUNT_ENTITIES"
 	// base path to store locked users
 	coreLockedUsersPath = "core/login/lockedUsers/"
 )
@@ -1607,7 +1607,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			mEntry != nil &&
 			c.identityStore != nil {
 
-			if mEntry.Local && os.Getenv(EnvVaultDisableLocalAuthMountEntities) != "" {
+			if mEntry.Local && api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
 				goto CREATE_TOKEN
 			}
 
@@ -1997,11 +1997,11 @@ func (c *Core) isUserLockoutDisabled(mountEntry *MountEntry) (bool, error) {
 	}
 
 	// check environment variable
-	if disableUserLockoutEnv := os.Getenv(consts.VaultDisableUserLockout); disableUserLockoutEnv != "" {
+	if disableUserLockoutEnv := api.ReadBaoVariable(consts.VaultDisableUserLockout); disableUserLockoutEnv != "" {
 		var err error
 		disableUserLockout, err := strconv.ParseBool(disableUserLockoutEnv)
 		if err != nil {
-			return false, errors.New("Error parsing the environment variable VAULT_DISABLE_USER_LOCKOUT")
+			return false, errors.New("Error parsing the environment variable BAO_DISABLE_USER_LOCKOUT")
 		}
 		if disableUserLockout {
 			return true, nil

--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -16,13 +15,14 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/gammazero/workerpool"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/logical"
 )
 
 const (
 	RollbackDefaultNumWorkers = 256
-	RollbackWorkersEnvVar     = "VAULT_ROLLBACK_WORKERS"
+	RollbackWorkersEnvVar     = "BAO_ROLLBACK_WORKERS"
 )
 
 // RollbackManager is responsible for performing rollbacks of partial
@@ -98,7 +98,7 @@ func NewRollbackManager(ctx context.Context, logger log.Logger, backendsFunc fun
 
 func (m *RollbackManager) numRollbackWorkers() int {
 	numWorkers := m.core.numRollbackWorkers
-	envOverride := os.Getenv(RollbackWorkersEnvVar)
+	envOverride := api.ReadBaoVariable(RollbackWorkersEnvVar)
 	if envOverride != "" {
 		envVarWorkers, err := strconv.Atoi(envOverride)
 		if err != nil || envVarWorkers < 1 {


### PR DESCRIPTION
This is a follow-up to #138; will be rebased when that one merges. 

---

This cleans up the logic of `api.ReadBaoVariable` a touch, and then replaces a bunch of instances of `os.GetEnv` with `api.ReadBaoVariable` instead. 

I'm thinking perhaps we want to have an option (`BAO_IGNORE_VAULT_VARIABLES`) might be useful to globally ignore `VAULT_` prefixed environment variables? That way Vault and Bao could coexist on the same system with different environments and not have a partial environment from one leak into the other?

Thoughts? 