### PR TITLE
Add transactions to PKI

### DIFF
--- a/changelog/498.txt
+++ b/changelog/498.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Use transactions for root generation, issuer import
+```


### PR DESCRIPTION
This adds transactions to PKI in two places:

1. Root generation
2. Intermediate CA import

Notably, because the CRL rebuild isn't strictly important (though, if it fails, we'd prefer to avoid writing the CAs to storage), we do this in a non-transaction backed storage (if available).