### PR TITLE
Add soft deletion of Transit keys

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -56,6 +56,8 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathImport(),
 			b.pathImportVersion(),
 			b.pathKeys(),
+			b.pathKeysSoftDelete(),
+			b.pathKeysSoftDeleteRestore(),
 			b.pathListKeys(),
 			b.pathBYOKExportKeys(),
 			b.pathExportKeys(),

--- a/builtin/logical/transit/path_backup_test.go
+++ b/builtin/logical/transit/path_backup_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	"github.com/openbao/openbao/sdk/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransit_BackupRestore(t *testing.T) {
+	t.Parallel()
+
 	// Test encryption/decryption after a restore for supported keys
 	testBackupRestore(t, "aes128-gcm96", "encrypt-decrypt")
 	testBackupRestore(t, "aes256-gcm96", "encrypt-decrypt")
@@ -83,12 +86,36 @@ func testBackupRestore(t *testing.T, keyType, feature string) {
 		t.Fatalf("resp: %#v\nerr: %v", resp, err)
 	}
 
-	// Take a backup of the key
+	// Soft delete the key; ensure a backup can be done, and then soft
+	// restore the key.
+	softDeleteReq := &logical.Request{
+		Path:      "keys/test/soft-delete",
+		Operation: logical.DeleteOperation,
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(context.Background(), softDeleteReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
 	backupReq := &logical.Request{
 		Path:      "backup/test",
 		Operation: logical.ReadOperation,
 		Storage:   s,
 	}
+	resp, err = b.HandleRequest(context.Background(), softDeleteReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	softRestoreReq := &logical.Request{
+		Path:      "keys/test/soft-delete-restore",
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(context.Background(), softRestoreReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Take a (real) backup of the key
 	resp, err = b.HandleRequest(context.Background(), backupReq)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("resp: %#v\nerr: %v", resp, err)

--- a/builtin/logical/transit/path_byok.go
+++ b/builtin/logical/transit/path_byok.go
@@ -78,6 +78,10 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 	}
 	defer dstP.Unlock()
 
+	if dstP.SoftDeleted {
+		return nil, fmt.Errorf("for destination key: %v", keysutil.ErrSoftDeleted)
+	}
+
 	srcP, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    src,
@@ -95,6 +99,10 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 
 	if !srcP.Exportable {
 		return logical.ErrorResponse("key is not exportable"), nil
+	}
+
+	if srcP.SoftDeleted {
+		return nil, fmt.Errorf("for source key: %v", keysutil.ErrSoftDeleted)
 	}
 
 	retKeys := map[string]string{}

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -95,6 +95,10 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("private key material is not exportable"), nil
 	}
 
+	if p.SoftDeleted {
+		return nil, fmt.Errorf("%v", keysutil.ErrSoftDeleted)
+	}
+
 	switch exportType {
 	case exportTypeEncryptionKey:
 		if !p.Type.EncryptionSupported() {

--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -1,9 +1,11 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package transit_test
+package transit
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -14,16 +16,16 @@ import (
 	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/builtin/audit/file"
-	"github.com/openbao/openbao/builtin/logical/transit"
 	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/logical"
 	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransit_Issue_2958(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
-			"transit": transit.Factory,
+			"transit": Factory,
 		},
 		AuditBackends: map[string]audit.Factory{
 			"file": file.Factory,
@@ -136,7 +138,7 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
-			"transit": transit.Factory,
+			"transit": Factory,
 		},
 	}
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
@@ -195,4 +197,239 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpsFailAfterDeletion(t *testing.T) {
+	t.Parallel()
+
+	testOpsFailAfterDeletion(t, "aes128-gcm96", true, false)
+	testOpsFailAfterDeletion(t, "aes256-gcm96", true, false)
+	testOpsFailAfterDeletion(t, "chacha20-poly1305", true, false)
+	testOpsFailAfterDeletion(t, "xchacha20-poly1305", true, false)
+	testOpsFailAfterDeletion(t, "rsa-2048", true, true)
+	testOpsFailAfterDeletion(t, "rsa-3072", true, true)
+	testOpsFailAfterDeletion(t, "rsa-4096", true, true)
+}
+
+func testOpsFailAfterDeletion(t *testing.T, keyType string, encrypt bool, sign bool) {
+	b, s := createBackendWithStorage(t)
+
+	// Create a key
+	req := &logical.Request{
+		Path:      "keys/test",
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type":       keyType,
+			"exportable": true,
+		},
+	}
+	if keyType == "hmac" {
+		req.Data["key_size"] = 32
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Now create a wrapping key for BYOK
+	req.Path = "keys/byok-key"
+	req.Data = map[string]interface{}{
+		"type": "rsa-4096",
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Validate ops work with the key.
+	validateOpsFail(t, b, s, encrypt, sign, false)
+
+	// Mark the key as soft deleted
+	req.Path = "keys/test/soft-delete"
+	req.Operation = logical.DeleteOperation
+	req.Data = nil
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Validate ops fail with the key now.
+	validateOpsFail(t, b, s, encrypt, sign, true)
+
+	// Restore the key.
+	req.Path = "keys/test/soft-delete-restore"
+	req.Operation = logical.UpdateOperation
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Validate ops work with the key.
+	validateOpsFail(t, b, s, encrypt, sign, false)
+}
+
+func validateOpsFail(t *testing.T, b *backend, s logical.Storage, encrypt bool, sign bool, expectedFailure bool) {
+	// Reading a key should always succeed
+	req := &logical.Request{
+		Path:      "keys/test",
+		Operation: logical.ReadOperation,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	req.Operation = logical.UpdateOperation
+
+	if encrypt {
+		// Encryption operations should succeed conditionally.
+		req.Path = "encrypt/test"
+		req.Data = map[string]interface{}{
+			"plaintext": base64.StdEncoding.EncodeToString([]byte("hello world")),
+		}
+
+		resp, err = b.HandleRequest(context.Background(), req)
+		if expectedFailure {
+			require.Error(t, err)
+			resp = &logical.Response{
+				Data: map[string]interface{}{},
+			}
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Contains(t, resp.Data, "ciphertext")
+			require.NotNil(t, resp.Data["ciphertext"])
+		}
+
+		req.Path = "decrypt/test"
+		req.Data = map[string]interface{}{
+			"ciphertext": resp.Data["ciphertext"],
+		}
+
+		resp, err = b.HandleRequest(context.Background(), req)
+		if expectedFailure {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Contains(t, resp.Data, "plaintext")
+			require.NotNil(t, resp.Data["plaintext"])
+		}
+	}
+
+	if sign {
+		// Signature operations should succeed conditionally.
+		req.Path = "sign/test"
+		req.Data = map[string]interface{}{
+			"input": base64.StdEncoding.EncodeToString([]byte("hello world")),
+		}
+
+		resp, err = b.HandleRequest(context.Background(), req)
+		if expectedFailure {
+			require.Error(t, err)
+			resp = &logical.Response{
+				Data: map[string]interface{}{},
+			}
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Contains(t, resp.Data, "signature")
+			require.NotNil(t, resp.Data["signature"])
+		}
+
+		req.Path = "verify/test"
+		req.Data = map[string]interface{}{
+			"input":     base64.StdEncoding.EncodeToString([]byte("hello world")),
+			"signature": resp.Data["signature"],
+		}
+
+		resp, err = b.HandleRequest(context.Background(), req)
+		if expectedFailure {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Contains(t, resp.Data, "valid")
+			require.NotNil(t, resp.Data["valid"])
+		}
+	}
+
+	// HMAC operations should succeed conditionally.
+	req.Path = "hmac/test"
+	req.Data = map[string]interface{}{
+		"input": base64.StdEncoding.EncodeToString([]byte("hello world")),
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if expectedFailure {
+		require.Error(t, err)
+		resp = &logical.Response{
+			Data: map[string]interface{}{},
+		}
+	} else {
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "hmac")
+		require.NotNil(t, resp.Data["hmac"])
+	}
+
+	req.Path = "verify/test"
+	req.Data = map[string]interface{}{
+		"input": base64.StdEncoding.EncodeToString([]byte("hello world")),
+		"hmac":  resp.Data["hmac"],
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if expectedFailure {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "valid")
+		require.NotNil(t, resp.Data["valid"])
+	}
+
+	// Validate that rotation conditionally fails
+	req.Path = "keys/test/rotate"
+	req.Data = nil
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if expectedFailure {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	}
+
+	// Validate that exporting conditionally fails.
+	req.Operation = logical.ReadOperation
+	if encrypt {
+		req.Path = "export/encryption-key/test"
+	} else if sign {
+		req.Path = "export/signing-key/test"
+	} else {
+		req.Path = "export/hmac-key/test"
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if expectedFailure {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err, "path: %v", req.Path)
+		require.NotNil(t, resp)
+	}
+
+	// Validate that BYOK exporting conditionally fails.
+	req.Path = "byok-export/byok-key/test"
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if expectedFailure {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	}
+
+	// Soft deleted keys remain updatable.
 }

--- a/changelog/211.txt
+++ b/changelog/211.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+secret/transit: Allow soft deletion of keys, preventing their use and rotation but retaining key material until restored or fully deleted.
+```
+```release-note:bug
+secret/transit: Allow use of generated destination wrapping keys rather than strictly requiring exported keys.
+```

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2332,8 +2332,11 @@ func (p *Policy) WrapKey(ver int, targetKey interface{}, targetKeyType KeyType, 
 func (ke *KeyEntry) WrapKey(targetKey interface{}, targetKeyType KeyType, hash hash.Hash) (string, error) {
 	// Presently this method implements a CKM_RSA_AES_KEY_WRAP-compatible
 	// wrapping interface and only works on RSA keyEntries as a result.
-	if ke.RSAPublicKey == nil {
+	if ke.RSAPublicKey == nil && ke.RSAKey == nil {
 		return "", fmt.Errorf("unsupported key type in use; must be a rsa key")
+	}
+	if !ke.IsPrivateKeyMissing() {
+		ke.RSAPublicKey = &ke.RSAKey.PublicKey
 	}
 
 	var preppedTargetKey []byte

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -510,6 +510,68 @@ $ curl \
     http://127.0.0.1:8200/v1/transit/keys/my-key/rotate
 ```
 
+## Soft delete key
+
+This endpoint softly deletes a named encryption key, allowing it to be
+restored later if this deletion was done in error. This doesn't depend
+on the value of `deletion_allowed`.
+
+The following operations will not work on the `:name`'d key until the
+key is restored:
+
+ - BYOK exporting, either as a source or destination key
+   (`/transit/byok-export/:dest/:name` and `/transit/byok-export/:name/:src`),
+ - Exporting (`/transit/export/:key_type/:name`),
+ - Encrypting and decrypting (`/transit/encrypt/:name` and
+   `/transit/decrypt/:name`),
+ - Signing and verifying including with HMAC keys (`/transit/sign/:name`,
+   `/transit/hmac/:name`, and `/transit/verify/:name`), and
+ - Rotating the specified key (`/transit/keys/:name/rotate`).
+
+However, this key will still be able to be updated, backed up, read, and will
+appear in list operations.
+
+| Method   | Path                              |
+| :------- | :-------------------------------- |
+| `DELETE` | `/transit/keys/:name/soft-delete` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the encryption key to
+  softly delete. This is specified as part of the URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request DELETE \
+    http://127.0.0.1:8200/v1/transit/keys/my-key/soft-delete
+```
+
+## Restore soft deleted key
+
+This endpoint restores a softly deleted named encryption key, allowing it to
+be used again.
+
+| Method | Path                                      |
+| :----- | :---------------------------------------- |
+| `POST` | `/transit/keys/:name/soft-delete-restore` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the encryption key to
+  restore from soft deletion. This is specified as part of the URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/transit/keys/my-key/soft-delete-restore
+```
+
 ## Securely export key
 
 This endpoint returns a wrapped copy of the `source` key, protected by the


### PR DESCRIPTION
This adds soft deletion of Transit keys, allowing users to mark keys as
deleted without impacting the ability to backup the key or affecting its
availability to be restored (but preventing all other operations). This
explicitly allows non-exportable keys to be more safely removed, first
via soft deletion (to see if any workloads break and to generally
prevent usage of the key) and then via permanent deletion.

Resolves: #88

---

I also noticed a bug while adding this:

When a RSA keypolicy is generated (and not merely imported),
`RSAPublicKey` is set to `nil`, incorrectly preventing the wrapping of
other keys with this policy. Fix this condition, allowing BYOK export
with destination (wrapping) keys created inside the same Transit
instance.