### PR TITLE
Deny empty valid_principals during SSH issuance

### DIFF
--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -201,7 +201,8 @@ func createDeleteHelper(t *testing.T, b logical.Backend, config *logical.Backend
 	}
 
 	issueOptions := map[string]interface{}{
-		"public_key": testCAPublicKeyEd25519,
+		"public_key":       testCAPublicKeyEd25519,
+		"valid_principals": "toor",
 	}
 	issueReq := &logical.Request{
 		Path:      "sign/ca-issuance",

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -191,6 +191,10 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 
 	switch {
 	case len(parsedPrincipals) == 0:
+		if !role.AllowEmptyPrincipals && principalsAllowedByRole != "*" {
+			return nil, fmt.Errorf("refusing to issue unsafe, globally-valid certificate with no principals specified; set valid_principals or default_user")
+		}
+
 		// There is nothing to process
 		return nil, nil
 	case len(allowedPrincipals) == 0:

--- a/changelog/561.txt
+++ b/changelog/561.txt
@@ -1,0 +1,3 @@
+```release-note:security
+secrets/ssh: Deny globally valid certificate issuance without valid_principals or allow_empty_principals override. HCSEC-2024-20 / CVE-2024-7594.
+```

--- a/changelog/561.txt
+++ b/changelog/561.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-secrets/ssh: Deny globally valid certificate issuance without valid_principals or allow_empty_principals override. HCSEC-2024-20 / CVE-2024-7594.
+secrets/ssh: Deny globally valid certificate issuance without valid_principals or allow_empty_principals override. HCSEC-2024-20 / CVE-2024-7594. (**potentially breaking**)
 ```

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -202,6 +202,15 @@ This endpoint creates or updates a named role.
 - `not_before_duration` `(duration: "30s")` – Specifies the duration by which to
   backdate the `ValidAfter` property. Uses [duration format strings](/docs/concepts/duration-format).
 
+- `allow_empty_principals` `(bool: false)` – If true, host and user
+certificates can be issued without any valid principals. For host
+certificates, this means that any domain a host claims to be will be trusted
+by the connecting client. For user certificates, when a CA certificate is
+placed in a user's AuthorizedKeys file, any principal on that certificate
+will be allowed to connect. When `allowed_users` or `allowed_domains` is set
+to `*` (corresponding to the role/certificate type),
+`allow_empty_principals=false` still permits issuance.
+
 ### Sample payload
 
 ```json


### PR DESCRIPTION
HashiCorp Vault recently released a security vulnerability identifying global issuance without `valid_principals`. They [introduced a new role option](https://developer.hashicorp.com/vault/api-docs/secret/ssh#allow_empty_principals), `allow_empty_principals`, breaking existing users (as it defaults to `false`), but allowing operators to override it on a per-role level.

As evidenced by the extent of the test changes, this is definitely considered a breaking change.

See also: https://discuss.hashicorp.com/t/hcsec-2024-20-vault-ssh-secrets-engine-configuration-did-not-restrict-valid-principals-by-default/70251
See also: https://groups.google.com/g/opensshunixdev/c/RFKeIwNvtn8
See also: https://github.com/openssh/openssh-portable/commit/0a80ca190a39943029719facf7edb990def7ae62
See also: https://github.com/openssh/openssh-portable/blob/67a115e7a56dbdc3f5a58c64b29231151f3670f5/regress/cert-userkey.sh#L341-L343
See also: https://github.com/openssh/openssh-portable/blob/67a115e7a56dbdc3f5a58c64b29231151f3670f5/regress/cert-hostkey.sh#L247
