### PR TITLE
Fix kubernetes Service Registration Guide

### DIFF
--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -26,8 +26,8 @@ service_registration "kubernetes" {
 Alternatively, the namespace and pod name can be set through the following
 environment variables:
 
-- `VAULT_K8S_NAMESPACE`
-- `VAULT_K8S_POD_NAME`
+- `BAO_K8S_NAMESPACE`
+- `BAO_K8S_POD_NAME`
 
 This allows you to set these parameters using
 [the Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/).


### PR DESCRIPTION
I was trying out the Kubernetes service registration in openbao and noticed that, setting up,

`VAULT_K8S_NAMESPACE` and `VAULT_K8S_POD_NAME` env's as described in the documentation does not work. We get the below error,
`[WARN]  service_registration.kubernetes: unable to set initial state due to \"namespace\" is unset, will retry`


Fix - These env's have to be replaced with `BAO_K8S_NAMESPACE` and `BAO_K8S_POD_NAME`