### PR TITLE
fix command `vault print token` to `bao print token` in curl string generated by `buildCurlString()` 

### DIFF
--- a/api/output_string.go
+++ b/api/output_string.go
@@ -81,7 +81,7 @@ func (d *OutputStringError) buildCurlString() (string, error) {
 	for k, v := range d.Request.Header {
 		for _, h := range v {
 			if strings.ToLower(k) == "x-vault-token" {
-				h = `$(vault print token)`
+				h = `$(bao print token)`
 			}
 			finalCurlString = fmt.Sprintf("%s-H \"%s: %s\" ", finalCurlString, k, h)
 		}

--- a/changelog/511.txt
+++ b/changelog/511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api/output_string: Change vault reference to bao.
+```


### PR DESCRIPTION
This is a trivial fix to ensure the curl string generated by `buildCurlString()`, invoked by the `-output-curl-string` flag, actually uses the `bao` client instead of attempting to use the `vault` client.

## Resolves

https://github.com/openbao/openbao/issues/510

## Target Release

Next minor release
