### PR TITLE
Allow specifying key type during issuance

### DIFF
--- a/changelog/209.txt
+++ b/changelog/209.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Allow pki/issue/:role with key_type=any roles, via explicit key_type and key_bits request parameters.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -675,6 +675,17 @@ field if `format=pem_bundle` parameter is specified.
   signed certificate. This field is validated against `allowed_user_ids` on
   the role.
 
+- `key_type` `(string: "")` - Specifies the desired key type when the role
+  allows any key type; must be `rsa`, `ed25519`, or `ec`. Use the literal
+  empty string when the role's key type should be respected.
+
+- `key_bits` `(int: 0)` - Specifies the number of bits to use for the
+  generated keys when the role allows any key type. Allowed values are
+  0 (universal default); with `key_type=rsa`, allowed values are:
+  2048 (default), 3072, or 4096; with `key_type=ec`, allowed values are:
+  224, 256 (default), 384, or 521; ignored with `key_type=ed25519`. Ignored
+  when the role has an explicit key type specified.
+
 #### Sample payload
 
 ```json


### PR DESCRIPTION
When a role explicitly allows any key type, certificates of any type or size can be issued via the `pki/sign/:role` endpoint. However, issuing with OpenBao-generated key material isn't possible as OpenBao doesn't know what key type to assign. Thus, introduce new `key_type` and `key_bits` parameters, letting callers opt-in to specific certificate types.

Resolves: #188 