### PR TITLE
Correctly handle IPv6 for HTTP-01

### DIFF
--- a/builtin/logical/pki/acme_authorizations.go
+++ b/builtin/logical/pki/acme_authorizations.go
@@ -20,6 +20,7 @@ type ACMEIdentifier struct {
 	Value         string             `json:"value"`
 	OriginalValue string             `json:"original_value"`
 	IsWildcard    bool               `json:"is_wildcard"`
+	IsIPv6        bool               `json:"is_ipv6"`
 }
 
 func (ai *ACMEIdentifier) MaybeParseWildcard() (bool, string, error) {

--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -435,7 +435,12 @@ func (ace *ACMEChallengeEngine) _verifyChallenge(sc *storageContext, id string, 
 			return ace._verifyChallengeCleanup(sc, err, id)
 		}
 
-		valid, err = ValidateHTTP01Challenge(authz.Identifier.Value, cv.Token, cv.Thumbprint, config)
+		addr := authz.Identifier.Value
+		if authz.Identifier.Type == ACMEIPIdentifier && authz.Identifier.IsIPv6 {
+			addr = fmt.Sprintf("[%v]", addr)
+		}
+
+		valid, err = ValidateHTTP01Challenge(addr, cv.Token, cv.Thumbprint, config)
 		if err != nil {
 			err = fmt.Errorf("%w: error validating http-01 challenge %v: %v; %v", ErrIncorrectResponse, id, err, ChallengeAttemptFailedMsg)
 			return ace._verifyChallengeRetry(sc, cv, authzPath, authz, challenge, err, id)

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -966,6 +966,7 @@ func parseOrderIdentifiers(data map[string]interface{}) ([]*ACMEIdentifier, erro
 			if ip == nil {
 				return nil, fmt.Errorf("value argument (%s) failed validation: failed parsing as IP: %w", valueStr, ErrMalformed)
 			}
+			identifier.IsIPv6 = ip.To4() == nil
 		case string(ACMEDNSIdentifier):
 			identifier.Type = ACMEDNSIdentifier
 

--- a/changelog/559.txt
+++ b/changelog/559.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix ACME HTTP-01 challenge validation with IPv6 addresses
+```


### PR DESCRIPTION
When using IPv6 addresses for HTTP-01 challenge in PKI's ACME engine, we needed to correctly template them into the `[bracket]` form.
    
Resolves: #551

---

TODO:

 - [x] Merge #558 
 - [x] Test in IPv6 environment; our dockerized tests do not appear to have any.

I reverted the changes to ALPN-01 challenge: per [RFC 8737 section 6.3](https://datatracker.ietf.org/doc/html/rfc8737#name-acme-validation-method), ALPN type only supports domain name. The line identified by @M0NsTeRRR in #551 should only ever be a DNS name and thus doesn't need square bracket special casing.