### PR TITLE
Add transactional storage to PostgreSQL

### DIFF
--- a/changelog/608.txt
+++ b/changelog/608.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/postgresql: Add support for transactional storage semantics.
+```

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -77,6 +77,8 @@ func TestPostgreSQLBackend(t *testing.T) {
 
 	logger.Info("Running basic backend tests")
 	physical.ExerciseBackend(t, b1)
+	logger.Info("Running transactional backend tests")
+	physical.ExerciseTransactionalBackend(t, b1.(physical.TransactionalBackend))
 	logger.Info("Running list prefix backend tests")
 	physical.ExerciseBackend_ListPrefix(t, b1)
 

--- a/physical/postgresql/transaction.go
+++ b/physical/postgresql/transaction.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+type PostgreSQLBackendTransaction struct {
+	l  sync.Mutex
+	b  *PostgreSQLBackend
+	tx *sql.Tx
+
+	readOnly       bool
+	haveFinishedTx bool
+}
+
+func (b *PostgreSQLBackend) newTransaction(ctx context.Context, readOnly bool) (physical.Transaction, error) {
+	// Grab a transaction permit pool entry so that we can limit the number of
+	// concurrent transactions.
+	b.txnPermitPool.Acquire()
+
+	tx, err := b.client.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  readOnly,
+	})
+	if err != nil {
+		b.txnPermitPool.Release()
+		return nil, fmt.Errorf("failed to start underlying postgresql transaction: %w", err)
+	}
+
+	return &PostgreSQLBackendTransaction{
+		b:        b,
+		tx:       tx,
+		readOnly: readOnly,
+	}, nil
+}
+
+func (b *PostgreSQLBackend) BeginTx(ctx context.Context) (physical.Transaction, error) {
+	return b.newTransaction(ctx, false)
+}
+
+func (b *PostgreSQLBackend) BeginReadOnlyTx(ctx context.Context) (physical.Transaction, error) {
+	return b.newTransaction(ctx, true)
+}
+
+func (t *PostgreSQLBackendTransaction) Put(ctx context.Context, entry *physical.Entry) error {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.readOnly {
+		return physical.ErrTransactionReadOnly
+	}
+	if t.haveFinishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	parentPath, path, key := t.b.splitKey(entry.Key)
+
+	_, err := t.tx.ExecContext(ctx, t.b.put_query, parentPath, path, key, entry.Value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *PostgreSQLBackendTransaction) Delete(ctx context.Context, fullPath string) error {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.readOnly {
+		return physical.ErrTransactionReadOnly
+	}
+	if t.haveFinishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	_, path, key := t.b.splitKey(fullPath)
+
+	_, err := t.tx.ExecContext(ctx, t.b.delete_query, path, key)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *PostgreSQLBackendTransaction) Get(ctx context.Context, fullPath string) (*physical.Entry, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.haveFinishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	_, path, key := t.b.splitKey(fullPath)
+
+	var result []byte
+	err := t.tx.QueryRowContext(ctx, t.b.get_query, path, key).Scan(&result)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ent := &physical.Entry{
+		Key:   fullPath,
+		Value: result,
+	}
+	return ent, nil
+}
+
+func (t *PostgreSQLBackendTransaction) List(ctx context.Context, prefix string) ([]string, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.haveFinishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	rows, err := t.tx.QueryContext(ctx, t.b.list_query, "/"+prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		err = rows.Scan(&key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan rows: %w", err)
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+func (t *PostgreSQLBackendTransaction) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.haveFinishedTx {
+		return nil, physical.ErrTransactionAlreadyCommitted
+	}
+
+	var rows *sql.Rows
+	var err error
+	if limit <= 0 {
+		rows, err = t.tx.QueryContext(ctx, t.b.list_page_query, "/"+prefix, after)
+	} else {
+		rows, err = t.tx.QueryContext(ctx, t.b.list_page_limited_query, "/"+prefix, after, limit)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		err = rows.Scan(&key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan rows: %w", err)
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+func (t *PostgreSQLBackendTransaction) Commit(ctx context.Context) error {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.haveFinishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	defer func() {
+		t.b.txnPermitPool.Release()
+		t.haveFinishedTx = true
+	}()
+
+	if err := t.tx.Commit(); err != nil {
+		return fmt.Errorf("%v: %w", err, physical.ErrTransactionCommitFailure)
+	}
+
+	return nil
+}
+
+func (t *PostgreSQLBackendTransaction) Rollback(ctx context.Context) error {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	if t.haveFinishedTx {
+		return physical.ErrTransactionAlreadyCommitted
+	}
+
+	defer func() {
+		t.b.txnPermitPool.Release()
+		t.haveFinishedTx = true
+	}()
+
+	if err := t.tx.Rollback(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -8,6 +8,10 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -549,188 +553,243 @@ func ExerciseTransactionalBackend(t testing.TB, b TransactionalBackend) {
 	err = txn.Commit(context.Background())
 	require.Error(t, err, "expected subsequent commit of read-only transaction to fail")
 
-	// Empty transactions can be interwoven.
-	txn1, err := b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first interwoven transaction")
-	txn2, err := b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second interwoven transaction")
-	err = txn2.Commit(context.Background())
-	require.NoError(t, err, "failed to commit second interwoven transaction")
-	err = txn1.Commit(context.Background())
-	require.NoError(t, err, "failed to commit second interwoven transaction")
-
-	// Writing to a read-only transaction should fail; committing this
-	// transaction should have no impact on storage.
-	entry := &Entry{Key: "foo", Value: []byte("test")}
-
-	rtx, err := b.BeginReadOnlyTx(context.Background())
-	require.NoError(t, err, "failed to create read-only transaction for writing")
-	err = rtx.Put(context.Background(), entry)
-	require.Error(t, err, "expected failure to put in read-only transaction")
-	err = rtx.Delete(context.Background(), "foo")
-	require.Error(t, err, "expected failure to delete in read-only transaction")
-
-	err = rtx.Commit(context.Background())
-	require.NoError(t, err, "failed to commit empty read-only transaction")
-
+	// Ensure we have an empty storage
 	entries, err := b.List(context.Background(), "")
 	require.NoError(t, err, "failed to list storage entries")
 	require.Empty(t, entries, "expected nothing in storage")
 
-	// Creating the same entry in two transactions should conflict the
-	// second committed one, even though they have the same contents.
+	// Now do functionality tests: we have a few readers and writers inside of
+	// transactions plus a lister outside of transactions (which should still
+	// be atomic relative to the transactions that are occurring). When the
+	// writers are done, signal the readers/listers to finish up.
+	var wg sync.WaitGroup
+	var done atomic.Bool
+	var numFiles int = 25
+	var numWriters int = 10
+	var numWrites int = 25
+	var writeBreak int = 50
+	var numReaders int = 25
+	var readBreak int = 5
+	var numListers int = 5
+	var listBreak int = 10
+	var numErrors atomic.Int32
+	for i := 1; i <= numWriters; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			time.Sleep(time.Duration(worker) * time.Millisecond)
 
-	txn1, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first conflicting transaction")
-	txn2, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second conflicting transaction")
+			for write := 1; write <= numWrites; write++ {
+				// Write files
+				ctx := context.Background()
+				txn, err := b.BeginTx(ctx)
+				if err != nil {
+					t.Logf("[%d/%d] write begin tx failed: %v", worker, write, err)
+					numErrors.Add(1)
+					return
+				}
 
-	err = txn1.Put(context.Background(), entry)
-	require.NoError(t, err, "unexpected failure writing to first transaction")
-	err = txn2.Put(context.Background(), entry)
-	require.NoError(t, err, "unexpected failure writing to second transaction")
+				for file := 1; file <= numFiles; file++ {
+					key := fmt.Sprintf("%d-%d", worker, file)
+					value := fmt.Sprintf("%d-%d-%d", worker, write, file)
+					entry := &Entry{Key: key, Value: []byte(value)}
+					err = txn.Put(ctx, entry)
+					if err != nil {
+						t.Logf("[%d/%d] write put failed: %v", worker, write, err)
+						numErrors.Add(1)
+						return
+					}
+				}
 
-	err = txn1.Commit(context.Background())
-	require.NoError(t, err, "failed to commit first conflicting transaction")
-	err = txn2.Commit(context.Background())
-	require.Error(t, err, "expected failure to commit second conflicting transaction")
+				err = txn.Commit(ctx)
+				if err != nil {
+					t.Logf("[%d/%d] write commit failed: %v", worker, write, err)
+					numErrors.Add(1)
+					return
+				}
 
-	result, err := b.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("test"))
+				time.Sleep(time.Duration(writeBreak) * time.Millisecond)
 
-	bazEntry := &Entry{Key: "foo", Value: []byte("baz")}
+				// Delete files
+				txn, err = b.BeginTx(ctx)
+				if err != nil {
+					t.Logf("[%d/%d] write begin tx failed: %v", worker, write, err)
+					numErrors.Add(1)
+					return
+				}
 
-	txn1, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first conflicting transaction (round 2)")
-	txn2, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second conflicting transaction (round 2)")
+				for file := 1; file <= numFiles; file++ {
+					key := fmt.Sprintf("%d-%d", worker, file)
+					err = txn.Delete(ctx, key)
+					if err != nil {
+						t.Logf("[%d/%d] write put failed: %v", worker, write, err)
+						numErrors.Add(1)
+						return
+					}
+				}
 
-	err = txn1.Put(context.Background(), bazEntry)
-	require.NoError(t, err, "unexpected failure writing to first transaction (round 2)")
-	err = txn2.Put(context.Background(), bazEntry)
-	require.NoError(t, err, "unexpected failure writing to second transaction (round 2)")
+				err = txn.Commit(ctx)
+				if err != nil {
+					t.Logf("[%d/%d] write commit failed: %v", worker, write, err)
+					numErrors.Add(1)
+					return
+				}
 
-	err = txn2.Commit(context.Background())
-	require.NoError(t, err, "failed to commit second conflicting transaction")
-	err = txn1.Commit(context.Background())
-	require.Error(t, err, "expected failure to commit first conflicting transaction")
-
-	result, err = b.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("baz"))
-
-	// Creating different entries in two transactions should be fine.
-
-	txn1, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first parallel transaction")
-	txn2, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second parallel transaction")
-
-	barEntry := &Entry{Key: "bar", Value: []byte("baz")}
-	err = txn1.Put(context.Background(), entry)
-	require.NoError(t, err, "unexpected failure writing to first transaction")
-	err = txn2.Put(context.Background(), barEntry)
-	require.NoError(t, err, "unexpected failure writing to second transaction")
-
-	err = txn1.Commit(context.Background())
-	require.NoError(t, err, "failed to commit first parallel transaction")
-	err = txn2.Commit(context.Background())
-	require.NoError(t, err, "failed to commit second parallel transaction")
-
-	result, err = b.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("test"))
-
-	result, err = b.Get(context.Background(), "bar")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("baz"))
-
-	// Getting an item and writing to the same item in different transactions
-	// should fail one of the two.
-
-	txn1, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first parallel transaction")
-	txn2, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second parallel transaction")
-
-	result, err = txn1.Get(context.Background(), "bar")
-	require.NoError(t, err, "failed to read storage entry in first transaction")
-	require.Equal(t, result.Value, []byte("baz"))
-	err = txn1.Put(context.Background(), bazEntry)
-	require.NoError(t, err, "failed to put storage entry in first transaction")
-
-	result, err = txn2.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry in second transaction")
-	require.Equal(t, result.Value, []byte("test"))
-	barTestEntry := &Entry{Key: "bar", Value: []byte("test")}
-	err = txn2.Put(context.Background(), barTestEntry)
-	require.NoError(t, err, "failed to put storage entry in second transaction")
-
-	err = txn1.Commit(context.Background())
-	require.NoError(t, err, "failed to commit first conflicting read transaction")
-	err = txn2.Commit(context.Background())
-	require.Error(t, err, "expected failure to commit second conflicting read transaction")
-
-	result, err = b.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("baz"))
-
-	result, err = b.Get(context.Background(), "bar")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("baz"))
-
-	// Try again, with delete this time, committing in a different order.
-
-	txn1, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin first parallel transaction")
-	txn2, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin second parallel transaction")
-
-	result, err = txn1.Get(context.Background(), "bar")
-	require.NoError(t, err, "failed to read storage entry in first transaction")
-	require.Equal(t, result.Value, []byte("baz"))
-	err = txn1.Delete(context.Background(), "foo")
-	require.NoError(t, err, "failed to delete storage entry in first transaction")
-
-	result, err = txn2.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry in second transaction")
-	require.Equal(t, result.Value, []byte("baz"))
-	err = txn2.Delete(context.Background(), "bar")
-	require.NoError(t, err, "failed to delete storage entry in second transaction")
-
-	err = txn2.Commit(context.Background())
-	require.NoError(t, err, "failed to commit second conflicting read transaction")
-	err = txn1.Commit(context.Background())
-	require.Error(t, err, "expected failure to commit first conflicting read transaction")
-
-	result, err = b.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry")
-	require.Equal(t, result.Value, []byte("baz"))
-
-	entries, err = b.List(context.Background(), "")
-	require.NoError(t, err, "failed to list storage entries")
-	require.Equal(t, entries, []string{"foo"}, "expected only a single entry in storage")
-
-	// Reading entries that don't exist shouldn't cause issues.
-	txn, err = b.BeginTx(context.Background())
-	require.NoError(t, err, "failed to begin empty-read transaction")
-
-	result, err = txn.Get(context.Background(), "bar")
-	require.NoError(t, err, "failed to read storage entry in first transaction")
-	if result != nil {
-		require.Equal(t, len(result.Value), 0, "expected empty storage entry `bar`")
+				time.Sleep(time.Duration(writeBreak) * time.Millisecond)
+			}
+		}(i)
 	}
 
-	result, err = txn.Get(context.Background(), "foo")
-	require.NoError(t, err, "failed to read storage entry in second transaction")
-	require.Equal(t, result.Value, []byte("baz"))
+	// Validate reads within a transaction are consistent.
+	for i := 1; i <= numReaders; i++ {
+		go func(worker int) {
+			var read int = 1
+			time.Sleep(time.Duration(worker) * time.Millisecond)
 
-	err = txn.Delete(context.Background(), "foo")
-	require.NoError(t, err, "failed to delete entry in transaction")
+			for {
+				switch {
+				case done.Load() == true:
+					t.Logf("shutting down reader")
+					return
+				default:
+					ctx := context.Background()
 
-	err = txn.Commit(context.Background())
-	require.NoError(t, err, "failed to commit deletion transaction")
+					txn, err := b.BeginReadOnlyTx(ctx)
+					if err != nil {
+						t.Logf("[%d/%d] read begin tx failed: %v", worker, read, err)
+						numErrors.Add(1)
+						return
+					}
+
+					list, err := txn.List(ctx, "")
+					if err != nil {
+						t.Logf("[%d/%d] read begin tx failed: %v", worker, read, err)
+						numErrors.Add(1)
+						return
+					}
+
+					workerFileValueMap := make(map[int]map[int]string)
+					for index, key := range list {
+						split := strings.Split(key, "-")
+						if len(split) != 2 {
+							t.Logf("[%d/%d/%d] list item %v had %d components; expected 2", worker, read, index, key, len(split))
+							numErrors.Add(1)
+							return
+						}
+
+						keyWorker, _ := strconv.Atoi(split[0])
+						keyFile, _ := strconv.Atoi(split[1])
+						if _, ok := workerFileValueMap[keyWorker]; !ok {
+							workerFileValueMap[keyWorker] = make(map[int]string)
+						}
+
+						entry, err := txn.Get(ctx, key)
+						if err != nil {
+							t.Logf("[%d/%d/%d] read entry %v failed: %v", worker, read, index, key, err)
+							numErrors.Add(1)
+							return
+						}
+
+						if entry == nil {
+							t.Logf("[%d/%d/%d] read entry %v failed: was unexpectedly nil", worker, read, index, key)
+							numErrors.Add(1)
+							return
+						}
+
+						expectedValue, present := workerFileValueMap[keyWorker][keyFile]
+						if present {
+							if string(entry.Value) != expectedValue {
+								t.Logf("[%d/%d/%d] read entry %v failed: different value: expected=%v / actual=%v", worker, read, index, key, expectedValue, string(entry.Value))
+								numErrors.Add(1)
+								return
+							}
+						} else {
+							workerFileValueMap[keyWorker][keyFile] = string(entry.Value)
+						}
+					}
+
+					for keyWorker, keyFiles := range workerFileValueMap {
+						if len(keyFiles) != 0 && len(keyFiles) != numFiles {
+							t.Logf("[%d/%d] read list files failed: expected 0 or %v files due to transaction consistency; got %v for worker %v: %v", worker, read, numFiles, len(keyFiles), keyWorker, keyFiles)
+							numErrors.Add(1)
+							return
+						}
+					}
+
+					err = txn.Rollback(ctx)
+					if err != nil {
+						t.Logf("[%d/%d] read rollback failed: %v", worker, read, err)
+						numErrors.Add(1)
+						return
+					}
+				}
+
+				time.Sleep(time.Duration(readBreak) * time.Millisecond)
+				read += 1
+			}
+		}(i)
+	}
+
+	// Validate lists outside of a transaction are consistent.
+	for i := 1; i <= numListers; i++ {
+		go func(worker int) {
+			var list int = 1
+			time.Sleep(time.Duration(worker) * time.Millisecond)
+
+			for {
+				switch {
+				case done.Load() == true:
+					t.Logf("shutting down lister")
+					return
+				default:
+					ctx := context.Background()
+
+					entries, err := b.List(ctx, "")
+					if err != nil {
+						t.Logf("[%d/%d] list failed: %v", worker, list, err)
+					}
+
+					workerFileMap := make(map[int]int)
+					for index, key := range entries {
+						split := strings.Split(key, "-")
+						if len(split) != 2 {
+							t.Logf("[%d/%d/%d] list item %v had %d components; expected 2", worker, list, index, key, len(split))
+							numErrors.Add(1)
+							return
+						}
+
+						keyWorker, _ := strconv.Atoi(split[0])
+						workerFileMap[keyWorker] += 1
+					}
+
+					for keyWorker, keyFiles := range workerFileMap {
+						if keyFiles != 0 && keyFiles != numFiles {
+							t.Logf("[%d/%d] list files inconsistent: expected 0 or %v files due to transaction consistency; got %v for worker %v: %v", worker, list, numFiles, keyFiles, keyWorker, entries)
+							numErrors.Add(1)
+							return
+						}
+					}
+				}
+
+				time.Sleep(time.Duration(listBreak) * time.Millisecond)
+				list += 1
+			}
+		}(i)
+	}
+
+	// Wait for writers to finish
+	wg.Wait()
+
+	// Give readers additional time to finish before we potentially call
+	// fatal.
+	time.Sleep(100 * time.Millisecond)
+	done.Store(true)
+	time.Sleep(250 * time.Millisecond)
+
+	// Handle cleanup
+	if numErrors.Load() > 0 {
+		t.Fatalf("got %v errors while running test; see log messages for more info", numErrors.Load())
+	}
 
 	// Ensure we left it as we found it.
 	entries, err = b.List(context.Background(), "")

--- a/website/content/docs/rfcs/index.mdx
+++ b/website/content/docs/rfcs/index.mdx
@@ -20,3 +20,7 @@ Steering Committee.
    [PR #363](https://github.com/openbao/openbao/pull/363).
  - [Discontinue enforcing signed commits](/docs/rfcs/signed-commits), for
    allowing users to contribute without GPG/SSH signing their commits.
+ - [Transactional storage](/docs/rfcs/transactions), for supporting safer
+   storage semantics in `physical.Backend` and `logical.Storage` for use
+   by Core and plugins. This landed in several parts concluding in
+   [PR #292](https://github.com/openbao/openbao/pull/292).

--- a/website/content/docs/rfcs/transactions.mdx
+++ b/website/content/docs/rfcs/transactions.mdx
@@ -168,7 +168,11 @@ The Postgres backend stores [all data in a single table](https://github.com/open
 
 This will be much easier than the Raft+`bbolt` implementation above, should we wish to resurrect the Postgres backend in the future.
 
-The above Raft semantics likely roughly [correspond to `read committed` isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+The above Raft semantics likely roughly [correspond to `repeatable read` isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+
+:::info
+Raft and PostgreSQL will have different semantics: PostgreSQL prevents a single thread from interacting with two separate transactions, so developers will need to take care to avoid this.
+:::
 
 ### Implementation in File, InMem
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -489,6 +489,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/paginated-lists",
                 "rfcs/mlock-removal",
                 "rfcs/signed-commits",
+                "rfcs/transactions",
             ],
             FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },


### PR DESCRIPTION
Title says it all :-)

This updates our test suite to test transactions in parallel go routines so that it can conform to PostgreSQL's semantics. Then we add transactions using PostgreSQL's native transactions. I've done some testing with K/V and things seem to behave nicely with the reproducer from #482. 

Resolves: #270