### PR TITLE
Adding OpenBao's new maintainers, working group, and tsc voting member.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,22 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 
 ## Technical Steering Committee (TSC) Members
 
-| Member            | Email                               | GitHub                                   | Alternate                                | Company/Organization | TSC Position |
-|-------------------|-------------------------------------|------------------------------------------|------------------------------------------|----------------------|--------------|
-| James Butcher     | james@iotechsys.com                 |                                          |                                          | IOtech Systems       | Member       |
-| Julian Cassignol  | jcassignol@wallix.com               |                                          | Cristian Popi (cpopi@wallix.com)         | Wallix               | Member       |
-| Alain Nochimowski | alain.Nochimowski@viaccess-orca.com |                                          | Dan Ghita (dan.ghita@viaccess-orca.com)  | Viaccess-Orca        | Member       |
-| Michael Maxey     | maxey@zededa.com                    |                                          |                                          | Zededa               | Member       |
-| Nathan Phelps     | naphelps@us.ibm.com                 | [@naphelps](https://github.com/naphelps) |                                          | IBM                  | Chair        |
+| Member            | Email                               | GitHub                                     | Alternate                               | Company/Organization      | TSC Position |
+|-------------------|-------------------------------------|--------------------------------------------|-----------------------------------------|---------------------------|--------------|
+| Alex Scheel       | alexander.m.scheel@gmail.com        | [@cipherboy](https://github.com/cipherboy) |                                         | Development Working Group | Member       |
+| Nathan Phelps     | naphelps@us.ibm.com                 | [@naphelps](https://github.com/naphelps)   |                                         | IBM                       | Chair        |
+| James Butcher     | james@iotechsys.com                 |                                            |                                         | IOtech Systems            | Member       |
+| Alain Nochimowski | alain.Nochimowski@viaccess-orca.com |                                            | Dan Ghita (dan.ghita@viaccess-orca.com) | Viaccess-Orca             | Member       |
+| Julian Cassignol  | jcassignol@wallix.com               |                                            | Cristian Popi (cpopi@wallix.com)        | Wallix                    | Member       |
+| Michael Maxey     | maxey@zededa.com                    |                                            |                                         | Zededa                    | Member       |
+
+
+### OpenBao Working Groups
+
+| Working Group             | Chair       |
+|---------------------------|-------------|
+| Development Working Group | Alex Scheel |
+
 
 ## Issues
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,8 +3,9 @@ Repository Maintainers
 
 See the information about community membership roles to learn about the role of the maintainers and the process to become one.
 
-| Name         | GitHub                                   | Email                     |
-|--------------|------------------------------------------|---------------------------|
-|  |  |  |
-|  |  |  |
-|  |  |  |
+| Name          | Email                        | GitHub                                     |
+|---------------|------------------------------|--------------------------------------------|
+| Dan Ghita     | dan.ghita@viaccess-orca.com  | [@DanGhita](https://github.com/DanGhita)   |
+| Jan Martens   | jan@martens.eu.org           | [@JanMa](https://github.com/JanMa)         |
+| Nathan Phelps | naphelps@us.ibm.com          | [@naphelps](https://github.com/naphelps)   |
+| Alex Scheel   | alexander.m.scheel@gmail.com | [@cipherboy](https://github.com/cipherboy) |


### PR DESCRIPTION
References:

Changes:
- Adding new maintainers. 
- Adding new Development Working Group.
- Adding new TSC voting member.

https://wiki.lfedge.org/display/OH/2024-06-13+OpenBao+TSC+Meeting
