### PR TITLE
Update dependency to sigs.k8s.io/yaml

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/ryanuber/columnize"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
+	"sigs.k8s.io/yaml"
 )
 
 type mockUi struct {

--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/openbao/openbao/command/healthcheck"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/cli"
 	"github.com/posener/complete"
 	"github.com/ryanuber/columnize"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/command/pki_list_intermediate.go
+++ b/command/pki_list_intermediate.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/openbao/openbao/api/v2"
 
-	"github.com/ghodss/yaml"
 	"github.com/ryanuber/columnize"
+	"sigs.k8s.io/yaml"
 )
 
 type PKIListIntermediateCommand struct {

--- a/command/pki_verify_sign.go
+++ b/command/pki_verify_sign.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/openbao/openbao/command/healthcheck"
 
-	"github.com/ghodss/yaml"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/ryanuber/columnize"
+	"sigs.k8s.io/yaml"
 )
 
 type PKIVerifySignCommand struct {

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/favadi/protoc-go-inject-tag v1.4.0
 	github.com/gammazero/workerpool v1.1.3
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-errors/errors v1.4.2
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/go-ldap/ldap/v3 v3.4.4
@@ -168,6 +167,7 @@ require (
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
 	layeh.com/radius v0.0.0-20230922032716-6579be8edf5d
 	mvdan.cc/gofumpt v0.3.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -359,7 +359,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 retract [v0.1.0, v1.17.0]

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,6 @@ github.com/gammazero/workerpool v1.1.3 h1:WixN4xzukFoN0XSeXF6puqEqFTl2mECI9S6W44
 github.com/gammazero/workerpool v1.1.3/go.mod h1:wPjyBLDbyKnUn2XwwyD3EEwo9dHutia9/fwNmSHWACc=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
-github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-asn1-ber/asn1-ber v1.4.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=


### PR DESCRIPTION
Module `github.com/ghodss/yaml` is not maintained anymore and `sigs.k8s.io/yaml` is a maintained fork that is already pulled by other dependencies.