### PR TITLE
Add oidc device flow after direct flow

### DIFF
--- a/builtin/credential/jwt/cli.go
+++ b/builtin/credential/jwt/cli.go
@@ -153,18 +153,20 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 	var pollInterval string
 	var interval int
 	var state string
+	var userCode string
 	var listener net.Listener
 
 	if secret != nil {
 		pollInterval, _ = secret.Data["poll_interval"].(string)
 		state, _ = secret.Data["state"].(string)
+		userCode, _ = secret.Data["user_code"].(string)
 	}
-	if callbackMode == "direct" {
+	if callbackMode != "client" {
 		if state == "" {
-			return nil, errors.New("no state returned in direct callback mode")
+			return nil, errors.New("no state returned in " + callbackMode + " callback mode")
 		}
 		if pollInterval == "" {
-			return nil, errors.New("no poll_interval returned in direct callback mode")
+			return nil, errors.New("no poll_interval returned in " + callbackMode + " callback mode")
 		}
 		interval, err = strconv.Atoi(pollInterval)
 		if err != nil {
@@ -201,7 +203,11 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 	}
 	fmt.Fprintf(os.Stderr, "Waiting for OIDC authentication to complete...\n")
 
-	if callbackMode == "direct" {
+	if userCode != "" {
+		fmt.Fprintf(os.Stderr, "When prompted, enter code %s\n\n", userCode)
+	}
+
+	if callbackMode != "client" {
 		data := map[string]interface{}{
 			"state":        state,
 			"client_nonce": clientNonce,
@@ -380,8 +386,9 @@ Configuration:
     OpenBao role of type "OIDC" to use for authentication.
 
   %s=<string>
-    Mode of callback: "direct" for direct connection to the server or "client"
-    for connection to the command line client (default: client).
+    Mode of callback: "client" for connection to the command line client,
+    "direct" for direct connection to the server, or "device" for device
+    flow which has no callback (default: client).
 
   %s=<string>
     Optional address to bind the OIDC callback listener to in client callback

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -8,8 +8,12 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/cap/jwt"
@@ -161,6 +165,91 @@ func (b *jwtAuthBackend) config(ctx context.Context, s logical.Storage) (*jwtCon
 	b.cachedConfig = config
 
 	return config, nil
+}
+
+func contactIssuer(ctx context.Context, uri string, data *url.Values, ignoreBad bool) ([]byte, error) {
+	var req *http.Request
+	var err error
+	if data == nil {
+		req, err = http.NewRequest("GET", uri, nil)
+	} else {
+		req, err = http.NewRequest("POST", uri, strings.NewReader(data.Encode()))
+	}
+	if err != nil {
+		return nil, err
+	}
+	if data != nil {
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	client, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	if !ok {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK && (!ignoreBad || resp.StatusCode != http.StatusBadRequest) {
+		return nil, fmt.Errorf("%s: %s", resp.Status, body)
+	}
+
+	return body, nil
+}
+
+// Discover the device_authorization_endpoint URL and store it in the config
+// This should be in coreos/go-oidc but they don't yet support device flow
+// At the same time, look up token_endpoint and store it as well
+// Returns nil on success, otherwise returns an error
+func (b *jwtAuthBackend) configDeviceAuthURL(ctx context.Context, s logical.Storage) error {
+	config, err := b.config(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	b.l.Lock()
+	defer b.l.Unlock()
+
+	if config.OIDCDeviceAuthURL != "" {
+		if config.OIDCDeviceAuthURL == "N/A" {
+			return fmt.Errorf("no device auth endpoint url discovered")
+		}
+		return nil
+	}
+
+	caCtx, err := b.createCAContext(b.providerCtx, config.OIDCDiscoveryCAPEM)
+	if err != nil {
+		return errwrap.Wrapf("error creating context for device auth: {{err}}", err)
+	}
+
+	issuer := config.OIDCDiscoveryURL
+
+	wellKnown := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+	body, err := contactIssuer(caCtx, wellKnown, nil, false)
+	if err != nil {
+		return errwrap.Wrapf("error reading issuer config: {{err}}", err)
+	}
+
+	var daj struct {
+		DeviceAuthURL string `json:"device_authorization_endpoint"`
+		TokenURL      string `json:"token_endpoint"`
+	}
+	err = json.Unmarshal(body, &daj)
+	if err != nil || daj.DeviceAuthURL == "" {
+		b.cachedConfig.OIDCDeviceAuthURL = "N/A"
+		return fmt.Errorf("no device auth endpoint url discovered")
+	}
+
+	b.cachedConfig.OIDCDeviceAuthURL = daj.DeviceAuthURL
+	b.cachedConfig.OIDCTokenURL = daj.TokenURL
+	return nil
 }
 
 func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -420,6 +509,9 @@ type jwtConfig struct {
 	NamespaceInState     bool                   `json:"namespace_in_state"`
 
 	ParsedJWTPubKeys []crypto.PublicKey `json:"-"`
+	// These are looked up from OIDCDiscoveryURL when needed
+	OIDCDeviceAuthURL string `json:"-"`
+	OIDCTokenURL      string `json:"-"`
 }
 
 const (

--- a/builtin/credential/jwt/path_oidc.go
+++ b/builtin/credential/jwt/path_oidc.go
@@ -53,6 +53,9 @@ type oidcRequest struct {
 
 	// this is for storing the response in direct callback mode
 	auth *logical.Auth
+
+	// the device flow code
+	deviceCode string
 }
 
 func pathOIDC(b *jwtAuthBackend) []*framework.Path {
@@ -145,7 +148,7 @@ func pathOIDC(b *jwtAuthBackend) []*framework.Path {
 				},
 				"redirect_uri": {
 					Type:        framework.TypeString,
-					Description: "The OAuth redirect_uri to use in the authorization URL.",
+					Description: "The OAuth redirect_uri to use in the authorization URL.  Not needed with device flow.",
 				},
 				"client_nonce": {
 					Type:        framework.TypeString,
@@ -240,6 +243,13 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(errLoginFailed + " Expired or missing OAuth state."), nil
 	}
 
+	deleteRequest := true
+	defer func() {
+		if deleteRequest {
+			b.deleteOIDCRequest(stateID)
+		}
+	}()
+
 	roleName := oidcReq.rolename
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
@@ -247,16 +257,14 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		return nil, err
 	}
 	if role == nil {
-		b.deleteOIDCRequest(stateID)
 		return logical.ErrorResponse(errLoginFailed + " Role could not be found"), nil
 	}
 
 	useHttp := false
 	if role.CallbackMode == callbackModeDirect {
 		useHttp = true
-	} else {
-		// state is only accessed once when not using direct callback
-		b.deleteOIDCRequest(stateID)
+		// save request for poll
+		deleteRequest = false
 	}
 
 	errorDescription := d.Get("error_description").(string)
@@ -288,8 +296,13 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
 	}
 
-	var rawToken oidc.IDToken
+	oidcCtx, err := b.createCAContext(ctx, config.OIDCDiscoveryCAPEM)
+	if err != nil {
+		return nil, errwrap.Wrapf("error preparing context for login operation: {{err}}", err)
+	}
+
 	var token *oidc.Tk
+	var tokenSource oauth2.TokenSource
 
 	code := d.Get("code").(string)
 	if code == noCode {
@@ -302,9 +315,14 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 
 		// Verify the ID token received from the authentication response.
-		rawToken = oidc.IDToken(oidcReq.idToken)
+		rawToken := oidc.IDToken(oidcReq.idToken)
 		if _, err := provider.VerifyIDToken(ctx, rawToken, oidcReq); err != nil {
 			return logical.ErrorResponse("%s %s", errTokenVerification, err.Error()), nil
+		}
+
+		token, err = oidc.NewToken(rawToken, nil)
+		if err != nil {
+			return nil, errwrap.Wrapf("error creating oidc token: {{err}}", err)
 		}
 	} else {
 		// Exchange the authorization code for an ID token and access token.
@@ -314,13 +332,19 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 			return loginFailedResponse(useHttp, fmt.Sprintf("Error exchanging oidc code: %q.", err.Error())), nil
 		}
 
-		rawToken = token.IDToken()
+		tokenSource = token.StaticTokenSource()
 	}
 
+	return b.processToken(ctx, req, config, oidcCtx, provider, roleName, role, token, tokenSource, stateID, oidcReq, useHttp)
+}
+
+// Continue processing a token after it has been received from the
+// OIDC provider from either code or device authorization flows
+func (b *jwtAuthBackend) processToken(ctx context.Context, req *logical.Request, config *jwtConfig, oidcCtx context.Context, provider *oidc.Provider, roleName string, role *jwtRole, token *oidc.Tk, tokenSource oauth2.TokenSource, stateID string, oidcReq *oidcRequest, useHttp bool) (*logical.Response, error) {
 	if role.VerboseOIDCLogging {
 		loggedToken := "invalid token format"
 
-		parts := strings.Split(string(rawToken), ".")
+		parts := strings.Split(string(token.IDToken()), ".")
 		if len(parts) == 3 {
 			// strip signature from logged token
 			loggedToken = fmt.Sprintf("%s.%s.xxxxxxxxxxx", parts[0], parts[1])
@@ -331,10 +355,16 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 
 	// Parse claims from the ID token payload.
 	var allClaims map[string]interface{}
-	if err := rawToken.Claims(&allClaims); err != nil {
+	if err := token.IDToken().Claims(&allClaims); err != nil {
 		return nil, err
 	}
-	delete(allClaims, "nonce")
+
+	if claimNonce, ok := allClaims["nonce"]; ok {
+		if oidcReq != nil && claimNonce != oidcReq.Nonce() {
+			return loginFailedResponse(useHttp, "invalid ID token nonce."), nil
+		}
+		delete(allClaims, "nonce")
+	}
 
 	// Get the subject claim for bound subject and user info validation
 	var subject string
@@ -346,15 +376,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		return loginFailedResponse(useHttp, "sub claim does not match bound subject"), nil
 	}
 
-	// Set the token source for the access token if it's available. It will only
-	// be available for the authorization code flow (oidc_response_types=code).
-	// The access token will be used for fetching additional user and group info.
-	var tokenSource oauth2.TokenSource
-	if token != nil {
-		tokenSource = token.StaticTokenSource()
-	}
-
-	// If we have a token, attempt to fetch information from the /userinfo endpoint
+	// If we have a tokenSource, attempt to fetch information from the /userinfo endpoint
 	// and merge it with the existing claims data. A failure to fetch additional information
 	// from this endpoint will not invalidate the authorization flow.
 	if tokenSource != nil {
@@ -449,19 +471,109 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 	return resp, nil
 }
 
+// second half of the client API for direct and device callback modes
 func (b *jwtAuthBackend) pathPoll(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	stateID := d.Get("state").(string)
-
 	oidcReq := b.getOIDCRequest(stateID)
 	if oidcReq == nil {
 		return logical.ErrorResponse(errLoginFailed + " Expired or missing OAuth state."), nil
 	}
 
+	deleteRequest := true
+	defer func() {
+		if deleteRequest {
+			b.deleteOIDCRequest(stateID)
+		}
+	}()
+
 	clientNonce := d.Get("client_nonce").(string)
 
 	if oidcReq.clientNonce != "" && clientNonce != oidcReq.clientNonce {
-		b.deleteOIDCRequest(stateID)
 		return logical.ErrorResponse("invalid client_nonce"), nil
+	}
+
+	roleName := oidcReq.rolename
+	role, err := b.role(ctx, req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return logical.ErrorResponse(errLoginFailed + " Role could not be found"), nil
+	}
+
+	if role.CallbackMode == callbackModeDevice {
+		config, err := b.config(ctx, req.Storage)
+		if err != nil {
+			return nil, err
+		}
+		if config == nil {
+			return logical.ErrorResponse(errLoginFailed + " Could not load configuration"), nil
+		}
+
+		caCtx, err := b.createCAContext(ctx, config.OIDCDiscoveryCAPEM)
+		if err != nil {
+			return nil, err
+		}
+		provider, err := b.getProvider(config)
+		if err != nil {
+			return nil, errwrap.Wrapf("error getting provider for poll operation: {{err}}", err)
+		}
+
+		values := url.Values{
+			"client_id":     {config.OIDCClientID},
+			"client_secret": {config.OIDCClientSecret},
+			"device_code":   {oidcReq.deviceCode},
+			"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
+		}
+		body, err := contactIssuer(caCtx, config.OIDCTokenURL, &values, true)
+		if err != nil {
+			return nil, errwrap.Wrapf("error polling for device authorization: {{err}}", err)
+		}
+
+		var tokenOrError struct {
+			*oauth2.Token
+			Error string `json:"error,omitempty"`
+		}
+		err = json.Unmarshal(body, &tokenOrError)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding issuer response while polling for token: %v; response: %v", err, string(body))
+		}
+
+		if tokenOrError.Error != "" {
+			if tokenOrError.Error == "authorization_pending" || tokenOrError.Error == "slow_down" {
+				// save request for another poll
+				deleteRequest = false
+				return logical.ErrorResponse(tokenOrError.Error), nil
+			}
+			return logical.ErrorResponse("authorization failed: %v", tokenOrError.Error), nil
+		}
+
+		extra := make(map[string]interface{})
+		err = json.Unmarshal(body, &extra)
+		if err != nil {
+			// already been unmarshalled once, unlikely
+			return nil, err
+		}
+		oauth2Token := tokenOrError.Token.WithExtra(extra)
+
+		// idToken, ok := oauth2Token.Extra("id_token").(oidc.IDToken)
+		rawToken, ok := oauth2Token.Extra("id_token").(string)
+		if !ok {
+			return logical.ErrorResponse(errTokenVerification + " No id_token found in response."), nil
+		}
+		idToken := oidc.IDToken(rawToken)
+		token, err := oidc.NewToken(idToken, tokenOrError.Token)
+		if err != nil {
+			return nil, errwrap.Wrapf("error creating oidc token: {{err}}", err)
+		}
+
+		return b.processToken(ctx, req, config, caCtx, provider, roleName, role, token, oauth2.StaticTokenSource(oauth2Token), "", nil, false)
+	}
+
+	// else it's the direct callback mode
+	if oidcReq.auth == nil {
+		// save request for another poll
+		deleteRequest = false
 	}
 
 	if oidcReq.auth == nil {
@@ -469,7 +581,6 @@ func (b *jwtAuthBackend) pathPoll(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse("authorization_pending"), nil
 	}
 
-	b.deleteOIDCRequest(stateID)
 	resp := &logical.Response{
 		Auth: oidcReq.auth,
 	}
@@ -511,9 +622,6 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 	}
 
 	redirectURI := d.Get("redirect_uri").(string)
-	if redirectURI == "" {
-		return logical.ErrorResponse("missing redirect_uri"), nil
-	}
 
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
@@ -524,8 +632,86 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 	}
 
 	clientNonce := d.Get("client_nonce").(string)
-	if clientNonce == "" && role.CallbackMode == callbackModeDirect {
+	if clientNonce == "" &&
+		(role.CallbackMode == callbackModeDirect ||
+			role.CallbackMode == callbackModeDevice) {
 		return logical.ErrorResponse("missing client_nonce"), nil
+	}
+
+	if role.CallbackMode == callbackModeDevice {
+		// start a device flow
+		caCtx, err := b.createCAContext(ctx, config.OIDCDiscoveryCAPEM)
+		if err != nil {
+			return nil, err
+		}
+
+		// Discover the device url endpoint if not already known
+		// This adds it to the cached config
+		err = b.configDeviceAuthURL(ctx, req.Storage)
+		if err != nil {
+			return nil, err
+		}
+
+		// "openid" is a required scope for OpenID Connect flows
+		scopes := append([]string{"openid"}, role.OIDCScopes...)
+
+		values := url.Values{
+			"client_id":     {config.OIDCClientID},
+			"client_secret": {config.OIDCClientSecret},
+			"scope":         {strings.Join(scopes, " ")},
+		}
+		body, err := contactIssuer(caCtx, config.OIDCDeviceAuthURL, &values, false)
+		if err != nil {
+			return nil, errwrap.Wrapf("error authorizing device: {{err}}", err)
+		}
+
+		var deviceCode struct {
+			DeviceCode              string `json:"device_code"`
+			UserCode                string `json:"user_code"`
+			VerificationURI         string `json:"verification_uri"`
+			VerificationURIComplete string `json:"verification_uri_complete"`
+			// Google and other old implementations use url instead of uri
+			VerificationURL         string `json:"verification_url"`
+			VerificationURLComplete string `json:"verification_url_complete"`
+			Interval                int    `json:"interval"`
+		}
+		err = json.Unmarshal(body, &deviceCode)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding issuer response to device auth: %v; response: %v", err, string(body))
+		}
+		// currently hashicorp/cap/oidc.NewRequest requires
+		//  redirectURL to be non-empty so throw in place holder
+		oidcReq, err := b.createOIDCRequest(config, role, roleName, "-", deviceCode.DeviceCode, clientNonce)
+		if err != nil {
+			logger.Warn("error generating OAuth state", "error", err)
+			return resp, nil
+		}
+
+		if deviceCode.VerificationURIComplete != "" {
+			resp.Data["auth_url"] = deviceCode.VerificationURIComplete
+		} else if deviceCode.VerificationURLComplete != "" {
+			resp.Data["auth_url"] = deviceCode.VerificationURLComplete
+		} else {
+			if deviceCode.VerificationURI != "" {
+				resp.Data["auth_url"] = deviceCode.VerificationURI
+			} else {
+				resp.Data["auth_url"] = deviceCode.VerificationURL
+			}
+			resp.Data["user_code"] = deviceCode.UserCode
+		}
+		resp.Data["state"] = oidcReq.State()
+		interval := 5
+		if role.PollInterval != 0 {
+			interval = role.PollInterval
+		} else if deviceCode.Interval != 0 {
+			interval = deviceCode.Interval
+		}
+		resp.Data["poll_interval"] = fmt.Sprintf("%d", interval)
+		return resp, nil
+	}
+
+	if redirectURI == "" {
+		return logical.ErrorResponse("missing redirect_uri"), nil
 	}
 
 	// If namespace will be passed around in oidcReq, and it has been provided as
@@ -566,7 +752,7 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 		return resp, nil
 	}
 
-	oidcReq, err := b.createOIDCRequest(config, role, roleName, redirectURI, clientNonce)
+	oidcReq, err := b.createOIDCRequest(config, role, roleName, redirectURI, "", clientNonce)
 	if err != nil {
 		logger.Warn("error generating OAuth state", "error", err)
 		return resp, nil
@@ -587,7 +773,11 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 	resp.Data["auth_url"] = urlStr
 	if role.CallbackMode == callbackModeDirect {
 		resp.Data["state"] = oidcReq.State()
-		resp.Data["poll_interval"] = "5"
+		interval := 5
+		if role.PollInterval != 0 {
+			interval = role.PollInterval
+		}
+		resp.Data["poll_interval"] = fmt.Sprintf("%d", interval)
 	}
 
 	return resp, nil
@@ -595,7 +785,7 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 
 // createOIDCRequest makes an expiring request object, associated with a random state ID
 // that is passed throughout the OAuth process. A nonce is also included in the auth process.
-func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rolename, redirectURI, clientNonce string) (*oidcRequest, error) {
+func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rolename, redirectURI, deviceCode string, clientNonce string) (*oidcRequest, error) {
 	options := []oidc.Option{
 		oidc.WithAudiences(role.BoundAudiences...),
 		oidc.WithScopes(role.OIDCScopes...),
@@ -625,6 +815,7 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 		Request:     request,
 		rolename:    rolename,
 		clientNonce: clientNonce,
+		deviceCode:  deviceCode,
 	}
 	b.oidcRequests.SetDefault(request.State(), oidcReq)
 

--- a/builtin/credential/jwt/path_role.go
+++ b/builtin/credential/jwt/path_role.go
@@ -27,6 +27,7 @@ const (
 	boundClaimsTypeGlob   = "glob"
 	callbackModeDirect    = "direct"
 	callbackModeClient    = "client"
+	callbackModeDevice    = "device"
 )
 
 func pathRoleList(b *jwtAuthBackend) *framework.Path {
@@ -176,8 +177,13 @@ for referencing claims.`,
 			},
 			"callback_mode": {
 				Type:        framework.TypeString,
-				Description: `OIDC callback mode from Authorization Server: allowed values are 'direct' to server or 'client', default 'client'`,
+				Description: `OIDC callback mode from Authorization Server: allowed values are 'device' for device flow, 'direct' to server, or 'client', default 'client'`,
 				Default:     callbackModeClient,
+			},
+			"poll_interval": {
+				Type:        framework.TypeInt,
+				Description: `poll interval in seconds for device and direct flows, default value from Authorization Server for device flow, or '5'`,
+				// don't set Default here because server may set a default
 			},
 			"verbose_oidc_logging": {
 				Type: framework.TypeBool,
@@ -249,6 +255,7 @@ type jwtRole struct {
 	OIDCScopes           []string               `json:"oidc_scopes"`
 	AllowedRedirectURIs  []string               `json:"allowed_redirect_uris"`
 	CallbackMode         string                 `json:"callback_mode"`
+	PollInterval         int                    `json:"poll_interval"`
 	VerboseOIDCLogging   bool                   `json:"verbose_oidc_logging"`
 	MaxAge               time.Duration          `json:"max_age"`
 	UserClaimJSONPointer bool                   `json:"user_claim_json_pointer"`
@@ -372,6 +379,10 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 	}
 
 	role.PopulateTokenData(d)
+
+	if role.PollInterval > 0 {
+		d["poll_interval"] = role.PollInterval
+	}
 
 	if len(role.Policies) > 0 {
 		d["policies"] = d["token_policies"]
@@ -604,9 +615,13 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		role.AllowedRedirectURIs = allowedRedirectURIs.([]string)
 	}
 
+	if pollInterval, ok := data.GetOk("poll_interval"); ok {
+		role.PollInterval = pollInterval.(int)
+	}
+
 	callbackMode := data.Get("callback_mode").(string)
 	switch callbackMode {
-	case callbackModeDirect, callbackModeClient:
+	case callbackModeDevice, callbackModeDirect, callbackModeClient:
 		role.CallbackMode = callbackMode
 	default:
 		return logical.ErrorResponse("invalid 'callback_mode': %s", callbackMode), nil

--- a/changelog/319.txt
+++ b/changelog/319.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+auth/oidc: Add a new `callback_mode` role option value `device` to use the oidc device flow instead of a callback, add a new `poll_interval` role option to control how often to poll for a response, and add a new `callbackmode=device` option to the oidc login method in the cli.
+```

--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -166,10 +166,15 @@ entities attempting to login. At least one of the bound values must be set.
   treats the information in a safe manner.
 - `oidc_scopes` `(list: <optional>)` - If set, a list of OIDC scopes to be used with an OIDC role.
   The standard scope "openid" is automatically included and need not be specified.
-- `allowed_redirect_uris` `(list: <required>)` - The list of allowed values for redirect_uri
+- `allowed_redirect_uris` `(list: <required except in device callback mode>)` - The list of allowed values for redirect_uri
   during OIDC logins.
 - `callback_mode` `(string: <optional>)` - The callback mode from the OIDC provider, either "client" (the default)
-  to call back to the client or "direct" to call back to the OpenBao server.
+  to call back to the client,
+  "direct" to call back to the OpenBao server,
+  or "device" for device flow which has no callback.
+- `poll_interval` `(int: <optional>)` - Poll interval in seconds for device
+  and direct callback modes, default value from Authorization Server for
+  device flow, or '5'.
 - `verbose_oidc_logging` `(bool: false)` - Log received OIDC tokens and claims when debug-level
   logging is active. Not recommended in production since sensitive information may be present
   in OIDC responses.
@@ -320,6 +325,12 @@ $ curl \
 
 Obtain an authorization URL from OpenBao to start an OIDC login flow.
 
+The response will include a `auth_url` that the user will need to go
+to in a web browser to complete the login flow.
+
+In device callback mode the response may include a `user_code` keyword
+which should be shown to the user to enter at the `auth_url`.
+
 | Method | Path                      |
 | :----- | :------------------------ |
 | `POST` | `/auth/jwt/oidc/auth_url` |
@@ -328,7 +339,7 @@ Obtain an authorization URL from OpenBao to start an OIDC login flow.
 
 - `role` `(string: <optional>)` - Name of the role against which the login is being
   attempted. Defaults to configured `default_role` if not provided.
-- `redirect_uri` `(string: <required>)` - Path to the callback to complete the login. This will be
+- `redirect_uri` `(string: <required except in device callback mode>)` - Path to the callback to complete the login. This will be
   of the form, "https&#x3A;//.../oidc/callback" where the leading portion is dependent on your OpenBao
   server location, port, and the mount of the JWT plugin. This must be configured with OpenBao and the
   provider. See [Redirect URIs](/docs/auth/jwt#redirect-uris) for more information.
@@ -336,14 +347,27 @@ Obtain an authorization URL from OpenBao to start an OIDC login flow.
   must match the `client_nonce` value provided during a subsequent request to the
   [callback](/api-docs/auth/jwt#oidc-callback) API.
 
-### Sample payload
+### Sample payloads
+
+For client or direct callback modes:
 
 ```json
 {
   "role": "dev-role",
-  "redirect_uri": "https://openbao.myco.com:8200/ui/openbao/auth/jwt/oidc/callback"
+  "redirect_uri": "https://openbao.myco.com:8200/ui/openbao/auth/jwt/oidc/callback",
+  "client_nonce": "ni42i2idj2jj"
 }
 ```
+
+For device callback mode:
+
+```json
+{
+  "role": "dev-role",
+  "client_nonce": "ni42i2idj2jj"
+}
+```
+
 
 ### Sample request
 
@@ -354,7 +378,9 @@ $ curl \
     https://127.0.0.1:8200/v1/auth/jwt/oidc/auth_url
 ```
 
-### Sample response
+### Sample responses
+
+For client or direct callback modes:
 
 ```json
 {
@@ -366,10 +392,26 @@ $ curl \
 }
 ```
 
+For device callback mode:
+
+```json
+{
+  "request_id": "c701169c-64f8-26cc-0315-078e8c3ce897",
+  "data": {
+    "auth_url": "https://myco.auth0.com/device",
+    "user_code": "ABCDEFGHIJK"
+  },
+  ...
+}
+```
+
 ## OIDC callback
 
 Exchange an authorization code for an OIDC ID Token. The ID token will be further validated
 against any bound claims, and if valid an OpenBao token will be returned.
+
+This is normally invoked by the Authorization Server in client
+or direct callback modes, and is not used in device callback mode.
 
 | Method | Path                      |
 | :----- | :------------------------ |
@@ -417,17 +459,18 @@ $ curl \
 
 ## OIDC poll
 
-Poll for a response when using the direct callback mode in order to complete a login.
+Poll for a response when using the direct or device callback modes in order to complete a login.
 The response from the [auth_url](/api-docs/auth/jwt#oidc-authorization-url-request) API
 returns a `poll_interval` data item containing the number of seconds that the client
 should wait between invoking the poll API.
 
-If the callback hasn't yet occurred, the HTTP response code will be 400 and include
+If the direct callback or device mode authorization hasn't yet occurred,
+the HTTP response code will be 400 and include
 an `errors` JSON list including either `authorization_pending` or `slow_down`.
 If the response is `slow_down` then the client should add additional time before
 calling the poll API again.
 
-When the callback has occurred, the response will include either a different `errors`
+When the callback or authorization has occurred, the response will include either a different `errors`
 message or sucessfully return an authorization token.
 
 | Method | Path                      |

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -45,7 +45,8 @@ using a `bao login`.
 
 ### Redirect URIs
 
-An important part of OIDC role configuration is properly setting redirect URIs. This must be
+Unless you are using `callbackmode=device`,
+an important part of OIDC role configuration is properly setting redirect URIs. This must be
 done both in OpenBao and with the OIDC provider, and these configurations must align. The
 redirect URIs are specified for a role with the `allowed_redirect_uris` parameter. There are
 different redirect URIs to configure the OpenBao UI and CLI flows, so one or both will need to
@@ -53,10 +54,11 @@ be set up depending on the installation.
 
 **CLI**
 
-If you plan to support authentication via `bao login -method=oidc`, a redirect URI with a path ending
-in `oidc/callback` must be set. With the default `callbackmode` of `client`
+If you plan to support authentication via `bao login -method=oidc` and
+are not using `callbackmode=device`, a redirect URI with a path ending
+in `oidc/callback` must be set. With the default `callbackmode=client`
 this can usually be `http://localhost:8250/oidc/callback`.
-With a `callbackmode` of `direct` this should be a URI of the form:
+With `callbackmode=direct` this should be a URI of the form:
 
 `https://{host:port}/v1/auth/{path}/oidc/callback`
 
@@ -109,8 +111,10 @@ The callback listener may be customized with the following optional parameters. 
 not required to be set:
 
 - `mount` (default: "oidc")
-- `callbackmode` (default: "client").  When set to `direct`, the callback is to the OpenBao server instead
-   of to a port on the cli client.
+- `callbackmode` (default: "client").  Mode of callback:
+   "client" for connection to a port on the cli client,
+   `direct` for direct connection to the OpenBao server,
+   or "device" for device flow which has no callback.
 - `listenaddress` (default: "localhost").  Only for `client` callback mode.
 - `port` (default: 8250).  Only for `client` callback mode.
 - `callbackhost` (default: the OpenBao's server and port in direct callback mode, else "localhost")


### PR DESCRIPTION
This adds support for OIDC device flow on top of pr #318.  #318 has to be committed first and all its changes are included here.  If you'd like to see just the changes compared to that pr, see [my own pr 1](https://github.com/DrDaveD/openbao/pull/1).

Device flow has several advantages over direct callback mode:
1. There's no need to configure allowed redirect uris for the client.
2. There's no need to configure firewalls to allow the Authorization Server to call back to Vault.
3. There's no need for the Authorization Server to recognize the CA cert for Vault.
4. The URL that the user sees is simpler.

So it's worth having device flow even compared to direct callback mode, although direct callback mode is good when Authorization Servers don't support device flow.

Device flow is enabled with this implementation by setting the role configuration `callback_mode=device`.  The device authorization endpoint is auto-discovered.   This also adds an additional optional role configuration option `poll_interval` which defaults to 5.

The client API is slightly extended, to add an optional `user_code` option in the auth response, and to add a `slow_down` reply to a poll request.  A `redirect_uri` passed in to the auth API is ignored in device flow.

This is essentially the same PR as hashicorp/vault-plugin-auth-jwt#131 which many people have expressed an interest in but has been sitting unmerged for a few years.