### PR TITLE
Update "vault-" label to "openbao-" in documentation

### DIFF
--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -97,7 +97,7 @@ metadata:
 - `openbao-sealed` `(string: "true"/"false")` – openbao-sealed is updated dynamically each
   time OpenBao's sealed/unsealed status changes. True indicates that OpenBao is currently sealed. False indicates that OpenBao
   is currently unsealed.
-- `openbao-version` `(string: "2.0.1")` – Openbao version is a string that will not change during a pod's lifecycle.
+- `openbao-version` `(string: "2.0.1")` – OpenBao version is a string that will not change during a pod's lifecycle.
 
 ## Working with OpenBao's service discovery labels
 

--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -66,11 +66,11 @@ kind: Pod
 metadata:
   name: openbao
   labels:
-    vault-active: "false"
-    vault-initialized: "true"
-    vault-perf-standby: "false"
-    vault-sealed: "false"
-    vault-version: 1.14.0
+    openbao-active: "false"
+    openbao-initialized: "true"
+    openbao-perf-standby: "false"
+    openbao-sealed: "false"
+    openbao-version: 2.0.1
 ```
 
 After shutdowns, OpenBao pods will bear the following labels:
@@ -81,30 +81,30 @@ kind: Pod
 metadata:
   name: openbao
   labels:
-    vault-active: "false"
-    vault-initialized: "false"
-    vault-perf-standby: "false"
-    vault-sealed: "true"
-    vault-version: 1.14.0
+    openbao-active: "false"
+    openbao-initialized: "false"
+    openbao-perf-standby: "false"
+    openbao-sealed: "true"
+    openbao-version: 2.0.1
 ```
 
 ## Label definitions
 
-- `vault-active` `(string: "true"/"false")` – Vault active is updated dynamically each time OpenBao's active status changes.
+- `openbao-active` `(string: "true"/"false")` – openbao-active is updated dynamically each time OpenBao's active status changes.
   True indicates that this OpenBao pod is currently the leader. False indicates that this OpenBao pod is currently a standby.
-- `vault-initialized` `(string: "true"/"false")` – Vault initialized is updated dynamically each time OpenBao's initialization
+- `openbao-initialized` `(string: "true"/"false")` – openbao-initialized is updated dynamically each time OpenBao's initialization
   status changes. True indicates that OpenBao is currently initialized. False indicates the OpenBao is currently uninitialized.
-- `vault-sealed` `(string: "true"/"false")` – Vault sealed is updated dynamically each
+- `openbao-sealed` `(string: "true"/"false")` – openbao-sealed is updated dynamically each
   time OpenBao's sealed/unsealed status changes. True indicates that OpenBao is currently sealed. False indicates that OpenBao
   is currently unsealed.
-- `vault-version` `(string: "1.14.0")` – Vault version is a string that will not change during a pod's lifecycle.
+- `openbao-version` `(string: "2.0.1")` – Openbao version is a string that will not change during a pod's lifecycle.
 
 ## Working with OpenBao's service discovery labels
 
 ### Example service
 
 With labels applied to the pod, services can be created using selectors to filter pods with specific OpenBao HA roles,
-effectively allowing direct communication with subsets of OpenBao pods. Note the `vault-active: "true"` line below.
+effectively allowing direct communication with subsets of OpenBao pods. Note the `openbao-active: "true"` line below.
 
 ```
 apiVersion: v1
@@ -132,7 +132,7 @@ spec:
     app.kubernetes.io/instance: openbao
     app.kubernetes.io/name: openbao
     component: server
-    vault-active: "true"
+    openbao-active: "true"
   type: ClusterIP
 ```
 
@@ -147,11 +147,11 @@ In conjunction with the pod labels and the `OnDelete` upgrade strategy, upgrades
 ```shell-session
 $ helm upgrade openbao --set='server.image.tag=1.14.0'
 
-$ kubectl delete pod --selector=vault-active=false \
-    --selector=vault-version=1.2.3
+$ kubectl delete pod --selector=openbao-active=false \
+    --selector=openbao-version=2.0.1
 
-$ kubectl delete pod --selector=vault-active=true \
-    --selector=vault-version=1.2.3
+$ kubectl delete pod --selector=openbao-active=true \
+    --selector=openbao-version=2.0.1
 ```
 
 When deleting an instance of a pod, the `Statefulset` defining the desired state of the cluster will reschedule the


### PR DESCRIPTION
Update all occurrences of `vault-` label with `openbao-` in Kubernetes service registration documentation.

PR : https://github.com/openbao/openbao/pull/416 updated all `vault-` prefix with `openbao-`.

This PR updates the documentation for the same.