### PR TITLE
Add sys/internal/inspect/request endpoint

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -65,6 +65,7 @@ var sudoPaths = map[string]*regexp.Regexp{
 	"/sys/revoke-force/{prefix}":                    regexp.MustCompile(`^/sys/revoke-force/.+$`),
 	"/sys/revoke-prefix/{prefix}":                   regexp.MustCompile(`^/sys/revoke-prefix/.+$`),
 	"/sys/rotate":                                   regexp.MustCompile(`^/sys/rotate$`),
+	"/sys/internal/inspect/request":                 regexp.MustCompile(`^/sys/internal/inspect/request$`),
 	"/sys/internal/inspect/router/{tag}":            regexp.MustCompile(`^/sys/internal/inspect/router/.+$`),
 }
 

--- a/changelog/513.txt
+++ b/changelog/513.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add endpoint to inspect request information
+```

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -2542,6 +2542,22 @@ func (b *SystemBackend) introspectionPaths() []*framework.Path {
 			HelpSynopsis:    strings.TrimSpace(sysHelp["internal-inspect-router"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["internal-inspect-router"][1]),
 		},
+		{
+			Pattern: "internal/inspect/request",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "internal",
+				OperationVerb:   "inspect",
+				OperationSuffix: "request",
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathInternalInspectRequest,
+					Summary:  "Expose all request information to the caller",
+				},
+			},
+			HelpSynopsis:    strings.TrimSpace(sysHelp["internal-inspect-request"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["internal-inspect-request"][1]),
+		},
 	}
 }
 

--- a/website/content/api-docs/system/inspect/index.mdx
+++ b/website/content/api-docs/system/inspect/index.mdx
@@ -21,4 +21,5 @@ enable. Once the endpoint is turned on, it can be accessed with a root token or 
 
 ## Supported inspection paths
 
+- [Request](/api-docs/system/inspect/request)
 - [Router](/api-docs/system/inspect/router)

--- a/website/content/api-docs/system/inspect/request.mdx
+++ b/website/content/api-docs/system/inspect/request.mdx
@@ -1,0 +1,103 @@
+---
+description: >-
+  The '/sys/internal/inspect/request' endpoint focuses on viewing the contents of specific structures in the request.
+---
+
+# `/sys/internal/inspect/request`
+
+The `/sys/internal/inspect/request` endpoint is intended for an OpenBao admin
+or developer to inspect the internal components of OpenBao's request
+structures, including entity and group information.
+
+This endpoint can be accessed with a root token or sudo privileges.
+
+| Method | Path          |
+| :----- | :------------ |
+| `GET`  | `/sys/internal/inspect/request/root` |
+
+## Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/internal/inspect/request
+```
+
+## Sample response
+
+```json
+{
+  "request_id": "abbaaa32-a234-e010-3041-fc5e35f88f8b",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "cluster_id": "e39cb9bf-faf3-5bc0-3857-375f032b2487",
+    "cluster_id_error": null,
+    "data": {},
+    "entity": {
+      "ID": "c207eba9-ea92-c474-965d-54dfe357eeac",
+      "aliases": [
+        {
+          "ID": "f5a14b19-6bfb-3cf5-91fb-1421fbceeab0",
+          "metadata": {
+            "my-keyword": "value",
+            "role_name": "testing"
+          },
+          "mount_accessor": "auth_approle_bf30e678",
+          "mount_type": "approle",
+          "name": "032f0687-3553-4fc4-60f1-97a2f6748fd6",
+          "namespace_id": "root"
+        }
+      ],
+      "name": "entity_6afb48a7"
+    },
+    "entity_error": null,
+    "groups": [],
+    "groups_error": null,
+    "plugin_env": {
+      "vault_version": "2.0.0",
+      "vault_version_prerelease": "HEAD"
+    },
+    "plugin_env_error": null,
+    "req": {
+      "ClientTokenSource": 1,
+      "InboundSSCToken": "",
+      "auth": null,
+      "client_id": "c207eba9-ea92-c474-965d-54dfe357eeac",
+      "client_token": "s.cCrFGPcc4HVdrXovkkOzhZkK",
+      "client_token_accessor": "h5tDsSFp8SZL0wHCDSI9cE4k",
+      "client_token_remaining_uses": 0,
+      "connection": {
+        "ConnState": null,
+        "remote_addr": "127.0.0.1",
+        "remote_port": 41032
+      },
+      "display_name": "approle",
+      "entity_id": "c207eba9-ea92-c474-965d-54dfe357eeac",
+      "headers": {},
+      "id": "abbaaa32-a234-e010-3041-fc5e35f88f8b",
+      "map": null,
+      "mfa_creds": null,
+      "mount_accessor": "",
+      "mount_point": "sys/",
+      "mount_type": "system",
+      "operation": "read",
+      "path": "internal/inspect/request",
+      "policy_override": false,
+      "replication_cluster": "",
+      "secret": null,
+      "unauthenticated": false,
+      "wrap_info": null
+    },
+    "vault_version": "2.0.0",
+    "vault_version_error": null
+  },
+  "warnings": null
+}
+```
+
+Note that the value of some fields, such as `client_token`, may differ because
+this handler is in the privileged System backend which does not have HMAC
+protections applied to sensitive fields. For a list of such fields, see
+[`sdk/logical/request.go`](https://github.com/openbao/openbao/blob/main/sdk/logical/request.go).

--- a/website/sidebarsApi.ts
+++ b/website/sidebarsApi.ts
@@ -96,6 +96,7 @@ const sidebars: SidebarsConfig = {
         {
           "sys/internal/inspect": [
             "system/inspect/index",
+            "system/inspect/request",
             "system/inspect/router",
           ],
         },


### PR DESCRIPTION
This adds an endpoint to allow introspection of request data for developers and admins. For instance, one could validate that entity metadata is begin set appropriately or the plugin environment information.