### PR TITLE
Add transactions to K/V secrets engine

### DIFF
--- a/changelog/560.txt
+++ b/changelog/560.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/kv: Implement transactions to prevent canceled operations from corrupting storage.
+```


### PR DESCRIPTION
This adds transaction support to the K/V secrets engine, enabling safe modifications to entries stored in the engine, even when operations are canceled partway through.

Notably, this requires careful for ordering: locks should be grabbed before beginning the transaction, otherwise we risk parallel operations causing issues when modifying the same entries, even when we previously would've succeeded.

Resolves: #482