### PR TITLE
Fix aliasNameFromLoginRequest panic

### DIFF
--- a/changelog/512.txt
+++ b/changelog/512.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix server panic on AppRole login requests with invalid parameter typing
+```

--- a/vault/external_tests/approle/alias_name_panic_test.go
+++ b/vault/external_tests/approle/alias_name_panic_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package approle
+
+import (
+	"testing"
+
+	"github.com/openbao/openbao/api/v2"
+	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
+	vaulthttp "github.com/openbao/openbao/http"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppRole_AliasNameFromLoginRequest_Panic(t *testing.T) {
+	var err error
+	coreConfig := &vault.CoreConfig{
+		CredentialBackends: map[string]logical.Factory{
+			"approle": credAppRole.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+	client.SetToken(cluster.RootToken)
+
+	err = client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
+		Type: "approle",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/approle/login", map[string]interface{}{
+		"role_id":   make(map[string]interface{}),
+		"secret_id": "",
+	})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "INTERNAL_ERROR")
+}


### PR DESCRIPTION
In `aliasNameFromLoginRequest`, a malformed request could be routed to the plugin, which resulted in a `logical.ErrorResponse(...)` being returned. This is a "secret" typed response and not an auth response like we're expecting. We'd thus panic:

> 2024-09-05T08:12:48.249+0100 [INFO]  http: panic serving 127.0.0.1:54504: runtime error: invalid memory address or nil pointer dereference
> goroutine 945 [running]:
> net/http.(*conn).serve.func1()
>         /opt/hostedtoolcache/go/1.22.6/x64/src/net/http/server.go:1903 +0xbe
> panic({0x3428060?, 0x649f2d0?})
>         /opt/hostedtoolcache/go/1.22.6/x64/src/runtime/panic.go:770 +0x132
> github.com/openbao/openbao/vault.(*Core).aliasNameFromLoginRequest(0xc000806e08, {0x45622f8, 0xc000d6f530}, 0xc00080c1a0)
>         /home/runner/work/openbao/openbao/vault/core.go:3692 +0x37a
> github.com/openbao/openbao/vault.(*Core).getLoginUserInfoKey(0xc001104540?, {0x45622f8?, 0xc000d6f530?}, 0xc00059b180, 0xc001104540?)
>         /home/runner/work/openbao/openbao/vault/request_handling.go:1710 +0x29

Instead, update this handler to properly return both error cases: an error from the request handling and a `logical.ErrorResponse(...)`, converting the latter into a regular error again.

This also addresses a case in `doResolveRoleLocked` where a similar panic could potentially occur, though without the error resolution.

Resolves: #509 