### PR TITLE
Linting fixes - Part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,19 +154,19 @@ ci-vet-codechecker: ci-bootstrap tools/codechecker/.bin/codechecker prep
 # lint runs vet plus a number of other checkers, it is more comprehensive, but louder
 lint:
 	@$(GO_CMD) list -f '{{.Dir}}' ./... | grep -v /vendor/ \
-		| xargs golangci-lint run; if [ $$? -eq 1 ]; then \
+		| xargs golangci-lint run --timeout 10m; if [ $$? -eq 1 ]; then \
 			echo ""; \
 			echo "Lint found suspicious constructs. Please check the reported constructs"; \
 			echo "and fix them if necessary before submitting the code for reviewal."; \
 		fi
 	@$(GO_CMD) list -f '{{.Dir}}' github.com/openbao/openbao/api/v2/... | grep -v /vendor/ \
-		| xargs golangci-lint run; if [ $$? -eq 1 ]; then \
+		| xargs golangci-lint run --timeout 10m; if [ $$? -eq 1 ]; then \
 			echo ""; \
 			echo "Lint found suspicious constructs. Please check the reported constructs"; \
 			echo "and fix them if necessary before submitting the code for reviewal."; \
 		fi
 	@$(GO_CMD) list -f '{{.Dir}}' github.com/openbao/openbao/sdk/v2/... | grep -v /vendor/ \
-		| xargs golangci-lint run; if [ $$? -eq 1 ]; then \
+		| xargs golangci-lint run --timeout 10m; if [ $$? -eq 1 ]; then \
 			echo ""; \
 			echo "Lint found suspicious constructs. Please check the reported constructs"; \
 			echo "and fix them if necessary before submitting the code for reviewal."; \
@@ -174,7 +174,7 @@ lint:
 
 # for ci jobs, runs lint against the changed packages in the commit
 ci-lint:
-	@golangci-lint run --deadline 10m --new-from-rev=HEAD~
+	@golangci-lint run --timeout 10m --new-from-rev=HEAD~
 
 # prep runs `go generate` to build the dynamically generated
 # source files.

--- a/api/client.go
+++ b/api/client.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/go-rootcerts"
@@ -576,7 +575,7 @@ func NewClient(c *Config) (*Client, error) {
 		return nil, fmt.Errorf("could not create/read default configuration")
 	}
 	if def.Error != nil {
-		return nil, errwrap.Wrapf("error encountered setting up default configuration: {{err}}", def.Error)
+		return nil, fmt.Errorf("error encountered setting up default configuration: %w", def.Error)
 	}
 
 	if c == nil {
@@ -667,7 +666,7 @@ func (c *Client) SetAddress(addr string) error {
 
 	parsedAddr, err := c.config.ParseAddress(addr)
 	if err != nil {
-		return errwrap.Wrapf("failed to set address: {{err}}", err)
+		return fmt.Errorf("failed to set address: %w", err)
 	}
 
 	c.addr = parsedAddr
@@ -1350,7 +1349,7 @@ START:
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "tls: oversized") {
-			err = errwrap.Wrapf("{{err}}\n\n"+TLSErrorString, err)
+			err = fmt.Errorf("%w\n\n"+TLSErrorString, err)
 		}
 		return result, err
 	}
@@ -1479,7 +1478,7 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 
 	if err != nil {
 		if strings.Contains(err.Error(), "tls: oversized") {
-			err = errwrap.Wrapf("{{err}}\n\n"+TLSErrorString, err)
+			err = fmt.Errorf("%w\n\n"+TLSErrorString, err)
 		}
 		return result, err
 	}

--- a/api/logical.go
+++ b/api/logical.go
@@ -12,8 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/hashicorp/errwrap"
 )
 
 const (
@@ -419,7 +417,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 
 	secret, err = c.ReadWithContext(ctx, wrappedResponseLocation)
 	if err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("error reading %q: {{err}}", wrappedResponseLocation), err)
+		return nil, fmt.Errorf("error reading %q: %w", wrappedResponseLocation, err)
 	}
 	if secret == nil {
 		return nil, fmt.Errorf("no value found at %q", wrappedResponseLocation)
@@ -436,7 +434,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 	dec := json.NewDecoder(buf)
 	dec.UseNumber()
 	if err := dec.Decode(wrappedSecret); err != nil {
-		return nil, errwrap.Wrapf("error unmarshalling wrapped secret: {{err}}", err)
+		return nil, fmt.Errorf("error unmarshalling wrapped secret: %w", err)
 	}
 
 	return wrappedSecret, nil

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -10,12 +10,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"flag"
+	"fmt"
 	"net/url"
 	"regexp"
 
 	"github.com/go-jose/go-jose/v3/jwt"
-
-	"github.com/hashicorp/errwrap"
 )
 
 const (
@@ -131,12 +130,12 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		parsedJWT, err := jwt.ParseSigned(unwrapToken)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing wrapping token: {{err}}", err)
+			return nil, fmt.Errorf("error parsing wrapping token: %w", err)
 		}
 
 		allClaims := make(map[string]interface{})
 		if err = parsedJWT.UnsafeClaimsWithoutVerification(&allClaims); err != nil {
-			return nil, errwrap.Wrapf("error parsing claims from wrapping token: {{err}}", err)
+			return nil, fmt.Errorf("error parsing claims from wrapping token: %w", err)
 		}
 
 		addrClaimRaw, ok := allClaims["addr"]
@@ -153,7 +152,7 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		// Sanity check the value
 		if _, err := url.Parse(vaultAddr); err != nil {
-			return nil, errwrap.Wrapf("error parsing the vault api_addr: {{err}}", err)
+			return nil, fmt.Errorf("error parsing the vault api_addr: %w", err)
 		}
 
 		// Unwrap the token
@@ -162,12 +161,12 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 		if apiTLSConfig != nil {
 			err := clientConf.ConfigureTLS(apiTLSConfig)
 			if err != nil {
-				return nil, errwrap.Wrapf("error configuring api client {{err}}", err)
+				return nil, fmt.Errorf("error configuring api client %w", err)
 			}
 		}
 		client, err := NewClient(clientConf)
 		if err != nil {
-			return nil, errwrap.Wrapf("error during api client creation: {{err}}", err)
+			return nil, fmt.Errorf("error during api client creation: %w", err)
 		}
 
 		// Reset token value to make sure nothing has been set by default
@@ -175,7 +174,7 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		secret, err := client.Logical().UnwrapWithContext(ctx, unwrapToken)
 		if err != nil {
-			return nil, errwrap.Wrapf("error during token unwrap request: {{err}}", err)
+			return nil, fmt.Errorf("error during token unwrap request: %w", err)
 		}
 		if secret == nil {
 			return nil, errors.New("error during token unwrap request: secret is nil")
@@ -189,12 +188,12 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		serverCertBytes, err := base64.StdEncoding.DecodeString(serverCertBytesRaw)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 
 		serverCert, err := x509.ParseCertificate(serverCertBytes)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 
 		// Retrieve and parse the server's private key
@@ -205,12 +204,12 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		serverKeyRaw, err := base64.StdEncoding.DecodeString(serverKeyB64)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 
 		serverKey, err := x509.ParseECPrivateKey(serverKeyRaw)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 
 		// Add CA cert to the cert pool

--- a/api/secret.go
+++ b/api/secret.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 )
 
@@ -243,7 +242,7 @@ func (s *Secret) TokenIsRenewable() (bool, error) {
 
 	renewable, err := parseutil.ParseBool(s.Data["renewable"])
 	if err != nil {
-		return false, errwrap.Wrapf("could not convert renewable value to a boolean: {{err}}", err)
+		return false, fmt.Errorf("could not convert renewable value to a boolean: %v", err)
 	}
 
 	return renewable, nil

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	multierror "github.com/hashicorp/go-multierror"
 	rootcerts "github.com/hashicorp/go-rootcerts"
@@ -151,7 +150,7 @@ func LoadSSHHelperConfig(path string) (*SSHHelperConfig, error) {
 func ParseSSHHelperConfig(contents string) (*SSHHelperConfig, error) {
 	root, err := hcl.Parse(string(contents))
 	if err != nil {
-		return nil, errwrap.Wrapf("error parsing config: {{err}}", err)
+		return nil, fmt.Errorf("error parsing config: %w", err)
 	}
 
 	list, ok := root.Node.(*ast.ObjectList)

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -2176,7 +2176,7 @@ func (b *backend) pathRoleBoundCIDRUpdateCommon(ctx context.Context, req *logica
 		}
 		valid, err := cidrutil.ValidateCIDRListSlice(cidrs)
 		if err != nil {
-			return logical.ErrorResponse(fmt.Errorf("failed to validate CIDR blocks: %w", err).Error()), nil
+			return logical.ErrorResponse(fmt.Sprintf("failed to validate CIDR blocks: %v", err)), nil
 		}
 		if !valid {
 			return logical.ErrorResponse("failed to validate CIDR blocks"), nil
@@ -2186,7 +2186,7 @@ func (b *backend) pathRoleBoundCIDRUpdateCommon(ctx context.Context, req *logica
 	} else if cidrsIfc, ok := data.GetOk("token_bound_cidrs"); ok {
 		cidrs, err := parseutil.ParseAddrs(cidrsIfc.([]string))
 		if err != nil {
-			return logical.ErrorResponse(fmt.Errorf("failed to parse token_bound_cidrs: %w", err).Error()), nil
+			return logical.ErrorResponse(fmt.Sprintf("failed to parse token_bound_cidrs: %v", err)), nil
 		}
 		role.TokenBoundCIDRs = cidrs
 	}

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/openbao/openbao/sdk/v2/framework"
-	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -169,33 +168,6 @@ func (b *backend) findSerialInCRLs(serial *big.Int) map[string]RevokedSerialInfo
 		}
 	}
 	return ret
-}
-
-func parseSerialString(input string) (*big.Int, error) {
-	ret := &big.Int{}
-
-	switch {
-	case strings.Count(input, ":") > 0:
-		serialBytes := certutil.ParseHexFormatted(input, ":")
-		if serialBytes == nil {
-			return nil, fmt.Errorf("error parsing serial %q", input)
-		}
-		ret.SetBytes(serialBytes)
-	case strings.Count(input, "-") > 0:
-		serialBytes := certutil.ParseHexFormatted(input, "-")
-		if serialBytes == nil {
-			return nil, fmt.Errorf("error parsing serial %q", input)
-		}
-		ret.SetBytes(serialBytes)
-	default:
-		var success bool
-		ret, success = ret.SetString(input, 0)
-		if !success {
-			return nil, fmt.Errorf("error parsing serial %q", input)
-		}
-	}
-
-	return ret, nil
 }
 
 func (b *backend) pathCRLDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -656,15 +656,6 @@ func (b *backend) checkForChainInCRLs(chain []*x509.Certificate) bool {
 	return badChain
 }
 
-func (b *backend) checkForValidChain(chains [][]*x509.Certificate) bool {
-	for _, chain := range chains {
-		if !b.checkForChainInCRLs(chain) {
-			return true
-		}
-	}
-	return false
-}
-
 // parsePEM parses a PEM encoded x509 certificate
 func parsePEM(raw []byte) (certs []*x509.Certificate) {
 	for len(raw) > 0 {

--- a/builtin/credential/cert/path_login_test.go
+++ b/builtin/credential/cert/path_login_test.go
@@ -355,7 +355,3 @@ func TestCert_RoleResolveOCSP(t *testing.T) {
 		})
 	}
 }
-
-func serialFromBigInt(serial *big.Int) string {
-	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":"))
-}

--- a/builtin/credential/cert/test_responder.go
+++ b/builtin/credential/cert/test_responder.go
@@ -14,7 +14,6 @@
 package cert
 
 import (
-	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -30,8 +29,6 @@ import (
 var (
 	malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
 	internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
-	tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
-	sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
 	unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
 
 	// ErrNotFound indicates the request OCSP response was not found. It is used to
@@ -106,15 +103,6 @@ func overrideHeaders(response http.ResponseWriter, headers http.Header) {
 			}
 		}
 	}
-}
-
-// hashToString contains mappings for the only hash functions
-// x/crypto/ocsp supports
-var hashToString = map[crypto.Hash]string{
-	crypto.SHA1:   "SHA1",
-	crypto.SHA256: "SHA256",
-	crypto.SHA384: "SHA384",
-	crypto.SHA512: "SHA512",
 }
 
 // A Responder can process both GET and POST requests.  The mapping

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -9,12 +9,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/hashicorp/cap/jwt"
 	"github.com/hashicorp/cap/oidc"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -153,7 +153,7 @@ func (b *jwtAuthBackend) config(ctx context.Context, s logical.Storage) (*jwtCon
 	for _, v := range config.JWTValidationPubKeys {
 		key, err := certutil.ParsePublicKeyPEM([]byte(v))
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing public key: {{err}}", err)
+			return nil, fmt.Errorf("error parsing public key: %w", err)
 		}
 		config.ParsedJWTPubKeys = append(config.ParsedJWTPubKeys, key)
 	}
@@ -302,7 +302,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	case len(config.JWTValidationPubKeys) != 0:
 		for _, v := range config.JWTValidationPubKeys {
 			if _, err := certutil.ParsePublicKeyPEM([]byte(v)); err != nil {
-				return logical.ErrorResponse(errwrap.Wrapf("error parsing public key: {{err}}", err).Error()), nil
+				return logical.ErrorResponse(fmt.Sprintf("error parsing public key: %v", err)), nil
 			}
 		}
 
@@ -365,12 +365,12 @@ func (b *jwtAuthBackend) createProvider(config *jwtConfig) (*oidc.Provider, erro
 		oidc.ClientSecret(config.OIDCClientSecret), supportedSigAlgs, []string{},
 		oidc.WithProviderCA(config.OIDCDiscoveryCAPEM))
 	if err != nil {
-		return nil, errwrap.Wrapf("error creating provider: {{err}}", err)
+		return nil, fmt.Errorf("error creating provider: %w", err)
 	}
 
 	provider, err := oidc.NewProvider(c)
 	if err != nil {
-		return nil, errwrap.Wrapf("error creating provider with given values: {{err}}", err)
+		return nil, fmt.Errorf("error creating provider with given values: %w", err)
 	}
 
 	return provider, nil

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/cap/jwt"
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/cidrutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -204,7 +203,7 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	// Ensure that the Role still exists.
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("failed to validate role %s during renewal: {{err}}", roleName), err)
+		return nil, fmt.Errorf("failed to validate role %s during renewal: %w", roleName, err)
 	}
 	if role == nil {
 		return nil, fmt.Errorf("role %s does not exist during renewal", roleName)

--- a/builtin/credential/jwt/path_oidc.go
+++ b/builtin/credential/jwt/path_oidc.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/cap/oidc"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/cidrutil"
@@ -285,7 +284,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 
 	provider, err := b.getProvider(config)
 	if err != nil {
-		return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
+		return nil, fmt.Errorf("error getting provider for login operation: %w", err)
 	}
 
 	var rawToken oidc.IDToken

--- a/builtin/credential/kerberos/path_login.go
+++ b/builtin/credential/kerberos/path_login.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/jcmturner/gokrb5/v8/keytab"
@@ -77,7 +76,7 @@ func (b *backend) pathLoginGet(ctx context.Context, req *logical.Request, d *fra
 func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	kerbCfg, err := b.config(ctx, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get kerberos config: {{err}}", err)
+		return nil, fmt.Errorf("unable to get kerberos config: %w", err)
 	}
 	if kerbCfg == nil {
 		return nil, errors.New("backend kerberos not configured")
@@ -85,7 +84,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 
 	ldapCfg, err := b.ConfigLdap(ctx, req)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get ldap config: {{err}}", err)
+		return nil, fmt.Errorf("unable to get ldap config: %w", err)
 	}
 	if ldapCfg == nil {
 		return nil, errors.New("ldap backend not configured")
@@ -112,7 +111,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 
 	kt, err := parseKeytab(kerbCfg.Keytab)
 	if err != nil {
-		return nil, errwrap.Wrapf("could not parse keytab: {{err}}", err)
+		return nil, fmt.Errorf("could not parse keytab: %w", err)
 	}
 
 	if kerbCfg.RemoveInstanceName {
@@ -208,7 +207,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 
 	ldapConnection, err := ldapClient.DialLDAP(ldapCfg.ConfigEntry)
 	if err != nil {
-		return nil, errwrap.Wrapf("could not connect to LDAP: {{err}}", err)
+		return nil, fmt.Errorf("could not connect to LDAP: %w", err)
 	}
 	if ldapConnection == nil {
 		return nil, errors.New("invalid connection returned from LDAP dial")
@@ -228,18 +227,18 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 
 	userBindDN, err := ldapClient.GetUserBindDN(ldapCfg.ConfigEntry, ldapConnection, username)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get user binddn: {{err}}", err)
+		return nil, fmt.Errorf("unable to get user binddn: %w", err)
 	}
 	b.Logger().Debug("auth/ldap: User BindDN fetched", "username", identity.UserName(), "binddn", userBindDN)
 
 	userDN, err := ldapClient.GetUserDN(ldapCfg.ConfigEntry, ldapConnection, userBindDN, username)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get user dn: {{err}}", err)
+		return nil, fmt.Errorf("unable to get user dn: %w", err)
 	}
 
 	ldapGroups, err := ldapClient.GetLdapGroups(ldapCfg.ConfigEntry, ldapConnection, userDN, username)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get ldap groups: {{err}}", err)
+		return nil, fmt.Errorf("unable to get ldap groups: %w", err)
 	}
 	b.Logger().Debug("auth/ldap: Groups fetched from server", "num_server_groups", len(ldapGroups), "server_groups", ldapGroups)
 

--- a/builtin/logical/database/mockv5.go
+++ b/builtin/logical/database/mockv5.go
@@ -15,9 +15,7 @@ import (
 const mockV5Type = "mockv5"
 
 // MockDatabaseV5 is an implementation of Database interface
-type MockDatabaseV5 struct {
-	config map[string]interface{}
-}
+type MockDatabaseV5 struct{}
 
 var _ v5.Database = &MockDatabaseV5{}
 

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -854,12 +854,6 @@ func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts
 	}
 }
 
-type createUserCommand struct {
-	Username string        `bson:"createUser"`
-	Password string        `bson:"pwd"`
-	Roles    []interface{} `bson:"roles"`
-}
-
 // Demonstrates a bug fix for the credential rotation not releasing locks
 func TestBackend_StaticRole_LockRegression(t *testing.T) {
 	cluster, sys := getCluster(t)

--- a/builtin/logical/database/version_wrapper_test.go
+++ b/builtin/logical/database/version_wrapper_test.go
@@ -363,8 +363,7 @@ func TestUpdateUser_newDB(t *testing.T) {
 		updateUserErr   error
 		updateUserCalls int
 
-		expectedResp v5.UpdateUserResponse
-		expectErr    bool
+		expectErr bool
 	}
 
 	tests := map[string]testCase{

--- a/builtin/logical/kv/path_metadata.go
+++ b/builtin/logical/kv/path_metadata.go
@@ -76,8 +76,8 @@ version-agnostic information about a secret.
 
 		ExistenceCheck: b.metadataExistenceCheck(),
 
-		HelpSynopsis:    confHelpSyn,
-		HelpDescription: confHelpDesc,
+		HelpSynopsis:    metadataHelpSyn,
+		HelpDescription: metadataHelpDesc,
 	}
 }
 

--- a/builtin/logical/openldap/checkout_handler_test.go
+++ b/builtin/logical/openldap/checkout_handler_test.go
@@ -5,7 +5,6 @@ package openldap
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestCheckOutHandlerStorageLayer(t *testing.T) {
 		t.Fatal("storedCheckOut should not be nil")
 	}
 	if !reflect.DeepEqual(checkOut, storedCheckOut) {
-		t.Fatalf(fmt.Sprintf(`expected %+v to be equal to %+v`, checkOut, storedCheckOut))
+		t.Fatalf(`expected %+v to be equal to %+v`, checkOut, storedCheckOut)
 	}
 
 	// If we try to check something out that's already checked out, we should

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2312,7 +2312,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")
@@ -2502,7 +2502,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1312,7 +1312,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 	if data.role.UseCSRSANs && csr != nil && len(csr.Extensions) > 0 {
 		others, err := getOtherSANsFromX509Extensions(csr.Extensions)
 		if err != nil {
-			return nil, nil, errutil.UserError{Err: fmt.Errorf("could not parse requested other SAN: %w", err).Error()}
+			return nil, nil, errutil.UserError{Err: fmt.Sprintf("could not parse requested other SAN: %v", err)}
 		}
 		for _, other := range others {
 			otherSANsInput = append(otherSANsInput, other.String())
@@ -1321,7 +1321,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 	if len(otherSANsInput) > 0 {
 		requested, err := parseOtherSANs(otherSANsInput)
 		if err != nil {
-			return nil, nil, errutil.UserError{Err: fmt.Errorf("could not parse requested other SAN: %w", err).Error()}
+			return nil, nil, errutil.UserError{Err: fmt.Sprintf("could not parse requested other SAN: %v", err)}
 		}
 		badOID, badName, err := validateOtherSANs(data, requested)
 		switch {

--- a/builtin/logical/pki/chain_util.go
+++ b/builtin/logical/pki/chain_util.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"bytes"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -438,7 +439,7 @@ func (sc *storageContext) rebuildIssuersChains(referenceCert *issuerEntry /* opt
 		}
 	}
 	if len(msg) > 0 {
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 
 	// Finally, write all issuers to disk.

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -666,7 +666,7 @@ func TestAcmeDisabledWithEnvVar(t *testing.T) {
 
 	// Make sure that ACME is disabled now.
 	for _, method := range []string{http.MethodHead, http.MethodGet} {
-		t.Run(fmt.Sprintf("%s", method), func(t *testing.T) {
+		t.Run(method, func(t *testing.T) {
 			req := client.NewRequest(method, "/v1/pki/acme/new-nonce")
 			_, err := client.RawRequestWithContext(ctx, req)
 			require.Error(t, err, "should have received an error as ACME should have been disabled")

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -1142,7 +1142,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 	default:
 		_, err := parseOtherSANs(allowedOtherSANs)
 		if err != nil {
-			return logical.ErrorResponse(fmt.Errorf("error parsing allowed_other_sans: %w", err).Error()), nil
+			return logical.ErrorResponse(fmt.Sprintf("error parsing allowed_other_sans: %v", err)), nil
 		}
 	}
 	entry.AllowedOtherSANs = allowedOtherSANs
@@ -1344,7 +1344,7 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		default:
 			_, err := parseOtherSANs(allowedOtherSANs)
 			if err != nil {
-				return logical.ErrorResponse(fmt.Errorf("error parsing allowed_other_sans: %w", err).Error()), nil
+				return logical.ErrorResponse(fmt.Sprintf("error parsing allowed_other_sans: %v", err)), nil
 			}
 		}
 		entry.AllowedOtherSANs = allowedOtherSANs

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1432,10 +1432,6 @@ func (sc *storageContext) writeAutoTidyConfig(config *tidyConfig) error {
 	return nil
 }
 
-func (sc *storageContext) listRevokedCerts() ([]string, error) {
-	return sc.listRevokedCertsPage("", -1)
-}
-
 func (sc *storageContext) listRevokedCertsPage(after string, limit int) ([]string, error) {
 	list, err := sc.Storage.ListPage(sc.Context, revokedPath, after, limit)
 	if err != nil {

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -54,12 +54,6 @@ func denormalizeSerial(serial string) string {
 	return strings.ReplaceAll(strings.ToLower(serial), "-", ":")
 }
 
-func serialToBigInt(serial string) (*big.Int, bool) {
-	norm := normalizeSerial(serial)
-	hex := strings.ReplaceAll(norm, "-", "")
-	return big.NewInt(0).SetString(hex, 16)
-}
-
 func existingKeyRequested(input *inputBundle) bool {
 	return existingKeyRequestedFromFieldData(input.apiData)
 }
@@ -285,14 +279,4 @@ func addWarnings(resp *logical.Response, warnings []string) *logical.Response {
 		resp.AddWarning(warning)
 	}
 	return resp
-}
-
-// sliceToMapKey return a map that who's keys are entries in a map.
-func sliceToMapKey(s []string) map[string]struct{} {
-	var empty struct{}
-	myMap := make(map[string]struct{}, len(s))
-	for _, s := range s {
-		myMap[s] = empty
-	}
-	return myMap
 }

--- a/builtin/logical/pkiext/test_helpers.go
+++ b/builtin/logical/pkiext/test_helpers.go
@@ -18,18 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func requireFieldsSetInResp(t *testing.T, resp *logical.Response, fields ...string) {
-	var missingFields []string
-	for _, field := range fields {
-		value, ok := resp.Data[field]
-		if !ok || value == nil {
-			missingFields = append(missingFields, field)
-		}
-	}
-
-	require.Empty(t, missingFields, "The following fields were required but missing from response:\n%v", resp.Data)
-}
-
 func requireSuccessNonNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
 	require.NoError(t, err, msgAndArgs...)
 	if resp.IsError() {
@@ -37,18 +25,6 @@ func requireSuccessNonNilResponse(t *testing.T, resp *logical.Response, err erro
 		require.Falsef(t, resp.IsError(), errContext, msgAndArgs...)
 	}
 	require.NotNil(t, resp, msgAndArgs...)
-}
-
-func requireSuccessNilResponse(t *testing.T, resp *logical.Response, err error, msgAndArgs ...interface{}) {
-	require.NoError(t, err, msgAndArgs...)
-	if resp.IsError() {
-		errContext := fmt.Sprintf("Expected successful response but got error: %v", resp.Error())
-		require.Falsef(t, resp.IsError(), errContext, msgAndArgs...)
-	}
-	if resp != nil {
-		msg := fmt.Sprintf("expected nil response but got: %v", resp)
-		require.Nilf(t, resp, msg, msgAndArgs...)
-	}
 }
 
 func parseCert(t *testing.T, pemCert string) *x509.Certificate {

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -500,21 +500,21 @@ func TestBackend_DefaultUserTemplateFalse_AllowedUsersTemplateFalse(t *testing.T
 	}
 	actualPrincipals := parsedKey.(*ssh.Certificate).ValidPrincipals
 	if len(actualPrincipals) < 1 {
-		t.Fatal(
-			fmt.Sprintf("No ValidPrincipals returned: should have been %v",
-				[]string{"{{identity.entity.metadata.ssh_username}}"}),
+		t.Fatalf(
+			"No ValidPrincipals returned: should have been %v",
+			[]string{"{{identity.entity.metadata.ssh_username}}"},
 		)
 	}
 	if len(actualPrincipals) > 1 {
-		t.Error(
-			fmt.Sprintf("incorrect number ValidPrincipals, expected only 1: %v should be %v",
-				actualPrincipals, []string{"{{identity.entity.metadata.ssh_username}}"}),
+		t.Errorf(
+			"incorrect number ValidPrincipals, expected only 1: %v should be %v",
+			actualPrincipals, []string{"{{identity.entity.metadata.ssh_username}}"},
 		)
 	}
 	if actualPrincipals[0] != "{{identity.entity.metadata.ssh_username}}" {
-		t.Fatal(
-			fmt.Sprintf("incorrect ValidPrincipals: %v should be %v",
-				actualPrincipals, []string{"{{identity.entity.metadata.ssh_username}}"}),
+		t.Fatalf(
+			"incorrect ValidPrincipals: %v should be %v",
+			actualPrincipals, []string{"{{identity.entity.metadata.ssh_username}}"},
 		)
 	}
 }
@@ -1995,9 +1995,9 @@ func testDefaultUserTemplate(t *testing.T, testDefaultUserTemplate string,
 	}
 	actualPrincipals := parsedKey.(*ssh.Certificate).ValidPrincipals
 	if actualPrincipals[0] != expectedValidPrincipal {
-		t.Fatal(
-			fmt.Sprintf("incorrect ValidPrincipals: %v should be %v",
-				actualPrincipals, []string{expectedValidPrincipal}),
+		t.Fatalf(
+			"incorrect ValidPrincipals: %v should be %v",
+			actualPrincipals, []string{expectedValidPrincipal},
 		)
 	}
 }
@@ -2269,7 +2269,7 @@ func testConfigZeroAddressRead(t *testing.T, expected map[string]interface{}) lo
 func testVerifyWrite(t *testing.T, data map[string]interface{}, expected map[string]interface{}) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
-		Path:      fmt.Sprintf("verify"),
+		Path:      "verify",
 		Data:      data,
 		Check: func(resp *logical.Response) error {
 			var ac api.SSHVerifyResponse

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -38,8 +38,6 @@ const (
 	testCIDRList      = "127.0.0.1/32"
 	testAtRoleName    = "test@RoleName"
 	testOTPRoleName   = "testOTPRoleName"
-	// testKeyName is the name of the entry that will be written to SSHMOUNTPOINT/ssh/keys
-	testKeyName = "testKeyName"
 	// testSharedPrivateKey is the value of the entry that will be written to SSHMOUNTPOINT/ssh/keys
 	testSharedPrivateKey = `
 -----BEGIN RSA PRIVATE KEY-----

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -623,7 +623,7 @@ func (b *backend) checkUpgrade(ctx context.Context, s logical.Storage, n string,
 			goto SKIPVERSION2
 		}
 		if publicKeyEntry == nil || publicKeyEntry.Key == "" {
-			b.Logger().Debug(fmt.Sprintf("got empty public key entry while attempting to migrate"))
+			b.Logger().Debug("got empty public key entry while attempting to migrate")
 			goto SKIPVERSION2
 		}
 

--- a/builtin/logical/ssh/util.go
+++ b/builtin/logical/ssh/util.go
@@ -5,11 +5,7 @@ package ssh
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"fmt"
 	"net"
 	"strings"
@@ -18,27 +14,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"golang.org/x/crypto/ssh"
 )
-
-// Creates a new RSA key pair with the given key length. The private key will be
-// of pem format and the public key will be of OpenSSH format.
-func generateRSAKeys(keyBits int) (publicKeyRsa string, privateKeyRsa string, err error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, keyBits)
-	if err != nil {
-		return "", "", fmt.Errorf("error generating RSA key-pair: %w", err)
-	}
-
-	privateKeyRsa = string(pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-	}))
-
-	sshPublicKey, err := ssh.NewPublicKey(privateKey.Public())
-	if err != nil {
-		return "", "", fmt.Errorf("error generating RSA key-pair: %w", err)
-	}
-	publicKeyRsa = "ssh-rsa " + base64.StdEncoding.EncodeToString(sshPublicKey.Marshal())
-	return
-}
 
 // Takes an IP address and role name and checks if the IP is part
 // of CIDR blocks belonging to the role.

--- a/command/agent.go
+++ b/command/agent.go
@@ -348,7 +348,7 @@ func (c *AgentCommand) Run(args []string) int {
 				}
 				s, err := file.NewFileSink(config)
 				if err != nil {
-					c.UI.Error(fmt.Errorf("error creating file sink: %w", err).Error())
+					c.UI.Error(fmt.Sprintf("error creating file sink: %v", err))
 					return 1
 				}
 				config.Sink = s

--- a/command/agent/exec/test-app/main.go
+++ b/command/agent/exec/test-app/main.go
@@ -26,7 +26,6 @@ import (
 
 var (
 	port                 uint
-	ignoreStopSignal     bool
 	sleepAfterStopSignal time.Duration
 	useSigusr1StopSignal bool
 	stopAfter            time.Duration

--- a/command/agent/testing.go
+++ b/command/agent/testing.go
@@ -16,13 +16,8 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 
-	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
-
-const envVarRunAccTests = "BAO_ACC"
-
-var runAcceptanceTests = api.ReadBaoVariable(envVarRunAccTests) == "1"
 
 func GetTestJWT(t *testing.T) (string, *ecdsa.PrivateKey) {
 	t.Helper()

--- a/command/agentproxyshared/cache/api_proxy.go
+++ b/command/agentproxyshared/cache/api_proxy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	gohttp "net/http"
-	"sync"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/api/v2"
@@ -18,8 +17,6 @@ import (
 type APIProxy struct {
 	client                  *api.Client
 	logger                  hclog.Logger
-	l                       sync.RWMutex
-	lastIndexStates         []string
 	userAgentString         string
 	userAgentStringFunction func(string) string
 }

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -236,7 +236,7 @@ func TestCache_ConcurrentRequests(t *testing.T) {
 				t.Fatal(err)
 			}
 			if secret == nil || secret.Data["key"].(string) != key {
-				t.Fatal(fmt.Sprintf("failed to read value for key: %q", key))
+				t.Fatalf("failed to read value for key: %q", key)
 			}
 		}(i)
 

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -789,7 +789,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			// check permissions of the parent debug directory
 			err = isValidFilePermissions(fs)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 
 			// check permissions of the files within the parent directory
@@ -804,7 +804,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 					}
 					err = isValidFilePermissions(fh.FileInfo())
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 					return nil
 				})
@@ -813,7 +813,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 				err = filepath.Walk(bundlePath, func(path string, info os.FileInfo, err error) error {
 					err = isValidFilePermissions(info)
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 					return nil
 				})

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -541,7 +541,7 @@ SEALFAIL:
 	diagnose.Test(ctx, "Check Core Creation", func(ctx context.Context) error {
 		var newCoreError error
 		if coreConfig.RawConfig == nil {
-			return fmt.Errorf(CoreConfigUninitializedErr)
+			return errors.New(CoreConfigUninitializedErr)
 		}
 		core, newCoreError := vault.CreateCore(&coreConfig)
 		if newCoreError != nil {

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -320,7 +320,7 @@ func (c *ProxyCommand) Run(args []string) int {
 				}
 				s, err := file.NewFileSink(config)
 				if err != nil {
-					c.UI.Error(fmt.Errorf("error creating file sink: %w", err).Error())
+					c.UI.Error(fmt.Sprintf("error creating file sink: %v", err))
 					return 1
 				}
 				config.Sink = s

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -111,10 +111,6 @@ type Config struct {
 	DisableSSCTokens *bool `hcl:"-"`
 }
 
-const (
-	sectionSeal = "Seal"
-)
-
 func (c *Config) Validate(sourceFilePath string) []configutil.ConfigError {
 	results := configutil.ValidateUnusedFields(c.UnusedKeys, sourceFilePath)
 	if c.Telemetry != nil {

--- a/command/server/config_custom_response_headers_test.go
+++ b/command/server/config_custom_response_headers_test.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -65,7 +64,7 @@ func TestCustomResponseHeadersConfigs(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }
 
@@ -84,29 +83,29 @@ func TestCustomResponseHeadersConfigsMultipleListeners(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[1].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader["default"], config.Listeners[1].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[2].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[2].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[3].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[3].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -1170,37 +1170,3 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
-
-func testConfigRaftAutopilot(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/raft_autopilot.hcl")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	disableSSCTs := true
-	autopilotConfig := `[{"cleanup_dead_servers":true,"last_contact_threshold":"500ms","max_trailing_logs":250,"min_quorum":3,"server_stabilization_time":"10s"}]`
-	expected := &Config{
-		SharedConfig: &configutil.SharedConfig{
-			Listeners: []*configutil.Listener{
-				{
-					Type:    "tcp",
-					Address: "127.0.0.1:8200",
-				},
-			},
-		},
-
-		Storage: &Storage{
-			Type: "raft",
-			Config: map[string]string{
-				"path":      "/storage/path/raft",
-				"node_id":   "raft1",
-				"autopilot": autopilotConfig,
-			},
-		},
-		DisableSSCTokens: &disableSSCTs,
-	}
-	config.Prune()
-	if diff := deep.Equal(config, expected); diff != nil {
-		t.Fatal(diff)
-	}
-}

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -4,8 +4,6 @@
 package builtinplugins
 
 import (
-	"context"
-
 	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
 	credCert "github.com/openbao/openbao/builtin/credential/cert"
 	credJWT "github.com/openbao/openbao/builtin/credential/jwt"
@@ -26,7 +24,6 @@ import (
 	dbInflux "github.com/openbao/openbao/plugins/database/influxdb"
 	dbMysql "github.com/openbao/openbao/plugins/database/mysql"
 	dbPostgres "github.com/openbao/openbao/plugins/database/postgresql"
-	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -55,16 +52,6 @@ type databasePlugin struct {
 type logicalBackend struct {
 	logical.Factory
 	consts.DeprecationStatus
-}
-
-type removedBackend struct {
-	*framework.Backend
-}
-
-func removedFactory(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
-	removedBackend := &removedBackend{}
-	removedBackend.Backend = &framework.Backend{}
-	return removedBackend, nil
 }
 
 func newRegistry() *registry {

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -204,7 +204,7 @@ func ParseLogLevel(logLevel string) (hclog.Level, error) {
 	case "err", "error":
 		result = hclog.Error
 	default:
-		return -1, errors.New(fmt.Sprintf("unknown log level: %s", logLevel))
+		return -1, fmt.Errorf("unknown log level: %s", logLevel)
 	}
 
 	return result, nil

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -77,7 +77,7 @@ func TestCheckPathInfo(t *testing.T) {
 			t.Errorf("invalid result. expected error")
 		}
 		if !tc.expectError && err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		err = os.RemoveAll("testFile")

--- a/helper/storagepacker/storagepacker.go
+++ b/helper/storagepacker/storagepacker.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	bucketCount = 256
 	// StoragePackerBucketsPrefix is the default storage key prefix under which
 	// bucket data will be stored.
 	StoragePackerBucketsPrefix = "packer/buckets/"

--- a/helper/testhelpers/logical/testing_test.go
+++ b/helper/testhelpers/logical/testing_test.go
@@ -75,19 +75,3 @@ func (t *mockT) Skip(args ...interface{}) {
 	t.SkipArgs = args
 	t.f = true
 }
-
-func (t *mockT) failed() bool {
-	return t.f
-}
-
-func (t *mockT) failMessage() string {
-	if t.FatalCalled {
-		return t.FatalArgs[0].(string)
-	} else if t.ErrorCalled {
-		return t.ErrorArgs[0].(string)
-	} else if t.SkipCalled {
-		return t.SkipArgs[0].(string)
-	}
-
-	return "unknown"
-}

--- a/http/handler.go
+++ b/http/handler.go
@@ -524,21 +524,6 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 	})
 }
 
-// stripPrefix is a helper to strip a prefix from the path. It will
-// return false from the second return value if it the prefix doesn't exist.
-func stripPrefix(prefix, path string) (string, bool) {
-	if !strings.HasPrefix(path, prefix) {
-		return "", false
-	}
-
-	path = path[len(prefix):]
-	if path == "" {
-		return "", false
-	}
-
-	return path, true
-}
-
 func handleUIHeaders(core *vault.Core, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		header := w.Header()

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -4,6 +4,7 @@
 package configutil
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -85,7 +86,7 @@ func ParseConfig(d string) (*SharedConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error parsing 'disable_mlock': %w", err)
 		} else if !isDisabled {
-			return nil, fmt.Errorf(mlockMsg)
+			return nil, errors.New(mlockMsg)
 		}
 		result.DisableMlockRaw = nil
 	}

--- a/internalshared/configutil/encrypt_decrypt_test.go
+++ b/internalshared/configutil/encrypt_decrypt_test.go
@@ -13,9 +13,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func getAEADTestKMS(t *testing.T) {
-}
-
 func TestEncryptParams(t *testing.T) {
 	rawStr := `
 storage "consul" {

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestParseSingleIPTemplate(t *testing.T) {
-	type args struct {
-		ipTmpl string
-	}
 	tests := []struct {
 		name    string
 		arg     string

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -24,13 +24,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/plugin/pb"
 )
 
-type idAddr struct {
-	id string
-}
-
-func (a *idAddr) Network() string { return "inmem" }
-func (a *idAddr) String() string  { return a.id }
-
 func addPeer(t *testing.T, leader, follower *RaftBackend) {
 	t.Helper()
 	if err := leader.AddPeer(context.Background(), follower.NodeID(), follower.NodeID()); err != nil {

--- a/physical/raft/streamlayer.go
+++ b/physical/raft/streamlayer.go
@@ -164,8 +164,6 @@ type raftLayer struct {
 
 	logger log.Logger
 
-	dialerFunc func(string, time.Duration) (net.Conn, error)
-
 	// TLS config
 	keyring         *TLSKeyring
 	clusterListener cluster.ClusterHook

--- a/physical/raft/varint.go
+++ b/physical/raft/varint.go
@@ -31,15 +31,9 @@ package raft
 import (
 	"bufio"
 	"encoding/binary"
-	"errors"
 	"io"
 
 	"github.com/golang/protobuf/proto"
-)
-
-var (
-	errSmallBuffer = errors.New("Buffer Too Small")
-	errLargeValue  = errors.New("Value is Larger than 64 bits")
 )
 
 func NewDelimitedWriter(w io.Writer) WriteCloser {

--- a/sdk/database/dbplugin/plugin.go
+++ b/sdk/database/dbplugin/plugin.go
@@ -10,7 +10,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -96,7 +95,7 @@ func PluginFactoryVersion(ctx context.Context, pluginName string, pluginVersion 
 		// from the pluginRunner. Then cast it to a Database.
 		dbRaw, err := pluginRunner.BuiltinFactory()
 		if err != nil {
-			return nil, errwrap.Wrapf("error initializing plugin: {{err}}", err)
+			return nil, fmt.Errorf("error initializing plugin: %w", err)
 		}
 
 		var ok bool
@@ -125,7 +124,7 @@ func PluginFactoryVersion(ctx context.Context, pluginName string, pluginVersion 
 
 	typeStr, err := db.Type()
 	if err != nil {
-		return nil, errwrap.Wrapf("error getting plugin type: {{err}}", err)
+		return nil, fmt.Errorf("error getting plugin type: %w", err)
 	}
 
 	// Wrap with metrics middleware

--- a/sdk/database/dbplugin/v5/plugin_factory.go
+++ b/sdk/database/dbplugin/v5/plugin_factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/pluginutil"
@@ -37,7 +36,7 @@ func PluginFactoryVersion(ctx context.Context, pluginName string, pluginVersion 
 		// from the pluginRunner. Then cast it to a Database.
 		dbRaw, err := pluginRunner.BuiltinFactory()
 		if err != nil {
-			return nil, errwrap.Wrapf("error initializing plugin: {{err}}", err)
+			return nil, fmt.Errorf("error initializing plugin: %w", err)
 		}
 
 		var ok bool
@@ -77,7 +76,7 @@ func PluginFactoryVersion(ctx context.Context, pluginName string, pluginVersion 
 
 	typeStr, err := db.Type()
 	if err != nil {
-		return nil, errwrap.Wrapf("error getting plugin type: {{err}}", err)
+		return nil, fmt.Errorf("error getting plugin type: %w", err)
 	}
 	logger.Debug("got database plugin instance", "type", typeStr)
 

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openbao/openbao/sdk/v2/database/dbplugin"
@@ -104,7 +103,7 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 
 	c.maxConnectionLifetime, err = parseutil.ParseDurationSecond(c.MaxConnectionLifetimeRaw)
 	if err != nil {
-		return nil, errwrap.Wrapf("invalid max_connection_lifetime: {{err}}", err)
+		return nil, fmt.Errorf("invalid max_connection_lifetime: %w", err)
 	}
 
 	// Set initialized to true at this point since all fields are set,
@@ -113,11 +112,11 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 
 	if verifyConnection {
 		if _, err := c.Connection(ctx); err != nil {
-			return nil, errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return nil, fmt.Errorf("error verifying connection: %w", err)
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {
-			return nil, errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return nil, fmt.Errorf("error verifying connection: %w", err)
 		}
 	}
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openbao/go-kms-wrapping/entropy/v2"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -667,7 +666,7 @@ func (b *Backend) handleWALRollback(ctx context.Context, req *logical.Request) (
 		// Attempt a WAL rollback
 		err = b.WALRollback(ctx, req, entry.Kind, entry.Data)
 		if err != nil {
-			err = errwrap.Wrapf(fmt.Sprintf("error rolling back %q entry: {{err}}", entry.Kind), err)
+			err = fmt.Errorf("error rolling back %q entry: %w", entry.Kind, err)
 		}
 		if err == nil {
 			err = DeleteWAL(ctx, req.Storage, k)

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/mapstructure"
@@ -46,7 +45,7 @@ func (d *FieldData) Validate() error {
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
-				return errwrap.Wrapf(fmt.Sprintf("error converting input %v for field %q: {{err}}", value, field), err)
+				return fmt.Errorf("error converting input %v for field %q: %w", value, field, err)
 			}
 		default:
 			return fmt.Errorf("unknown field type %q for field %q", schema.Type, field)

--- a/sdk/framework/identity.go
+++ b/sdk/framework/identity.go
@@ -5,8 +5,8 @@ package framework
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/identitytpl"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -53,7 +53,7 @@ func ValidateIdentityTemplate(tpl string) (bool, error) {
 		String:            tpl,
 	})
 	if err != nil {
-		return false, errwrap.Wrapf("failed to validate policy templating: {{err}}", err)
+		return false, fmt.Errorf("failed to validate policy templating: %w", err)
 	}
 
 	return hasTemplating, nil

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/license"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -360,7 +359,7 @@ func (p *Path) helpCallback(b *Backend) OperationFunc {
 
 		help, err := executeTemplate(pathHelpTemplate, &tplData)
 		if err != nil {
-			return nil, errwrap.Wrapf("error executing template: {{err}}", err)
+			return nil, fmt.Errorf("error executing template: %w", err)
 		}
 
 		// The plugin type (e.g. "kv", "cubbyhole") is only assigned at the time

--- a/sdk/framework/template.go
+++ b/sdk/framework/template.go
@@ -6,10 +6,9 @@ package framework
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"strings"
 	"text/template"
-
-	"github.com/hashicorp/errwrap"
 )
 
 func executeTemplate(tpl string, data interface{}) (string, error) {
@@ -21,13 +20,13 @@ func executeTemplate(tpl string, data interface{}) (string, error) {
 	// Parse the help template
 	t, err := template.New("root").Funcs(funcs).Parse(tpl)
 	if err != nil {
-		return "", errwrap.Wrapf("error parsing template: {{err}}", err)
+		return "", fmt.Errorf("error parsing template: %w", err)
 	}
 
 	// Execute the template and store the output
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
-		return "", errwrap.Wrapf("error executing template: {{err}}", err)
+		return "", fmt.Errorf("error executing template: %w", err)
 	}
 
 	return strings.TrimSpace(buf.String()), nil

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -67,7 +67,7 @@ func TestCertBundleConversion(t *testing.T) {
 
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }
@@ -131,7 +131,7 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		dataMap := structs.New(cbut).Map()
@@ -143,7 +143,7 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		pcbut, err = ParsePEMBundle(cbut.ToPEMBundle())
@@ -154,7 +154,7 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }
@@ -280,7 +280,7 @@ func TestCSRBundleConversion(t *testing.T) {
 
 		err = compareCSRBundleToParsedCSRBundle(csrbut, pcsrbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		csrbut, err = pcsrbut.ToCSRBundle()
@@ -290,7 +290,7 @@ func TestCSRBundleConversion(t *testing.T) {
 
 		err = compareCSRBundleToParsedCSRBundle(csrbut, pcsrbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -909,7 +908,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 	}
 
 	if err := HandleOtherSANs(certTemplate, data.Params.OtherSANs); err != nil {
-		return nil, errutil.InternalError{Err: errwrap.Wrapf("error marshaling other SANs: {{err}}", err).Error()}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error marshaling other SANs: %v", err)}
 	}
 
 	// Add this before calling addKeyUsages
@@ -1099,7 +1098,7 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 	}
 
 	if err := HandleOtherCSRSANs(csrTemplate, data.Params.OtherSANs); err != nil {
-		return nil, errutil.InternalError{Err: errwrap.Wrapf("error marshaling other SANs: {{err}}", err).Error()}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error marshaling other SANs: %v", err)}
 	}
 
 	if addBasicConstraints {
@@ -1109,7 +1108,7 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 		}
 		val, err := asn1.Marshal(basicConstraints{IsCA: true, MaxPathLen: -1})
 		if err != nil {
-			return nil, errutil.InternalError{Err: errwrap.Wrapf("error marshaling basic constraints: {{err}}", err).Error()}
+			return nil, errutil.InternalError{Err: fmt.Sprintf("error marshaling basic constraints: %v", err)}
 		}
 		ext := pkix.Extension{
 			Id:       ExtensionBasicConstraintsOID,
@@ -1242,7 +1241,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	}
 
 	if err := HandleOtherSANs(certTemplate, data.Params.OtherSANs); err != nil {
-		return nil, errutil.InternalError{Err: errwrap.Wrapf("error marshaling other SANs: {{err}}", err).Error()}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error marshaling other SANs: %v", err)}
 	}
 
 	AddPolicyIdentifiers(data, certTemplate)

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 )
 
@@ -358,7 +357,7 @@ func (p *ParsedCertBundle) Verify() error {
 	if p.PrivateKey != nil && p.Certificate != nil {
 		equal, err := ComparePublicKeys(p.Certificate.PublicKey, p.PrivateKey.Public())
 		if err != nil {
-			return errwrap.Wrapf("could not compare public and private keys: {{err}}", err)
+			return fmt.Errorf("could not compare public and private keys: %w", err)
 		}
 		if !equal {
 			return fmt.Errorf("public key of certificate does not match private key")
@@ -638,7 +637,7 @@ func (p *ParsedCertBundle) GetTLSConfig(usage TLSUsage) (*tls.Config, error) {
 		// Technically we only need one cert, but this doesn't duplicate code
 		certBundle, err := p.ToCertBundle()
 		if err != nil {
-			return nil, errwrap.Wrapf("error converting parsed bundle to string bundle when getting TLS config: {{err}}", err)
+			return nil, fmt.Errorf("error converting parsed bundle to string bundle when getting TLS config: %w", err)
 		}
 
 		caPool := x509.NewCertPool()

--- a/sdk/helper/cidrutil/cidr.go
+++ b/sdk/helper/cidrutil/cidr.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	sockaddr "github.com/hashicorp/go-sockaddr"
 )
@@ -134,7 +133,7 @@ func Subset(cidr1, cidr2 string) (bool, error) {
 
 	ip1, net1, err := net.ParseCIDR(cidr1)
 	if err != nil {
-		return false, errwrap.Wrapf("failed to parse the CIDR to be checked against: {{err}}", err)
+		return false, fmt.Errorf("failed to parse the CIDR to be checked against: %w", err)
 	}
 
 	zeroAddr := false
@@ -152,7 +151,7 @@ func Subset(cidr1, cidr2 string) (bool, error) {
 
 	ip2, net2, err := net.ParseCIDR(cidr2)
 	if err != nil {
-		return false, errwrap.Wrapf("failed to parse the CIDR that needs to be checked: {{err}}", err)
+		return false, fmt.Errorf("failed to parse the CIDR that needs to be checked: %w", err)
 	}
 
 	zeroAddr = false

--- a/sdk/helper/compressutil/compress.go
+++ b/sdk/helper/compressutil/compress.go
@@ -11,7 +11,6 @@ import (
 	"io"
 
 	"github.com/golang/snappy"
-	"github.com/hashicorp/errwrap"
 	"github.com/pierrec/lz4"
 )
 
@@ -116,7 +115,7 @@ func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
 	}
 
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create a compression writer: {{err}}", err)
+		return nil, fmt.Errorf("failed to create a compression writer: %w", err)
 	}
 
 	if writer == nil {
@@ -126,7 +125,7 @@ func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
 	// Compress the input and place it in the same buffer containing the
 	// canary byte.
 	if _, err = writer.Write(data); err != nil {
-		return nil, errwrap.Wrapf("failed to compress input data: err: {{err}}", err)
+		return nil, fmt.Errorf("failed to compress input data: err: %w", err)
 	}
 
 	// Close the io.WriteCloser
@@ -206,7 +205,7 @@ func DecompressWithCanary(data []byte) ([]byte, string, bool, error) {
 		return nil, "", true, nil
 	}
 	if err != nil {
-		return nil, "", false, errwrap.Wrapf("failed to create a compression reader: {{err}}", err)
+		return nil, "", false, fmt.Errorf("failed to create a compression reader: %w", err)
 	}
 	if reader == nil {
 		return nil, "", false, fmt.Errorf("failed to create a compression reader")

--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -333,7 +332,7 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 		case 3:
 			duration, err := parseutil.ParseDurationSecond(opsSplit[2])
 			if err != nil {
-				return "", errwrap.Wrapf("invalid duration: {{err}}", err)
+				return "", fmt.Errorf("invalid duration: %w", err)
 			}
 
 			switch opsSplit[1] {

--- a/sdk/helper/jsonutil/json.go
+++ b/sdk/helper/jsonutil/json.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/compressutil"
 )
 
@@ -68,7 +67,7 @@ func DecodeJSON(data []byte, out interface{}) error {
 	// Decompress the data if it was compressed in the first place
 	decompressedBytes, uncompressed, err := compressutil.Decompress(data)
 	if err != nil {
-		return errwrap.Wrapf("failed to decompress JSON: {{err}}", err)
+		return fmt.Errorf("failed to decompress JSON: %w", err)
 	}
 	if !uncompressed && (decompressedBytes == nil || len(decompressedBytes) == 0) {
 		return fmt.Errorf("decompressed data being decoded is invalid")

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -88,7 +87,7 @@ func NewLockManager(useCache bool, cacheSize int) (*LockManager, error) {
 	case cacheSize > 0:
 		newLRUCache, err := NewTransitLRU(cacheSize)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to create cache: {{err}}", err)
+			return nil, fmt.Errorf("failed to create cache: %w", err)
 		}
 		cache = newLRUCache
 	}
@@ -129,7 +128,7 @@ func (lm *LockManager) InitCache(cacheSize int) error {
 		case cacheSize > 0:
 			newLRUCache, err := NewTransitLRU(cacheSize)
 			if err != nil {
-				return errwrap.Wrapf("failed to create cache: {{err}}", err)
+				return fmt.Errorf("failed to create cache: %w", err)
 			}
 			lm.cache = newLRUCache
 		}
@@ -214,7 +213,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 	if keyData.ArchivedKeys != nil {
 		err = keyData.Policy.storeArchive(ctx, storage, keyData.ArchivedKeys)
 		if err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("failed to restore archived keys for key %q: {{err}}", name), err)
+			return fmt.Errorf("failed to restore archived keys for key %q: %w", name, err)
 		}
 	}
 
@@ -227,7 +226,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 	// Restore the policy. This will also attempt to adjust the archive.
 	err = keyData.Policy.Persist(ctx, storage)
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf("failed to restore the policy %q: {{err}}", name), err)
+		return fmt.Errorf("failed to restore the policy %q: %w", name, err)
 	}
 
 	keyData.Policy.l = new(sync.RWMutex)
@@ -548,12 +547,12 @@ func (lm *LockManager) DeletePolicy(ctx context.Context, storage logical.Storage
 
 	err = storage.Delete(ctx, "policy/"+name)
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf("error deleting key %q: {{err}}", name), err)
+		return fmt.Errorf("error deleting key %q: %w", name, err)
 	}
 
 	err = storage.Delete(ctx, "archive/"+name)
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf("error deleting key %q archive: {{err}}", name), err)
+		return fmt.Errorf("error deleting key %q archive: %w", name, err)
 	}
 
 	return nil

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -36,7 +36,6 @@ import (
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/hkdf"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -1651,7 +1650,7 @@ func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 		entry.EC_Y = privKey.Y
 		derBytes, err := x509.MarshalPKIXPublicKey(privKey.Public())
 		if err != nil {
-			return errwrap.Wrapf("error marshaling public key: {{err}}", err)
+			return fmt.Errorf("error marshaling public key: %w", err)
 		}
 		pemBlock := &pem.Block{
 			Type:  "PUBLIC KEY",
@@ -1759,7 +1758,7 @@ func (p *Policy) Backup(ctx context.Context, storage logical.Storage) (out strin
 	}
 	err := p.Persist(ctx, storage)
 	if err != nil {
-		return "", errwrap.Wrapf("failed to persist policy with backup info: {{err}}", err)
+		return "", fmt.Errorf("failed to persist policy with backup info: %w", err)
 	}
 
 	// Load the archive only after persisting the policy as the archive can get
@@ -2230,7 +2229,7 @@ func (ke *KeyEntry) parseFromKey(PolKeyType KeyType, parsedKey any) error {
 
 			derBytes, err = x509.MarshalPKIXPublicKey(ecdsaKey.Public())
 			if err != nil {
-				return errwrap.Wrapf("error marshaling public key: {{err}}", err)
+				return fmt.Errorf("error marshaling public key: %w", err)
 			}
 		} else {
 			ecdsaKey := parsedKey.(*ecdsa.PublicKey)
@@ -2244,7 +2243,7 @@ func (ke *KeyEntry) parseFromKey(PolKeyType KeyType, parsedKey any) error {
 
 			derBytes, err = x509.MarshalPKIXPublicKey(ecdsaKey)
 			if err != nil {
-				return errwrap.Wrapf("error marshaling public key: {{err}}", err)
+				return fmt.Errorf("error marshaling public key: %w", err)
 			}
 		}
 

--- a/sdk/helper/ldaputil/config.go
+++ b/sdk/helper/ldaputil/config.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
 
-	"github.com/hashicorp/errwrap"
-
 	"github.com/go-ldap/ldap/v3"
 )
 
@@ -293,7 +291,7 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 			// Validate the template before proceeding
 			_, err := template.New("queryTemplate").Parse(userfilter)
 			if err != nil {
-				return nil, errwrap.Wrapf("invalid userfilter: {{err}}", err)
+				return nil, fmt.Errorf("invalid userfilter: %w", err)
 			}
 		}
 
@@ -318,7 +316,7 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 			// Validate the template before proceeding
 			_, err := template.New("queryTemplate").Parse(groupfilter)
 			if err != nil {
-				return nil, errwrap.Wrapf("invalid groupfilter: {{err}}", err)
+				return nil, fmt.Errorf("invalid groupfilter: %w", err)
 			}
 		}
 
@@ -337,7 +335,7 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 		certificate := d.Get("certificate").(string)
 		if certificate != "" {
 			if err := validateCertificate([]byte(certificate)); err != nil {
-				return nil, errwrap.Wrapf("failed to parse server tls cert: {{err}}", err)
+				return nil, fmt.Errorf("failed to parse server tls cert: %w", err)
 			}
 		}
 		cfg.Certificate = certificate
@@ -355,7 +353,7 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 
 	if cfg.ClientTLSCert != "" && cfg.ClientTLSKey != "" {
 		if _, err := tls.X509KeyPair([]byte(cfg.ClientTLSCert), []byte(cfg.ClientTLSKey)); err != nil {
-			return nil, errwrap.Wrapf("failed to parse client X509 key pair: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse client X509 key pair: %w", err)
 		}
 	} else if cfg.ClientTLSCert != "" || cfg.ClientTLSKey != "" {
 		return nil, fmt.Errorf("both client_tls_cert and client_tls_key must be set")
@@ -549,12 +547,12 @@ func (c *ConfigEntry) Validate() error {
 	}
 	if c.Certificate != "" {
 		if err := validateCertificate([]byte(c.Certificate)); err != nil {
-			return errwrap.Wrapf("failed to parse server tls cert: {{err}}", err)
+			return fmt.Errorf("failed to parse server tls cert: %w", err)
 		}
 	}
 	if c.ClientTLSCert != "" && c.ClientTLSKey != "" {
 		if _, err := tls.X509KeyPair([]byte(c.ClientTLSCert), []byte(c.ClientTLSKey)); err != nil {
-			return errwrap.Wrapf("failed to parse client X509 key pair: {{err}}", err)
+			return fmt.Errorf("failed to parse client X509 key pair: %w", err)
 		}
 	}
 	return nil

--- a/sdk/helper/pluginutil/tls.go
+++ b/sdk/helper/pluginutil/tls.go
@@ -11,9 +11,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 )
@@ -54,7 +54,7 @@ func generateCert() ([]byte, *ecdsa.PrivateKey, error) {
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
 	if err != nil {
-		return nil, nil, errwrap.Wrapf("unable to generate client certificate: {{err}}", err)
+		return nil, nil, fmt.Errorf("unable to generate client certificate: %w", err)
 	}
 
 	return certBytes, key, nil
@@ -65,7 +65,7 @@ func generateCert() ([]byte, *ecdsa.PrivateKey, error) {
 func createClientTLSConfig(certBytes []byte, key *ecdsa.PrivateKey) (*tls.Config, error) {
 	clientCert, err := x509.ParseCertificate(certBytes)
 	if err != nil {
-		return nil, errwrap.Wrapf("error parsing generated plugin certificate: {{err}}", err)
+		return nil, fmt.Errorf("error parsing generated plugin certificate: %w", err)
 	}
 
 	cert := tls.Certificate{

--- a/sdk/helper/salt/salt.go
+++ b/sdk/helper/salt/salt.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"hash"
 
-	"github.com/hashicorp/errwrap"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -82,7 +81,7 @@ func NewSalt(ctx context.Context, view logical.Storage, config *Config) (*Salt, 
 	if view != nil {
 		raw, err = view.Get(ctx, config.Location)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to read salt: {{err}}", err)
+			return nil, fmt.Errorf("failed to read salt: %w", err)
 		}
 	}
 
@@ -95,7 +94,7 @@ func NewSalt(ctx context.Context, view logical.Storage, config *Config) (*Salt, 
 	if s.salt == "" {
 		s.salt, err = uuid.GenerateUUID()
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to generate uuid: {{err}}", err)
+			return nil, fmt.Errorf("failed to generate uuid: %w", err)
 		}
 		s.generated = true
 		if view != nil {
@@ -104,7 +103,7 @@ func NewSalt(ctx context.Context, view logical.Storage, config *Config) (*Salt, 
 				Value: []byte(s.salt),
 			}
 			if err := view.Put(ctx, raw); err != nil {
-				return nil, errwrap.Wrapf("failed to persist salt: {{err}}", err)
+				return nil, fmt.Errorf("failed to persist salt: %w", err)
 			}
 		}
 	}

--- a/sdk/helper/stepwise/helpers.go
+++ b/sdk/helper/stepwise/helpers.go
@@ -14,8 +14,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-
-	"github.com/hashicorp/errwrap"
 )
 
 const pluginPrefix = "vault-plugin-"
@@ -103,7 +101,7 @@ func (cg *CertificateGetter) Reload() error {
 	if x509.IsEncryptedPEMBlock(keyBlock) {
 		keyBlock.Bytes, err = x509.DecryptPEMBlock(keyBlock, []byte(cg.passphrase))
 		if err != nil {
-			return errwrap.Wrapf("Decrypting PEM block failed {{err}}", err)
+			return fmt.Errorf("Decrypting PEM block failed %w", err)
 		}
 		keyPEMBlock = pem.EncodeToMemory(keyBlock)
 	}

--- a/sdk/helper/testcluster/docker/cert.go
+++ b/sdk/helper/testcluster/docker/cert.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-
-	"github.com/hashicorp/errwrap"
 )
 
 // ReloadFunc are functions that are called when a reload is requested
@@ -58,7 +56,7 @@ func (cg *CertificateGetter) Reload() error {
 	if x509.IsEncryptedPEMBlock(keyBlock) {
 		keyBlock.Bytes, err = x509.DecryptPEMBlock(keyBlock, []byte(cg.passphrase))
 		if err != nil {
-			return errwrap.Wrapf("Decrypting PEM block failed {{err}}", err)
+			return fmt.Errorf("Decrypting PEM block failed %w", err)
 		}
 		keyPEMBlock = pem.EncodeToMemory(keyBlock)
 	}

--- a/sdk/logical/storage.go
+++ b/sdk/logical/storage.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 )
@@ -53,7 +52,7 @@ func (e *StorageEntry) DecodeJSON(out interface{}) error {
 func StorageEntryJSON(k string, v interface{}) (*StorageEntry, error) {
 	encodedBytes, err := jsonutil.EncodeJSON(v)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to encode storage entry: {{err}}", err)
+		return nil, fmt.Errorf("failed to encode storage entry: %w", err)
 	}
 
 	return &StorageEntry{
@@ -78,7 +77,7 @@ func ScanView(ctx context.Context, view ClearableView, cb func(path string)) err
 		// List the contents
 		contents, err := view.List(ctx, current)
 		if err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("list failed at path %q: {{err}}", current), err)
+			return fmt.Errorf("list failed at path %q: %w", current, err)
 		}
 
 		// Handle the contents in the directory

--- a/sdk/physical/file/file.go
+++ b/sdk/physical/file/file.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -90,7 +89,7 @@ func (b *FileBackend) DeleteInternal(ctx context.Context, path string) error {
 
 	err := os.Remove(fullPath)
 	if err != nil && !os.IsNotExist(err) {
-		return errwrap.Wrapf(fmt.Sprintf("failed to remove %q: {{err}}", fullPath), err)
+		return fmt.Errorf("failed to remove %q: %w", fullPath, err)
 	}
 
 	err = b.cleanupLogicalPath(path)

--- a/sdk/plugin/mock/path_kv.go
+++ b/sdk/plugin/mock/path_kv.go
@@ -5,8 +5,8 @@ package mock
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -42,7 +42,7 @@ func kvPaths(b *backend) []*framework.Path {
 func (b *backend) pathExistenceCheck(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
 	out, err := req.Storage.Get(ctx, req.Path)
 	if err != nil {
-		return false, errwrap.Wrapf("existence check failed: {{err}}", err)
+		return false, fmt.Errorf("existence check failed: %w", err)
 	}
 
 	return out != nil, nil

--- a/serviceregistration/kubernetes/testing/testserver.go
+++ b/serviceregistration/kubernetes/testing/testserver.go
@@ -42,21 +42,9 @@ var updatePodTagsResponse string
 //go:embed token
 var token string
 
-var (
-	// ReturnGatewayTimeouts toggles whether the test server should return,
-	// well, gateway timeouts...
-	ReturnGatewayTimeouts = atomic.NewBool(false)
-
-	pathToFiles = func() string {
-		wd, _ := os.Getwd()
-		repoName := "vault-enterprise"
-		if !strings.Contains(wd, repoName) {
-			repoName = "vault"
-		}
-		pathParts := strings.Split(wd, repoName)
-		return pathParts[0] + "vault/serviceregistration/kubernetes/testing/"
-	}()
-)
+// ReturnGatewayTimeouts toggles whether the test server should return,
+// well, gateway timeouts...
+var ReturnGatewayTimeouts = atomic.NewBool(false)
 
 // Conf returns the info needed to configure the client to point at
 // the test server. This must be done by the caller to avoid an import
@@ -229,12 +217,4 @@ func parsePath(urlPath string) (namespace, podName string, err error) {
 		return "", "", fmt.Errorf("received unexpected path: %s", original)
 	}
 	return namespace, podName, nil
-}
-
-func readFile(fileName string) (string, error) {
-	b, err := os.ReadFile(pathToFiles + fileName)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
 }

--- a/vault/diagnose/mock_storage_backend.go
+++ b/vault/diagnose/mock_storage_backend.go
@@ -5,6 +5,7 @@ package diagnose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -43,11 +44,11 @@ func (m mockStorageBackend) storageLogicGeneralInternal(op string) error {
 		(m.callType == timeoutCallDelete && op == deleteOp) {
 		time.Sleep(2 * time.Second)
 	} else if m.callType == errCallWrite && op == writeOp {
-		return fmt.Errorf(storageErrStringWrite)
+		return errors.New(storageErrStringWrite)
 	} else if m.callType == errCallDelete && op == deleteOp {
-		return fmt.Errorf(storageErrStringDelete)
+		return errors.New(storageErrStringDelete)
 	} else if m.callType == errCallRead && op == readOp {
-		return fmt.Errorf(storageErrStringRead)
+		return errors.New(storageErrStringRead)
 	}
 
 	return nil

--- a/vault/diagnose/output.go
+++ b/vault/diagnose/output.go
@@ -5,7 +5,6 @@ package diagnose
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -33,8 +32,6 @@ const (
 	OkStatus       = 0
 	SkippedStatus  = -1
 )
-
-var errUnimplemented = errors.New("unimplemented")
 
 type status int
 
@@ -96,7 +93,6 @@ func (r *Result) ZeroTimes() {
 type TelemetryCollector struct {
 	ui         io.Writer
 	spans      map[trace.SpanID]sdktrace.ReadOnlySpan
-	rootSpan   sdktrace.ReadOnlySpan
 	results    map[trace.SpanID]*Result
 	RootResult *Result
 	mu         sync.Mutex

--- a/vault/diagnose/tls_verification_test.go
+++ b/vault/diagnose/tls_verification_test.go
@@ -29,7 +29,7 @@ func TestTLSValidCert(t *testing.T) {
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs != nil {
 		// The test failed -- we can just return one of the errors
-		t.Fatalf(errs[0].Error())
+		t.Fatal(errs[0].Error())
 	}
 	if warnings != nil {
 		t.Fatalf("warnings returned from good listener")
@@ -268,7 +268,7 @@ func TestTLSInvalidMinVersion(t *testing.T) {
 	if errs == nil || len(errs) != 1 {
 		t.Fatalf("TLS Config check on invalid 'tls_min_version' should fail")
 	}
-	if !strings.Contains(errs[0].Error(), fmt.Errorf(minVersionError, "0").Error()) {
+	if !strings.Contains(errs[0].Error(), fmt.Sprintf(minVersionError, "0")) {
 		t.Fatalf("Bad error message: %s", errs[0])
 	}
 }
@@ -292,7 +292,7 @@ func TestTLSInvalidMaxVersion(t *testing.T) {
 	if errs == nil || len(errs) != 1 {
 		t.Fatalf("TLS Config check on invalid 'tls_max_version' should fail")
 	}
-	if !strings.Contains(errs[0].Error(), fmt.Errorf(maxVersionError, "0").Error()) {
+	if !strings.Contains(errs[0].Error(), fmt.Sprintf(maxVersionError, "0")) {
 		t.Fatalf("Bad error message: %s", errs[0])
 	}
 }

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -73,8 +73,6 @@ const (
 	LeaseActionAllow
 )
 
-type leaseWalkFunc func(context.Context, func(request *Request) bool) error
-
 // String converts each quota type into its string equivalent value
 func (q Type) String() string {
 	switch q {

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -87,7 +87,7 @@ func (c *Core) RekeyThreshold(ctx context.Context, recovery bool) (int, logical.
 		config, err = c.seal.BarrierConfig(ctx)
 	}
 	if err != nil {
-		return 0, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("unable to look up config: %w", err).Error())
+		return 0, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("unable to look up config: %v", err))
 	}
 	if config == nil {
 		return 0, logical.CodedError(http.StatusBadRequest, ErrNotInit.Error())
@@ -207,7 +207,7 @@ func (c *Core) BarrierRekeyInit(config *SealConfig) logical.HTTPCodedError {
 	// Check if the seal configuration is valid
 	if err := config.Validate(); err != nil {
 		c.logger.Error("invalid rekey seal configuration", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("invalid rekey seal configuration: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("invalid rekey seal configuration: %v", err))
 	}
 
 	c.stateLock.RLock()
@@ -234,7 +234,7 @@ func (c *Core) BarrierRekeyInit(config *SealConfig) logical.HTTPCodedError {
 	nonce, err := uuid.GenerateUUID()
 	if err != nil {
 		c.barrierRekeyConfig = nil
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error generating nonce for procedure: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error generating nonce for procedure: %v", err))
 	}
 	c.barrierRekeyConfig.Nonce = nonce
 
@@ -253,7 +253,7 @@ func (c *Core) RecoveryRekeyInit(config *SealConfig) logical.HTTPCodedError {
 	// Check if the seal configuration is valid
 	if err := config.Validate(); err != nil {
 		c.logger.Error("invalid recovery configuration", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("invalid recovery configuration: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("invalid recovery configuration: %v", err))
 	}
 
 	if !c.seal.RecoveryKeySupported() {
@@ -284,7 +284,7 @@ func (c *Core) RecoveryRekeyInit(config *SealConfig) logical.HTTPCodedError {
 	nonce, err := uuid.GenerateUUID()
 	if err != nil {
 		c.recoveryRekeyConfig = nil
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error generating nonce for procedure: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error generating nonce for procedure: %v", err))
 	}
 	c.recoveryRekeyConfig.Nonce = nonce
 
@@ -342,7 +342,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		existingConfig, err = c.seal.BarrierConfig(ctx)
 	}
 	if err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to fetch existing config: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to fetch existing config: %v", err))
 	}
 	// Ensure the barrier is initialized
 	if existingConfig == nil {
@@ -389,7 +389,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		recoveredKey, err = shamir.Combine(c.barrierRekeyConfig.RekeyProgress)
 		c.barrierRekeyConfig.RekeyProgress = nil
 		if err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to compute root key: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to compute root key: %v", err))
 		}
 	}
 
@@ -397,7 +397,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 	case useRecovery:
 		if err := c.seal.VerifyRecoveryKey(ctx, recoveredKey); err != nil {
 			c.logger.Error("rekey recovery key verification failed", "error", err)
-			return nil, logical.CodedError(http.StatusBadRequest, fmt.Errorf("recovery key verification failed: %w", err).Error())
+			return nil, logical.CodedError(http.StatusBadRequest, fmt.Sprintf("recovery key verification failed: %v", err))
 		}
 	case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
 		if c.seal.StoredKeysSupported() == seal.StoredKeysSupportedShamirRoot {
@@ -406,22 +406,22 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 			testseal.SetCore(c)
 			err = shamirWrapper.SetAesGcmKeyBytes(recoveredKey)
 			if err != nil {
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to setup unseal key: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to setup unseal key: %v", err))
 			}
 			cfg, err := c.seal.BarrierConfig(ctx)
 			if err != nil {
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to setup test barrier config: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to setup test barrier config: %v", err))
 			}
 			testseal.SetCachedBarrierConfig(cfg)
 			stored, err := testseal.GetStoredKeys(ctx)
 			if err != nil {
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to read root key: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to read root key: %v", err))
 			}
 			recoveredKey = stored[0]
 		}
 		if err := c.barrier.VerifyRoot(recoveredKey); err != nil {
 			c.logger.Error("root key verification failed", "error", err)
-			return nil, logical.CodedError(http.StatusBadRequest, fmt.Errorf("rootter key verification failed: %w", err).Error())
+			return nil, logical.CodedError(http.StatusBadRequest, fmt.Sprintf("rootter key verification failed: %v", err))
 		}
 	}
 
@@ -431,7 +431,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 	newKey, err := c.barrier.GenerateKey(c.secureRandomReader)
 	if err != nil {
 		c.logger.Error("failed to generate root key", "error", err)
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("root key generation failed: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("root key generation failed: %v", err))
 	}
 
 	results := &RekeyResult{
@@ -447,7 +447,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 			shares, err := shamir.Split(newKey, c.barrierRekeyConfig.SecretShares, c.barrierRekeyConfig.SecretThreshold)
 			if err != nil {
 				c.logger.Error("failed to generate shares", "error", err)
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to generate shares: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to generate shares: %v", err))
 			}
 			results.SecretShares = shares
 		}
@@ -461,7 +461,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		}
 		results.PGPFingerprints, results.SecretShares, err = pgpkeys.EncryptShares(hexEncodedShares, c.barrierRekeyConfig.PGPKeys)
 		if err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to encrypt shares: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to encrypt shares: %v", err))
 		}
 
 		// If backup is enabled, store backup info in vault.coreBarrierUnsealKeysBackupPath
@@ -483,7 +483,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 			buf, err := json.Marshal(backupVals)
 			if err != nil {
 				c.logger.Error("failed to marshal unseal key backup", "error", err)
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to marshal unseal key backup: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to marshal unseal key backup: %v", err))
 			}
 			pe := &physical.Entry{
 				Key:   coreBarrierUnsealKeysBackupPath,
@@ -491,7 +491,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 			}
 			if err = c.physical.Put(ctx, pe); err != nil {
 				c.logger.Error("failed to save unseal key backup", "error", err)
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save unseal key backup: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save unseal key backup: %v", err))
 			}
 		}
 	}
@@ -501,7 +501,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		nonce, err := uuid.GenerateUUID()
 		if err != nil {
 			c.barrierRekeyConfig = nil
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to generate verification nonce: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to generate verification nonce: %v", err))
 		}
 		c.barrierRekeyConfig.VerificationNonce = nonce
 		c.barrierRekeyConfig.VerificationKey = newKey
@@ -512,7 +512,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 	}
 
 	if err := c.performBarrierRekey(ctx, newKey); err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to perform barrier rekey: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to perform barrier rekey: %v", err))
 	}
 
 	c.barrierRekeyConfig = nil
@@ -525,7 +525,7 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 		// We won't be able to call SetStoredKeys without setting StoredShares=1.
 		existingConfig, err := c.seal.BarrierConfig(ctx)
 		if err != nil {
-			return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to fetch existing config: %w", err).Error())
+			return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to fetch existing config: %v", err))
 		}
 		existingConfig.StoredShares = 1
 		c.seal.SetCachedBarrierConfig(existingConfig)
@@ -537,23 +537,23 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 			err = shamirWrapper.SetAesGcmKeyBytes(newSealKey)
 		}
 		if err != nil {
-			return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to update barrier seal key: %w", err).Error())
+			return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to update barrier seal key: %v", err))
 		}
 	}
 
 	newRootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
 	if err != nil {
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to perform rekey: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to perform rekey: %v", err))
 	}
 	if err := c.seal.SetStoredKeys(ctx, [][]byte{newRootKey}); err != nil {
 		c.logger.Error("failed to store keys", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to store keys: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to store keys: %v", err))
 	}
 
 	// Rekey the barrier
 	if err := c.barrier.Rekey(ctx, newRootKey); err != nil {
 		c.logger.Error("failed to rekey barrier", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to rekey barrier: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to rekey barrier: %v", err))
 	}
 	if c.logger.IsInfo() {
 		c.logger.Info("security barrier rekeyed", "stored", c.barrierRekeyConfig.StoredShares, "shares", c.barrierRekeyConfig.SecretShares, "threshold", c.barrierRekeyConfig.SecretThreshold)
@@ -566,7 +566,7 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 		})
 		if err != nil {
 			c.logger.Error("failed to store new seal key", "error", err)
-			return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to store new seal key: %w", err).Error())
+			return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to store new seal key: %v", err))
 		}
 	}
 
@@ -574,7 +574,7 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 
 	if err := c.seal.SetBarrierConfig(ctx, c.barrierRekeyConfig); err != nil {
 		c.logger.Error("error saving rekey seal configuration", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save rekey seal configuration: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save rekey seal configuration: %v", err))
 	}
 
 	// Write to the canary path, which will force a synchronous truing during
@@ -584,7 +584,7 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 		Value: []byte(c.barrierRekeyConfig.Nonce),
 	}); err != nil {
 		c.logger.Error("error saving keyring canary", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save keyring canary: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save keyring canary: %v", err))
 	}
 
 	c.barrierRekeyConfig.RekeyProgress = nil
@@ -620,7 +620,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 	// Get the seal configuration
 	existingConfig, err := c.seal.RecoveryConfig(ctx)
 	if err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to fetch existing recovery config: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to fetch existing recovery config: %v", err))
 	}
 	// Ensure the seal is initialized
 	if existingConfig == nil {
@@ -667,21 +667,21 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 		recoveryKey, err = shamir.Combine(c.recoveryRekeyConfig.RekeyProgress)
 		c.recoveryRekeyConfig.RekeyProgress = nil
 		if err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to compute recovery key: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to compute recovery key: %v", err))
 		}
 	}
 
 	// Verify the recovery key
 	if err := c.seal.VerifyRecoveryKey(ctx, recoveryKey); err != nil {
 		c.logger.Error("recovery key verification failed", "error", err)
-		return nil, logical.CodedError(http.StatusBadRequest, fmt.Errorf("recovery key verification failed: %w", err).Error())
+		return nil, logical.CodedError(http.StatusBadRequest, fmt.Sprintf("recovery key verification failed: %v", err))
 	}
 
 	// Generate a new root key
 	newRecoveryKey, err := c.barrier.GenerateKey(c.secureRandomReader)
 	if err != nil {
 		c.logger.Error("failed to generate recovery key", "error", err)
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("recovery key generation failed: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("recovery key generation failed: %v", err))
 	}
 
 	// Return the root key if only a single key part is used
@@ -696,7 +696,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 		shares, err := shamir.Split(newRecoveryKey, c.recoveryRekeyConfig.SecretShares, c.recoveryRekeyConfig.SecretThreshold)
 		if err != nil {
 			c.logger.Error("failed to generate shares", "error", err)
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to generate shares: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to generate shares: %v", err))
 		}
 		results.SecretShares = shares
 	}
@@ -708,7 +708,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 		}
 		results.PGPFingerprints, results.SecretShares, err = pgpkeys.EncryptShares(hexEncodedShares, c.recoveryRekeyConfig.PGPKeys)
 		if err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to encrypt shares: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to encrypt shares: %v", err))
 		}
 
 		if c.recoveryRekeyConfig.Backup {
@@ -729,7 +729,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 			buf, err := json.Marshal(backupVals)
 			if err != nil {
 				c.logger.Error("failed to marshal recovery key backup", "error", err)
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to marshal recovery key backup: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to marshal recovery key backup: %v", err))
 			}
 			pe := &physical.Entry{
 				Key:   coreRecoveryUnsealKeysBackupPath,
@@ -737,7 +737,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 			}
 			if err = c.physical.Put(ctx, pe); err != nil {
 				c.logger.Error("failed to save unseal key backup", "error", err)
-				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save unseal key backup: %w", err).Error())
+				return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save unseal key backup: %v", err))
 			}
 		}
 	}
@@ -748,7 +748,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 		nonce, err := uuid.GenerateUUID()
 		if err != nil {
 			c.recoveryRekeyConfig = nil
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to generate verification nonce: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to generate verification nonce: %v", err))
 		}
 		c.recoveryRekeyConfig.VerificationNonce = nonce
 		c.recoveryRekeyConfig.VerificationKey = newRecoveryKey
@@ -759,7 +759,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 	}
 
 	if err := c.performRecoveryRekey(ctx, newRecoveryKey); err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to perform recovery rekey: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to perform recovery rekey: %v", err))
 	}
 
 	c.recoveryRekeyConfig = nil
@@ -769,14 +769,14 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 func (c *Core) performRecoveryRekey(ctx context.Context, newRootKey []byte) logical.HTTPCodedError {
 	if err := c.seal.SetRecoveryKey(ctx, newRootKey); err != nil {
 		c.logger.Error("failed to set recovery key", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to set recovery key: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to set recovery key: %v", err))
 	}
 
 	c.recoveryRekeyConfig.VerificationKey = nil
 
 	if err := c.seal.SetRecoveryConfig(ctx, c.recoveryRekeyConfig); err != nil {
 		c.logger.Error("error saving rekey seal configuration", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save rekey seal configuration: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save rekey seal configuration: %v", err))
 	}
 
 	// Write to the canary path, which will force a synchronous truing during
@@ -786,7 +786,7 @@ func (c *Core) performRecoveryRekey(ctx context.Context, newRootKey []byte) logi
 		Value: []byte(c.recoveryRekeyConfig.Nonce),
 	}); err != nil {
 		c.logger.Error("error saving keyring canary", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save keyring canary: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to save keyring canary: %v", err))
 	}
 
 	c.recoveryRekeyConfig.RekeyProgress = nil
@@ -878,7 +878,7 @@ func (c *Core) RekeyVerify(ctx context.Context, key []byte, nonce string, recove
 		var err error
 		recoveredKey, err = shamir.Combine(config.VerificationProgress)
 		if err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to compute key for verification: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to compute key for verification: %v", err))
 		}
 	}
 
@@ -890,12 +890,12 @@ func (c *Core) RekeyVerify(ctx context.Context, key []byte, nonce string, recove
 	switch recovery {
 	case false:
 		if err := c.performBarrierRekey(ctx, recoveredKey); err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to perform rekey: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to perform rekey: %v", err))
 		}
 		c.barrierRekeyConfig = nil
 	default:
 		if err := c.performRecoveryRekey(ctx, recoveredKey); err != nil {
-			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to perform recovery key rekey: %w", err).Error())
+			return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("failed to perform recovery key rekey: %v", err))
 		}
 		c.recoveryRekeyConfig = nil
 	}
@@ -990,7 +990,7 @@ func (c *Core) RekeyRetrieveBackup(ctx context.Context, recovery bool) (*RekeyBa
 		entry, err = c.physical.Get(ctx, coreBarrierUnsealKeysBackupPath)
 	}
 	if err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error getting keys from backup: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error getting keys from backup: %v", err))
 	}
 	if entry == nil {
 		return nil, nil
@@ -999,7 +999,7 @@ func (c *Core) RekeyRetrieveBackup(ctx context.Context, recovery bool) (*RekeyBa
 	ret := &RekeyBackup{}
 	err = jsonutil.DecodeJSON(entry.Value, ret)
 	if err != nil {
-		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error decoding backup keys: %w", err).Error())
+		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error decoding backup keys: %v", err))
 	}
 
 	return ret, nil
@@ -1020,13 +1020,13 @@ func (c *Core) RekeyDeleteBackup(ctx context.Context, recovery bool) logical.HTT
 	if recovery {
 		err := c.physical.Delete(ctx, coreRecoveryUnsealKeysBackupPath)
 		if err != nil {
-			return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error deleting backup keys: %w", err).Error())
+			return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error deleting backup keys: %v", err))
 		}
 		return nil
 	}
 	err := c.physical.Delete(ctx, coreBarrierUnsealKeysBackupPath)
 	if err != nil {
-		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error deleting backup keys: %w", err).Error())
+		return logical.CodedError(http.StatusInternalServerError, fmt.Sprintf("error deleting backup keys: %v", err))
 	}
 	return nil
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -178,7 +178,7 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 			// When we attempt to get a non-EGP policy type, and receive an
 			// explicit error that it doesn't exist (in the type map) we log the
 			// ns/policy and continue without error.
-			c.Logger().Debug(fmt.Errorf("%w: %v/%v", err, policyNS.ID, policyName).Error())
+			c.Logger().Debug(fmt.Sprintf("%v: %v/%v", err, policyNS.ID, policyName))
 			continue
 		}
 		if err != nil || t == nil {
@@ -683,7 +683,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 
 	ns, err = namespace.FromContext(ctx)
 	if err != nil {
-		return nil, errwrap.Wrapf("could not parse namespace from http context: {{err}}", err)
+		return nil, fmt.Errorf("could not parse namespace from http context: %w", err)
 	}
 
 	if ns.Path != "" {

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3670,7 +3670,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 
 	// Next parse token fields from the helper
 	if err := entry.ParseTokenFields(req, data); err != nil {
-		return logical.ErrorResponse(fmt.Errorf("error parsing role fields: %w", err).Error()), nil
+		return logical.ErrorResponse(fmt.Sprintf("error parsing role fields: %v", err)), nil
 	}
 
 	entry.TokenType = oldEntryTokenType
@@ -3723,7 +3723,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 		if ok {
 			boundCIDRs, err := parseutil.ParseAddrs(boundCIDRsRaw.([]string))
 			if err != nil {
-				return logical.ErrorResponse(fmt.Errorf("error parsing bound_cidrs: %w", err).Error()), nil
+				return logical.ErrorResponse(fmt.Sprintf("error parsing bound_cidrs: %v", err)), nil
 			}
 			entry.BoundCIDRs = boundCIDRs
 			entry.TokenBoundCIDRs = entry.BoundCIDRs

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -4129,7 +4129,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4286,7 +4286,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4678,7 +4678,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4739,7 +4739,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4791,7 +4791,7 @@ func testTokenStore_NumUses_ErrorCheckHelper(t *testing.T, resp *logical.Respons
 		t.Fatal("response was nil")
 	}
 	if resp.Auth == nil {
-		t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+		t.Fatalf("response auth was nil, resp is %#v", *resp)
 	}
 	if resp.Auth.ClientToken == "" {
 		t.Fatalf("bad: %#v", resp)
@@ -4938,7 +4938,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -5012,7 +5012,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)


### PR DESCRIPTION
This is the first in no doubt, many PRs, as I get time to help clean up linter failures. 

This part focuses on two things: incorrect formatting functions and a number of unused code removals. I think eventually we'll be able to fully remove `errwrap` as a dependency, but that will take a bit. 