### PR TITLE
use openbao instead of vault prefix for kubernetes labels

### DIFF
--- a/changelog/416.txt
+++ b/changelog/416.txt
@@ -1,0 +1,4 @@
+```release-note:change
+serviceregistration/kubernetes: labels use `openbao` as prefix instead of `vault`.
+```
+

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -17,11 +17,11 @@ import (
 
 const (
 	// Labels are placed in a pod's metadata.
-	labelVaultVersion = "vault-version"
-	labelActive       = "vault-active"
-	labelSealed       = "vault-sealed"
-	labelPerfStandby  = "vault-perf-standby"
-	labelInitialized  = "vault-initialized"
+	labelVaultVersion = "openbao-version"
+	labelActive       = "openbao-active"
+	labelSealed       = "openbao-sealed"
+	labelPerfStandby  = "openbao-perf-standby"
+	labelInitialized  = "openbao-initialized"
 
 	// This is the path to where these labels are applied.
 	pathToLabels = "/metadata/labels/"


### PR DESCRIPTION
The helm chart creates the service looking for the pod labels `openbao-active=true`. This PR fixes that the label is applied to this name instead of `vault-active`. Additionally it also puts all other labels into `openbao` prefix instead of `vault`.

This is the line in the helm chart has uses as only valid name `openbao-active`: https://github.com/openbao/openbao-helm/blob/main/charts/openbao/templates/server-ha-active-service.yaml#L60