### PR TITLE
Backport #527 to release 2.0.x

### DIFF
--- a/changelog/527.txt
+++ b/changelog/527.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serviceregistration/k8s: Fix compatibility with legacy VAULT_-prefixed environment variables.
+```

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -5,7 +5,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"sync"
 
@@ -111,7 +110,7 @@ func getRequiredField(logger hclog.Logger, config map[string]string, envVar, con
 	value := ""
 	switch {
 	case api.ReadBaoVariable(envVar) != "":
-		value = os.Getenv(envVar)
+		value = api.ReadBaoVariable(envVar)
 	case config[configParam] != "":
 		value = config[configParam]
 	default:


### PR DESCRIPTION
* Fix k8s registration variables

When VAULT_ prefixed variables were used, their value would be ignored.
As the BAO_ variables likely would be unset, this meant service
registration would not succeed.

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

* Add changelog entry

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

---------

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>
Signed-off-by: Jan Martens <jan@martens.eu.org>

## Target Release

2.0.2