### PR TITLE
remove build and CI workflows from merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: build
 
 on:
-  merge_group:
   pull_request:
     # The default types for pull_request are [ opened, synchronize, reopened ].
     # This is insufficient for our needs, since we're skipping stuff on PRs in
@@ -62,7 +61,7 @@ jobs:
       - uses: hashicorp/actions-generate-metadata@v1
         id: generate-metadata-file
         with:
-          repositoryOwner: 'openbao'
+          repositoryOwner: "openbao"
           version: ${{ steps.set-product-version.outputs.product-version }}
           product: ${{ steps.get-metadata.outputs.package-name }}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -71,45 +70,44 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
           if-no-files-found: error
 
-## Disable UI temporarily.
-#
-#  build-ui:
-#    name: UI
-#    runs-on: ubuntu-latest
-#    outputs:
-#      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-#    steps:
-#      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#      - name: Get UI hash
-#        id: ui-hash
-#        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
-#      - name: Set up UI asset cache
-#        id: cache-ui-assets
-#        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
-#        with:
-#          enableCrossOsArchive: true
-#          lookup-only: true
-#          path: http/web_ui
-#          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
-#          # Never do a partial restore of the web_ui if we don't get a cache hit.
-#          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
-#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-#        name: Set up node and yarn
-#        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
-#        with:
-#          node-version-file: ui/package.json
-#          cache: yarn
-#          cache-dependency-path: ui/yarn.lock
-#      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
-#        name: Build UI
-#        run: make ci-build-ui
-
+  ## Disable UI temporarily.
+  #
+  #  build-ui:
+  #    name: UI
+  #    runs-on: ubuntu-latest
+  #    outputs:
+  #      cache-key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+  #    steps:
+  #      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+  #      - name: Get UI hash
+  #        id: ui-hash
+  #        run: echo "ui-hash=$(git ls-tree HEAD ui --object-only)" >> "$GITHUB_OUTPUT"
+  #      - name: Set up UI asset cache
+  #        id: cache-ui-assets
+  #        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+  #        with:
+  #          enableCrossOsArchive: true
+  #          lookup-only: true
+  #          path: http/web_ui
+  #          # Only restore the UI asset cache if we haven't modified anything in the ui directory.
+  #          # Never do a partial restore of the web_ui if we don't get a cache hit.
+  #          key: ui-${{ steps.ui-hash.outputs.ui-hash }}
+  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+  #        name: Set up node and yarn
+  #        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+  #        with:
+  #          node-version-file: ui/package.json
+  #          cache: yarn
+  #          cache-dependency-path: ui/yarn.lock
+  #      - if: steps.cache-ui-assets.outputs.cache-hit != 'true'
+  #        name: Build UI
+  #        run: make ci-build-ui
 
   build-other:
     name: Other
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [freebsd, windows, netbsd, openbsd, solaris]
@@ -127,7 +125,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -135,7 +133,7 @@ jobs:
     name: Linux
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [linux]
@@ -147,7 +145,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 
@@ -155,7 +153,7 @@ jobs:
     name: Darwin
     needs:
       - product-metadata
-#      - build-ui
+    #      - build-ui
     strategy:
       matrix:
         goos: [darwin]
@@ -168,7 +166,7 @@ jobs:
       goos: ${{ matrix.goos }}
       go-tags:
       package-name: ${{ needs.product-metadata.outputs.package-name }}
-#      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
+      #      web-ui-cache-key: ${{ needs.build-ui.outputs.cache-key }}
       bao-version: ${{ needs.product-metadata.outputs.bao-version }}
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  merge_group:
   pull_request:
     # The default types for pull_request are [ opened, synchronize, reopened ].
     # This is insufficient for our needs, since we're skipping stuff on PRs in
@@ -60,7 +59,7 @@ jobs:
       binary-tests: true
       total-runners: 16
       go-arch: amd64
-      go-tags: '${{ needs.setup.outputs.go-tags }},deadlock'
+      go-tags: "${{ needs.setup.outputs.go-tags }},deadlock"
       runs-on: ubuntu-latest
       checkout-ref: ${{ needs.setup.outputs.checkout-ref }}
     secrets: inherit
@@ -79,7 +78,7 @@ jobs:
       testonly: true
       total-runners: 2 # test runners cannot be less than 2
       go-arch: amd64
-      go-tags: '${{ needs.setup.outputs.go-tags }},deadlock,testonly'
+      go-tags: "${{ needs.setup.outputs.go-tags }},deadlock,testonly"
       runs-on: ubuntu-latest
     secrets: inherit
 
@@ -100,7 +99,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: '-race'
+      extra-flags: "-race"
       go-arch: amd64
       go-tags: ${{ needs.setup.outputs.go-tags }}
       runs-on: ubuntu-latest
@@ -130,14 +129,14 @@ jobs:
       # Setup node.js without caching to allow running npm install -g yarn (next step)
       - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
         with:
-          node-version-file: './ui/package.json'
+          node-version-file: "./ui/package.json"
       - id: install-yarn
         run: |
           npm install -g yarn
       # Setup node.js with caching using the yarn.lock file
       - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
         with:
-          node-version-file: './ui/package.json'
+          node-version-file: "./ui/package.json"
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - id: install-browser
@@ -169,7 +168,7 @@ jobs:
           name: test-results-ui
           path: ui/test-results
         if: success() || failure()
-      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f  # TSCCR: no entry for repository "test-summary/action"
+      - uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # TSCCR: no entry for repository "test-summary/action"
         with:
           paths: "ui/test-results/qunit/results.xml"
           show: "fail"


### PR DESCRIPTION
They run on every PR commit and on push to main, so there's little value
in running them again in the merge queue.

Signed-off-by: Jan Martens <jan@martens.eu.org>