### PR TITLE
Use custom serialization of rabbitmq role

### DIFF
--- a/builtin/logical/rabbitmq/path_roles.go
+++ b/builtin/logical/rabbitmq/path_roles.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fatih/structs"
 	"github.com/openbao/openbao/sdk/framework"
 	"github.com/openbao/openbao/sdk/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/logical"
@@ -106,8 +105,33 @@ func (b *backend) pathRoleRead(ctx context.Context, req *logical.Request, d *fra
 		return nil, nil
 	}
 
+	resp := map[string]interface{}{}
+	resp["tags"] = role.Tags
+	respVHost := map[string]interface{}{}
+	for key, value := range role.VHosts {
+		respVHost[key] = map[string]interface{}{
+			"configure": value.Configure,
+			"write":     value.Write,
+			"read":      value.Read,
+		}
+	}
+	resp["vhosts"] = respVHost
+
+	respVHostTopics := map[string]interface{}{}
+	for key, topic := range role.VHostTopics {
+		respVHostTopic := map[string]interface{}{}
+		for topicKey, value := range topic {
+			respVHostTopic[topicKey] = map[string]interface{}{
+				"write": value.Write,
+				"read":  value.Read,
+			}
+		}
+		respVHostTopics[key] = respVHostTopic
+	}
+	resp["vhost_topics"] = respVHostTopics
+
 	return &logical.Response{
-		Data: structs.New(role).Map(),
+		Data: resp,
 	}, nil
 }
 

--- a/changelog/224.txt
+++ b/changelog/224.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secret/rabbitmq: Fix role reading causing audit log panic when vhost_topics are set.
+```


### PR DESCRIPTION
As reported by @mr-miles, the `rabbitmq` plugin can cause the audit subsystem to crash, due bad response serialization:

> ```
> 2024-03-19T18:50:37.610-0400 [ERROR] TestBackend_RoleReadCrash.core0.audit: panic during logging: request_path=rabbitmq/roles/newrole error="reflect: reflect.Value.Set using unaddressable value"
> ... output elided ...
>   | github.com/openbao/openbao/audit.HashResponse(0xc000739c00, 0xc000ccc6e0, 0x0, {0x0, 0x0, 0x0}, 0x0)
>   | \t/home/cipherboy/GitHub/cipherboy/openbao/audit/hashstructure.go:148 +0x311
>   | github.com/openbao/openbao/audit.(*AuditFormatter).FormatResponse(0xc000760130, {0x33d9068, 0xc0011be210}, {0x33b2b40, 0xc0011be8a0}, {0x0?, 0x0?, 0x0?, 0x0?}, 0xc000304b60)
> ```

This occurs because the output type of the response is bad and includes nested private types (`rabbitmq.vhostTopicPermission`):

> ```
> response from structs: map[string]interface{}
>  {"tags":"administrator",
>   "vhost_topics":map[string]map[string]rabbitmq.vhostTopicPermission
>   {"/":map[string]rabbitmq.vhostTopicPermission{
>    "amq.topic":rabbitmq.vhostTopicPermission{Write:".*", Read:".*"}}},
>   "vhosts":map[string]interface{}{
>    "/":map[string]interface{}{
>     "configure":".*", "read":".*", "write":".*"}}}
> ```

Fixing this requires custom serialization of the response, in line with other plugins (e.g., PKI).

Resolves: #97