### PR TITLE
Allow customizing key export format in Transit

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -455,7 +455,7 @@ func (b *backend) formatKeyPolicy(p *keysutil.Policy, context []byte) (*logical.
 					key.Name = "rsa-4096"
 				}
 
-				pubKey, err := encodeRSAPublicKey(&v)
+				pubKey, err := encodeRSAPublicKey(&v, "")
 				if err != nil {
 					return nil, err
 				}

--- a/changelog/212.txt
+++ b/changelog/212.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/transit: Allow choosing export key format, specifying format=der or format=pem for consistent PKIX encoded public keys.
+```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -659,6 +659,15 @@ be valid.
   all versions of the key will be returned. This is specified as part of the
   URL. If the version is set to `latest`, the current key will be returned.
 
+- `format` `(string: "")` - Specifies the format of the exported key. The
+  empty string preserves existing behavior, with format unique to each key
+  type (`base64` encoded raw keys for symmetric keys or Ed25519 keys, PKCS#1
+  for RSA private keys, SEC 1 for EC private keys, and PKIX format for
+  RSA or EC public keys). The `raw` format always returns a base64 encoded
+  raw key (only applicable to symmetric keys and Ed25519 keys). The `der` and
+  `pem` formats always returns a PKIX (SubjectPublicKeyInfo) or PrivateKeyInfo
+  encoded object for asymmetric keys.
+
 ### Sample request
 
 ```shell-session


### PR DESCRIPTION
Transit's export functionality didn't allow choosing the desired output key format and was largely inconsistent about typing. Symmetric keys (and ed25519!) were returned in raw (base64-encoded byte array) format, but RSA and EC keys were returned in their native container formats. This prevents easy interoperability as some tools will not read all of these formats easily; add "der" and "pem" forms for asymmetric keys, to allow native PKIX-typed exports (in typed `SubjectPublicKeyInfo` or `PrivateKeyInfo` containers).

Resolves: #86