### PR TITLE
Add docker-based website viewer

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,17 @@
+## Dockerfile adapted from https://docusaurus.community/knowledge/deployment/docker/.
+
+## Start with a base image containing NodeJS so we can build Docusaurus.
+FROM node:lts
+
+## Enable corepack.
+RUN corepack enable
+
+## Set the working directory to `/opt/docusaurus`.
+VOLUME /opt/docusaurus
+WORKDIR /opt/docusaurus
+
+## Expose the port that Docusaurus will run on.
+EXPOSE 3000
+
+## Run the development server.
+CMD [ -d "node_modules" ] && npm run start -- --host 0.0.0.0 --poll 1000 || npm install && npm run start -- --host 0.0.0.0 --poll 1000

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,8 @@
 NPM := $(shell which npm)
+DOCKER?=docker
+
+# For Podman, invoke via `make docker-start DOCKER=podman DOCKER_MOUNT_ARGS=,chown=true,relabel=shared`
+DOCKER_MOUNT_ARGS?=
 
 .PHONY: start, clean, deploy, serve, install, build
 
@@ -21,3 +25,7 @@ node_modules: package.json
 	@$(NPM) install
 
 install: node_modules
+
+docker-start:
+	$(DOCKER) build -t openbao-docs .
+	$(DOCKER) run -p 3000:3000 --mount "type=bind,source=$(CURDIR),destination=/opt/docusaurus$(DOCKER_MOUNT_ARGS)" -it openbao-docs


### PR DESCRIPTION
This adds a new `Dockerfile` and command to enable users to run the website without installing any dependencies locally besides Docker.

In my case, my work laptop lacks `npm` and I've gotten good mileage off of this instead. :-) 

It looks like between v1 and v2 of Docusaurus, they've quit provisioning the `Dockerfile` automatically. 