### PR TITLE
Fix anchor generation in website partials

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -44,7 +44,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: "https://github.com/openbao/openbao/tree/main/website/",
-          remarkPlugins: [
+          beforeDefaultRemarkPlugins: [
             [
               includeMarkdown,
               {
@@ -71,7 +71,7 @@ const config: Config = {
         routeBasePath: "api-docs",
         sidebarPath: "./sidebarsApi.ts",
         editUrl: "https://github.com/openbao/openbao/tree/main/website/",
-        remarkPlugins: [
+        beforeDefaultRemarkPlugins: [
           [
             includeMarkdown,
             {


### PR DESCRIPTION
We use a custom plugin from upstream to include partials in our MDX docs
which can also contain MDX syntax that needs to be evaluated. The
inclusion needs to happen before the default docusaurus remark plugins
run for them to be able to properly evaluate the contained MDX syntax.

One example where this currently does not work is when we overwrite the
generated anchors of a heading.

**Current status:**
![image](https://github.com/openbao/openbao/assets/44572196/f0ac5657-b508-4b32-9bf6-c92d0413a8ec)

**Fixed status:**
![image](https://github.com/openbao/openbao/assets/44572196/f0ae4d78-1a38-431c-be43-ca260d1dd5ea)
