### PR TITLE
fix: variable name collision in docker-entrypoint

### DIFF
--- a/changelog/446.txt
+++ b/changelog/446.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: fix collision between the cluster address and local JSON configuration sharing the same variable within the docker-entrypoint script
+```

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -37,13 +37,13 @@ fi
 
 # BAO_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
-# BAO_CLUSTER_ADDR below.
+# BAO_LOCAL_CONFIG below.
 BAO_CONFIG_DIR=/openbao/config
 
-# You can also set the BAO_CLUSTER_ADDR environment variable to pass some
+# You can also set the BAO_LOCAL_CONFIG environment variable to pass some
 # OpenBao configuration JSON without having to bind any volumes.
-if [ -n "$BAO_CLUSTER_ADDR" ]; then
-    echo "$BAO_CLUSTER_ADDR" > "$BAO_CONFIG_DIR/local.json"
+if [ -n "$BAO_LOCAL_CONFIG" ]; then
+    echo "$BAO_LOCAL_CONFIG" > "$BAO_CONFIG_DIR/local.json"
 fi
 
 # If the user is trying to run OpenBao directly with some arguments, then


### PR DESCRIPTION
In the `docker-entrypoint.sh` script there is an issue with collision between the variable name `BAO_CLUSTER_ADDR` which is used for the redirect interface and for local JSON configuration. Any attempt to set JSON configuration will cause `bao` to fail when attempt to parse what it expects is the cluster interface when it actually JSON configuration.

Therefore, in the lines relating to local JSON configuration the variable has been renamed to `BAO_LOCAL_CONFIG` allowing for users to provide custom JSON configuration without also breaking the cluster address.

Closes #445
