### PR TITLE
Add global handling of -non-interactive

### DIFF
--- a/builtin/credential/cert/cli.go
+++ b/builtin/credential/cert/cli.go
@@ -13,7 +13,7 @@ import (
 
 type CLIHandler struct{}
 
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	var data struct {
 		Mount string `mapstructure:"mount"`
 		Name  string `mapstructure:"name"`

--- a/builtin/credential/jwt/cli.go
+++ b/builtin/credential/jwt/cli.go
@@ -48,7 +48,7 @@ type loginResp struct {
 	err    error
 }
 
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	// handle ctrl-c while waiting for the callback
 	sigintCh := make(chan os.Signal, 1)
 	signal.Notify(sigintCh, authHalts...)

--- a/builtin/credential/kerberos/cli.go
+++ b/builtin/credential/kerberos/cli.go
@@ -22,7 +22,7 @@ import (
 type CLIHandler struct{}
 
 // Auth takes a client and a config map, and returns a secret if appropriate.
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	mount, ok := m["mount"]
 	if !ok {
 		mount = "kerberos"

--- a/builtin/credential/ldap/cli.go
+++ b/builtin/credential/ldap/cli.go
@@ -14,7 +14,7 @@ import (
 
 type CLIHandler struct{}
 
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	mount, ok := m["mount"]
 	if !ok {
 		mount = "ldap"
@@ -31,6 +31,10 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if !ok {
 		password = passwordFromEnv()
 		if password == "" {
+			if nonInteractive {
+				return nil, fmt.Errorf("'password' not supplied and refusing to pull from stdin")
+			}
+
 			fmt.Fprintf(os.Stderr, "Password (will be hidden): ")
 			var err error
 			password, err = pwd.Read(os.Stdin)

--- a/builtin/credential/token/cli.go
+++ b/builtin/credential/token/cli.go
@@ -20,7 +20,7 @@ type CLIHandler struct {
 	testStdout io.Writer
 }
 
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	// Parse "lookup" first - we want to return an early error if the user
 	// supplied an invalid value here before we prompt them for a token. It would
 	// be annoying to type your token and then be told you supplied an invalid
@@ -41,6 +41,10 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		stdout := h.testStdout
 		if stdout == nil {
 			stdout = os.Stderr
+		}
+
+		if nonInteractive {
+			return nil, fmt.Errorf("'token' not supplied and refusing to pull from stdin")
 		}
 
 		// No arguments given, read the token from user input

--- a/builtin/credential/userpass/cli.go
+++ b/builtin/credential/userpass/cli.go
@@ -17,7 +17,7 @@ type CLIHandler struct {
 	DefaultMount string
 }
 
-func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive bool) (*api.Secret, error) {
 	var data struct {
 		Username string `mapstructure:"username"`
 		Password string `mapstructure:"password"`
@@ -31,6 +31,10 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		return nil, fmt.Errorf("'username' must be specified")
 	}
 	if data.Password == "" {
+		if nonInteractive {
+			return nil, fmt.Errorf("'password' must be specified and refusing to pull from stdin")
+		}
+
 		fmt.Fprintf(os.Stderr, "Password (will be hidden): ")
 		password, err := pwd.Read(os.Stdin)
 		fmt.Fprintf(os.Stderr, "\n")

--- a/changelog/221.txt
+++ b/changelog/221.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Expand handling of -non-interactive to prevent reading from stdin.
+```

--- a/command/audit_enable.go
+++ b/command/audit_enable.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -130,6 +131,9 @@ func (c *AuditEnableCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	options, err := parseArgsDataString(stdin, args[1:])

--- a/command/delete.go
+++ b/command/delete.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -92,6 +93,9 @@ func (c *DeleteCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	path := sanitizePath(args[0])

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -156,6 +157,9 @@ func (c *KVPatchCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	switch {

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -119,6 +120,9 @@ func (c *KVPutCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	switch {

--- a/command/operator_generate_root.go
+++ b/command/operator_generate_root.go
@@ -317,6 +317,9 @@ func (c *OperatorGenerateRootCommand) decode(client *api.Client, encoded, otp st
 		if c.testStdin != nil {
 			stdin = c.testStdin
 		}
+		if c.flagNonInteractive {
+			stdin = bytes.NewReader(nil)
+		}
 
 		var buf bytes.Buffer
 		if _, err := io.Copy(&buf, stdin); err != nil {
@@ -433,6 +436,9 @@ func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, ki
 		if c.testStdin != nil {
 			stdin = c.testStdin
 		}
+		if c.flagNonInteractive {
+			stdin = bytes.NewReader(nil)
+		}
 
 		var buf bytes.Buffer
 		if _, err := io.Copy(&buf, stdin); err != nil {
@@ -444,6 +450,11 @@ func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, ki
 	case "": // Prompt using the tty
 		// Nonce value is not required if we are prompting via the terminal
 		nonce = status.Nonce
+
+		if c.flagNonInteractive {
+			c.UI.Error(wrapAtLength(fmt.Sprintf("Refusing to read from stdin with -non-interactive specified; specify nonce via the -nonce flag")))
+			return 1
+		}
 
 		w := getWriterFromUI(c.UI)
 		fmt.Fprintf(w, "Operation nonce: %s\n", nonce)

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -450,6 +450,9 @@ func (c *OperatorRekeyCommand) provide(client *api.Client, key string) int {
 		if c.testStdin != nil {
 			stdin = c.testStdin
 		}
+		if c.flagNonInteractive {
+			stdin = bytes.NewReader(nil)
+		}
 
 		var buf bytes.Buffer
 		if _, err := io.Copy(&buf, stdin); err != nil {
@@ -460,6 +463,11 @@ func (c *OperatorRekeyCommand) provide(client *api.Client, key string) int {
 		key = buf.String()
 	case "": // Prompt using the tty
 		// Nonce value is not required if we are prompting via the terminal
+		if c.flagNonInteractive {
+			c.UI.Error(wrapAtLength(fmt.Sprintf("Refusing to read from stdin with -non-interactive specified; specify nonce via the -nonce flag")))
+			return 1
+		}
+
 		w := getWriterFromUI(c.UI)
 		fmt.Fprintf(w, "Rekey operation nonce: %s\n", nonce)
 		fmt.Fprintf(w, "%s Key (will be hidden): ", keyTypeRequired)

--- a/command/operator_unseal.go
+++ b/command/operator_unseal.go
@@ -129,6 +129,11 @@ func (c *OperatorUnsealCommand) Run(args []string) int {
 	}
 
 	if unsealKey == "" {
+		if c.flagNonInteractive {
+			c.UI.Error(wrapAtLength(fmt.Sprintf("Refusing to read from stdin with -non-interactive specified; specify unseal key as an argument to this command")))
+			return 1
+		}
+
 		// Override the output
 		writer := (io.Writer)(os.Stdout)
 		if c.testOutput != nil {

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -50,6 +50,28 @@ func TestOperatorUnsealCommand_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("error_non_interactive", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testOperatorUnsealCommand(t)
+		cmd.client = client
+		cmd.testOutput = ioutil.Discard
+
+		code := cmd.Run([]string{"-non-interactive"})
+		if exp := 1; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Refusing to read from stdin"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
 	t.Run("reset", func(t *testing.T) {
 		t.Parallel()
 

--- a/command/patch.go
+++ b/command/patch.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -117,6 +118,9 @@ func (c *PatchCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	path := sanitizePath(args[0])

--- a/command/pki_issue_intermediate.go
+++ b/command/pki_issue_intermediate.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -86,6 +87,10 @@ func (c *PKIIssueCACommand) Run(args []string) int {
 	}
 
 	stdin := (io.Reader)(os.Stdin)
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
+	}
+
 	data, err := parseArgsData(stdin, args[2:])
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))

--- a/command/pki_reissue_intermediate.go
+++ b/command/pki_reissue_intermediate.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -81,6 +82,10 @@ func (c *PKIReIssueCACommand) Run(args []string) int {
 	}
 
 	stdin := (io.Reader)(os.Stdin)
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
+	}
+
 	userData, err := parseArgsData(stdin, args[3:])
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))

--- a/command/read.go
+++ b/command/read.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -89,6 +90,9 @@ func (c *ReadCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	path := sanitizePath(args[0])

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -488,6 +489,9 @@ func (c *SSHCommand) handleTypeCA(username, ip, port string, sshArgs []string) i
 
 	cmd := exec.Command(c.flagSSHExecutable, args...)
 	cmd.Stdin = os.Stdin
+	if c.flagNonInteractive {
+		cmd.Stdin = bytes.NewReader(nil)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -578,6 +582,9 @@ func (c *SSHCommand) handleTypeOTP(username, ip, port string, sshArgs []string) 
 	cmd.Env = env
 
 	cmd.Stdin = os.Stdin
+	if c.flagNonInteractive {
+		cmd.Stdin = bytes.NewReader(nil)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -649,6 +656,9 @@ func (c *SSHCommand) handleTypeDynamic(username, ip, port string, sshArgs []stri
 
 	cmd := exec.Command(c.flagSSHExecutable, args...)
 	cmd.Stdin = os.Stdin
+	if c.flagNonInteractive {
+		cmd.Stdin = bytes.NewReader(nil)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()

--- a/command/transit_import_key.go
+++ b/command/transit_import_key.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -12,6 +13,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -166,7 +168,12 @@ func ImportKey(c *BaseCommand, operation string, pathFunc ImportKeyFunc, flags *
 	importCiphertext := base64.StdEncoding.EncodeToString(combinedCiphertext)
 
 	// Parse all the key options
-	data, err := parseArgsData(os.Stdin, args[2:])
+	var stdin io.Reader = os.Stdin
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
+	}
+
+	data, err := parseArgsData(stdin, args[2:])
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to parse extra K=V data: %s", err))
 		return 1

--- a/command/write.go
+++ b/command/write.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -125,6 +126,9 @@ func (c *WriteCommand) Run(args []string) int {
 	stdin := (io.Reader)(os.Stdin)
 	if c.testStdin != nil {
 		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
 	}
 
 	path := sanitizePath(args[0])


### PR DESCRIPTION
This adds global handling of the `-non-interactive` flag introduced originally for non-interactive MFA support. Most commands with interactive use of `stdin` will either get an empty reader (presumably allowing it to err later) or explicitly err about not being passed input that would otherwise be requested via stdin (e.g., `operator unseal` or `login`).

Resolves: #220