### PR TITLE
Fix OpenBao OIDC followed by Google OIDC not working on Android

### DIFF
--- a/changelog/184.txt
+++ b/changelog/184.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: The latest versions of Chrome do not automatically redirect back to an Android app after multiple redirects during an OIDC authentication flow. A link was added to allow the user to manually redirect back to the app.
+```

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -94,17 +94,17 @@ export default class VaultClusterOidcProviderRoute extends Route {
   _handleSuccess(response, baseUrl, state) {
     const { code } = response;
     const redirectUrl = this._buildUrl(baseUrl, { code, state });
-    if (Ember.testing) {
-      return { redirectUrl };
+    if (!Ember.testing) {
+      this.win.location.replace(redirectUrl);
     }
-    this.win.location.replace(redirectUrl);
+    return { redirectUrl };
   }
   _handleError(errorResp, baseUrl) {
     const redirectUrl = this._buildUrl(baseUrl, { ...errorResp });
-    if (Ember.testing) {
-      return { redirectUrl };
+    if (!Ember.testing) {
+      this.win.location.replace(redirectUrl);
     }
-    this.win.location.replace(redirectUrl);
+    return { redirectUrl };
   }
 
   /**

--- a/ui/app/templates/vault/cluster/oidc-provider.hbs
+++ b/ui/app/templates/vault/cluster/oidc-provider.hbs
@@ -14,7 +14,9 @@
           @onSuccess={{this._handleSuccess}}
         />
       {{else if this.model.redirectUrl}}
-        <div data-test-oidc-redirect>{{this.model.redirectUrl}}</div>
+        <VaultLogoSpinner />
+        <p>If you are not automatically redirected,
+          <a href={{this.model.redirectUrl}} data-test-oidc-redirect>click here to go back to app.</a></p>
       {{else}}
         <VaultLogoSpinner />
       {{/if}}

--- a/ui/tests/acceptance/oidc-provider-test.js
+++ b/ui/tests/acceptance/oidc-provider-test.js
@@ -164,10 +164,11 @@ module('Acceptance | oidc provider', function (hooks) {
     await authFormComponent.login();
     await settled();
     assert.strictEqual(currentURL(), url, 'URL is as expected after login');
-    assert.dom('[data-test-oidc-redirect]').exists('redirect text exists');
     assert
       .dom('[data-test-oidc-redirect]')
-      .hasTextContaining(`${callback}?code=`, 'Successful redirect to callback');
+      .hasTextContaining(`click here to go back to app`, 'Shows link back to app');
+    const link = document.querySelector('[data-test-oidc-redirect]').getAttribute('href');
+    assert.ok(link.includes('/callback?code='), 'Redirects to correct url');
 
     //* clean up test state
     await clearRecord(this.store, 'oidc/client', 'my-webapp');
@@ -192,7 +193,9 @@ module('Acceptance | oidc provider', function (hooks) {
     await settled();
     assert
       .dom('[data-test-oidc-redirect]')
-      .hasTextContaining(`${callback}?code=`, 'Successful redirect to callback');
+      .hasTextContaining(`click here to go back to app`, 'Shows link back to app');
+    const link = document.querySelector('[data-test-oidc-redirect]').getAttribute('href');
+    assert.ok(link.includes('/callback?code='), 'Redirects to correct url');
 
     //* clean up test state
     await clearRecord(this.store, 'oidc/client', 'my-webapp');


### PR DESCRIPTION
This fixes the issue when having an Android app authenticate with the OpenBoa OIDC identity provider and having OpenBao in turn authenticate the user with Google OIDC the redirect back to the Android app from OpenBao doesn't work. So after logging in with Google you get correctly redirected to OpenBao but then OpenBAO doesn't redirect back to the app. Chrome (104) on Android would show the logo loading animation forever.

This code was originally developed by @prajnamohan1 while working at Service Planet Rotterdam B.V.. I, Jasper Siepkes, in my capacity of IT Manager at Service Planet Rotterdam B.V. herby grant permission to use this code under the MPL-2.0 license.

Resolves: openbao#184
