### PR TITLE
Remove remaining permissions issues in pipelines

### DIFF
--- a/.github/workflows/build-vault-ce.yml
+++ b/.github/workflows/build-vault-ce.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/set-up-go
       - name: Restore UI from cache
         if: inputs.web-ui-cache-key != ''
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           # Restore the UI asset from the UI build workflow. Never use a partial restore key.
           enableCrossOsArchive: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 #        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
 #      - name: Set up UI asset cache
 #        id: cache-ui-assets
-#        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+#        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
 #        with:
 #          enableCrossOsArchive: true
 #          lookup-only: true
@@ -102,6 +102,7 @@ jobs:
 #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
 #        name: Build UI
 #        run: make ci-build-ui
+
 
   build-other:
     name: Other

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -296,7 +296,7 @@ jobs:
           path: test-results/go-test
           key: go-test-reports-${{ github.run_number }}
           restore-keys: go-test-reports-
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: test-results
           path: test-results/go-test

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -72,7 +72,7 @@ jobs:
         name: Setup Git configuration (public)
       - uses: ./.github/actions/set-up-gotestsum
       - run: mkdir -p test-results/go-test
-      - uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - uses: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: test-results/go-test
           key: go-test-reports-${{ github.run_number }}
@@ -291,7 +291,7 @@ jobs:
     needs: test-go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: test-results/go-test
           key: go-test-reports-${{ github.run_number }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -63,9 +63,6 @@ env: ${{ fromJSON(inputs.env-vars) }}
 
 jobs:
   test-matrix:
-    permissions:
-      id-token: write  # Note: this permission is explicitly required for Vault auth
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -73,9 +70,6 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
       - uses: ./.github/actions/set-up-go
         name: Setup Git configuration (public)
-      - id: setup-git-public
-        run: |
-          git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN}}@github.com".insteadOf https://github.com
       - uses: ./.github/actions/set-up-gotestsum
       - run: mkdir -p test-results/go-test
       - uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -151,10 +145,6 @@ jobs:
 
   test-go:
     needs: test-matrix
-    permissions:
-      actions: read
-      contents: read
-      id-token: write  # Note: this permission is explicitly required for Vault auth
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This removes the remaining unused permissions from the test-go workflow, fixing testing upstream.

See https://github.com/openbao/openbao/actions/runs/8207302185/workflow for an example failing workflow. 