### PR TITLE
Add LF Edge Google Tag Manager analytics

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -69,6 +69,9 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
+		gtag: {
+		  trackingID: "GTM-MWH2V47T",
+		},
       } satisfies Preset.Options,
     ],
   ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -71,6 +71,7 @@ const config: Config = {
         },
 		gtag: {
 		  trackingID: "GTM-MWH2V47T",
+		  anonymizeIP: true,
 		},
       } satisfies Preset.Options,
     ],


### PR DESCRIPTION
Per October 3rd meeting and TSC mailing list, enable LF Edge's Google Tag Manager / Analytics for insights on blog viewership and for prioritizing documentation updates.

See also: https://lf-edge.atlassian.net/wiki/spaces/OP/pages/15211863/OpenBao+Meetings
See also: https://lists.lfedge.org/g/OpenBao-TSC/topic/openbao_org_lf_s_google/108669761