### PR TITLE
Add not_before to precisely set validity window start timestamp

### DIFF
--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -1816,13 +1816,15 @@ func TestSSHBackend_ValidateNotBeforeDuration(t *testing.T) {
 	logicaltest.Test(t, testCase)
 }
 
-func TestSSHBackend_ValidadeNotBefore(t *testing.T) {
+func TestSSHBackend_ValidateNotBefore(t *testing.T) {
 	config := logical.TestBackendConfig()
 
 	b, err := Factory(context.Background(), config)
 	if err != nil {
 		t.Fatalf("Cannot create backend: %s", err)
 	}
+
+	pastTime := time.Now().Add(-1 * time.Hour).Round(time.Second)
 
 	testCase := logicaltest.TestCase{
 		LogicalBackend: b,
@@ -1834,21 +1836,11 @@ func TestSSHBackend_ValidadeNotBefore(t *testing.T) {
 				"allow_host_certificates": true,
 				"allowed_domains":         "example.com,example.org",
 				"allow_subdomains":        true,
-				"default_critical_options": map[string]interface{}{
-					"option": "value",
-				},
-				"default_extensions": map[string]interface{}{
-					"extension": "extended",
-				},
-				"not_before": time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+				"not_before":              pastTime.Format(time.RFC3339),
 			}),
 
-			signCertificateStep("testing", "vault-root-22608f5ef173aabf700797cb95c5641e792698ec6380e8e1eb55523e39aa5e51", ssh.HostCert, []string{"dummy.example.org", "second.example.com"}, map[string]string{
-				"option": "value",
-			}, map[string]string{
-				"extension": "extended",
-			},
-				2*time.Hour, map[string]interface{}{
+			signCertificateStep("testing", "vault-root-22608f5ef173aabf700797cb95c5641e792698ec6380e8e1eb55523e39aa5e51", ssh.HostCert, []string{"dummy.example.org", "second.example.com"},
+				nil, nil, 2*time.Hour, map[string]interface{}{
 					"public_key":       publicKey2,
 					"ttl":              "2h",
 					"cert_type":        "host",
@@ -1856,6 +1848,7 @@ func TestSSHBackend_ValidadeNotBefore(t *testing.T) {
 				}),
 		},
 	}
+
 	logicaltest.Test(t, testCase)
 }
 

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -1816,6 +1816,14 @@ func TestSSHBackend_ValidateNotBeforeDuration(t *testing.T) {
 	logicaltest.Test(t, testCase)
 }
 
+func TestSSHBackend_ValidadeNotBefore(t *testing.T) {
+	config := logical.TestBackendConfig()
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Cannot create backend: %s", err)
+	}
+}
 func TestSSHBackend_IssueSign(t *testing.T) {
 	config := logical.TestBackendConfig()
 

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -492,14 +492,14 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 	}
 
 	now := time.Now()
-	var validAfter uint64
+	var validAfter time.Time
 
 	if !b.Role.NotBefore.IsZero() {
-		validAfter = uint64(b.Role.NotBefore.In(time.UTC).Unix())
+		validAfter = b.Role.NotBefore.UTC()
 	} else if b.Role.NotBeforeDuration > 0 {
-		validAfter = uint64(now.Add(-b.Role.NotBeforeDuration).In(time.UTC).Unix())
+		validAfter = now.Add(-b.Role.NotBeforeDuration).UTC()
 	} else {
-		validAfter = uint64(now.In(time.UTC).Unix())
+		validAfter = now.UTC()
 	}
 
 	sshAlgorithmSigner, ok := b.Signer.(ssh.AlgorithmSigner)
@@ -517,8 +517,8 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 		Key:             b.PublicKey,
 		KeyId:           b.KeyID,
 		ValidPrincipals: b.ValidPrincipals,
-		ValidAfter:      validAfter,
-		ValidBefore:     uint64(now.Add(b.TTL).In(time.UTC).Unix()),
+		ValidAfter:      uint64(validAfter.Unix()),
+		ValidBefore:     uint64(validAfter.Add(b.TTL).Unix()),
 		CertType:        b.CertificateType,
 		Permissions: ssh.Permissions{
 			CriticalOptions: b.CriticalOptions,

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -493,13 +493,17 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 
 	now := time.Now()
 	var validAfter time.Time
+	var validBefore time.Time
 
 	if !b.Role.NotBefore.IsZero() {
 		validAfter = b.Role.NotBefore.UTC()
+		validBefore = validAfter.Add(b.TTL)
 	} else if b.Role.NotBeforeDuration > 0 {
 		validAfter = now.Add(-b.Role.NotBeforeDuration).UTC()
+		validBefore = now.Add(b.TTL).UTC()
 	} else {
 		validAfter = now.UTC()
+		validBefore = now.Add(b.TTL).UTC()
 	}
 
 	sshAlgorithmSigner, ok := b.Signer.(ssh.AlgorithmSigner)
@@ -518,7 +522,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 		KeyId:           b.KeyID,
 		ValidPrincipals: b.ValidPrincipals,
 		ValidAfter:      uint64(validAfter.Unix()),
-		ValidBefore:     uint64(validAfter.Add(b.TTL).Unix()),
+		ValidBefore:     uint64(validBefore.Unix()),
 		CertType:        b.CertificateType,
 		Permissions: ssh.Permissions{
 			CriticalOptions: b.CriticalOptions,

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -365,7 +365,8 @@ func pathRoles(b *backend) *framework.Path {
 				},
 			},
 			"not_before_duration": {
-				Type: framework.TypeDurationSecond,
+				Type:    framework.TypeDurationSecond,
+				Default: 30,
 				Description: `
 				[Not applicable for OTP type] [Optional for CA type]
    				The duration that the SSH certificate should be backdated by at issuance.`,

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -365,7 +365,7 @@ func pathRoles(b *backend) *framework.Path {
 				},
 			},
 			"not_before_duration": {
-				Type:    framework.TypeDurationSecond,
+				Type: framework.TypeDurationSecond,
 				Description: `
 				[Not applicable for OTP type] [Optional for CA type]
    				The duration that the SSH certificate should be backdated by at issuance.`,

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -521,6 +521,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 		AlgorithmSigner:           signer,
 		Version:                   roleEntryVersion,
 		NotBeforeDuration:         time.Duration(data.Get("not_before_duration").(int)) * time.Second,
+		NotBefore:                 data.Get("not_before").(time.Time),
 	}
 
 	if !role.AllowUserCertificates && !role.AllowHostCertificates {

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -366,7 +366,6 @@ func pathRoles(b *backend) *framework.Path {
 			},
 			"not_before_duration": {
 				Type:    framework.TypeDurationSecond,
-				Default: 30,
 				Description: `
 				[Not applicable for OTP type] [Optional for CA type]
    				The duration that the SSH certificate should be backdated by at issuance.`,

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -540,6 +540,15 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 			`"ttl" value must be less than "max_ttl" when both are specified`)
 	}
 
+	if !role.NotBefore.IsZero() {
+		if role.NotBefore.Before(time.Now()) {
+			return nil, logical.ErrorResponse("'not_before' value can not be in the past")
+		}
+		if ttl != 0 && role.NotBefore.Add(ttl).Before(time.Now()) {
+			return nil, logical.ErrorResponse("'not_before' plus TTL value can not be in the past")
+		}
+	}
+
 	// Persist TTLs
 	role.TTL = ttl.String()
 	role.MaxTTL = maxTTL.String()

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -540,15 +540,6 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 			`"ttl" value must be less than "max_ttl" when both are specified`)
 	}
 
-	if !role.NotBefore.IsZero() {
-		if role.NotBefore.Before(time.Now()) {
-			return nil, logical.ErrorResponse("'not_before' value can not be in the past")
-		}
-		if ttl != 0 && role.NotBefore.Add(ttl).Before(time.Now()) {
-			return nil, logical.ErrorResponse("'not_before' plus TTL value can not be in the past")
-		}
-	}
-
 	// Persist TTLs
 	role.TTL = ttl.String()
 	role.MaxTTL = maxTTL.String()

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -540,6 +540,12 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 			`"ttl" value must be less than "max_ttl" when both are specified`)
 	}
 
+	if !role.NotBefore.IsZero() {
+		if role.NotBefore.After(time.Now()) {
+			return nil, logical.ErrorResponse("'not_before' value can not be in the future")
+		}
+	}
+
 	// Persist TTLs
 	role.TTL = ttl.String()
 	role.MaxTTL = maxTTL.String()

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -66,6 +66,7 @@ type sshRole struct {
 	AlgorithmSigner            string            `mapstructure:"algorithm_signer" json:"algorithm_signer"`
 	Version                    int               `mapstructure:"role_version" json:"role_version"`
 	NotBeforeDuration          time.Duration     `mapstructure:"not_before_duration" json:"not_before_duration"`
+	NotBefore                  time.Time         `mapstructure:"not_before" json:"not_before"`
 }
 
 func pathListRoles(b *backend) *framework.Path {

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -723,6 +723,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 			"allowed_user_key_lengths":    role.AllowedUserKeyTypesLengths,
 			"algorithm_signer":            role.AlgorithmSigner,
 			"not_before_duration":         int64(role.NotBeforeDuration.Seconds()),
+			"not_before":                  role.NotBefore,
 		}
 	case KeyTypeDynamic:
 		return nil, fmt.Errorf("dynamic key type roles are no longer supported")

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -375,6 +375,16 @@ func pathRoles(b *backend) *framework.Path {
 					Value: 30,
 				},
 			},
+			"not_before": {
+				Type: framework.TypeTime,
+				Description: `
+				[Not applicable for OTP type] [Optional for CA type]
+      	The time before which the certificate is not valid. This is specified as a RFC3339 formatted string.
+        If specified, takes precedence over 'not_before_duration'.`,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "Not Before",
+				},
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{


### PR DESCRIPTION
## Overview

This PR introduces the `not_before` configuration option to the SSH role, addressing the need for precise control over certificate validity. This is a reimplementation of a previous attempt ([#487](https://github.com/openbao/openbao/pull/487)), incorporating feedback received, implementing the feature in a new branch and with a new name.

This will also be a draft, the feature itself is functional, but there is an unresolved issue with TTL calculation (this is what's causing tests to fail). Specifically, when `not_before` is specified, the TTL is consistently off by 30 seconds. I suspect this issue may be related to the default value of `not_before_duration`, but I haven't been able to pinpoint what piece of code causes this, even after tinkering with it for some days.

### Test Output

```
--- FAIL: TestSSHBackend_ValidateNotBefore (0.01s)
    testing.go:365: Failed step 3: incorrect ttl: expected: 2h0m0s, actual 1h59m30s
```

I decided to open the PR anyways and seek assistance to resolve this issue before the feature is merged. More tests, a changelog entry and docs updates will be added too.

## Related Issues

Resolves [#485](https://github.com/openbao/openbao/issues/485), [#24084](https://github.com/hashicorp/vault/issues/24084)

## Target Release

1.14.7