### PR TITLE
Improve download page

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -48,8 +48,21 @@
  * as even moderately sized screens will cause the buttons to exceed the
  * size of their container.
  */
-@media screen and (max-width:1400px) {
-  div.download-card .button-group--block {
-    flex-wrap: wrap;
-  }
+div.download-card div.button-group--block {
+  flex-wrap: wrap;
+}
+
+div.download-card a.button {
+  padding: 0px 0px !important;
+}
+
+div.download-card a.button span {
+  display: inline-block;
+  margin:
+    calc(
+      var(--ifm-button-padding-vertical) * var(--ifm-button-size-multiplier) * 1.50
+    )
+    calc(
+      var(--ifm-button-padding-horizontal) * var(--ifm-button-size-multiplier) * 0.50
+    );
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -66,3 +66,14 @@ div.download-card a.button span {
       var(--ifm-button-padding-horizontal) * var(--ifm-button-size-multiplier) * 0.50
     );
 }
+
+@media (max-width: 500px) {
+  div.all-downloads nav.pagination-nav {
+    grid-template-columns: 1fr;
+  }
+
+  div.all-downloads nav.pagination-nav div.download-card {
+    max-width: 85%;
+    margin: 0 auto;
+  }
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -54,6 +54,7 @@ div.download-card div.button-group--block {
 
 div.download-card a.button {
   padding: 0px 0px !important;
+  border-radius: var(--ifm-button-border-radius) !important;
 }
 
 div.download-card a.button span {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -27,4 +27,29 @@
   --ifm-color-primary-lighter: #99cfbf;
   --ifm-color-primary-lightest: #b9ded3;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  /*
+   * Fix shadow on all cards in dark mode. This was too light for the display
+   * to view on certain background colors.
+   */
+  --ifm-global-shadow-lw: 0 1px 2px 0 rgba(255, 255, 255, 0.1);
+}
+
+/*
+ * Make our download page cards a darker color in dark mode so they look
+ * visually different than the main part of the page.
+ */
+[data-theme="dark"] div.download-card {
+  background-color: var(--ifm-background-color);
+}
+
+/*
+ * Allow buttons to reflow on smaller width screens. Smaller is relative
+ * as even moderately sized screens will cause the buttons to exceed the
+ * size of their container.
+ */
+@media screen and (max-width:1400px) {
+  div.download-card .button-group--block {
+    flex-wrap: wrap;
+  }
 }

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -158,18 +158,18 @@ const Asset = ({ urls }) => {
                 </div>
                 <div className="card__footer">
                     <div class="button-group button-group--block">
-                        <a class="button button--primary" href={asset}>Download</a>
+                        <a class="button button--primary" href={asset}><span>Download</span></a>
                         {
                             gpgSig &&
-                            <a class="button button--secondary" href={gpgSig}>GPG Signature</a>
+                            <a class="button button--secondary" href={gpgSig}><span>GPG Signature</span></a>
                         }
                         {
                             coSig &&
-                            <a class="button button--secondary" href={coSig}>Cosign Signature</a>
+                            <a class="button button--secondary" href={coSig}><span>Cosign Signature</span></a>
                         }
                         {
                             coCert &&
-                            <a class="button button--secondary" href={coCert}>Cosign Certificate</a>
+                            <a class="button button--secondary" href={coCert}><span>Cosign Certificate</span></a>
                         }
                     </div>
                 </div>

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -142,7 +142,8 @@ const Asset = ({ urls }) => {
 
     const { selectedItem } = useOptions();
     return (
-        <div className="pagination-nav__item card">
+        <div className="card download-card">
+            <div className="pagination-nav__item">
                 <div className="card__header">
                     <h5>
                         <a href={asset}>
@@ -172,6 +173,7 @@ const Asset = ({ urls }) => {
                         }
                     </div>
                 </div>
+            </div>
         </div>
     );
 };

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -136,7 +136,6 @@ const Asset = ({ urls }) => {
     }
 
     if (asset === undefined) {
-        console.trace("UNKOWN ASSET: ", asset, urls, gpgSig, coCert, coSig);
         return;
     }
 
@@ -312,7 +311,7 @@ const DownloadComponent = () => {
         version = selectedItem;
     }
     return (
-        <div className="container margin-vert--lg">
+        <div className="container margin-vert--lg all-downloads">
             <div className="row">
                 <div
                     className="col col--12 text--center margin-horiz--md"


### PR DESCRIPTION
This adds both GPG and Cosign signatures to our download page, improves visibility of our container registries, and mentions where to find our GPG key and SBOMs.

----

<details>

<summary> Full-page screenshot </summary>

![Screenshot 2024-09-11 at 17-22-19 Downloads OpenBao](https://github.com/user-attachments/assets/80ff06bd-5392-4e77-a5fc-d28d1a618ee5)

</details>

Docker switcher:

![image](https://github.com/user-attachments/assets/a95393d7-f8dc-48f7-a080-7ff8934ebc52)

New download card:

![image](https://github.com/user-attachments/assets/0536264e-2753-4875-8645-4ef4c83e9796)

Both the "Download" and label up top ("AMD64 - Debian Package") take you to download the package. 