### PR TITLE
Issue 358: Swapped Hashicorp's CoC for LF's.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,5 +1,2 @@
 # Code of Conduct
-
-HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
-
-Please read the full text at https://www.hashicorp.com/community-guidelines
+OpenBao adheres to the Linux Foundation's [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) for projects.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+Repository Maintainers
+======================
+
+See the information about community membership roles to learn about the role of the maintainers and the process to become one.
+
+| Name         | GitHub                                   | Email                     |
+|--------------|------------------------------------------|---------------------------|
+|  |  |  |
+|  |  |  |
+|  |  |  |


### PR DESCRIPTION
References: #358

Changes:
- Swapped Code of Conduct from Hashicorp's to the Linux Foundation project's.
- Added a Maintainers markdown file.