### PR TITLE
Fixed issue PKI: Support explicit Basic Constraints isCA=False #81

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2332,6 +2332,115 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatalf("sign-verbatim did not properly cap validity period (notBefore) on signed CSR: was %v vs expected %v", cert.NotBefore, time.Now().Add(-2*time.Hour))
 	}
 
+	if cert.BasicConstraintsValid {
+		t.Fatalf("By default, sign-verbatim must not issue certificates containing the x509 Basic Constraints extension")
+	}
+
+	// test the Basic Constraints extension: when the option is explicitly specified (as an explicit option or in a role), the issued certificate must be generated with the Basic Constraints extension.
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sign-verbatim",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"csr":                                pemCSR,
+			"ttl":                                "5h",
+			"basic_constraints_valid_for_non_ca": true,
+		},
+		MountPoint: "pki/",
+	})
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to sign-verbatim CSR using option \"basic_constraints_valid_for_non_ca\": %#v", *resp)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Data == nil || resp.Data["certificate"] == nil {
+		t.Fatal("did not get expected data")
+	}
+	certString = resp.Data["certificate"].(string)
+	block, _ = pem.Decode([]byte(certString))
+	if block == nil {
+		t.Fatal("nil pem block")
+	}
+	certs, err = x509.ParseCertificates(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected a single cert, got %d", len(certs))
+	}
+	cert = certs[0]
+
+	if !cert.BasicConstraintsValid {
+		t.Fatalf("When explicitly specified through the option \"basic_constraints_valid_for_non_ca\", sign-verbatim must issue certificates containing the x509 Basic Constraints extension")
+	}
+
+	// test the Basic Constraints extension with a role: when the option is explicitly specified in a role, the issued certificate must be generated with the Basic Constraints extension.
+	roleData = map[string]interface{}{
+		"ttl":                                "4h",
+		"max_ttl":                            "8h",
+		"key_type":                           keyType,
+		"not_before_duration":                "2h",
+		"basic_constraints_valid_for_non_ca": true,
+	}
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation:  logical.UpdateOperation,
+		Path:       "roles/test",
+		Storage:    storage,
+		Data:       roleData,
+		MountPoint: "pki/",
+	})
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create a role, %#v", *resp)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sign-verbatim/test",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"csr": pemCSR,
+			"ttl": "12h",
+		},
+		MountPoint: "pki/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to sign-verbatim CSR with role using \"basic_constraints_valid_for_non_ca\": %#v", *resp)
+	}
+	if resp.Data == nil || resp.Data["certificate"] == nil {
+		t.Fatal("did not get expected data")
+	}
+	certString = resp.Data["certificate"].(string)
+	block, _ = pem.Decode([]byte(certString))
+	if block == nil {
+		t.Fatal("nil pem block")
+	}
+	certs, err = x509.ParseCertificates(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected a single cert, got %d", len(certs))
+	}
+	cert = certs[0]
+	if math.Abs(float64(time.Now().Add(12*time.Hour).Unix()-cert.NotAfter.Unix())) < 10 {
+		t.Fatalf("sign-verbatim did not properly cap validity period (notAfter) on signed CSR: was %v vs requested %v but should've been %v", cert.NotAfter, time.Now().Add(12*time.Hour), time.Now().Add(8*time.Hour))
+	}
+	if math.Abs(float64(time.Now().Add(-2*time.Hour).Unix()-cert.NotBefore.Unix())) > 10 {
+		t.Fatalf("sign-verbatim did not properly cap validity period (notBefore) on signed CSR: was %v vs expected %v", cert.NotBefore, time.Now().Add(-2*time.Hour))
+	}
+
+	if !cert.BasicConstraintsValid {
+		t.Fatalf("When using a role with the option \"basic_constraints_valid_for_non_ca\", sign-verbatim must issue certificates containing the x509 Basic Constraints extension")
+	}
+
 	// Now check signing a certificate using the not_after input using the Y10K value
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -230,11 +230,12 @@ func buildSignVerbatimRole(data *framework.FieldData, role *roleEntry) *roleEntr
 		CNValidations:             []string{"disabled"},
 		GenerateLease:             new(bool),
 		// If adding new fields to be read, update the field list within addSignVerbatimRoleFields
-		KeyUsage:        data.Get("key_usage").([]string),
-		ExtKeyUsage:     data.Get("ext_key_usage").([]string),
-		ExtKeyUsageOIDs: data.Get("ext_key_usage_oids").([]string),
-		SignatureBits:   data.Get("signature_bits").(int),
-		UsePSS:          data.Get("use_pss").(bool),
+		KeyUsage:                      data.Get("key_usage").([]string),
+		ExtKeyUsage:                   data.Get("ext_key_usage").([]string),
+		ExtKeyUsageOIDs:               data.Get("ext_key_usage_oids").([]string),
+		SignatureBits:                 data.Get("signature_bits").(int),
+		UsePSS:                        data.Get("use_pss").(bool),
+		BasicConstraintsValidForNonCA: data.Get("basic_constraints_valid_for_non_ca").(bool),
 	}
 	*entry.AllowWildcardCertificates = true
 	*entry.GenerateLease = false

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -255,7 +255,9 @@ func buildSignVerbatimRole(data *framework.FieldData, role *roleEntry) *roleEntr
 		}
 		entry.NoStore = role.NoStore
 		entry.Issuer = role.Issuer
-		entry.BasicConstraintsValidForNonCA = role.BasicConstraintsValidForNonCA
+		if _, ok := data.GetOk("basic_constraints_valid_for_non_ca"); !ok {
+			entry.BasicConstraintsValidForNonCA = role.BasicConstraintsValidForNonCA
+		}
 	}
 
 	if len(entry.Issuer) == 0 {

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -255,6 +255,7 @@ func buildSignVerbatimRole(data *framework.FieldData, role *roleEntry) *roleEntr
 		}
 		entry.NoStore = role.NoStore
 		entry.Issuer = role.Issuer
+		entry.BasicConstraintsValidForNonCA = role.BasicConstraintsValidForNonCA
 	}
 
 	if len(entry.Issuer) == 0 {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1047,7 +1047,7 @@ func signCert(b *backend,
 		}
 	} else {
 		for _, ext := range csr.Extensions {
-			if ext.Id.Equal(certutil.ExtensionBasicConstraintsOID) {
+			if ext.Id.Equal(certutil.ExtensionBasicConstraintsOID) && !data.role.BasicConstraintsValidForNonCA {
 				warnings = append(warnings, "specified CSR contained a Basic Constraints extension that was ignored during issuance")
 			}
 		}

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -633,5 +633,11 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 RSA key-type issuer. Defaults to false.`,
 	}
 
+	fields["basic_constraints_valid_for_non_ca"] = &framework.FieldSchema{
+		Type:        framework.TypeBool,
+		Default:     false,
+		Description: `Mark Basic Constraints valid when issuing non-CA certificates.`,
+	}
+
 	return fields
 }

--- a/changelog/201.txt
+++ b/changelog/201.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add support for basicConstraints x509 extension when issuing certificates with sign-verbatim.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1206,6 +1206,7 @@ path and takes the value `default`.
 
 - `name` `(string: "")` - Specifies a role. If set, the following parameters
   from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store`,  `not_before_duration` and `basic_constraints_valid_for_non_ca`.
+  However, if the `basic_constraints_valid_for_non_ca` parameter is explicitly provided in the API call, it takes priority over the value set in the role.
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 
@@ -1290,7 +1291,7 @@ based on this parameter.
   signed certificate. No validation on names is performed using this endpoint.
 
   - `basic_constraints_valid_for_non_ca` `(bool: false)` - Mark Basic Constraints
-  valid when issuing non-CA certificates.
+  valid when issuing non-CA certificates. When the endpoint is used with a role, this parameter overwrites the `basic_constraints_valid_for_non_ca` value set in the role.
 
 #### Sample payload
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1205,7 +1205,7 @@ path and takes the value `default`.
 :::
 
 - `name` `(string: "")` - Specifies a role. If set, the following parameters
-  from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store` and `not_before_duration`.
+  from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store`,  `not_before_duration` and `basic_constraints_valid_for_non_ca`.
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 
@@ -1288,6 +1288,9 @@ based on this parameter.
 - `user_ids` `(string: "")` - Specifies the comma-separated list of requested
   User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the
   signed certificate. No validation on names is performed using this endpoint.
+
+  - `basic_constraints_valid_for_non_ca` `(bool: false)` - Mark Basic Constraints
+  valid when issuing non-CA certificates.
 
 #### Sample payload
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->
When issuing certificates with /pki_int/sign-verbatim, if the initial CSR contains the extension basicConstraints=CA:FALSE, the issued certificate must include this extension.
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them
-->

Resolves #

https://github.com/openbao/openbao/issues/81

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.14.7
