### PR TITLE
Goreleaser updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            ./dist/**/bao
+            ./dist/**/*.exe
             ./dist/**/*.deb
             ./dist/**/*.rpm
             ./dist/*.tar.gz
+            ./dist/*.tar.gz.zst
             ./dist/*.zip
           key: ${{ github.ref }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
-      - dragonfly
+      #- dragonfly
       - freebsd
       - illumos
       - netbsd

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,13 @@ before:
     - go generate ./...
     - make bootstrap
 
+# Cannot have replace directives in the go modules.
+#gomod:
+#  proxy: true
+#  env:
+#    - GOPROXY=https://proxy.golang.org,direct
+#    - GOSUMDB=sum.golang.org
+
 builds:
   - id: builds-linux
     ldflags:
@@ -28,7 +35,9 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - riscv64
+      - s390x
     goarm:
       - "6"
     mod_timestamp: "{{ .CommitTimestamp }}"
@@ -52,7 +61,9 @@ builds:
       - amd64
       - arm
       - arm64
+      #- ppc64le
       - riscv64
+      #- s390x
       #- wasm
     goarm:
       - "6"
@@ -63,7 +74,11 @@ builds:
       - goos: darwin
         goarch: arm
       - goos: darwin
+        goarch: ppc64le
+      - goos: darwin
         goarch: riscv64
+      - goos: darwin
+        goarch: s390x
       - goos: darwin
         goarch: wasm
       - goos: dragonfly
@@ -77,21 +92,37 @@ builds:
       - goos: freebsd
         goarm: "7"
       - goos: freebsd
+        goarch: ppc64le
+      - goos: freebsd
+        goarch: s390x
+      - goos: freebsd
         goarch: wasm
       - goos: illumos
         goarch: arm
       - goos: illumos
         goarch: arm64
       - goos: illumos
+        goarch: ppc64le
+      - goos: illumos
+        goarch: s390x
+      - goos: illumos
         goarch: wasm
       - goos: netbsd
+        goarch: ppc64le
+      - goos: netbsd
         goarch: riscv64
+      - goos: netbsd
+        goarch: s390x
       - goos: netbsd
         goarch: wasm
       - goos: netbsd
         goarm: "7"
       - goos: openbsd
+        goarch: ppc64le
+      - goos: openbsd
         goarch: riscv64
+      - goos: openbsd
+        goarch: s390x
       - goos: openbsd
         goarch: wasm
       - goos: openbsd
@@ -101,12 +132,28 @@ builds:
       - goos: solaris
         goarch: arm64
       - goos: solaris
+        goarch: ppc64le
+      - goos: solaris
+        goarch: s390x
+      - goos: solaris
         goarch: wasm
+      - goos: wasip1
+        goarch: amd64
+      - goos: wasip1
+        goarch: arm
+      - goos: wasip1
+        goarch: arm64
+      - goos: wasip1
+        goarch: riscv64
       - goos: windows
         goarch: arm
         goarm: "7"
       - goos: windows
+        goarch: ppc64le
+      - goos: windows
         goarch: riscv64
+      - goos: windows
+        goarch: s390x
       - goos: windows
         goarch: wasm
     mod_timestamp: "{{ .CommitTimestamp }}"
@@ -116,8 +163,8 @@ report_sizes: true
 
 nfpms:
   - vendor: OpenBao
-    homepage: https://github.com/openbao/openbao
-    maintainer: OpenBao
+    homepage: https://openbao.org
+    maintainer: OpenBao <openbao@lists.lfedge.org>
     description: |
       OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.
@@ -306,6 +353,41 @@ dockers:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
       - ./CHANGELOG.md
+  - id: alpine-ppc64le
+    use: buildx
+    goos: linux
+    goarch: ppc64le
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{.ProjectName}}"
+      - "--build-arg=REVISION={{.FullCommit}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--platform=linux/ppc64le"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=default"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/docker-entrypoint.sh
+      - ./CHANGELOG.md
   - id: alpine-riscv64
     use: buildx
     goos: linux
@@ -332,11 +414,46 @@ dockers:
       - "--label=release={{ .Version }}"
       - "--label=revision={{ .FullCommit }}"
       - "--label=version={{ .Version }}"
-      - "--target=default-riscv64"
+      - "--target=default"
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
       - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
       - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/docker-entrypoint.sh
+      - ./CHANGELOG.md
+  - id: alpine-s390x
+    use: buildx
+    goos: linux
+    goarch: s390x
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/s390x"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=default"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -412,6 +529,76 @@ dockers:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
       - ./CHANGELOG.md
+  - id: ubi-ppc64le
+    use: buildx
+    goos: linux
+    goarch: ppc64le
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/ppc64le"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=ubi"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/ubi-docker-entrypoint.sh
+      - ./CHANGELOG.md
+  - id: ubi-s390x
+    use: buildx
+    goos: linux
+    goarch: s390x
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/s390x"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=ubi"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/ubi-docker-entrypoint.sh
+      - ./CHANGELOG.md
 
 docker_manifests:
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
@@ -420,144 +607,192 @@ docker_manifests:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
     skip_push: false
     image_templates:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
     skip_push: false
     image_templates:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-ppc64le
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
     skip_push: false
     image_templates:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
 
 archives:
   - format: tar.gz
@@ -572,6 +807,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+      -
     builds_info:
       group: root
       owner: root
@@ -579,8 +815,15 @@ archives:
       # format is `time.RFC3339Nano`
       mtime: 2008-01-02T15:04:05Z
 
+#source:
+#  enabled: true
+
 sboms:
   - artifacts: archive
+  - id: binary
+    artifacts: binary
+  - id: package
+    artifacts: package
 
 changelog:
   use: github
@@ -622,7 +865,7 @@ docker_signs:
 
 release:
   github:
-    owner: ${{ .Env.GITHUB_REPOSITORY_OWNER }}
+    owner: openbao
     name: openbao
   draft: true #${{ .Env.GITHUB_RELEASE_DRAFT }}
   replace_existing_draft: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -579,6 +579,9 @@ archives:
       # format is `time.RFC3339Nano`
       mtime: 2008-01-02T15:04:05Z
 
+sboms:
+  - artifacts: archive
+
 changelog:
   use: github
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -807,7 +807,6 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-      -
     builds_info:
       group: root
       owner: root

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
-      #- dragonfly
+      - dragonfly
       - freebsd
       - illumos
       - netbsd
@@ -66,13 +66,13 @@ builds:
         goarch: riscv64
       - goos: darwin
         goarch: wasm
-      - goos: dragofly
+      - goos: dragonfly
         goarch: arm
-      - goos: dragofly
+      - goos: dragonfly
         goarch: arm64
-      - goos: dragofly
+      - goos: dragonfly
         goarch: riscv64
-      - goos: dragofly
+      - goos: dragonfly
         goarch: wasm
       - goos: freebsd
         goarm: "7"
@@ -227,9 +227,9 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64"
-      - "quay.io/openbao/openbao:{{ .Version }}-alpine-amd64"
-      - "docker.io/openbao/openbao:{{ .Version }}-alpine-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -263,9 +263,9 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm"
-      - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm"
-      - "docker.io/openbao/openbao:{{ .Version }}-alpine-arm"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -299,9 +299,9 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=default"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64"
-      - "quay.io/openbao/openbao:{{ .Version }}-alpine-arm64"
-      - "docker.io/openbao/openbao:{{ .Version }}-alpine-arm64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -334,9 +334,9 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=default-riscv64"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
-      - "quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
-      - "docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/docker-entrypoint.sh
@@ -369,9 +369,9 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=ubi"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64"
-      - "quay.io/openbao/openbao:{{ .Version }}-ubi-amd64"
-      - "docker.io/openbao/openbao:{{ .Version }}-ubi-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
@@ -405,123 +405,159 @@ dockers:
       - "--label=version={{ .Version }}"
       - "--target=ubi"
     image_templates:
-      - "ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64"
-      - "quay.io/openbao/openbao:{{ .Version }}-ubi-arm64"
-      - "docker.io/openbao/openbao:{{ .Version }}-ubi-arm64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
       - ./CHANGELOG.md
 
 docker_manifests:
-  - name_template: ghcr.io/openbao/openbao:{{ .Version }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
     skip_push: false
     image_templates:
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: ghcr.io/openbao/openbao:{{ .Major }}.{{ .Minor }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: ghcr.io/openbao/openbao:{{ .Major }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
     skip_push: false
     image_templates:
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: ghcr.io/openbao/openbao:latest
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
     skip_push: false
     image_templates:
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - ghcr.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - ghcr.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: docker.io/openbao/openbao:{{ .Version }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
     skip_push: false
     image_templates:
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: docker.io/openbao/openbao:{{ .Major }}.{{ .Minor }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: docker.io/openbao/openbao:{{ .Major }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
     skip_push: false
     image_templates:
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: docker.io/openbao/openbao:latest
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
     skip_push: false
     image_templates:
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - docker.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - docker.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: quay.io/openbao/openbao:{{ .Version }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
     skip_push: false
     image_templates:
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: quay.io/openbao/openbao:{{ .Major }}.{{ .Minor }}
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
     skip_push: false
     image_templates:
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: quay.io/openbao/openbao:{{ .Major }}
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
     skip_push: false
     image_templates:
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
-  - name_template: quay.io/openbao/openbao:latest
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
     skip_push: false
     image_templates:
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-arm64
-      - quay.io/openbao/openbao:{{ .Version }}-alpine-riscv64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-amd64
-      - quay.io/openbao/openbao:{{ .Version }}-ubi-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
+    skip_push: false
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
+    skip_push: false
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
+    skip_push: false
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}.{{ .Minor }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Major }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:latest
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao:{{ .Version }}-riscv64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}.{{ .Minor }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Major }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:latest
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-arm64
 
 archives:
   - format: tar.gz
@@ -583,7 +619,7 @@ docker_signs:
 
 release:
   github:
-    owner: openbao
+    owner: ${{ .Env.GITHUB_REPOSITORY_OWNER }}
     name: openbao
   draft: true #${{ .Env.GITHUB_RELEASE_DRAFT }}
   replace_existing_draft: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-## DOCKERHUB DOCKERFILE ##
-FROM alpine:3.19 as default
+#### DOCKERHUB DOCKERFILE ####
+FROM alpine:3.20 as default
 
 ARG BIN_NAME
 # NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
@@ -14,7 +14,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao Team <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.lfedge.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \
@@ -73,80 +73,8 @@ CMD ["server", "-dev"]
 
 
 
-## DOCKERHUB DOCKERFILE RISCV64 ##
-FROM alpine:20240315 as default-riscv64
-
-ARG BIN_NAME
-# NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
-# and the version to download. Example: NAME=openbao PRODUCT_VERSION=1.2.3.
-ARG NAME=openbao
-ARG PRODUCT_VERSION
-ARG PRODUCT_REVISION
-
-# Additional metadata labels used by container registries, platforms
-# and certification scanners.
-LABEL name="OpenBao" \
-      maintainer="OpenBao Team <openbao@lists.lfedge.org>" \
-      vendor="OpenBao" \
-      version=${PRODUCT_VERSION} \
-      release=${PRODUCT_REVISION} \
-      revision=${PRODUCT_REVISION} \
-      summary="OpenBao is a tool for securely accessing secrets." \
-      description="OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log."
-
-COPY LICENSE /licenses/mozilla.txt
-
-# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
-ENV NAME=$NAME
-ENV VERSION=$VERSION
-
-# Create a non-root user to run the software.
-RUN addgroup ${NAME} && adduser -S -G ${NAME} ${NAME}
-
-RUN apk add --no-cache libcap su-exec dumb-init tzdata
-
-COPY $BIN_NAME /bin/
-
-# /vault/logs is made available to use as a location to store audit logs, if
-# desired; /vault/file is made available to use as a location with the file
-# storage backend, if desired; the server will be started with /vault/config as
-# the configuration directory so you can add additional config files in that
-# location.
-RUN mkdir -p /openbao/logs && \
-    mkdir -p /openbao/file && \
-    mkdir -p /openbao/config && \
-    chown -R ${NAME}:${NAME} /openbao
-
-# Expose the logs directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/logs
-
-# Expose the file directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/file
-
-# 8200/tcp is the primary interface that applications use to interact with
-# OpenBao.
-EXPOSE 8200
-
-# The entry point script uses dumb-init as the top-level process to reap any
-# zombie processes created by OpenBao sub-processes.
-#
-# For production derivatives of this container, you shoud add the IPC_LOCK
-# capability so that OpenBao can mlock memory.
-COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["docker-entrypoint.sh"]
-
-
-# # By default you'll get a single-node development server that stores everything
-# # in RAM and bootstraps itself. Don't use this configuration for production.
-CMD ["server", "-dev"]
-
-
-
-
-## UBI DOCKERFILE ##
-FROM registry.access.redhat.com/ubi9-minimal:9.3 as ubi
+#### UBI DOCKERFILE ####
+FROM registry.access.redhat.com/ubi9-minimal:9.4 as ubi
 
 ARG BIN_NAME
 # PRODUCT_VERSION is the version built dist/$TARGETOS/$TARGETARCH/$BIN_NAME,
@@ -157,7 +85,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao Team <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.lfedge.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \


### PR DESCRIPTION
References:

Changes:
- Split UBI and Alpine images into two separate container registries.
- Added linux/ppc64le and linux/s390x support.
- Added sbom support to build artifacts.
- Updated Alpine to v3.20 and UBI to v9.4.
- Container registry organization name is now a reference.
- Added additional items to build cache.
