### PR TITLE
add download page to website

### DIFF
--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -18,10 +18,16 @@ There are several options to install OpenBao:
 
 ## Package manager
 
-OpenBao manages packages for Ubuntu, Debian, Fedora, RHEL, Amazon
-Linux, and other distributions. Follow the instructions at [OpenBao
-Tutorials][learn-vault-install] to add our PGP key, add a repository, and
-install.
+:::info
+
+OpenBao does not yet have a package repository. For now you need to download and
+install packages manually.
+
+:::
+
+OpenBao manages packages for Ubuntu, Debian, Fedora, RHEL, Amazon Linux, and
+other distributions. [Download](/downloads) the appropriate package for your
+operating system and architecture.
 
 ## Precompiled binaries
 

--- a/website/src/components/Releases/index.tsx
+++ b/website/src/components/Releases/index.tsx
@@ -1,0 +1,153 @@
+interface Release {
+    assets: {
+        linux: {
+            deb: string[];
+            rpm: string[];
+            binary: string[];
+            docker: string[];
+        };
+        darwin: {
+            binary: string[];
+        };
+        freebsd: {
+            binary: string[];
+        };
+        netbsd: {
+            binary: string[];
+        };
+        openbsd: {
+            binary: string[];
+        };
+        windows: {
+            binary: string[];
+        };
+    };
+}
+
+interface Releases {
+    [key: string]: Release;
+}
+
+interface GHRelease {
+    tag_name: string;
+    assets: GHAsset[];
+}
+
+interface GHAsset {
+    browser_download_url: string;
+}
+
+export function GetReleases(response): Releases {
+    const releases: GHRelease[] = response as GHRelease[];
+    const result: Releases = {};
+
+    releases.forEach((r) => {
+        const version = r.tag_name;
+
+        var release = {
+            assets: {
+                linux: {
+                    deb: [],
+                    rpm: [],
+                    binary: [],
+                    docker: [],
+                },
+                darwin: {
+                    binary: [],
+                },
+                freebsd: {
+                    binary: [],
+                },
+                netbsd: {
+                    binary: [],
+                },
+                openbsd: {
+                    binary: [],
+                },
+                windows: {
+                    binary: [],
+                },
+            },
+        } as Release;
+        for (var a of r.assets) {
+            if (a.browser_download_url.includes("windows")) {
+                release.assets.windows.binary.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("openbsd")) {
+                release.assets.openbsd.binary.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("netbsd")) {
+                release.assets.netbsd.binary.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("freebsd")) {
+                release.assets.freebsd.binary.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("darwin")) {
+                release.assets.darwin.binary.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("docker")) {
+                release.assets.linux.docker.push(a.browser_download_url);
+                // docker urls also contain "linux", so contiune if we find it
+                continue;
+            }
+            if (a.browser_download_url.includes("rpm")) {
+                release.assets.linux.rpm.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("deb")) {
+                release.assets.linux.deb.push(a.browser_download_url);
+            }
+            if (a.browser_download_url.includes("linux")) {
+                release.assets.linux.binary.push(a.browser_download_url);
+            }
+        }
+        result[version] = release;
+    });
+
+    return result;
+}
+
+export function AssetArchitecture(url: string): string {
+    if (url.includes("amd64")) {
+        return "amd64";
+    }
+    if (url.includes("arm64")) {
+        return "arm64";
+    }
+    if (url.includes("armhf")) {
+        return "armhf";
+    }
+    if (url.includes("armv7hl")) {
+        return "armv7hl";
+    }
+    if (url.includes("arm")) {
+        return "arm";
+    }
+    if (url.includes("riscv64")) {
+        return "riscv64";
+    }
+    if (url.includes("aarch64")) {
+        return "aarch64";
+    }
+    if (url.includes("x86_64")) {
+        return "x86_64";
+    }
+    return "<none>";
+}
+
+export function OsPrettyPrint(name: string): string {
+    switch (name) {
+        case "linux":
+            return "Linux";
+        case "darwin":
+            return "MacOS";
+        case "freebsd":
+            return "FreeBSD";
+        case "openbsd":
+            return "OpenBSD";
+        case "netbsd":
+            return "NetBSD";
+        case "windows":
+            return "Windows";
+    }
+    return "";
+}

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -1,0 +1,267 @@
+import React, { useState, useEffect, createContext, useContext } from "react";
+import Layout from "@theme/Layout";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import styles from "./index.module.css";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import {
+    GetReleases,
+    AssetArchitecture,
+    OsPrettyPrint,
+} from "@site/src/components/Releases";
+
+// Create a context
+const OptionsContext = createContext(null);
+
+// Provider component
+const OptionsProvider = ({ children }) => {
+    const [options, setOptions] = useState({});
+    const [selectedItem, setSelectedItem] = useState("");
+
+    useEffect(() => {
+        // Function to fetch options from API
+        const fetchOptions = async () => {
+            try {
+                // Check if options are cached in localStorage and not expired
+                const cachedOptions = localStorage.getItem("options");
+                if (cachedOptions) {
+                    const { data, timestamp } = JSON.parse(cachedOptions);
+                    if (new Date().getTime() - timestamp < 600000) {
+                        setOptions(data);
+                        const versions = Object.keys(data);
+                        // Auto-select the first option
+                        if (versions.length > 0) {
+                            setSelectedItem(versions[0]);
+                        }
+                        return;
+                    }
+                }
+                const response = await fetch(
+                    "https://api.github.com/repos/openbao/openbao/releases",
+                );
+                if (!response.ok) {
+                    throw new Error("Failed to fetch options");
+                }
+                const ghReleases = await response.json();
+                const releases = GetReleases(ghReleases);
+                const versions = Object.keys(releases);
+                setOptions(releases);
+                localStorage.setItem(
+                    "options",
+                    JSON.stringify({
+                        data: releases,
+                        timestamp: new Date().getTime(),
+                    }),
+                );
+
+                // Auto-select the first option
+                if (versions.length > 0) {
+                    setSelectedItem(versions[0]);
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        };
+
+        fetchOptions(); // Call the fetchOptions function when the component mounts
+    }, []);
+
+    return (
+        <OptionsContext.Provider
+            value={{ options, selectedItem, setSelectedItem }}
+        >
+            {children}
+        </OptionsContext.Provider>
+    );
+};
+
+// Custom hook to consume the context
+const useOptions = () => useContext(OptionsContext);
+
+const VersionSelect = () => {
+    const { options, selectedItem, setSelectedItem } = useOptions();
+
+    const handleSelectChange = (event) => {
+        setSelectedItem(event.target.value);
+    };
+
+    return (
+        <>
+            <select
+                value={selectedItem}
+                onChange={handleSelectChange}
+                className="button button--secondary margin-right--lg"
+            >
+                {Object.entries(options).map(([key, value]) => (
+                    <option key={key} value={key} className={styles.options}>
+                        {key}
+                    </option>
+                ))}
+            </select>
+        </>
+    );
+};
+
+const Asset = ({ url }) => {
+    const { selectedItem } = useOptions();
+    return (
+        <div className="pagination-nav__item">
+            <a className="pagination-nav__link" href={url}>
+                <div className="pagination-nav__label">
+                    {AssetArchitecture(url).toUpperCase()}
+                </div>
+                <div className="pagination-nav__sublabel">
+                    Version: {selectedItem}
+                </div>
+            </a>
+        </div>
+    );
+};
+
+const Docker = ({ version, name }) => {
+    const { options } = useOptions();
+    return (
+        <Tabs>
+            {version &&
+                Object(options)[version]["assets"][name] &&
+                Object(options)[version]["assets"][name]["docker"] &&
+                Object(options)[version]["assets"][name]["docker"].map(
+                    (url) => (
+                        <TabItem
+                            value={AssetArchitecture(url)}
+                            label={AssetArchitecture(url).toUpperCase()}
+                        >
+                            <CodeBlock language="shell">
+                                {`curl -sL "${url}" -o openbao.tar;
+unzip -p openbao.tar | docker load`}
+                            </CodeBlock>
+                        </TabItem>
+                    ),
+                )}
+        </Tabs>
+    );
+};
+
+const LinuxPackage = ({ version, name }) => {
+    const { options } = useOptions();
+    return (
+        <Tabs>
+            <TabItem value="deb" label="Deb">
+                <nav className="pagination-nav">
+                    {/* Check if version is not undefined before accessing releases */}
+                    {version &&
+                        Object(options)[version]["assets"][name] &&
+                        Object(options)[version]["assets"][name]["deb"] &&
+                        Object(options)[version]["assets"][name]["deb"].map(
+                            (props, idx) => <Asset key={idx} url={props} />,
+                        )}
+                </nav>
+            </TabItem>
+            <TabItem value="rpm" label="RPM">
+                <nav className="pagination-nav">
+                    {/* Check if version is not undefined before accessing releases */}
+                    {version &&
+                        Object(options)[version]["assets"][name] &&
+                        Object(options)[version]["assets"][name]["rpm"] &&
+                        Object(options)[version]["assets"][name]["rpm"].map(
+                            (props, idx) => <Asset key={idx} url={props} />,
+                        )}
+                </nav>
+            </TabItem>
+        </Tabs>
+    );
+};
+
+const OS = ({ name }) => {
+    const { options, selectedItem } = useOptions();
+    var version = "";
+    if (selectedItem === undefined && options) {
+        version = Object.keys(options)[0];
+    } else {
+        version = selectedItem;
+    }
+    return (
+        <div className="col col-12 margin-vert--md">
+            <div className="card">
+                <div className="card__header">
+                    <h2>{OsPrettyPrint(name)}</h2>
+                </div>
+                <div className="card__body">
+                    {name == "linux" ? (
+                        <>
+                            <h4>Docker</h4>
+                            <Docker version={version} name={name} />
+                            <h4>Package manager</h4>
+                            <LinuxPackage version={version} name={name} />
+                        </>
+                    ) : (
+                        <></>
+                    )}
+                    <h4>Binary download</h4>
+                    <nav className="pagination-nav">
+                        {/* Check if version is not undefined before accessing releases */}
+                        {version &&
+                            Object(options)[version]["assets"][name] &&
+                            Object(options)[version]["assets"][name][
+                                "binary"
+                            ] &&
+                            Object(options)[version]["assets"][name][
+                                "binary"
+                            ].map((props, idx) => (
+                                <Asset key={idx} url={props} />
+                            ))}
+                    </nav>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const DownloadComponent = () => {
+    const { options, selectedItem } = useOptions();
+    var version = "";
+    if (selectedItem === undefined && options) {
+        version = Object.keys(options)[0];
+    } else {
+        version = selectedItem;
+    }
+    return (
+        <div className="container margin-vert--lg">
+            <div className="row">
+                <div
+                    className="col col--12 text--center margin-horiz--md"
+                    style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                    }}
+                >
+                    <h1 className="margin-bottom--none">Download OpenBao</h1>
+                    <VersionSelect />
+                </div>
+            </div>
+            {/* Check if version is not undefined before accessing releases */}
+            {version &&
+                options[version]["assets"] &&
+                Object.entries(options[version]["assets"]).map(
+                    ([key, value]) => (
+                        <div className="row">
+                            <OS name={key} />
+                        </div>
+                    ),
+                )}
+        </div>
+    );
+};
+
+export default function Download(): JSX.Element {
+    const { siteConfig } = useDocusaurusContext();
+
+    return (
+        <Layout title="Downloads" description="Download OpenBao">
+            <OptionsProvider>
+                <DownloadComponent />
+            </OptionsProvider>
+        </Layout>
+    );
+}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -22,3 +22,8 @@
   justify-content: center;
   flex-wrap: wrap;
 }
+
+.options {
+  background-color: var(--ifm-dropdown-background-color);
+  color: var(--ifm-dropdown-link-color);
+}


### PR DESCRIPTION
This adds a download page to our website. When visiting the site, all releases and their assets are automatically fetched from GitHub and displayed per operating system. The fetched release information is cached in the browser storage for 60 minutes to not cause issues with GitHub API rate limits. 

**Note**: This is mediocre React code at best and has been written with a lot of help by Chat GPT. If anyone reviewing this PR has any React knowledge, suggestions for improvements are very welcome :-) 

As usually, preview of this PR has been deployed to my fork:
https://janma.github.io/openbao/downloads/

Signed-off-by: Jan Martens <jan@martens.eu.org>
Closes: #256 

## Target Release

Alpha