### PR TITLE
(secrets/pki): add not_before parameter

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -226,6 +226,7 @@ func TestPKI_DeviceCert(t *testing.T) {
 		"allow_bare_domains": true,
 		"allow_subdomains":   true,
 		"not_after":          "9999-12-31T23:59:59Z",
+		"not_before":         "1900-01-01T00:00:00Z",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -252,6 +253,10 @@ func TestPKI_DeviceCert(t *testing.T) {
 	notAfter = cert.NotAfter.Format(time.RFC3339)
 	if notAfter != "9999-12-31T23:59:59Z" {
 		t.Fatal(fmt.Errorf("not after from certificate  is not matching with input parameter"))
+	}
+	notBefore := cert.NotBefore.Format(time.RFC3339)
+	if notBefore != "1900-01-01T00:00:00Z" {
+		t.Fatal(fmt.Errorf("not before from certificate  is not matching with input parameter"))
 	}
 }
 
@@ -3868,6 +3873,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 		"allowed_domains_template":           false,
 		"allow_token_displayname":            false,
 		"country":                            []interface{}{},
+		"not_before":                         "",
 		"not_after":                          "",
 		"postal_code":                        []interface{}{},
 		"use_csr_common_name":                true,

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -235,3 +235,23 @@ func TestPki_PermitFQDNs(t *testing.T) {
 		})
 	}
 }
+
+func TestPki_getCertificateNotBefore(t *testing.T) {
+	data := inputBundle{
+		role: &roleEntry{
+			NotBefore: "2024-12-31T23:59:59Z",
+		},
+		apiData: &framework.FieldData{},
+	}
+
+	expectedNotBefore := "2024-12-31 23:59:59 +0000 UTC"
+
+	notBefore, err := getCertificateNotBefore(&data)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if expectedNotBefore != notBefore.String() {
+		t.Fatalf("Expected Not Before %v, got %v", expectedNotBefore, notBefore)
+	}
+}

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -143,6 +143,12 @@ be larger than the role max TTL.`,
 		},
 	}
 
+	fields["not_before"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Set the not before field of the certificate with specified date value.
+The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
+	}
+
 	fields["not_after"] = &framework.FieldSchema{
 		Type: framework.TypeString,
 		Description: `Set the not after field of the certificate with specified date value.
@@ -274,6 +280,12 @@ See RFC 4519 Section 2.31 'serialNumber' for a description of this field.
 If you want more than one, specify alternative names in the alt_names
 map using OID 2.5.4.5. This has no impact on the final certificate's
 Serial Number field.`,
+	}
+
+	fields["not_before"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Set the not before field of the certificate with specified date value.
+The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
 	fields["not_after"] = &framework.FieldSchema{

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -77,6 +77,11 @@ func buildPathIssue(b *backend, pattern string, displayAttrs *framework.DisplayA
 								Description: `Serial Number`,
 								Required:    true,
 							},
+							"not_before": {
+								Type:        framework.TypeInt64,
+								Description: `Starting time of validity`,
+								Required:    true,
+							},
 							"expiration": {
 								Type:        framework.TypeInt64,
 								Description: `Time of expiration`,
@@ -187,6 +192,11 @@ func buildPathSign(b *backend, pattern string, displayAttrs *framework.DisplayAt
 								Description: `Serial Number`,
 								Required:    true,
 							},
+							"not_before": {
+								Type:        framework.TypeInt64,
+								Description: `Starting time of validity`,
+								Required:    true,
+							},
 							"expiration": {
 								Type:        framework.TypeInt64,
 								Description: `Time of expiration`,
@@ -278,6 +288,11 @@ func buildPathIssuerSignVerbatim(b *backend, pattern string, displayAttrs *frame
 							"serial_number": {
 								Type:        framework.TypeString,
 								Description: `Serial Number`,
+								Required:    true,
+							},
+							"not_before": {
+								Type:        framework.TypeInt64,
+								Description: `Starting time of validity`,
 								Required:    true,
 							},
 							"expiration": {
@@ -470,6 +485,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	caChainGen := newCaChainOutput(parsedBundle, data)
 
 	respData := map[string]interface{}{
+		"not_before":    int64(parsedBundle.Certificate.NotBefore.Unix()),
 		"expiration":    int64(parsedBundle.Certificate.NotAfter.Unix()),
 		"serial_number": cb.SerialNumber,
 	}

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -398,6 +398,11 @@ information, which must include an oid, and may include a notice and/or cps url,
 			Type:        framework.TypeInt64,
 			Description: `The duration in seconds before now which the certificate needs to be backdated by.`,
 		},
+		"not_before": {
+			Type: framework.TypeString,
+			Description: `Set the not before field of the certificate with specified date value.
+The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ.`,
+		},
 		"not_after": {
 			Type: framework.TypeString,
 			Description: `Set the not after field of the certificate with specified date value.
@@ -818,6 +823,11 @@ information, which must include an oid, and may include a notice and/or cps url,
 					Value: 30,
 				},
 			},
+			"not_before": {
+				Type: framework.TypeString,
+				Description: `Set the not before field of the certificate with specified date value.
+The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ.`,
+			},
 			"not_after": {
 				Type: framework.TypeString,
 				Description: `Set the not after field of the certificate with specified date value.
@@ -1119,6 +1129,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		PolicyIdentifiers:             getPolicyIdentifier(data, nil),
 		BasicConstraintsValidForNonCA: data.Get("basic_constraints_valid_for_non_ca").(bool),
 		NotBeforeDuration:             time.Duration(data.Get("not_before_duration").(int)) * time.Second,
+		NotBefore:                     data.Get("not_before").(string),
 		NotAfter:                      data.Get("not_after").(string),
 		Issuer:                        data.Get("issuer_ref").(string),
 		Name:                          name,
@@ -1319,6 +1330,7 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		PolicyIdentifiers:             getPolicyIdentifier(data, &oldEntry.PolicyIdentifiers),
 		BasicConstraintsValidForNonCA: getWithExplicitDefault(data, "basic_constraints_valid_for_non_ca", oldEntry.BasicConstraintsValidForNonCA).(bool),
 		NotBeforeDuration:             getTimeWithExplicitDefault(data, "not_before_duration", oldEntry.NotBeforeDuration),
+		NotBefore:                     data.Get("not_before").(string),
 		NotAfter:                      getWithExplicitDefault(data, "not_after", oldEntry.NotAfter).(string),
 		Issuer:                        getWithExplicitDefault(data, "issuer_ref", oldEntry.Issuer).(string),
 	}
@@ -1529,6 +1541,7 @@ type roleEntry struct {
 	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids"`
 	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca"`
 	NotBeforeDuration             time.Duration `json:"not_before_duration"`
+	NotBefore                     string        `json:"not_before"`
 	NotAfter                      string        `json:"not_after"`
 	Issuer                        string        `json:"issuer"`
 	// Name is only set when the role has been stored, on the fly roles have a blank name
@@ -1581,6 +1594,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"policy_identifiers":                 r.PolicyIdentifiers,
 		"basic_constraints_valid_for_non_ca": r.BasicConstraintsValidForNonCA,
 		"not_before_duration":                int64(r.NotBeforeDuration.Seconds()),
+		"not_before":                         r.NotBefore,
 		"not_after":                          r.NotAfter,
 		"issuer_ref":                         r.Issuer,
 	}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -359,6 +359,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},
+		NotBefore:                 data.Get("not_before").(string),
 		NotAfter:                  data.Get("not_after").(string),
 		NotBeforeDuration:         time.Duration(data.Get("not_before_duration").(int)) * time.Second,
 		CNValidations:             []string{"disabled"},

--- a/changelog/515.txt
+++ b/changelog/515.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: add `not_before` parameter to precisely define a certificate's "not before" field.
+```

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -774,6 +774,7 @@ type CreationParameters struct {
 	IsCA                          bool
 	KeyType                       string
 	KeyBits                       int
+	NotBefore                     time.Time
 	NotAfter                      time.Time
 	KeyUsage                      x509.KeyUsage
 	ExtKeyUsage                   CertExtKeyUsage

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -677,6 +677,11 @@ field if `format=pem_bundle` parameter is specified.
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
 
+ `not_before` `(string)` - Specifies the Not Before field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
+
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
@@ -998,6 +1003,11 @@ path and takes the value `default`.
   of the requested certificate, specified in the `ttl` field.
   Uses [duration format strings](/docs/concepts/duration-format).
 
+- `not_before` `(string)` - Specifies the Not Before field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
+
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format
   `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
@@ -1258,6 +1268,11 @@ extension is missing from the CSR.
   `pem_bundle`, the `certificate` field will contain the certificate and, if the
   issuing CA is not an OpenBao-derived self-signed root, it will be concatenated
   with the certificate.
+
+- `not_before` `(string)` - Specifies the Not Before field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
 
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format
@@ -2252,6 +2267,11 @@ and thus should not be used: `ed25519`.
   backdate the NotBefore property. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.
   Uses [duration format strings](/docs/concepts/duration-format).
+
+- `not_before` `(string)` - Set the Not Before field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
 
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format
@@ -3570,6 +3590,11 @@ based on this parameter.
 
 - `not_before_duration` `(duration: "30s")` - Specifies the duration by which to
   backdate the NotBefore property. This value has no impact in the validity period
+  of the requested certificate, specified in the `ttl` field.
+
+- `not_before` `(string)` - Set the Not Before field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.
 
 - `not_after` `(string)` - Set the Not After field of the certificate with


### PR DESCRIPTION
I went ahead and created a first draft PR.

I let the existing `not_before_duration` but made it so that `not_before` take precedence over it. As with `not_before_duration`, `not_before` has currently no impact on TTL. I am not sure if we should change that. 
Maybe we should even get rid of `not_before_duration` all together?

I noticed there was no existing test in for `getCertificateNotAfter`. Anyway, I added a very simple one for `getCertificateNotBefore`. I need to double-check if we need some other test somewhere else.

Resolves #490 

(I also noticed my editor made some linting on save, hope it's fine; otherwise I can revert it).