### PR TITLE
Fix transactions and PKI interactions

### DIFF
--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -422,25 +422,6 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	if len(createdIssuers) > 0 {
-		warnings, err := b.crlBuilder.rebuild(crlSc, true)
-		if err != nil {
-			// Before returning, check if the error message includes the
-			// string "PSS". If so, it indicates we might've wanted to modify
-			// this issuer, so convert the error to a warning.
-			if strings.Contains(err.Error(), "PSS") || strings.Contains(err.Error(), "pss") {
-				err = fmt.Errorf("Rebuilding the CRL failed with a message relating to the PSS signature algorithm. This likely means the revocation_signature_algorithm needs to be set on the newly imported issuer(s) because a managed key supports only the PSS algorithm; by default PKCS#1v1.5 was used to build the CRLs. CRLs will not be generated until this has been addressed, however the import was successful. The original error is reproduced below:\n\n\t%w", err)
-			} else {
-				// Note to the caller that while this is an error, we did
-				// successfully import the issuers.
-				err = fmt.Errorf("Rebuilding the CRL failed. While this is indicative of a problem with the imported issuers (perhaps because of their revocation_signature_algorithm), they did import successfully and are now usable. It is strongly suggested to fix the CRL building errors before continuing. The original error is reproduced below:\n\n\t%w", err)
-			}
-
-			return nil, err
-		}
-		for index, warning := range warnings {
-			response.AddWarning(fmt.Sprintf("Warning %d during CRL rebuild: %v", index+1, warning))
-		}
-
 		var issuersWithKeys []string
 		for _, issuer := range createdIssuers {
 			if issuerKeyMap[issuer] != "" {
@@ -508,12 +489,39 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		response.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information.")
 	}
 
-	// Finally, commit our transaction if we created one!
+	// Commit our transaction if we created one!
 	if txn, ok := req.Storage.(logical.Transaction); ok && req.Storage != originalStorage {
 		if err := txn.Commit(ctx); err != nil {
 			return nil, err
 		}
 		req.Storage = originalStorage
+	}
+
+	// Lastly, rebuild the CRL: note that above, we might've potentially
+	// modified entries that CRL rebuild would read and modify itself, so
+	// the above transaction needs to be closed before we can do the CRL
+	// rebuild, otherwise we'll get commit failures.
+	if len(createdIssuers) > 0 {
+		warnings, err := b.crlBuilder.rebuild(crlSc, true)
+		if err != nil {
+			// Before returning, check if the error message includes the
+			// string "PSS". If so, it indicates we might've wanted to modify
+			// this issuer, so convert the error to a warning.
+			if strings.Contains(err.Error(), "PSS") || strings.Contains(err.Error(), "pss") {
+				err = fmt.Errorf("Rebuilding the CRL failed with a message relating to the PSS signature algorithm. This likely means the revocation_signature_algorithm needs to be set on the newly imported issuer(s) because a managed key supports only the PSS algorithm; by default PKCS#1v1.5 was used to build the CRLs. CRLs will not be generated until this has been addressed, however the import was successful. The original error is reproduced below:\n\n\t%w", err)
+			} else {
+				// Note to the caller that while this is an error, we did
+				// successfully import the issuers.
+				err = fmt.Errorf("Rebuilding the CRL failed. While this is indicative of a problem with the imported issuers (perhaps because of their revocation_signature_algorithm), they did import successfully and are now usable. It is strongly suggested to fix the CRL building errors before continuing. The original error is reproduced below:\n\n\t%w", err)
+			}
+
+			// Transition this to a warning rather than an error, as the
+			// issuers were created and committed.
+			response.AddWarning(err.Error())
+		}
+		for index, warning := range warnings {
+			response.AddWarning(fmt.Sprintf("Warning %d during CRL rebuild: %v", index+1, warning))
+		}
 	}
 
 	return response, nil


### PR DESCRIPTION
This should fix `main` and was caused by the incremental, not-up-to-date merging of the transactional PR series (#292). 

---

There were two separate bugs:

1. Cache invalidation was not occurring correctly. There were two separate bugs here, one which I observed (not invalidating the cache) and the other (race condition on `cacheTransaction.modified`) was only theoretically possible. I'm not sure if concurrent access to the same transaction is something we should deal with, given some backends like PostgreSQL may not support it.
2. Fixing the transaction commit ordering w.r.t. CRL rebuild in PKI. I had forgotten common entries were modified in both, so I've since fixed that. Also, that order may not have worked on PostgreSQL with transactions.