### PR TITLE
fix command usage spaces and punctuation

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -441,7 +441,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				Default: false,
 				EnvVar:  api.EnvVaultDisableRedirects,
 				Usage: "Disable the default client behavior, which honors a single " +
-					"redirect response from a request",
+					"redirect response from a request.",
 			})
 
 			f.BoolVar(&BoolVar{
@@ -449,7 +449,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				Target:  &c.flagPolicyOverride,
 				Default: false,
 				Usage: "Override a Sentinel policy that has a soft-mandatory " +
-					"enforcement_level specified",
+					"enforcement_level specified.",
 			})
 
 			f.DurationVar(&DurationVar{
@@ -501,8 +501,8 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				Name:       "header",
 				Target:     &c.flagHeader,
 				Completion: complete.PredictAnything,
-				Usage: "Key-value pair provided as key=value to provide http header added to any request done by the CLI." +
-					"Trying to add headers starting with 'X-Vault-' is forbidden and will make the command fail " +
+				Usage: "Key-value pair provided as key=value to provide http header added to any request done by the CLI. " +
+					"Trying to add headers starting with 'X-Vault-' is forbidden and will make the command fail. " +
 					"This can be specified multiple times.",
 			})
 
@@ -550,7 +550,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					Target:  &c.flagDetailed,
 					Default: false,
 					EnvVar:  EnvVaultDetailed,
-					Usage:   "Enables additional metadata during some operations",
+					Usage:   "Enables additional metadata during some operations.",
 				})
 			}
 		}


### PR DESCRIPTION
Very minor fixes of spaces and punctuation in the command (cli) usage descriptions.

