### PR TITLE
Issue 330: Adding Technical Steering Committee members to the Contrib…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,16 @@ Signing off a commit signifies your agreement to the terms outlined at
 https://developercertificate.org/ for that specific contribution. Any contribution 
 that lacks a sign-off to this agreement will not be accepted by the OpenBao project.
 
+## Technical Steering Committee (TSC) Members
+
+| Member            | Email                               | GitHub    | Alternate | Company/Organization | TSC Position |
+|-------------------|-------------------------------------|-----------|-----------|----------------------|--------------|
+| James Butcher     | james@iotechsys.com                 |           |           | IOtech Systems       | Member       |
+| Julian Cassignol  | jcassignol@wallix.com               |           |           | Wallix               | Member       |
+| Alain Nochimowski | alain.Nochimowski@viaccess-orca.com |           |           | Viaccess-Orca        | Member       |
+| Michael Maxey     | maxey@zededa.com                    |           |           | Zededa               | Member       |
+| Nathan Phelps     | naphelps@us.ibm.com                 | @naphelps |           | IBM                  | Chair        |
+
 ## Issues
 
 This section will cover what we're looking for in terms of reporting issues.


### PR DESCRIPTION
References: #330

Changes:
- Adds Technical Steering Committee (TSC) members to Contributing.md.
