### PR TITLE
Downgrade test-summary/action from 2.3 to 2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           name: test-results-ui
           path: ui/test-results
         if: success() || failure()
-      - uses: test-summary/action@032c8a9cec6aaa3c20228112cae6ca10a3b29336 # TSCCR: no entry for repository "test-summary/action"
+      - uses: test-summary/action@fee35d7df20790255fe6aa92cf0f6d28092ecf2f # TSCCR: no entry for repository "test-summary/action"
         with:
           paths: "ui/test-results/qunit/results.xml"
           show: "fail"


### PR DESCRIPTION
We're running into this open Issue which seems to have been introduced
in version 2.3:
https://github.com/test-summary/action/issues/44

Signed-off-by: Jan Martens <jan@martens.eu.org>