### PR TITLE
Fix artifact signing, use default runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -836,6 +836,7 @@ signs:
   - id: cosign
     artifacts: all
     cmd: cosign
+    certificate: "${artifact}.pem"
     args:
       - "sign-blob"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
@@ -852,7 +853,8 @@ signs:
       - "--batch"
       - "--default-key={{ .Env.GPG_FINGERPRINT }}"
       - "--output=${signature}"
-      - "--detach-sign=${artifact}"
+      - "--detach-sign"
+      - "${artifact}"
 
 docker_signs:
   - artifacts: all


### PR DESCRIPTION
GPG signing was broken as `--detach-sign` does not itself take an argument to a file to sign; instead this should be a separate positional argument to the CLI as a whole. This means that stdin was signed instead of the specified file, resulting in bogus signatures.

While the existing cosign signatures work, they require additional calls to rekor to fetch the corresponding certificate used to sign. Mirroring with what OpenTofu does, we can save the certificates directly so that users can verify without additional calls to the rekor network.

Lastly, switch to GitHub-hosted runners to avoid needing to use a self-hosted runner for this release stage.

Thanks to @JanMa and @janosdebugs for their help.