### PR TITLE
remove obsolete docs sidebar entry

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -400,7 +400,6 @@ const sidebars: SidebarsConfig = {
             Platforms: [
                 "platform/index",
                 {
-                    AWS: ["platform/aws/lambda-extension"],
                     GitHub: ["platform/github-actions"],
                     Kubernetes: [
                         "platform/k8s/index",
@@ -478,15 +477,8 @@ const sidebars: SidebarsConfig = {
                 "policies/deprecation",
                 "policies/plugins",
             ],
-            RFCs: [
-                "rfcs/index",
-                "rfcs/paginated-lists",
-            ],
-            FAQ: [
-                "faq/index",
-                "deprecation/faq",
-                "auth/login-mfa/faq",
-            ],
+            RFCs: ["rfcs/index", "rfcs/paginated-lists"],
+            FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },
         "glossary",
     ],


### PR DESCRIPTION
The AWS lambda extension docs were removed, but the sidebar entry is
still there. This blocks the website from being build