### PR TITLE
Add GOOS matrix to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,6 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      # Defaults to publishing draft releases.
-      # Review draft before formally releasing!
-      draft:
-        description: "Create a release draft"
-        required: false
-        default: true
-        type: boolean
       prerelease:
         description: "Mark this release as a prerelease"
         required: false
@@ -39,6 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+    strategy:
+      matrix:
+        release_os:
+          - linux
+          - darwin
+          - freebsd
+          - illumos
+          - netbsd
+          - openbsd
+          - solaris
+          - windows
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
@@ -53,6 +57,9 @@ jobs:
 
       - name: go-check
         run: go version
+
+      # Supports syft/sbom generation
+      - uses: anchore/sbom-action/download-syft@v0
 
         # Supports Buildx
       - name: Qemu Setup
@@ -117,13 +124,19 @@ jobs:
         env:
           GPG_TTY: /dev/ttys000 # Set the GPG_TTY to avoid issues with pinentry
 
+      - name: "Template GoRelaser configuration"
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          sed "s/REPLACE_WITH_RELEASE_GOOS/${{ matrix.release_os }}/g" .goreleaser-template.yaml > .goreleaser.yaml
+          [ "${{ matrix.release_os }}" == "linux" ] && sed -i "s/^#LINUXONLY#//g" .goreleaser.yaml || true
+
       - name: "GoReleaser: Release"
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --timeout=60m --verbose --debug --parallelism 2
+          args: release --clean --timeout=60m --verbose --parallelism 2
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
@@ -141,3 +154,7 @@ jobs:
           if [ -n "${GPG_KEY_FILE}" ]; then
             rm -rf "${GPG_KEY_FILE}"
           fi
+
+      - name: "Check free space on runner"
+        run: |
+          df -h .

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ tools/codechecker/.bin
 
 # OpenAPI
 scripts/openapi.json
+
+# auto-generated goreleaser configuration
+.goreleaser.yaml

--- a/.goreleaser-template.yaml
+++ b/.goreleaser-template.yaml
@@ -30,7 +30,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - linux
+      - REPLACE_WITH_RELEASE_GOOS
     goarch:
       - amd64
       - arm
@@ -40,6 +40,16 @@ builds:
       - s390x
     goarm:
       - "6"
+    ignore:
+      - goos: darwin
+      - goos: dragonfly
+      - goos: freebsd
+      - goos: illumos
+      - goos: netbsd
+      - goos: openbsd
+      - goos: solaris
+      - goos: wasip1
+      - goos: windows
     mod_timestamp: "{{ .CommitTimestamp }}"
     skip: false
   - id: builds-other
@@ -48,15 +58,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
-      #- dragonfly
-      - freebsd
-      - illumos
-      - netbsd
-      - openbsd
-      - solaris
-      #- wasip1
-      - windows
+      - REPLACE_WITH_RELEASE_GOOS
     goarch:
       - amd64
       - arm
@@ -69,6 +71,7 @@ builds:
       - "6"
       - "7"
     ignore:
+      - goos: linux
       - goos: darwin
         goarm: "6"
       - goos: darwin
@@ -161,65 +164,65 @@ builds:
 
 report_sizes: true
 
-nfpms:
-  - vendor: OpenBao
-    homepage: https://openbao.org
-    maintainer: OpenBao <openbao@lists.lfedge.org>
-    description: |
-      OpenBao exists to provide a software solution to manage, store, and distribute
-      sensitive data including secrets, certificates, and keys.
-    license: MPL-2.0
-    formats:
-      # - apk
-      - deb
-      - rpm
-      - archlinux
-    dependencies:
-      - openssl
-    provides:
-      - bao
-    bindir: /usr/bin
-    section: default
-    contents:
-      - src: ./LICENSE
-        dst: /usr/share/doc/openbao/copyright
-        file_info:
-          mode: 0644
-      - src: ./.release/linux/package/etc/openbao/openbao.env
-        dst: /etc/openbao/openbao.env
-        file_info:
-          mode: 0644
-      - src: ./.release/linux/package/etc/openbao/openbao.hcl
-        dst: /etc/openbao/openbao.hcl
-        file_info:
-          mode: 0644
-      - src: ./.release/linux/package/usr/lib/systemd/system/openbao.service
-        dst: /usr/lib/systemd/system/openbao.service
-        file_info:
-          mode: 0644
-    scripts:
-      preinstall: ".release/linux/preinst"
-      postinstall: ".release/linux/postinst"
-      postremove: ".release/linux/postrm"
-    overrides:
-      deb:
-        dependencies:
-          - openssl
-      rpm:
-        dependencies:
-          - openssl
-      archlinux:
-        dependencies:
-          - openssl
-    deb:
-      signature:
-        key_file: "{{ .Env.GPG_KEY_FILE }}"
-    rpm:
-      signature:
-        key_file: "{{ .Env.GPG_KEY_FILE }}"
+#LINUXONLY#nfpms:
+#LINUXONLY#  - vendor: OpenBao
+#LINUXONLY#    homepage: https://openbao.org
+#LINUXONLY#    maintainer: OpenBao <openbao@lists.lfedge.org>
+#LINUXONLY#    description: |
+#LINUXONLY#      OpenBao exists to provide a software solution to manage, store, and distribute
+#LINUXONLY#      sensitive data including secrets, certificates, and keys.
+#LINUXONLY#    license: MPL-2.0
+#LINUXONLY#    formats:
+#LINUXONLY#      # - apk
+#LINUXONLY#      - deb
+#LINUXONLY#      - rpm
+#LINUXONLY#      - archlinux
+#LINUXONLY#    dependencies:
+#LINUXONLY#      - openssl
+#LINUXONLY#    provides:
+#LINUXONLY#      - bao
+#LINUXONLY#    bindir: /usr/bin
+#LINUXONLY#    section: default
+#LINUXONLY#    contents:
+#LINUXONLY#      - src: ./LICENSE
+#LINUXONLY#        dst: /usr/share/doc/openbao/copyright
+#LINUXONLY#        file_info:
+#LINUXONLY#          mode: 0644
+#LINUXONLY#      - src: ./.release/linux/package/etc/openbao/openbao.env
+#LINUXONLY#        dst: /etc/openbao/openbao.env
+#LINUXONLY#        file_info:
+#LINUXONLY#          mode: 0644
+#LINUXONLY#      - src: ./.release/linux/package/etc/openbao/openbao.hcl
+#LINUXONLY#        dst: /etc/openbao/openbao.hcl
+#LINUXONLY#        file_info:
+#LINUXONLY#          mode: 0644
+#LINUXONLY#      - src: ./.release/linux/package/usr/lib/systemd/system/openbao.service
+#LINUXONLY#        dst: /usr/lib/systemd/system/openbao.service
+#LINUXONLY#        file_info:
+#LINUXONLY#          mode: 0644
+#LINUXONLY#    scripts:
+#LINUXONLY#      preinstall: ".release/linux/preinst"
+#LINUXONLY#      postinstall: ".release/linux/postinst"
+#LINUXONLY#      postremove: ".release/linux/postrm"
+#LINUXONLY#    overrides:
+#LINUXONLY#      deb:
+#LINUXONLY#        dependencies:
+#LINUXONLY#          - openssl
+#LINUXONLY#      rpm:
+#LINUXONLY#        dependencies:
+#LINUXONLY#          - openssl
+#LINUXONLY#      archlinux:
+#LINUXONLY#        dependencies:
+#LINUXONLY#          - openssl
+#LINUXONLY#    deb:
+#LINUXONLY#      signature:
+#LINUXONLY#        key_file: "{{ .Env.GPG_KEY_FILE }}"
+#LINUXONLY#    rpm:
+#LINUXONLY#      signature:
+#LINUXONLY#        key_file: "{{ .Env.GPG_KEY_FILE }}"
 
 checksum:
-  name_template: "checksums.txt"
+  name_template: "checksums-REPLACE_WITH_RELEASE_GOOS.txt"
   disable: false
   # split: false
 
@@ -868,8 +871,15 @@ release:
   github:
     owner: openbao
     name: openbao
-  draft: true #${{ .Env.GITHUB_RELEASE_DRAFT }}
-  replace_existing_draft: false
+
   prerelease: ${{ .Env.GITHUB_PRERELEASE }}
   make_latest: ${{ .Env.GITHUB_RELEASE_MAKE_LATEST }}
   disable: false
+
+  # We overwrite the following variables to support multi-stage execution of
+  # goreleaser on the same artifacts with different GOOS values, to avoid
+  # running out of disk space. We can't support draft releases because the same
+  # release needs to be used for all artifacts uploaded from separate stages.
+  draft: false
+  replace_existing_draft: false
+  replace_existing_artifacts: false


### PR DESCRIPTION
This splits the release workflow into a matrix, using matrix parallelism to avoid exceeding default disk space (14GB) per OS. If we have too many Linux architectures in the future, we could split by architecture as well.

This should mean that each workflow executes a separate operating system but contributes to a single release draft. We'll need to remember to do manual clean up of releases in the event that a pipeline fails, as currently we'll default to appending to the existing one due to the parallelism.

---

We'll need to recreate the tag after this in order to use this workflow, since `tag` isn't an option in the inputs, only the source branch. We could change that if we desire.

In particular, the issue with this approach is that we have to create a non-draft release right away, however, we get the benefit of being able to rerun failed jobs. If we want to rerun everything, we could drop the release and re-do the pipeline from the same commit.

v6 is require to "support" this type of custom matrix to reuse the same release; it looks like this code wasn't in the version of the tool that v5 uses. `--debug` was removed as an option from that tool version too. 

We keep the two underlying build jobs (`build-linux` and `build-other`); in the future we'll probably have a `build-hsm` and potentially other options; using the sed approach seems best from the templating PoV. `nfpms` cannot exist in a `build-other` non-linux list so we have to exclude it manually. `checksums.txt` is the only artifact that is the same between runs in the matrix, so we've manually created a OS variant of it since we're already invoking `sed` on the file.

A sample release without signatures or containers is available here: https://github.com/cipherboy/openbao/releases/tag/v2.0.0-testing12 