### PR TITLE
Clarify Integrated Storage is only backend

### DIFF
--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -1,15 +1,10 @@
 ---
-description: Learn about the integrated raft storage in OpenBao.
+description: Learn about the integrated Raft storage in OpenBao.
 ---
 
 # Integrated storage
 
-OpenBao supports several storage options for the durable storage of OpenBao's
-information. Each backend offers pros, cons, advantages, and trade-offs. For
-example, some backends support high availability while others provide a more
-robust backup and restoration process.
-
-An Integrated Storage option is offered. This storage backend
+OpenBao comes integrated with a native storage backend system. This storage backend
 does not rely on any third party systems; it implements high availability and
 provides backup/restore workflows.
 


### PR DESCRIPTION
The Internals / Integrated Storage page contained legacy Vault information about supporting "several storage options". This commit makes clear that Integrated Storage is the only storage backend in OpenBao.