### PR TITLE
Remove Zededa from TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,6 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | James Butcher     | james@iotechsys.com                 |                                            | Brad Corrion (brad@iotechsys.com)       | IOTech Systems            | Member       |
 | Alain Nochimowski | alain.Nochimowski@viaccess-orca.com |                                            | Dan Ghita (dan.ghita@viaccess-orca.com) | Viaccess-Orca             | Member       |
 | Julian Cassignol  | jcassignol@wallix.com               |                                            | Cristian Popi (cpopi@wallix.com)        | Wallix                    | Member       |
-| Michael Maxey     | maxey@zededa.com                    |                                            |                                         | Zededa                    | Member       |
 
 
 ### OpenBao Working Groups

--- a/website/src/components/Supporters/index.tsx
+++ b/website/src/components/Supporters/index.tsx
@@ -27,10 +27,6 @@ const SupportList: SupportItem[] = [
         description: "Open-source community efforts",
     },
     {
-        title: "ZEDEDA",
-        description: "Open-source community efforts",
-    },
-    {
         title: "Viaccess-Orca",
         description: "Development; open-source community efforts",
     },


### PR DESCRIPTION
Per clarification, Michael Maxey intends to resign from the TSC on behalf of Zededa without replacement by Zededa.

See also: https://lists.lfedge.org/g/OpenBao-TSC/topic/zededa_and_open_bao/108134993

---

The change in PCC has also been made.