### PR TITLE
Add GitLab as full TSC member

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,7 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | James Butcher     | james@iotechsys.com                 |                                            | Brad Corrion (brad@iotechsys.com)       | IOTech Systems            | Member             |
 | Alain Nochimowski | alain.Nochimowski@viaccess-orca.com |                                            | Dan Ghita (dan.ghita@viaccess-orca.com) | Viaccess-Orca             | Member             |
 | Julian Cassignol  | jcassignol@wallix.com               |                                            | Cristian Popi (cpopi@wallix.com)        | Wallix                    | Member             |
-| Alexander Scheel  | ascheel@gitlab.com                  | [@cipherboy](https://github.com/cipherboy) |                                         | GitLab                    | Chair (non-voting) |
-
+| Alexander Scheel  | ascheel@gitlab.com                  | [@cipherboy](https://github.com/cipherboy) | Jocelyn Eillis (jeillis@gitlab.com)     | GitLab                    | Chair              |
 
 ### OpenBao Working Groups
 


### PR DESCRIPTION
Per 10/10/24 TSC meeting, adding GitLab as full TSC member.

See also: https://lf-edge.atlassian.net/wiki/spaces/OP/pages/62586881/2024-10-10+OpenBao+TSC+Meeting