### PR TITLE
docs(token): document the token format

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -39,7 +39,7 @@ Tokens are composed of a _prefix_ and a _body_.
 - The _prefix_ indicates the token's type:
 
   Token Type | Prefix
-  -- | -- | --
+  -- | --
   Service tokens | s.
   Batch tokens | b.
   Recovery tokens | r.

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -32,6 +32,31 @@ holder is allowed to do within OpenBao. Other mapped information includes
 metadata that can be viewed and is added to the audit log, such as creation
 time, last renewal time, and more.
 
+## Token formats
+
+Tokens are composed of a _prefix_ and a _body_.
+
+- The _prefix_ indicates the token's type:
+
+  Token Type | Prefix
+  -- | -- | --
+  Service tokens | s.
+  Batch tokens | b.
+  Recovery tokens | r.
+
+- The _body_ is a randomly-generated 24 or more characters
+  [Base62](https://en.wikipedia.org/wiki/Base62) string.
+
+Token are expected to match the following regexp: `[sbr]\.[a-zA-Z0-9]{24,}`
+
+Examples:
+
+```shell
+b.n6keuKu5Q6pXhaIcfnC9cFNd
+r.JaKnR2AIHNk3fC4SGyyyDVoQ9O
+s.raPGTZdARXdY0KvHcWSpp5wWZIHNT
+```
+
 ## Token types
 
 There are two types of tokens: `service` tokens and `batch` tokens. A section


### PR DESCRIPTION
Add details on the format of OpenBao tokens, it should hopefully add clear documentation as to one can detect tokens.

The body's format was inferred from:
- https://github.com/openbao/openbao/blob/180024468640acc82eb8dc621f7fd21ce6bfd125/vault/token_store.go#L72-L74
- https://github.com/openbao/openbao/blob/180024468640acc82eb8dc621f7fd21ce6bfd125/vault/token_store.go#L997-L999

Resolves #369 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.14.7
