### PR TITLE
Add in-memory transactional database

### DIFF
--- a/sdk/logical/storage_inmem.go
+++ b/sdk/logical/storage_inmem.go
@@ -68,6 +68,11 @@ func (s *InmemStorage) ListPage(ctx context.Context, prefix string, after string
 func (s *InmemStorage) Underlying() *inmem.InmemBackend {
 	s.once.Do(s.init)
 
+	ts, ok := s.underlying.(*inmem.TransactionalInmemBackend)
+	if ok {
+		return &ts.InmemBackend
+	}
+
 	return s.underlying.(*inmem.InmemBackend)
 }
 

--- a/sdk/physical/inmem/inmem.go
+++ b/sdk/physical/inmem/inmem.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,11 +27,10 @@ var (
 )
 
 var (
-	PutDisabledError      = errors.New("put operations disabled in inmem backend")
-	GetDisabledError      = errors.New("get operations disabled in inmem backend")
-	DeleteDisabledError   = errors.New("delete operations disabled in inmem backend")
-	ListDisabledError     = errors.New("list operations disabled in inmem backend")
-	GetInTxnDisabledError = errors.New("get operations inside transactions are disabled in inmem backend")
+	PutDisabledError    = errors.New("put operations disabled in inmem backend")
+	GetDisabledError    = errors.New("get operations disabled in inmem backend")
+	DeleteDisabledError = errors.New("delete operations disabled in inmem backend")
+	ListDisabledError   = errors.New("list operations disabled in inmem backend")
 )
 
 // InmemBackend is an in-memory only physical backend. It is useful
@@ -45,13 +45,87 @@ type InmemBackend struct {
 	failPut      *uint32
 	failDelete   *uint32
 	failList     *uint32
-	failGetInTxn *uint32
 	logOps       bool
 	maxValueSize int
 }
 
-// NewInmem constructs a new in-memory backend
-func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, error) {
+var _ physical.Backend = &InmemBackend{}
+
+type TransactionalInmemBackend struct {
+	InmemBackend
+
+	txnPermitPool *physical.PermitPool
+}
+
+var _ physical.TransactionalBackend = &TransactionalInmemBackend{}
+
+// listInMemOp isn't required as it is handled by listPageInMemOp
+const (
+	PutInMemOp int = 1 << iota
+	DeleteInMemOp
+	ListInMemOp
+	ListPageInMemOp
+	GetInMemOp
+	BeginTxInMemOp
+	BeginReadOnlyTxInMemOp
+	CommitTxInMemOp
+	RollbackTxInMemOp
+)
+
+func OpName(op int) string {
+	switch op {
+	case PutInMemOp:
+		return "put"
+	case DeleteInMemOp:
+		return "delete"
+	case ListInMemOp:
+		return "list"
+	case ListPageInMemOp:
+		return "list-page"
+	case GetInMemOp:
+		return "get"
+	case BeginTxInMemOp:
+		return "begin-tx"
+	case BeginReadOnlyTxInMemOp:
+		return "begin-ro-tx"
+	case CommitTxInMemOp:
+		return "commit-tx"
+	case RollbackTxInMemOp:
+		return "rollback-tx"
+	}
+
+	return "unknown"
+}
+
+type InmemOp struct {
+	OpType int
+	OpTx   int
+
+	ArgKey   string
+	ArgEntry *physical.Entry
+	ArgAfter string
+	ArgLimit int
+
+	CurrEntry *physical.Entry
+
+	RetList  []string
+	RetEntry *physical.Entry
+}
+
+type InmemBackendTransaction struct {
+	InmemBackend
+
+	txLock     sync.Mutex
+	writable   bool
+	written    bool
+	finishedTx bool
+	operations []*InmemOp
+	parent     *TransactionalInmemBackend
+}
+
+var _ physical.Transaction = &InmemBackendTransaction{}
+
+func NewDirectInmem(conf map[string]string, logger log.Logger) (physical.Backend, error) {
 	maxValueSize := 0
 	maxValueSizeStr, ok := conf["max_value_size"]
 	if ok {
@@ -70,9 +144,25 @@ func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, erro
 		failPut:      new(uint32),
 		failDelete:   new(uint32),
 		failList:     new(uint32),
-		failGetInTxn: new(uint32),
 		logOps:       api.ReadBaoVariable("BAO_INMEM_LOG_ALL_OPS") != "",
 		maxValueSize: maxValueSize,
+	}, nil
+}
+
+// NewInmem constructs a new in-memory backend
+func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, error) {
+	b, err := NewDirectInmem(conf, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if value, ok := conf["disable_transactions"]; ok && value == "true" {
+		return b, nil
+	}
+
+	return &TransactionalInmemBackend{
+		*b.(*InmemBackend),
+		physical.NewPermitPool(physical.DefaultParallelOperations),
 	}, nil
 }
 
@@ -142,6 +232,10 @@ func (i *InmemBackend) GetInternal(ctx context.Context, key string) (*physical.E
 	default:
 	}
 
+	return i.getInternal(ctx, key)
+}
+
+func (i *InmemBackend) getInternal(ctx context.Context, key string) (*physical.Entry, error) {
 	if raw, ok := i.root.Get(key); ok {
 		return &physical.Entry{
 			Key:   key,
@@ -157,14 +251,6 @@ func (i *InmemBackend) FailGet(fail bool) {
 		val = 1
 	}
 	atomic.StoreUint32(i.failGet, val)
-}
-
-func (i *InmemBackend) FailGetInTxn(fail bool) {
-	var val uint32
-	if fail {
-		val = 1
-	}
-	atomic.StoreUint32(i.failGetInTxn, val)
 }
 
 // Delete is used to permanently delete an entry
@@ -240,6 +326,10 @@ func (i *InmemBackend) ListPaginatedInternal(ctx context.Context, prefix string,
 		return nil, ListDisabledError
 	}
 
+	return i.listPaginatedInternal(ctx, prefix, after, limit)
+}
+
+func (i *InmemBackend) listPaginatedInternal(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
 	var out []string
 	seen := make(map[string]interface{})
 	walkFn := func(s string, v interface{}) bool {
@@ -293,4 +383,298 @@ func (i *InmemBackend) FailList(fail bool) {
 		val = 1
 	}
 	atomic.StoreUint32(i.failList, val)
+}
+
+func (i *TransactionalInmemBackend) BeginReadOnlyTx(ctx context.Context) (physical.Transaction, error) {
+	tx, err := i.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	itx := tx.(*InmemBackendTransaction)
+	itx.writable = false
+
+	return tx, nil
+}
+
+func (i *TransactionalInmemBackend) BeginTx(ctx context.Context) (physical.Transaction, error) {
+	i.InmemBackend.Lock()
+	defer i.InmemBackend.Unlock()
+
+	// Grab a transaction pool instance.
+	i.txnPermitPool.Acquire()
+
+	tx := &InmemBackendTransaction{
+		InmemBackend: InmemBackend{
+			root:         radix.NewFromMap(i.InmemBackend.root.ToMap()),
+			permitPool:   physical.NewPermitPool(physical.DefaultParallelOperations),
+			logger:       i.logger,
+			failGet:      new(uint32),
+			failPut:      new(uint32),
+			failDelete:   new(uint32),
+			failList:     new(uint32),
+			logOps:       i.logOps,
+			maxValueSize: i.maxValueSize,
+		},
+		writable: true,
+		written:  false,
+		parent:   i,
+	}
+
+	*tx.failGet = *i.InmemBackend.failGet
+	*tx.failPut = *i.InmemBackend.failPut
+	*tx.failDelete = *i.InmemBackend.failDelete
+	*tx.failList = *i.InmemBackend.failList
+
+	return tx, nil
+}
+
+func (i *InmemBackendTransaction) Put(ctx context.Context, entry *physical.Entry) error {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if !i.writable {
+		return physical.ErrTransactionReadOnly
+	}
+
+	if i.finishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	currEntry, err := i.InmemBackend.getInternal(ctx, entry.Key)
+	if err != nil {
+		return err
+	}
+	err = i.InmemBackend.Put(ctx, entry)
+	if err == nil {
+		op := &InmemOp{
+			OpType: PutInMemOp,
+			ArgKey: entry.Key,
+			ArgEntry: &physical.Entry{
+				Key:   entry.Key,
+				Value: make([]byte, len(entry.Value)),
+			},
+		}
+		copy(op.ArgEntry.Value, entry.Value)
+		if currEntry != nil {
+			op.CurrEntry = &physical.Entry{
+				Key:   currEntry.Key,
+				Value: make([]byte, len(currEntry.Value)),
+			}
+			copy(op.CurrEntry.Value, currEntry.Value)
+		}
+		i.operations = append(i.operations, op)
+		i.written = true
+	}
+	return err
+}
+
+func (i *InmemBackendTransaction) Delete(ctx context.Context, key string) error {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if !i.writable {
+		return physical.ErrTransactionReadOnly
+	}
+
+	if i.finishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	entry, err := i.InmemBackend.getInternal(ctx, key)
+	if err != nil {
+		return err
+	}
+	err = i.InmemBackend.Delete(ctx, key)
+	if err == nil {
+		op := &InmemOp{
+			OpType: DeleteInMemOp,
+			ArgKey: key,
+		}
+		if entry != nil {
+			op.CurrEntry = &physical.Entry{
+				Key:   entry.Key,
+				Value: make([]byte, len(entry.Value)),
+			}
+			copy(op.CurrEntry.Value, entry.Value)
+		}
+		i.operations = append(i.operations, op)
+		i.written = true
+	}
+	return err
+}
+
+func (i *InmemBackendTransaction) Get(ctx context.Context, key string) (*physical.Entry, error) {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if i.finishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	entry, err := i.InmemBackend.Get(ctx, key)
+	if err == nil {
+		op := &InmemOp{
+			OpType: GetInMemOp,
+			ArgKey: key,
+		}
+		if entry != nil {
+			op.RetEntry = &physical.Entry{
+				Key:   entry.Key,
+				Value: make([]byte, len(entry.Value)),
+			}
+			copy(op.RetEntry.Value, entry.Value)
+		}
+		i.operations = append(i.operations, op)
+	}
+
+	return entry, err
+}
+
+func (i *InmemBackendTransaction) List(ctx context.Context, prefix string) ([]string, error) {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if i.finishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	entries, err := i.InmemBackend.List(ctx, prefix)
+	if err == nil {
+		op := &InmemOp{
+			OpType: ListInMemOp,
+			ArgKey: prefix,
+		}
+		if entries != nil {
+			op.RetList = make([]string, len(entries))
+			copy(op.RetList, entries)
+		}
+		i.operations = append(i.operations, op)
+	}
+	return entries, err
+}
+
+func (i *InmemBackendTransaction) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if i.finishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	entries, err := i.InmemBackend.ListPage(ctx, prefix, after, limit)
+	if err == nil {
+		op := &InmemOp{
+			OpType:   ListPageInMemOp,
+			ArgKey:   prefix,
+			ArgAfter: after,
+			ArgLimit: limit,
+		}
+		if entries != nil {
+			op.RetList = make([]string, len(entries))
+			copy(op.RetList, entries)
+		}
+		i.operations = append(i.operations, op)
+	}
+	return entries, err
+}
+
+func (i *InmemBackendTransaction) Commit(ctx context.Context) error {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if i.finishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	// At this point, we mark the transaction as finished either way.
+	i.finishedTx = true
+	i.parent.txnPermitPool.Release()
+
+	if !i.writable || !i.written {
+		// Nothing to do.
+		return nil
+	}
+
+	// The following operations update parent's tree, so we'll want
+	// to recreate it.
+	i.parent.Lock()
+	defer i.parent.Unlock()
+
+	// We don't have a way of creating a transaction on the radix tree
+	// natively, so we take a copy and restore it on any failure.
+	parentCopy := i.parent.root.ToMap()
+
+	retErr := func() error {
+		// Replay all operations back on the parent backend.
+		for index, op := range i.operations {
+			switch op.OpType {
+			case GetInMemOp:
+				entry, err := i.parent.getInternal(ctx, op.ArgKey)
+				if err != nil {
+					return fmt.Errorf("get failed: %v: %w", err, physical.ErrTransactionCommitFailure)
+				}
+
+				if !reflect.DeepEqual(entry, op.RetEntry) {
+					return fmt.Errorf("[%d] gets had different structure: %v vs %v: %w\n%#v", index, entry, op.RetEntry, physical.ErrTransactionCommitFailure, i.operations)
+				}
+			case ListInMemOp, ListPageInMemOp:
+				entries, err := i.parent.listPaginatedInternal(ctx, op.ArgKey, op.ArgAfter, op.ArgLimit)
+				if err != nil {
+					return fmt.Errorf("list failed: %v: %w", err, physical.ErrTransactionCommitFailure)
+				}
+
+				if !reflect.DeepEqual(entries, op.RetList) {
+					return fmt.Errorf("[%d] lists had different structure: %v vs %v: %w\n%#v", index, entries, op.RetList, physical.ErrTransactionCommitFailure, i.operations)
+				}
+			case PutInMemOp:
+				entry, err := i.parent.getInternal(ctx, op.ArgKey)
+				if err != nil {
+					return fmt.Errorf("verify failed: %v: %w", err, physical.ErrTransactionCommitFailure)
+				}
+
+				if !reflect.DeepEqual(entry, op.CurrEntry) {
+					return fmt.Errorf("[%d] contents changed before put: %v vs %v: %w: %#v", index, entry, op.CurrEntry, physical.ErrTransactionCommitFailure, i.operations)
+				}
+
+				i.parent.root.Insert(op.ArgEntry.Key, op.ArgEntry.Value)
+			case DeleteInMemOp:
+				entry, err := i.parent.getInternal(ctx, op.ArgKey)
+				if err != nil {
+					return fmt.Errorf("verify failed: %v: %w", err, physical.ErrTransactionCommitFailure)
+				}
+
+				if !reflect.DeepEqual(entry, op.CurrEntry) {
+					return fmt.Errorf("[%d] contents changed before delete: %v vs %v: %w: %#v", index, entry, op.CurrEntry, physical.ErrTransactionCommitFailure, i.operations)
+				}
+
+				i.parent.root.Delete(op.ArgKey)
+			default:
+				return fmt.Errorf("unknown operation: %v", op.OpType)
+			}
+		}
+
+		return nil
+	}()
+	if retErr != nil {
+		i.parent.root = radix.NewFromMap(parentCopy)
+		return retErr
+	}
+
+	// All good. Parent is now up-to-date with the latest state.
+	return nil
+}
+
+func (i *InmemBackendTransaction) Rollback(ctx context.Context) error {
+	i.txLock.Lock()
+	defer i.txLock.Unlock()
+
+	if i.finishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	i.finishedTx = true
+	i.parent.txnPermitPool.Release()
+
+	return nil
 }


### PR DESCRIPTION
This modifies the in-memory physical backend to support transactions in an inefficient manner: clone the entire tree, build an action log, and reply the log against the main tree, validating the state of any touched entries.

A copy-on-write version of go-radix would improve the performance substantially (letting the old version be maintained in the transaction), but since this backend isn't persistent across restarts of OpenBao, it likely is not worth the effort.