### PR TITLE
Fix broken zlint test

### DIFF
--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -114,7 +114,6 @@ func RunZLintRootTest(t *testing.T, keyType string, keyBits int, usePSS bool, ig
 		"common_name":  "Root X1",
 		"country":      "US",
 		"organization": "Dadgarcorp",
-		"ou":           "QA",
 		"key_type":     keyType,
 		"key_bits":     keyBits,
 		"use_pss":      usePSS,


### PR DESCRIPTION
ZLint recently introduced a new check to ensure that the "ou" attribute is not present on TLS CA certificates. Remove this from our test to ensure we can still generate zlint-clean CA certificates from OpenBao.

See also: https://github.com/zmap/zlint/commit/2440571870f32ad14a73eb5f9e74b500c69ecda3
