### PR TITLE
Add new transaction interfaces to sdk/

### DIFF
--- a/sdk/logical/storage_transactions.go
+++ b/sdk/logical/storage_transactions.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+import (
+	"context"
+)
+
+// Transactional is an optional interface for backends that support
+// interactive (mixed code & statement) transactions in a similar
+// style as Go's Database paradigm. This is equivalent to
+// physical.Transactional, not the earlier, one-shot version of the
+// interface.
+type Transactional interface {
+	// This function allows the creation of a new interactive transaction
+	// handle, only supporting read operations. Attempts to perform write
+	// operations (
+	BeginReadOnlyTx(context.Context) (Transaction, error)
+
+	// This function allows the creation of a new interactive transaction
+	// handle, supporting read/write transactions. In some cases, the
+	// underlying physical storage backend cannot handle parallel read/write
+	// transactions.
+	BeginTx(context.Context) (Transaction, error)
+}
+
+// Transaction is an interactive transactional interface: backend storage
+// operations can be performed, and when finished, Commit or Rollback can
+// be called. When a read-only transaction is created, write calls (Put(...)
+// and Delete(...)) will err out.
+type Transaction interface {
+	Storage
+
+	// Commit a transaction; this is equivalent to Rollback on a read-only
+	// transaction.
+	Commit(context.Context) error
+
+	// Rollback a transaction, preventing any changes from being persisted.
+	Rollback(context.Context) error
+}
+
+// TransactionalStorage is implemented if a storage backend implements
+// Transactional as well.
+type TransactionalStorage interface {
+	Storage
+	Transactional
+}

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/hashicorp/go-hclog"
 )
 
-const DefaultParallelOperations = 128
+const (
+	DefaultParallelOperations   = 128
+	DefaultParallelTransactions = 64
+)
 
 // The operation type
 type Operation string

--- a/sdk/physical/transactions.go
+++ b/sdk/physical/transactions.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+// This file was completely removed in a prior commit and entirely
+// new contents added to it.
+
+package physical
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrTransactionReadOnly         error = errors.New("transaction is read-only")
+	ErrTransactionCommitFailure    error = errors.New("transaction commit failed")
+	ErrTransactionAlreadyCommitted error = errors.New("transaction has been committed or rolled back")
+)
+
+// Transactional is an optional interface for backends that support
+// interactive (mixed code & statement) transactions in a similar style
+// as Go's Database paradigm. This differs from the earlier Transactional:
+// that one is a one-shot (list of transactions to execute) transaction
+// interface.
+type Transactional interface {
+	// This function allows the creation of a new interactive transaction
+	// handle, only supporting read operations. Attempts to perform write
+	// operations (PUT or DELETE) will result in immediate errors.
+	BeginReadOnlyTx(context.Context) (Transaction, error)
+
+	// This function allows the creation of a new interactive transaction
+	// handle, supporting read/write transactions. In some cases, the
+	// underlying physical storage backend cannot handle parallel read/write
+	// transactions.
+	BeginTx(context.Context) (Transaction, error)
+}
+
+// Transaction is an interactive transactional interface: backend storage
+// operations can be performed, and when finished, Commit or Rollback can
+// be called. When a read-only transaction is created, write calls (Put(...)
+// and Delete(...)) will err out.
+type Transaction interface {
+	Backend
+
+	// Commit a transaction; this is equivalent to Rollback on a read-only
+	// transaction.
+	Commit(context.Context) error
+
+	// Rollback a transaction, preventing any changes from being persisted.
+	Rollback(context.Context) error
+}
+
+// TransactionalBackend is implemented if a storage backend implements
+// interactive transactions as well as normal backend operations.
+type TransactionalBackend interface {
+	Backend
+	Transactional
+}


### PR DESCRIPTION
This adds interfaces for incremental transactions in sdk/, including to logical.Storage and physical.Backend, eventually allowing support throughout the storage stack.

---

This was split from #292 and was the next required commit to review. 

/cc: @schultz-is 