### PR TITLE
Re-add Postgres storage engine

### DIFF
--- a/changelog/467.txt
+++ b/changelog/467.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+physical/postgres: Reintroduce Postgres database for OpenBao storage, implementing paginated list support. This feature is currently in **preview** and breaking changes may occur.
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -36,6 +36,7 @@ import (
 	logicalDb "github.com/openbao/openbao/builtin/logical/database"
 	logicalKv "github.com/openbao/openbao/builtin/logical/kv"
 
+	physPostgresql "github.com/openbao/openbao/physical/postgresql"
 	physRaft "github.com/openbao/openbao/physical/raft"
 	physFile "github.com/openbao/openbao/sdk/v2/physical/file"
 	physInmem "github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -145,10 +146,11 @@ var (
 	}
 
 	physicalBackends = map[string]physical.Factory{
-		"file":     physFile.NewFileBackend,
-		"inmem_ha": physInmem.NewInmemHA,
-		"inmem":    physInmem.NewInmem,
-		"raft":     physRaft.NewRaftBackend,
+		"file":       physFile.NewFileBackend,
+		"inmem_ha":   physInmem.NewInmemHA,
+		"inmem":      physInmem.NewInmem,
+		"raft":       physRaft.NewRaftBackend,
+		"postgresql": physPostgresql.NewPostgreSQLBackend,
 	}
 
 	serviceRegistrations = map[string]sr.Factory{

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -105,11 +105,11 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 	}
 	quoted_table := dbutil.QuoteIdentifier(unquoted_table)
 
-	quoted_upsert_function, ok := conf["upsert_function"]
+	unquoted_upsert_function, ok := conf["upsert_function"]
 	if !ok {
-		quoted_upsert_function = "openbao_kv_put"
+		unquoted_upsert_function = "openbao_kv_put"
 	}
-	quoted_upsert_function := dbutil.QuoteIdentifier(quoted_upsert_function)
+	quoted_upsert_function := dbutil.QuoteIdentifier(unquoted_upsert_function)
 
 	maxParStr, ok := conf["max_parallel"]
 	var maxParInt int
@@ -196,6 +196,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 			" UNION ALL SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " + quoted_table +
 			" WHERE parent_path LIKE $1 || '%' AND substring(substr(path, length($1)+1) from '^.*?/') > $2" +
 			" ORDER BY key LIMIT $3",
+		ha_table: quoted_ha_table,
 		haGetLockValueQuery:
 		// only read non expired data
 		" SELECT ha_value FROM " + quoted_ha_table + " WHERE NOW() <= valid_until AND ha_key = $1 ",

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -1,0 +1,474 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/armon/go-metrics"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/openbao/openbao/sdk/v2/database/helper/dbutil"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+const (
+
+	// The lock TTL matches the default that Consul API uses, 15 seconds.
+	// Used as part of SQL commands to set/extend lock expiry time relative to
+	// database clock.
+	PostgreSQLLockTTLSeconds = 15
+
+	// The amount of time to wait between the lock renewals
+	PostgreSQLLockRenewInterval = 5 * time.Second
+
+	// PostgreSQLLockRetryInterval is the amount of time to wait
+	// if a lock fails before trying again.
+	PostgreSQLLockRetryInterval = time.Second
+)
+
+// Verify PostgreSQLBackend satisfies the correct interfaces
+var _ physical.Backend = (*PostgreSQLBackend)(nil)
+
+// HA backend was implemented based on the DynamoDB backend pattern
+// With distinction using central postgres clock, hereby avoiding
+// possible issues with multiple clocks
+var (
+	_ physical.HABackend = (*PostgreSQLBackend)(nil)
+	_ physical.Lock      = (*PostgreSQLLock)(nil)
+)
+
+// PostgreSQL Backend is a physical backend that stores data
+// within a PostgreSQL database.
+type PostgreSQLBackend struct {
+	table        string
+	client       *sql.DB
+	put_query    string
+	get_query    string
+	delete_query string
+	list_query   string
+
+	ha_table                 string
+	haGetLockValueQuery      string
+	haUpsertLockIdentityExec string
+	haDeleteLockExec         string
+
+	haEnabled  bool
+	logger     log.Logger
+	permitPool *physical.PermitPool
+}
+
+// PostgreSQLLock implements a lock using an PostgreSQL client.
+type PostgreSQLLock struct {
+	backend    *PostgreSQLBackend
+	value, key string
+	identity   string
+	lock       sync.Mutex
+
+	renewTicker *time.Ticker
+
+	// ttlSeconds is how long a lock is valid for
+	ttlSeconds int
+
+	// renewInterval is how much time to wait between lock renewals.  must be << ttl
+	renewInterval time.Duration
+
+	// retryInterval is how much time to wait between attempts to grab the lock
+	retryInterval time.Duration
+}
+
+// NewPostgreSQLBackend constructs a PostgreSQL backend using the given
+// API client, server address, credentials, and database.
+func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.Backend, error) {
+	// Get the PostgreSQL credentials to perform read/write operations.
+	connURL := connectionURL(conf)
+	if connURL == "" {
+		return nil, fmt.Errorf("missing connection_url")
+	}
+
+	unquoted_table, ok := conf["table"]
+	if !ok {
+		unquoted_table = "vault_kv_store"
+	}
+	quoted_table := dbutil.QuoteIdentifier(unquoted_table)
+
+	maxParStr, ok := conf["max_parallel"]
+	var maxParInt int
+	var err error
+	if ok {
+		maxParInt, err = strconv.Atoi(maxParStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing max_parallel parameter: %w", err)
+		}
+		if logger.IsDebug() {
+			logger.Debug("max_parallel set", "max_parallel", maxParInt)
+		}
+	} else {
+		maxParInt = physical.DefaultParallelOperations
+	}
+
+	maxIdleConnsStr, maxIdleConnsIsSet := conf["max_idle_connections"]
+	var maxIdleConns int
+	if maxIdleConnsIsSet {
+		maxIdleConns, err = strconv.Atoi(maxIdleConnsStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing max_idle_connections parameter: %w", err)
+		}
+		if logger.IsDebug() {
+			logger.Debug("max_idle_connections set", "max_idle_connections", maxIdleConnsStr)
+		}
+	}
+
+	// Create PostgreSQL handle for the database.
+	db, err := sql.Open("pgx", connURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to postgres: %w", err)
+	}
+	db.SetMaxOpenConns(maxParInt)
+
+	if maxIdleConnsIsSet {
+		db.SetMaxIdleConns(maxIdleConns)
+	}
+
+	// Determine if we should use a function to work around lack of upsert (versions < 9.5)
+	var upsertAvailable bool
+	upsertAvailableQuery := "SELECT current_setting('server_version_num')::int >= 90500"
+	if err := db.QueryRow(upsertAvailableQuery).Scan(&upsertAvailable); err != nil {
+		return nil, fmt.Errorf("failed to check for native upsert: %w", err)
+	}
+
+	if !upsertAvailable && conf["ha_enabled"] == "true" {
+		return nil, fmt.Errorf("ha_enabled=true in config but PG version doesn't support HA, must be at least 9.5")
+	}
+
+	// Setup our put strategy based on the presence or absence of a native
+	// upsert.
+	var put_query string
+	if !upsertAvailable {
+		put_query = "SELECT vault_kv_put($1, $2, $3, $4)"
+	} else {
+		put_query = "INSERT INTO " + quoted_table + " VALUES($1, $2, $3, $4)" +
+			" ON CONFLICT (path, key) DO " +
+			" UPDATE SET (parent_path, path, key, value) = ($1, $2, $3, $4)"
+	}
+
+	unquoted_ha_table, ok := conf["ha_table"]
+	if !ok {
+		unquoted_ha_table = "vault_ha_locks"
+	}
+	quoted_ha_table := dbutil.QuoteIdentifier(unquoted_ha_table)
+
+	// Setup the backend.
+	m := &PostgreSQLBackend{
+		table:        quoted_table,
+		client:       db,
+		put_query:    put_query,
+		get_query:    "SELECT value FROM " + quoted_table + " WHERE path = $1 AND key = $2",
+		delete_query: "DELETE FROM " + quoted_table + " WHERE path = $1 AND key = $2",
+		list_query: "SELECT key FROM " + quoted_table + " WHERE path = $1" +
+			" UNION ALL SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " + quoted_table +
+			" WHERE parent_path LIKE $1 || '%'",
+		haGetLockValueQuery:
+		// only read non expired data
+		" SELECT ha_value FROM " + quoted_ha_table + " WHERE NOW() <= valid_until AND ha_key = $1 ",
+		haUpsertLockIdentityExec:
+		// $1=identity $2=ha_key $3=ha_value $4=TTL in seconds
+		// update either steal expired lock OR update expiry for lock owned by me
+		" INSERT INTO " + quoted_ha_table + " as t (ha_identity, ha_key, ha_value, valid_until) VALUES ($1, $2, $3, NOW() + $4 * INTERVAL '1 seconds'  ) " +
+			" ON CONFLICT (ha_key) DO " +
+			" UPDATE SET (ha_identity, ha_key, ha_value, valid_until) = ($1, $2, $3, NOW() + $4 * INTERVAL '1 seconds') " +
+			" WHERE (t.valid_until < NOW() AND t.ha_key = $2) OR " +
+			" (t.ha_identity = $1 AND t.ha_key = $2)  ",
+		haDeleteLockExec:
+		// $1=ha_identity $2=ha_key
+		" DELETE FROM " + quoted_ha_table + " WHERE ha_identity=$1 AND ha_key=$2 ",
+		logger:     logger,
+		permitPool: physical.NewPermitPool(maxParInt),
+		haEnabled:  conf["ha_enabled"] == "true",
+	}
+
+	return m, nil
+}
+
+// connectionURL first check the environment variables for a connection URL. If
+// no connection URL exists in the environment variable, the Vault config file is
+// checked. If neither the environment variables or the config file set the connection
+// URL for the Postgres backend, because it is a required field, an error is returned.
+func connectionURL(conf map[string]string) string {
+	connURL := conf["connection_url"]
+	if envURL := os.Getenv("VAULT_PG_CONNECTION_URL"); envURL != "" {
+		connURL = envURL
+	}
+
+	return connURL
+}
+
+// splitKey is a helper to split a full path key into individual
+// parts: parentPath, path, key
+func (m *PostgreSQLBackend) splitKey(fullPath string) (string, string, string) {
+	var parentPath string
+	var path string
+
+	pieces := strings.Split(fullPath, "/")
+	depth := len(pieces)
+	key := pieces[depth-1]
+
+	if depth == 1 {
+		parentPath = ""
+		path = "/"
+	} else if depth == 2 {
+		parentPath = "/"
+		path = "/" + pieces[0] + "/"
+	} else {
+		parentPath = "/" + strings.Join(pieces[:depth-2], "/") + "/"
+		path = "/" + strings.Join(pieces[:depth-1], "/") + "/"
+	}
+
+	return parentPath, path, key
+}
+
+// Put is used to insert or update an entry.
+func (m *PostgreSQLBackend) Put(ctx context.Context, entry *physical.Entry) error {
+	defer metrics.MeasureSince([]string{"postgres", "put"}, time.Now())
+
+	m.permitPool.Acquire()
+	defer m.permitPool.Release()
+
+	parentPath, path, key := m.splitKey(entry.Key)
+
+	_, err := m.client.ExecContext(ctx, m.put_query, parentPath, path, key, entry.Value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get is used to fetch and entry.
+func (m *PostgreSQLBackend) Get(ctx context.Context, fullPath string) (*physical.Entry, error) {
+	defer metrics.MeasureSince([]string{"postgres", "get"}, time.Now())
+
+	m.permitPool.Acquire()
+	defer m.permitPool.Release()
+
+	_, path, key := m.splitKey(fullPath)
+
+	var result []byte
+	err := m.client.QueryRowContext(ctx, m.get_query, path, key).Scan(&result)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ent := &physical.Entry{
+		Key:   fullPath,
+		Value: result,
+	}
+	return ent, nil
+}
+
+// Delete is used to permanently delete an entry
+func (m *PostgreSQLBackend) Delete(ctx context.Context, fullPath string) error {
+	defer metrics.MeasureSince([]string{"postgres", "delete"}, time.Now())
+
+	m.permitPool.Acquire()
+	defer m.permitPool.Release()
+
+	_, path, key := m.splitKey(fullPath)
+
+	_, err := m.client.ExecContext(ctx, m.delete_query, path, key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// List is used to list all the keys under a given
+// prefix, up to the next prefix.
+func (m *PostgreSQLBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	defer metrics.MeasureSince([]string{"postgres", "list"}, time.Now())
+
+	m.permitPool.Acquire()
+	defer m.permitPool.Release()
+
+	rows, err := m.client.QueryContext(ctx, m.list_query, "/"+prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		err = rows.Scan(&key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan rows: %w", err)
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// LockWith is used for mutual exclusion based on the given key.
+func (p *PostgreSQLBackend) LockWith(key, value string) (physical.Lock, error) {
+	identity, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, err
+	}
+	return &PostgreSQLLock{
+		backend:       p,
+		key:           key,
+		value:         value,
+		identity:      identity,
+		ttlSeconds:    PostgreSQLLockTTLSeconds,
+		renewInterval: PostgreSQLLockRenewInterval,
+		retryInterval: PostgreSQLLockRetryInterval,
+	}, nil
+}
+
+func (p *PostgreSQLBackend) HAEnabled() bool {
+	return p.haEnabled
+}
+
+// Lock tries to acquire the lock by repeatedly trying to create a record in the
+// PostgreSQL table. It will block until either the stop channel is closed or
+// the lock could be acquired successfully. The returned channel will be closed
+// once the lock in the PostgreSQL table cannot be renewed, either due to an
+// error speaking to PostgreSQL or because someone else has taken it.
+func (l *PostgreSQLLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	var (
+		success = make(chan struct{})
+		errors  = make(chan error)
+		leader  = make(chan struct{})
+	)
+	// try to acquire the lock asynchronously
+	go l.tryToLock(stopCh, success, errors)
+
+	select {
+	case <-success:
+		// after acquiring it successfully, we must renew the lock periodically
+		l.renewTicker = time.NewTicker(l.renewInterval)
+		go l.periodicallyRenewLock(leader)
+	case err := <-errors:
+		return nil, err
+	case <-stopCh:
+		return nil, nil
+	}
+
+	return leader, nil
+}
+
+// Unlock releases the lock by deleting the lock record from the
+// PostgreSQL table.
+func (l *PostgreSQLLock) Unlock() error {
+	pg := l.backend
+	pg.permitPool.Acquire()
+	defer pg.permitPool.Release()
+
+	if l.renewTicker != nil {
+		l.renewTicker.Stop()
+	}
+
+	// Delete lock owned by me
+	_, err := pg.client.Exec(pg.haDeleteLockExec, l.identity, l.key)
+	return err
+}
+
+// Value checks whether or not the lock is held by any instance of PostgreSQLLock,
+// including this one, and returns the current value.
+func (l *PostgreSQLLock) Value() (bool, string, error) {
+	pg := l.backend
+	pg.permitPool.Acquire()
+	defer pg.permitPool.Release()
+	var result string
+	err := pg.client.QueryRow(pg.haGetLockValueQuery, l.key).Scan(&result)
+
+	switch err {
+	case nil:
+		return true, result, nil
+	case sql.ErrNoRows:
+		return false, "", nil
+	default:
+		return false, "", err
+
+	}
+}
+
+// tryToLock tries to create a new item in PostgreSQL every `retryInterval`.
+// As long as the item cannot be created (because it already exists), it will
+// be retried. If the operation fails due to an error, it is sent to the errors
+// channel. When the lock could be acquired successfully, the success channel
+// is closed.
+func (l *PostgreSQLLock) tryToLock(stop <-chan struct{}, success chan struct{}, errors chan error) {
+	ticker := time.NewTicker(l.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			gotlock, err := l.writeItem()
+			switch {
+			case err != nil:
+				errors <- err
+				return
+			case gotlock:
+				close(success)
+				return
+			}
+		}
+	}
+}
+
+func (l *PostgreSQLLock) periodicallyRenewLock(done chan struct{}) {
+	for range l.renewTicker.C {
+		gotlock, err := l.writeItem()
+		if err != nil || !gotlock {
+			close(done)
+			l.renewTicker.Stop()
+			return
+		}
+	}
+}
+
+// Attempts to put/update the PostgreSQL item using condition expressions to
+// evaluate the TTL.  Returns true if the lock was obtained, false if not.
+// If false error may be nil or non-nil: nil indicates simply that someone
+// else has the lock, whereas non-nil means that something unexpected happened.
+func (l *PostgreSQLLock) writeItem() (bool, error) {
+	pg := l.backend
+	pg.permitPool.Acquire()
+	defer pg.permitPool.Release()
+
+	// Try steal lock or update expiry on my lock
+
+	sqlResult, err := pg.client.Exec(pg.haUpsertLockIdentityExec, l.identity, l.key, l.value, l.ttlSeconds)
+	if err != nil {
+		return false, err
+	}
+	if sqlResult == nil {
+		return false, fmt.Errorf("empty SQL response received")
+	}
+
+	ar, err := sqlResult.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return ar == 1, nil
+}

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,6 +16,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/database/helper/dbutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 )
@@ -216,7 +216,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 // URL for the Postgres backend, because it is a required field, an error is returned.
 func connectionURL(conf map[string]string) string {
 	connURL := conf["connection_url"]
-	if envURL := os.Getenv("VAULT_PG_CONNECTION_URL"); envURL != "" {
+	if envURL := api.ReadBaoVariable("BAO_PG_CONNECTION_URL"); envURL != "" {
 		connURL = envURL
 	}
 

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -1,0 +1,426 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgresql
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/openbao/openbao/helper/testhelpers/postgresql"
+	"github.com/openbao/openbao/sdk/v2/helper/logging"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+func TestPostgreSQLBackend(t *testing.T) {
+	logger := logging.NewVaultLogger(log.Debug)
+
+	// Use docker as pg backend if no url is provided via environment variables
+	connURL := os.Getenv("PGURL")
+	if connURL == "" {
+		cleanup, u := postgresql.PrepareTestContainer(t, "11.1")
+		defer cleanup()
+		connURL = u
+	}
+
+	table := os.Getenv("PGTABLE")
+	if table == "" {
+		table = "vault_kv_store"
+	}
+
+	hae := os.Getenv("PGHAENABLED")
+	if hae == "" {
+		hae = "true"
+	}
+
+	// Run vault tests
+	logger.Info(fmt.Sprintf("Connection URL: %v", connURL))
+
+	b1, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": connURL,
+		"table":          table,
+		"ha_enabled":     hae,
+	}, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+
+	b2, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": connURL,
+		"table":          table,
+		"ha_enabled":     hae,
+	}, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+	pg := b1.(*PostgreSQLBackend)
+
+	// Read postgres version to test basic connects works
+	var pgversion string
+	if err = pg.client.QueryRow("SELECT current_setting('server_version_num')").Scan(&pgversion); err != nil {
+		t.Fatalf("Failed to check for Postgres version: %v", err)
+	}
+	logger.Info(fmt.Sprintf("Postgres Version: %v", pgversion))
+
+	setupDatabaseObjects(t, logger, pg)
+
+	defer func() {
+		pg := b1.(*PostgreSQLBackend)
+		_, err := pg.client.Exec(fmt.Sprintf(" TRUNCATE TABLE %v ", pg.table))
+		if err != nil {
+			t.Fatalf("Failed to truncate table: %v", err)
+		}
+	}()
+
+	logger.Info("Running basic backend tests")
+	physical.ExerciseBackend(t, b1)
+	logger.Info("Running list prefix backend tests")
+	physical.ExerciseBackend_ListPrefix(t, b1)
+
+	ha1, ok := b1.(physical.HABackend)
+	if !ok {
+		t.Fatalf("PostgreSQLDB does not implement HABackend")
+	}
+
+	ha2, ok := b2.(physical.HABackend)
+	if !ok {
+		t.Fatalf("PostgreSQLDB does not implement HABackend")
+	}
+
+	if ha1.HAEnabled() && ha2.HAEnabled() {
+		logger.Info("Running ha backend tests")
+		physical.ExerciseHABackend(t, ha1, ha2)
+		testPostgresSQLLockTTL(t, ha1)
+		testPostgresSQLLockRenewal(t, ha1)
+	}
+}
+
+func TestPostgreSQLBackendMaxIdleConnectionsParameter(t *testing.T) {
+	_, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url":       "some connection url",
+		"max_idle_connections": "bad param",
+	}, logging.NewVaultLogger(log.Debug))
+	if err == nil {
+		t.Error("Expected invalid max_idle_connections param to return error")
+	}
+	expectedErrStr := "failed parsing max_idle_connections parameter: strconv.Atoi: parsing \"bad param\": invalid syntax"
+	if err.Error() != expectedErrStr {
+		t.Errorf("Expected: %q but found %q", expectedErrStr, err.Error())
+	}
+}
+
+func TestConnectionURL(t *testing.T) {
+	type input struct {
+		envar string
+		conf  map[string]string
+	}
+
+	cases := map[string]struct {
+		want  string
+		input input
+	}{
+		"environment_variable_not_set_use_config_value": {
+			want: "abc",
+			input: input{
+				envar: "",
+				conf:  map[string]string{"connection_url": "abc"},
+			},
+		},
+
+		"no_value_connection_url_set_key_exists": {
+			want: "",
+			input: input{
+				envar: "",
+				conf:  map[string]string{"connection_url": ""},
+			},
+		},
+
+		"no_value_connection_url_set_key_doesnt_exist": {
+			want: "",
+			input: input{
+				envar: "",
+				conf:  map[string]string{},
+			},
+		},
+
+		"environment_variable_set": {
+			want: "abc",
+			input: input{
+				envar: "abc",
+				conf:  map[string]string{"connection_url": "def"},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			// This is necessary to avoid always testing the branch where the env is set.
+			// As long the the env is set --- even if the value is "" --- `ok` returns true.
+			if tt.input.envar != "" {
+				os.Setenv("VAULT_PG_CONNECTION_URL", tt.input.envar)
+				defer os.Unsetenv("VAULT_PG_CONNECTION_URL")
+			}
+
+			got := connectionURL(tt.input.conf)
+
+			if got != tt.want {
+				t.Errorf("connectionURL(%s): want %q, got %q", tt.input, tt.want, got)
+			}
+		})
+	}
+}
+
+// Similar to testHABackend, but using internal implementation details to
+// trigger the lock failure scenario by setting the lock renew period for one
+// of the locks to a higher value than the lock TTL.
+const maxTries = 3
+
+func testPostgresSQLLockTTL(t *testing.T, ha physical.HABackend) {
+	t.Log("Skipping testPostgresSQLLockTTL portion of test.")
+	return
+
+	for tries := 1; tries <= maxTries; tries++ {
+		// Try this several times.  If the test environment is too slow the lock can naturally lapse
+		if attemptLockTTLTest(t, ha, tries) {
+			break
+		}
+	}
+}
+
+func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
+	// Set much smaller lock times to speed up the test.
+	lockTTL := 3
+	renewInterval := time.Second * 1
+	retryInterval := time.Second * 1
+	longRenewInterval := time.Duration(lockTTL*2) * time.Second
+	lockkey := "postgresttl"
+
+	var leaderCh <-chan struct{}
+
+	// Get the lock
+	origLock, err := ha.LockWith(lockkey, "bar")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	{
+		// set the first lock renew period to double the expected TTL.
+		lock := origLock.(*PostgreSQLLock)
+		lock.renewInterval = longRenewInterval
+		lock.ttlSeconds = lockTTL
+
+		// Attempt to lock
+		lockTime := time.Now()
+		leaderCh, err = lock.Lock(nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if leaderCh == nil {
+			t.Fatalf("failed to get leader ch")
+		}
+
+		if tries == 1 {
+			time.Sleep(3 * time.Second)
+		}
+		// Check the value
+		held, val, err := lock.Value()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !held {
+			if tries < maxTries && time.Since(lockTime) > (time.Second*time.Duration(lockTTL)) {
+				// Our test environment is slow enough that we failed this, retry
+				return false
+			}
+			t.Fatalf("should be held")
+		}
+		if val != "bar" {
+			t.Fatalf("bad value: %v", val)
+		}
+	}
+
+	// Second acquisition should succeed because the first lock should
+	// not renew within the 3 sec TTL.
+	origLock2, err := ha.LockWith(lockkey, "baz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	{
+		lock2 := origLock2.(*PostgreSQLLock)
+		lock2.renewInterval = renewInterval
+		lock2.ttlSeconds = lockTTL
+		lock2.retryInterval = retryInterval
+
+		// Cancel attempt in 6 sec so as not to block unit tests forever
+		stopCh := make(chan struct{})
+		time.AfterFunc(time.Duration(lockTTL*2)*time.Second, func() {
+			close(stopCh)
+		})
+
+		// Attempt to lock should work
+		lockTime := time.Now()
+		leaderCh2, err := lock2.Lock(stopCh)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if leaderCh2 == nil {
+			t.Fatalf("should get leader ch")
+		}
+		defer lock2.Unlock()
+
+		// Check the value
+		held, val, err := lock2.Value()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !held {
+			if tries < maxTries && time.Since(lockTime) > (time.Second*time.Duration(lockTTL)) {
+				// Our test environment is slow enough that we failed this, retry
+				return false
+			}
+			t.Fatalf("should be held")
+		}
+		if val != "baz" {
+			t.Fatalf("bad value: %v", val)
+		}
+	}
+	// The first lock should have lost the leader channel
+	select {
+	case <-time.After(longRenewInterval * 2):
+		t.Fatalf("original lock did not have its leader channel closed.")
+	case <-leaderCh:
+	}
+	return true
+}
+
+// Verify that once Unlock is called, we don't keep trying to renew the original
+// lock.
+func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
+	// Get the lock
+	origLock, err := ha.LockWith("pgrenewal", "bar")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// customize the renewal and watch intervals
+	lock := origLock.(*PostgreSQLLock)
+	// lock.renewInterval = time.Second * 1
+
+	// Attempt to lock
+	leaderCh, err := lock.Lock(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if leaderCh == nil {
+		t.Fatalf("failed to get leader ch")
+	}
+
+	// Check the value
+	held, val, err := lock.Value()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !held {
+		t.Fatalf("should be held")
+	}
+	if val != "bar" {
+		t.Fatalf("bad value: %v", val)
+	}
+
+	// Release the lock, which will delete the stored item
+	if err := lock.Unlock(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Wait longer than the renewal time
+	time.Sleep(1500 * time.Millisecond)
+
+	// Attempt to lock with new lock
+	newLock, err := ha.LockWith("pgrenewal", "baz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	timeout := time.Duration(lock.ttlSeconds)*time.Second + lock.retryInterval + time.Second
+
+	var leaderCh2 <-chan struct{}
+	newlockch := make(chan struct{})
+	go func() {
+		leaderCh2, err = newLock.Lock(stopCh)
+		close(newlockch)
+	}()
+
+	// Cancel attempt after lock ttl + 1s so as not to block unit tests forever
+	select {
+	case <-time.After(timeout):
+		t.Logf("giving up on lock attempt after %v", timeout)
+		close(stopCh)
+	case <-newlockch:
+		// pass through
+	}
+
+	// Attempt to lock should work
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if leaderCh2 == nil {
+		t.Fatalf("should get leader ch")
+	}
+
+	// Check the value
+	held, val, err = newLock.Value()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !held {
+		t.Fatalf("should be held")
+	}
+	if val != "baz" {
+		t.Fatalf("bad value: %v", val)
+	}
+
+	// Cleanup
+	newLock.Unlock()
+}
+
+func setupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend) {
+	var err error
+	// Setup tables and indexes if not exists.
+	createTableSQL := fmt.Sprintf(
+		"  CREATE TABLE IF NOT EXISTS %v ( "+
+			"  parent_path TEXT COLLATE \"C\" NOT NULL, "+
+			"  path        TEXT COLLATE \"C\", "+
+			"  key         TEXT COLLATE \"C\", "+
+			"  value       BYTEA, "+
+			"  CONSTRAINT pkey PRIMARY KEY (path, key) "+
+			" ); ", pg.table)
+
+	_, err = pg.client.Exec(createTableSQL)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	createIndexSQL := fmt.Sprintf(" CREATE INDEX IF NOT EXISTS parent_path_idx ON %v (parent_path); ", pg.table)
+
+	_, err = pg.client.Exec(createIndexSQL)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	createHaTableSQL := " CREATE TABLE IF NOT EXISTS vault_ha_locks ( " +
+		" ha_key                                      TEXT COLLATE \"C\" NOT NULL, " +
+		" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, " +
+		" ha_value                                    TEXT COLLATE \"C\", " +
+		" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, " +
+		" CONSTRAINT ha_key PRIMARY KEY (ha_key) " +
+		" ); "
+
+	_, err = pg.client.Exec(createHaTableSQL)
+	if err != nil {
+		t.Fatalf("Failed to create hatable: %v", err)
+	}
+}

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -28,7 +28,7 @@ func TestPostgreSQLBackend(t *testing.T) {
 
 	table := os.Getenv("PGTABLE")
 	if table == "" {
-		table = "vault_kv_store"
+		table = "openbao_kv_store"
 	}
 
 	hae := os.Getenv("PGHAENABLED")

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -22,8 +22,7 @@ func TestPostgreSQLBackend(t *testing.T) {
 	// Use docker as pg backend if no url is provided via environment variables
 	connURL := os.Getenv("PGURL")
 	if connURL == "" {
-		cleanup, u := postgresql.PrepareTestContainer(t, "11.1")
-		defer cleanup()
+		_, u := postgresql.PrepareTestContainer(t, "11.1")
 		connURL = u
 	}
 
@@ -66,7 +65,7 @@ func TestPostgreSQLBackend(t *testing.T) {
 	}
 	logger.Info(fmt.Sprintf("Postgres Version: %v", pgversion))
 
-	setupDatabaseObjects(t, logger, pg)
+	SetupDatabaseObjects(t, logger, pg)
 
 	defer func() {
 		pg := b1.(*PostgreSQLBackend)
@@ -385,42 +384,4 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 
 	// Cleanup
 	newLock.Unlock()
-}
-
-func setupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend) {
-	var err error
-	// Setup tables and indexes if not exists.
-	createTableSQL := fmt.Sprintf(
-		"  CREATE TABLE IF NOT EXISTS %v ( "+
-			"  parent_path TEXT COLLATE \"C\" NOT NULL, "+
-			"  path        TEXT COLLATE \"C\", "+
-			"  key         TEXT COLLATE \"C\", "+
-			"  value       BYTEA, "+
-			"  CONSTRAINT pkey PRIMARY KEY (path, key) "+
-			" ); ", pg.table)
-
-	_, err = pg.client.Exec(createTableSQL)
-	if err != nil {
-		t.Fatalf("Failed to create table: %v", err)
-	}
-
-	createIndexSQL := fmt.Sprintf(" CREATE INDEX IF NOT EXISTS parent_path_idx ON %v (parent_path); ", pg.table)
-
-	_, err = pg.client.Exec(createIndexSQL)
-	if err != nil {
-		t.Fatalf("Failed to create index: %v", err)
-	}
-
-	createHaTableSQL := " CREATE TABLE IF NOT EXISTS vault_ha_locks ( " +
-		" ha_key                                      TEXT COLLATE \"C\" NOT NULL, " +
-		" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, " +
-		" ha_value                                    TEXT COLLATE \"C\", " +
-		" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, " +
-		" CONSTRAINT ha_key PRIMARY KEY (ha_key) " +
-		" ); "
-
-	_, err = pg.client.Exec(createHaTableSQL)
-	if err != nil {
-		t.Fatalf("Failed to create hatable: %v", err)
-	}
 }

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -65,7 +65,7 @@ func TestPostgreSQLBackend(t *testing.T) {
 	}
 	logger.Info(fmt.Sprintf("Postgres Version: %v", pgversion))
 
-	SetupDatabaseObjects(t, logger, pg)
+	SetupDatabaseObjects(t, pg)
 
 	defer func() {
 		pg := b1.(*PostgreSQLBackend)

--- a/physical/postgresql/testing.go
+++ b/physical/postgresql/testing.go
@@ -9,9 +9,12 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	_ "github.com/jackc/pgx/v4/stdlib"
+	thpsql "github.com/openbao/openbao/helper/testhelpers/postgresql"
+	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/stretchr/testify/require"
 )
 
-func SetupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend) {
+func SetupDatabaseObjects(t *testing.T, pg *PostgreSQLBackend) {
 	var err error
 	// Setup tables and indexes if not exists.
 	createTableSQL := fmt.Sprintf(
@@ -35,16 +38,31 @@ func SetupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend
 		t.Fatalf("Failed to create index: %v", err)
 	}
 
-	createHaTableSQL := " CREATE TABLE IF NOT EXISTS openbao_ha_locks ( " +
-		" ha_key                                      TEXT COLLATE \"C\" NOT NULL, " +
-		" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, " +
-		" ha_value                                    TEXT COLLATE \"C\", " +
-		" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, " +
-		" CONSTRAINT ha_key PRIMARY KEY (ha_key) " +
-		" ); "
+	createHaTableSQL := fmt.Sprintf(
+		" CREATE TABLE IF NOT EXISTS %v ( "+
+			" ha_key                                      TEXT COLLATE \"C\" NOT NULL, "+
+			" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, "+
+			" ha_value                                    TEXT COLLATE \"C\", "+
+			" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, "+
+			" CONSTRAINT ha_key PRIMARY KEY (ha_key) "+
+			" ); ", pg.ha_table)
 
 	_, err = pg.client.Exec(createHaTableSQL)
 	if err != nil {
 		t.Fatalf("Failed to create hatable: %v", err)
 	}
+}
+
+func GetTestPostgreSQLBackend(t *testing.T, logger log.Logger) (physical.Backend, func()) {
+	cleanup, url := thpsql.PrepareTestContainer(t, "11.1")
+
+	pg, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": url,
+		"ha_enable":      "true",
+	}, logger)
+	require.NoError(t, err, "failed initializing postgres database")
+
+	SetupDatabaseObjects(t, pg.(*PostgreSQLBackend))
+
+	return pg, cleanup
 }

--- a/physical/postgresql/testing.go
+++ b/physical/postgresql/testing.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	_ "github.com/jackc/pgx/v4/stdlib"
+)
+
+func SetupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend) {
+	var err error
+	// Setup tables and indexes if not exists.
+	createTableSQL := fmt.Sprintf(
+		"  CREATE TABLE IF NOT EXISTS %v ( "+
+			"  parent_path TEXT COLLATE \"C\" NOT NULL, "+
+			"  path        TEXT COLLATE \"C\", "+
+			"  key         TEXT COLLATE \"C\", "+
+			"  value       BYTEA, "+
+			"  CONSTRAINT pkey PRIMARY KEY (path, key) "+
+			" ); ", pg.table)
+
+	_, err = pg.client.Exec(createTableSQL)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	createIndexSQL := fmt.Sprintf(" CREATE INDEX IF NOT EXISTS parent_path_idx ON %v (parent_path); ", pg.table)
+
+	_, err = pg.client.Exec(createIndexSQL)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	createHaTableSQL := " CREATE TABLE IF NOT EXISTS vault_ha_locks ( " +
+		" ha_key                                      TEXT COLLATE \"C\" NOT NULL, " +
+		" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, " +
+		" ha_value                                    TEXT COLLATE \"C\", " +
+		" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, " +
+		" CONSTRAINT ha_key PRIMARY KEY (ha_key) " +
+		" ); "
+
+	_, err = pg.client.Exec(createHaTableSQL)
+	if err != nil {
+		t.Fatalf("Failed to create hatable: %v", err)
+	}
+}

--- a/physical/postgresql/testing.go
+++ b/physical/postgresql/testing.go
@@ -35,7 +35,7 @@ func SetupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend
 		t.Fatalf("Failed to create index: %v", err)
 	}
 
-	createHaTableSQL := " CREATE TABLE IF NOT EXISTS vault_ha_locks ( " +
+	createHaTableSQL := " CREATE TABLE IF NOT EXISTS openbao_ha_locks ( " +
 		" ha_key                                      TEXT COLLATE \"C\" NOT NULL, " +
 		" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, " +
 		" ha_value                                    TEXT COLLATE \"C\", " +

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -123,6 +123,10 @@ LANGUAGE plpgsql;
   for storing high availability information. This table must already exist (OpenBao
   will not attempt to create it).
 
+- `upsert_function` `(string: "openbao_kv_put")` – Specifies the name of the
+  function to execute for upsert capabilities on PostgreSQL versions earlier
+  than 9.5. This function must already exist. See above documentation.
+
 ## `postgresql` examples
 
 ### Custom SSL verification

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -1,0 +1,151 @@
+---
+sidebar_label: PostgreSQL Storage
+description: |-
+  The PostgreSQL storage backend is used to persist OpenBao's data in a PostgreSQL
+  server or cluster.
+---
+
+# PostgreSQL storage backend
+
+:::warning
+
+**Note**: The PostgreSQL Storage Backend is in early preview. Use at your own
+risk. Some breaking changes may occur prior to GA.
+
+:::
+
+The PostgreSQL storage backend is used to persist OpenBao's data in a
+[PostgreSQL][postgresql] server or cluster.
+
+- **High Availability** – the PostgreSQL storage backend supports
+  high availability. Requires PostgreSQL 9.5 or later.
+
+- **Community Supported** – the PostgreSQL storage backend is supported by the
+  community. While it has undergone review by HashiCorp employees, they may not
+  be as knowledgeable about the technology. If you encounter problems with them,
+  you may be referred to the original author.
+
+```hcl
+storage "postgresql" {
+  connection_url = "postgres://user123:secret123!@localhost:5432/openbao"
+}
+```
+
+:::warning
+
+**Note**: The PostgreSQL storage backend plugin will attempt to use SSL
+when connecting to the database. If SSL is not enabled the `connection_url`
+will need to be configured to disable SSL. See the documentation below
+to disable SSL.
+
+:::
+
+The PostgreSQL storage backend does not automatically create the table. Here is
+some sample SQL to create the schema and indexes.
+
+```sql
+CREATE TABLE openbao_kv_store (
+  parent_path TEXT COLLATE "C" NOT NULL,
+  path        TEXT COLLATE "C",
+  key         TEXT COLLATE "C",
+  value       BYTEA,
+  CONSTRAINT pkey PRIMARY KEY (path, key)
+);
+
+CREATE INDEX parent_path_idx ON openbao_kv_store (parent_path);
+```
+
+Store for HAEnabled backend
+
+```sql
+CREATE TABLE openbao_ha_locks (
+  ha_key                                      TEXT COLLATE "C" NOT NULL,
+  ha_identity                                 TEXT COLLATE "C" NOT NULL,
+  ha_value                                    TEXT COLLATE "C",
+  valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL,
+  CONSTRAINT ha_key PRIMARY KEY (ha_key)
+);
+```
+
+If you're using a version of PostgreSQL prior to 9.5, create the following function:
+
+```sql
+CREATE FUNCTION openbao_kv_put(_parent_path TEXT, _path TEXT, _key TEXT, _value BYTEA) RETURNS VOID AS
+$$
+BEGIN
+    LOOP
+        -- first try to update the key
+        UPDATE openbao_kv_store
+          SET (parent_path, path, key, value) = (_parent_path, _path, _key, _value)
+          WHERE _path = path AND key = _key;
+        IF found THEN
+            RETURN;
+        END IF;
+        -- not there, so try to insert the key
+        -- if someone else inserts the same key concurrently,
+        -- we could get a unique-key failure
+        BEGIN
+            INSERT INTO openbao_kv_store (parent_path, path, key, value)
+              VALUES (_parent_path, _path, _key, _value);
+            RETURN;
+        EXCEPTION WHEN unique_violation THEN
+            -- Do nothing, and loop to try the UPDATE again.
+        END;
+    END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+```
+
+## `postgresql` parameters
+
+- `connection_url` `(string: <required>)` – Specifies the connection string to
+  use to authenticate and connect to PostgreSQL. The connection URL can also be
+  set using the `BAO_PG_CONNECTION_URL` environment variable. A full list of supported
+  parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
+  documentation. For example connection string URLs, see the examples section below.
+
+- `table` `(string: "openbao_kv_store")` – Specifies the name of the table in
+  which to write OpenBao data. This table must already exist (OpenBao will not
+  attempt to create it).
+
+- `max_idle_connections` `(int)` - Default not set. Sets the maximum number of
+  connections in the idle connection pool. See
+  [golang docs on SetMaxIdleConns][golang_setmaxidleconns] for more information.
+  Requires 1.2 or later.
+
+- `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
+  requests to PostgreSQL.
+
+- `ha_enabled` `(string: "true|false")` – Default not enabled, requires 9.5 or later.
+
+- `ha_table` `(string: "openbao_ha_locks")` – Specifies the name of the table to use
+  for storing high availability information. This table must already exist (OpenBao
+  will not attempt to create it).
+
+## `postgresql` examples
+
+### Custom SSL verification
+
+This example shows connecting to a PostgreSQL cluster using full SSL
+verification (recommended).
+
+```hcl
+storage "postgresql" {
+  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=verify-full"
+}
+```
+
+To disable SSL verification (not recommended), replace `verify-full` with
+`disable`:
+
+```hcl
+storage "postgresql" {
+  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=disable"
+}
+```
+
+[golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
+[postgresql]: https://www.postgresql.org/
+[pgxlib]: https://pkg.go.dev/github.com/jackc/pgx/stdlib
+[pg_conn_docs]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -106,6 +106,7 @@ const sidebars: SidebarsConfig = {
                         "configuration/storage/filesystem",
                         "configuration/storage/in-memory",
                         "configuration/storage/raft",
+                        "configuration/storage/postgresql",
                     ],
                 },
                 "configuration/telemetry",


### PR DESCRIPTION
This starts to re-adds the Postgres storage engine, albeit without transaction support.

We still ~need to add it to the backend binary itself (see e.g. [here](https://github.com/openbao/openbao/blob/0dcb5778fce69c6948d84d2982c3d6aa698ae425/command/server.go#L458-L464) and [here](https://github.com/openbao/openbao/blob/0dcb5778fce69c6948d84d2982c3d6aa698ae425/command/commands.go#L147-L152) and more)~ and, once the testing portion of #292 merges, we'll want to add this to the relevant test suite.

I'm reopening this in case someone else wants to pick up the work to make this Postgres backend transactional while I focus on other portions of the Transactional storage PR series.

---

Related: #270