### PR TITLE
Correctly split TxErrors

### DIFF
--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -86,7 +86,7 @@ func (f *FSMEntry) AsTxError() error {
 	str := string(f.Value)
 	commitErr := physical.ErrTransactionCommitFailure.Error()
 
-	split := strings.SplitN(str, commitErr, 1)
+	split := strings.SplitN(str, commitErr, 2)
 	if len(split) != 2 {
 		return errors.New(str)
 	}

--- a/tools/semgrep/ci/splitn-1.yml
+++ b/tools/semgrep/ci/splitn-1.yml
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: splitn-1
+    patterns:
+        - pattern: |
+            strings.SplitN(..., 1)
+    message: "Using SplitN with a value of 1 does not split the target string."
+    languages: [go]
+    severity: ERROR


### PR DESCRIPTION
This adds a semgrep rule to prevent other instances of the same mistake in the future. The extent of this issue is that

  errors.Is(err, physical.ErrTransactionCommitFailure) == false

for actual transaction commit failures, though no code currently conditions around this. The ideal would be that, if an operation should be retried in the event of a transaction commit failure, it theoretically could be. But, other errors during the commit process (not related to consistency) could potentially return a different error and not trigger an automatic retry.