### PR TITLE
Support transactions in BarrierView

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -104,13 +104,13 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 	}
 	viewPath := entry.ViewPath()
 	view := NewBarrierView(c.barrier, viewPath)
-	origViewReadOnlyErr := view.getReadOnlyErr()
+	origViewReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
 	// ensure that it is reset after. This ensures that there will be no
 	// writes during the construction of the backend.
-	view.setReadOnlyErr(logical.ErrSetupReadOnly)
-	defer view.setReadOnlyErr(origViewReadOnlyErr)
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	defer view.SetReadOnlyErr(origViewReadOnlyErr)
 
 	// Lookup the new backend
 	backend, err := c.newAuditBackend(ctx, entry, view, entry.Options)
@@ -390,14 +390,14 @@ func (c *Core) setupAudits(ctx context.Context) error {
 		// Create a barrier view using the UUID
 		viewPath := entry.ViewPath()
 		view := NewBarrierView(c.barrier, viewPath)
-		origViewReadOnlyErr := view.getReadOnlyErr()
+		origViewReadOnlyErr := view.GetReadOnlyErr()
 
 		// Mark the view as read-only until the mounting is complete and
 		// ensure that it is reset after. This ensures that there will be no
 		// writes during the construction of the backend.
-		view.setReadOnlyErr(logical.ErrSetupReadOnly)
+		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			view.setReadOnlyErr(origViewReadOnlyErr)
+			view.SetReadOnlyErr(origViewReadOnlyErr)
 		})
 
 		// Initialize the backend

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -19,7 +19,7 @@ import (
 
 type backendEntry struct {
 	backend audit.Backend
-	view    *BarrierView
+	view    BarrierView
 	local   bool
 }
 
@@ -41,7 +41,7 @@ func NewAuditBroker(log log.Logger) *AuditBroker {
 }
 
 // Register is used to add new audit backend to the broker
-func (a *AuditBroker) Register(name string, b audit.Backend, v *BarrierView, local bool) {
+func (a *AuditBroker) Register(name string, b audit.Backend, v BarrierView, local bool) {
 	a.Lock()
 	defer a.Unlock()
 	a.backends[name] = backendEntry{

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -31,7 +31,7 @@ type auditedHeaderSettings struct {
 type AuditedHeadersConfig struct {
 	Headers map[string]*auditedHeaderSettings
 
-	view *BarrierView
+	view BarrierView
 	sync.RWMutex
 }
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -152,13 +152,13 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	viewPath := entry.ViewPath()
 	view := NewBarrierView(c.barrier, viewPath)
 
-	origViewReadOnlyErr := view.getReadOnlyErr()
+	origViewReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
 	// ensure that it is reset after. This ensures that there will be no
 	// writes during the construction of the backend.
-	view.setReadOnlyErr(logical.ErrSetupReadOnly)
-	defer view.setReadOnlyErr(origViewReadOnlyErr)
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	defer view.SetReadOnlyErr(origViewReadOnlyErr)
 
 	var backend logical.Backend
 	// Create the new backend
@@ -202,7 +202,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 
 	// restore the original readOnlyErr, so we can write to the view in
 	// Initialize() if necessary
-	view.setReadOnlyErr(origViewReadOnlyErr)
+	view.SetReadOnlyErr(origViewReadOnlyErr)
 	// initialize, using the core's active context.
 	err = backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
 	if err != nil {
@@ -706,14 +706,14 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 
 		view := NewBarrierView(c.barrier, viewPath)
 
-		origViewReadOnlyErr := view.getReadOnlyErr()
+		origViewReadOnlyErr := view.GetReadOnlyErr()
 
 		// Mark the view as read-only until the mounting is complete and
 		// ensure that it is reset after. This ensures that there will be no
 		// writes during the construction of the backend.
-		view.setReadOnlyErr(logical.ErrSetupReadOnly)
+		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 		if strutil.StrListContains(singletonMounts, entry.Type) {
-			defer view.setReadOnlyErr(origViewReadOnlyErr)
+			defer view.SetReadOnlyErr(origViewReadOnlyErr)
 		}
 
 		// Initialize the backend
@@ -814,7 +814,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 				return
 			}
 			if !strutil.StrListContains(singletonMounts, localEntry.Type) {
-				view.setReadOnlyErr(origViewReadOnlyErr)
+				view.SetReadOnlyErr(origViewReadOnlyErr)
 			}
 
 			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})

--- a/vault/barrier_view.go
+++ b/vault/barrier_view.go
@@ -11,6 +11,14 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
+// BarrierCore defines the core operations unique to BarrierView.
+type BarrierCore interface {
+	Prefix() string
+	SubView(string) BarrierView
+	SetReadOnlyErr(error)
+	GetReadOnlyErr() error
+}
+
 // BarrierView wraps a SecurityBarrier and ensures all access is automatically
 // prefixed. This is used to prevent anyone with access to the view to access
 // any data in the durable storage outside of their prefix. Conceptually this
@@ -18,60 +26,107 @@ import (
 //
 // BarrierView implements logical.Storage so it can be passed in as the
 // durable storage mechanism for logical views.
-type BarrierView struct {
+type BarrierView interface {
+	logical.Storage
+	BarrierCore
+}
+
+type barrierView struct {
 	storage         logical.StorageView
 	readOnlyErr     error
 	readOnlyErrLock sync.RWMutex
-	iCheck          interface{}
 }
+
+var _ BarrierView = &barrierView{}
+
+// TransactionalBarrierView is like BarrierView but transactional.
+type TransactionalBarrierView interface {
+	logical.TransactionalStorage
+	BarrierCore
+}
+
+type transactionalBarrierView struct {
+	barrierView
+}
+
+var (
+	_ BarrierView              = &transactionalBarrierView{}
+	_ TransactionalBarrierView = &transactionalBarrierView{}
+)
+
+// BarrierViewTransaction is the result of beginning a transaction on a
+// BarrierView.
+type BarrierViewTransaction interface {
+	logical.Transaction
+	BarrierCore
+}
+
+type barrierViewTransaction struct {
+	barrierView
+	wasReadOnly bool
+}
+
+var (
+	_ BarrierView            = &barrierViewTransaction{}
+	_ logical.Transaction    = &barrierViewTransaction{}
+	_ BarrierViewTransaction = &barrierViewTransaction{}
+)
 
 // NewBarrierView takes an underlying security barrier and returns
 // a view of it that can only operate with the given prefix.
-func NewBarrierView(barrier logical.Storage, prefix string) *BarrierView {
-	return &BarrierView{
-		storage: logical.NewStorageView(barrier, prefix),
+func NewBarrierView(barrier logical.Storage, prefix string) BarrierView {
+	return newBarrierView(logical.NewStorageView(barrier, prefix))
+}
+
+func newBarrierView(s logical.StorageView) BarrierView {
+	bv := &barrierView{
+		storage: s,
 	}
+
+	if _, ok := s.(logical.TransactionalStorageView); ok {
+		return &transactionalBarrierView{
+			*bv,
+		}
+	}
+
+	return bv
 }
 
-func (v *BarrierView) setICheck(iCheck interface{}) {
-	v.iCheck = iCheck
-}
-
-func (v *BarrierView) setReadOnlyErr(readOnlyErr error) {
+func (v *barrierView) SetReadOnlyErr(readOnlyErr error) {
 	v.readOnlyErrLock.Lock()
 	defer v.readOnlyErrLock.Unlock()
 	v.readOnlyErr = readOnlyErr
 }
 
-func (v *BarrierView) getReadOnlyErr() error {
+func (v *barrierView) GetReadOnlyErr() error {
 	v.readOnlyErrLock.RLock()
 	defer v.readOnlyErrLock.RUnlock()
 	return v.readOnlyErr
 }
 
-func (v *BarrierView) Prefix() string {
+func (v *barrierView) Prefix() string {
 	return v.storage.Prefix()
 }
 
-func (v *BarrierView) List(ctx context.Context, prefix string) ([]string, error) {
+func (v *barrierView) List(ctx context.Context, prefix string) ([]string, error) {
 	return v.storage.List(ctx, prefix)
 }
 
-func (v *BarrierView) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+func (v *barrierView) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
 	return v.storage.ListPage(ctx, prefix, after, limit)
 }
 
-func (v *BarrierView) Get(ctx context.Context, key string) (*logical.StorageEntry, error) {
+func (v *barrierView) Get(ctx context.Context, key string) (*logical.StorageEntry, error) {
 	return v.storage.Get(ctx, key)
 }
 
 // Put differs from List/Get because it checks read-only errors
-func (v *BarrierView) Put(ctx context.Context, entry *logical.StorageEntry) error {
+func (v *barrierView) Put(ctx context.Context, entry *logical.StorageEntry) error {
 	if entry == nil {
 		return errors.New("cannot write nil entry")
 	}
 
-	roErr := v.getReadOnlyErr()
+	roErr := v.GetReadOnlyErr()
 	if roErr != nil {
 		return roErr
 	}
@@ -79,9 +134,8 @@ func (v *BarrierView) Put(ctx context.Context, entry *logical.StorageEntry) erro
 	return v.storage.Put(ctx, entry)
 }
 
-// logical.Storage impl.
-func (v *BarrierView) Delete(ctx context.Context, key string) error {
-	roErr := v.getReadOnlyErr()
+func (v *barrierView) Delete(ctx context.Context, key string) error {
+	roErr := v.GetReadOnlyErr()
 	if roErr != nil {
 		return roErr
 	}
@@ -90,10 +144,51 @@ func (v *BarrierView) Delete(ctx context.Context, key string) error {
 }
 
 // SubView constructs a nested sub-view using the given prefix
-func (v *BarrierView) SubView(prefix string) *BarrierView {
-	return &BarrierView{
-		storage:     v.storage.SubView(prefix),
-		readOnlyErr: v.getReadOnlyErr(),
-		iCheck:      v.iCheck,
+func (v *barrierView) SubView(prefix string) BarrierView {
+	bv := newBarrierView(v.storage.SubView(prefix))
+	bv.SetReadOnlyErr(v.GetReadOnlyErr())
+	return bv
+}
+
+func (v *transactionalBarrierView) BeginReadOnlyTx(ctx context.Context) (logical.Transaction, error) {
+	txn, err := v.barrierView.storage.(logical.TransactionalStorage).BeginReadOnlyTx(ctx)
+	if err != nil {
+		return nil, err
 	}
+
+	return &barrierViewTransaction{
+		barrierView{
+			storage:     txn.(logical.StorageView),
+			readOnlyErr: v.GetReadOnlyErr(),
+		},
+		true,
+	}, nil
+}
+
+func (v *transactionalBarrierView) BeginTx(ctx context.Context) (logical.Transaction, error) {
+	txn, err := v.barrierView.storage.(logical.TransactionalStorage).BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &barrierViewTransaction{
+		barrierView{
+			storage:     txn.(logical.StorageView),
+			readOnlyErr: v.GetReadOnlyErr(),
+		},
+		false,
+	}, nil
+}
+
+func (v *barrierViewTransaction) Commit(ctx context.Context) error {
+	roErr := v.GetReadOnlyErr()
+	if roErr != nil && !v.wasReadOnly {
+		return roErr
+	}
+
+	return v.barrierView.storage.(logical.Transaction).Commit(ctx)
+}
+
+func (v *barrierViewTransaction) Rollback(ctx context.Context) error {
+	return v.barrierView.storage.(logical.Transaction).Rollback(ctx)
 }

--- a/vault/barrier_view_test.go
+++ b/vault/barrier_view_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
-func TestBarrierView_impl(t *testing.T) {
-	var _ logical.Storage = new(BarrierView)
-}
-
 func TestBarrierView_spec(t *testing.T) {
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "foo/")
@@ -298,7 +294,7 @@ func TestBarrierView_Readonly(t *testing.T) {
 	}
 
 	// Enable read only mode
-	view.readOnlyErr = logical.ErrReadOnly
+	view.SetReadOnlyErr(logical.ErrReadOnly)
 
 	// Put should fail in readonly mode
 	if err := view.Put(context.Background(), entry); err != logical.ErrReadOnly {

--- a/vault/core.go
+++ b/vault/core.go
@@ -362,7 +362,7 @@ type Core struct {
 	cubbyholeBackend *CubbyholeBackend
 
 	// systemBarrierView is the barrier view for the system backend
-	systemBarrierView *BarrierView
+	systemBarrierView BarrierView
 
 	// expiration manager is used for managing LeaseIDs,
 	// renewal, expiration and revocation

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -27,7 +27,7 @@ func coreInit(c *Core, conf *CoreConfig) error {
 	return nil
 }
 
-func (c *Core) barrierViewForNamespace(namespaceId string) (*BarrierView, error) {
+func (c *Core) barrierViewForNamespace(namespaceId string) (BarrierView, error) {
 	if namespaceId != namespace.RootNamespaceID {
 		return nil, fmt.Errorf("failed to find barrier view for non-root namespace")
 	}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -99,8 +99,8 @@ type pendingInfo struct {
 type ExpirationManager struct {
 	core       *Core
 	router     *Router
-	idView     *BarrierView
-	tokenView  *BarrierView
+	idView     BarrierView
+	tokenView  BarrierView
 	tokenStore *TokenStore
 	logger     log.Logger
 
@@ -326,7 +326,7 @@ func getNumExpirationWorkers(c *Core, l log.Logger) int {
 
 // NewExpirationManager creates a new ExpirationManager that is backed
 // using a given view, and uses the provided router for revocation.
-func NewExpirationManager(c *Core, view *BarrierView, e ExpireLeaseStrategy, logger log.Logger, detectDeadlocks bool) *ExpirationManager {
+func NewExpirationManager(c *Core, view BarrierView, e ExpireLeaseStrategy, logger log.Logger, detectDeadlocks bool) *ExpirationManager {
 	managerLogger := logger.Named("job-manager")
 	jobManager := fairshare.NewJobManager("expire", getNumExpirationWorkers(c, logger), managerLogger, c.metricSink)
 	jobManager.Start()

--- a/vault/expiration_util.go
+++ b/vault/expiration_util.go
@@ -10,11 +10,11 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
-func (m *ExpirationManager) leaseView(*namespace.Namespace) *BarrierView {
+func (m *ExpirationManager) leaseView(*namespace.Namespace) BarrierView {
 	return m.idView
 }
 
-func (m *ExpirationManager) tokenIndexView(*namespace.Namespace) *BarrierView {
+func (m *ExpirationManager) tokenIndexView(*namespace.Namespace) BarrierView {
 	return m.tokenView
 }
 

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -107,7 +107,7 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 	}
 }
 
-func (b *CubbyholeBackend) revoke(ctx context.Context, view *BarrierView, saltedToken string) error {
+func (b *CubbyholeBackend) revoke(ctx context.Context, view BarrierView, saltedToken string) error {
 	if saltedToken == "" {
 		return fmt.Errorf("client token empty during revocation")
 	}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2876,7 +2876,7 @@ func (b *LoginMFABackend) putMFAConfigByID(ctx context.Context, mConfig *mfa.Con
 	return b.putMFAConfigCommon(ctx, mConfig, loginMFAConfigPrefix, mConfig.ID, barrierView)
 }
 
-func (b *MFABackend) putMFAConfigCommon(ctx context.Context, mConfig *mfa.Config, prefix, suffix string, barrierView *BarrierView) error {
+func (b *MFABackend) putMFAConfigCommon(ctx context.Context, mConfig *mfa.Config, prefix, suffix string, barrierView BarrierView) error {
 	entryIndex := prefix + suffix
 	marshaledEntry, err := proto.Marshal(mConfig)
 	if err != nil {
@@ -2889,7 +2889,7 @@ func (b *MFABackend) putMFAConfigCommon(ctx context.Context, mConfig *mfa.Config
 	})
 }
 
-func (b *MFABackend) getMFAConfig(ctx context.Context, path string, barrierView *BarrierView) (*mfa.Config, error) {
+func (b *MFABackend) getMFAConfig(ctx context.Context, path string, barrierView BarrierView) (*mfa.Config, error) {
 	entry, err := barrierView.Get(ctx, path)
 	if err != nil {
 		return nil, err
@@ -2908,7 +2908,7 @@ func (b *MFABackend) getMFAConfig(ctx context.Context, path string, barrierView 
 	return &mConfig, nil
 }
 
-func (b *LoginMFABackend) getMFALoginEnforcementConfig(ctx context.Context, path string, barrierView *BarrierView) (*mfa.MFAEnforcementConfig, error) {
+func (b *LoginMFABackend) getMFALoginEnforcementConfig(ctx context.Context, path string, barrierView BarrierView) (*mfa.MFAEnforcementConfig, error) {
 	entry, err := barrierView.Get(ctx, path)
 	if err != nil {
 		return nil, err

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -649,15 +649,15 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	viewPath := entry.ViewPath()
 	view := NewBarrierView(c.barrier, viewPath)
 
-	origReadOnlyErr := view.getReadOnlyErr()
+	origReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
 	// ensure that it is reset after. This ensures that there will be no
 	// writes during the construction of the backend.
-	view.setReadOnlyErr(logical.ErrSetupReadOnly)
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 	// We defer this because we're already up and running so we don't need to
 	// time it for after postUnseal
-	defer view.setReadOnlyErr(origReadOnlyErr)
+	defer view.SetReadOnlyErr(origReadOnlyErr)
 
 	var backend logical.Backend
 	sysView := c.mountEntrySysView(entry)
@@ -705,7 +705,7 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 
 	// restore the original readOnlyErr, so we can write to the view in
 	// Initialize() if necessary
-	view.setReadOnlyErr(origReadOnlyErr)
+	view.SetReadOnlyErr(origReadOnlyErr)
 	// initialize, using the core's active context.
 	err = backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
 	if err != nil {
@@ -1394,14 +1394,14 @@ func (c *Core) setupMounts(ctx context.Context) error {
 		// Create a barrier storage view using the UUID
 		view := NewBarrierView(c.barrier, barrierPath)
 
-		origReadOnlyErr := view.getReadOnlyErr()
+		origReadOnlyErr := view.GetReadOnlyErr()
 
 		// Mark the view as read-only until the mounting is complete and
 		// ensure that it is reset after. This ensures that there will be no
 		// writes during the construction of the backend.
-		view.setReadOnlyErr(logical.ErrSetupReadOnly)
+		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 		if strutil.StrListContains(singletonMounts, entry.Type) {
-			defer view.setReadOnlyErr(origReadOnlyErr)
+			defer view.SetReadOnlyErr(origReadOnlyErr)
 		}
 
 		var backend logical.Backend
@@ -1476,7 +1476,7 @@ func (c *Core) setupMounts(ctx context.Context) error {
 				return
 			}
 			if !strutil.StrListContains(singletonMounts, localEntry.Type) {
-				view.setReadOnlyErr(origReadOnlyErr)
+				view.SetReadOnlyErr(origReadOnlyErr)
 			}
 
 			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
@@ -1756,7 +1756,7 @@ func (c *Core) singletonMountTables() (mounts, auth *MountTable) {
 	return
 }
 
-func (c *Core) setCoreBackend(entry *MountEntry, backend logical.Backend, view *BarrierView) {
+func (c *Core) setCoreBackend(entry *MountEntry, backend logical.Backend, view BarrierView) {
 	switch entry.Type {
 	case mountTypeSystem:
 		c.systemBackend = backend.(*SystemBackend)

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -538,7 +538,7 @@ func testCore_Unmount_Cleanup(t *testing.T, causeFailure bool) {
 	}
 
 	if causeFailure {
-		view.(*BarrierView).setReadOnlyErr(logical.ErrSetupReadOnly)
+		view.(BarrierView).SetReadOnlyErr(logical.ErrSetupReadOnly)
 	}
 
 	// Unmount, this should cleanup

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -45,7 +45,7 @@ var (
 // plugins are automatically detected and included in the catalog.
 type PluginCatalog struct {
 	builtinRegistry BuiltinRegistry
-	catalogView     *BarrierView
+	catalogView     BarrierView
 	directory       string
 	logger          log.Logger
 

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -150,7 +150,7 @@ var (
 // manage ACLs associated with them.
 type PolicyStore struct {
 	core    *Core
-	aclView *BarrierView
+	aclView BarrierView
 
 	tokenPoliciesLRU *lru.TwoQueueCache
 	egpLRU           *lru.TwoQueueCache
@@ -177,7 +177,7 @@ type PolicyEntry struct {
 
 // NewPolicyStore creates a new PolicyStore that is backed
 // using a given view. It used used to durable store and manage named policy.
-func NewPolicyStore(ctx context.Context, core *Core, baseView *BarrierView, system logical.SystemView, logger log.Logger) (*PolicyStore, error) {
+func NewPolicyStore(ctx context.Context, core *Core, baseView BarrierView, system logical.SystemView, logger log.Logger) (*PolicyStore, error) {
 	ps := &PolicyStore{
 		aclView:    baseView.SubView(policyACLSubPath),
 		modifyLock: new(sync.RWMutex),
@@ -382,7 +382,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	index := ps.cacheKey(ns, name)
 
 	var cache *lru.TwoQueueCache
-	var view *BarrierView
+	var view BarrierView
 
 	switch policyType {
 	case PolicyTypeACL:

--- a/vault/policy_store_util.go
+++ b/vault/policy_store_util.go
@@ -9,11 +9,11 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 )
 
-func (ps *PolicyStore) getACLView(*namespace.Namespace) *BarrierView {
+func (ps *PolicyStore) getACLView(*namespace.Namespace) BarrierView {
 	return ps.aclView
 }
 
-func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) *BarrierView {
+func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) BarrierView {
 	return ps.getACLView(ns)
 }
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -166,7 +166,7 @@ func (re *routeEntry) SaltID(id string) string {
 
 // Mount is used to expose a logical backend at a given prefix, using a unique salt,
 // and the barrier view for that path.
-func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *MountEntry, storageView *BarrierView) error {
+func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *MountEntry, storageView BarrierView) error {
 	r.l.Lock()
 	defer r.l.Unlock()
 

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -56,7 +56,7 @@ func TestRouter_Mount(t *testing.T) {
 		t.Fatalf("bad: %s", path)
 	}
 
-	if v := r.MatchingStorageByAPIPath(namespace.RootContext(nil), "prod/aws/foo"); v.(*BarrierView) != view {
+	if v := r.MatchingStorageByAPIPath(namespace.RootContext(nil), "prod/aws/foo"); v.(BarrierView) != view {
 		t.Fatalf("bad: %v", v)
 	}
 
@@ -163,7 +163,7 @@ func TestRouter_MountCredential(t *testing.T) {
 		t.Fatalf("bad: %s", path)
 	}
 
-	if v := r.MatchingStorageByAPIPath(namespace.RootContext(nil), "auth/aws/foo"); v.(*BarrierView) != view {
+	if v := r.MatchingStorageByAPIPath(namespace.RootContext(nil), "auth/aws/foo"); v.(BarrierView) != view {
 		t.Fatalf("bad: %v", v)
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -117,7 +117,7 @@ var (
 		if storage == nil {
 			return fmt.Errorf("no cubby mount entry")
 		}
-		view := storage.(*BarrierView)
+		view := storage.(BarrierView)
 
 		switch {
 		case te.NamespaceID == namespace.RootNamespaceID && !IsServiceToken(te.ID):
@@ -713,11 +713,11 @@ type TokenStore struct {
 
 	batchTokenEncryptor BarrierEncryptor
 
-	baseBarrierView     *BarrierView
-	idBarrierView       *BarrierView
-	accessorBarrierView *BarrierView
-	parentBarrierView   *BarrierView
-	rolesBarrierView    *BarrierView
+	baseBarrierView     BarrierView
+	idBarrierView       BarrierView
+	accessorBarrierView BarrierView
+	parentBarrierView   BarrierView
+	rolesBarrierView    BarrierView
 
 	expiration *ExpirationManager
 
@@ -2180,7 +2180,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			if view == nil {
 				return fmt.Errorf("no cubby mount entry")
 			}
-			bview := view.(*BarrierView)
+			bview := view.(BarrierView)
 
 			cubbyholeKeys, err := bview.List(quitCtx, "")
 			if err != nil {

--- a/vault/token_store_util.go
+++ b/vault/token_store_util.go
@@ -7,22 +7,22 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 )
 
-func (ts *TokenStore) baseView(ns *namespace.Namespace) *BarrierView {
+func (ts *TokenStore) baseView(ns *namespace.Namespace) BarrierView {
 	return ts.baseBarrierView
 }
 
-func (ts *TokenStore) idView(ns *namespace.Namespace) *BarrierView {
+func (ts *TokenStore) idView(ns *namespace.Namespace) BarrierView {
 	return ts.idBarrierView
 }
 
-func (ts *TokenStore) accessorView(ns *namespace.Namespace) *BarrierView {
+func (ts *TokenStore) accessorView(ns *namespace.Namespace) BarrierView {
 	return ts.accessorBarrierView
 }
 
-func (ts *TokenStore) parentView(ns *namespace.Namespace) *BarrierView {
+func (ts *TokenStore) parentView(ns *namespace.Namespace) BarrierView {
 	return ts.parentBarrierView
 }
 
-func (ts *TokenStore) rolesView(ns *namespace.Namespace) *BarrierView {
+func (ts *TokenStore) rolesView(ns *namespace.Namespace) BarrierView {
 	return ts.rolesBarrierView
 }


### PR DESCRIPTION
This converts `BarrierView` to an interface, updating definitions
everywhere to use it as such. This lets us replace it with two different
structs (`barrierView` and `transacitonalBarrierView`) depending on whether
the underlying physical storage supports transactions.

Note that `BarrierView` is a translation layer, like
`logical.LogicalStorage`, which converts from a `physical.Backend` to a
`logical.Storage` instance. This means `BarrierView` is not itself
stackable.

`BarrierView` is used to ensure mounts only have local access to storage
and cannot impact other plugins' data.