### PR TITLE
Fix OpenAPI spec operation descriptions

### DIFF
--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -340,8 +340,14 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 				requestResponsePrefix,
 			)
 
-			op.Summary = props.Summary
-			op.Description = props.Description
+			op.Summary = cleanString(props.Summary)
+			if len(op.Summary) == 0 {
+				op.Summary = cleanString(p.HelpSynopsis)
+			}
+			op.Description = cleanString(props.Description)
+			if len(op.Description) == 0 {
+				op.Description = cleanString(p.HelpDescription)
+			}
 			op.Deprecated = props.Deprecated
 			op.OperationID = operationID
 


### PR DESCRIPTION
Many entries were missing summary and descriptions because while they used the new format, they didn't add separate summary and descriptions for each operation separately from the path. This meant our OAS generator was leaving them empty.

In the future, we should probably audit these cases and see if the global synopsis/description are good or if we'd prefer per-operation descriptions instead.