### PR TITLE
Fix compatibility with Vault plugins

### DIFF
--- a/api/env.go
+++ b/api/env.go
@@ -5,8 +5,22 @@ import (
 	"strings"
 )
 
+const (
+	OpenBaoEnvPrefix  = "BAO_"
+	UpstreamEnvPrefix = "VAULT_"
+)
+
+func UpstreamVariableName(name string) string {
+	if !strings.HasPrefix(name, OpenBaoEnvPrefix) {
+		return name
+	}
+
+	nonPrefixedName := strings.Replace(name, OpenBaoEnvPrefix, "", 1)
+	return UpstreamEnvPrefix + nonPrefixedName
+}
+
 func ReadBaoVariable(name string) string {
-	if !strings.HasPrefix(name, "BAO_") {
+	if !strings.HasPrefix(name, OpenBaoEnvPrefix) {
 		return os.Getenv(name)
 	}
 
@@ -16,12 +30,11 @@ func ReadBaoVariable(name string) string {
 		return baoValue
 	}
 
-	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
-	return os.Getenv("VAULT_" + nonPrefixedName)
+	return os.Getenv(UpstreamVariableName(name))
 }
 
 func LookupBaoVariable(name string) (string, bool) {
-	if !strings.HasPrefix(name, "BAO_") {
+	if !strings.HasPrefix(name, OpenBaoEnvPrefix) {
 		return os.LookupEnv(name)
 	}
 
@@ -29,6 +42,5 @@ func LookupBaoVariable(name string) (string, bool) {
 		return baoValue, baoPresent
 	}
 
-	nonPrefixedName := strings.Replace(name, "BAO_", "", 1)
-	return os.LookupEnv("VAULT_" + nonPrefixedName)
+	return os.LookupEnv(UpstreamVariableName(name))
 }

--- a/changelog/321.txt
+++ b/changelog/321.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/pluings: Fix compatibility when running pre-built Vault plugins.
+```

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
+	"github.com/openbao/openbao/api"
 	"github.com/openbao/openbao/sdk/helper/consts"
 )
 
@@ -47,20 +48,26 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 	// Add the mlock setting to the ENV of the plugin
 	if rc.MLock || (rc.Wrapper != nil && rc.Wrapper.MlockEnabled()) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PluginMlockEnabled, "true"))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", api.UpstreamVariableName(PluginMlockEnabled), "true"))
 	}
 	version, err := rc.Wrapper.VaultVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", api.UpstreamVariableName(PluginVaultVersionEnv), version))
 
 	if rc.IsMetadataMode {
 		rc.Logger = rc.Logger.With("metadata", "true")
 	}
 	metadataEnv := fmt.Sprintf("%s=%t", PluginMetadataModeEnv, rc.IsMetadataMode)
 	cmd.Env = append(cmd.Env, metadataEnv)
+	metadataEnv = fmt.Sprintf("%s=%t", api.UpstreamVariableName(PluginMetadataModeEnv), rc.IsMetadataMode)
+	cmd.Env = append(cmd.Env, metadataEnv)
 
 	automtlsEnv := fmt.Sprintf("%s=%t", PluginAutoMTLSEnv, rc.AutoMTLS)
+	cmd.Env = append(cmd.Env, automtlsEnv)
+	automtlsEnv = fmt.Sprintf("%s=%t", api.UpstreamVariableName(PluginAutoMTLSEnv), rc.AutoMTLS)
 	cmd.Env = append(cmd.Env, automtlsEnv)
 
 	var clientTLSConfig *tls.Config
@@ -86,6 +93,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 
 		// Add the response wrap token to the ENV of the plugin
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PluginUnwrapTokenEnv, wrapToken))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", api.UpstreamVariableName(PluginUnwrapTokenEnv), wrapToken))
 	}
 
 	secureConfig := &plugin.SecureConfig{


### PR DESCRIPTION
This adds Upstream (`VAULT_` prefixed) variants of all OpenBao-set variables during plugin startup, allowing plugins compiled for upstream to work with OpenBao.

This should resolve #317 (a discussion).

@DrDaveD Let me know if this works for you!