### PR TITLE
Use quay.io/openbao/openbao in docker tests

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -28,7 +28,7 @@ func NewVaultPkiCluster(t *testing.T) *VaultPkiCluster {
 	}
 
 	opts := &docker.DockerClusterOptions{
-		ImageRepo: "docker.mirror.hashicorp.services/hashicorp/vault",
+		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
 		// the docker image version tag.
 		ImageTag:    "latest",

--- a/changelog/427.txt
+++ b/changelog/427.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk: Use quay.io/openbao/openbao in containerized testing
+```

--- a/command/server/server_seal_transit_acc_test.go
+++ b/command/server/server_seal_transit_acc_test.go
@@ -135,7 +135,7 @@ func prepareTestContainer(t *testing.T) (func(), *DockerVaultConfig) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ContainerName: "vault",
-		ImageRepo:     "docker.mirror.hashicorp.services/hashicorp/vault",
+		ImageRepo:     "quay.io/openbao/openbao",
 		ImageTag:      "latest",
 		Cmd: []string{
 			"server", "-log-level=trace", "-dev", fmt.Sprintf("-dev-root-token-id=%s", rootToken),

--- a/vault/external_tests/misc/misc_binary/recovery_test.go
+++ b/vault/external_tests/misc/misc_binary/recovery_test.go
@@ -31,7 +31,7 @@ func TestRecovery_Docker(t *testing.T) {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}
 	opts := &docker.DockerClusterOptions{
-		ImageRepo: "hashicorp/vault",
+		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
 		// the docker image version tag.
 		ImageTag:    "latest",

--- a/vault/external_tests/raft/raft_binary/raft_test.go
+++ b/vault/external_tests/raft/raft_binary/raft_test.go
@@ -19,7 +19,7 @@ func TestRaft_Configuration_Docker(t *testing.T) {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}
 	opts := &docker.DockerClusterOptions{
-		ImageRepo: "hashicorp/vault",
+		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
 		// the docker image version tag.
 		ImageTag:    "latest",

--- a/vault/external_tests/userpass_binary/ip_token_binding_test.go
+++ b/vault/external_tests/userpass_binary/ip_token_binding_test.go
@@ -33,7 +33,7 @@ func Test_StrictIPBinding(t *testing.T) {
 	}
 
 	opts := &docker.DockerClusterOptions{
-		ImageRepo: "docker.mirror.hashicorp.services/hashicorp/vault",
+		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
 		// the docker image version tag.
 		ImageTag:    "latest",


### PR DESCRIPTION
Now that OpenBao has GA'd with v2.0.0, we should update the SDK's docker testing framework to pull that instead of upstream Vault images.

---

This should land ahead of #425 so that consumers of the SDK have the right repository. This ended up being slightly larger than I expected as `sdk/helper/stepwise/environments/docker/environment.go` wasn't updated, but I didn't know how much it was actually used. 