### PR TITLE
Fix remote port information in plugins

### DIFF
--- a/sdk/plugin/pb/translation.go
+++ b/sdk/plugin/pb/translation.go
@@ -325,6 +325,7 @@ func LogicalConnectionToProtoConnection(c *logical.Connection) *Connection {
 
 	return &Connection{
 		RemoteAddr:      c.RemoteAddr,
+		RemotePort:      int32(c.RemotePort),
 		ConnectionState: TLSConnectionStateToProtoConnectionState(c.ConnState),
 	}
 }
@@ -341,6 +342,7 @@ func ProtoConnectionToLogicalConnection(c *Connection) (*logical.Connection, err
 
 	return &logical.Connection{
 		RemoteAddr: c.RemoteAddr,
+		RemotePort: int(c.RemotePort),
 		ConnState:  cs,
 	}, nil
 }


### PR DESCRIPTION
The remote port was not properly propagated to the plugin through grpc.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #306 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.14.7
