### PR TITLE
Transit: Support signing a CSR template and setting a certificate chain

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -76,7 +76,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathCacheConfig(),
 			b.pathConfigKeys(),
 			b.pathCreateCSR(),
-			// b.pathImportCertChain(),
+			b.pathImportCertChain(),
 		},
 
 		Secrets:      []*framework.Secret{},

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -75,6 +75,8 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathTrim(),
 			b.pathCacheConfig(),
 			b.pathConfigKeys(),
+			b.pathCreateCSR(),
+			// b.pathImportCertChain(),
 		},
 
 		Secrets:      []*framework.Secret{},

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -38,7 +38,7 @@ func (b *backend) pathCreateCSR() *framework.Path {
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathCreateCSRWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "write",
+					OperationVerb: "get-csr",
 				},
 			},
 		},
@@ -49,7 +49,7 @@ func (b *backend) pathCreateCSR() *framework.Path {
 
 func (b *backend) pathImportCertChain() *framework.Path {
 	return &framework.Path{
-		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set_certificate",
+		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set-certificate",
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeString,
@@ -71,7 +71,7 @@ func (b *backend) pathImportCertChain() *framework.Path {
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathImportCertChainWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "write",
+					OperationVerb: "set-chain",
 				},
 			},
 		},

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -49,7 +49,7 @@ func (b *backend) pathCreateCSR() *framework.Path {
 
 func (b *backend) pathImportCertChain() *framework.Path {
 	return &framework.Path{
-		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set-certificate",
+		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set_certificate",
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeString,

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -257,5 +257,5 @@ const (
 	pathCreateCSRHelpDescription = "This path is used to create a CSR for a key in transit. If a CSR template is provided, its significant information, expect key related data, are included in the CSR otherwise an empty CSR is returned. The key in transit must be a signing key and not be derived. The CSR can be signed by the latest version of the key in transit or by a specific version of the key in transit. The custom template must a valid CSR and PEM encoded."
 
 	pathImportCertChainHelpSynopsis    = "Imports an externally-signed certificate chain into an existing key version"
-	pathImportCertChainHelpDescription = "This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate key has to match the selected key."
+	pathImportCertChainHelpDescription = "This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate has to be in the first element and match the selected key."
 )

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
@@ -40,15 +41,58 @@ func (b *backend) pathCreateCSR() *framework.Path {
 					OperationVerb: "write",
 				},
 			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathCreateCSRWrite,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb: "write",
+				},
+			},
 		},
 		HelpSynopsis:    pathCreateCSRHelpSynopsis,
 		HelpDescription: pathCreateCSRHelpDescription,
 	}
 }
 
-// func (b *backend) pathImportCertChain() *framework.Path {
-// 	return nil
-// }
+func (b *backend) pathImportCertChain() *framework.Path {
+	return &framework.Path{
+		// NOTE: `set-certificate` or `set_certificate`? Paths seem to use different
+		// case, such as `transit/wrapping_key` and `transit/cache-config`
+		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set-certificate",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Required:    true,
+				Description: "Name of the key.",
+			},
+			"version": {
+				Type:        framework.TypeInt,
+				Required:    false,
+				Description: "Key version of which the certificate chain is going to be attatched to. If not set, the latest version, `latest`, will be used.",
+			},
+			"certificate_chain": {
+				Type:        framework.TypeString,
+				Required:    true,
+				Description: "PEM encoded certificate chain. It should be composed by one or more concatenated PEM blocks and ordered starting from the end-entity certificate.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathImportCertChainWrite,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb: "write",
+				},
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathImportCertChainWrite,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb: "write",
+				},
+			},
+		},
+		HelpSynopsis:    pathImportCertChainHelpSynopsis,
+		HelpDescription: pathImportCertChainHelpDescription,
+	}
+}
 
 func (b *backend) pathCreateCSRWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	name := data.Get("name").(string)
@@ -80,10 +124,10 @@ func (b *backend) pathCreateCSRWrite(ctx context.Context, req *logical.Request, 
 	}
 
 	// transit key version
-	signingKeyVersion := policy.LatestVersion
+	keyVersion := policy.LatestVersion
 	version, versionSet := data.GetOk("version")
 	if versionSet {
-		signingKeyVersion = version.(int)
+		keyVersion = version.(int)
 	}
 
 	// read and parse CSR template
@@ -93,7 +137,7 @@ func (b *backend) pathCreateCSRWrite(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
-	csr, err := policy.CreateCSR(signingKeyVersion, csrTemplate)
+	csr, err := policy.CreateCSR(keyVersion, csrTemplate)
 	if err != nil {
 		prefixedErr := fmt.Errorf("could not create the csr: %w", err)
 		switch err.(type) {
@@ -124,11 +168,109 @@ func parseCSR(csrTemplate string) (*x509.CertificateRequest, error) {
 	return x509.ParseCertificateRequest(csrBlock.Bytes)
 }
 
+func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	name := data.Get("name").(string)
+
+	policy, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	}, b.GetRandomReader())
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return logical.ErrorResponse(fmt.Sprintf("key with provided name '%s' not found", name)), logical.ErrInvalidRequest
+	}
+
+	if !b.System().CachingDisabled() {
+		policy.Lock(true) // NOTE: Lck as we might write to the policy
+	}
+	defer policy.Unlock()
+
+	// check if transit key supports signing
+	if !policy.Type.SigningSupported() {
+		return logical.ErrorResponse(fmt.Sprintf("key type '%s' does not support signing", policy.Type)), logical.ErrInvalidRequest
+	}
+
+	// check if key can be derived
+	if policy.Derived {
+		return logical.ErrorResponse("operation not supported for keys with derivation enabled"), logical.ErrInvalidRequest
+	}
+
+	// transit key version
+	keyVersion := policy.LatestVersion
+	version, versionSet := data.GetOk("version")
+	if versionSet {
+		keyVersion = version.(int)
+	}
+
+	// get certificate chain
+	pemCertChain := data.Get("certificate_chain").(string)
+	certChain, err := parseCertificateChain(pemCertChain)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	err = policy.ValidateAndPersistCertificateChain(ctx, req.Storage, keyVersion, certChain)
+	if err != nil {
+		prefixedErr := fmt.Errorf("failed to persist certificate chain: %w", err)
+		switch err.(type) {
+		case errutil.UserError:
+			return logical.ErrorResponse(prefixedErr.Error()), logical.ErrInvalidRequest
+		default:
+			return nil, prefixedErr
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"name":              policy.Name,
+			"type":              policy.Type.String(),
+			"certificate_chain": pemCertChain,
+		},
+	}, nil
+}
+
+func parseCertificateChain(certChain string) ([]*x509.Certificate, error) {
+	var certificates []*x509.Certificate
+
+	var pemCertBlocks []*pem.Block
+	pemBytes := []byte(strings.TrimSpace(certChain))
+	for len(pemBytes) > 0 {
+		var pemCertBlock *pem.Block
+		pemCertBlock, pemBytes = pem.Decode(pemBytes)
+		if pemCertBlock == nil {
+			return nil, errors.New("could not decode a PEM block in the certificate chain")
+		}
+
+		switch pemCertBlock.Type {
+		case "CERTIFICATE", "X509 CERTIFICATE":
+			pemCertBlocks = append(pemCertBlocks, pemCertBlock)
+		default:
+			// Ignore other PEM blocks
+		}
+	}
+
+	if len(pemCertBlocks) == 0 {
+		return nil, errors.New("provided certificate chain did not contain any valid PEM encoded certificate")
+	}
+
+	for _, pemCertBlock := range pemCertBlocks {
+		certificate, err := x509.ParseCertificate(pemCertBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse a certificate in the certificate chain: %w", err)
+		}
+		certificates = append(certificates, certificate)
+	}
+
+	return certificates, nil
+}
+
 const (
 	// NOTE: `from` or `for`?
 	pathCreateCSRHelpSynopsis    = "Create a CSR for a key in transit."
 	pathCreateCSRHelpDescription = "This path is used to create a CSR for a key in transit. If a CSR template is provided, its significant information, expect key related data, are included in the CSR otherwise an empty CSR is returned. The key in transit must be a signing key and not be derived. The CSR can be signed by the latest version of the key in transit or by a specific version of the key in transit. The custom template must a valid CSR and PEM encoded."
 
-	pathImportCertChainHelpSynopsis    = ""
-	pathImportCertChainHelpDescription = ""
+	pathImportCertChainHelpSynopsis    = "Imports an externally-signed certificate chain into an existing key version"
+	pathImportCertChainHelpDescription = "This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate key has to match the selected key."
 )

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -35,12 +35,6 @@ func (b *backend) pathCreateCSR() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathCreateCSRWrite,
-				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "write",
-				},
-			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathCreateCSRWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
@@ -55,8 +49,6 @@ func (b *backend) pathCreateCSR() *framework.Path {
 
 func (b *backend) pathImportCertChain() *framework.Path {
 	return &framework.Path{
-		// NOTE: `set-certificate` or `set_certificate`? Paths seem to use different
-		// case, such as `transit/wrapping_key` and `transit/cache-config`
 		Pattern: "keys/" + framework.GenericNameRegex("name") + "/set-certificate",
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
@@ -76,12 +68,6 @@ func (b *backend) pathImportCertChain() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathImportCertChainWrite,
-				DisplayAttrs: &framework.DisplayAttributes{
-					OperationVerb: "write",
-				},
-			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathImportCertChainWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
@@ -183,7 +169,7 @@ func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Req
 	}
 
 	if !b.System().CachingDisabled() {
-		policy.Lock(true) // NOTE: Lck as we might write to the policy
+		policy.Lock(true) // NOTE: Lock as we might write to the policy
 	}
 	defer policy.Unlock()
 
@@ -267,7 +253,6 @@ func parseCertificateChain(certChain string) ([]*x509.Certificate, error) {
 }
 
 const (
-	// NOTE: `from` or `for`?
 	pathCreateCSRHelpSynopsis    = "Create a CSR for a key in transit."
 	pathCreateCSRHelpDescription = "This path is used to create a CSR for a key in transit. If a CSR template is provided, its significant information, expect key related data, are included in the CSR otherwise an empty CSR is returned. The key in transit must be a signing key and not be derived. The CSR can be signed by the latest version of the key in transit or by a specific version of the key in transit. The custom template must a valid CSR and PEM encoded."
 

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -1,0 +1,134 @@
+package transit
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/errutil"
+	"github.com/openbao/openbao/sdk/v2/helper/keysutil"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (b *backend) pathCreateCSR() *framework.Path {
+	return &framework.Path{
+		Pattern: "keys/" + framework.GenericNameRegex("name") + "/csr",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Required:    true,
+				Description: "Name of the key to create a CSR for.",
+			},
+			"version": {
+				Type:        framework.TypeInt,
+				Required:    false,
+				Description: "The version of the key to create a CSR for. If not set, the latest version, `latest`, will be used.",
+			},
+			"csr": {
+				Type:        framework.TypeString,
+				Required:    false,
+				Description: "PEM encoded CSR template to use. The information attributes will be used as a basis for the CSR with the key in transit. If not set, a default template will be used.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathCreateCSRWrite,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb: "write",
+				},
+			},
+		},
+		HelpSynopsis:    pathCreateCSRHelpSynopsis,
+		HelpDescription: pathCreateCSRHelpDescription,
+	}
+}
+
+// func (b *backend) pathImportCertChain() *framework.Path {
+// 	return nil
+// }
+
+func (b *backend) pathCreateCSRWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	name := data.Get("name").(string)
+
+	policy, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	}, b.GetRandomReader())
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return logical.ErrorResponse(fmt.Sprintf("key with provided name '%s' not found", name)), logical.ErrInvalidRequest
+	}
+
+	if !b.System().CachingDisabled() {
+		policy.Lock(false)
+	}
+	defer policy.Unlock()
+
+	// check if key supports signing
+	if !policy.Type.SigningSupported() {
+		return logical.ErrorResponse("key type '%s' does not support signing", policy.Type), logical.ErrInvalidRequest
+	}
+
+	// check if key can be derived
+	if policy.Derived {
+		return logical.ErrorResponse("operation not supported for keys with derivation enabled"), logical.ErrInvalidRequest
+	}
+
+	// transit key version
+	signingKeyVersion := policy.LatestVersion
+	version, versionSet := data.GetOk("version")
+	if versionSet {
+		signingKeyVersion = version.(int)
+	}
+
+	// read and parse CSR template
+	pemCSRTemplate := data.Get("csr").(string)
+	csrTemplate, err := parseCSR(pemCSRTemplate)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	csr, err := policy.CreateCSR(signingKeyVersion, csrTemplate)
+	if err != nil {
+		prefixedErr := fmt.Errorf("could not create the csr: %w", err)
+		switch err.(type) {
+		case errutil.UserError:
+			return logical.ErrorResponse(prefixedErr.Error()), logical.ErrInvalidRequest
+		default:
+			return nil, prefixedErr
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"name": policy.Name,
+			"type": policy.Type.String(),
+			"csr":  string(csr),
+		},
+	}, nil
+}
+
+func parseCSR(csrTemplate string) (*x509.CertificateRequest, error) {
+	if csrTemplate == "" {
+		return &x509.CertificateRequest{}, nil
+	}
+	csrBlock, _ := pem.Decode([]byte(csrTemplate))
+	if csrBlock == nil {
+		return nil, errors.New("could not decode PEM CSR")
+	}
+	return x509.ParseCertificateRequest(csrBlock.Bytes)
+}
+
+const (
+	// NOTE: `from` or `for`?
+	pathCreateCSRHelpSynopsis    = "Create a CSR for a key in transit."
+	pathCreateCSRHelpDescription = "This path is used to create a CSR for a key in transit. If a CSR template is provided, its significant information, expect key related data, are included in the CSR otherwise an empty CSR is returned. The key in transit must be a signing key and not be derived. The CSR can be signed by the latest version of the key in transit or by a specific version of the key in transit. The custom template must a valid CSR and PEM encoded."
+
+	pathImportCertChainHelpSynopsis    = ""
+	pathImportCertChainHelpDescription = ""
+)

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -169,7 +169,7 @@ func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Req
 	}
 
 	if !b.System().CachingDisabled() {
-		policy.Lock(true) // NOTE: Lock as we might write to the policy
+		policy.Lock(true)
 	}
 	defer policy.Unlock()
 

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -197,7 +197,7 @@ func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Req
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
-	err = policy.ValidateAndPersistCertificateChain(ctx, req.Storage, keyVersion, certChain)
+	err = policy.PersistCertificateChain(ctx, req.Storage, keyVersion, certChain)
 	if err != nil {
 		prefixedErr := fmt.Errorf("failed to persist certificate chain: %w", err)
 		switch err.(type) {

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -22,19 +22,22 @@ import (
 const (
 	templateCSR = `
 -----BEGIN CERTIFICATE REQUEST-----
-MIICRTCCAS0CAQAwADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM49
-McW7u3ILuAJfSFLUtGOMGBytHmMFcjTiX+5JcajFj0Uszb+HQ7eIsJJNXhVc/7fg
-Z01DZvcCqb9ChEWE3xi4GEkPMXay7p7G1ooSLnQp6Z0lL5CuIFfMVOTvjfhTwRaJ
-l9v2mMlm80BeiAUBqeoyGVrIh5fKASxaE0jrhjAxhGzqrXdDnL8A4na6ArprV4iS
-aEAziODd2WmplSKgUwEaFdeG1t1bJf3o5ZQRCnKNtQcAk8UmgtvFEO8ohGMln/Fj
-O7u7s6iRhOGf1g1NCAP5pGqxNx3bjz5f/CUcTSIGAReEomg41QTIhD9muCTL8qnm
-6lS87wkGTv7qbeIGB7sCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQAfjE+jNqIk
-4V1tL3g5XPjxr2+QcwddPf8opmbAzgt0+TiIHcDGBAxsXyi7sC9E5AFfFp7W07Zv
-r5+v4i529K9q0BgGtHFswoEnhd4dC8Ye53HtSoEtXkBpZMDrtbS7eZa9WccT6zNx
-4taTkpptZVrmvPj+jLLFkpKJJ3d+Gbrp6hiORPadT+igLKkqvTeocnhOdAtt427M
-RXTVgN14pV3tqO+5MXzNw5tGNPcwWARWwPH9eCRxLwLUuxE4Qu73pUeEFjDEfGkN
-iBnlTsTXBOMqSGryEkmRaZslWDvblvYeObYw+uc3kCbJ7jRy9soVwkbb5FueF/yC
-O1aQIm23HrrG
+MIIC5zCCAc8CAQAwaDELMAkGA1UEBhMCVVMxDjAMBgNVBAgMBVN0YXRlMQ0wCwYD
+VQQHDARDaXR5MRUwEwYDVQQKDAxPcmdhbml6YXRpb24xDTALBgNVBAsMBFVuaXQx
+FDASBgNVBAMMC2V4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAtqoiFEAdvKtBe5LdhPXddsQBGfq2wU7oLRjg85ow6TeDFCP4X/QvKWqk
+/oaZuy7RENQ8rZZML5XN1zlwRyxyqYUoIwLJrvZUHKyBVDp7axQ4X6RzSl++A6KI
+vlMAiOzn0ByaI/qrTzpMvKyn/Y2AaIM0SdSczVBczmcfrthYikzWzphvYFqsCTRn
+01E1hBiqk5/JoaFgljzQp7Xv+fl3E0grnuLPjc1p6gDJDG/5QNIQt144ahwt8you
+rpryjYmRWlFX0UhK5X4aywLGtGP8pEZcxmMvslziqeKt1YfzYcI0zsWkOeLXtjVd
+pkBT9r2tz/Df6d5+RtmtNrketXN1AQIDAQABoDowOAYJKoZIhvcNAQkOMSswKTAn
+BgNVHREEIDAeggtleGFtcGxlLmNvbYIPd3d3LmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBCwUAA4IBAQAmGyhKkDbTs156EiXhXUim8/eoB5+Gp+2lldNhh3/jUqj487CG
+vR0ArKx2xGBQNwBOR5Z+rMRh5Xg+OQaK7uMeQM0El4hW4VL4GEXRbqrAy1ixYk9s
+hvZTQD5XGxkJM0ffKsyxk5t/tQWcCDPWwoBv+R5ikkABFzCcwRq+IHvOUxB59cgC
+VldIH29XCpF71qiIbpg9Y+LJI9skdE3x/Ufa9h9Z8ioHhPu1xXCaKKjaZ3lv8t1+
+9iWpATejh7Av9o/8y+vpRN8vrxNcprbj0ItJ5jcg6pnA7DEqW7QNIKYtWg2YjKBd
+Bgw5bMA6qRI09cxO4pN2diD2KYI+YuioXtYl
 -----END CERTIFICATE REQUEST-----
 `
 )
@@ -83,7 +86,7 @@ func testTransit_Certificates_CreateCSR(t *testing.T, keyType string, pemTemplat
 		},
 	}
 
-	// request creation of CSR
+	// request the CSR
 	resp, err = b.HandleRequest(context.Background(), csrSignReq)
 	switch keyType {
 	case "rsa-2048", "rsa-3072", "rsa-4096", "ecdsa-p256", "ecdsa-p384", "ecdsa-p521", "ed25519":
@@ -106,9 +109,24 @@ func testTransit_Certificates_CreateCSR(t *testing.T, keyType string, pemTemplat
 			t.Fatalf("failed to parse returned template CSR, err:%v", err)
 		}
 
-		// NOTE: Check other fields?
 		if !reflect.DeepEqual(signedCSR.Subject, templateCSR.Subject) {
-			t.Fatalf("subjects should have matched:%v", err)
+			t.Fatal("CSR subjects should have matched")
+		}
+
+		if !reflect.DeepEqual(signedCSR.DNSNames, templateCSR.DNSNames) {
+			t.Fatal("CSR DNS names should have matched")
+		}
+
+		if !reflect.DeepEqual(signedCSR.EmailAddresses, templateCSR.EmailAddresses) {
+			t.Fatal("CSR email addresses should have matched")
+		}
+
+		if !reflect.DeepEqual(signedCSR.IPAddresses, templateCSR.IPAddresses) {
+			t.Fatal("CSR IP addresses should have matched")
+		}
+
+		if !reflect.DeepEqual(signedCSR.URIs, templateCSR.URIs) {
+			t.Fatal("CSR URIs should have matched")
 		}
 	default:
 		if err == nil || (resp != nil && !resp.IsError()) {
@@ -117,7 +135,6 @@ func testTransit_Certificates_CreateCSR(t *testing.T, keyType string, pemTemplat
 	}
 }
 
-// NOTE: Tests are using two 'different' methods of checking for errors, which one should we prefer?
 func TestTransit_Certificates_ImportCertChain(t *testing.T) {
 	// create cluster
 	coreConfig := &vault.CoreConfig{

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -2,11 +2,21 @@ package transit
 
 import (
 	"context"
+	cryptoRand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/builtin/logical/pki"
+	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -105,4 +115,149 @@ func testTransitCreateCSR(t *testing.T, keyType string, pemTemplateCSR string) {
 			t.Fatalf("should have failed to sign CSR, provided key type (%s) does not support signing", keyType)
 		}
 	}
+}
+
+// NOTE: Tests are using two 'different' methods of checking for errors, which one should we prefer?
+func TestTransit_ImportCertChain(t *testing.T) {
+	// create cluster
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"transit": Factory,
+			"pki":     pki.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	// mount transit backend
+	err := client.Sys().Mount("transit", &api.MountInput{
+		Type: "transit",
+	})
+	require.NoError(t, err)
+
+	// mount PKI backend
+	err = client.Sys().Mount("pki", &api.MountInput{
+		Type: "pki",
+	})
+	require.NoError(t, err) // NOTE: These functions accept a message
+
+	t.Parallel() // NOTE: Can it be called here?
+
+	testTransit_ImportCertChain(t, client, "rsa-2048")
+	testTransit_ImportCertChain(t, client, "rsa-3072")
+	testTransit_ImportCertChain(t, client, "rsa-4096")
+	testTransit_ImportCertChain(t, client, "ecdsa-p256")
+	testTransit_ImportCertChain(t, client, "ecdsa-p384")
+	testTransit_ImportCertChain(t, client, "ecdsa-p521")
+	testTransit_ImportCertChain(t, client, "ed25519")
+}
+
+func testTransit_ImportCertChain(t *testing.T, apiClient *api.Client, keyType string) {
+	keyName := keyType
+	issuerName := fmt.Sprintf("%s-issuer", keyType)
+
+	// create transit key
+	_, err := apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s", keyName), map[string]interface{}{
+		"type": keyType,
+	})
+	require.NoError(t, err)
+
+	// setup a new CSR
+	privKey, err := rsa.GenerateKey(cryptoRand.Reader, 3072)
+	require.NoError(t, err)
+
+	var csrTemplate x509.CertificateRequest
+	csrTemplate.Subject.CommonName = "example.com"
+	reqCsrBytes, err := x509.CreateCertificateRequest(cryptoRand.Reader, &csrTemplate, privKey)
+	require.NoError(t, err)
+
+	pemTemplateCsr := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: reqCsrBytes,
+	})
+	t.Logf("csr: %v", string(pemTemplateCsr))
+
+	// create CSR from template CSR fields and key in transit
+	resp, err := apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/csr", keyName), map[string]interface{}{
+		"csr": string(pemTemplateCsr),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	pemCsr := resp.Data["csr"].(string)
+
+	// generate PKI root
+	resp, err = apiClient.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+		"issuer_name": issuerName,
+		"common_name": "PKI Root X1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	rootCertPEM := resp.Data["certificate"].(string)
+	pemBlock, _ := pem.Decode([]byte(rootCertPEM))
+	require.NotNil(t, pemBlock)
+
+	rootCert, err := x509.ParseCertificate(pemBlock.Bytes)
+	require.NoError(t, err)
+
+	// create role to be used in the certificate issuing
+	resp, err = apiClient.Logical().Write("pki/roles/example-dot-com", map[string]interface{}{
+		"issuer_ref":                         issuerName,
+		"allowed_domains":                    "example.com",
+		"allow_bare_domains":                 true,
+		"basic_constraints_valid_for_non_ca": true,
+		"key_type":                           "any",
+	})
+	require.NoError(t, err)
+
+	// sign the CSR
+	resp, err = apiClient.Logical().Write("pki/sign/example-dot-com", map[string]interface{}{
+		"issuer_ref": issuerName,
+		"csr":        pemCsr,
+		"ttl":        "10m",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	leafCertPEM := resp.Data["certificate"].(string)
+	pemBlock, _ = pem.Decode([]byte(leafCertPEM))
+	require.NotNil(t, pemBlock)
+
+	leafCert, err := x509.ParseCertificate(pemBlock.Bytes)
+	require.NoError(t, err)
+
+	require.NoError(t, leafCert.CheckSignatureFrom(rootCert))
+	t.Logf("root: %v", rootCertPEM)
+	t.Logf("leaf: %v", leafCertPEM)
+
+	certificateChain := strings.Join([]string{leafCertPEM, rootCertPEM}, "\n")
+	// import certificate chain to transit key version
+	resp, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set-certificate", keyName), map[string]interface{}{
+		"certificate_chain": certificateChain,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// resp, err = apiClient.Logical().Read(fmt.Sprintf("transit/keys/%s", keyName))
+	// require.NotNil(t, resp)
+	// keys, ok := resp.Data["keys"].(map[string]interface{})
+	// if !ok {
+	// 	t.Fatalf("could not cast Keys value")
+	// }
+	// keyData, ok := keys["1"].(map[string]interface{})
+	// if !ok {
+	// 	t.Fatalf("could not cast key version 1 from keys")
+	// }
+	// _, present := keyData["certificate_chain"]
+	// if !present {
+	// 	t.Fatalf("certificate chain not present in key version 1")
+	// }
 }

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -239,7 +239,7 @@ func testTransit_Certificates_ImportCertChain(t *testing.T, apiClient *api.Clien
 
 	certificateChain := strings.Join([]string{leafCertPEM, rootCertPEM}, "\n")
 	// import certificate chain to transit key version
-	resp, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set_certificate", keyName), map[string]interface{}{
+	resp, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set-certificate", keyName), map[string]interface{}{
 		"certificate_chain": certificateChain,
 	})
 	require.NoError(t, err)

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -39,20 +39,20 @@ O1aQIm23HrrG
 `
 )
 
-func TestTransit_CreateCSR(t *testing.T) {
+func TestTransit_Certificates_CreateCSR(t *testing.T) {
 	t.Parallel()
 
-	testTransitCreateCSR(t, "rsa-2048", templateCSR)
-	testTransitCreateCSR(t, "rsa-3072", templateCSR)
-	testTransitCreateCSR(t, "rsa-4096", templateCSR)
-	testTransitCreateCSR(t, "ecdsa-p256", templateCSR)
-	testTransitCreateCSR(t, "ecdsa-p384", templateCSR)
-	testTransitCreateCSR(t, "ecdsa-p521", templateCSR)
-	testTransitCreateCSR(t, "ed25519", templateCSR)
-	testTransitCreateCSR(t, "aes256-gcm96", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "rsa-2048", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "rsa-3072", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "rsa-4096", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "ecdsa-p256", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "ecdsa-p384", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "ecdsa-p521", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "ed25519", templateCSR)
+	testTransit_Certificates_CreateCSR(t, "aes256-gcm96", templateCSR)
 }
 
-func testTransitCreateCSR(t *testing.T, keyType string, pemTemplateCSR string) {
+func testTransit_Certificates_CreateCSR(t *testing.T, keyType string, pemTemplateCSR string) {
 	keyName := "test-key"
 	var resp *logical.Response
 	var err error
@@ -118,7 +118,7 @@ func testTransitCreateCSR(t *testing.T, keyType string, pemTemplateCSR string) {
 }
 
 // NOTE: Tests are using two 'different' methods of checking for errors, which one should we prefer?
-func TestTransit_ImportCertChain(t *testing.T) {
+func TestTransit_Certificates_ImportCertChain(t *testing.T) {
 	// create cluster
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
@@ -147,20 +147,19 @@ func TestTransit_ImportCertChain(t *testing.T) {
 	err = client.Sys().Mount("pki", &api.MountInput{
 		Type: "pki",
 	})
-	require.NoError(t, err) // NOTE: These functions accept a message
+	require.NoError(t, err)
 
-	t.Parallel() // NOTE: Can it be called here?
-
-	testTransit_ImportCertChain(t, client, "rsa-2048")
-	testTransit_ImportCertChain(t, client, "rsa-3072")
-	testTransit_ImportCertChain(t, client, "rsa-4096")
-	testTransit_ImportCertChain(t, client, "ecdsa-p256")
-	testTransit_ImportCertChain(t, client, "ecdsa-p384")
-	testTransit_ImportCertChain(t, client, "ecdsa-p521")
-	testTransit_ImportCertChain(t, client, "ed25519")
+	t.Parallel()
+	testTransit_Certificates_ImportCertChain(t, client, "rsa-2048")
+	testTransit_Certificates_ImportCertChain(t, client, "rsa-3072")
+	testTransit_Certificates_ImportCertChain(t, client, "rsa-4096")
+	testTransit_Certificates_ImportCertChain(t, client, "ecdsa-p256")
+	testTransit_Certificates_ImportCertChain(t, client, "ecdsa-p384")
+	testTransit_Certificates_ImportCertChain(t, client, "ecdsa-p521")
+	testTransit_Certificates_ImportCertChain(t, client, "ed25519")
 }
 
-func testTransit_ImportCertChain(t *testing.T, apiClient *api.Client, keyType string) {
+func testTransit_Certificates_ImportCertChain(t *testing.T, apiClient *api.Client, keyType string) {
 	keyName := keyType
 	issuerName := fmt.Sprintf("%s-issuer", keyType)
 

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -75,7 +75,7 @@ func testTransit_Certificates_CreateCSR(t *testing.T, keyType string, pemTemplat
 	}
 
 	csrSignReq := &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      fmt.Sprintf("keys/%s/csr", keyName),
 		Storage:   s,
 		Data: map[string]interface{}{

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -240,24 +240,24 @@ func testTransit_ImportCertChain(t *testing.T, apiClient *api.Client, keyType st
 
 	certificateChain := strings.Join([]string{leafCertPEM, rootCertPEM}, "\n")
 	// import certificate chain to transit key version
-	resp, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set-certificate", keyName), map[string]interface{}{
+	resp, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set_certificate", keyName), map[string]interface{}{
 		"certificate_chain": certificateChain,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// resp, err = apiClient.Logical().Read(fmt.Sprintf("transit/keys/%s", keyName))
-	// require.NotNil(t, resp)
-	// keys, ok := resp.Data["keys"].(map[string]interface{})
-	// if !ok {
-	// 	t.Fatalf("could not cast Keys value")
-	// }
-	// keyData, ok := keys["1"].(map[string]interface{})
-	// if !ok {
-	// 	t.Fatalf("could not cast key version 1 from keys")
-	// }
-	// _, present := keyData["certificate_chain"]
-	// if !present {
-	// 	t.Fatalf("certificate chain not present in key version 1")
-	// }
+	resp, err = apiClient.Logical().Read(fmt.Sprintf("transit/keys/%s", keyName))
+	require.NotNil(t, resp)
+	keys, ok := resp.Data["keys"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("could not cast Keys value")
+	}
+	keyData, ok := keys["1"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("could not cast key version 1 from keys")
+	}
+	_, present := keyData["certificate_chain"]
+	if !present {
+		t.Fatalf("certificate chain not present in key version 1")
+	}
 }

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -1,0 +1,108 @@
+package transit
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+const (
+	templateCSR = `
+-----BEGIN CERTIFICATE REQUEST-----
+MIICRTCCAS0CAQAwADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM49
+McW7u3ILuAJfSFLUtGOMGBytHmMFcjTiX+5JcajFj0Uszb+HQ7eIsJJNXhVc/7fg
+Z01DZvcCqb9ChEWE3xi4GEkPMXay7p7G1ooSLnQp6Z0lL5CuIFfMVOTvjfhTwRaJ
+l9v2mMlm80BeiAUBqeoyGVrIh5fKASxaE0jrhjAxhGzqrXdDnL8A4na6ArprV4iS
+aEAziODd2WmplSKgUwEaFdeG1t1bJf3o5ZQRCnKNtQcAk8UmgtvFEO8ohGMln/Fj
+O7u7s6iRhOGf1g1NCAP5pGqxNx3bjz5f/CUcTSIGAReEomg41QTIhD9muCTL8qnm
+6lS87wkGTv7qbeIGB7sCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQAfjE+jNqIk
+4V1tL3g5XPjxr2+QcwddPf8opmbAzgt0+TiIHcDGBAxsXyi7sC9E5AFfFp7W07Zv
+r5+v4i529K9q0BgGtHFswoEnhd4dC8Ye53HtSoEtXkBpZMDrtbS7eZa9WccT6zNx
+4taTkpptZVrmvPj+jLLFkpKJJ3d+Gbrp6hiORPadT+igLKkqvTeocnhOdAtt427M
+RXTVgN14pV3tqO+5MXzNw5tGNPcwWARWwPH9eCRxLwLUuxE4Qu73pUeEFjDEfGkN
+iBnlTsTXBOMqSGryEkmRaZslWDvblvYeObYw+uc3kCbJ7jRy9soVwkbb5FueF/yC
+O1aQIm23HrrG
+-----END CERTIFICATE REQUEST-----
+`
+)
+
+func TestTransit_CreateCSR(t *testing.T) {
+	t.Parallel()
+
+	testTransitCreateCSR(t, "rsa-2048", templateCSR)
+	testTransitCreateCSR(t, "rsa-3072", templateCSR)
+	testTransitCreateCSR(t, "rsa-4096", templateCSR)
+	testTransitCreateCSR(t, "ecdsa-p256", templateCSR)
+	testTransitCreateCSR(t, "ecdsa-p384", templateCSR)
+	testTransitCreateCSR(t, "ecdsa-p521", templateCSR)
+	testTransitCreateCSR(t, "ed25519", templateCSR)
+	testTransitCreateCSR(t, "aes256-gcm96", templateCSR)
+}
+
+func testTransitCreateCSR(t *testing.T, keyType string, pemTemplateCSR string) {
+	keyName := "test-key"
+	var resp *logical.Response
+	var err error
+	b, s := createBackendWithStorage(t)
+
+	// create a policy
+	policyReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      fmt.Sprintf("keys/%s", keyName),
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type": keyType,
+		},
+	}
+
+	// request creation of key
+	resp, err = b.HandleRequest(context.Background(), policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v\nerr:%v", resp, err)
+	}
+
+	csrSignReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      fmt.Sprintf("keys/%s/csr", keyName),
+		Storage:   s,
+		Data: map[string]interface{}{
+			"csr": pemTemplateCSR,
+		},
+	}
+
+	// request creation of CSR
+	resp, err = b.HandleRequest(context.Background(), csrSignReq)
+	switch keyType {
+	case "rsa-2048", "rsa-3072", "rsa-4096", "ecdsa-p256", "ecdsa-p384", "ecdsa-p521", "ed25519":
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("failed to sign CSR, err:%v resp:%#v", err, resp)
+		}
+
+		signedCSRBytes, ok := resp.Data["csr"]
+		if !ok {
+			t.Fatal("expected response data to hold a 'csr' key")
+		}
+
+		signedCSR, err := parseCSR(signedCSRBytes.(string))
+		if err != nil {
+			t.Fatalf("failed to parse returned CSR, err:%v", err)
+		}
+
+		templateCSR, err := parseCSR(pemTemplateCSR)
+		if err != nil {
+			t.Fatalf("failed to parse returned template CSR, err:%v", err)
+		}
+
+		// NOTE: Check other fields?
+		if !reflect.DeepEqual(signedCSR.Subject, templateCSR.Subject) {
+			t.Fatalf("subjects should have matched:%v", err)
+		}
+	default:
+		if err == nil || (resp != nil && !resp.IsError()) {
+			t.Fatalf("should have failed to sign CSR, provided key type (%s) does not support signing", keyType)
+		}
+	}
+}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -126,7 +126,7 @@ to the min_encryption_version configured on the key.`,
 			"partial_failure_response_code": {
 				Type: framework.TypeInt,
 				Description: `
-Ordinarily, if a batch item fails to encrypt due to a bad input, but other batch items succeed, 
+Ordinarily, if a batch item fails to encrypt due to a bad input, but other batch items succeed,
 the HTTP response code is 400 (Bad Request).  Some applications may want to treat partial failures differently.
 Providing the parameter returns the given response code integer instead of a 400 in this case. If all values fail
 HTTP 400 is still returned.`,

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -126,7 +126,7 @@ to the min_encryption_version configured on the key.`,
 			"partial_failure_response_code": {
 				Type: framework.TypeInt,
 				Description: `
-Ordinarily, if a batch item fails to encrypt due to a bad input, but other batch items succeed,
+Ordinarily, if a batch item fails to encrypt due to a bad input, but other batch items succeed, 
 the HTTP response code is 400 (Bad Request).  Some applications may want to treat partial failures differently.
 Providing the parameter returns the given response code integer instead of a 400 in this case. If all values fail
 HTTP 400 is still returned.`,

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	exportTypeEncryptionKey = "encryption-key"
-	exportTypeSigningKey    = "signing-key"
-	exportTypeHMACKey       = "hmac-key"
-	exportTypePublicKey     = "public-key"
+	exportTypeEncryptionKey    = "encryption-key"
+	exportTypeSigningKey       = "signing-key"
+	exportTypeHMACKey          = "hmac-key"
+	exportTypePublicKey        = "public-key"
+	exportTypeCertificateChain = "certificate-chain"
 )
 
 const (
@@ -85,6 +86,7 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	case exportTypeSigningKey:
 	case exportTypeHMACKey:
 	case exportTypePublicKey:
+	case exportTypeCertificateChain:
 	default:
 		return logical.ErrorResponse(fmt.Sprintf("invalid export type: %s", exportType)), logical.ErrInvalidRequest
 	}
@@ -113,7 +115,7 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	}
 	defer p.Unlock()
 
-	if !p.Exportable && exportType != exportTypePublicKey {
+	if !p.Exportable && exportType != exportTypePublicKey && exportType != exportTypeCertificateChain {
 		return logical.ErrorResponse("private key material is not exportable"), nil
 	}
 
@@ -129,6 +131,10 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	case exportTypeSigningKey:
 		if !p.Type.SigningSupported() {
 			return logical.ErrorResponse("signing not supported for the key"), logical.ErrInvalidRequest
+		}
+	case exportTypeCertificateChain:
+		if !p.Type.SigningSupported() {
+			return logical.ErrorResponse("certificate chain not supported for keys that do not support signing"), logical.ErrInvalidRequest
 		}
 	}
 
@@ -271,6 +277,21 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 			}
 			return rsaKey, nil
 		}
+	case exportTypeCertificateChain:
+		if key.CertificateChain == nil {
+			return "", errors.New("selected key version does not have a certificate chain imported")
+		}
+		var pemCertificates []string
+		for _, derCertificateBytes := range key.CertificateChain {
+			pemCert := strings.TrimSpace(string(pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: derCertificateBytes,
+				})))
+			pemCertificates = append(pemCertificates, pemCert)
+		}
+		certificateChain := strings.Join(pemCertificates, "\n")
+		return certificateChain, nil
 	}
 
 	return "", fmt.Errorf("unknown key type %v for export type %v", policy.Type, exportType)

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -675,8 +675,6 @@ func testTransit_Export_CertificateChain(t *testing.T, apiClient *api.Client, ke
 	})
 	require.NoError(t, err)
 
-	// NOTE: Should it be possible for the "import" endpoint to also import the cert chain?
-	// import cert chain
 	_, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set_certificate", keyName), map[string]interface{}{
 		"certificate_chain": leafCertPEM,
 	})

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -675,7 +675,7 @@ func testTransit_Export_CertificateChain(t *testing.T, apiClient *api.Client, ke
 	})
 	require.NoError(t, err)
 
-	_, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set_certificate", keyName), map[string]interface{}{
+	_, err = apiClient.Logical().Write(fmt.Sprintf("transit/keys/%s/set-certificate", keyName), map[string]interface{}{
 		"certificate_chain": leafCertPEM,
 	})
 	require.NoError(t, err)

--- a/changelog/536.txt
+++ b/changelog/536.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/transit: Add support to sign CSRs from keys in transit engine and import/export x509 certificates
+```

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2479,7 +2479,7 @@ func (p *Policy) PersistCertificateChain(ctx context.Context, storage logical.St
 	}
 
 	// validate that the first element in the certificate chain is a leaf certificate
-	if !certificateChain[0].BasicConstraintsValid || certificateChain[0].IsCA {
+	if certificateChain[0].BasicConstraintsValid && certificateChain[0].IsCA {
 		return errutil.UserError{Err: "certificate in the first element is not a valid leaf certificate"}
 	}
 
@@ -2489,9 +2489,11 @@ func (p *Policy) PersistCertificateChain(ctx context.Context, storage logical.St
 	}
 
 	// validate that the certificate chain contains only one leaf certificate
-	for _, certificate := range certificateChain[1 : len(certificateChain)-1] {
-		if !certificate.BasicConstraintsValid || !certificate.IsCA {
-			return errutil.UserError{Err: "could not validate if there is only one leaf certificate in the provided chain"}
+	if len(certificateChain) > 1 {
+		for _, certificate := range certificateChain[1 : len(certificateChain)-1] {
+			if !certificate.BasicConstraintsValid || !certificate.IsCA {
+				return errutil.UserError{Err: "could not validate if there is only one leaf certificate in the provided chain"}
+			}
 		}
 	}
 

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2473,16 +2473,27 @@ func (p *Policy) getECDSAKeyCurve() (elliptic.Curve, error) {
 }
 
 func (p *Policy) ValidateAndPersistCertificateChain(ctx context.Context, storage logical.Storage, keyVersion int, certificateChain []*x509.Certificate) error {
-	if len(certificateChain) == 0 {
+	// validate that the certificate chain has at least two certificates, a leaf certificate and a CA certificate
+	switch len(certificateChain) {
+	case 0:
 		return errutil.UserError{Err: "expected at least one certificate in the certificate chain"}
+	case 1:
+		return errutil.UserError{Err: "certificate chain must contain at least two certificates, a leaf certificate and a CA certificate"}
 	}
 
-	if certificateChain[0].BasicConstraintsValid && certificateChain[0].IsCA {
-		return errutil.UserError{Err: "certificate in the first position is not a leaf certificate"}
+	// validate that the first element in the certificate chain is a leaf certificate
+	if certificateChain[0].IsCA && certificateChain[0].BasicConstraintsValid {
+		return errutil.UserError{Err: "certificate in the first element is not a valid leaf certificate"}
 	}
 
-	for _, certificate := range certificateChain[1:] {
-		if certificate.BasicConstraintsValid && !certificate.IsCA {
+	// validate that the first element in the certificate chain is a CA certificate
+	if !certificateChain[len(certificateChain)-1].IsCA {
+		return errutil.UserError{Err: "certificate in the last element is not a valid CA certificate"}
+	}
+
+	// validate that the certificate chain contains only one leaf certificate
+	for _, certificate := range certificateChain[1 : len(certificateChain)-1] {
+		if !certificate.IsCA {
 			return errutil.UserError{Err: "provided certificate chain contains more than one leaf certificate"}
 		}
 	}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -242,7 +242,7 @@ type KeyEntry struct {
 	// is more precise
 	DeprecatedCreationTime int64 `json:"creation_time"`
 
-	// Key entry certificate chain. If set, leaf certificate key matches the keyEntry 'key'
+	// Key entry certificate chain. If set, leaf certificate key matches the keyEntry 'key'. The leaf certificate is the first element in the chain.
 	CertificateChain [][]byte `json:"certificate_chain"`
 }
 
@@ -2474,7 +2474,7 @@ func (p *Policy) getECDSAKeyCurve() (elliptic.Curve, error) {
 
 func (p *Policy) ValidateAndPersistCertificateChain(ctx context.Context, storage logical.Storage, keyVersion int, certificateChain []*x509.Certificate) error {
 	if len(certificateChain) == 0 {
-		return errutil.UserError{Err: "expected at least a certificate in the certificate chain"}
+		return errutil.UserError{Err: "expected at least one certificate in the certificate chain"}
 	}
 
 	if certificateChain[0].BasicConstraintsValid && certificateChain[0].IsCA {

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -2483,10 +2483,12 @@ func (p *Policy) PersistCertificateChain(ctx context.Context, storage logical.St
 		return errutil.UserError{Err: "certificate in the first element is not a valid leaf certificate"}
 	}
 
-	// validate that the first element in the certificate chain is a CA certificate
+	// validate that the last element in the certificate chain is a CA certificate
 	if len(certificateChain) > 1 && !certificateChain[len(certificateChain)-1].IsCA {
 		return errutil.UserError{Err: "certificate in the last element is not a valid CA certificate"}
 	}
+
+	// NOTE: Does this check make sense?
 
 	// validate that the certificate chain contains only one leaf certificate
 	for _, certificate := range certificateChain[1 : len(certificateChain)-1] {

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -2020,6 +2020,18 @@ $ curl \
     http://127.0.0.1:8200/v1/transit/keys/my-key/csr
 ```
 
+### Sample response
+
+```json
+{
+  "data": {
+    "name": "my-key",
+    "type": "rsa-2048",
+    "csr": "..."
+  }
+}
+```
+
 ## Import Certificate Chain
 
 This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate key has to be in the first element and match the selected key.
@@ -2055,4 +2067,16 @@ $ curl \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/transit/keys/my-key/set-certificate
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "name": "my-key",
+    "type": "rsa-2048",
+    "certificate_chain": "..."
+  }
+}
 ```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -939,7 +939,8 @@ This endpoint decrypts the provided ciphertext using the named key.
   derivation. This is required if key derivation is enabled.
 
 - `nonce` `(string: "")` – Specifies a base64 encoded nonce value used during
-  encryption. 
+  encryption.
+
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
   corresponding `batch_results` item in the response, to assist in understanding
@@ -1026,7 +1027,7 @@ functionality to untrusted users or scripts.
   to the key's `min_encryption_version`, if set.
 
 - `nonce` `(string: "")` – Specifies a base64 encoded nonce value used during
-  encryption. 
+  encryption.
 
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
@@ -1975,4 +1976,83 @@ $ curl \
   "data": {
     "size": 0
   },
+  ```
+
+## Create CSR
+
+This path is used to create a CSR for a key in transit. If a CSR template is provided,
+its significant information, expect key related data, are included in the CSR otherwise
+an empty CSR is returned. The key in transit must be a signing key and not be derived.
+The CSR can be signed by the latest version of the key in transit or by a specific version
+of the key in transit. The custom template must a valid CSR and PEM encoded."
+
+| Method | Path                      |
+| :----- | :------------------------ |
+| `POST` | `/transit/keys/:name/csr` |
+
+### Parameters
+
+- `name` `(string: <required>)` - Name of the key to create a CSR for. This is specified as part of
+the URL.
+
+- `version` `(int, optional)` - The version of the key to create a CSR for. If not set,
+the latest version, `latest`, will be used.
+
+- `csr` `(string, optional)` - PEM encoded CSR template to use. The information attributes will
+be used as a basis for the CSR with the key in transit. If not set, a default template will be used.
+
+### Sample payload
+
+```json
+{
+  "version": 3,
+  "csr": "..."
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/transit/keys/my-key/csr
+```
+
+## Import Certificate Chain
+
+This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate key has to be in the first element and match the selected key.
+
+| Method | Path                                  |
+| :----- | :------------------------------------ |
+| `POST` | `/transit/keys/:name/set-certificate` |
+
+### Parameters
+
+- `name` `(string: <required>)` - Name of the key This is specified as part of the URL.
+
+- `version` `(int, optional)` - Key version of which the certificate chain is going to be
+attatched to. If not set, the latest version, `latest`, will be used.
+
+- `certificate_chain` `(string: <required>)` - PEM encoded certificate chain. It should be
+composed by one or more concatenated PEM blocks and ordered starting from the end-entity certificate.
+
+### Sample payload
+
+```json
+{
+  "version": 3,
+  "certificate_chain": "..."
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/transit/keys/my-key/set-certificate
 ```

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -1978,13 +1978,12 @@ $ curl \
   },
   ```
 
-## Create CSR
+## Sign CSR
 
-This path is used to create a CSR for a key in transit. If a CSR template is provided,
-its significant information, expect key related data, are included in the CSR otherwise
-an empty CSR is returned. The key in transit must be a signing key and not be derived.
-The CSR can be signed by the latest version of the key in transit or by a specific version
-of the key in transit. The custom template must a valid CSR and PEM encoded."
+This endpoint signs a CSR using the `:name` key, ensuring the key material stays
+within Transit. If no CSR is provided, it signs an empty CSR. Otherwise, it signs
+the provided CSR, replacing its key material with the `:name` key material. The
+key in transit must be a signing key and not be derived.
 
 | Method | Path                      |
 | :----- | :------------------------ |
@@ -1992,14 +1991,16 @@ of the key in transit. The custom template must a valid CSR and PEM encoded."
 
 ### Parameters
 
-- `name` `(string: <required>)` - Name of the key to create a CSR for. This is specified as part of
-the URL.
+- `name` `(string: <required>)` - Specifies the name of the key to sign the
+  CSR with. This is specified as part of the URL.
 
-- `version` `(int, optional)` - The version of the key to create a CSR for. If not set,
-the latest version, `latest`, will be used.
+- `version` `(int, optional)` - The version of the key to use for signing.
+  If the version is set to `latest` or is not set, the current key will be
+  returned.
 
-- `csr` `(string, optional)` - PEM encoded CSR template to use. The information attributes will
-be used as a basis for the CSR with the key in transit. If not set, a default template will be used.
+- `csr` `(string, optional)` - Optional PEM-encoded CSR template to use
+  as a basis for the new CSR signed by this key. If not set, an empty
+  CSR is used.
 
 ### Sample payload
 
@@ -2032,9 +2033,11 @@ $ curl \
 }
 ```
 
-## Import Certificate Chain
+## Set Certificate Chain
 
-This path is used to import an externally-signed certificate chain into an existing key version in transit. The leaf certificate key has to be in the first element and match the selected key.
+This endpoint sets the certificate chain for the `:name` key, ensuring the key
+material stays within Transit and certificates are managed in one place.
+It also allows chain updates and rotation, as it will overwrite any existing certificate chain.
 
 | Method | Path                                  |
 | :----- | :------------------------------------ |
@@ -2042,13 +2045,16 @@ This path is used to import an externally-signed certificate chain into an exist
 
 ### Parameters
 
-- `name` `(string: <required>)` - Name of the key This is specified as part of the URL.
+- `name` `(string: <required>)` - Specifies the name of the key to import the
+  certificate chain against. This is specified as part of the URL.
 
-- `version` `(int, optional)` - Key version of which the certificate chain is going to be
-attatched to. If not set, the latest version, `latest`, will be used.
+- `version` `(int, optional)` - Specifies the version of the key to import the
+  certificate chain against.  If the version is set to `latest` or is not set,
+  the current key will be returned.
 
-- `certificate_chain` `(string: <required>)` - PEM encoded certificate chain. It should be
-composed by one or more concatenated PEM blocks and ordered starting from the end-entity certificate.
+- `certificate_chain` `(string: <required>)` - A PEM encoded certificate chain.
+  It should be composed by one or more concatenated PEM blocks and ordered starting
+  from the end-entity certificate.
 
 ### Sample payload
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

This PR adds two new endpoints to the Transit engine.
- `keys/:name/csr` signs a CSR using the provided key, ensuring the key material stays within Transit. If no CSR is provided, it signs an empty CSR. Otherwise, it signs the provided CSR, replacing its key material with the key material. The key in transit must be a signing key and not be derived.

- `keys/:name/set-certificate` sets the certificate chain for the provided key, ensuring the key material stays within Transit and certificates are managed in one place. It also allows chain updates and rotation, as it will overwrite any existing certificate chain.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.14.7
