### PR TITLE
Replace github.com/mholt/archiver/v3 with stdlib

### DIFF
--- a/changelog/611.txt
+++ b/changelog/611.txt
@@ -1,0 +1,3 @@
+```release-note:change
+command/debug: Replace mholt/archiver with standard library utils. This may change file permissions but does not affect archive layout.
+```

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -5,8 +5,12 @@ package command
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,7 +20,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
-	"github.com/mholt/archiver/v3"
 	"github.com/openbao/openbao/api/v2"
 )
 
@@ -182,25 +185,37 @@ func TestDebugCommand_Archive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tgz := archiver.NewTarGz()
-			err = tgz.Walk(bundlePath, func(f archiver.File) error {
-				fh, ok := f.Header.(*tar.Header)
-				if !ok {
-					return fmt.Errorf("invalid file header: %#v", f.Header)
-				}
-
-				// Ignore base directory and index file
-				if fh.Name == basePath+"/" || fh.Name == filepath.Join(basePath, "index.json") {
-					return nil
-				}
-
-				if fh.Name != filepath.Join(basePath, "server_status.json") {
-					return fmt.Errorf("unexpected file: %s", fh.Name)
-				}
-				return nil
-			})
+			input, err := os.Open(bundlePath)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("failed opening file for reading: %v", err)
+			}
+			defer input.Close()
+
+			gunzipped, err := gzip.NewReader(input)
+			if err != nil {
+				t.Fatalf("failed reading gzip header: %v", err)
+			}
+			defer gunzipped.Close()
+
+			unarchived := tar.NewReader(gunzipped)
+
+			header, err := unarchived.Next()
+			for err == nil {
+				// Ignore base directory and index file
+				if header.Name == basePath+"/" || header.Name == filepath.Join(basePath, "index.json") {
+					header, err = unarchived.Next()
+					continue
+				}
+
+				if header.Name != filepath.Join(basePath, "server_status.json") {
+					t.Fatalf("unexpected file: %s ; basePath=%v", header.Name, basePath)
+				}
+
+				header, err = unarchived.Next()
+			}
+
+			if err != nil && !errors.Is(err, io.EOF) {
+				t.Fatalf("failed reading file: %v", err)
 			}
 		})
 	}
@@ -291,29 +306,51 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 				t.Fatalf("failed to open archive: %s", err)
 			}
 
-			tgz := archiver.NewTarGz()
-			err = tgz.Walk(bundlePath, func(f archiver.File) error {
-				fh, ok := f.Header.(*tar.Header)
-				if !ok {
-					t.Fatalf("invalid file header: %#v", f.Header)
-				}
+			input, err := os.Open(bundlePath)
+			if err != nil {
+				t.Fatalf("failed opening file for reading: %v", err)
+			}
+			defer input.Close()
 
+			gunzipped, err := gzip.NewReader(input)
+			if err != nil {
+				t.Fatalf("failed reading gzip header: %v", err)
+			}
+			defer gunzipped.Close()
+
+			unarchived := tar.NewReader(gunzipped)
+
+			foundMap := make(map[string]bool)
+			header, err := unarchived.Next()
+			for err == nil {
 				// Ignore base directory and index file
-				if fh.Name == basePath+"/" || fh.Name == filepath.Join(basePath, "index.json") {
-					return nil
+				if header.Name == basePath+"/" || header.Name == filepath.Join(basePath, "index.json") {
+					header, err = unarchived.Next()
+					continue
 				}
 
+				foundMap[header.Name] = true
+
+				header, err = unarchived.Next()
+			}
+
+			if err != nil && !errors.Is(err, io.EOF) {
+				t.Fatalf("failed reading file: %v", err)
+			}
+
+			for actualFilePath := range foundMap {
+				found := false
 				for _, fileName := range tc.expectedFiles {
-					if fh.Name == filepath.Join(basePath, fileName) {
-						return nil
+					filePath := filepath.Join(basePath, fileName)
+					if actualFilePath == filePath {
+						found = true
+						break
 					}
 				}
 
-				// If we reach here, it means that this is an unexpected file
-				return fmt.Errorf("unexpected file: %s", fh.Name)
-			})
-			if err != nil {
-				t.Fatal(err)
+				if !found {
+					t.Fatalf("%v is unexpected present in archive", actualFilePath)
+				}
 			}
 		})
 	}
@@ -679,37 +716,47 @@ func TestDebugCommand_PartialPermissions(t *testing.T) {
 		t.Fatalf("failed to open archive: %s", err)
 	}
 
-	tgz := archiver.NewTarGz()
-	err = tgz.Walk(bundlePath, func(f archiver.File) error {
-		fh, ok := f.Header.(*tar.Header)
-		if !ok {
-			t.Fatalf("invalid file header: %#v", f.Header)
+	input, err := os.Open(bundlePath)
+	if err != nil {
+		t.Fatalf("failed opening file for reading: %v", err)
+	}
+	defer input.Close()
+
+	gunzipped, err := gzip.NewReader(input)
+	if err != nil {
+		t.Fatalf("failed reading gzip header: %v", err)
+	}
+	defer gunzipped.Close()
+
+	unarchived := tar.NewReader(gunzipped)
+
+	header, err := unarchived.Next()
+	for err == nil {
+		// Ignore base directory
+		if header.Name == basePath+"/" {
+			header, err = unarchived.Next()
+			continue
 		}
 
-		// Ignore base directory and index file
-		if fh.Name == basePath+"/" {
-			return nil
-		}
-
-		// Ignore directories, which still get created by pprof but should
-		// otherwise be empty.
-		if fh.FileInfo().IsDir() {
-			return nil
+		if header.Typeflag == tar.TypeDir {
+			header, err = unarchived.Next()
+			continue
 		}
 
 		switch {
-		case fh.Name == filepath.Join(basePath, "index.json"):
-		case fh.Name == filepath.Join(basePath, "replication_status.json"):
-		case fh.Name == filepath.Join(basePath, "server_status.json"):
-		case fh.Name == filepath.Join(basePath, "bao.log"):
+		case header.Name == filepath.Join(basePath, "index.json"):
+		case header.Name == filepath.Join(basePath, "replication_status.json"):
+		case header.Name == filepath.Join(basePath, "server_status.json"):
+		case header.Name == filepath.Join(basePath, "bao.log"):
 		default:
-			return fmt.Errorf("unexpected file: %s", fh.Name)
+			t.Fatalf("unexpected file: %s", header.Name)
 		}
 
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+		header, err = unarchived.Next()
+	}
+
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("failed reading file: %v", err)
 	}
 }
 
@@ -781,13 +828,13 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			}
 
 			bundlePath := filepath.Join(testDir, tc.outputFile)
-			fs, err := os.Stat(bundlePath)
+			stat, err := os.Stat(bundlePath)
 			if os.IsNotExist(err) {
 				t.Log(ui.OutputWriter.String())
 				t.Fatal(err)
 			}
 			// check permissions of the parent debug directory
-			err = isValidFilePermissions(fs)
+			err = isValidFilePermissions(stat.Mode(), stat.Name())
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -795,23 +842,35 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			// check permissions of the files within the parent directory
 			switch tc.compress {
 			case true:
-				tgz := archiver.NewTarGz()
+				input, err := os.Open(bundlePath)
+				if err != nil {
+					t.Fatalf("failed opening file for reading: %v", err)
+				}
+				defer input.Close()
 
-				err = tgz.Walk(bundlePath, func(f archiver.File) error {
-					fh, ok := f.Header.(*tar.Header)
-					if !ok {
-						return fmt.Errorf("invalid file header: %#v", f.Header)
-					}
-					err = isValidFilePermissions(fh.FileInfo())
-					if err != nil {
-						t.Fatalf(err.Error())
-					}
-					return nil
-				})
+				gunzipped, err := gzip.NewReader(input)
+				if err != nil {
+					t.Fatalf("failed reading gzip header: %v", err)
+				}
+				defer gunzipped.Close()
 
+				unarchived := tar.NewReader(gunzipped)
+
+				header, err := unarchived.Next()
+				for err == nil {
+					if err := isValidFilePermissions(fs.FileMode(header.Mode), header.Name); err != nil {
+						t.Fatalf("%v", err)
+					}
+
+					header, err = unarchived.Next()
+				}
+
+				if err != nil && !errors.Is(err, io.EOF) {
+					t.Fatalf("failed reading file: %v", err)
+				}
 			case false:
 				err = filepath.Walk(bundlePath, func(path string, info os.FileInfo, err error) error {
-					err = isValidFilePermissions(info)
+					err = isValidFilePermissions(info.Mode(), info.Name())
 					if err != nil {
 						t.Fatalf(err.Error())
 					}
@@ -826,19 +885,18 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 	}
 }
 
-func isValidFilePermissions(info os.FileInfo) (err error) {
-	mode := info.Mode()
+func isValidFilePermissions(mode fs.FileMode, name string) (err error) {
 	// check group permissions
 	for i := 4; i < 7; i++ {
 		if string(mode.String()[i]) != "-" {
-			return fmt.Errorf("expected no permissions for group but got %s permissions for file %s", string(mode.String()[i]), info.Name())
+			return fmt.Errorf("expected no permissions for group but got %s permissions for file %s", string(mode.String()[i]), name)
 		}
 	}
 
 	// check others permissions
 	for i := 7; i < 10; i++ {
 		if string(mode.String()[i]) != "-" {
-			return fmt.Errorf("expected no permissions for others but got %s permissions for file %s", string(mode.String()[i]), info.Name())
+			return fmt.Errorf("expected no permissions for others but got %s permissions for file %s", string(mode.String()[i]), name)
 		}
 	}
 	return err

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20
-	github.com/mholt/archiver/v3 v3.5.1
 	github.com/michaelklishin/rabbit-hole/v2 v2.12.0
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	github.com/mitchellh/copystructure v1.2.0
@@ -204,7 +203,6 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 // indirect
-	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.269 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -229,7 +227,6 @@ require (
 	github.com/docker/docker v25.0.6+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
@@ -284,7 +281,6 @@ require (
 	github.com/joyent/triton-go v1.7.1-0.20200416154420-6801d15b779f // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/linode/linodego v0.7.1 // indirect
@@ -301,7 +297,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
-	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0 // indirect
 	github.com/openbao/openbao/api v1.9.2 // indirect
 	github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20240227182507-a8c90d250c17 // indirect
@@ -313,7 +308,6 @@ require (
 	github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
@@ -333,12 +327,10 @@ require (
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c // indirect
-	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmware/govmomi v0.18.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,9 +146,6 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 h1:8mgvCpqsv3mQAcqZ/baAaMGUBj5J6MKMhxLd+K8L27Q=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301/go.mod h1:Api2AkmMgGaSUAhmk76oaFObkoeCPc/bKAqcyplPODs=
-github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
-github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
-github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -261,9 +258,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
-github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
-github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74 h1:2MIhn2R6oXQbgW5yHfS+d6YqyMfXiu2L55rFZC4UD/M=
 github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74/go.mod h1:UqXY1lYT/ERa4OEAywUqdok1T4RCRdArkhic1Opuavo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -412,7 +406,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -732,13 +725,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
 github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
-github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -793,8 +781,6 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
-github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/michaelklishin/rabbit-hole/v2 v2.12.0 h1:946p6jOYFcVJdtBBX8MwXvuBkpPjwm1Nm2Qg8oX+uFk=
 github.com/michaelklishin/rabbit-hole/v2 v2.12.0/go.mod h1:AN/3zyz7d++OHf+4WUo/LR0+Q5nlPHMaXasIsG/mPY0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -853,9 +839,6 @@ github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc h1:7xGrl4tTpBQu5Z
 github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc/go.mod h1:1rLVY/DWf3U6vSZgH16S7pymfrhK2lcUlXjgGglw/lY=
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 h1:BQ1HW7hr4IVovMwWg0E0PYcyW8CzqDcVmaew9cujU4s=
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2/go.mod h1:TLb2Sg7HQcgGdloNxkrmtgDNR9uVYF3lfdFIN4Ro6Sk=
-github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/nwaples/rardecode v1.1.2 h1:Cj0yZY6T1Zx1R7AhTbyGSALm44/Mmq+BAPc4B/p/d3M=
-github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -929,9 +912,6 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
-github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pires/go-proxyproto v0.6.1 h1:EBupykFmo22SDjv4fQVQd2J9NOoLPmyZA/15ldOGkPw=
 github.com/pires/go-proxyproto v0.6.1/go.mod h1:Odh9VFOZJCf9G8cLW5o435Xf1J95Jw9Gw5rnCjcwzAY=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
@@ -1094,10 +1074,6 @@ github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVK
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
-github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -1107,8 +1083,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
As suggested by Wojciech Kocjan, replace insecure archiver (which lacks a patched release except via third-party fork) with standard library. This removes it as a direct dependency.

Notably, our use of archiver was not affected by the vulnerability, as we only created archives (in `bao debug -compress`) and did not read them (except for self-created archives as part of the test suite).

---

Jan, not sure if we'll do a 2.0.3 release before 2.1.0, but figured I'd add the `needs-backport` label in case we do that before 2.1.0 is cut. 

cc @wojciechka 