### PR TITLE
Fix OIDC challenge_code regex in test

### DIFF
--- a/builtin/credential/jwt/path_oidc_test.go
+++ b/builtin/credential/jwt/path_oidc_test.go
@@ -106,7 +106,7 @@ func TestOIDC_AuthURL(t *testing.T) {
 				`state=st_\w{20}`,
 				`redirect_uri=https%3A%2F%2Fexample.com`,
 				`response_type=code`,
-				`code_challenge=\w+`,
+				`code_challenge=[\w_-]+`,
 				`scope=openid`,
 			}
 
@@ -116,7 +116,7 @@ func TestOIDC_AuthURL(t *testing.T) {
 					t.Fatal(err)
 				}
 				if !matched {
-					t.Fatalf("expected to match regex: %s", test)
+					t.Fatalf("expected to match regex=%s / authURL=%v", test, authURL)
 				}
 			}
 		}


### PR DESCRIPTION
The given authURL is validated against various components that are expected to exist. Per RFC however, the challenge code may have non-word characters (`-` and `_`) when using the alternative URL-safe Base64 encoding mechanism. Expand the regex to handle this case.

See also: https://datatracker.ietf.org/doc/html/rfc7636#section-4.2