### PR TITLE
Add oauth2_metadata config option

### DIFF
--- a/builtin/credential/jwt/path_oidc.go
+++ b/builtin/credential/jwt/path_oidc.go
@@ -367,6 +367,24 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 	}
 
+	// Also fetch any requested extra oauth2 metadata
+	oauth2Metadata := make(map[string]string)
+	for _, mdname := range role.Oauth2Metadata {
+		var md string
+		switch mdname {
+		case "id_token":
+			md = string(token.IDToken())
+		case "refresh_token":
+			md = string(token.RefreshToken())
+		case "access_token":
+			md = string(token.AccessToken())
+		default:
+			// previously validated so this should never happen
+			return logical.ErrorResponse(errLoginFailed + " Unrecognized oauth2 metadata name " + mdname), nil
+		}
+		oauth2Metadata[mdname] = md
+	}
+
 	if role.VerboseOIDCLogging {
 		if c, err := json.Marshal(allClaims); err == nil {
 			b.Logger().Debug("OIDC provider response", "claims", string(c))
@@ -387,6 +405,9 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 	tokenMetadata := make(map[string]string)
 	for k, v := range alias.Metadata {
 		tokenMetadata[k] = v
+	}
+	for k, v := range oauth2Metadata {
+		tokenMetadata["oauth2_"+k] = v
 	}
 
 	auth := &logical.Auth{

--- a/builtin/credential/jwt/path_oidc_test.go
+++ b/builtin/credential/jwt/path_oidc_test.go
@@ -846,8 +846,16 @@ func TestOIDC_Callback(t *testing.T) {
 
 			auth := resp.Auth
 
+			if auth != nil {
+				// Can't predict the content of oauth2_id_token
+				//  so instead copy it.  This does at least
+				//  verify that it is present because if not it
+				//  introduces an empty value into expected.
+				expected.Metadata["oauth2_id_token"] = auth.Metadata["oauth2_id_token"]
+			}
+
 			if !reflect.DeepEqual(auth, expected) {
-				t.Fatalf("expected: %v, auth: %v", expected, resp)
+				t.Fatalf("expected: %v, resp: %v", expected, resp)
 			}
 		}
 	})
@@ -1617,6 +1625,7 @@ func getBackendAndServer(t *testing.T, boundCIDRs bool, callbackMode string) (lo
 			"/nested/secret_code": "bar",
 			"temperature":         "76",
 		},
+		"oauth2_metadata": []string{"id_token"},
 	}
 
 	if boundCIDRs {

--- a/builtin/credential/jwt/path_role_test.go
+++ b/builtin/credential/jwt/path_role_test.go
@@ -769,6 +769,7 @@ func TestPath_Read(t *testing.T) {
 		"bound_claims_type":       "string",
 		"bound_claims":            map[string]interface{}(nil),
 		"claim_mappings":          map[string]string(nil),
+		"oauth2_metadata":         []string(nil),
 		"bound_subject":           "testsub",
 		"bound_audiences":         []string{"vault"},
 		"allowed_redirect_uris":   []string{"http://127.0.0.1"},

--- a/changelog/320.txt
+++ b/changelog/320.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/oidc: Add a new `oauth2_metadata` configuration option to enable sending any of the tokens from the token issuer to the client.
+```

--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -156,6 +156,14 @@ entities attempting to login. At least one of the bound values must be set.
 - `claim_mappings` `(map: <optional>)` - If set, a map of claims (keys) to be copied to
   specified metadata fields (values). Keys support [JSON pointer](/docs/auth/jwt#claim-specifications-and-json-pointer)
   syntax for referencing claims.
+- `oauth2_metadata` `(list: <optional>` - If set, a list of token types
+  that come from the OIDC provider to return in metadata.
+  The types can be any of `access_token`, `id_token`, or `refresh_token`,
+  and when present the values are returned in corresponding metadata fields
+  with `oauth2_` prefixes as names.
+  Note that these tokens can potentially include sensitive security
+  information so use caution before enabling them and make sure the client
+  treats the information in a safe manner.
 - `oidc_scopes` `(list: <optional>)` - If set, a list of OIDC scopes to be used with an OIDC role.
   The standard scope "openid" is automatically included and need not be specified.
 - `allowed_redirect_uris` `(list: <required>)` - The list of allowed values for redirect_uri


### PR DESCRIPTION
This PR adds a configuration option `oauth2_metadata` which is a list of token types that can be returned in metadata.  The list can be any of `access_token`, `id_token`, and `refresh_token`, and when selected they are returned in metadata names `oauth2_access_token`, `oauth2_id_token`, and `oauth2_refresh_token`, respectively.

This option makes it possible for a user to authenticate with bao once and also use the tokens directly from the oauth2 issuer for another purpose.   For example, with some help from a client application to store the refresh token back into a vault secrets plugin like the [Puppet labs oauthapp plugin](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp), from then on access tokens can be read from the secrets plugin and renewed when they expire. 

The new option simply puts the selected tokens into the returned metadata in a similarly to the way that the `claims_mapping` option returns things in metadata.

This PR was proposed for vault several years ago in hashicorp/vault-plugin-auth-jwt#119 but has been sitting unmerged since then.  It is an essential component of the https://github.com/fermitools/htvault-config package and has been in production use for a couple of years.