### PR TITLE
add workflow to verify maintainer commits

### DIFF
--- a/.github/scripts/verify-commits.jq
+++ b/.github/scripts/verify-commits.jq
@@ -1,0 +1,23 @@
+# Expects the list of commits on a pull requests as input.
+# See: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
+[
+  # Iterate over all commits
+  .[] |
+  # select maintainer commits
+  select(
+    .author.login == "JanMa" or
+    .author.login == "cipherboy" or
+    .author.login == "DanGhita" or
+    .author.login == "naphelps"
+  ) |
+  # select any unsigned commits
+  select(.commit.verification.verified == false)
+] |
+# check if there are unsigned commits
+if (. | length) != 0 then
+  # return error
+  ("Pr contains unsigned maintainer commits!\n" | halt_error(1))
+else
+  # return success
+  "All maintainer commits are signed"
+end

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -1,0 +1,22 @@
+name: Ensure Verified Commits
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  verify_commits:
+    name: Verify Commit Signatures
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check commit signatures
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/openbao/openbao/pulls/${{ github.event.pull_request.number }}/commits | \
+          jq -f .github/scripts/verify-commits.jq
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
When a Pr is opened, this workflow checks if all commits made by any of the core
maintainers of OpenBao are verified. This way we can stop enforcing commits via
GitHub branch protection rules for all committers while still ensuring that
maintainer commits need to be signed.