### PR TITLE
Add meetings to community website section

### DIFF
--- a/website/content/docs/contributing/index.mdx
+++ b/website/content/docs/contributing/index.mdx
@@ -11,6 +11,32 @@ programmers, or even those curious about what OpenBao is! For more
 general information, see our [`CONTRIBUTING.md`](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md)
 document in the root of [our repository](https://github.com/openbao/openbao).
 
+## Community calls
+
+The public community call is hosted every non-holiday Thursday, at 8AM Pacific,
+11AM Eastern for 30 minutes on Zoom. After joining the [mailing
+list](https://lists.lfedge.org/g/openbao), the [calendar](https://lists.lfedge.org/g/openbao/calendar)
+includes a link to subscribe to invite notifications and the Zoom bridge for
+the call.
+
+Feel free to join and/or send agenda topics via email, GitHub discussion, or
+on the Matrix server!
+
+[Meeting recordings](https://lf-edge.atlassian.net/wiki/spaces/OH/pages/15211863/OpenBao+Meetings)
+are available on the LF Edge's Confluence wiki page.
+
+## TSC calls
+
+The public Technical Steering Committee (TSC) calls are hosted every second
+Thursday of the month at 7AM Pacific, 10AM Eastern for 30 minutes on Zoom.
+This bridge is stable from past meets and can be found from the recordings
+below.
+
+Feel free to join!
+
+[Meeting recordings](https://lf-edge.atlassian.net/wiki/spaces/OH/pages/15210975/OpenBao+TSC+Meetings)
+and agendas are available on the LF Edge's Confluence wiki page.
+
 ## Development guides
 
  - To ease contribution, we've put together a [code organization](/docs/contributing/code-organization)


### PR DESCRIPTION
After a past attendee noticed that recordings were hard to find, it would be good to place these on our website so they're in a central place.