### PR TITLE
add vault symlink to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN apk add --no-cache libcap su-exec dumb-init tzdata
 
 COPY $BIN_NAME /bin/
 
+RUN ln -s /bin/${BIN_NAME} /bin/vault
+
 # /vault/logs is made available to use as a location to store audit logs, if
 # desired; /vault/file is made available to use as a location with the file
 # storage backend, if desired; the server will be started with /vault/config as
@@ -110,6 +112,8 @@ RUN groupadd --gid 1000 openbao && \
 # Copy in the new OpenBao from CRT pipeline, rather than fetching it from our
 # public releases.
 COPY $BIN_NAME /bin/
+
+RUN ln -s /bin/${BIN_NAME} /bin/vault
 
 # /vault/logs is made available to use as a location to store audit logs, if
 # desired; /vault/file is made available to use as a location with the file

--- a/changelog/548.txt
+++ b/changelog/548.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+docker: add `/bin/vault` symlink to docker images
+```

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN set -eux; \
     apk add --no-cache ca-certificates libcap su-exec dumb-init tzdata
 
 COPY --from=builder /go/src/github.com/openbao/openbao/bin/bao /bin/bao
+RUN ln -s /bin/bao /bin/vault
 
 # /openbao/logs is made available to use as a location to store audit logs, if
 # desired; /openbao/file is made available to use as a location with the file


### PR DESCRIPTION
This adds a symlink to our Docker images which links `/bin/vault` to
`/bin/bao`. It will fix the issue of a not working Vault/OpenBao agent
injector in our HELM chart.

Signed-off-by: Jan Martens <jan@martens.eu.org>