### PR TITLE
Improvements to Shamir's implementation

### DIFF
--- a/changelog/210.txt
+++ b/changelog/210.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/helper/shamir: Use CS-PRNG for shuffling X coordinates; do not rely on math/rand.
+```

--- a/sdk/helper/shamir/shamir.go
+++ b/sdk/helper/shamir/shamir.go
@@ -7,8 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"fmt"
-	mathrand "math/rand"
-	"time"
+	"math/big"
 )
 
 const (
@@ -42,11 +41,39 @@ func makePolynomial(intercept, degree uint8) (polynomial, error) {
 	return p, nil
 }
 
+// Shuffle X coordinates for use; explicitly exclude x=0 as this results
+// in leaking a byte of the secret.
+//
+// See https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+func shuffledXCoordinates() ([]uint8, error) {
+	var result []uint8
+	for i := 1; i < 256; i++ {
+		result = append(result, uint8(i))
+	}
+
+	for i := len(result) - 1; i > 0; i-- {
+		// Overkill but useful: rand.Int ensures a uniformly randomly chosen
+		// integer between 0 and i-1 (inclusive); if we were to merely read a
+		// byte from the RNG and return (byte % i), our results would not be
+		// uniformly distributed. Since we're going through the effort of
+		// using a CS-PRNG here, we should also ensure our distribution is
+		// uniform.
+		jI, err := rand.Int(rand.Reader, big.NewInt(int64(i)))
+		if err != nil {
+			return nil, err
+		}
+
+		j := int(jI.Int64())
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result, nil
+}
+
 // evaluate returns the value of the polynomial for the given x
 func (p *polynomial) evaluate(x uint8) uint8 {
-	// Special case the origin
 	if x == 0 {
-		return p.coefficients[0]
+		panic("evaluation at x=0 would leak a byte of the secret")
 	}
 
 	// Compute the polynomial value using Horner's method.
@@ -98,17 +125,42 @@ func div(a, b uint8) uint8 {
 
 // inverse calculates the inverse of a number in GF(2^8)
 func inverse(a uint8) uint8 {
+	// Computing a^-1 is equivalent to computing a^254 in GF(2^8 == 256).
+	//
+	// This is shorter than a for loop with 6 iterations as it involves 11
+	// multiplications due to asymmetry rather than 13.
+
+	// a^1 * a^1 = a^2
 	b := mult(a, a)
+
+	// a^1 * a^2 = a^3
 	c := mult(a, b)
+
+	// a^3 * a^3 = a^6
 	b = mult(c, c)
+
+	// a^6 + a^6 = a^12
 	b = mult(b, b)
+
+	// a^12 * a^3 = a^15
 	c = mult(b, c)
+
+	// a^12 * a^12 = a^24
 	b = mult(b, b)
+
+	// a^24 * a^24 = a^48
 	b = mult(b, b)
+
+	// a^48 * a^15 = a^63
 	b = mult(b, c)
+
+	// a^63 * a^63 = a^126
 	b = mult(b, b)
+
+	// a^126 * a = a^127
 	b = mult(a, b)
 
+	// a^127 * a^127 = a^254
 	return mult(b, b)
 }
 
@@ -155,8 +207,10 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	}
 
 	// Generate random list of x coordinates
-	mathrand.Seed(time.Now().UnixNano())
-	xCoordinates := mathrand.Perm(255)
+	xCoordinates, err := shuffledXCoordinates()
+	if err != nil {
+		return nil, err
+	}
 
 	// Allocate the output array, initialize the final byte
 	// of the output with the offset. The representation of each
@@ -164,7 +218,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	out := make([][]byte, parts)
 	for idx := range out {
 		out[idx] = make([]byte, len(secret)+1)
-		out[idx][len(secret)] = uint8(xCoordinates[idx]) + 1
+		out[idx][len(secret)] = xCoordinates[idx]
 	}
 
 	// Construct a random polynomial for each byte of the secret.
@@ -181,7 +235,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 		// We cheat by encoding the x value once as the final index,
 		// so that it only needs to be stored once.
 		for i := 0; i < parts; i++ {
-			x := uint8(xCoordinates[i]) + 1
+			x := xCoordinates[i]
 			y := p.evaluate(x)
 			out[i][idx] = y
 		}

--- a/sdk/helper/shamir/shamir_test.go
+++ b/sdk/helper/shamir/shamir_test.go
@@ -103,6 +103,7 @@ func TestCombine(t *testing.T) {
 				if k == i || k == j {
 					continue
 				}
+
 				parts := [][]byte{out[i], out[j], out[k]}
 				recomb, err := Combine(parts)
 				if err != nil {
@@ -173,9 +174,18 @@ func TestPolynomial_Eval(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if out := p.evaluate(0); out != 42 {
-		t.Fatalf("bad: %v", out)
-	}
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("expected panic trying to call p.evaluate(0)")
+			}
+		}()
+
+		if out := p.evaluate(0); out != 42 {
+			t.Fatalf("bad: %v", out)
+		}
+	}()
 
 	out := p.evaluate(1)
 	exp := add(42, mult(1, p.coefficients[1]))


### PR DESCRIPTION
This adds several improvements to Shamir's implementation:

 1. Use a CS-PRNG with a shuffling algorithm to permute X coordinates in the range [1, 254], removing the need for a later +1 addition later.
 2. Panic in the (unreachable) event that the polynomial is evaluated at x == 0; this was already unreachable (and further explicit improvements to shuffling have ensured it remains so), and as it is in a private library function, panicing is an acceptable approach rather than returning an error.
 3. Annotate the inverse function to describe multiplications for maintainability.

Resolves: #182

Co-authored-by: @wavefnx