### PR TITLE
Ensure modifying entries do not affect cache

### DIFF
--- a/changelog/483.txt
+++ b/changelog/483.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/cache: Ensure later modifications to entry do not impact cached value.
+```


### PR DESCRIPTION
Previously, modifications to the storage entry (after performing a put call) could impact the value saved in cache. While likely not common in actual plugins (unless a large number of writes are performed), this pattern is common in tests, to reuse a single Entry for multiple direct write operations.

Switch to creating a deep copied entry to prevent future modifications to the entry from impacting the cache.