### PR TITLE
Pass `BAO_ADDR` to the token helper

### DIFF
--- a/changelog/348.txt
+++ b/changelog/348.txt
@@ -1,4 +1,5 @@
 ```release-note:bug
 cli: Always pass `BAO_ADDR` to the token helper, so the token helper can know
-the address even if it was provided through the `-address` flag.
+the address even if it was provided through the `-address` flag. For
+compatibility we also set `VAULT_ADDR`.
 ```

--- a/changelog/348.txt
+++ b/changelog/348.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Always pass `BAO_ADDR` to the token helper, so the token helper can know
+the address even if it was provided through the `-address` flag.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -185,7 +185,7 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 
 	// If we don't have a token, check the token helper
 	if token == "" {
-		helper, err := c.TokenHelper()
+		helper, err := c.TokenHelper(client.Address())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get token helper")
 		}
@@ -216,12 +216,12 @@ func (c *BaseCommand) SetTokenHelper(th token.TokenHelper) {
 }
 
 // TokenHelper returns the token helper attached to the command.
-func (c *BaseCommand) TokenHelper() (token.TokenHelper, error) {
+func (c *BaseCommand) TokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	if c.tokenHelper != nil {
 		return c.tokenHelper, nil
 	}
 
-	helper, err := DefaultTokenHelper()
+	helper, err := DefaultTokenHelper(vaultAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/command/base_predict.go
+++ b/command/base_predict.go
@@ -27,7 +27,7 @@ func (p *Predict) Client() *api.Client {
 			client, _ := api.NewClient(nil)
 
 			if client.Token() == "" {
-				helper, err := DefaultTokenHelper()
+				helper, err := DefaultTokenHelper(client.Address())
 				if err != nil {
 					return
 				}

--- a/command/config/util.go
+++ b/command/config/util.go
@@ -9,7 +9,7 @@ import (
 
 // DefaultTokenHelper returns the token helper that is configured for Vault.
 // This helper should only be used for non-server CLI commands.
-func DefaultTokenHelper() (token.TokenHelper, error) {
+func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	config, err := LoadConfig("")
 	if err != nil {
 		return nil, err
@@ -24,5 +24,12 @@ func DefaultTokenHelper() (token.TokenHelper, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &token.ExternalTokenHelper{BinaryPath: path}, nil
+
+	// If the user specifed the address to connect to on the command line instead
+	// of through an environment variable, we propagate the address to the token
+	// helper through an environment variable. Otherwise the token helper may
+	// read BAO_ADDR and assume a different address than the one we are using.
+	env := []string{"BAO_ADDR=" + vaultAddr}
+
+	return &token.ExternalTokenHelper{BinaryPath: path, Env: env}, nil
 }

--- a/command/config/util.go
+++ b/command/config/util.go
@@ -29,7 +29,7 @@ func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	// of through an environment variable, we propagate the address to the token
 	// helper through an environment variable. Otherwise the token helper may
 	// read BAO_ADDR and assume a different address than the one we are using.
-	env := []string{"BAO_ADDR=" + vaultAddr}
+	env := []string{"BAO_ADDR=" + vaultAddr, "VAULT_ADDR=" + vaultAddr}
 
 	return &token.ExternalTokenHelper{BinaryPath: path, Env: env}, nil
 }

--- a/command/login.go
+++ b/command/login.go
@@ -300,7 +300,7 @@ func (c *LoginCommand) Run(args []string) int {
 
 	if !c.flagNoStore {
 		// Grab the token helper so we can store
-		tokenHelper, err := c.TokenHelper()
+		tokenHelper, err := c.TokenHelper(client.Address())
 		if err != nil {
 			c.UI.Error(wrapAtLength(fmt.Sprintf(
 				"Error initializing token helper. Please verify that the token "+

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -62,7 +62,7 @@ func TestCustomPath(t *testing.T) {
 	ui, cmd := testLoginCommand(t)
 	cmd.client = client
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestNoStore(t *testing.T) {
 	_, cmd := testLoginCommand(t)
 	cmd.client = client
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestStores(t *testing.T) {
 	_, cmd := testLoginCommand(t)
 	cmd.client = client
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestTokenOnly(t *testing.T) {
 	ui, cmd := testLoginCommand(t)
 	cmd.client = client
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestFailureNoStore(t *testing.T) {
 	ui, cmd := testLoginCommand(t)
 	cmd.client = client
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestWrapAutoUnwrap(t *testing.T) {
 	// Unset the wrapping
 	client.SetWrappingLookupFunc(func(string, string) string { return "" })
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestWrapTokenOnly(t *testing.T) {
 	// Unset the wrapping
 	client.SetWrappingLookupFunc(func(string, string) string { return "" })
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestWrapNoStore(t *testing.T) {
 	// Unset the wrapping
 	client.SetWrappingLookupFunc(func(string, string) string { return "" })
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,7 +491,7 @@ func TestLoginMFASinglePhase(t *testing.T) {
 			t.Errorf("expected %d to be %d", code, exp)
 		}
 
-		tokenHelper, err := cmd.TokenHelper()
+		tokenHelper, err := cmd.TokenHelper(client.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -542,7 +542,7 @@ func TestLoginMFATwoPhase(t *testing.T) {
 		t.Fatalf("expected stored token: %q, got: %q", expected, output)
 	}
 
-	tokenHelper, err := cmd.TokenHelper()
+	tokenHelper, err := cmd.TokenHelper(client.Address())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/server.go
+++ b/command/server.go
@@ -1822,7 +1822,7 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 
 	// Set the token
 	if !c.flagDevNoStoreToken {
-		tokenHelper, err := c.TokenHelper()
+		tokenHelper, err := c.TokenHelper("dev-server")
 		if err != nil {
 			return nil, err
 		}
@@ -1971,7 +1971,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	}
 
 	// Set the token
-	tokenHelper, err := c.TokenHelper()
+	tokenHelper, err := c.TokenHelper("dev-server")
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error getting token helper: %s", err))
 		return 1

--- a/command/util.go
+++ b/command/util.go
@@ -18,8 +18,8 @@ import (
 
 // DefaultTokenHelper returns the token helper that is configured for Vault.
 // This helper should only be used for non-server CLI commands.
-func DefaultTokenHelper() (token.TokenHelper, error) {
-	return config.DefaultTokenHelper()
+func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
+	return config.DefaultTokenHelper(vaultAddr)
 }
 
 // RawField extracts the raw field from the given data and returns it as a


### PR DESCRIPTION
Previously the token helper might inherit `BAO_ADDR` from the process, but if the address was specified through an `-address` command-line flag, then the token helper would not know the address, or it would use the wrong one. Fix that by propagating the address everywhere, and then setting `BAO_ADDR` explicitly in the token helper's environment.

Resolves #314.

* [x] One thing I’m not sure about: should we set `VAULT_ADDR` in addition to `BAO_ADDR`? I see there are still many uses of `VAULT_ADDR` in the codebase. ⇒ Yes, set both.

## Target Release

It filled out this by default: 1.14.7
