### PR TITLE
Allow container upload to multiple registries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm, arm64, amd64]
-        registry: [hub.docker.com, quay.io, ghcr.io]
+        registry: [docker.io, quay.io, ghcr.io]
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.product-metadata.outputs.bao-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: hashicorp/actions-generate-metadata@v1
         id: generate-metadata-file
         with:
-          repositoryOwner: "openbao"
+          repositoryOwner: 'openbao'
           version: ${{ steps.set-product-version.outputs.product-version }}
           product: ${{ steps.get-metadata.outputs.package-name }}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -71,44 +71,45 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
           if-no-files-found: error
 
-  ## Disable UI temporarily.
-  #
-  #  build-ui:
-  #    name: UI
-  #    runs-on: ubuntu-latest
-  #    outputs:
-  #      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-  #    steps:
-  #      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-  #      - name: Get UI hash
-  #        id: ui-hash
-  #        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
-  #      - name: Set up UI asset cache
-  #        id: cache-ui-assets
-  #        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
-  #        with:
-  #          enableCrossOsArchive: true
-  #          lookup-only: true
-  #          path: http/web_ui
-  #          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
-  #          # Never do a partial restore of the web_ui if we don't get a cache hit.
-  #          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-  #        name: Set up node and yarn
-  #        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
-  #        with:
-  #          node-version-file: ui/package.json
-  #          cache: yarn
-  #          cache-dependency-path: ui/yarn.lock
-  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-  #        name: Build UI
-  #        run: make ci-build-ui
+## Disable UI temporarily.
+#
+#  build-ui:
+#    name: UI
+#    runs-on: ubuntu-latest
+#    outputs:
+#      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+#    steps:
+#      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#      - name: Get UI hash
+#        id: ui-hash
+#        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
+#      - name: Set up UI asset cache
+#        id: cache-ui-assets
+#        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+#        with:
+#          enableCrossOsArchive: true
+#          lookup-only: true
+#          path: http/web_ui
+#          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
+#          # Never do a partial restore of the web_ui if we don't get a cache hit.
+#          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+#        name: Set up node and yarn
+#        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+#        with:
+#          node-version-file: ui/package.json
+#          cache: yarn
+#          cache-dependency-path: ui/yarn.lock
+#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+#        name: Build UI
+#        run: make ci-build-ui
+
 
   build-other:
     name: Other
     needs:
       - product-metadata
-    #      - build-ui
+#      - build-ui
     strategy:
       matrix:
         goos: [freebsd, windows, netbsd, openbsd, solaris]
@@ -126,7 +127,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -134,7 +135,7 @@ jobs:
     name: Linux
     needs:
       - product-metadata
-    #      - build-ui
+#      - build-ui
     strategy:
       matrix:
         goos: [linux]
@@ -146,7 +147,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -154,7 +155,7 @@ jobs:
     name: Darwin
     needs:
       - product-metadata
-    #      - build-ui
+#      - build-ui
     strategy:
       matrix:
         goos: [darwin]
@@ -167,7 +168,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: hashicorp/actions-generate-metadata@v1
         id: generate-metadata-file
         with:
-          repositoryOwner: 'openbao'
+          repositoryOwner: "openbao"
           version: ${{ steps.set-product-version.outputs.product-version }}
           product: ${{ steps.get-metadata.outputs.package-name }}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -71,45 +71,44 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
           if-no-files-found: error
 
-## Disable UI temporarily.
-#
-#  build-ui:
-#    name: UI
-#    runs-on: ubuntu-latest
-#    outputs:
-#      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-#    steps:
-#      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#      - name: Get UI hash
-#        id: ui-hash
-#        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
-#      - name: Set up UI asset cache
-#        id: cache-ui-assets
-#        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
-#        with:
-#          enableCrossOsArchive: true
-#          lookup-only: true
-#          path: http/web_ui
-#          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
-#          # Never do a partial restore of the web_ui if we don't get a cache hit.
-#          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-#        name: Set up node and yarn
-#        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
-#        with:
-#          node-version-file: ui/package.json
-#          cache: yarn
-#          cache-dependency-path: ui/yarn.lock
-#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-#        name: Build UI
-#        run: make ci-build-ui
-
+  ## Disable UI temporarily.
+  #
+  #  build-ui:
+  #    name: UI
+  #    runs-on: ubuntu-latest
+  #    outputs:
+  #      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+  #    steps:
+  #      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #      - name: Get UI hash
+  #        id: ui-hash
+  #        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
+  #      - name: Set up UI asset cache
+  #        id: cache-ui-assets
+  #        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+  #        with:
+  #          enableCrossOsArchive: true
+  #          lookup-only: true
+  #          path: http/web_ui
+  #          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
+  #          # Never do a partial restore of the web_ui if we don't get a cache hit.
+  #          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+  #        name: Set up node and yarn
+  #        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+  #        with:
+  #          node-version-file: ui/package.json
+  #          cache: yarn
+  #          cache-dependency-path: ui/yarn.lock
+  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+  #        name: Build UI
+  #        run: make ci-build-ui
 
   build-other:
     name: Other
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [freebsd, windows, netbsd, openbsd, solaris]
@@ -127,7 +126,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -135,7 +134,7 @@ jobs:
     name: Linux
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [linux]
@@ -147,7 +146,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -155,7 +154,7 @@ jobs:
     name: Darwin
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [darwin]
@@ -168,7 +167,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -181,6 +180,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm, arm64, amd64]
+        registry: [hub.docker.com, quay.io, ghcr.io]
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.product-metadata.outputs.bao-version }}
@@ -194,7 +194,7 @@ jobs:
           arch: ${{ matrix.arch }}
           zip_artifact_name: openbao_${{ env.version }}_linux_${{ matrix.arch }}.zip
           tags: |
-            docker.io/openbao/${{ env.repo }}:${{ env.version }}
+            ${{ matrix.registry }}/openbao/${{ env.repo }}:${{ env.version }}
 
   build-ubi:
     name: UBI image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ on:
       prerelease:
         description: "Mark this release as a prerelease"
         required: false
-        default: 'auto'
+        default: "auto"
         type: choice
         # auto follows semver. Prerelease versions are hyphenated with a label. ex. 0.0.0-alpha, 1.0.0-rc1
         options:
           - auto
-          - 'true'
-          - 'false'
+          - "true"
+          - "false"
       make-latest:
         description: "Latest release"
         required: false
@@ -71,7 +71,6 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSWORD }}
 
-
       - name: Cache Setup
         uses: actions/cache@v4
         with:
@@ -97,7 +96,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: "Docker Login: ghcr.io"
+      - name: "Docker Login: quay.io"
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3
         with:
@@ -113,7 +112,7 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY_BASE64 }}" | base64 -di > "${GPG_KEY_FILE}"
           echo "GPG_KEY_FILE=${GPG_KEY_FILE}" >> "${GITHUB_ENV}"
         env:
-          GPG_TTY: /dev/ttys000  # Set the GPG_TTY to avoid issues with pinentry
+          GPG_TTY: /dev/ttys000 # Set the GPG_TTY to avoid issues with pinentry
 
       - name: "GoReleaser: Release"
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Docker Login: docker.io"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: "Docker Login: ghcr.io"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
         # Needed for nPFM
       - name: Create GPG Signing Key File
         if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,7 +119,7 @@ nfpms:
     homepage: https://github.com/openbao/openbao
     maintainer: OpenBao
     description: |
-      OpenBao exists to provide a software solution to manage, store, and distribute 
+      OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.
     license: MPL-2.0
     formats:
@@ -229,7 +229,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64"
       - "quay.io/openbao/openbao:{{ .Version }}-alpine-amd64"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64"
+      - "docker.io/openbao/openbao:{{ .Version }}-alpine-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -265,7 +265,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm"
       - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm"
+      - "docker.io/openbao/openbao:{{ .Version }}-alpine-arm"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -301,7 +301,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64"
       - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm64"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64"
+      - "docker.io/openbao/openbao:{{ .Version }}-alpine-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -336,7 +336,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
       - "quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64"
+      - "docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -371,7 +371,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64"
       - "quay.io/openbao/openbao:{{ .Version }}-ubi-amd64"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64"
+      - "docker.io/openbao/openbao:{{ .Version }}-ubi-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
@@ -407,7 +407,7 @@ dockers:
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64"
       - "quay.io/openbao/openbao:{{ .Version }}-ubi-arm64"
-      - "hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64"
+      - "docker.io/openbao/openbao:{{ .Version }}-ubi-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
@@ -450,42 +450,42 @@ docker_manifests:
       - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
       - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
       - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: hub.docker.com/openbao/openbao:{{ .Version }}
+  - name_template: docker.io/openbao/openbao:{{ .Version }}
     skip_push: false
     image_templates:
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: hub.docker.com/openbao/openbao:{{ .Major }}.{{ .Minor }}
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: docker.io/openbao/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: hub.docker.com/openbao/openbao:{{ .Major }}
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: docker.io/openbao/openbao:{{ .Major }}
     skip_push: false
     image_templates:
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: hub.docker.com/openbao/openbao:latest
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: docker.io/openbao/openbao:latest
     skip_push: false
     image_templates:
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
-      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
   - name_template: quay.io/openbao/openbao:{{ .Version }}
     skip_push: false
     image_templates:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,7 +119,7 @@ nfpms:
     homepage: https://github.com/openbao/openbao
     maintainer: OpenBao
     description: |
-      OpenBao exists to provide a software solution to manage, store, and distribute
+      OpenBao exists to provide a software solution to manage, store, and distribute 
       sensitive data including secrets, certificates, and keys.
     license: MPL-2.0
     formats:
@@ -221,7 +221,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
@@ -257,7 +257,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
@@ -293,7 +293,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
@@ -328,7 +328,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
@@ -363,7 +363,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
@@ -399,7 +399,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,7 +119,7 @@ nfpms:
     homepage: https://github.com/openbao/openbao
     maintainer: OpenBao
     description: |
-      OpenBao exists to provide a software solution to manage, store, and distribute 
+      OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.
     license: MPL-2.0
     formats:
@@ -221,13 +221,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64"
+      - "quay.io/openbao/openbao:{{ .Version }}-alpine-amd64"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -255,13 +257,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm"
+      - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -289,13 +293,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64"
+      - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm64"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -322,13 +328,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=default-riscv64"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
+      - "quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -355,13 +363,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=ubi"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64"
+      - "quay.io/openbao/openbao:{{ .Version }}-ubi-amd64"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
@@ -389,13 +399,15 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MPL-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
       - "--target=ubi"
     image_templates:
       - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64"
+      - "quay.io/openbao/openbao:{{ .Version }}-ubi-arm64"
+      - "hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
@@ -438,6 +450,78 @@ docker_manifests:
       - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
       - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
       - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: hub.docker.com/openbao/openbao:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: hub.docker.com/openbao/openbao:{{ .Major }}.{{ .Minor }}
+    skip_push: false
+    image_templates:
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: hub.docker.com/openbao/openbao:{{ .Major }}
+    skip_push: false
+    image_templates:
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: hub.docker.com/openbao/openbao:latest
+    skip_push: false
+    image_templates:
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-arm64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-amd64
+      - hub.docker.com/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: quay.io/openbao/openbao:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: quay.io/openbao/openbao:{{ .Major }}.{{ .Minor }}
+    skip_push: false
+    image_templates:
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: quay.io/openbao/openbao:{{ .Major }}
+    skip_push: false
+    image_templates:
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
+  - name_template: quay.io/openbao/openbao:latest
+    skip_push: false
+    image_templates:
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
+      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
+      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
 
 archives:
   - format: tar.gz

--- a/changelog/269.txt
+++ b/changelog/269.txt
@@ -1,0 +1,3 @@
+```release-note:change
+IMPROVEMENTS: added other registries for docker images
+```


### PR DESCRIPTION
Fixes #260 
Allows pushes to Docker hub, ghcr.io, and quay.io.
Needs secrets to be added for Docker and quay.io.