### PR TITLE
Issue 225: Add Merge Queue Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 
 on:
-  workflow_dispatch:
+  merge_group:
   pull_request:
     # The default types for pull_request are [ opened, synchronize, reopened ].
     # This is insufficient for our needs, since we're skipping stuff on PRs in
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - release/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-build

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -4,6 +4,7 @@
 name: Check Changelog
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
     # Runs on PRs to main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  merge_group:
   pull_request:
     # The default types for pull_request are [ opened, synchronize, reopened ].
     # This is insufficient for our needs, since we're skipping stuff on PRs in

--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -1,6 +1,7 @@
 name: Run linters
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:

--- a/.github/workflows/dummy-dco-merge-queue.yml
+++ b/.github/workflows/dummy-dco-merge-queue.yml
@@ -1,0 +1,13 @@
+# DCO bot does not currently support GitHub Merge Queues. https://github.com/dcoapp/app/issues/199
+# This is a dummy workflow to automatically force the check to pass. Pull Requests are checked by the DCO bot prior
+# to being added to the Merge Queue. Pull Requests that fail the check are never added for merge.
+name: DCO
+on:
+  merge_group:
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"


### PR DESCRIPTION
References: #225

Changes:
- Added `merge_queue` triggers to existing GitHub workflows.
- Added a dummy workflow work-around for the DCO bot.