### PR TITLE
Correctly seek in raft's ListPage when after=.

### DIFF
--- a/changelog/294.txt
+++ b/changelog/294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/raft: fix ListPage calls when after=. resulting in an empty list
+```

--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -543,6 +543,12 @@ func (f *FSM) ListPage(ctx context.Context, prefix string, after string, limit i
 	seekPrefix := []byte(filepath.Join(prefix, after))
 	if after == "" {
 		seekPrefix = prefixBytes
+	} else if !bytes.HasPrefix(seekPrefix, prefixBytes) {
+		// filepath.Join has the very unfortunate behavior of trimming the
+		// trailing slash when after=".". When e.g., prefix=foo/, this gives
+		// us seekPrefix=foo, which fails the initial HasPrefix check,
+		// skipping all results.
+		seekPrefix = prefixBytes
 	}
 
 	var keys []string

--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -31,6 +31,10 @@ func testListAndPage(t testing.TB, b Backend, prefix string, expected []string) 
 	require.NoError(t, err, "initial list page failed")
 	sortaEqualSlice(t, expected, page, "expected list page to match")
 
+	page, err = b.ListPage(context.Background(), prefix, ".", -100)
+	require.NoError(t, err, "initial list page failed")
+	sortaEqualSlice(t, expected, page, "expected list page with after=. to match bare list")
+
 	page, err = b.ListPage(context.Background(), prefix, "", -1)
 	require.NoError(t, err, "initial list page failed")
 	sortaEqualSlice(t, expected, page, "expected list page to match")


### PR DESCRIPTION
When a non-empty path is given that ends in a slash and after=., the resulting seek prefix from joining the path and the period has the slash trimmed off. This results in no list results, because this seek prefix lacks the trailing slash and is thus not prefixed by the expected prefix. E.g., for foo/ and after=., we end up with seekPrefix=foo, which doesn't start with our prefix (foo/).

Correctly handle this edge case. This was caught by randomized testing across multiple storage backends.