### PR TITLE
Add transaction support to StorageEncoding

### DIFF
--- a/sdk/physical/encoding.go
+++ b/sdk/physical/encoding.go
@@ -17,24 +17,56 @@ var (
 )
 
 // StorageEncoding is used to add errors into underlying physical requests
-type StorageEncoding struct {
+type StorageEncoding interface {
 	Backend
+}
+
+type storageEncoding struct {
+	Backend
+}
+
+// TransactionalStorageEncoding is used to add errors to underlying physical
+// requests, when the backend supports Transactions.
+type TransactionalStorageEncoding interface {
+	TransactionalBackend
+}
+
+type transactionalStorageEncoding struct {
+	storageEncoding
+}
+
+type StorageEncodingTransaction interface {
+	Transaction
+}
+
+type storageEncodingTransaction struct {
+	storageEncoding
 }
 
 // Verify StorageEncoding satisfies the correct interfaces
 var (
-	_ Backend = (*StorageEncoding)(nil)
+	_ Backend              = &storageEncoding{}
+	_ TransactionalBackend = &transactionalStorageEncoding{}
+	_ Transaction          = &storageEncodingTransaction{}
 )
 
 // NewStorageEncoding returns a wrapped physical backend and verifies the key
 // encoding
 func NewStorageEncoding(b Backend) Backend {
-	return &StorageEncoding{
+	se := &storageEncoding{
 		Backend: b,
 	}
+
+	if _, ok := b.(TransactionalBackend); ok {
+		return &transactionalStorageEncoding{
+			*se,
+		}
+	}
+
+	return se
 }
 
-func (e *StorageEncoding) containsNonPrintableChars(key string) bool {
+func (e *storageEncoding) containsNonPrintableChars(key string) bool {
 	idx := strings.IndexFunc(key, func(c rune) bool {
 		return !unicode.IsPrint(c)
 	})
@@ -42,7 +74,7 @@ func (e *StorageEncoding) containsNonPrintableChars(key string) bool {
 	return idx != -1
 }
 
-func (e *StorageEncoding) Put(ctx context.Context, entry *Entry) error {
+func (e *storageEncoding) Put(ctx context.Context, entry *Entry) error {
 	if !utf8.ValidString(entry.Key) {
 		return ErrNonUTF8
 	}
@@ -54,7 +86,7 @@ func (e *StorageEncoding) Put(ctx context.Context, entry *Entry) error {
 	return e.Backend.Put(ctx, entry)
 }
 
-func (e *StorageEncoding) Delete(ctx context.Context, key string) error {
+func (e *storageEncoding) Delete(ctx context.Context, key string) error {
 	if !utf8.ValidString(key) {
 		return ErrNonUTF8
 	}
@@ -66,14 +98,48 @@ func (e *StorageEncoding) Delete(ctx context.Context, key string) error {
 	return e.Backend.Delete(ctx, key)
 }
 
-func (e *StorageEncoding) Purge(ctx context.Context) {
+func (e *storageEncoding) Purge(ctx context.Context) {
 	if purgeable, ok := e.Backend.(ToggleablePurgemonster); ok {
 		purgeable.Purge(ctx)
 	}
 }
 
-func (e *StorageEncoding) SetEnabled(enabled bool) {
+func (e *storageEncoding) SetEnabled(enabled bool) {
 	if purgeable, ok := e.Backend.(ToggleablePurgemonster); ok {
 		purgeable.SetEnabled(enabled)
 	}
+}
+
+func (e *transactionalStorageEncoding) BeginReadOnlyTx(ctx context.Context) (Transaction, error) {
+	txn, err := e.storageEncoding.Backend.(TransactionalBackend).BeginReadOnlyTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &storageEncodingTransaction{
+		storageEncoding{
+			Backend: txn,
+		},
+	}, nil
+}
+
+func (e *transactionalStorageEncoding) BeginTx(ctx context.Context) (Transaction, error) {
+	txn, err := e.storageEncoding.Backend.(TransactionalBackend).BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &storageEncodingTransaction{
+		storageEncoding{
+			Backend: txn,
+		},
+	}, nil
+}
+
+func (e *storageEncodingTransaction) Commit(ctx context.Context) error {
+	return e.storageEncoding.Backend.(Transaction).Commit(ctx)
+}
+
+func (e *storageEncodingTransaction) Rollback(ctx context.Context) error {
+	return e.storageEncoding.Backend.(Transaction).Rollback(ctx)
 }


### PR DESCRIPTION
`StorageEncoding` is a layer which enforces invariants w.r.t. key names in the underlying physical backend. Because it is always added as a layer in the binaries, we need to add transactions to it for a transactional `physical.Backend` to successfully become a transactional `logical.Storage`.