### PR TITLE
Avoid invoking token helper on login

### DIFF
--- a/changelog/313.txt
+++ b/changelog/313.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/login: Avoid calling the token helper in `get` mode.
+```

--- a/command/login.go
+++ b/command/login.go
@@ -216,7 +216,7 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	// Create the client
-	client, err := c.Client()
+	client, err := c.ClientWithoutToken()
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2


### PR DESCRIPTION
Resolves #312.

### Problem

`bao login` used to call the token helper in `get` mode, because it constructs an HTTP client, and the client automatically loads the token. For almost everything that is the right thing to do, but for login, that is the thing that is supposed to retrieve the token, and login itself does not require the token. In fact, `vault login` would erase the token on the client later on.

Calling the token helper in `get` mode is a problem, because if the token helper fails, that blocks the login. But the token helper might fail because it doesn't have a token yet.

The call to `Get` originates here, in the construction of the http client: https://github.com/openbao/openbao/blob/6ef2a6031453b8bdc62fe9cb9511c223323a9e66/command/base.go#L145

That is being called from here: https://github.com/openbao/openbao/blob/6ef2a6031453b8bdc62fe9cb9511c223323a9e66/command/login.go#L215

### Solution

Split `Client` into two parts: a `ClientWithoutToken` that does most of what `Client` did previously, except for setting a token. And `Client` that also sets the token. This does change _when_ the token gets set on the client for calls to `Client`, but as far as I can tell, the remainder of the former `Client`, now `ClientWithToken` method does not rely on the token being set.

For all existing code except `login`, `Client` still behaves the way it did and nothing changes. For `login` in particular, we can now call `ClientWithoutToken`. This ensures that the token helper does not get called when the http client is initialized. The token helper still gets called to store the token later.

### Open questions, testing

There is still this snippet that happens after constructing the client: https://github.com/openbao/openbao/blob/6ef2a6031453b8bdc62fe9cb9511c223323a9e66/command/login.go#L221-L225

I _think_ this is now useless, the client will not have a token anyway so we don’t need to reset it. But it makes me wonder — if `authMethod == "token"`, does my change break anything?

Also, I am not sure what the best way is to add tests for this, if somebody can point me in the right direction, I would appreciate.

## Note about Source-Available License Policy

I adapted this patch from one I originally submitted to Hashicorp Vault in https://github.com/hashicorp/vault/pull/23209. However, the change was not accepted there and never included into a Hashicorp release, so I think it’s fine to submit it here?

The pull request was closed there with a message that’s unclear to me, but given that it took more than half a year and me posting and asking in multiple places before a person even looked at it, I don’t have high hopes for getting a clarification there. I hope OpenBao is more open to community contributions. If the approach in this pull request is not the right one, I’m happy to change it if somebody can explain what the correct approach would be.

## Target Release

No particular target, by default this was pre-filled to 1.14.7.