### PR TITLE
Remove mlock and replace with cgroups

### DIFF
--- a/.release/docker/docker-entrypoint.sh
+++ b/.release/docker/docker-entrypoint.sh
@@ -88,17 +88,6 @@ if [ "$1" = 'bao' ]; then
         fi
     fi
 
-    if [ -z "$SKIP_SETCAP" ]; then
-        # Allow mlock to avoid swapping OpenBao memory to disk
-        setcap cap_ipc_lock=+ep $(readlink -f $(which bao))
-
-        # In the case bao has been started in a container without IPC_LOCK privileges
-        if ! bao -version 1>/dev/null 2>/dev/null; then
-            >&2 echo "Couldn't start bao with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK"
-            setcap cap_ipc_lock=-ep $(readlink -f $(which bao))
-        fi
-    fi
-
     if [ "$(id -u)" = '0' ]; then
       set -- su-exec openbao "$@"
     fi

--- a/.release/linux/package/etc/openbao/openbao.hcl
+++ b/.release/linux/package/etc/openbao/openbao.hcl
@@ -5,17 +5,9 @@
 
 ui = true
 
-#mlock = true
-#disable_mlock = true
-
 storage "file" {
   path = "/opt/openbao/data"
 }
-
-#storage "consul" {
-#  address = "127.0.0.1:8500"
-#  path    = "openbao"
-#}
 
 # HTTP listener
 #listener "tcp" {

--- a/.release/linux/package/usr/lib/systemd/system/openbao.service
+++ b/.release/linux/package/usr/lib/systemd/system/openbao.service
@@ -17,8 +17,7 @@ ProtectHome=read-only
 PrivateTmp=yes
 PrivateDevices=yes
 SecureBits=keep-caps
-AmbientCapabilities=CAP_IPC_LOCK
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG
 NoNewPrivileges=yes
 ExecStart=/usr/bin/bao server -config=/etc/openbao/openbao.hcl
 ExecReload=/bin/kill --signal HUP $MAINPID
@@ -28,7 +27,7 @@ Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
 LimitNOFILE=65536
-LimitMEMLOCK=infinity
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target

--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -32,9 +32,6 @@ chmod 700 /opt/openbao/tls
 
 echo "OpenBao TLS key and self-signed certificate have been generated in '/opt/openbao/tls'."
 
-# Set IPC_LOCK capabilities on bao
-setcap cap_ipc_lock=+ep /usr/bin/bao
-
 if [ -d /run/systemd/system ]; then
     systemctl --system daemon-reload >/dev/null || true
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,6 @@ EXPOSE 8200
 
 # The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by OpenBao sub-processes.
-#
-# For production derivatives of this container, you shoud add the IPC_LOCK
-# capability so that OpenBao can mlock memory.
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
@@ -142,9 +139,6 @@ EXPOSE 8200
 
 # The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by OpenBao sub-processes.
-#
-# For production derivatives of this container, you shoud add the IPC_LOCK
-# capability so that OpenBao can mlock memory.
 COPY .release/docker/ubi-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -252,7 +252,6 @@ func connectionState(serverCAPath, serverCertPath, serverKeyPath, clientCertPath
 func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 	// Enable PKI secret engine and Cert auth method
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -478,7 +477,6 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 func TestBackend_MetadataBasedACLPolicy(t *testing.T) {
 	// Start cluster with cert auth method enabled
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -2518,7 +2516,6 @@ mr2dJsMn54TXDOZYRQd5WVKDDu8xoJI=
 func TestBackend_RegressionDifferentTrustedLeaf(t *testing.T) {
 	// Cert auth method
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/builtin/credential/cert/test-fixtures/generate.txt
+++ b/builtin/credential/cert/test-fixtures/generate.txt
@@ -7,7 +7,6 @@ vi cakey.pem
 vaultcert.hcl
 backend "inmem" {
 }
-disable_mlock = true
 default_lease_ttl = "700h"
 max_lease_ttl = "768h"
 listener "tcp" {

--- a/builtin/credential/kerberos/scripts/dev_env.sh
+++ b/builtin/credential/kerberos/scripts/dev_env.sh
@@ -53,7 +53,7 @@ function delete_network() {
 }
 
 function start_vault() {
-  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --cap-add=IPC_LOCK -v $(pwd)/pkg/linux_amd64:/plugins:Z -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" -p ${VAULT_PORT}:${VAULT_PORT} vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/plugins)
+  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --memory-swappiness=0 -v $(pwd)/pkg/linux_amd64:/plugins:Z -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" -p ${VAULT_PORT}:${VAULT_PORT} vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/plugins)
   export VAULT_ADDR=http://127.0.0.1:${VAULT_PORT}
 }
 

--- a/builtin/credential/kerberos/scripts/integration_env.sh
+++ b/builtin/credential/kerberos/scripts/integration_env.sh
@@ -58,7 +58,7 @@ function delete_network() {
 }
 
 function start_vault() {
-  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --cap-add=IPC_LOCK \
+  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --memory-swappiness=0 \
     -v "${REPO_ROOT}:/tmp/repo-root:Z" \
     -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" \
     -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" \

--- a/builtin/credential/kerberos/test/acceptance/_helpers.bash
+++ b/builtin/credential/kerberos/test/acceptance/_helpers.bash
@@ -64,7 +64,7 @@ delete_network() {
 
 start_vault() {
   docker run -d -ti --net=${DNS_NAME} \
-    --cap-add=IPC_LOCK \
+    --memory-swappiness=0 \
     -v "$(pwd)/pkg/linux_amd64:/plugins:Z" \
     -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" \
     -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200" \

--- a/builtin/logical/openldap/scripts/acceptance-tests.bats
+++ b/builtin/logical/openldap/scripts/acceptance-tests.bats
@@ -128,7 +128,7 @@ start_vault() {
     --name "${vault_docker_name}" \
     --rm \
     --detach \
-    --cap-add=IPC_LOCK \
+    --memory-swappiness=0 \
     --network "${docker_network}" \
     -v "${vault_plugin_dir}:/vault/plugins" \
     -p ${vault_port}:8200 \

--- a/changelog/363.txt
+++ b/changelog/363.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core: Remove mlock functionality from OpenBao and make the "disable_mlock" config option obsolete.
+```

--- a/command/agent/approle_end_to_end_test.go
+++ b/command/agent/approle_end_to_end_test.go
@@ -69,7 +69,6 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 	var err error
 	logger := logging.NewVaultLogger(log.Trace)
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -410,7 +409,6 @@ func TestAppRoleLongRoleName(t *testing.T) {
 	approleName := strings.Repeat("a", 5000)
 
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -476,7 +474,6 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 	var err error
 	logger := logging.NewVaultLogger(log.Trace)
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -44,7 +44,6 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	var err error
 	logger := logging.NewVaultLogger(log.Trace)
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -204,11 +204,6 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.APIProxy = c2.APIProxy
 	}
 
-	result.DisableMlock = c.DisableMlock
-	if c2.DisableMlock {
-		result.DisableMlock = c2.DisableMlock
-	}
-
 	// For these, ignore the non-specific one and overwrite them all
 	result.DisableIdleConnsAutoAuth = c.DisableIdleConnsAutoAuth
 	if c2.DisableIdleConnsAutoAuth {

--- a/command/agent/token_file_end_to_end_test.go
+++ b/command/agent/token_file_end_to_end_test.go
@@ -24,7 +24,6 @@ func TestTokenFileEndToEnd(t *testing.T) {
 	var err error
 	logger := logging.NewVaultLogger(log.Trace)
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 	}

--- a/command/agentproxyshared/cache/api_proxy_test.go
+++ b/command/agentproxyshared/cache/api_proxy_test.go
@@ -191,7 +191,6 @@ func setupClusterAndAgentCommon(ctx context.Context, t *testing.T, coreConfig *v
 	// Handle sane defaults
 	if coreConfig == nil {
 		coreConfig = &vault.CoreConfig{
-			DisableMlock: true,
 			DisableCache: true,
 			Logger:       logging.NewVaultLogger(hclog.Trace),
 		}

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -202,7 +202,6 @@ func TestCache_AutoAuthClientTokenProxyStripping(t *testing.T) {
 
 func TestCache_ConcurrentRequests(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -247,7 +246,6 @@ func TestCache_ConcurrentRequests(t *testing.T) {
 
 func TestCache_TokenRevocations_RevokeOrphan(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -348,7 +346,6 @@ func TestCache_TokenRevocations_RevokeOrphan(t *testing.T) {
 
 func TestCache_TokenRevocations_LeafLevelToken(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -448,7 +445,6 @@ func TestCache_TokenRevocations_LeafLevelToken(t *testing.T) {
 
 func TestCache_TokenRevocations_IntermediateLevelToken(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -546,7 +542,6 @@ func TestCache_TokenRevocations_IntermediateLevelToken(t *testing.T) {
 
 func TestCache_TokenRevocations_TopLevelToken(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -641,7 +636,6 @@ func TestCache_TokenRevocations_TopLevelToken(t *testing.T) {
 
 func TestCache_TokenRevocations_Shutdown(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -731,7 +725,6 @@ func TestCache_TokenRevocations_Shutdown(t *testing.T) {
 
 func TestCache_TokenRevocations_BaseContextCancellation(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -822,7 +815,6 @@ func TestCache_TokenRevocations_BaseContextCancellation(t *testing.T) {
 
 func TestCache_NonCacheable(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -930,7 +922,6 @@ func TestCache_Caching_AuthResponse(t *testing.T) {
 
 func TestCache_Caching_LeaseResponse(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{
@@ -1032,7 +1023,6 @@ func TestCache_Caching_CacheClear(t *testing.T) {
 
 func testCachingCacheClearCommon(t *testing.T, clearType string) {
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		LogicalBackends: map[string]logical.Factory{

--- a/command/approle_concurrency_integ_test.go
+++ b/command/approle_concurrency_integ_test.go
@@ -20,7 +20,6 @@ import (
 func TestAppRole_Integ_ConcurrentLogins(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -126,7 +126,6 @@ func testVaultServerAllBackends(tb testing.TB) (*api.Client, func()) {
 	tb.Helper()
 
 	client, _, closer := testVaultServerCoreConfig(tb, &vault.CoreConfig{
-		DisableMlock:       true,
 		DisableCache:       true,
 		Logger:             defaultVaultLogger,
 		CredentialBackends: credentialBackends,
@@ -163,7 +162,6 @@ func testVaultServerUnsealWithKVVersionWithSeal(tb testing.TB, kvVersion string,
 	})
 
 	return testVaultServerCoreConfigWithOpts(tb, &vault.CoreConfig{
-		DisableMlock:       true,
 		DisableCache:       true,
 		Logger:             logger,
 		CredentialBackends: defaultVaultCredentialBackends,
@@ -185,7 +183,6 @@ func testVaultServerPluginDir(tb testing.TB, pluginDir string) (*api.Client, []s
 	tb.Helper()
 
 	return testVaultServerCoreConfig(tb, &vault.CoreConfig{
-		DisableMlock:       true,
 		DisableCache:       true,
 		Logger:             defaultVaultLogger,
 		CredentialBackends: defaultVaultCredentialBackends,
@@ -250,7 +247,6 @@ func testVaultServerUninit(tb testing.TB) (*api.Client, func()) {
 	}
 
 	core, err := vault.NewCore(&vault.CoreConfig{
-		DisableMlock:       true,
 		DisableCache:       true,
 		Logger:             defaultVaultLogger,
 		Physical:           inm,

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -176,11 +176,6 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.APIProxy = c2.APIProxy
 	}
 
-	result.DisableMlock = c.DisableMlock
-	if c2.DisableMlock {
-		result.DisableMlock = c2.DisableMlock
-	}
-
 	// For these, ignore the non-specific one and overwrite them all
 	result.DisableIdleConnsAutoAuth = c.DisableIdleConnsAutoAuth
 	if c2.DisableIdleConnsAutoAuth {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -134,11 +134,9 @@ func (c *Config) validateEnt(sourceFilePath string) []configutil.ConfigError {
 	return entConfigValidate(c, sourceFilePath)
 }
 
-// DevConfig is a Config that is used for dev mode of Vault.
+// DevConfig is a Config that is used for dev mode of OpenBao.
 func DevConfig(storageType string) (*Config, error) {
 	hclStr := `
-disable_mlock = true
-
 listener "tcp" {
 	address = "127.0.0.1:8200"
 	tls_disable = true
@@ -194,8 +192,6 @@ func DevTLSConfig(storageType, certDir string) (*Config, error) {
 
 func parseDevTLSConfig(storageType, certDir string) (*Config, error) {
 	hclStr := `
-disable_mlock = true
-
 listener "tcp" {
 	address = "[::]:8200"
 	tls_cert_file = "%s/vault-cert.pem"

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -46,7 +46,6 @@ func testConfigRaftRetryJoin(t *testing.T) {
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
-			DisableMlock: true,
 		},
 
 		Storage: &Storage{
@@ -96,8 +95,6 @@ func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
 				NumLeaseMetricsTimeBuckets:  168,
 				LeaseMetricsNameSpaceLabels: false,
 			},
-
-			DisableMlock: true,
 
 			PidFile: "./pidfile",
 
@@ -294,7 +291,6 @@ func testLoadConfigFileIntegerAndBooleanValuesCommon(t *testing.T, path string) 
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
-			DisableMlock: true,
 		},
 
 		Storage: &Storage{
@@ -357,8 +353,6 @@ func testLoadConfigFile(t *testing.T) {
 				NumLeaseMetricsTimeBuckets:  168,
 				LeaseMetricsNameSpaceLabels: false,
 			},
-
-			DisableMlock: true,
 
 			PidFile: "./pidfile",
 
@@ -447,8 +441,8 @@ func testUnknownFieldValidation(t *testing.T) {
 			Problem: "unknown or unsupported field bad_value found in configuration",
 			Position: token.Pos{
 				Filename: "./test-fixtures/config.hcl",
-				Offset:   651,
-				Line:     37,
+				Offset:   630,
+				Line:     36,
 				Column:   5,
 			},
 		},
@@ -632,8 +626,6 @@ func testLoadConfigDir(t *testing.T) {
 
 	expected := &Config{
 		SharedConfig: &configutil.SharedConfig{
-			DisableMlock: true,
-
 			Listeners: []*configutil.Listener{
 				{
 					Type:                  "tcp",
@@ -707,7 +699,6 @@ func testConfig_Sanitized(t *testing.T) {
 		"disable_cache":                       true,
 		"disable_clustering":                  false,
 		"disable_indexing":                    false,
-		"disable_mlock":                       true,
 		"disable_performance_standby":         false,
 		"plugin_file_uid":                     0,
 		"plugin_file_permissions":             0,
@@ -1122,8 +1113,6 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 				LeaseMetricsNameSpaceLabels: true,
 			},
 
-			DisableMlock: true,
-
 			PidFile: "./pidfile",
 
 			ClusterName: "testcluster",
@@ -1198,7 +1187,6 @@ func testConfigRaftAutopilot(t *testing.T) {
 					Address: "127.0.0.1:8200",
 				},
 			},
-			DisableMlock: true,
 		},
 
 		Storage: &Storage{

--- a/command/server/test-fixtures/config-dir/foo.hcl
+++ b/command/server/test-fixtures/config-dir/foo.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 backend "consul" {
     foo = "bar"

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/config2.hcl
+++ b/command/server/test-fixtures/config2.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/config3.hcl
+++ b/command/server/test-fixtures/config3.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 log_requests_level = "Basic"
 
 ui = true

--- a/command/server/test-fixtures/config4.hcl
+++ b/command/server/test-fixtures/config4.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 ui = true
 
 listener "tcp" {

--- a/command/server/test-fixtures/config4.hcl.json
+++ b/command/server/test-fixtures/config4.hcl.json
@@ -1,6 +1,5 @@
 {
 	"disable_cache": true,
-	"disable_mlock": true,
 	"ui":true,
 	"listener": [{
 		"tcp": {

--- a/command/server/test-fixtures/config5.hcl
+++ b/command/server/test-fixtures/config5.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
- disable_mlock = true
 
  ui = true
 

--- a/command/server/test-fixtures/config_bad_https_storage.hcl
+++ b/command/server/test-fixtures/config_bad_https_storage.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/config_custom_response_headers_1.hcl
+++ b/command/server/test-fixtures/config_custom_response_headers_1.hcl
@@ -31,4 +31,3 @@ listener "tcp" {
      }
   }
 }
-disable_mlock = true

--- a/command/server/test-fixtures/config_custom_response_headers_multiple_listeners.hcl
+++ b/command/server/test-fixtures/config_custom_response_headers_multiple_listeners.hcl
@@ -56,4 +56,3 @@ listener "tcp" {
 }
 
 
-disable_mlock = true

--- a/command/server/test-fixtures/config_diagnose_hastorage_bad_https.hcl
+++ b/command/server/test-fixtures/config_diagnose_hastorage_bad_https.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/config_diagnose_ok.hcl
+++ b/command/server/test-fixtures/config_diagnose_ok.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/config_raft.hcl
+++ b/command/server/test-fixtures/config_raft.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/diagnose_bad_https_consul_sr.hcl
+++ b/command/server/test-fixtures/diagnose_bad_https_consul_sr.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/diagnose_bad_telemetry1.hcl
+++ b/command/server/test-fixtures/diagnose_bad_telemetry1.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 ui = true
 
 listener "tcp" {

--- a/command/server/test-fixtures/diagnose_bad_telemetry2.hcl
+++ b/command/server/test-fixtures/diagnose_bad_telemetry2.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 ui = true
 
 listener "tcp" {

--- a/command/server/test-fixtures/diagnose_bad_telemetry3.hcl
+++ b/command/server/test-fixtures/diagnose_bad_telemetry3.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 ui = true
 
 listener "tcp" {

--- a/command/server/test-fixtures/diagnose_ok_storage_direct_access.hcl
+++ b/command/server/test-fixtures/diagnose_ok_storage_direct_access.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/diagnose_seal_transit_tls_check.hcl
+++ b/command/server/test-fixtures/diagnose_seal_transit_tls_check.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/hcp_link_config.hcl
+++ b/command/server/test-fixtures/hcp_link_config.hcl
@@ -11,4 +11,3 @@ cloud {
     client_id = "J2TtcSYOyPUkPV2z0mSyDtvitxLVjJmu"
     client_secret = "N9JtHZyOnHrIvJZs82pqa54vd4jnkyU3xCcqhFXuQKJZZuxqxxbP1xCfBZVB82vY"
 }
-disable_mlock = true

--- a/command/server/test-fixtures/nostore_config.hcl
+++ b/command/server/test-fixtures/nostore_config.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/raft_retry_join.hcl
+++ b/command/server/test-fixtures/raft_retry_join.hcl
@@ -19,4 +19,3 @@ storage "raft" {
 listener "tcp" {
 	address = "127.0.0.1:8200"
 }
-disable_mlock = true

--- a/command/server/test-fixtures/storage-listener-config.json
+++ b/command/server/test-fixtures/storage-listener-config.json
@@ -1,7 +1,6 @@
 {
     "api_addr": "https://localhost:8200",
     "default_lease_ttl": "6h",
-    "disable_mlock": true,
     "listener": {
         "tcp": {
             "address": "0.0.0.0:8200"
@@ -14,4 +13,4 @@
         }
     },
     "ui": true
-} 
+}

--- a/command/server/test-fixtures/telemetry/filter_default_override.hcl
+++ b/command/server/test-fixtures/telemetry/filter_default_override.hcl
@@ -1,7 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-disable_mlock = true
 ui            = true
 
 telemetry {

--- a/command/server/test-fixtures/telemetry/valid_prefix_filter.hcl
+++ b/command/server/test-fixtures/telemetry/valid_prefix_filter.hcl
@@ -1,7 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-disable_mlock = true
 ui            = true
 
 telemetry {

--- a/command/server/test-fixtures/tls_config_ok.hcl
+++ b/command/server/test-fixtures/tls_config_ok.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 disable_cache = true
-disable_mlock = true
 
 ui = true
 

--- a/command/server/test-fixtures/unauth_in_flight_access.hcl
+++ b/command/server/test-fixtures/unauth_in_flight_access.hcl
@@ -9,4 +9,3 @@ listener "tcp" {
      unauthenticated_in_flight_requests_access = true
   }
 }
-disable_mlock = true

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -30,7 +30,6 @@ func testBaseHCL(tb testing.TB, listenerExtras string) string {
 	tb.Helper()
 
 	return strings.TrimSpace(fmt.Sprintf(`
-		disable_mlock = true
 		listener "tcp" {
 			address     = "127.0.0.1:%d"
 			tls_disable = "true"
@@ -67,7 +66,6 @@ ha_backend "inmem" {}
 
 	reloadHCL = `
 backend "inmem" {}
-disable_mlock = true
 listener "tcp" {
   address       = "127.0.0.1:8203"
   tls_cert_file = "TMPDIR/reload_cert.pem"

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/fileutil v0.1.0
 	github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1
 	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2
-	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3
 	github.com/hashicorp/go-secure-stdlib/nonceutil v0.1.0
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
@@ -254,6 +253,7 @@ require (
 	github.com/hashicorp/consul/sdk v0.14.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.2.3 // indirect
+	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 // indirect

--- a/helper/testhelpers/logical/testing.go
+++ b/helper/testhelpers/logical/testing.go
@@ -167,7 +167,6 @@ func Test(tt TestT, c TestCase) {
 
 	config := &vault.CoreConfig{
 		Physical:        phys,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 	}
 

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -110,7 +110,6 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 		Physical:     inmha,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: addr1,
-		DisableMlock: true,
 	}
 	core1, err := vault.NewCore(conf)
 	if err != nil {
@@ -133,7 +132,6 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 		Physical:     inmha,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: addr2,
-		DisableMlock: true,
 	}
 	core2, err := vault.NewCore(conf2)
 	if err != nil {

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -147,7 +147,6 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"disable_cache":                       false,
 				"disable_clustering":                  false,
 				"disable_indexing":                    false,
-				"disable_mlock":                       false,
 				"disable_performance_standby":         false,
 				"disable_printable_check":             false,
 				"disable_sealwrap":                    false,

--- a/internalshared/configutil/merge.go
+++ b/internalshared/configutil/merge.go
@@ -36,11 +36,6 @@ func (c *SharedConfig) Merge(c2 *SharedConfig) *SharedConfig {
 		result.Telemetry = c2.Telemetry
 	}
 
-	result.DisableMlock = c.DisableMlock
-	if c2.DisableMlock {
-		result.DisableMlock = c2.DisableMlock
-	}
-
 	result.DefaultMaxRequestDuration = c.DefaultMaxRequestDuration
 	if c2.DefaultMaxRequestDuration > result.DefaultMaxRequestDuration {
 		result.DefaultMaxRequestDuration = c2.DefaultMaxRequestDuration

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -55,9 +55,6 @@ EXPOSE 8200
 
 # The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by OpenBao sub-processes.
-#
-# For production derivatives of this container, you should add the IPC_LOCK
-# capability so that OpenBao can mlock memory.
 COPY ./scripts/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -78,9 +78,6 @@ EXPOSE 8200
 
 # The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by Vault sub-processes.
-#
-# For production derivatives of this container, you should add the IPC_LOCK
-# capability so that Vault can mlock memory.
 COPY ./scripts/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -88,17 +88,6 @@ if [ "$1" = 'bao' ]; then
         fi
     fi
 
-    if [ -z "$SKIP_SETCAP" ]; then
-        # Allow mlock to avoid swapping OpenBao memory to disk
-        setcap cap_ipc_lock=+ep $(readlink -f $(which bao))
-
-        # In the case OpenBao has been started in a container without IPC_LOCK privileges
-        if ! bao -version 1>/dev/null 2>/dev/null; then
-            >&2 echo "Couldn't start bao with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK"
-            setcap cap_ipc_lock=-ep $(readlink -f $(which bao))
-        fi
-    fi
-
     if [ "$(id -u)" = '0' ]; then
       set -- su-exec openbao "$@"
     fi

--- a/serviceregistration/kubernetes/testing/README.md
+++ b/serviceregistration/kubernetes/testing/README.md
@@ -42,7 +42,6 @@ spec:
 ```
 storage "inmem" {}
 service_registration "kubernetes" {}
-disable_mlock = true
 ui = true
 api_addr = "http://127.0.0.1:8200"
 log_level = "debug"

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -71,7 +71,6 @@ func TestCore_EnableAudit(t *testing.T) {
 	conf := &CoreConfig{
 		Physical:      c.physical,
 		AuditBackends: make(map[string]audit.Factory),
-		DisableMlock:  true,
 	}
 	conf.AuditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
 	c2, err := NewCore(conf)
@@ -265,8 +264,7 @@ func TestCore_DisableAudit(t *testing.T) {
 	}
 
 	conf := &CoreConfig{
-		Physical:     c.physical,
-		DisableMlock: true,
+		Physical: c.physical,
 	}
 	c2, err := NewCore(conf)
 	if err != nil {
@@ -300,8 +298,7 @@ func TestCore_DefaultAuditTable(t *testing.T) {
 
 	// Start a second core with same physical
 	conf := &CoreConfig{
-		Physical:     c.physical,
-		DisableMlock: true,
+		Physical: c.physical,
 	}
 	c2, err := NewCore(conf)
 	if err != nil {

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -122,7 +122,6 @@ func TestCore_DefaultAuthTable(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -154,7 +153,6 @@ func TestCore_BuiltinRegistry(t *testing.T) {
 		// be there when we are mounting the builtin approle
 		PluginDirectory: "/Users/foo",
 
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 	}
 	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
@@ -205,7 +203,6 @@ func TestCore_EnableCredential(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -264,7 +261,6 @@ func TestCore_EnableCredential_aws_ec2(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -466,7 +462,6 @@ func TestCore_DisableCredential(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -60,7 +60,6 @@ func TestClusterHAFetching(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirect,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -349,7 +349,6 @@ func TestNewCore_badRedirectAddr(t *testing.T) {
 	conf := &CoreConfig{
 		RedirectAddr: "127.0.0.1:8200",
 		Physical:     inm,
-		DisableMlock: true,
 	}
 	_, err = NewCore(conf)
 	if err == nil {
@@ -1844,7 +1843,6 @@ func TestCore_Standby_Seal(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1883,7 +1881,6 @@ func TestCore_Standby_Seal(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1956,7 +1953,6 @@ func TestCore_StepDown(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
-		DisableMlock: true,
 		Logger:       logger.Named("core1"),
 	})
 	if err != nil {
@@ -1996,7 +1992,6 @@ func TestCore_StepDown(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 		Logger:       logger.Named("core2"),
 	})
 	defer core2.Shutdown()
@@ -2150,7 +2145,6 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -2216,7 +2210,6 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -2329,7 +2322,6 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		Physical:        inm,
 		HAPhysical:      inmha,
 		RedirectAddr:    redirectOriginal,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 	})
 	if err != nil {
@@ -2385,7 +2377,6 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		Physical:     inm,
 		HAPhysical:   inmha,
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -2913,7 +2904,6 @@ func TestCore_Standby_Rotate(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -2935,7 +2925,6 @@ func TestCore_Standby_Rotate(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -3230,7 +3219,6 @@ func TestCore_ServiceRegistration(t *testing.T) {
 		Physical:            inm,
 		HAPhysical:          inmha.(physical.HABackend),
 		RedirectAddr:        redirectAddr,
-		DisableMlock:        true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -274,9 +274,9 @@ func (d dynamicSystemView) ListVersionedPlugins(ctx context.Context, pluginType 
 	return d.core.pluginCatalog.ListVersionedPlugins(ctx, pluginType)
 }
 
-// MlockEnabled returns the configuration setting for enabling mlock on plugins.
+// OpenBao no longer uses mlock but MlockEnabled is retained for plugin compatibility.
 func (d dynamicSystemView) MlockEnabled() bool {
-	return d.core.enableMlock
+	return false
 }
 
 func (d dynamicSystemView) EntityInfo(entityID string) (*logical.Entity, error) {

--- a/vault/dynamic_system_view_test.go
+++ b/vault/dynamic_system_view_test.go
@@ -40,7 +40,6 @@ rule "charset" {
 func TestIdentity_BackendTemplating(t *testing.T) {
 	var err error
 	coreConfig := &CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -180,7 +179,6 @@ func TestIdentity_BackendTemplating(t *testing.T) {
 func TestDynamicSystemView_GeneratePasswordFromPolicy_successful(t *testing.T) {
 	var err error
 	coreConfig := &CoreConfig{
-		DisableMlock:       true,
 		DisableCache:       true,
 		Logger:             log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{},

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -68,7 +68,6 @@ func TestCore_EnableExternalPlugin(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			coreConfig := &CoreConfig{
-				DisableMlock:       true,
 				DisableCache:       true,
 				Logger:             log.NewNullLogger(),
 				CredentialBackends: map[string]logical.Factory{},

--- a/vault/external_tests/api/api_integration_test.go
+++ b/vault/external_tests/api/api_integration_test.go
@@ -37,7 +37,6 @@ func testVaultServerUnseal(t testing.TB) (*api.Client, []string, func()) {
 	t.Helper()
 
 	return testVaultServerCoreConfig(t, &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/vault/external_tests/api/sudo_paths_test.go
+++ b/vault/external_tests/api/sudo_paths_test.go
@@ -28,7 +28,6 @@ func TestSudoPaths(t *testing.T) {
 	t.Parallel()
 
 	coreConfig := &vault.CoreConfig{
-		DisableMlock:        true,
 		DisableCache:        true,
 		EnableRaw:           true,
 		EnableIntrospection: true,

--- a/vault/external_tests/approle/wrapped_secretid_test.go
+++ b/vault/external_tests/approle/wrapped_secretid_test.go
@@ -18,7 +18,6 @@ import (
 func TestApproleSecretId_Wrapped(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -78,7 +77,6 @@ func TestApproleSecretId_Wrapped(t *testing.T) {
 func TestApproleSecretId_NotWrapped(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -149,7 +149,6 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -448,7 +447,6 @@ func TestIdentityStore_Integ_RemoveFromExternalGroup(t *testing.T) {
 	t.Parallel()
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       log.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/vault/external_tests/policy/policy_test.go
+++ b/vault/external_tests/policy/policy_test.go
@@ -22,7 +22,6 @@ import (
 func TestPolicy_NoDefaultPolicy(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{
@@ -99,7 +98,6 @@ func TestPolicy_NoDefaultPolicy(t *testing.T) {
 func TestPolicy_NoConfiguredPolicy(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
-		DisableMlock: true,
 		DisableCache: true,
 		Logger:       hclog.NewNullLogger(),
 		CredentialBackends: map[string]logical.Factory{

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -32,8 +32,7 @@ func testCore_NewTestCoreLicensing(t *testing.T, seal Seal) (*Core, *CoreConfig)
 		t.Fatal(err)
 	}
 	conf := &CoreConfig{
-		Physical:     inm,
-		DisableMlock: true,
+		Physical: inm,
 		LogicalBackends: map[string]logical.Factory{
 			"kv": LeasedPassthroughBackendFactory,
 		},

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -122,7 +122,6 @@ func TestCore_DefaultMountTable(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -167,7 +166,6 @@ func TestCore_Mount(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -239,7 +237,6 @@ func TestCore_Mount_kv_generic(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),
@@ -453,7 +450,6 @@ func TestCore_Unmount(t *testing.T) {
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
 	conf := &CoreConfig{
 		Physical:        c.physical,
-		DisableMlock:    true,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		MetricSink:      metricsutil.NewClusterMetricSink("test-cluster", inmemSink),
 		MetricsHelper:   metricsutil.NewMetricsHelper(inmemSink, false),

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -172,8 +172,9 @@ func (c *Core) setupPluginCatalog(ctx context.Context) error {
 		catalogView:     NewBarrierView(c.barrier, pluginCatalogPath),
 		directory:       c.pluginDirectory,
 		logger:          c.logger,
-		mlockPlugins:    c.enableMlock,
-		wrapper:         logical.StaticSystemView{VersionString: version.GetVersion().Version},
+		// mlock is not currently used in OpenBao, but this setting is retained for Vault compat
+		mlockPlugins: false,
+		wrapper:      logical.StaticSystemView{VersionString: version.GetVersion().Version},
 	}
 
 	// Run upgrade if untyped plugins exist

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -412,7 +412,6 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
-		DisableMlock: true,
 		DisableCache: true,
 	})
 	if err != nil {
@@ -435,7 +434,6 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		Physical:     inm,
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
-		DisableMlock: true,
 		DisableCache: true,
 	})
 	if err != nil {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -162,7 +162,6 @@ func TestCoreWithCustomResponseHeaderAndUI(t testing.T, CustomResponseHeaders ma
 					CustomResponseHeaders: CustomResponseHeaders,
 				},
 			},
-			DisableMlock: true,
 		},
 	}
 	conf := &CoreConfig{
@@ -305,7 +304,6 @@ func testCoreConfig(t testing.T, physicalBackend physical.Backend, logger log.Lo
 		AuditBackends:      noopAudits,
 		LogicalBackends:    logicalBackends,
 		CredentialBackends: credentialBackends,
-		DisableMlock:       true,
 		Logger:             logger,
 		NumRollbackWorkers: 10,
 		BuiltinRegistry:    corehelpers.NewMockBuiltinRegistry(),
@@ -1509,7 +1507,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		AuditBackends:      make(map[string]audit.Factory),
 		RedirectAddr:       fmt.Sprintf("https://127.0.0.1:%d", listeners[0][0].Address.Port),
 		ClusterAddr:        "https://127.0.0.1:0",
-		DisableMlock:       true,
 		EnableUI:           true,
 		EnableRaw:          true,
 		BuiltinRegistry:    corehelpers.NewMockBuiltinRegistry(),
@@ -1543,10 +1540,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 		if base.BuiltinRegistry != nil {
 			coreConfig.BuiltinRegistry = base.BuiltinRegistry
-		}
-
-		if !coreConfig.DisableMlock {
-			base.DisableMlock = false
 		}
 
 		if base.Physical != nil {

--- a/website/content/api-docs/system/config-state.mdx
+++ b/website/content/api-docs/system/config-state.mdx
@@ -41,7 +41,6 @@ $ curl \
   "disable_cache": false,
   "disable_clustering": false,
   "disable_indexing": false,
-  "disable_mlock": false,
   "disable_performance_standby": false,
   "disable_printable_check": false,
   "disable_sealwrap": false,

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -16,7 +16,6 @@ An example configuration is shown below:
 ui            = true
 cluster_addr  = "https://127.0.0.1:8201"
 api_addr      = "https://127.0.0.1:8200"
-disable_mlock = true
 
 storage "raft" {
   path = "/path/to/raft/data"
@@ -78,52 +77,6 @@ to specify where the configuration is.
 - `disable_cache` `(bool: false)` – Disables all caches within OpenBao, including
   the read cache used by the physical storage subsystem. This will very
   significantly impact performance.
-
-- `disable_mlock` `(bool: false)` – Disables the server from executing the
-  `mlock` syscall. `mlock` prevents memory from being swapped to disk. Disabling
-  `mlock` is not recommended unless using [integrated storage](/docs/internals/integrated-storage).
-  Follow the additional security precautions outlined below when disabling `mlock`.
-  This can also be provided via the environment variable `VAULT_DISABLE_MLOCK`.
-
-  Disabling `mlock` is not recommended unless the systems running OpenBao only
-  use encrypted swap or do not use swap at all. OpenBao only supports memory
-  locking on UNIX-like systems that support the mlock() syscall (Linux, FreeBSD, etc).
-  Non UNIX-like systems (e.g. Windows, NaCL, Android) lack the primitives to keep a
-  process's entire memory address space from spilling to disk and is therefore
-  automatically disabled on unsupported platforms.
-
-  Disabling `mlock` is strongly recommended if using [integrated
-  storage](/docs/internals/integrated-storage) due to
-  the fact that `mlock` does not interact well with memory mapped files such as
-  those created by BoltDB, which is used by Raft to track state. When using
-  `mlock`, memory-mapped files get loaded into resident memory which causes
-  OpenBao's entire dataset to be loaded in-memory and cause out-of-memory
-  issues if OpenBao's data becomes larger than the available RAM. In this case,
-  even though the data within BoltDB remains encrypted at rest, swap should be
-  disabled to prevent OpenBao's other in-memory sensitive data from being dumped
-  into disk.
-
-  On Linux, to give the OpenBao executable the ability to use the `mlock`
-  syscall without running the process as root, run:
-
-  ```shell
-  sudo setcap cap_ipc_lock=+ep $(readlink -f $(which bao))
-  ```
-
-:::warning
-
- Note: Since each plugin runs as a separate process, you need to do the same
-  for each plugin in your [plugins
-  directory](/docs/plugins/plugin-architecture#plugin-directory).
-
-:::
-
-  If you use a Linux distribution with a modern version of systemd, you can add
-  the following directive to the "[Service]" configuration section:
-
-  ```ini
-  LimitMEMLOCK=infinity
-  ```
 
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. OpenBao must have permission to read files in this

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -46,13 +46,6 @@ backend cannot be declared.
 
 :::
 
-:::warning
-
-**Note:** When using the Integrated Storage backend, it is strongly recommended to
-set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disable memory swapping on the system.
-
-:::
-
 ## `raft` parameters
 
 - `path` `(string: "")` – The file system path where all the OpenBao data gets

--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -82,3 +82,56 @@ on your `PATH` to avoid receiving an error that OpenBao is not found.
 ```shell-session
 $ bao -h
 ```
+
+## Post-installation hardening
+
+After installing OpenBao, you may want to take additional steps to secure it
+against leaking your secrets. OpenBao normally does this very well, but there
+is an operating system feature that undermines OpenBao's protection. This is
+[memory paging (aka swap)](https://en.wikipedia.org/wiki/Memory_paging). To
+provide extra security, you will want to make sure that your OS has swap
+disabled or that its swap space is encrypted.
+
+### Linux
+
+The example systemd service file provided with the OpenBao source code comes
+configured to disable swap for the OpenBao process. To verify that swap is
+disabled, run `systemctl cat openbao` and check for the line `MemorySwapMax=0`.
+Alternatively, to allow the openbao process to swap out, make sure that line is
+deleted.
+
+If you are not using systemd, you can achieve the same effect by setting the 
+cgroupv2 value `memory.swap.max` to `0` using your tool of choice. You can
+disable swap for the entire OS by running `swapoff` (this is not recommended).
+Encrypting swap space in Linux is possible, but as usual, there are many
+options, and a guide is outside the scope of these docs. Consult your distro's
+documentation.
+
+### BSDs and other Unix-like
+
+It is recommended to confirm that swap is encrypted. This can be done on all the
+major BSDs.
+ * [FreeBSD guide to encrypted swap](https://docs.freebsd.org/en/books/handbook/disks/#swap-encrypting)
+ * [NetBSD guide to encrypted swap](https://netbsd.org/docs/guide/en/netbsd.html#chap-cgd-swap-encryption)
+ * [OpenBSD info on encrypted swap (enabled by default)](https://man.openbsd.org/sysctl.2#VM_SWAPENCRYPT~2)
+
+### Windows
+
+You can check if your swap space is encrypted by opening Powershell and running:
+```shell-session
+> fsutil behavior query encryptpagingfile
+```
+If the value is 0 (that is, `DISABLED`), you are recommended to enable swap
+encryption by running:
+```shell-session
+> fsutil behavior set encryptpagingfile 1
+```
+Then reboot.
+
+### Docker
+
+When running the Docker image, include the flag `--memory-swappiness=0`.
+
+### macOS
+
+[The swap space on macOS is always encrypted](https://support.apple.com/guide/mac-help/what-is-secure-virtual-memory-on-mac-mh11852/mac).

--- a/website/content/docs/plugins/plugin-architecture.mdx
+++ b/website/content/docs/plugins/plugin-architecture.mdx
@@ -108,16 +108,7 @@ Success! Registered plugin: myplugin-database-plugin
 When a backend wants to run a plugin, it first looks up the plugin, by name, in
 the catalog. It then checks the executable's SHA256 sum against the one
 configured in the plugin catalog. Finally OpenBao runs the command configured in
-the catalog, sending along the JWT formatted response wrapping token and mlock
-settings. Like OpenBao, plugins support [the use of mlock when available](/docs/configuration#disable_mlock).
-
-:::warning
-
-Note: If OpenBao is configured with `mlock` enabled, then the OpenBao executable
-and each plugin executable in your [plugins directory](/docs/plugins/plugin-architecture#plugin-directory)
-must be given the ability to use the `mlock` syscall.
-
-:::
+the catalog, sending along the JWT formatted response wrapping token.
 
 ### Plugin upgrades
 
@@ -143,25 +134,3 @@ plugin, i.e., the plugin calls the `Serve` function.
 More resources on implementing plugin multiplexing:
 * [Database secrets engines](/docs/secrets/databases/custom#serving-a-plugin-with-multiplexing)
 * [Secrets engines and auth methods](/docs/plugins/plugin-development)
-
-## Troubleshooting
-
-### Unrecognized remote plugin message
-
-If the following error is encountered when enabling a plugin secret engine or
-auth method:
-
-```sh
-Unrecognized remote plugin message:
-
-This usually means that the plugin is either invalid or simply
-needs to be recompiled to support the latest protocol.
-```
-
-Verify whether the OpenBao process has `mlock` enabled, and if so, run the
-following command against the plugin binary:
-
-```shell-session
-$ sudo setcap cap_ipc_lock=+ep <plugin-binary>
-```
-

--- a/website/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/website/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -24,9 +24,7 @@ backend).
 Perform these steps on each standby:
 
 1. Properly shut down OpenBao on the standby node via `SIGINT` or `SIGTERM`
-2. Replace the OpenBao binary with the new version; ensure that `mlock()`
-   capability is added to the new binary with
-   [setcap](/docs/configuration#disable_mlock)
+2. Replace the OpenBao binary with the new version
 3. Start the standby node
 4. Unseal the standby node
 5. Verify `bao status` shows correct Version and HA Mode is `standby`
@@ -51,9 +49,7 @@ is backend-specific but could be ten seconds or more.
 
 :::
 
-2. Replace the OpenBao binary with the new version; ensure that `mlock()`
-   capability is added to the new binary with
-   [setcap](/docs/configuration#disable_mlock)
+2. Replace the OpenBao binary with the new version
 3. Start the node
 4. Unseal the node
 5. Verify `bao status` shows correct Version and HA Mode is `standby`


### PR DESCRIPTION
In [RFC #354](https://github.com/openbao/openbao/issues/354), the mlock implementation inherited from Vault was deemed buggy. Here it is ripped out of all core OpenBao code. A few stubs are retained for compatibility's sake:

1. The config file parser will still parse the setting "disable_mlock". It will do nothing when set to true, and it will immediately error if set to false (i.e. the user is explicitly expecting mlock to be enabled).
2. The dynamicSystemView struct has a MlockEnabled method so it can still implement pluginutil.RunnerUtil. This method now just returns false.

All mlock code is RETAINED in all ./sdk files, because the question is not yet settled whether plugins built against the *OpenBao SDK* should be binary-compatible with Vault. If this is eventually resolved in the negative, most of the mlock related code in the SDK can be subbed out.

As mlock is no longer used, Docker-related scripts have also had setcap calls removed.

In place of mlock, documentation has been added to draw attention to the danger of sensitive information leaking through swap space and stress the importance of disabling or encrypting swap on any platform, or on Linux, changing the cgroupv2 setting memory.swap.max to 0. This last option has also been included in the example systemd service file.
