### PR TITLE
Transactional storage - Tests & RFC

### DIFF
--- a/changelog/292.txt
+++ b/changelog/292.txt
@@ -1,0 +1,10 @@
+```release-note:feature
+**Transactional Storage**: Plugin developers can now take advantage of safe
+  storage modification APIs when the underlying physical storage supports
+  them. The `physical.TransactionalBackend` and `logical.TransactionalStorage`
+  types allow developers to begin read-only and writable transactions,
+  committing or rolling back the desired changes.
+```
+```release-note:improvement
+storage/raft: Add support for transactional storage semantics.
+```

--- a/physical/crosstest/cross_test.go
+++ b/physical/crosstest/cross_test.go
@@ -1,0 +1,1255 @@
+// We wish to build a backend cross-testing framework which allows us to find
+// differences in the way various storage interfaces behave. This will also
+// ultimately allow us to compose and stack various layers to ensure we have
+// correct semantics across composition as well.
+//
+// In OpenBao, the following storage layers are used, from lowest to highest:
+//
+//	[disk]
+//	1. A low-level backend, such as raft, file, or inmem. Only the former is
+//	   supported for production use, but inmem is frequently used for dev mode
+//	   and as a part of our test suite.
+//	2. A cache; this caches read operations, avoiding having to round-trip to
+//	   a potentially slow backend over a slow network for repeated reads to
+//	   the same entry.
+//	3. An error validation layer (encoding); this prevents writes with invalid
+//	   keys (non-utf-8 or non-printable characters).
+//	4. Our barrier encryption; this handles all encryption of storage entries.
+//	   At this point, we convert a physical.Backend into a logical.Storage
+//	   interface.
+//	5. A storage view; this restricts the access of the above barrier
+//	   encryption layer to a prefix.
+//	6. A barrier view; this is what is ultimately given to the backends; it
+//	   has a limited interface.
+//	[plugin]
+//
+// In the event of a GRPC-attached plugin, another layer appears as the GRPC
+// client stubs out support to transit storage operations through to the
+// GRPC server, though this isn't tested here.
+package crosstest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/armon/go-metrics"
+	"github.com/go-test/deep"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openbao/openbao/physical/postgresql"
+	"github.com/openbao/openbao/physical/raft"
+	"github.com/openbao/openbao/sdk/v2/helper/logging"
+	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/openbao/openbao/sdk/v2/physical/file"
+	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+)
+
+const (
+	opsLogFile   = "/tmp/openbao-physical-random-ops.json"
+	txOpsLogFile = "/tmp/openbao-physical-random-tx-ops.json"
+	numOps       = 1000
+	numTxOps     = numOps
+)
+
+func Test_ExerciseBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allPhysical(t)
+	defer cleanup()
+
+	exerciseBackends(t, backends)
+
+	// If any were transactions, let's rollback. We can't commit them as
+	// we wrote to the same area of storage in lots of places.
+	for name, backend := range backends {
+		if txn, ok := backend.(physical.Transaction); ok {
+			err := txn.Rollback(context.Background())
+			require.NoError(t, err, "failed to rollback transaction: %v", name)
+		}
+	}
+}
+
+func Test_RandomOpsBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allPhysical(t)
+	defer cleanup()
+
+	ops := getRandomOps(t, numOps, false, 0)
+	// ops := replayOps(t, opsLogFile)
+	executeRandomOps(t, backends, ops)
+}
+
+func Test_RandomOpsTransactionalBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allTransactionalPhysical(t)
+	defer cleanup()
+
+	txLimit := 10
+	ops := getRandomOps(t, numTxOps, true, txLimit)
+	executeRandomTransactionalOps(t, backends, ops, txLimit)
+}
+
+func replayOps(t *testing.T, file string) []*inmem.InmemOp {
+	data, err := os.ReadFile(file)
+	require.NoError(t, err, "error reading operations file")
+
+	var results []*inmem.InmemOp
+	err = json.Unmarshal(data, &results)
+	require.NoError(t, err, "error unmarshaling operations json")
+
+	return results
+}
+
+func Test_ExerciseTransactionalBackends(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	backends, cleanup := allTransactionalPhysical(t)
+	defer cleanup()
+
+	// Create transactions and exercise the backend, rolling them back.
+	txns := make(map[string]physical.Backend, 2*len(backends))
+	for name, backend := range backends {
+		txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create write transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-rw", name)] = txn
+
+		ro_txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create read-only transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-ro", name)] = ro_txn
+	}
+
+	exerciseBackends(t, txns)
+
+	for name, txn := range txns {
+		err := txn.(physical.Transaction).Rollback(ctx)
+		require.NoError(t, err, "failed to rollback transaction: %v", name)
+	}
+
+	// Ensure we can do a single read/write transactions and commit them.
+	// This will leave us with an empty state, but potentially entries in
+	// any transaction logs.
+	txns = make(map[string]physical.Backend, len(backends))
+	for name, backend := range backends {
+		txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create write transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-rw", name)] = txn
+	}
+
+	exerciseBackends(t, txns)
+
+	for name, txn := range txns {
+		err := txn.(physical.Transaction).Commit(ctx)
+		require.NoError(t, err, "failed to commit transaction: %v", name)
+	}
+
+	// Finally, exercise transactions.
+	exerciseTransactions(t, backends)
+}
+
+func getFile(t *testing.T, logger log.Logger) (physical.Backend, func()) {
+	backendPath, err := ioutil.TempDir("", "vault")
+	require.NoError(t, err, "error while creating file storage")
+
+	b, err := file.NewFileBackend(map[string]string{
+		"path": backendPath,
+	}, logger)
+	require.NoError(t, err, "error while initializing file backend")
+
+	return b, func() {
+		os.RemoveAll(backendPath)
+	}
+}
+
+func allPhysical(t *testing.T) (map[string]physical.Backend, func()) {
+	ctx := context.Background()
+	logger := logging.NewVaultLogger(log.Debug)
+	disableTxConf := map[string]string{"disable_transactions": "true"}
+
+	// Basic storage backends.
+
+	// raft, no transaction called on it.
+	prb, raftPureDir := raft.GetRaft(t, true, true)
+
+	// raft
+	rb, raftDir := raft.GetRaft(t, true, true)
+
+	// raft-in-tx
+	//
+	// Inside a raft transaction should behave the same as outside
+	// if it is writable. We are fine to reuse the same raft instance
+	// here as the transaction should not see stuff created after it.
+	rt, err := rb.BeginTx(ctx)
+	require.NoError(t, err, "failed to start raft transaction")
+
+	// file
+	fb, fileCleanup := getFile(t, logger)
+
+	// inmem
+	inm, err := inmem.NewInmem(disableTxConf, logger)
+	require.NoError(t, err, "failed to create in-memory backend")
+
+	// txinmem
+	_txinm, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-memory backend")
+	txinm := _txinm.(physical.TransactionalBackend)
+
+	// txinmem-in-tx
+	txinmtx, err := txinm.BeginTx(ctx)
+	require.NoError(t, err, "failed to start transaction from transactional in-memory backend")
+
+	// postgresql
+	psql, psqlCleanup := postgresql.GetTestPostgreSQLBackend(t, logger)
+
+	// Now compose multiple storage backends together!
+
+	// raft + cache
+	rbc, raftCacheDir := raft.GetRaft(t, true, true)
+	crb := physical.NewCache(rbc, 0, logger, &metrics.BlackholeSink{})
+
+	// raft + cache-in-tx
+	rbctx := physical.NewCache(rbc, 0, logger, &metrics.BlackholeSink{})
+	ctxr, err := rbctx.(physical.TransactionalBackend).BeginTx(ctx)
+	require.NoError(t, err, "failed to start cache transaction from raft backend")
+
+	// raft-in-tx + cache
+	rtc, err := rbc.BeginTx(ctx)
+	require.NoError(t, err, "failed to start raft transaction for cache")
+	crt := physical.NewCache(rtc, 0, logger, &metrics.BlackholeSink{})
+
+	// file + cache
+	fbc, fileCacheCleanup := getFile(t, logger)
+	cfb := physical.NewCache(fbc, 0, logger, &metrics.BlackholeSink{})
+
+	// inmem + cache
+	inmc, err := inmem.NewInmem(disableTxConf, logger)
+	require.NoError(t, err, "failed to create in-memory backend for cache")
+	cinm := physical.NewCache(inmc, 0, logger, &metrics.BlackholeSink{})
+
+	// psql + cache
+	psqlc, psqlcCleanup := postgresql.GetTestPostgreSQLBackend(t, logger)
+	cpsql := physical.NewCache(psqlc, 0, logger, &metrics.BlackholeSink{})
+
+	// raft + encoding
+	rbe, raftEncodingDir := raft.GetRaft(t, true, true)
+	erb := physical.NewStorageEncoding(rbe)
+
+	// raft + encoding-in-tx
+	rbetx := physical.NewStorageEncoding(rbe)
+	etxr, err := rbetx.(physical.TransactionalBackend).BeginTx(ctx)
+	require.NoError(t, err, "failed to start encoding transaction from raft backend")
+
+	// raft-in-tx + encoding
+	rte, err := rbe.BeginTx(ctx)
+	require.NoError(t, err, "failed to start raft transaction for encoding")
+	ert := physical.NewStorageEncoding(rte)
+
+	// file + encoding
+	fbe, fileEncodingCleanup := getFile(t, logger)
+	efb := physical.NewStorageEncoding(fbe)
+
+	// inmem + encoding
+	inme, err := inmem.NewInmem(disableTxConf, logger)
+	require.NoError(t, err, "failed to create in-memory backend for encoding")
+	einm := physical.NewStorageEncoding(inme)
+
+	// psql + encoding
+	psqle, psqleCleanup := postgresql.GetTestPostgreSQLBackend(t, logger)
+	epsql := physical.NewStorageEncoding(psqle)
+
+	// raft + cache + encoding
+	rbce, raftCacheEncodingDir := raft.GetRaft(t, true, true)
+	crbe := physical.NewCache(rbce, 0, logger, &metrics.BlackholeSink{})
+	erbc := physical.NewStorageEncoding(crbe)
+
+	// file + cache + encoding
+	fbce, fileCacheEncodingCleanup := getFile(t, logger)
+	cfbe := physical.NewCache(fbce, 0, logger, &metrics.BlackholeSink{})
+	efbc := physical.NewStorageEncoding(cfbe)
+
+	// inmem + cache + encoding
+	inmce, err := inmem.NewInmem(disableTxConf, logger)
+	require.NoError(t, err, "failed to create in-memory backend for cache+encoding")
+	cinme := physical.NewCache(inmce, 0, logger, &metrics.BlackholeSink{})
+	einmc := physical.NewStorageEncoding(cinme)
+
+	// psql + encoding
+	psqlce, psqlceCleanup := postgresql.GetTestPostgreSQLBackend(t, logger)
+	cpsqle := physical.NewCache(psqlce, 0, logger, &metrics.BlackholeSink{})
+	epsqlc := physical.NewStorageEncoding(cpsqle)
+
+	return map[string]physical.Backend{
+			"pure-raft": prb,
+
+			"raft":                rb,
+			"raft+cache":          crb,
+			"raft+encoding":       erb,
+			"raft+cache+encoding": erbc,
+
+			"raft-in-tx":          rt,
+			"raft-in-tx+cache":    crt,
+			"raft-in-tx+encoding": ert,
+
+			"raft+cache-in-tx":    ctxr,
+			"raft+encoding-in-tx": etxr,
+
+			"file":                fb,
+			"file+cache":          cfb,
+			"file+encoding":       efb,
+			"file+cache+encoding": efbc,
+
+			"inmem":                inm,
+			"inmem+cache":          cinm,
+			"inmem+encoding":       einm,
+			"inmem+cache+encoding": einmc,
+
+			"txinmem": txinm,
+
+			"txinmtx": txinmtx,
+
+			"psql":                psql,
+			"psql+cache":          cpsql,
+			"psql+encoding":       epsql,
+			"psql+cache+encoding": epsqlc,
+		}, func() {
+			os.RemoveAll(raftPureDir)
+			os.RemoveAll(raftDir)
+			fileCleanup()
+			psqlCleanup()
+			os.RemoveAll(raftCacheDir)
+			fileCacheCleanup()
+			psqlcCleanup()
+			os.RemoveAll(raftEncodingDir)
+			fileEncodingCleanup()
+			psqleCleanup()
+			os.RemoveAll(raftCacheEncodingDir)
+			fileCacheEncodingCleanup()
+			psqlceCleanup()
+		}
+}
+
+func allTransactionalPhysical(t *testing.T) (map[string]physical.TransactionalBackend, func()) {
+	logger := logging.NewVaultLogger(log.Debug)
+
+	// Basic storage backends.
+
+	// raft
+	rb, raftDir := raft.GetRaft(t, true, true)
+
+	// raft + cache
+	rbc, raftCacheDir := raft.GetRaft(t, true, true)
+	crb := physical.NewCache(rbc, 0, logger, &metrics.BlackholeSink{}).(physical.TransactionalBackend)
+
+	// raft + encoding
+	rbe, raftEncodingDir := raft.GetRaft(t, true, true)
+	erb := physical.NewStorageEncoding(rbe).(physical.TransactionalBackend)
+
+	// raft + cache + encoding
+	rbce, raftCacheEncodingDir := raft.GetRaft(t, true, true)
+	crbe := physical.NewCache(rbce, 0, logger, &metrics.BlackholeSink{}).(physical.TransactionalBackend)
+	ecrb := physical.NewStorageEncoding(crbe).(physical.TransactionalBackend)
+
+	// inmem
+	_im, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem")
+	im := _im.(physical.TransactionalBackend)
+
+	// inmem + cache
+	_imc, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem for cache")
+	imc := _imc.(physical.TransactionalBackend)
+	cim := physical.NewCache(imc, 0, logger, &metrics.BlackholeSink{}).(physical.TransactionalBackend)
+
+	return map[string]physical.TransactionalBackend{
+			"raft":                rb,
+			"raft+cache":          crb,
+			"raft+encoding":       erb,
+			"raft+cache+encoding": ecrb,
+			"txinmem":             im,
+			"txinmem+cache":       cim,
+		}, func() {
+			os.RemoveAll(raftDir)
+			os.RemoveAll(raftCacheDir)
+			os.RemoveAll(raftEncodingDir)
+			os.RemoveAll(raftCacheEncodingDir)
+		}
+}
+
+func allDoList(t *testing.T, backends map[string]physical.Backend, prefix string) (map[string][]string, map[string]error) {
+	results := make(map[string][]string, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.List(context.Background(), prefix)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoListPage(t *testing.T, backends map[string]physical.Backend, prefix string, after string, limit int) (map[string][]string, map[string]error) {
+	results := make(map[string][]string, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.ListPage(context.Background(), prefix, after, limit)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoDelete(t *testing.T, backends map[string]physical.Backend, key string) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		err := backend.Delete(context.Background(), key)
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoPut(t *testing.T, backends map[string]physical.Backend, key string, value []byte) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		// Other entry fields are unnecessary.
+		err := backend.Put(context.Background(), &physical.Entry{
+			Key:   key,
+			Value: value,
+		})
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoGet(t *testing.T, backends map[string]physical.Backend, key string) (map[string]*physical.Entry, map[string]error) {
+	results := make(map[string]*physical.Entry, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.Get(context.Background(), key)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+// Results are physical.Backend to allow for passing to above allDoX methods.
+func allDoBeginTx(t *testing.T, backends map[string]physical.TransactionalBackend) (map[string]physical.Backend, map[string]error) {
+	results := make(map[string]physical.Backend, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.BeginTx(context.Background())
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoBeginReadOnlyTx(t *testing.T, backends map[string]physical.TransactionalBackend) (map[string]physical.Backend, map[string]error) {
+	results := make(map[string]physical.Backend, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.BeginReadOnlyTx(context.Background())
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoCommit(t *testing.T, backends map[string]physical.Backend) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		tx := backend.(physical.Transaction)
+		err := tx.Commit(context.Background())
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoRollback(t *testing.T, backends map[string]physical.Backend) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		tx := backend.(physical.Transaction)
+		err := tx.Rollback(context.Background())
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoSameListNoBenchmark(t *testing.T, backends map[string]physical.Backend, prefix string, shouldError bool) {
+	results, errs := allDoList(t, backends, prefix)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST with backend %v", name)
+		}
+	}
+
+	var expected []string
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST results between %v and %v:\n====%v (%v items)====\n\t%v\n====%v (%v items)====\n\t%v\n==== diff ====\n%v", expectedName, name, expectedName, len(expected), strings.Join(expected, "\n\t"), name, len(result), strings.Join(result, "\n\t"), diff)
+		}
+	}
+}
+
+func allDoSameList(t *testing.T, backends map[string]physical.Backend, prefix string, expected []string, shouldError bool) {
+	results, errs := allDoList(t, backends, prefix)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", "expected", name, "expected", strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff, results)
+		}
+	}
+}
+
+func allDoSameListPageNoBenchmark(t *testing.T, backends map[string]physical.Backend, prefix string, after string, limit int, shouldError bool) {
+	results, errs := allDoListPage(t, backends, prefix, after, limit)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST-PAGE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST-PAGE with backend %v", name)
+		}
+	}
+
+	var expected []string
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST-PAGE results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", expectedName, name, expectedName, strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff, results)
+		}
+	}
+}
+
+func allDoSameListPage(t *testing.T, backends map[string]physical.Backend, prefix string, after string, limit int, expected []string, shouldError bool) {
+	results, errs := allDoListPage(t, backends, prefix, after, limit)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST PAGE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST PAGE with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST PAGE results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v", "expected", name, "expected", strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff)
+		}
+	}
+}
+
+func allDoSameDelete(t *testing.T, backends map[string]physical.Backend, key string, shouldError bool) {
+	errs := allDoDelete(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing DELETE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing DELETE with backend %v", name)
+		}
+	}
+}
+
+func allDoSameGetNoBenchmark(t *testing.T, backends map[string]physical.Backend, key string, shouldError bool) {
+	results, errs := allDoGet(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing GET with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing GET with backend %v", name)
+		}
+	}
+
+	var expected *physical.Entry
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different GET results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", expectedName, name, expectedName, expected, name, result, diff, results)
+		}
+	}
+}
+
+func allDoSameGet(t *testing.T, backends map[string]physical.Backend, key string, expected *physical.Entry, shouldError bool) {
+	results, errs := allDoGet(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing GET with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing GET with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different GET results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v", "expected", name, "expected", expected, name, result, diff)
+		}
+	}
+}
+
+func allDoSamePut(t *testing.T, backends map[string]physical.Backend, key string, value []byte, shouldError bool) {
+	errs := allDoPut(t, backends, key, value)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing PUT with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing PUT with backend %v", name)
+		}
+	}
+}
+
+func allDoSameBeginTx(t *testing.T, backends map[string]physical.TransactionalBackend, shouldError bool) map[string]physical.Backend {
+	results, errs := allDoBeginTx(t, backends)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing BeginTx with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing BeginTx with backend %v", name)
+		}
+	}
+
+	return results
+}
+
+func allDoSameBeginReadOnlyTx(t *testing.T, backends map[string]physical.TransactionalBackend, shouldError bool) map[string]physical.Backend {
+	results, errs := allDoBeginReadOnlyTx(t, backends)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing BeginTx with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing BeginTx with backend %v", name)
+		}
+	}
+
+	return results
+}
+
+func allDoSameCommit(t *testing.T, txns map[string]physical.Backend, shouldError bool) {
+	errs := allDoCommit(t, txns)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing Commit with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing Commit with backend %v", name)
+		}
+	}
+}
+
+func allDoSameRollback(t *testing.T, txns map[string]physical.Backend, shouldError bool) {
+	errs := allDoRollback(t, txns)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing Rollback with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing Rollback with backend %v", name)
+		}
+	}
+}
+
+// This mirrors physical.ExerciseBackends, but applied to many backends in
+// parallel to ensure no discernible differences exist between them.
+func exerciseBackends(t *testing.T, backends map[string]physical.Backend) {
+	// Empty string should be the root.
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Delete should work if it doesn't exist.
+	allDoSameDelete(t, backends, "foo", false)
+
+	// Get should not fail, but be nil.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Put should create an entry.
+	testString := []byte("test")
+	allDoSamePut(t, backends, "foo", testString, false)
+
+	// Get should immediately see this entry.
+	allDoSameGet(t, backends, "foo", &physical.Entry{Key: "foo", Value: testString}, false)
+
+	// List should see this entry.
+	allDoSameList(t, backends, "", []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, []string{"foo"}, false)
+
+	// Delete should work.
+	allDoSameDelete(t, backends, "foo", false)
+
+	// List should no longer see this entry.
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Get should not fail, but be nil again.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Repeated puts to the same entry with the same value should
+	// succeed.
+	allDoSamePut(t, backends, "foo", testString, false)
+	allDoSamePut(t, backends, "foo", testString, false)
+	allDoSamePut(t, backends, "foo", testString, false)
+
+	// Get should see that entry.
+	allDoSameGet(t, backends, "foo", &physical.Entry{Key: "foo", Value: testString}, false)
+
+	// Make a nested entry.
+	bazString := []byte("baz")
+	allDoSamePut(t, backends, "foo/bar", bazString, false)
+
+	// Get should work on it.
+	allDoSameGet(t, backends, "foo/bar", &physical.Entry{Key: "foo/bar", Value: bazString}, false)
+
+	// List should have both a key and a subtree.
+	allDoSameList(t, backends, "", []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, []string{"foo", "foo/"}, false)
+
+	// Delete with children should only remove the base entry.
+	allDoSameDelete(t, backends, "foo", false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Get should not fail, but be nil.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Get should return the child still.
+	allDoSameGet(t, backends, "foo/bar", &physical.Entry{Key: "foo/bar", Value: bazString}, false)
+
+	// Removal of random nested secrets should not leave artifacts.
+	allDoSamePut(t, backends, "foo/nested1/nested2/nested3/nested4", bazString, false)
+	allDoSameDelete(t, backends, "foo/nested1/nested2/nested3/nested4", false)
+	allDoSameList(t, backends, "foo/", []string{"bar"}, false)
+	allDoSameListPage(t, backends, "foo/", "", -1, []string{"bar"}, false)
+
+	// Make a second entry to test prefix removal.
+	zapString := []byte("zap")
+	allDoSamePut(t, backends, "foo/zip", zapString, false)
+
+	// Delete should not remove the prefix.
+	allDoSameDelete(t, backends, "foo/bar", false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Zip's contents should not be affected by this delete.
+	allDoSameGet(t, backends, "foo/zip", &physical.Entry{Key: "foo/zip", Value: zapString}, false)
+
+	// Repeated writes to zip should yield the last one. Note that the final
+	// write is shorter than an intermediate write.
+	allDoSamePut(t, backends, "foo/zip", zapString, false)
+	allDoSamePut(t, backends, "foo/zip", testString, false)
+	allDoSamePut(t, backends, "foo/zip", bazString, false)
+	allDoSameGet(t, backends, "foo/zip", &physical.Entry{Key: "foo/zip", Value: bazString}, false)
+
+	// Delete zip, getting back the empty storage.
+	allDoSameDelete(t, backends, "foo/zip", false)
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Creating a deeply nested entry in an empty root should show up on
+	// list.
+	allDoSamePut(t, backends, "foo/nested1/nested2/nested3/nested4", bazString, false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Deleting it should leave no artifacts.
+	allDoSameDelete(t, backends, "foo/nested1/nested2/nested3/nested4", false)
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+
+	// Finally, test pagination exhaustively.
+	var created []string
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("key-%d", i)
+		allDoSamePut(t, backends, name, testString, false)
+		created = append(created, name)
+
+		// Listing everything should work.
+		allDoSameList(t, backends, "", created, false)
+		allDoSameListPage(t, backends, "", "", -1, created, false)
+
+		// Listing after our previous entry should work.
+		justBefore := ""
+		if len(created) >= 2 {
+			justBefore = created[len(created)-2]
+		}
+		allDoSameListPage(t, backends, "", justBefore, -1, []string{name}, false)
+		allDoSameListPage(t, backends, "", justBefore, 1, []string{name}, false)
+		allDoSameListPage(t, backends, "", justBefore, 2, []string{name}, false)
+
+		// Listing previously created entries should work. Note that limit=0
+		// is equivalent to limit=-1 and thus returns all entries.
+		if i > 0 {
+			allDoSameListPage(t, backends, "", "", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "asdf", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "key-", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "aaaaaaaaaaaaaaaa", i, created[:i], false)
+		}
+
+		// Listing future entries should be blank.
+		allDoSameListPage(t, backends, "", name, -1, nil, false)
+		allDoSameListPage(t, backends, "", "key-99999999", -1, nil, false)
+		allDoSameListPage(t, backends, "", "zzzzzzzzz", -1, nil, false)
+	}
+
+	// Finally, clean up after paginated list testing.
+	for _, name := range created {
+		allDoSameDelete(t, backends, name, false)
+	}
+}
+
+func exerciseTransactions(t *testing.T, backends map[string]physical.TransactionalBackend) {
+	direct := make(map[string]physical.Backend, len(backends))
+	for name, backend := range backends {
+		direct[name] = backend
+	}
+
+	// Creating a transaction and committing or rolling it back without doing
+	// anything should succeed, regardless of type of transaction. Doing the
+	// same operation twice should fail as the transaction was already
+	// finished.
+	txns := allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameRollback(t, txns, true)
+
+	// This should also be true if we swap types (commit->rollback and
+	// visa-versa).
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameCommit(t, txns, true)
+
+	// Empty transactions can be interwoven.
+	txn1 := allDoSameBeginTx(t, backends, false)
+	txn2 := allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, false)
+
+	// Writing to a read-only transaction should fail; committing this
+	// transaction should have no impact on storage.
+	test := []byte("test")
+	rtx := allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSamePut(t, rtx, "foo", test, true)
+	allDoSameDelete(t, rtx, "foo", true)
+	allDoSameCommit(t, rtx, false)
+	allDoSameList(t, direct, "", nil, false)
+
+	// Creating the same entry in two transactions should conflict the
+	// second committed one, even though they have the same contents.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", test, false)
+	allDoSamePut(t, txn2, "foo", test, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, true)
+	allDoSameGet(t, direct, "foo", &physical.Entry{Key: "foo", Value: test}, false)
+
+	baz := []byte("baz")
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", baz, false)
+	allDoSamePut(t, txn2, "foo", baz, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, true)
+	allDoSameGet(t, direct, "foo", &physical.Entry{Key: "foo", Value: baz}, false)
+
+	// Creating different entries in two transactions should be fine.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", test, false)
+	allDoSamePut(t, txn2, "bar", baz, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameGet(t, direct, "foo", &physical.Entry{Key: "foo", Value: test}, false)
+	allDoSameGet(t, direct, "bar", &physical.Entry{Key: "bar", Value: baz}, false)
+
+	// Getting an item and writing to the same item in different transactions
+	// should fail one of the two.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txn1, "bar", &physical.Entry{Key: "bar", Value: baz}, false)
+	allDoSamePut(t, txn1, "foo", baz, false)
+	allDoSameGet(t, txn2, "foo", &physical.Entry{Key: "foo", Value: test}, false)
+	allDoSamePut(t, txn2, "bar", test, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, true)
+	allDoSameGet(t, direct, "foo", &physical.Entry{Key: "foo", Value: baz}, false)
+	allDoSameGet(t, direct, "bar", &physical.Entry{Key: "bar", Value: baz}, false)
+
+	// Try again, with delete this time, committing in a different order.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txn1, "bar", &physical.Entry{Key: "bar", Value: baz}, false)
+	allDoSameDelete(t, txn1, "foo", false)
+	allDoSameGet(t, txn2, "foo", &physical.Entry{Key: "foo", Value: baz}, false)
+	allDoSameDelete(t, txn2, "bar", false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, true)
+	allDoSameGet(t, direct, "foo", &physical.Entry{Key: "foo", Value: baz}, false)
+	allDoSameList(t, direct, "", []string{"foo"}, false)
+
+	// Reading entries that don't exist shouldn't cause issues.
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txns, "bar", nil, false)
+	allDoSameGet(t, txns, "foo", &physical.Entry{Key: "foo", Value: baz}, false)
+	allDoSameDelete(t, txns, "foo", false)
+	allDoSameCommit(t, txns, false)
+	allDoSameList(t, direct, "", nil, false)
+}
+
+func getRandomOps(t *testing.T, count int, transactional bool, txLimit int) []*inmem.InmemOp {
+	var ops []*inmem.InmemOp
+
+	// Track transactions. Allow
+	opTypes := []int{
+		inmem.PutInMemOp, inmem.DeleteInMemOp,
+		inmem.ListInMemOp, inmem.ListPageInMemOp,
+		inmem.GetInMemOp,
+	}
+	if transactional {
+		opTypes = append(opTypes, []int{
+			inmem.BeginTxInMemOp, inmem.BeginReadOnlyTxInMemOp,
+			inmem.CommitTxInMemOp, inmem.RollbackTxInMemOp,
+		}...)
+	}
+
+	// We only want to create files, but will allow delete/get/list on
+	// both files and folders.
+	opFiles := []string{
+		"a",
+		"b",
+		"c",
+		"d",
+		"e",
+		"f",
+		"foo",
+		"foo/apple",
+		"foo/bar",
+		"foo/baz",
+		"foo/cherry",
+		"foo/foo",
+		"foo/fud",
+		"foo/very/highly/nested/subpath",
+		"foo/very/highly/nested/subpath/that/goes/on/for/ever/and/ever/and/ever/until/it/runs/out/of/usual/path/space/on/a/file/system",
+		"g",
+		"h",
+		"i",
+		"z",
+	}
+
+	opFolders := []string{
+		"",
+		"foo/very",
+		"foo/very/highly",
+		"foo/very/highly/nested",
+		"foo/very/highly/nested/subpath/that",
+		"foo/very/highly/nested/subpath/that/goes/on/for/ever/and/ever/and/ever/until/it/runs/out/of/usual/path/space/on/a/file",
+		"this-path-does-not-exist",
+		"this/path/also/does/not/exist",
+	}
+	opFolders = append(opFolders, opFiles...)
+
+	var opAfter []string
+	for _, entry := range opFolders {
+		opAfter = append(opAfter, filepath.Base(entry))
+	}
+
+	opContents := []string{
+		"",
+		"here",
+		"a",
+		"test",
+		"there",
+		"is-a-test",
+		"everywhere-is",
+		"a-test",
+		"bar",
+		"baz",
+		"somewhat-long-string-with-very",
+		"always-last-add-new-ones-above-me-start-of-a-very-very-long-string-",
+	}
+	for len(opContents[len(opContents)-1]) < 32*1024 {
+		opContents[len(opContents)-1] += "0123456789"
+	}
+
+	for i := 0; i < count; i++ {
+		opI := rand.Intn(len(opTypes))
+		op := opTypes[opI]
+
+		var tx int = rand.Intn(txLimit+1) - 1
+		var path string
+		var contents string
+		var after string
+		var limit int
+		switch op {
+		case inmem.PutInMemOp:
+			pathI := rand.Intn(len(opFiles))
+			path = opFiles[pathI]
+			contentsI := rand.Intn(len(opContents))
+			contents = opContents[contentsI]
+		case inmem.DeleteInMemOp, inmem.GetInMemOp, inmem.ListInMemOp:
+			pathI := rand.Intn(len(opFolders))
+			path = opFolders[pathI]
+		case inmem.ListPageInMemOp:
+			pathI := rand.Intn(len(opFolders))
+			path = opFolders[pathI]
+			afterI := rand.Intn(len(opAfter))
+			after = opAfter[afterI]
+		case inmem.CommitTxInMemOp, inmem.RollbackTxInMemOp, inmem.BeginTxInMemOp, inmem.BeginReadOnlyTxInMemOp:
+			tx = rand.Intn(txLimit)
+		default:
+			t.Fatalf("unknown op: %v", op)
+		}
+
+		if (op == inmem.ListInMemOp || op == inmem.ListPageInMemOp) && path != "" {
+			path = path + "/"
+		}
+
+		ops = append(ops, &inmem.InmemOp{
+			OpType:   op,
+			OpTx:     tx,
+			ArgKey:   path,
+			ArgAfter: after,
+			ArgLimit: limit,
+			ArgEntry: &physical.Entry{
+				Key:   path,
+				Value: []byte(contents),
+			},
+		})
+	}
+
+	return ops
+}
+
+func executeRandomOps(t *testing.T, backends map[string]physical.Backend, ops []*inmem.InmemOp) {
+	data, err := json.Marshal(ops)
+	require.NoError(t, err, "failed to marshal ops to json")
+	err = os.WriteFile(opsLogFile, data, 0o644)
+	require.NoError(t, err, "failed to save ops to file")
+
+	for index, op := range ops {
+		switch op.OpType {
+		case inmem.PutInMemOp:
+			allDoSamePut(t, backends, op.ArgEntry.Key, op.ArgEntry.Value, false)
+		case inmem.DeleteInMemOp:
+			allDoSameDelete(t, backends, op.ArgKey, false)
+		case inmem.GetInMemOp:
+			allDoSameGetNoBenchmark(t, backends, op.ArgKey, false)
+		case inmem.ListInMemOp:
+			allDoSameListNoBenchmark(t, backends, op.ArgKey, false)
+		case inmem.ListPageInMemOp:
+			allDoSameListPageNoBenchmark(t, backends, op.ArgKey, op.ArgAfter, op.ArgLimit, false)
+		default:
+			t.Fatalf("[%d] unknown operation: %v (%v)", index, op.OpType, inmem.OpName(op.OpType))
+		}
+	}
+
+	os.Remove(opsLogFile)
+}
+
+func executeRandomTransactionalOps(t *testing.T, txBackends map[string]physical.TransactionalBackend, ops []*inmem.InmemOp, txLimit int) {
+	data, err := json.Marshal(ops)
+	require.NoError(t, err, "failed to marshal ops to json")
+	err = os.WriteFile(txOpsLogFile, data, 0o644)
+	require.NoError(t, err, "failed to save ops to file")
+
+	direct := make(map[string]physical.Backend, len(txBackends))
+	for name, backend := range txBackends {
+		direct[name] = backend
+	}
+
+	txs := make([]map[string]physical.Backend, txLimit)
+	for index, op := range ops {
+		var listRet map[string][]string
+		var entryRet map[string]*physical.Entry
+		var errorRet map[string]error
+
+		bk := direct
+		if op.OpTx >= 0 && op.OpTx < txLimit {
+			bk = txs[op.OpTx]
+		}
+		if bk == nil {
+			continue
+		}
+
+		switch op.OpType {
+		case inmem.PutInMemOp:
+			errorRet = allDoPut(t, bk, op.ArgEntry.Key, op.ArgEntry.Value)
+		case inmem.DeleteInMemOp:
+			errorRet = allDoDelete(t, bk, op.ArgKey)
+		case inmem.GetInMemOp:
+			entryRet, errorRet = allDoGet(t, bk, op.ArgKey)
+		case inmem.ListInMemOp:
+			listRet, errorRet = allDoList(t, bk, op.ArgKey)
+		case inmem.ListPageInMemOp:
+			listRet, errorRet = allDoListPage(t, bk, op.ArgKey, op.ArgAfter, op.ArgLimit)
+		case inmem.BeginTxInMemOp:
+			if txs[op.OpTx] != nil {
+				allDoSameRollback(t, txs[op.OpTx], false)
+				txs[op.OpTx] = nil
+			}
+
+			txs[op.OpTx], errorRet = allDoBeginTx(t, txBackends)
+		case inmem.BeginReadOnlyTxInMemOp:
+			if txs[op.OpTx] != nil {
+				allDoSameRollback(t, txs[op.OpTx], false)
+				txs[op.OpTx] = nil
+			}
+
+			txs[op.OpTx], errorRet = allDoBeginReadOnlyTx(t, txBackends)
+		case inmem.CommitTxInMemOp:
+			errorRet = allDoCommit(t, bk)
+			txs[op.OpTx] = nil
+		case inmem.RollbackTxInMemOp:
+			errorRet = allDoRollback(t, bk)
+			txs[op.OpTx] = nil
+		default:
+			t.Fatalf("unknown operation: %v (%v)", op.OpType, inmem.OpName(op.OpType))
+		}
+
+		var errExpected error
+		var errExpectedName string
+		for name, err := range errorRet {
+			if errExpectedName == "" {
+				errExpectedName = name
+				errExpected = err
+				continue
+			}
+
+			if (errExpected != nil) != (err != nil) {
+				t.Fatalf("[op %d] different error results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n", index, op.OpType, inmem.OpName(op.OpType), errExpectedName, errExpected, name, err)
+			}
+		}
+
+		if listRet != nil {
+			var listExpected []string
+			var listExpectedName string
+			for name, result := range listRet {
+				if listExpectedName == "" {
+					listExpectedName = name
+					listExpected = result
+					continue
+				}
+
+				if len(listExpected) == 0 && len(result) == 0 {
+					continue
+				}
+
+				if diff := deep.Equal(listExpected, result); diff != nil {
+					t.Fatalf("[op %d] different list results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n==== diff ====\n%v\n", index, op.OpType, inmem.OpName(op.OpType), listExpectedName, listExpected, name, err, diff)
+				}
+			}
+		}
+
+		if entryRet != nil {
+			var entryExpected *physical.Entry
+			var entryExpectedName string
+			for name, result := range entryRet {
+				if entryExpectedName == "" {
+					entryExpectedName = name
+					entryExpected = result
+					continue
+				}
+
+				if diff := deep.Equal(entryExpected, result); diff != nil {
+					t.Fatalf("[op %d] different entry results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n==== diff ====\n%v\n", index, op.OpType, inmem.OpName(op.OpType), entryExpectedName, entryExpected, name, err, diff)
+				}
+			}
+		}
+
+	}
+
+	os.Remove(txOpsLogFile)
+}

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -159,6 +159,13 @@ func TestRaft_Backend(t *testing.T) {
 	physical.ExerciseBackend(t, b)
 }
 
+func TestRaft_TransactionalBackend(t *testing.T) {
+	b, dir := GetRaft(t, true, true)
+	defer os.RemoveAll(dir)
+
+	physical.ExerciseTransactionalBackend(t, b)
+}
+
 func TestRaft_ParseAutopilotUpgradeVersion(t *testing.T) {
 	raftDir, err := os.MkdirTemp("", "vault-raft-")
 	if err != nil {

--- a/sdk/physical/file/file_test.go
+++ b/sdk/physical/file/file_test.go
@@ -218,6 +218,7 @@ func TestFileBackend(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	// File backend is not transactional
 	physical.ExerciseBackend(t, b)
 
 	// Underscores should not trip things up; ref GH-3476

--- a/sdk/physical/inmem/cache_test.go
+++ b/sdk/physical/inmem/cache_test.go
@@ -25,6 +25,7 @@ func TestCache(t *testing.T) {
 	cache := physical.NewCache(inm, 0, logger, &metrics.BlackholeSink{})
 	cache.SetEnabled(true)
 	physical.ExerciseBackend(t, cache)
+	physical.ExerciseTransactionalBackend(t, cache.(physical.TransactionalBackend))
 	physical.ExerciseBackend_ListPrefix(t, cache)
 }
 

--- a/sdk/physical/inmem/inmem_test.go
+++ b/sdk/physical/inmem/inmem_test.go
@@ -19,5 +19,6 @@ func TestInmem(t *testing.T) {
 		t.Fatal(err)
 	}
 	physical.ExerciseBackend(t, inm)
+	physical.ExerciseTransactionalBackend(t, inm.(physical.TransactionalBackend))
 	physical.ExerciseBackend_ListPrefix(t, inm)
 }

--- a/vault/external_tests/storage/crosstest/cross_test.go
+++ b/vault/external_tests/storage/crosstest/cross_test.go
@@ -1,0 +1,1146 @@
+// See /physical/crosstest but with the following difference: this tests
+// logical.Storage rather than physical.Backend.
+package crosstest
+
+import (
+	"context"
+	crand "crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/armon/go-metrics"
+	"github.com/go-test/deep"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openbao/openbao/physical/postgresql"
+	"github.com/openbao/openbao/physical/raft"
+	"github.com/openbao/openbao/sdk/v2/helper/logging"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/openbao/openbao/sdk/v2/physical/file"
+	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+	"github.com/openbao/openbao/vault"
+)
+
+const (
+	opsLogFile   = "/tmp/openbao-storage-random-ops.json"
+	txOpsLogFile = "/tmp/openbao-storage-random-tx-ops.json"
+	numOps       = 1000
+	numTxOps     = numOps
+)
+
+func Test_ExerciseBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allLogical(t)
+	defer cleanup()
+
+	exerciseBackends(t, backends)
+
+	// If any were transactions, let's rollback. We can't commit them as
+	// we wrote to the same area of storage in lots of places.
+	for name, backend := range backends {
+		if txn, ok := backend.(logical.Transaction); ok {
+			err := txn.Rollback(context.Background())
+			require.NoError(t, err, "failed to rollback transaction: %v", name)
+		}
+	}
+}
+
+func Test_RandomOpsBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allLogical(t)
+	defer cleanup()
+
+	ops := getRandomOps(t, numOps, false, 0)
+	// ops := replayOps(t, opsLogFile)
+	executeRandomOps(t, backends, ops)
+}
+
+func Test_RandomOpsTransactionalBackends(t *testing.T) {
+	t.Parallel()
+
+	backends, cleanup := allTransactionalLogical(t)
+	defer cleanup()
+
+	txLimit := 10
+	ops := getRandomOps(t, numTxOps, true, txLimit)
+	executeRandomTransactionalOps(t, backends, ops, txLimit)
+}
+
+func replayOps(t *testing.T, file string) []*inmem.InmemOp {
+	data, err := os.ReadFile(file)
+	require.NoError(t, err, "error reading operations file")
+
+	var results []*inmem.InmemOp
+	err = json.Unmarshal(data, &results)
+	require.NoError(t, err, "error unmarshaling operations json")
+
+	return results
+}
+
+func Test_ExerciseTransactionalBackends(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	backends, cleanup := allTransactionalLogical(t)
+	defer cleanup()
+
+	// Create transactions and exercise the backend, rolling them back.
+	txns := make(map[string]logical.Storage, 2*len(backends))
+	for name, backend := range backends {
+		txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create write transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-rw", name)] = txn
+
+		ro_txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create read-only transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-ro", name)] = ro_txn
+	}
+
+	exerciseBackends(t, txns)
+
+	for name, txn := range txns {
+		err := txn.(logical.Transaction).Rollback(ctx)
+		require.NoError(t, err, "failed to rollback transaction: %v", name)
+	}
+
+	// Ensure we can do a single read/write transactions and commit them.
+	// This will leave us with an empty state, but potentially entries in
+	// any transaction logs.
+	txns = make(map[string]logical.Storage, len(backends))
+	for name, backend := range backends {
+		txn, err := backend.BeginTx(ctx)
+		require.NoError(t, err, "failed to create write transaction: %v", name)
+		txns[fmt.Sprintf("%v-tx-rw", name)] = txn
+	}
+
+	exerciseBackends(t, txns)
+
+	for name, txn := range txns {
+		err := txn.(logical.Transaction).Commit(ctx)
+		require.NoError(t, err, "failed to commit transaction: %v", name)
+	}
+
+	// Finally, exercise transactions.
+	exerciseTransactions(t, backends)
+}
+
+func getFile(t *testing.T, logger log.Logger) (physical.Backend, func()) {
+	backendPath, err := ioutil.TempDir("", "vault")
+	require.NoError(t, err, "error while creating file storage")
+
+	b, err := file.NewFileBackend(map[string]string{
+		"path": backendPath,
+	}, logger)
+	require.NoError(t, err, "error while initializing file backend")
+
+	return b, func() {
+		os.RemoveAll(backendPath)
+	}
+}
+
+func allLogical(t *testing.T) (map[string]logical.Storage, func()) {
+	ctx := context.Background()
+	logger := logging.NewVaultLogger(log.Debug)
+	disableTxConf := map[string]string{"disable_transactions": "true"}
+
+	// Basic storage backends.
+
+	// raft, no transaction called on it.
+	prb, raftPureDir := raft.GetRaft(t, true, true)
+
+	// raft
+	rb, raftDir := raft.GetRaft(t, true, true)
+
+	// raft-in-tx
+	//
+	// Inside a raft transaction should behave the same as outside
+	// if it is writable. We are fine to reuse the same raft instance
+	// here as the transaction should not see stuff created after it.
+	rt, err := rb.BeginTx(ctx)
+	require.NoError(t, err, "failed to start raft transaction")
+
+	// file
+	fb, fileCleanup := getFile(t, logger)
+
+	// inmem
+	inm, err := inmem.NewInmem(disableTxConf, logger)
+	require.NoError(t, err, "failed to create in-memory backend")
+
+	// txinmem
+	_txinm, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-memory backend")
+	txinm := _txinm.(physical.TransactionalBackend)
+
+	// postgres
+	psql, psqlCleanup := postgresql.GetTestPostgreSQLBackend(t, logger)
+
+	return map[string]logical.Storage{
+			"pure-raft": logical.NewLogicalStorage(prb),
+
+			"raft":       logical.NewLogicalStorage(rb),
+			"raft-in-tx": logical.NewLogicalStorage(rt),
+			"file":       logical.NewLogicalStorage(fb),
+
+			"inmem":               new(logical.InmemStorage),
+			"inmem-via-wrapper":   logical.NewLogicalStorage(inm),
+			"txinmem-via-wrapper": logical.NewLogicalStorage(txinm),
+
+			"psql": logical.NewLogicalStorage(psql),
+		}, func() {
+			os.RemoveAll(raftPureDir)
+			os.RemoveAll(raftDir)
+			fileCleanup()
+			psqlCleanup()
+		}
+}
+
+func newAESBarrier(t *testing.T, parent physical.Backend) vault.SecurityBarrier {
+	b, err := vault.NewAESGCMBarrier(parent)
+	require.NoError(t, err, "failed wrapping parent in AES-GCM barrier")
+
+	key, err := b.GenerateKey(crand.Reader)
+	require.NoError(t, err, "failed generating random key")
+
+	b.Initialize(context.Background(), key, nil, crand.Reader)
+	b.Unseal(context.Background(), key)
+
+	return b
+}
+
+func allTransactionalLogical(t *testing.T) (map[string]logical.TransactionalStorage, func()) {
+	logger := logging.NewVaultLogger(log.Debug)
+
+	// Basic storage backends.
+
+	// raft
+	rb, raftDir := raft.GetRaft(t, true, true)
+
+	// inmem
+	im, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem")
+
+	// inmem+storage-view
+	imsv, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem for storage view")
+	svim := logical.NewStorageView(logical.NewLogicalStorage(imsv), "my-prefix/")
+
+	// inmem+aes+sv -- this pollutes the global namespace (with core/) so hide it under a storage view
+	imasv, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem for AES-GCM with storage view")
+	aimsv := newAESBarrier(t, imasv)
+	svaim := logical.NewStorageView(aimsv, "prefix-for-testing/")
+
+	// inmem+aes+bv
+	imabv, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem for AES-GCM with barrier view")
+	aimbv := newAESBarrier(t, imabv)
+	bvaim := vault.NewBarrierView(aimbv, "prefix-for-testing/")
+
+	// inmem+cache+encoding+aes+bv
+	imceabv, err := inmem.NewInmem(nil, logger)
+	require.NoError(t, err, "failed to create transactional in-mem for AES-GCM with barrier view")
+	cimeabv := physical.NewCache(imceabv, 0, logger, &metrics.BlackholeSink{})
+	eimcabv := physical.NewStorageEncoding(cimeabv)
+	aimcebv := newAESBarrier(t, eimcabv)
+	bvimcae := vault.NewBarrierView(aimcebv, "prefix-for-testing/")
+
+	// raft+cache+encoding+aes+bv
+	rceabv, raftFullDir := raft.GetRaft(t, true, true)
+	require.NoError(t, err, "failed to create transactional in-mem for AES-GCM with barrier view")
+	creabv := physical.NewCache(rceabv, 0, logger, &metrics.BlackholeSink{})
+	ercabv := physical.NewStorageEncoding(creabv)
+	arcebv := newAESBarrier(t, ercabv)
+	bvrcae := vault.NewBarrierView(arcebv, "prefix-for-testing/")
+
+	return map[string]logical.TransactionalStorage{
+			"raft":                        logical.NewLogicalStorage(rb).(logical.TransactionalStorage),
+			"txinmem":                     logical.NewLogicalStorage(im).(logical.TransactionalStorage),
+			"inmem+sv":                    svim.(logical.TransactionalStorage),
+			"inmem+aes+sv":                svaim.(logical.TransactionalStorage),
+			"inmem+aes+bv":                bvaim.(logical.TransactionalStorage),
+			"inmem+cache+encoding+aes+bv": bvimcae.(logical.TransactionalStorage),
+			"raft+cache+encoding+aes+bv":  bvrcae.(logical.TransactionalStorage),
+		}, func() {
+			os.RemoveAll(raftDir)
+			os.RemoveAll(raftFullDir)
+		}
+}
+
+func allDoList(t *testing.T, backends map[string]logical.Storage, prefix string) (map[string][]string, map[string]error) {
+	results := make(map[string][]string, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.List(context.Background(), prefix)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoListPage(t *testing.T, backends map[string]logical.Storage, prefix string, after string, limit int) (map[string][]string, map[string]error) {
+	results := make(map[string][]string, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.ListPage(context.Background(), prefix, after, limit)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoDelete(t *testing.T, backends map[string]logical.Storage, key string) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		err := backend.Delete(context.Background(), key)
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoPut(t *testing.T, backends map[string]logical.Storage, key string, value []byte) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		// Other entry fields are unnecessary.
+		err := backend.Put(context.Background(), &logical.StorageEntry{
+			Key:   key,
+			Value: value,
+		})
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoGet(t *testing.T, backends map[string]logical.Storage, key string) (map[string]*logical.StorageEntry, map[string]error) {
+	results := make(map[string]*logical.StorageEntry, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.Get(context.Background(), key)
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+// Results are logical.Storage to allow for passing to above allDoX methods.
+func allDoBeginTx(t *testing.T, backends map[string]logical.TransactionalStorage) (map[string]logical.Storage, map[string]error) {
+	results := make(map[string]logical.Storage, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.BeginTx(context.Background())
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoBeginReadOnlyTx(t *testing.T, backends map[string]logical.TransactionalStorage) (map[string]logical.Storage, map[string]error) {
+	results := make(map[string]logical.Storage, len(backends))
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		result, err := backend.BeginReadOnlyTx(context.Background())
+		results[name] = result
+		errs[name] = err
+	}
+
+	return results, errs
+}
+
+func allDoCommit(t *testing.T, backends map[string]logical.Storage) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		tx := backend.(logical.Transaction)
+		err := tx.Commit(context.Background())
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoRollback(t *testing.T, backends map[string]logical.Storage) map[string]error {
+	errs := make(map[string]error, len(backends))
+	for name, backend := range backends {
+		tx := backend.(logical.Transaction)
+		err := tx.Rollback(context.Background())
+		errs[name] = err
+	}
+
+	return errs
+}
+
+func allDoSameListNoBenchmark(t *testing.T, backends map[string]logical.Storage, prefix string, shouldError bool) {
+	results, errs := allDoList(t, backends, prefix)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST with backend %v", name)
+		}
+	}
+
+	var expected []string
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST results between %v and %v:\n====%v (%v items)====\n\t%v\n====%v (%v items)====\n\t%v\n==== diff ====\n%v", expectedName, name, expectedName, len(expected), strings.Join(expected, "\n\t"), name, len(result), strings.Join(result, "\n\t"), diff)
+		}
+	}
+}
+
+func allDoSameList(t *testing.T, backends map[string]logical.Storage, prefix string, expected []string, shouldError bool) {
+	results, errs := allDoList(t, backends, prefix)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", "expected", name, "expected", strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff, results)
+		}
+	}
+}
+
+func allDoSameListPageNoBenchmark(t *testing.T, backends map[string]logical.Storage, prefix string, after string, limit int, shouldError bool) {
+	results, errs := allDoListPage(t, backends, prefix, after, limit)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST-PAGE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST-PAGE with backend %v", name)
+		}
+	}
+
+	var expected []string
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST-PAGE results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", expectedName, name, expectedName, strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff, results)
+		}
+	}
+}
+
+func allDoSameListPage(t *testing.T, backends map[string]logical.Storage, prefix string, after string, limit int, expected []string, shouldError bool) {
+	results, errs := allDoListPage(t, backends, prefix, after, limit)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing LIST PAGE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing LIST PAGE with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		// Ignore the difference between nil and an empty list. This
+		// trips up the file backend, where everyone else returns nil
+		// after deletion of an entry, but file returns an empty list.
+		if len(expected) == 0 && len(result) == 0 {
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different LIST PAGE results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v", "expected", name, "expected", strings.Join(expected, "\n\t"), name, strings.Join(result, "\n\t"), diff)
+		}
+	}
+}
+
+func allDoSameDelete(t *testing.T, backends map[string]logical.Storage, key string, shouldError bool) {
+	errs := allDoDelete(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing DELETE with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing DELETE with backend %v", name)
+		}
+	}
+}
+
+func allDoSameGetNoBenchmark(t *testing.T, backends map[string]logical.Storage, key string, shouldError bool) {
+	results, errs := allDoGet(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing GET with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing GET with backend %v", name)
+		}
+	}
+
+	var expected *logical.StorageEntry
+	var expectedName string
+	for name, result := range results {
+		if expectedName == "" {
+			expected = result
+			expectedName = name
+			continue
+		}
+
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different GET results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v\n==== results ====\n%v\n", expectedName, name, expectedName, expected, name, result, diff, results)
+		}
+	}
+}
+
+func allDoSameGet(t *testing.T, backends map[string]logical.Storage, key string, expected *logical.StorageEntry, shouldError bool) {
+	results, errs := allDoGet(t, backends, key)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing GET with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing GET with backend %v", name)
+		}
+	}
+
+	for name, result := range results {
+		if diff := deep.Equal(expected, result); diff != nil {
+			require.Nil(t, diff, "different GET results between %v and %v:\n====%v====\n\t%v\n====%v====\n\t%v\n==== diff ====\n%v", "expected", name, "expected", expected, name, result, diff)
+		}
+	}
+}
+
+func allDoSamePut(t *testing.T, backends map[string]logical.Storage, key string, value []byte, shouldError bool) {
+	errs := allDoPut(t, backends, key, value)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing PUT with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing PUT with backend %v", name)
+		}
+	}
+}
+
+func allDoSameBeginTx(t *testing.T, backends map[string]logical.TransactionalStorage, shouldError bool) map[string]logical.Storage {
+	results, errs := allDoBeginTx(t, backends)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing BeginTx with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing BeginTx with backend %v", name)
+		}
+	}
+
+	return results
+}
+
+func allDoSameBeginReadOnlyTx(t *testing.T, backends map[string]logical.TransactionalStorage, shouldError bool) map[string]logical.Storage {
+	results, errs := allDoBeginReadOnlyTx(t, backends)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing BeginTx with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing BeginTx with backend %v", name)
+		}
+	}
+
+	return results
+}
+
+func allDoSameCommit(t *testing.T, txns map[string]logical.Storage, shouldError bool) {
+	errs := allDoCommit(t, txns)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing Commit with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing Commit with backend %v", name)
+		}
+	}
+}
+
+func allDoSameRollback(t *testing.T, txns map[string]logical.Storage, shouldError bool) {
+	errs := allDoRollback(t, txns)
+	for name, err := range errs {
+		if !shouldError {
+			require.NoError(t, err, "error doing Rollback with backend %v", name)
+		} else {
+			require.Error(t, err, "expected error doing Rollback with backend %v", name)
+		}
+	}
+}
+
+// This mirrors physical.ExerciseBackends, but applied to many backends in
+// parallel to ensure no discernible differences exist between them.
+func exerciseBackends(t *testing.T, backends map[string]logical.Storage) {
+	// Empty string should be the root.
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Delete should work if it doesn't exist.
+	allDoSameDelete(t, backends, "foo", false)
+
+	// Get should not fail, but be nil.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Put should create an entry.
+	testString := []byte("test")
+	allDoSamePut(t, backends, "foo", testString, false)
+
+	// Get should immediately see this entry.
+	allDoSameGet(t, backends, "foo", &logical.StorageEntry{Key: "foo", Value: testString}, false)
+
+	// List should see this entry.
+	allDoSameList(t, backends, "", []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, []string{"foo"}, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, []string{"foo"}, false)
+
+	// Delete should work.
+	allDoSameDelete(t, backends, "foo", false)
+
+	// List should no longer see this entry.
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Get should not fail, but be nil again.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Repeated puts to the same entry with the same value should
+	// succeed.
+	allDoSamePut(t, backends, "foo", testString, false)
+	allDoSamePut(t, backends, "foo", testString, false)
+	allDoSamePut(t, backends, "foo", testString, false)
+
+	// Get should see that entry.
+	allDoSameGet(t, backends, "foo", &logical.StorageEntry{Key: "foo", Value: testString}, false)
+
+	// Make a nested entry.
+	bazString := []byte("baz")
+	allDoSamePut(t, backends, "foo/bar", bazString, false)
+
+	// Get should work on it.
+	allDoSameGet(t, backends, "foo/bar", &logical.StorageEntry{Key: "foo/bar", Value: bazString}, false)
+
+	// List should have both a key and a subtree.
+	allDoSameList(t, backends, "", []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, []string{"foo", "foo/"}, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, []string{"foo", "foo/"}, false)
+
+	// Delete with children should only remove the base entry.
+	allDoSameDelete(t, backends, "foo", false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Get should not fail, but be nil.
+	allDoSameGet(t, backends, "foo", nil, false)
+
+	// Get should return the child still.
+	allDoSameGet(t, backends, "foo/bar", &logical.StorageEntry{Key: "foo/bar", Value: bazString}, false)
+
+	// Removal of random nested secrets should not leave artifacts.
+	allDoSamePut(t, backends, "foo/nested1/nested2/nested3/nested4", bazString, false)
+	allDoSameDelete(t, backends, "foo/nested1/nested2/nested3/nested4", false)
+	allDoSameList(t, backends, "foo/", []string{"bar"}, false)
+	allDoSameListPage(t, backends, "foo/", "", -1, []string{"bar"}, false)
+
+	// Make a second entry to test prefix removal.
+	zapString := []byte("zap")
+	allDoSamePut(t, backends, "foo/zip", zapString, false)
+
+	// Delete should not remove the prefix.
+	allDoSameDelete(t, backends, "foo/bar", false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Zip's contents should not be affected by this delete.
+	allDoSameGet(t, backends, "foo/zip", &logical.StorageEntry{Key: "foo/zip", Value: zapString}, false)
+
+	// Repeated writes to zip should yield the last one. Note that the final
+	// write is shorter than an intermediate write.
+	allDoSamePut(t, backends, "foo/zip", zapString, false)
+	allDoSamePut(t, backends, "foo/zip", testString, false)
+	allDoSamePut(t, backends, "foo/zip", bazString, false)
+	allDoSameGet(t, backends, "foo/zip", &logical.StorageEntry{Key: "foo/zip", Value: bazString}, false)
+
+	// Delete zip, getting back the empty storage.
+	allDoSameDelete(t, backends, "foo/zip", false)
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", -1, nil, false)
+	allDoSameListPage(t, backends, "", "asdf", 11, nil, false)
+
+	// Creating a deeply nested entry in an empty root should show up on
+	// list.
+	allDoSamePut(t, backends, "foo/nested1/nested2/nested3/nested4", bazString, false)
+	allDoSameList(t, backends, "", []string{"foo/"}, false)
+	allDoSameListPage(t, backends, "", "", -1, []string{"foo/"}, false)
+
+	// Deleting it should leave no artifacts.
+	allDoSameDelete(t, backends, "foo/nested1/nested2/nested3/nested4", false)
+	allDoSameList(t, backends, "", nil, false)
+	allDoSameListPage(t, backends, "", "", -1, nil, false)
+
+	// Finally, test pagination exhaustively.
+	var created []string
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("key-%d", i)
+		allDoSamePut(t, backends, name, testString, false)
+		created = append(created, name)
+
+		// Listing everything should work.
+		allDoSameList(t, backends, "", created, false)
+		allDoSameListPage(t, backends, "", "", -1, created, false)
+
+		// Listing after our previous entry should work.
+		justBefore := ""
+		if len(created) >= 2 {
+			justBefore = created[len(created)-2]
+		}
+		allDoSameListPage(t, backends, "", justBefore, -1, []string{name}, false)
+		allDoSameListPage(t, backends, "", justBefore, 1, []string{name}, false)
+		allDoSameListPage(t, backends, "", justBefore, 2, []string{name}, false)
+
+		// Listing previously created entries should work. Note that limit=0
+		// is equivalent to limit=-1 and thus returns all entries.
+		if i > 0 {
+			allDoSameListPage(t, backends, "", "", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "asdf", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "key-", i, created[:i], false)
+			allDoSameListPage(t, backends, "", "aaaaaaaaaaaaaaaa", i, created[:i], false)
+		}
+
+		// Listing future entries should be blank.
+		allDoSameListPage(t, backends, "", name, -1, nil, false)
+		allDoSameListPage(t, backends, "", "key-99999999", -1, nil, false)
+		allDoSameListPage(t, backends, "", "zzzzzzzzz", -1, nil, false)
+	}
+
+	// Finally, clean up after paginated list testing.
+	for _, name := range created {
+		allDoSameDelete(t, backends, name, false)
+	}
+}
+
+func exerciseTransactions(t *testing.T, backends map[string]logical.TransactionalStorage) {
+	direct := make(map[string]logical.Storage, len(backends))
+	for name, backend := range backends {
+		direct[name] = backend.(logical.Storage)
+	}
+
+	// Creating a transaction and committing or rolling it back without doing
+	// anything should succeed, regardless of type of transaction. Doing the
+	// same operation twice should fail as the transaction was already
+	// finished.
+	txns := allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameRollback(t, txns, true)
+
+	// This should also be true if we swap types (commit->rollback and
+	// visa-versa).
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameCommit(t, txns, false)
+	allDoSameRollback(t, txns, true)
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameCommit(t, txns, true)
+	txns = allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSameRollback(t, txns, false)
+	allDoSameCommit(t, txns, true)
+
+	// Empty transactions can be interwoven.
+	txn1 := allDoSameBeginTx(t, backends, false)
+	txn2 := allDoSameBeginTx(t, backends, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, false)
+
+	// Writing to a read-only transaction should fail; committing this
+	// transaction should have no impact on storage.
+	test := []byte("test")
+	rtx := allDoSameBeginReadOnlyTx(t, backends, false)
+	allDoSamePut(t, rtx, "foo", test, true)
+	allDoSameDelete(t, rtx, "foo", true)
+	allDoSameCommit(t, rtx, false)
+	allDoSameList(t, direct, "", nil, false)
+
+	// Creating the same entry in two transactions should conflict the
+	// second committed one, even though they have the same contents.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", test, false)
+	allDoSamePut(t, txn2, "foo", test, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, true)
+	allDoSameGet(t, direct, "foo", &logical.StorageEntry{Key: "foo", Value: test}, false)
+
+	baz := []byte("baz")
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", baz, false)
+	allDoSamePut(t, txn2, "foo", baz, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, true)
+	allDoSameGet(t, direct, "foo", &logical.StorageEntry{Key: "foo", Value: baz}, false)
+
+	// Creating different entries in two transactions should be fine.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSamePut(t, txn1, "foo", test, false)
+	allDoSamePut(t, txn2, "bar", baz, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameGet(t, direct, "foo", &logical.StorageEntry{Key: "foo", Value: test}, false)
+	allDoSameGet(t, direct, "bar", &logical.StorageEntry{Key: "bar", Value: baz}, false)
+
+	// Getting an item and writing to the same item in different transactions
+	// should fail one of the two.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txn1, "bar", &logical.StorageEntry{Key: "bar", Value: baz}, false)
+	allDoSamePut(t, txn1, "foo", baz, false)
+	allDoSameGet(t, txn2, "foo", &logical.StorageEntry{Key: "foo", Value: test}, false)
+	allDoSamePut(t, txn2, "bar", test, false)
+	allDoSameCommit(t, txn1, false)
+	allDoSameCommit(t, txn2, true)
+	allDoSameGet(t, direct, "foo", &logical.StorageEntry{Key: "foo", Value: baz}, false)
+	allDoSameGet(t, direct, "bar", &logical.StorageEntry{Key: "bar", Value: baz}, false)
+
+	// Try again, with delete this time, committing in a different order.
+	txn1 = allDoSameBeginTx(t, backends, false)
+	txn2 = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txn1, "bar", &logical.StorageEntry{Key: "bar", Value: baz}, false)
+	allDoSameDelete(t, txn1, "foo", false)
+	allDoSameGet(t, txn2, "foo", &logical.StorageEntry{Key: "foo", Value: baz}, false)
+	allDoSameDelete(t, txn2, "bar", false)
+	allDoSameCommit(t, txn2, false)
+	allDoSameCommit(t, txn1, true)
+	allDoSameGet(t, direct, "foo", &logical.StorageEntry{Key: "foo", Value: baz}, false)
+	allDoSameList(t, direct, "", []string{"foo"}, false)
+
+	// Reading entries that don't exist shouldn't cause issues.
+	txns = allDoSameBeginTx(t, backends, false)
+	allDoSameGet(t, txns, "bar", nil, false)
+	allDoSameGet(t, txns, "foo", &logical.StorageEntry{Key: "foo", Value: baz}, false)
+	allDoSameDelete(t, txns, "foo", false)
+	allDoSameCommit(t, txns, false)
+	allDoSameList(t, direct, "", nil, false)
+}
+
+func getRandomOps(t *testing.T, count int, transactional bool, txLimit int) []*inmem.InmemOp {
+	var ops []*inmem.InmemOp
+
+	// Track transactions. Allow
+	opTypes := []int{
+		inmem.PutInMemOp, inmem.DeleteInMemOp,
+		inmem.ListInMemOp, inmem.ListPageInMemOp,
+		inmem.GetInMemOp,
+	}
+	if transactional {
+		opTypes = append(opTypes, []int{
+			inmem.BeginTxInMemOp, inmem.BeginReadOnlyTxInMemOp,
+			inmem.CommitTxInMemOp, inmem.RollbackTxInMemOp,
+		}...)
+	}
+
+	// We only want to create files, but will allow delete/get/list on
+	// both files and folders.
+	opFiles := []string{
+		"a",
+		"b",
+		"c",
+		"d",
+		"e",
+		"f",
+		"foo",
+		"foo/apple",
+		"foo/bar",
+		"foo/baz",
+		"foo/cherry",
+		"foo/foo",
+		"foo/fud",
+		"foo/very/highly/nested/subpath",
+		"foo/very/highly/nested/subpath/that/goes/on/for/ever/and/ever/and/ever/until/it/runs/out/of/usual/path/space/on/a/file/system",
+		"g",
+		"h",
+		"i",
+		"z",
+	}
+
+	opFolders := []string{
+		"",
+		"foo/very",
+		"foo/very/highly",
+		"foo/very/highly/nested",
+		"foo/very/highly/nested/subpath/that",
+		"foo/very/highly/nested/subpath/that/goes/on/for/ever/and/ever/and/ever/until/it/runs/out/of/usual/path/space/on/a/file",
+		"this-path-does-not-exist",
+		"this/path/also/does/not/exist",
+	}
+	opFolders = append(opFolders, opFiles...)
+
+	var opAfter []string
+	for _, entry := range opFolders {
+		opAfter = append(opAfter, filepath.Base(entry))
+	}
+
+	opContents := []string{
+		"",
+		"here",
+		"a",
+		"test",
+		"there",
+		"is-a-test",
+		"everywhere-is",
+		"a-test",
+		"bar",
+		"baz",
+		"somewhat-long-string-with-very",
+		"always-last-add-new-ones-above-me-start-of-a-very-very-long-string-",
+	}
+	for len(opContents[len(opContents)-1]) < 32*1024 {
+		opContents[len(opContents)-1] += "0123456789"
+	}
+
+	for i := 0; i < count; i++ {
+		opI := rand.Intn(len(opTypes))
+		op := opTypes[opI]
+
+		var tx int = rand.Intn(txLimit+1) - 1
+		var path string
+		var contents string
+		var after string
+		var limit int
+		switch op {
+		case inmem.PutInMemOp:
+			pathI := rand.Intn(len(opFiles))
+			path = opFiles[pathI]
+			contentsI := rand.Intn(len(opContents))
+			contents = opContents[contentsI]
+		case inmem.DeleteInMemOp, inmem.GetInMemOp, inmem.ListInMemOp:
+			pathI := rand.Intn(len(opFolders))
+			path = opFolders[pathI]
+		case inmem.ListPageInMemOp:
+			pathI := rand.Intn(len(opFolders))
+			path = opFolders[pathI]
+			afterI := rand.Intn(len(opAfter))
+			after = opAfter[afterI]
+		case inmem.CommitTxInMemOp, inmem.RollbackTxInMemOp, inmem.BeginTxInMemOp, inmem.BeginReadOnlyTxInMemOp:
+			tx = rand.Intn(txLimit)
+		default:
+			t.Fatalf("unknown op: %v", op)
+		}
+
+		if (op == inmem.ListInMemOp || op == inmem.ListPageInMemOp) && path != "" {
+			path = path + "/"
+		}
+
+		ops = append(ops, &inmem.InmemOp{
+			OpType:   op,
+			OpTx:     tx,
+			ArgKey:   path,
+			ArgAfter: after,
+			ArgLimit: limit,
+			ArgEntry: &physical.Entry{
+				Key:   path,
+				Value: []byte(contents),
+			},
+		})
+	}
+
+	return ops
+}
+
+func executeRandomOps(t *testing.T, backends map[string]logical.Storage, ops []*inmem.InmemOp) {
+	data, err := json.Marshal(ops)
+	require.NoError(t, err, "failed to marshal ops to json")
+	err = os.WriteFile(opsLogFile, data, 0o644)
+	require.NoError(t, err, "failed to save ops to file")
+
+	for index, op := range ops {
+		switch op.OpType {
+		case inmem.PutInMemOp:
+			allDoSamePut(t, backends, op.ArgEntry.Key, op.ArgEntry.Value, false)
+		case inmem.DeleteInMemOp:
+			allDoSameDelete(t, backends, op.ArgKey, false)
+		case inmem.GetInMemOp:
+			allDoSameGetNoBenchmark(t, backends, op.ArgKey, false)
+		case inmem.ListInMemOp:
+			allDoSameListNoBenchmark(t, backends, op.ArgKey, false)
+		case inmem.ListPageInMemOp:
+			allDoSameListPageNoBenchmark(t, backends, op.ArgKey, op.ArgAfter, op.ArgLimit, false)
+		default:
+			t.Fatalf("[%d] unknown operation: %v (%v)", index, op.OpType, inmem.OpName(op.OpType))
+		}
+	}
+
+	os.Remove(opsLogFile)
+}
+
+func executeRandomTransactionalOps(t *testing.T, txBackends map[string]logical.TransactionalStorage, ops []*inmem.InmemOp, txLimit int) {
+	data, err := json.Marshal(ops)
+	require.NoError(t, err, "failed to marshal ops to json")
+	err = os.WriteFile(txOpsLogFile, data, 0o644)
+	require.NoError(t, err, "failed to save ops to file")
+
+	direct := make(map[string]logical.Storage, len(txBackends))
+	for name, backend := range txBackends {
+		direct[name] = backend.(logical.Storage)
+	}
+
+	txs := make([]map[string]logical.Storage, txLimit)
+	for index, op := range ops {
+		var listRet map[string][]string
+		var entryRet map[string]*logical.StorageEntry
+		var errorRet map[string]error
+
+		bk := direct
+		if op.OpTx >= 0 && op.OpTx < txLimit {
+			bk = txs[op.OpTx]
+		}
+		if bk == nil {
+			continue
+		}
+
+		switch op.OpType {
+		case inmem.PutInMemOp:
+			errorRet = allDoPut(t, bk, op.ArgEntry.Key, op.ArgEntry.Value)
+		case inmem.DeleteInMemOp:
+			errorRet = allDoDelete(t, bk, op.ArgKey)
+		case inmem.GetInMemOp:
+			entryRet, errorRet = allDoGet(t, bk, op.ArgKey)
+		case inmem.ListInMemOp:
+			listRet, errorRet = allDoList(t, bk, op.ArgKey)
+		case inmem.ListPageInMemOp:
+			listRet, errorRet = allDoListPage(t, bk, op.ArgKey, op.ArgAfter, op.ArgLimit)
+		case inmem.BeginTxInMemOp:
+			if txs[op.OpTx] != nil {
+				allDoSameRollback(t, txs[op.OpTx], false)
+				txs[op.OpTx] = nil
+			}
+
+			txs[op.OpTx], errorRet = allDoBeginTx(t, txBackends)
+		case inmem.BeginReadOnlyTxInMemOp:
+			if txs[op.OpTx] != nil {
+				allDoSameRollback(t, txs[op.OpTx], false)
+				txs[op.OpTx] = nil
+			}
+
+			txs[op.OpTx], errorRet = allDoBeginReadOnlyTx(t, txBackends)
+		case inmem.CommitTxInMemOp:
+			errorRet = allDoCommit(t, bk)
+			txs[op.OpTx] = nil
+		case inmem.RollbackTxInMemOp:
+			errorRet = allDoRollback(t, bk)
+			txs[op.OpTx] = nil
+		default:
+			t.Fatalf("unknown operation: %v (%v)", op.OpType, inmem.OpName(op.OpType))
+		}
+
+		var errExpected error
+		var errExpectedName string
+		for name, err := range errorRet {
+			if errExpectedName == "" {
+				errExpectedName = name
+				errExpected = err
+				continue
+			}
+
+			if (errExpected != nil) != (err != nil) {
+				t.Fatalf("[op %d] different error results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n", index, op.OpType, inmem.OpName(op.OpType), errExpectedName, errExpected, name, err)
+			}
+		}
+
+		if listRet != nil {
+			var listExpected []string
+			var listExpectedName string
+			for name, result := range listRet {
+				if listExpectedName == "" {
+					listExpectedName = name
+					listExpected = result
+					continue
+				}
+
+				if len(listExpected) == 0 && len(result) == 0 {
+					continue
+				}
+
+				if diff := deep.Equal(listExpected, result); diff != nil {
+					t.Fatalf("[op %d] different list results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n==== diff ====\n%v\n", index, op.OpType, inmem.OpName(op.OpType), listExpectedName, listExpected, name, err, diff)
+				}
+			}
+		}
+
+		if entryRet != nil {
+			var entryExpected *logical.StorageEntry
+			var entryExpectedName string
+			for name, result := range entryRet {
+				if entryExpectedName == "" {
+					entryExpectedName = name
+					entryExpected = result
+					continue
+				}
+
+				if diff := deep.Equal(entryExpected, result); diff != nil {
+					t.Fatalf("[op %d] different entry results for %v (%v):\n==== %v ====\n\t%v\n==== %v ====\n\t%v\n==== diff ====\n%v\n", index, op.OpType, inmem.OpName(op.OpType), entryExpectedName, entryExpected, name, err, diff)
+				}
+			}
+		}
+
+	}
+
+	os.Remove(txOpsLogFile)
+}

--- a/website/content/docs/rfcs/transactions.mdx
+++ b/website/content/docs/rfcs/transactions.mdx
@@ -1,0 +1,398 @@
+---
+sidebar_label: transactional storage
+description: |-
+  Transactional Storage for Plugins & Core
+---
+
+# Transactional Storage for Plugins & Core
+
+## Summary
+
+OpenBao and its upstream lacks transactional storage semantics. This means all storage operations are logically separate: between two put operations, the contents of storage may differ or the system may crash. Adding support for transactions gives resilience and better fault tolerance to OpenBao.
+
+## Problem Statement
+
+Transactions are a well-utilized concept in databases. OpenBao's [storage interface](https://github.com/openbao/openbao/blob/main/sdk/logical/storage.go#L31-L38) remains primitive and does not support transactions. The underlying [physical layer](https://github.com/openbao/openbao/blob/main/sdk/physical/physical.go) supports a [one-shot transaction interface](https://github.com/openbao/openbao/blob/main/sdk/physical/transactions.go) but is used only [in a few places](https://github.com/openbao/openbao/blob/124a5f10bc234a68c1c954a2ff47f519b22d1d33/vault/sealunwrapper.go#L158-L175) due to its inflexibility.
+
+As [mentioned recently](https://github.com/openbao/openbao/issues/270), fixing this is important for hitting organization's internal SLA's and offering requirements. OpenBao fundamentally pairs a K/V storage engine with a plugin architecture; managing secrets requires strict storage safety guarantees.
+
+Extending OpenBao's storage model to include [more standard](https://pkg.go.dev/database/sql#DB.BeginTx) transaction support (with the ability to interleave storage operations with other code) would give the plugin programmer more standard but expressive safety mechanisms. This would resolve broad categories of faults and bring OpenBao in line with industry at large relying directly on transactional storage semantics.
+
+## User-facing description
+
+To the end-consumer of OpenBao, few changes are expected to occur: at most, some write operations may fail due to transactions failing. This will necessitate additional client side retries for a new category of errors: transaction commit failures. This is discussed more [below](#survey-of-requirements).
+
+This will not be client-driven transactions (i.e., long-lived transactions that the client can use to ensure consistency across multiple API calls and which could potentially starve other clients); these will be similar to database transactions that the plugins themselves can implement.
+
+To the programmer of plugins, this will conditionally open up new transaction APIs (if the backend supports it), allowing them to opt into safer storage semantics. This will be detectable at runtime through type assertions on the `logical.Storage` interface passed in to the plugin.
+
+## Technical Description
+
+This section is broken up as follows:
+
+ 1. [Survey of Requirements](#survey-of-requirements)
+ 2. [Prior Art](#prior-art)
+ 3. [Implementation in Raft](#implementation-in-raft)
+    1. [Implementing Read-Only Transactions](#implementing-read-only-transactions)
+    2. [Implementing Writable Transactions](#implementing-writable-transactions)
+    3. [Verification Hashes](#verification-hashes)
+ 4. [Implementation in Postgres](#implementation-in-postgres)
+ 5. [Implementation in File, InMem](#implementation-in-file-inmem)
+ 6. [Updates to Physical, Logical](#updates-to-physical-logical)
+ 7. [Global Updates](#global-updates)
+ 8. [Usage in Plugins](#usage-in-plugins)
+ 9. [Cleanup and Future Work](#cleanup-and-future-work)
+
+~This feature could be gated behind a flag that defaults to true if the underlying storage mechanism supports it: `transactional`. This will let operators disable this functionality if the performance tradeoff with a paritcular backend is too much, but otherwise opts them into it.~ This doesn't make much sense as there's no existing code expecting to use these types of transactions and so this is the default behavior: transactions do not impact existing code and if there's a bug in transactional support, it would hopefully be limited to the new transactions and we should probably just push a bug fix.
+
+The below description often refers to an "update" or "write" operation to agnostically mean both `storage.Put(...)` and `storage.Delete(...)` calls.
+
+### Survey of Requirements
+
+Some databases make a distinction between two types of transactions: read-only and writable. One example is [`bbolt`](https://pkg.go.dev/go.etcd.io/bbolt#readme-transactions), the backing data store for the Raft storage backend. `bbolt` allows multiple read transactions, but only a single write transaction at a given time. It additionally does not allow transaction upgrade (from read-only to writable). This necessitates that we defer to the plugin author as to which type of transaction we use, and to only have one transaction at a time per thread (as we may not be able to guarantee a read and write transaction can both make progress together).
+
+Further, `bbolt` does not allow nested transactions so we will not implement or require support for that.
+
+Within the transaction, we'd like to have all regular storage operations available (list, delete, read, put, ...) at a consistent point in time.
+
+We'd also like both transaction finalization mechanisms, commit and rollback, to be present.
+
+Similarly, OpenBao presently only allows a single node to perform write operations. This means we do not need any distributed locking mechanism and can thus rely on the active node using the underlying storage's transaction support. To my knowledge, this is true even of performance secondary nodes: updates from the primary cluster are sent out-of-band of the Raft protocol to secondaries, which the active node of the performance secondary cluster will then apply as if they were local writes (whereas true local writes return an `ErrReadOnly` for the active node of the performance primary cluster to handle). Writes to cluster-local storage in either case would behave as if the node was the active node of a primary cluster. Allowing multi-node writes is out of scope of this project.
+
+**Note**: we do not wish to impose a local-node exclusive write-lock requirement here with this statement. We wish to note various backends _may_ have different semantics, but that cross-node we will have already ensured only one writer.
+
+OpenBao and its upstream _already_ have a soft, client-driven retry requirement in some scenarios: operations can fail (e.g., due to quotas, expiring tokens, or broken cross-node replication) that require applications be aware of these scenarios and allow for retry. Transactions will likely be included as another reason operations fail, regardless of implementation (as transactions themselves can fail independent of any given operation outside of a transaction being able to succeed).
+
+Lastly, we want consistency of errors: read-only transactions should return a consistent error when attempting to write, commit failures should wrap a commit failure error, and attempting to use an already committed transaction should also fail.
+
+### Prior Art
+
+`etcd` is another popular pairing of `bbolt` with the Raft protocol. It [implements](https://pkg.go.dev/go.etcd.io/etcd/client/v3#Txn) a [transactional interface](https://etcd.io/docs/v3.4/learning/api/#transaction) similar to our existing one-shot transaction, with a few different capabilities. It supports a list of comparison predecates, evaluating the state of the storage. All success or any failure can then implement separate sets of storage requests, using the `RangeRequest`, `PutRequest` or `DeleteRangeRequest` semantics. However, note that modified keys within the transaction are enforced to be unique (e.g., no `DeleteRangeRequest` can operate over keys handled by another `PutRequest`). This makes it an improvement over our existing one-shot semantics, but not as expressive as the database-style interactive transactions.
+
+[`rqlite` pairs](https://github.com/rqlite/rqlite) the HashiCorp [Raft engine](https://github.com/hashicorp/raft) with [sqlite](https://www.sqlite.org/), the popular file-based relational database. It too supports a [limited form of transactions](https://rqlite.io/docs/api/api/#transactions): several queries can be sent together to the server, along with the `transaction` field, such that if any query errs, the transaction will be rolled back. This is again similar to our one-shot transactional model.
+
+A design constraint present with both `etcd` and `rqlite` is that the server (and data) is distinct from the client entity. They must communicate via one-shot API calls. OpenBao is co-located with the source of the data, which means local database transactions (even if read-only) can be used to our advantage, when backed by a Raft instance.
+
+### Implementation in Raft
+
+Raft is the only backend supported in OpenBao at this point in time. The Raft storage backend uses the Raft protocol for consensus on write operations (`Put(...)` and `Delete(...)`), with direct `bbolt` operations for reads (`Read(...)` and `List(...)`).
+
+Because of the [aforementioned limitations](#survey-of-requirements) of `bbolt`, we have two separate transactional mechanisms to implement: read-only and writable.
+
+#### Implementing Read-Only Transactions
+
+Implementing a read operation is simple: because we already pass through to the underlying local `bbolt` database, we can continue to do so. We can create a new `bbolt` read-only transaction and persist it through the lifetime of this transaction, using it for all read operations. This will not block writes [assuming an adequate mmap setup](https://pkg.go.dev/go.etcd.io/bbolt#Options). On commit, we can instead [rollback](https://pkg.go.dev/go.etcd.io/bbolt#Tx.Rollback) to gracefully handle this error scenario (as the database client requires rollback of read-only transactions).
+
+This will ensure a consistent view, similar to existing operations. Going through Raft will not be possible , as it would not guarantee a consistent view: unlike the existing one-shot transaction API, we do not have a list of all read operations up-front and thus would need to persist several open transactions (which may potentially be at different Raft states!) for subsequent Raft log queries. Parallel raft FSM update operations will not impact our view of this transaction, per `bbolt` guarantees (nor do we want to see them). Going through Raft is also not desirable for read operations as it incurs substantial performance cost.
+
+Thus for a read-only transaction, using a local `bbolt` transaction is the way to go.
+
+#### Implementing Writable Transactions
+
+Implementing writable transactions is more complex. To begin, let's look at how a write operation works today:
+
+ 1. [Call from higher levels](https://github.com/openbao/openbao/blob/main/physical/raft/raft.go#L1505) into the Raft physical storage backend.
+ 2. A [log entry is created](https://github.com/openbao/openbao/blob/main/physical/raft/raft.go#L1515-L1529) and [sent to raft](https://github.com/openbao/openbao/blob/main/physical/raft/raft.go#L1641-L1730).
+ 3. Upon consensus, each node's [FSM is updated](https://github.com/openbao/openbao/blob/main/physical/raft/fsm.go#L623-L779) to do this write to their local `bbolt` instance.
+ 4. A result (if necessary) and error (if any) is finally returned to the caller.
+
+Because we've completed the Raft consensus protocol, we know we've applied the write locally and subsequent reads will see this state. `bbolt` only allows a single write transaction at a time. All present updates are performed in a single transaction and thus will block on a plugin-initiated writable transaction being performed.
+
+(That is to say, a `Put(...)` operation at the plugin layer eventually causes a Raft log message with a single `Put(...)` and thus causes a transaction with a single write operation to occur. With the one-shot physical transactional interface, all operations are batched into a single Raft call and thus occur within a single `bbolt` transaction.)
+
+We have three approaches to implement writable transactional:
+
+ 1. Use our own global lock, ensuring no other write operation can succeed. This would block any other Raft operations from occurring, and since we're the only node with write permissions, we know we'll commit consistently through Raft, even though we'll have to rollback the transaction itself to ensure Raft applies the results successfully and consistently.
+ 2.  We could alternatively persist access to the transaction, such that when it comes time to apply the Raft log entry, we can simply attempt to commit the transaction (if we're on the node that started the transaction) and otherwise redo all write operations explicitly. But under this proposal, we'd not otherwise prevent parallel writers (beyond what `bbolt` would do for us by keeping the transaction open).
+ 3.  We could always rollback the local write transaction, converting all read steps to verifications and all updates to verify+update pairs. Here, there would be a small window in which (after rolling back the exclusive write transaction), we could race against other writes (if they beat us into the the FSM) and thus (if they modified the same data) the transaction could fail (even if a direct commit would've succeeded).
+
+Both 1 & 2 have the same fragility problem: problems with Raft could result in the `bbolt` transaction being held indefinitely, even when the application thinks they have attempted a commit. However with 3, we avoid this fragility via a trade off for the increased possibility of a failing transaction (due to parallel writes) and increased log entry size (as it now needs to contain all verified read/list operations). Notably, this retry needs to be done anyways (with 1 & 2) if the underlying native transaction were to fail, but the increase of size is likely too much in some scenarios (if a transaction is created greedily, as many authors do today). This size could be shrunk by using hashes (e.g., SHA-256 would likely involve an additional 32-64 bytes depending on encoding format), you still incur increasing cost per read entry; for read iteration over thousands of entries, this grows the commit log to 100s of KB, even if only a single write operation occurs. Because of the window between the initial rollback and the `bbolt` transaction being re-constructed, it'd likely be unsafe to verify state before just the write operations.
+
+Between 1 & 2, note that 2 doesn't fully guarantee exclusivity: if a write transaction is created and a parallel (un-transactional) write occurs, this will get sent to the Raft layer for committal out of order from the write transaction being completed, blocking it on the active node (but being allowed to continue on other nodes!). When the write commits, this would result in out-of-sync data between the nodes. However, 1 fixes this by ensuring strict write ordering _into_ Raft as well, from the PoV of the active node.
+
+Thus 2 is excluded.
+
+This means it is between 1 & 3. 1's strict exclusion is sufficiently restrictive (one global writer, which may cause locking problems due to lock/transaction aquisition order) that we'll want to isolate it to only the lower layer. Allowing transactions to be disabled will allow users (who want to trade off performance/raft log size with unsafeness) to make a decision best suited for their environment.
+
+This means, we'll implment 3.
+
+We have a few tricks for improving 3:
+
+ 1. Use a read transaction rather than a write transaction, implementing the write visibility side ourselves. Beacuse we know we're going to rollback this transaction (in order to apply it through the Raft process), we don't benefit from grabbing the exclusive lock. This is more work to implement, but gives us better parallelism.
+ 2. Reads only need to be verified if they did not occur prior to a write (put/delete); otherwise, we know (through write verification and being in a transaction) that the state is the same. This delays the verification, but saves on operations in the Raft log.
+ 3. Rather than a per-operation hash, we could implement a single, running operation hash. Each Verify operation (written to the raft log) would only contain a path, but write the contents to a globally running has hoperation. At the end of a transaction, a `CommitIfHash` or `VerifyFinish` message would contain the hash itself, and the transaction would only be committed if the overall state matched. This is more work to implement, but would reduce the size of the Raft log in the future.
+ 4. We want each top-level Raft transaction to execute in its own lower-level bbolt transaction for simplicity. However, raft application today currently uses a single large transaction for all batched Commands. This means we'll want to intelligently drop+recreate the transaction (reusing transactions for batched operations, but using a dedicated transaction for any Raft-level transactions).
+
+To achieve 3 now:
+
+ 1. When a higher layer initiates a write transaction, we'll being a new read-only transaction.
+ 3. Write storage operations will be locally cached to be replayed later. A read will be initiated first in order to issue a verify-read operation in the Raft log.
+ 2. Read storage operations will be transparently passed through to this transaction context, *if they were not modified locally*, and added as a verify-read operation in the Raft log.
+ 4. On rollback, we'll rollback the transaction.
+ 5. On commit, we'll initiate a raft commit operation of the combined verify+update operations. These new ops will be added to the FSM (allowing it to verify operations within the transaction) and handle commit/rollback on the transaction locally. We'll block (like `Put` does today) for Raft to finish, and return any errors.
+
+In particular, we introduce the following Raft log operation types:
+
+ 1. `verifyReadOp`, which verifies a given entry has the specified contents within a transaction. The key is the expected key and the value is a formatted hash.
+ 2. `verifyListOp`, which verifies the results of a list operation matches expectations within a transaction. The key is a JSON encoded structure describing the `ListPage` parameters (`prefix`, `after`, and `limit`). The result is a formatted hash.
+ 3. `beginTxOp` and `commitTxOp`, two sentinels of a transaction (beginning and ending, respectively). The former can be empty for now but later indicate the hash type, whereas `commitTxOp` can eventually include the hash value at the end of a running log.
+
+Lastly, we hijack the existing `FSMEntry` response to include a variant in which a sentinel key is used to send back a specific error message (commit failure).
+
+#### Verificaiton Hashes
+
+Verification hash formatting takes the following, variable-length format:
+
+```
+ < 1-byte identifier > | < n-byte raw hash >
+```
+
+The following identifiers are defined by this RFC:
+
+ 1. `0x01` - `sha384VerifyHash`, creating a 48-byte hash.
+
+Hashing is done as follows:
+
+1. A single `{` is written to the hash function input stream.
+2. The value of the operation's key is written to the hash function input tsream.
+3. A single `}` is written to the hash function input stream.
+4. The value of the data to be hashed (either the direct storage entry in the case of a `Get` operation or a new-line joined output from `List`).
+
+The hash is returned and the one-byte type sentinel is returned. Hashes should be compared in a constant-time manner to avoid leaking information about the data.
+
+### Implementation in Postgres
+
+Postgres can implement these semantics much easier.
+
+The Postgres backend stores [all data in a single table](https://github.com/openbao/openbao/blob/before-plugin-removal/physical/postgresql/postgresql.go#L98-L101). We have a [`*sql.DB`](https://github.com/openbao/openbao/blob/before-plugin-removal/physical/postgresql/postgresql.go#L173) instance, and thus can expose a [`sql.TX`](https://pkg.go.dev/database/sql#Tx) to implement the above semantics using the `pgx` connector. Note that no differentation between read and write transactions will be done, other than the required erring out.
+
+This will be much easier than the Raft+`bbolt` implementation above, should we wish to resurrect the Postgres backend in the future.
+
+The above Raft semantics likely roughly [correspond to `read committed` isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+
+### Implementation in File, InMem
+
+These backends will not be transactional. This means plugins will need to test against the Raft backend if they wish to test and take advantage of a transactional backend. Likely this will need to be opt-in for the plugin.
+
+### Updates to Physical, Logical
+
+The interface for Physical storage will need to be updated to include new transactional interfaces; the following are proposed as optional interfaces that backends can implement:
+
+```go
+// InteractiveTransactional is an optional interface for backends that
+// support interactive (mixed code & statement) transactions in a similar
+// style as Go's Database paradigm. This differs from Transactional above:
+// that one is a one-shot (list of transactions to execute) transaction
+// interface.
+type InteractiveTransactional interface {
+    // This function allows the creation of a new interactive transaction
+    // handle, only supporting read operations. Attempts to perform write
+    // operations (PUT or DELETE) will result in immediate errors.
+    BeginReadOnlyTx(context.Context) (Transaction, error)
+
+    // This function allows the creation of a new interactive transaction
+    // handle, supporting read/write transactions. In some cases, the
+    // underlying physical storage backend cannot handle parallel read/write
+    // transactions.
+    BeginTx(context.Context) (Transaction, error)
+}
+
+// Transaction is an interactive transactional interface: backend storage
+// operations can be performed, and when finished, Commit or Rollback can
+// be called. When a read-only transaction is created, write calls (Put(...)
+// and Delete(...)) will err out.
+type Transaction interface {
+    Backend
+
+    // Commit a transaction; this is equivalent to Rollback on a read-only
+    // transaction.
+    Commit(context.Context) error
+
+    // Rollback a transaction, preventing any changes from being persisted.
+    Rollback(context.Context) error
+}
+
+// InteractiveTransactionalBackend is implemented if a storage backend
+// implements interactive transactions as well.
+type InteractiveTransactionalBackend interface {
+    Backend
+    InteractiveTransactional
+}
+```
+
+When a `physical.Backend` supports transactions (being a `physical.InteractiveTransactionalBackend`), it is expected that the `logical.Storage` backend exposed to plugins will also support transactions via the following interface:
+
+```go
+// Transactional is an optional interface for backends that support
+// interactive (mixed code & statement) transactions in a similar
+// style as Go's Database paradigm. This is equivalent to
+// physical.InteractiveTransactional, not the earlier, one-shot
+// physical.Transactional interface.
+type Transactional interface {
+    // This function allows the creation of a new interactive transaction
+    // handle, only supporting read operations. Attempts to perform write
+    // operations (
+    BeginReadOnlyTx(context.Context) (Transaction, error)
+
+    // This function allows the creation of a new interactive transaction
+    // handle, supporting read/write transactions. In some cases, the
+    // underlying physical storage backend cannot handle parallel read/write
+    // transactions.
+    BeginTx(context.Context) (Transaction, error)
+}
+
+// Transaction is an interactive transactional interface: backend storage
+// operations can be performed, and when finished, Commit or Rollback can
+// be called. When a read-only transaction is created, write calls (Put(...)
+// and Delete(...)) will err out.
+type Transaction interface {
+    Storage
+
+    // Commit a transaction; this is equivalent to Rollback on a read-only
+    // transaction.
+    Commit(context.Context) error
+
+    // Rollback a transaction, preventing any changes from being persisted.
+    Rollback(context.Context) error
+}
+
+// TransactionalStorage is implemented if a storage backend implements
+// Transactional as well.
+type TransactionalStorage interface {
+    Storage
+    Transactional
+}
+```
+
+Once `InteractiveTransactional` is implemented on a physical backend, various layers will need to enable plugin support, just like with [paginated lists](https://github.com/openbao/openbao/issues/140):
+
+1. `physical/*`, as mentioned above for Raft.
+2. `helper/keysutil/encrypted_key_storage.go`, becoming transparently transactional if the underlying storage is transactional.
+3. `sdk/logical/logical_storage.go`, becoming transparently transactional if the underlying `physical.Backend` is transactional.
+4. `sdk/logical/storage_view.go`, becoming transparently transactional if the underlying storage is transactional.
+5. `sdk/physical/cache.go`, becoming transactional if the underlying storage is transactional. Likely this will mean creating a copy at transaction creation time (to continue accelerating reads) and replaying writes on commit. Longer term, this may necessitate a different cache design that supports an `if-older-than` lookup semantic.
+6. `sdk/physical/error.go` may or may not need to be updated, depending on if we want to support random error rates in transaction during testing.
+7. `sdk/physical/encoding.go` will need to be updated.
+8. `sdk/plugin` will need to be updated to conditionally support transactional storage when Core supports it. This will enable testing clusters (on file or inmem backends), non-transactional storage backends, and enable compatibility with upstream.
+9. `vault/barrier_view.go` will need to become conditionally transactional.
+10. `vault/barrier.go` and `vault/barrier_aes_gcm.go` will need to become conditionally transactional.
+11. `vault/sealunwrapper.go` will need to become conditionally transactional.
+
+We'll also want to provide adequate constants (similar to `ErrReadOnly`) that can be used to detect transactional failure scenarios (such as a write-in-read-only programmer errors or a failure to commit/rollback a transaction).
+
+### Global Updates
+
+One key concern is accidental *transaction leakage*. Given most storage operations are request-bound (outside of tidy operations), we'd like to ensure a poorly-written plugin is easily detectable. To that end, adding a transaction interposer to the API request layer seems ideal. It can:
+
+ - Track all new transactions created within the context of a request.
+ - Ensure they are properly closed.
+ - Abort them if not, logging the offending plugin's information and request path.
+
+This may need to be placed at an adequate layer such that panics are caught and handled as errors to avoid leaking connections due to panics, though these should be relatively rare.
+
+Additionally, storage backends which implement the incremental transactional can trivially be made to implement the existing one-shot transaction backend through a common helper. This is outside the scope of this effort though, and may not be worthwhile overall as more things switch to better transaction semantics.
+
+### Usage in Plugins
+
+Plugins may or may not be running under a transaction-aware OpenBao instance. This will be detectable by the caller by running:
+
+```go
+if txnable, ok := req.Storage.(logical.TransactionalStorage); ok {
+    ... do a transaction ...
+}
+```
+
+For sensitive operations that need consistency (e.g., CRL rebuilding, CA updates, &c), we suggest a transparently created transaction early in the req handling:
+
+```go
+txnable, haveTransaction = req.Storage.(logical.TransactionalStorage)
+if haveTransaction {
+    txn, err := txnable.BeginTx(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    defer txn.Rollback()
+    req.Storage = txn
+}
+
+// ... rest of handler ...
+
+// If all is ok, commit the transaction
+if haveTransaction {
+    txn = req.Storage.(logical.Transaction)
+    if err := txn.Commit(ctx); err != nil {
+        return nil, err
+    }
+}
+```
+
+This should allow minimal code to be transaction aware. However, if the wrong type of transaction is created (e.g., a read-only transaction is created when write capabilities are desired, independently of the transaction), this may require keeping a second (original) `req.Storage` instance around and passing it into more places.
+
+When implementing support in external (GRPC) plugins, we'll use a UUID to identify and correlate transactions between the plugin (which only has the identifier and a GRPC client) and the core server (which has the underlying "real" transaction). Since we presume the GRPC server serves multiple distinct plugins, and we don't want plugins to guess transactions from other plugins (thus letting it escape its sandboxed view of storage but only into a parallel sandbox), we do not want to use sequential integer identifiers here. All GRPC storage requests will take an optional transaction identifier, which when empty (the default) will operate outside of a transaction and will otherwise use the specified transaction. This avoids needing to add parallel versions of existing calls which only operate inside transactions.
+
+### Cleanup and Future Work
+
+As part of this, we'll transition existing callers to the new interactive transactional APIs from the one-shot interface. This is not a breaking change as this was only exposed internal to Core and thus doesn't affect any existing plugins.
+
+This enables additional future work:
+
+ 1. Many places in Core and various plugins can be audited for the use of scoped transactions. Some examples include token cleanup, revocation of leases, PKI issuer creation, and more.
+ 2. Safe backup APIs can be created, which take a read-transaction over the datastore. This ensures a consistent, recoverable view (assuming plugins are updated to use transactions where appropriate).
+ 3. Add support for transactions to the in-memory transaction. This will allow easier testing of transaction support (without needing to spin up), at the cost of a more complex in-memory backend storage.
+ 4. Creating a wrapping layer for requests, to identify the use of transactions and any failure to release them. This could automatically roll them back to avoid consuming resources.
+
+Further, we'll want to expand to build a cross-storage engine test suite to differentially compare various engines to ensure consistency between them. This could also incorporate differential fuzzing of operations in the future.
+
+## Rationale and alternatives
+
+The above should sufficiently motivate the rationale for this change.
+
+Two alternatives for Raft are presented above. Outside of segmenting the raft database into separate sections (which is outside the scope of this work), no other alternative for parallel writes is immediately obvious without some trade off. Open to discussing some though!
+
+Another alternative would be exposing the one-shot transaction currently present in the physical layer, everywhere. This is less than ideal as there is no flexibility here: transactions are one-shot and so at best are a check-and-set-with-manual-rollback. We could potentially introduce a check-and-write operation (wherein a read is issued manually, and at the one-shot transaction layer, subsequently re-done prior to applying the operation). However, this still places unfamiliarity and burden on the plugin author, unlike with this proposal (which largely aligns to common semantics).
+
+Another alternative rejected was leaving support for the one-shot transactions. As we can see from etcd and rqlite above, not every K/V storage system will implement for the full interactive transactions that OpenBao expects. While one-shot transactions can be implemented with full interactive transactions. However, it vastly extends the compatibility testing we'd need to do: each plugin would need to be tested in two scenarios (no transactions, one-shot transactions, and with interactive transactions). The compatibility between interactive transactions and no transactions, in the best case, is easy for a plugin (as mentioned above) -- but, with one-shot transactions, the underlying storage calls will need to differ and thus can't easily be done in parallel. This makes plugin authoring harder as well, if safe support for storage backends with only one-shot transactions is desired. Thus, we'll decline to do this and further, remove support from Core for one-shot transactions as well.
+
+## Downsides
+
+Widespread usage of transactions with Raft will result in more long-held global write locks. This means that presently, write transactions are best reserved for limited, high-assurance cases (rotating or creating CAs, consistency in certain operations, &c). In most scenarios, read transactions will not impact performance. Switching to separate `bbolt` instances per-plugin or re-introducing the Postgres backend could be alternatives which improve this.
+
+As noted above, not every storage backend will implement this type of transactions. This makes adding new storage backends (that don't implement these semantics) harder or unsafe.
+
+## Security Implications
+
+As before, malicious or poorly written plugins retain immense DoS capabilities: excessive transactions could starve resources elsewhere in the system (so use of Quotas remains important) and global write locks mean that long-lived write transactions could prevent progress elsewhere in the system.
+
+Long-term, this security trade off can be adjusted with alternative design decisions (such as separate `bbolt` instances or using Postgres which has better transaction error handling). None of the requirements above _should_ mandate locking us into a particular implementation.
+
+## User/Developer Experience
+
+No end-user or end-application developer experience should change outside of adding a new retry scenario (transaction failure) to their clients. If anything, this should result in a more consistent experience, wherein cleanup of certain failed operation should not need to occur.
+
+For plugin developers, this gives additional tools for safely handling failures within the plugin ecosystem.
+
+## Unresolved Questions
+
+1. While immediately out of scope, it is not clear how this would interact with performance secondaries (in which requests could need conditional forwarding): would acquiring a write-transaction (but not calling write) on a standby node trigger a forward to the active node? Or would that be delayed until write time?
+   - A similar way of handling plugin GRPC calls could be applied to performance secondaries' write forwarding: a transaction with an identifier could be created (with the underlying transaction on the PerfPrimary but a transparent version on the PerfSecondary). This could leave some spare unclosed transactions lying around if a perf secondary disappears but a stale transaction timeout could be applied in the future.
+2. In general, what error handling should be applied to commit/rollback failures? Are these able to be retried? Should they destroy state and mark themselves as committed (even though they have failed to commit)?
+   - Errors should probably be handed up to the client to deal with. The entire operation should probably be retried, if it is safe to do so, after finding the current state. No transaction/commit indication is given.
+3. If a writable transaction saw no writes, should we attempt to commit it still, verifying all reads, allowing it to potentially fail? Or should we treat it as the same as the (much less likely to fail) rollback operation?
+   - We should probably leave the existing transaction commit logic and not attempt to short-circuit writes in case the state differs due to other pending writes. This will give the caller an indication of other parallel writes, even if no local writes were attempted.
+
+## Related Issues
+
+ - This is motivated in part by https://github.com/openbao/openbao/issues/270, which brought this up to the OpenBao community.
+
+ - @nsimons has opened several related to the PKI engine upstream: https://github.com/hashicorp/vault/issues/19210, https://github.com/hashicorp/vault/issues/18667, and https://github.com/hashicorp/vault/issues/18583. Solving them on an ad-hoc basis, while possible, would be a lot more work than utilizing transactional storage more globally.
+
+ - https://github.com/hashicorp/vault/issues/16294#issuecomment-1197262112 is another shortcoming caused by lack of transactional storage for critical operations.
+
+ - https://github.com/hashicorp/vault/issues/5683#issuecomment-524454951 is an old issue that mentions the lack of transactional storage.
+
+## Proof of Concept
+
+Proof of concept branch is available here: https://github.com/openbao/openbao/pull/292
+
+This includes basic tests of transaction correctness under `physical/crosstest`. Additionally, one operation, PKI root generation (which is locked anyways) is updated to use transactions. In the future, more operations could be updated to support transactions.


### PR DESCRIPTION
This adds support for interactive transactions across the backend, physical, and plugin storage levels. This will ultimately allow for greater assurance in secrets management operations built on top of OpenBao.

See the RFC in #296 for more detailed information about the design of this change.

Resolves: #296

----

TODO:

 - [x] Resolve unresolved questions. 
 - [x] Benchmark subsystem performance when using transactions.
 - [x] Implement support for GRPC connected plugins.
 - [x] Expand randomized testing to `logical.Storage`, finish adding remaining layers to the cross-test. 
 - [x] Obey error handling discussed in RFC. 
 - [x] Add transaction concurrency limiting to InMem as well. 
 - [x] Expand `physical`'s `testing.go` to support basic testing of transactions. 
 - [x] ~Add support for disabling transactional storage from the configuration.~
 - [x] ~Update inmem-ha, `sdk/physical/latency.go`, and `sdk/physical/errors.go` to be transactional.~
 - [x] Think about separate raft limit size of transactions. 
 - [x] Rebase after GA and split PRs land.
    - [x] Split off removal of one-shot transactional interface into separate PR. -- #422 
    - [x] Split seal unwrapper removal into separate PR.  -- #423
    - [x] Split off core transaction definitions -- #433
    - [x] Split off each implementation -- #436, #437, #438, #439, #441, #442, and #443.
    - [x] Split off second level implementations (`BarrierView` and `AES-GCM Barrier View`) -- #440, #495
    - [x] Split off GRPC implementation -- #497
    - [x] Split off PKI root CA creation updates -- #498
    - [x] Add RFC text in this PR, merge.

<details>

<summary> Benchmarks </summary>

Without transactions (b56dc9c110b7b4f9170a1148d9febcc9a35cef38):

```
$ vault-benchmark run -config=docs/examples/pki/stored/pki-ed25519.hcl 
2024-07-22T12:28:57.564-0400 [INFO]  vault-benchmark: setting up targets
2024-07-22T12:29:01.596-0400 [INFO]  vault-benchmark: starting benchmarks: duration=30s
2024-07-22T12:29:31.604-0400 [INFO]  vault-benchmark: benchmark complete
Target: http://127.0.0.1:8200
op         count   rate         throughput   mean        95th%       99th%       successRatio
pki_issue  216959  7231.820942  7230.238976  1.363455ms  3.034576ms  5.149475ms  100.00%
```


With transactions (unused):

```
$ vault-benchmark run -config=docs/examples/pki/stored/pki-ed25519.hcl 
2024-07-22T12:27:22.730-0400 [INFO]  vault-benchmark: setting up targets
2024-07-22T12:27:26.775-0400 [INFO]  vault-benchmark: starting benchmarks: duration=30s
2024-07-22T12:27:56.779-0400 [INFO]  vault-benchmark: benchmark complete
Target: http://127.0.0.1:8200
op         count   rate         throughput   mean        95th%       99th%       successRatio
pki_issue  218338  7277.948872  7277.202214  1.356165ms  3.004142ms  4.872949ms  100.00%
```

With transactions (used for PKI issuance):

```
$ vault-benchmark run -config=docs/examples/pki/stored/pki-ed25519.hcl 
2024-07-22T12:33:15.869-0400 [INFO]  vault-benchmark: setting up targets
2024-07-22T12:33:19.896-0400 [INFO]  vault-benchmark: starting benchmarks: duration=30s
2024-07-22T12:33:49.898-0400 [INFO]  vault-benchmark: benchmark complete
Target: http://127.0.0.1:8200
op         count   rate         throughput   mean        95th%       99th%       successRatio
pki_issue  224037  7467.877003  7467.576805  1.318337ms  3.120374ms  5.828247ms  100.00%
```

<details>

<summary> Diff for PKI issuance transactions </summary>

```diff
$ git diff
diff --git a/builtin/logical/pki/path_issue_sign.go b/builtin/logical/pki/path_issue_sign.go
index 8c1a01451..7e554d129 100644
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -388,6 +388,18 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
                return nil, logical.ErrReadOnly
        }
 
+       // If we have a transactional storage backend, let's use it.
+       if txnStorage, ok := req.Storage.(logical.TransactionalStorage); ok {
+               b.Logger().Debug("using transaction for root CA generation")
+               txn, err := txnStorage.BeginTx(ctx)
+               if err != nil {
+                       return nil, err
+               }
+
+               defer txn.Rollback(ctx)
+               req.Storage = txn
+       }
+
        // We prefer the issuer from the role in two cases:
        //
        // 1. On the legacy sign-verbatim paths, as we always provision an issuer
@@ -561,6 +573,14 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
                }
        }
 
+       // Finally, commit our transaction if we have one!
+       if txn, ok := req.Storage.(logical.Transaction); ok {
+               if err := txn.Commit(ctx); err != nil {
+                       return nil, err
+               }
+               resp.AddWarning("cert issued with transactions")
+       }
+
        resp = addWarnings(resp, warnings)
 
        return resp, nil
```

</details>

</details>