### PR TITLE
Add delta CRL distribution point extension

### DIFF
--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -2162,6 +2162,14 @@ WRITE:
 			return nil, fmt.Errorf("could not create crl delta indicator extension: %w", err)
 		}
 		extensions = []pkix.Extension{ext}
+	} else {
+		if len(signingBundle.URLs.DeltaCRLDistributionPoints) > 0 {
+			ext, err := certutil.CreateFreshestCRLExt(signingBundle.URLs.DeltaCRLDistributionPoints)
+			if err != nil {
+				return nil, fmt.Errorf("could not create delta CRL distribution point extension: %w", err)
+			}
+			extensions = []pkix.Extension{ext}
+		}
 	}
 
 	revocationListTemplate := &x509.RevocationList{

--- a/builtin/logical/pki/integration_test.go
+++ b/builtin/logical/pki/integration_test.go
@@ -526,10 +526,11 @@ func TestIntegrationOCSPClientWithPKI(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.Logical().Write("pki/config/urls", map[string]interface{}{
-		"enable_templating":       true,
-		"crl_distribution_points": "{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/der",
-		"issuing_certificates":    "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
-		"ocsp_servers":            "{{cluster_aia_path}}/ocsp",
+		"enable_templating":             true,
+		"crl_distribution_points":       "{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/der",
+		"issuing_certificates":          "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
+		"ocsp_servers":                  "{{cluster_aia_path}}/ocsp",
+		"delta_crl_distribution_points": "{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der",
 	})
 	require.NoError(t, err)
 

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -35,6 +35,13 @@ for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.`,
 for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.`,
 			},
 
+			"delta_crl_distribution_points": {
+				Type: framework.TypeCommaStringSlice,
+				Description: `Comma-separated list of URLs to be used
+for the Delta CRL distribution points attribute. See also RFC 5280 Section 4.2.1.15
+and Section 5.2.6.`,
+			},
+
 			"ocsp_servers": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of URLs to be used
@@ -75,6 +82,12 @@ for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.`,
 								Description: `Comma-separated list of URLs to be used
 for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.`,
 							},
+							"delta_crl_distribution_points": {
+								Type: framework.TypeCommaStringSlice,
+								Description: `Comma-separated list of URLs to be used
+for the Delta CRL distribution points attribute. See also RFC 5280 Section 4.2.1.15
+and Section 5.2.6.`,
+							},
 							"ocsp_servers": {
 								Type: framework.TypeCommaStringSlice,
 								Description: `Comma-separated list of URLs to be used
@@ -112,6 +125,13 @@ for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.`,
 								Type: framework.TypeCommaStringSlice,
 								Description: `Comma-separated list of URLs to be used
 for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.`,
+								Required: true,
+							},
+							"delta_crl_distribution_points": {
+								Type: framework.TypeCommaStringSlice,
+								Description: `Comma-separated list of URLs to be used
+for the Delta CRL distribution points attribute. See also RFC 5280 Section 4.2.1.15
+and Section 5.2.6.`,
 								Required: true,
 							},
 							"ocsp_servers": {
@@ -157,10 +177,11 @@ func getGlobalAIAURLs(ctx context.Context, storage logical.Storage) (*aiaConfigE
 	}
 
 	entries := &aiaConfigEntry{
-		IssuingCertificates:   []string{},
-		CRLDistributionPoints: []string{},
-		OCSPServers:           []string{},
-		EnableTemplating:      false,
+		IssuingCertificates:        []string{},
+		CRLDistributionPoints:      []string{},
+		DeltaCRLDistributionPoints: []string{},
+		OCSPServers:                []string{},
+		EnableTemplating:           false,
 	}
 
 	if entry == nil {
@@ -199,10 +220,11 @@ func (b *backend) pathReadURL(ctx context.Context, req *logical.Request, _ *fram
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"issuing_certificates":    entries.IssuingCertificates,
-			"crl_distribution_points": entries.CRLDistributionPoints,
-			"ocsp_servers":            entries.OCSPServers,
-			"enable_templating":       entries.EnableTemplating,
+			"issuing_certificates":          entries.IssuingCertificates,
+			"crl_distribution_points":       entries.CRLDistributionPoints,
+			"delta_crl_distribution_points": entries.DeltaCRLDistributionPoints,
+			"ocsp_servers":                  entries.OCSPServers,
+			"enable_templating":             entries.EnableTemplating,
 		},
 	}
 
@@ -224,16 +246,20 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 	if urlsInt, ok := data.GetOk("crl_distribution_points"); ok {
 		entries.CRLDistributionPoints = urlsInt.([]string)
 	}
+	if urlsInt, ok := data.GetOk("delta_crl_distribution_points"); ok {
+		entries.DeltaCRLDistributionPoints = urlsInt.([]string)
+	}
 	if urlsInt, ok := data.GetOk("ocsp_servers"); ok {
 		entries.OCSPServers = urlsInt.([]string)
 	}
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"issuing_certificates":    entries.IssuingCertificates,
-			"crl_distribution_points": entries.CRLDistributionPoints,
-			"ocsp_servers":            entries.OCSPServers,
-			"enable_templating":       entries.EnableTemplating,
+			"issuing_certificates":          entries.IssuingCertificates,
+			"crl_distribution_points":       entries.CRLDistributionPoints,
+			"delta_crl_distribution_points": entries.DeltaCRLDistributionPoints,
+			"ocsp_servers":                  entries.OCSPServers,
+			"enable_templating":             entries.EnableTemplating,
 		},
 	}
 
@@ -266,6 +292,11 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 				"invalid URL found in Authority Information Access (AIA) parameter crl_distribution_points: %s", badURL)), nil
 		}
 
+		if badURL := validateURLs(entries.DeltaCRLDistributionPoints); badURL != "" {
+			return logical.ErrorResponse(fmt.Sprintf(
+				"invalid URL found in Authority Information Access (AIA) parameter delta_crl_distribution_points: %s", badURL)), nil
+		}
+
 		if badURL := validateURLs(entries.OCSPServers); badURL != "" {
 			return logical.ErrorResponse(fmt.Sprintf(
 				"invalid URL found in Authority Information Access (AIA) parameter ocsp_servers: %s", badURL)), nil
@@ -280,7 +311,7 @@ func (b *backend) pathWriteURL(ctx context.Context, req *logical.Request, data *
 }
 
 const pathConfigURLsHelpSyn = `
-Set the URLs for the issuing CA, CRL distribution points, and OCSP servers.
+Set the URLs for the issuing CA, CRL and Delta CRL distribution points, and OCSP servers.
 `
 
 const pathConfigURLsHelpDesc = `
@@ -291,4 +322,7 @@ certificates. To delete URLs, simply re-set the appropriate value with an
 empty string.
 
 Multiple URLs can be specified for each type; use commas to separate them.
+
+When Delta CRL distribution points are set, they will appear both on
+certificates and on the complete CRL.
 `

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -592,6 +592,11 @@ func pathRevokeIssuer(b *backend) *framework.Path {
 								Description: `Specifies the URL values for the CRL Distribution Points field`,
 								Required:    true,
 							},
+							"delta_crl_distribution_points": {
+								Type:        framework.TypeStringSlice,
+								Description: `Specifies the URL values for the Delta CRL Distribution Points field`,
+								Required:    true,
+							},
 							"ocsp_servers": {
 								Type:        framework.TypeStringSlice,
 								Description: `Specifies the URL values for the OCSP Servers field`,

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -202,10 +202,11 @@ type clusterConfigEntry struct {
 }
 
 type aiaConfigEntry struct {
-	IssuingCertificates   []string `json:"issuing_certificates"`
-	CRLDistributionPoints []string `json:"crl_distribution_points"`
-	OCSPServers           []string `json:"ocsp_servers"`
-	EnableTemplating      bool     `json:"enable_templating"`
+	IssuingCertificates        []string `json:"issuing_certificates"`
+	CRLDistributionPoints      []string `json:"crl_distribution_points"`
+	DeltaCRLDistributionPoints []string `json:"delta_crl_distribution_points"`
+	OCSPServers                []string `json:"ocsp_servers"`
+	EnableTemplating           bool     `json:"enable_templating"`
 }
 
 func (c *aiaConfigEntry) toURLEntries(sc *storageContext, issuer issuerID) (*certutil.URLEntries, error) {
@@ -214,9 +215,10 @@ func (c *aiaConfigEntry) toURLEntries(sc *storageContext, issuer issuerID) (*cer
 	}
 
 	result := certutil.URLEntries{
-		IssuingCertificates:   c.IssuingCertificates[:],
-		CRLDistributionPoints: c.CRLDistributionPoints[:],
-		OCSPServers:           c.OCSPServers[:],
+		IssuingCertificates:        c.IssuingCertificates[:],
+		CRLDistributionPoints:      c.CRLDistributionPoints[:],
+		DeltaCRLDistributionPoints: c.DeltaCRLDistributionPoints[:],
+		OCSPServers:                c.OCSPServers[:],
 	}
 
 	if c.EnableTemplating {
@@ -226,9 +228,10 @@ func (c *aiaConfigEntry) toURLEntries(sc *storageContext, issuer issuerID) (*cer
 		}
 
 		for name, source := range map[string]*[]string{
-			"issuing_certificates":    &result.IssuingCertificates,
-			"crl_distribution_points": &result.CRLDistributionPoints,
-			"ocsp_servers":            &result.OCSPServers,
+			"issuing_certificates":          &result.IssuingCertificates,
+			"crl_distribution_points":       &result.CRLDistributionPoints,
+			"delta_crl_distribution_points": &result.DeltaCRLDistributionPoints,
+			"ocsp_servers":                  &result.OCSPServers,
 		} {
 			templated := make([]string, len(*source))
 			for index, uri := range *source {

--- a/changelog/215.txt
+++ b/changelog/215.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add Delta CRL Distribution Point to AIA URLs, allowing AIA-aware clients to find Delta CRLs dynamically.
+```

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -676,9 +676,10 @@ type IssueData struct {
 }
 
 type URLEntries struct {
-	IssuingCertificates   []string `json:"issuing_certificates" structs:"issuing_certificates" mapstructure:"issuing_certificates"`
-	CRLDistributionPoints []string `json:"crl_distribution_points" structs:"crl_distribution_points" mapstructure:"crl_distribution_points"`
-	OCSPServers           []string `json:"ocsp_servers" structs:"ocsp_servers" mapstructure:"ocsp_servers"`
+	IssuingCertificates        []string `json:"issuing_certificates" structs:"issuing_certificates" mapstructure:"issuing_certificates"`
+	CRLDistributionPoints      []string `json:"crl_distribution_points" structs:"crl_distribution_points" mapstructure:"crl_distribution_points"`
+	DeltaCRLDistributionPoints []string `json:"delta_crl_distribution_points" structs:"delta_crl_distribution_points" mapstructure:"delta_crl_distribution_points"`
+	OCSPServers                []string `json:"ocsp_servers" structs:"ocsp_servers" mapstructure:"ocsp_servers"`
 }
 
 type NotAfterBehavior int

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2775,10 +2775,17 @@ signature algorithm; this may not always be known at modification time.
 Note: When multiple issuers are in use under a single mount, each issuer will
 have its own CRL distribution point. These separate CRLs should either be
 aggregated into a single CRL (externally; as OpenBao does not support this
-functionality) or multiple `crl_distribution_points` should be specified
-here, pointing to each cluster and issuer.
+functionality) or multiple `crl_distribution_points` and
+`delta_crl_distribution_points` values should be specified here, pointing to
+each cluster and issuer.
 
 :::
+
+- `delta_crl_distribution_points` `(array<string>: nil)` - Specifies the URL values
+  for the Delta CRL Distribution Points field. This can be an array or a
+  comma-separated string list. See also [RFC 5280 Section 4.2.1.15](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.15)
+  and [Section 5.2.6](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.6)
+  for information about the Delta CRL Distribution Points field.
 
 - `ocsp_servers` `(array<string>: nil)` - Specifies the URL values for the OCSP
   Servers field. This can be an array or a comma-separated string list. See also
@@ -2786,10 +2793,11 @@ here, pointing to each cluster and issuer.
   for information about the Authority Information Access field.
 
 - `enable_aia_url_templating` `(bool: false)` - Specifies that the above AIA
-  URL values (`issuing_certificates`, `crl_distribution_points`, and
-  `ocsp_servers`) should be templated. This replaces the literal value
-  `{{issuer_id}}` with the ID of the issuer doing the issuance, the
-  literal value `{{cluster_path}}` with the value of `path` from the
+  URL values (`issuing_certificates`, `crl_distribution_points`, 
+  `delta_crl_distribution_points`, and `ocsp_servers`) should be
+  templated. This replaces the literal value `{{issuer_id}}` with the
+  ID of the issuer doing the issuance, the literal value
+  `{{cluster_path}}` with the value of `path` from the
   cluster-local configuration endpoint `/config/cluster`, and the
   literal value `{{cluster_aia_path}}` with the value of `aia_path` from
   the cluster-local configuration endpoint `/config/cluster`.
@@ -2838,6 +2846,7 @@ $ curl \
     "revocation_signature_algorithm": "",
     "issuing_certificates": ["<url1>", "<url2>"],
     "crl_distribution_points": ["<url1>", "<url2>"],
+    "delta_crl_distribution_points": ["<url1>", "<url2>"],
     "ocsp_servers": ["<url1>", "<url2>"]
   }
 }
@@ -3588,6 +3597,7 @@ $ curl \
   "data": {
     "issuing_certificates": ["<url1>", "<url2>"],
     "crl_distribution_points": ["<url1>", "<url2>"],
+    "delta_crl_distribution_points": ["<url1>", "<url2>"],
     "ocsp_servers": ["<url1>", "<url2>"]
   },
   "auth": null
@@ -3635,10 +3645,17 @@ the cluster-local address in configuration.
 Note: When multiple issuers are in use under a single mount, each issuer will
 have its own CRL distribution point. These separate CRLs should either be
 aggregated into a single CRL (externally; as OpenBao does not support this
-functionality) or multiple `crl_distribution_points` should be specified
-here, pointing to each cluster and issuer.
+functionality) or multiple `crl_distribution_points` and
+`delta_crl_distribution_points` values should be specified here, pointing
+to each cluster and issuer.
 
 :::
+
+- `delta_crl_distribution_points` `(array<string>: nil)` - Specifies the URL values
+  for the Delta CRL Distribution Points field. This can be an array or a
+  comma-separated string list. See also [RFC 5280 Section 4.2.1.15](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.15)
+  and [Section 5.2.6](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.6)
+  for information about the Delta CRL Distribution Points field.
 
 - `ocsp_servers` `(array<string>: nil)` - Specifies the URL values for the OCSP
   Servers field. This can be an array or a comma-separated string list. See also
@@ -3646,10 +3663,11 @@ here, pointing to each cluster and issuer.
   for information about the Authority Information Access field.
 
 - `enable_templating` `(bool: false)` - Specifies that the above AIA
-  URL values (`issuing_certificates`, `crl_distribution_points`, and
-  `ocsp_servers`) should be templated. This replaces the literal value
-  `{{issuer_id}}` with the ID of the issuer doing the issuance, the
-  literal value `{{cluster_path}}` with the value of `path` from the
+  URL values (`issuing_certificates`, `crl_distribution_points`,
+  `delta_crl_distribution_points` and `ocsp_servers`) should
+  be templated. This replaces the literal value `{{issuer_id}}`
+  with the ID of the issuer doing the issuance, the literal
+  value `{{cluster_path}}` with the value of `path` from the
   cluster-local configuration endpoint `/config/cluster`, and the
   literal value `{{cluster_aia_path}}` with the value of `aia_path` from
   the cluster-local configuration endpoint `/config/cluster`.
@@ -3661,6 +3679,7 @@ here, pointing to each cluster and issuer.
 
    - `issuing_certificates={{cluster_aia_path}}/issuer/{{issuer_id}}/der`
    - `crl_distribution_points={{cluster_aia_path}}/issuer/{{issuer_id}}/crl/der`
+   - `delta_crl_distribution_points={{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der`
    - `ocsp_servers={{cluster_aia_path}}/ocsp`
 
 :::warning
@@ -3676,6 +3695,7 @@ issuance will fail.
 {
   "issuing_certificates": ["{{cluster_aia_path}}/issuer/{{issuer_id}}/der"],
   "crl_distribution_points": ["{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/der"],
+  "delta_crl_distribution_points": ["{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der"],
   "ocsp_servers": ["{{cluster_aia_path}}/ocsp"]
 }
 ```


### PR DESCRIPTION
Adds a new AIA URL parameter, delta_crl_distribution_points, which controls where a Delta CRL is located, allowing AIA-aware clients to automatically fetch Delta CRLs as necessary. Unlike other AIA extensions, this extension also appears on the complete CRL, allowing clients with a complete CRL copy to also find the Delta CRL.

Resolves: #84