### PR TITLE
Run external tools directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,6 @@ TEST_TIMEOUT?=45m
 EXTENDED_TEST_TIMEOUT=60m
 INTEG_TEST_TIMEOUT=120m
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
-EXTERNAL_TOOLS_CI=\
-	golang.org/x/tools/cmd/goimports \
-	github.com/golangci/revgrep/cmd/revgrep \
-	mvdan.cc/gofumpt \
-	honnef.co/go/tools/cmd/staticcheck
-EXTERNAL_TOOLS=\
-	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 SED?=$(shell command -v gsed || command -v sed)
 
@@ -144,17 +137,17 @@ tools/codechecker/.bin/codechecker:
 # piped to revgrep which will only return an error if new piece of code violates
 # the check
 vet-codechecker: bootstrap tools/codechecker/.bin/codechecker prep
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) ./... 2>&1 | revgrep
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/api/... 2>&1 | revgrep
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/sdk/... 2>&1 | revgrep
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) ./... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/api/... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/sdk/... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest
 
 # vet-codechecker runs our custom linters on the test functions. All output gets
 # piped to revgrep which will only return an error if new piece of code that is
 # not on main violates the check
 ci-vet-codechecker: ci-bootstrap tools/codechecker/.bin/codechecker prep
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) ./... 2>&1 | revgrep origin/main
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/api/... 2>&1 | revgrep origin/main
-	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/sdk/... 2>&1 | revgrep origin/main
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) ./... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest origin/main
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/api/... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest origin/main
+	@$(GO_CMD) vet -vettool=./tools/codechecker/.bin/codechecker -tags=$(BUILD_TAGS) github.com/openbao/openbao/sdk/... 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest origin/main
 
 # lint runs vet plus a number of other checkers, it is more comprehensive, but louder
 lint:
@@ -194,15 +187,6 @@ prep:
 	@GOARCH= GOOS= $(GO_CMD) generate $$($(GO_CMD) list github.com/openbao/openbao/api/... | grep -v /vendor/)
 	@GOARCH= GOOS= $(GO_CMD) generate $$($(GO_CMD) list github.com/openbao/openbao/sdk/... | grep -v /vendor/)
 	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
-
-# bootstrap the build by downloading additional tools needed to build
-ci-bootstrap: .ci-bootstrap
-.ci-bootstrap:
-	@for tool in  $(EXTERNAL_TOOLS_CI) ; do \
-		echo "Installing/Updating $$tool" ; \
-		GO111MODULE=off $(GO_CMD) get -u $$tool; \
-	done
-	@touch .ci-bootstrap
 
 # bootstrap the build by downloading additional tools that may be used by devs
 bootstrap: ci-bootstrap
@@ -278,7 +262,7 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 fmt: ci-bootstrap
-	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -w
+	find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt@latest -w
 
 semgrep:
 	semgrep --include '*.go' --exclude 'vendor' -a -f tools/semgrep .
@@ -292,7 +276,7 @@ assetcheck:
 
 spellcheck:
 	@echo "==> Spell checking website..."
-	@misspell -error -source=text website/source
+	$(GO_CMD) run github.com/client9/misspell/cmd/misspell@latest -error -source=text website/source
 
 mysql-database-plugin:
 	@CGO_ENABLED=0 $(GO_CMD) build -o bin/mysql-database-plugin ./plugins/database/mysql/mysql-database-plugin

--- a/builtin/credential/jwt/path_oidc_test.go
+++ b/builtin/credential/jwt/path_oidc_test.go
@@ -868,7 +868,6 @@ func TestOIDC_Callback(t *testing.T) {
 		}
 
 		resp, err = b.HandleRequest(context.Background(), req)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1346,7 +1345,6 @@ func TestOIDC_Callback(t *testing.T) {
 			}
 
 			resp, err = b.HandleRequest(context.Background(), req)
-
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/builtin/credential/kubernetes/path_login.go
+++ b/builtin/credential/kubernetes/path_login.go
@@ -146,7 +146,6 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 
 	// look up the JWT token in the kubernetes API
 	err = serviceAccount.lookup(ctx, client, jwtStr, role.Audience, b.reviewFactory(config))
-
 	if err != nil {
 		b.Logger().Debug(`login unauthorized`, "err", err)
 		return nil, logical.ErrPermissionDenied

--- a/builtin/logical/kv/path_metadata_test.go
+++ b/builtin/logical/kv/path_metadata_test.go
@@ -433,7 +433,6 @@ func TestVersionedKV_Metadata_Put_Bad_CustomMetadata(t *testing.T) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), req)
-
 	if err != nil {
 		t.Fatalf("Read err: %#v, resp: %#v", err, resp)
 	}
@@ -527,7 +526,6 @@ func TestVersionedKv_Metadata_Put_Too_Many_CustomMetadata_Keys(t *testing.T) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), req)
-
 	if err != nil {
 		t.Fatalf("Read err: %#v, resp :%#v", err, resp)
 	}
@@ -912,7 +910,6 @@ func TestVersionedKV_Metadata_Patch_Validation(t *testing.T) {
 			}
 
 			resp, err = b.HandleRequest(context.Background(), req)
-
 			if err != nil {
 				t.Fatalf("unexpected patch error, err: %#v", err)
 			}

--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -14,8 +14,10 @@ import (
 )
 
 // Error prefix; see RFC 8555 Section 6.7. Errors.
-const ErrorPrefix = "urn:ietf:params:acme:error:"
-const ErrorContentType = "application/problem+json"
+const (
+	ErrorPrefix      = "urn:ietf:params:acme:error:"
+	ErrorContentType = "application/problem+json"
+)
 
 // See RFC 8555 Section 6.7. Errors.
 var ErrAccountDoesNotExist = errors.New("The request specified an account that does not exist")

--- a/builtin/plugin/v5/backend.go
+++ b/builtin/plugin/v5/backend.go
@@ -80,7 +80,6 @@ func (b *backend) reloadBackend(ctx context.Context, storage logical.Storage) er
 	err = b.Backend.Initialize(ctx, &logical.InitializationRequest{
 		Storage: storage,
 	})
-
 	if err != nil {
 		return err
 	}

--- a/command/kv_metadata_put_test.go
+++ b/command/kv_metadata_put_test.go
@@ -145,7 +145,6 @@ func TestKvMetadataPutCommand_CustomMetadata(t *testing.T) {
 	}
 
 	metadata, err = client.Logical().Read(metaFullPath)
-
 	if err != nil {
 		t.Fatalf("Metadata read error: %#v", err)
 	}

--- a/helper/pgpkeys/encrypt_decrypt.go
+++ b/helper/pgpkeys/encrypt_decrypt.go
@@ -56,7 +56,6 @@ func GetFingerprints(pgpKeys []string, entities []*openpgp.Entity) ([]string, er
 	if entities == nil {
 		var err error
 		entities, err = GetEntities(pgpKeys)
-
 		if err != nil {
 			return nil, err
 		}

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -143,7 +143,6 @@ func compareDBs(t *testing.T, boltDB1, boltDB2 *bolt.DB, dataOnly bool) error {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/database/redis/redis.go
+++ b/plugins/database/redis/redis.go
@@ -123,7 +123,6 @@ func (c *RedisDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest
 	var response string
 
 	err = db.Do(ctx, radix.Cmd(&response, "ACL", "DELUSER", req.Username))
-
 	if err != nil {
 		return dbplugin.DeleteUserResponse{}, err
 	}
@@ -149,7 +148,6 @@ func newUser(ctx context.Context, db radix.Client, username string, req dbplugin
 	var response string
 
 	err = db.Do(ctx, radix.Cmd(&response, "ACL", aclargs...))
-
 	if err != nil {
 		return err
 	}
@@ -192,7 +190,6 @@ func (c *RedisDB) changeUserPassword(ctx context.Context, username, password str
 
 	var sresponse string
 	err = db.Do(ctx, radix.Cmd(&sresponse, "ACL", "SETUSER", username, "RESETPASS", ">"+password))
-
 	if err != nil {
 		return err
 	}

--- a/plugins/database/redis/redis_test.go
+++ b/plugins/database/redis/redis_test.go
@@ -208,7 +208,6 @@ func testRedisDBInitialize_TLS(t *testing.T, host string, port int) {
 		"insecure_tls": true,
 	}
 	err = setupRedisDBInitialize(t, connectionDetails)
-
 	if err != nil {
 		t.Fatalf("Testing TLS Init() failed: error: %s", err)
 	}

--- a/scripts/deprecations-checker.sh
+++ b/scripts/deprecations-checker.sh
@@ -30,9 +30,9 @@ echo "Performing deprecations check: running staticcheck"
 # Else only output the deprecations from the changes added
 if [ -z $1 ]
     then
-        staticcheck -checks="SA1019" -tags="$BUILD_TAGS"
+        go run honnef.co/go/tools/cmd/staticcheck@latest -checks="SA1019" -tags="$BUILD_TAGS"
     else
         # GitHub Actions will use this to find only changes wrt PR's base ref branch
         # revgrep CLI tool will return an exit status of 1 if any issues match, else it will return 0
-        staticcheck  -checks="SA1019" -tags="$BUILD_TAGS" 2>&1 | revgrep origin/"$1" 
+        go run honnef.co/go/tools/cmd/staticcheck@latest -checks="SA1019" -tags="$BUILD_TAGS" 2>&1 | go run github.com/golangci/revgrep/cmd/revgrep@latest origin/"$1"
 fi

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -7,10 +7,10 @@ echo "==> Checking that code complies with gofmt requirements..."
 files=$(echo $1 | xargs)
 if [ -n "$files" ]; then
     echo "Checking changed files..."
-    gofmt_files="$(echo $1 | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+    gofmt_files="$(echo $1 | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt@latest -l)"
 else
     echo "Checking all files..."
-    gofmt_files="$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt -l)"
+    gofmt_files="$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs go run mvdan.cc/gofumpt@latest -l)"
 fi
 
 if [[ -n "${gofmt_files}" ]]; then

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1271,7 +1271,6 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	}
 
 	certBytes, err = x509.CreateCertificate(randReader, certTemplate, caCert, data.CSR.PublicKey, data.SigningBundle.PrivateKey)
-
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to create certificate: %s", err)}
 	}

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -320,7 +320,6 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 		config = c
 		return nil
 	}, bo)
-
 	if err != nil {
 		if !d.RunOptions.DoNotAutoRemove {
 			cleanup()

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1406,7 +1406,6 @@ func (a *ActivityLog) HandleEndOfMonth(ctx context.Context, currentTime time.Tim
 	// empty when it returns, but dropping some measurements is acceptable.
 	// We use force=true here in case an entry didn't appear this month
 	err = a.saveCurrentSegmentToStorageLocked(ctx, true)
-
 	// Don't return this error, just log it, we are done with that segment anyway.
 	if err != nil {
 		a.logger.Warn("last save of segment failed", "error", err)

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -187,7 +187,6 @@ func TestKV_Patch_Audit(t *testing.T) {
 	resp, err = kvRequestWithRetry(t, func() (interface{}, error) {
 		return c.Logical().JSONMergePatch(context.Background(), "kv/data/foo", patchData)
 	})
-
 	if err != nil {
 		t.Fatalf("patch request failed, err: %#v, resp: %#v\n", err, resp)
 	}
@@ -258,7 +257,6 @@ func TestKV_Patch_RootToken(t *testing.T) {
 
 		return client.Logical().Write("kv/data/foo", data)
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +270,6 @@ func TestKV_Patch_RootToken(t *testing.T) {
 		}
 		return client.Logical().JSONMergePatch(context.Background(), "kv/data/foo", data)
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/identity_store_aliases_test.go
+++ b/vault/identity_store_aliases_test.go
@@ -642,7 +642,6 @@ func TestIdentityStore_AliasMove_DuplicateAccessor(t *testing.T) {
 	aliasReq.Data = updateData
 	aliasReq.Path = "entity-alias/id/" + alias2ID
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,7 +714,6 @@ func TestIdentityStore_AliasUpdate_DuplicateAccessor(t *testing.T) {
 	aliasReq.Data = updateData
 	aliasReq.Path = "entity-alias/id/" + alias2ID
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +767,6 @@ func TestIdentityStore_AliasCreate_DuplicateAccessor(t *testing.T) {
 
 	// This will try to create a new alias with the same accessor and entity
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -686,7 +686,6 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 			requestBodyToken = token.(string)
 			if IsSSCToken(token.(string)) {
 				token, err = c.CheckSSCToken(ctx, token.(string), c.isLoginRequest(ctx, req), c.perfStandby)
-
 				// If we receive an error from CheckSSCToken, we can assume the token is bad somehow, and the client
 				// should receive a 403 bad token error like they do for all other invalid tokens, unless the error
 				// specifies that we should forward the request or retry the request.

--- a/vault/version_store.go
+++ b/vault/version_store.go
@@ -45,7 +45,6 @@ func (c *Core) storeVersionEntry(ctx context.Context, vaultVersion *VaultVersion
 	if force {
 		// avoid storage lookup and write immediately
 		err = c.barrier.Put(ctx, newEntry)
-
 		if err != nil {
 			return false, err
 		}
@@ -63,7 +62,6 @@ func (c *Core) storeVersionEntry(ctx context.Context, vaultVersion *VaultVersion
 	}
 
 	err = c.barrier.Put(ctx, newEntry)
-
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Switch to running external tools directly

Rather than expecting them to be installed locally (via a previous
`go get` operation outside of the repo), use the `go run ...@latest`
pattern. This will download the package (the first time), but not
necessarily install it for the user on a `$PATH`-visible location.

This has the added side effect of ensuring everyone is on the same
version.

---

Also runs `make fmt` to fix a few blank lines. 

---

In particular, on a fresh system with no dependencies, running `make bootstrap` fails for me with:

```
Installing/Updating golang.org/x/tools/cmd/goimports
go: modules disabled by GO111MODULE=off; see 'go help modules'
Installing/Updating github.com/golangci/revgrep/cmd/revgrep
go: modules disabled by GO111MODULE=off; see 'go help modules'
Installing/Updating mvdan.cc/gofumpt
go: modules disabled by GO111MODULE=off; see 'go help modules'
Installing/Updating honnef.co/go/tools/cmd/staticcheck
go: modules disabled by GO111MODULE=off; see 'go help modules'
make: *** [Makefile:168: .ci-bootstrap] Error 1
```

This is because this hack:

```
# bootstrap the build by downloading additional tools needed to build
ci-bootstrap: .ci-bootstrap
.ci-bootstrap:
    @for tool in  $(EXTERNAL_TOOLS_CI) ; do \
        echo "Installing/Updating $$tool" ; \
        GO111MODULE=off $(GO_CMD) get -u $$tool; \
    done
    @touch .ci-bootstrap
```

doesn't work on Go 1.22+ apparently: https://tip.golang.org/doc/go1.22#go-command