### PR TITLE
Remove deprecated code paths

### DIFF
--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -278,12 +278,7 @@ func (b *backend) pathUserWrite(ctx context.Context, req *logical.Request, d *fr
 type UserEntry struct {
 	tokenutil.TokenParams
 
-	// Password is deprecated in Vault 0.2 in favor of
-	// PasswordHash, but is retained for backwards compatibility.
-	Password string
-
-	// PasswordHash is a bcrypt hash of the password. This is
-	// used instead of the actual password in Vault 0.2+.
+	// PasswordHash is a bcrypt hash of the password.
 	PasswordHash []byte
 
 	Policies []string

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -31,7 +31,6 @@ type OperatorInitCommand struct {
 	flagRecoveryShares    int
 	flagRecoveryThreshold int
 	flagRecoveryPGPKeys   []string
-	flagStoredShares      int
 }
 
 const (
@@ -122,8 +121,7 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 			"public PGP keys OR a comma-separated list of Keybase usernames using " +
 			"the format \"keybase:<username>\". When supplied, the generated " +
 			"unseal keys will be encrypted and base64-encoded in the order " +
-			"specified in this list. The number of entries must match -key-shares, " +
-			"unless -stored-shares are used.",
+			"specified in this list. The number of entries must match -key-shares.",
 	})
 
 	f.VarFlag(&VarFlag{
@@ -135,13 +133,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 			"using the format \"keybase:<username>\". When supplied, the generated " +
 			"root token will be encrypted and base64-encoded with the given public " +
 			"key.",
-	})
-
-	f.IntVar(&IntVar{
-		Name:    "stored-shares",
-		Target:  &c.flagStoredShares,
-		Default: -1,
-		Usage:   "DEPRECATED: This flag does nothing. It will be removed in Vault 1.3.",
 	})
 
 	// Auto Unseal Options
@@ -196,9 +187,6 @@ func (c *OperatorInitCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.flagStoredShares != -1 {
-		c.UI.Warn("-stored-shares has no effect and will be removed in Vault 1.3.\n")
-	}
 	client, err := c.Client()
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/sdk/helper/pluginutil/env.go
+++ b/sdk/helper/pluginutil/env.go
@@ -5,7 +5,6 @@ package pluginutil
 
 import (
 	"github.com/hashicorp/go-secure-stdlib/mlock"
-	version "github.com/hashicorp/go-version"
 	"github.com/openbao/openbao/api/v2"
 )
 
@@ -47,30 +46,6 @@ func OptionallyEnableMlock() error {
 	}
 
 	return nil
-}
-
-// GRPCSupport defaults to returning true, unless VAULT_VERSION is missing or
-// it fails to meet the version constraint.
-func GRPCSupport() bool {
-	verString := api.ReadBaoVariable(PluginVaultVersionEnv)
-	// If the env var is empty, we fall back to netrpc for backward compatibility.
-	if verString == "" {
-		return false
-	}
-	if verString != "unknown" {
-		ver, err := version.NewVersion(verString)
-		if err != nil {
-			return true
-		}
-		// Due to some regressions on 0.9.2 & 0.9.3 we now require version 0.9.4
-		// to allow the plugin framework to default to gRPC.
-		constraint, err := version.NewConstraint(">= 0.9.4")
-		if err != nil {
-			return true
-		}
-		return constraint.Check(ver)
-	}
-	return true
 }
 
 // InMetadataMode returns true if the plugin calling this function is running in metadata mode.

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -109,7 +109,6 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 		TLSConfig:        clientTLSConfig,
 		Logger:           rc.Logger,
 		AllowedProtocols: []plugin.Protocol{
-			plugin.ProtocolNetRPC,
 			plugin.ProtocolGRPC,
 		},
 		AutoMTLS: rc.AutoMTLS,

--- a/sdk/helper/pluginutil/run_config_test.go
+++ b/sdk/helper/pluginutil/run_config_test.go
@@ -91,7 +91,6 @@ func TestMakeConfig(t *testing.T) {
 					// Hash is generated
 				},
 				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
 					plugin.ProtocolGRPC,
 				},
 				Logger:   hclog.NewNullLogger(),
@@ -163,7 +162,6 @@ func TestMakeConfig(t *testing.T) {
 					// Hash is generated
 				},
 				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
 					plugin.ProtocolGRPC,
 				},
 				Logger:   hclog.NewNullLogger(),
@@ -228,7 +226,6 @@ func TestMakeConfig(t *testing.T) {
 					// Hash is generated
 				},
 				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
 					plugin.ProtocolGRPC,
 				},
 				Logger:   hclog.NewNullLogger(),
@@ -293,7 +290,6 @@ func TestMakeConfig(t *testing.T) {
 					// Hash is generated
 				},
 				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
 					plugin.ProtocolGRPC,
 				},
 				Logger:   hclog.NewNullLogger(),

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2153,15 +2153,6 @@ func (m *ExpirationManager) removeIndexByToken(ctx context.Context, le *leaseEnt
 		if tokenNS != nil {
 			saltCtx = namespace.ContextWithNamespace(ctx, tokenNS)
 		}
-
-		// Downgrade logic for old-style (V0) namespace leases that had its
-		// secondary index live in the root namespace. This reverts to the old
-		// behavior of looking for the secondary index on these leases in the
-		// root namespace to be cleaned up properly. We set it here because the
-		// old behavior used the namespace's token store salt for its saltCtx.
-		if le.Version < 1 {
-			tokenNS = namespace.RootNamespace
-		}
 	}
 
 	saltedID, err := m.tokenStore.SaltID(saltCtx, token)

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-sockaddr"
-	"github.com/hashicorp/go-version"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
@@ -1185,21 +1184,7 @@ func (ts *TokenStore) create(ctx context.Context, entry *logical.TokenEntry) err
 			return err
 		}
 
-		var newestVersion *version.Version
-		var oneTen *version.Version
-
-		if ver != "" {
-			newestVersion, err = version.NewVersion(ver)
-			if err != nil {
-				return err
-			}
-			oneTen, err = version.NewVersion("1.10.0")
-			if err != nil {
-				return err
-			}
-		}
-
-		if ts.core.DisableSSCTokens() || (newestVersion != nil && newestVersion.LessThan(oneTen)) {
+		if ts.core.DisableSSCTokens() {
 			entry.ID = consts.LegacyBatchTokenPrefix + bEntry
 		} else {
 			entry.ID = consts.BatchTokenPrefix + bEntry


### PR DESCRIPTION
This removes several code paths which should not be triggered (or supported) on OpenBao v2.0.0 as they were deprecated or removed prior to v1.14:

1. `-stored-shares` flag,
2. Legacy password handling in userpass,
3. LeaseEntry namespace handling (which also does not exist due to it being an Enterprise-only feature)
4. Auto-detection in SSH CLI
5. Legacy NetRPC support detection
6. Version check around SSCT token generation.

Resolves: #315