### PR TITLE
Allow PostgreSQL backend to create tables

### DIFF
--- a/changelog/614.txt
+++ b/changelog/614.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/postgresql: Allow table creation to improve first-start UX.
+```

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -4,6 +4,7 @@
 package postgresql
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -22,8 +23,9 @@ func TestPostgreSQLBackend(t *testing.T) {
 	// Use docker as pg backend if no url is provided via environment variables
 	connURL := os.Getenv("PGURL")
 	if connURL == "" {
-		_, u := postgresql.PrepareTestContainer(t, "11.1")
+		cleanup, u := postgresql.PrepareTestContainer(t, "11.1")
 		connURL = u
+		defer cleanup()
 	}
 
 	table := os.Getenv("PGTABLE")
@@ -386,4 +388,59 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 
 	// Cleanup
 	newLock.Unlock()
+}
+
+func TestPostgreSQLBackend_CreateTables(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	cleanup, connURL := postgresql.PrepareTestContainer(t, "11.1")
+	defer cleanup()
+
+	b, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": connURL,
+		"table":          "openbao_kv_store",
+		"ha_enabled":     "true",
+	}, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+
+	// Do not call SetupDatabaseObjects here; this should be handled automatically.
+
+	logger.Info("Running basic backend tests")
+	physical.ExerciseBackend(t, b)
+}
+
+func TestPostgreSQLBackend_NoCreateTables(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	cleanup, connURL := postgresql.PrepareTestContainer(t, "11.1")
+	defer cleanup()
+
+	b, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url":    connURL,
+		"table":             "openbao_kv_store",
+		"ha_enabled":        "true",
+		"skip_create_table": "true",
+	}, logger)
+	if err != nil {
+		t.Fatalf("Failed to create new backend: %v", err)
+	}
+
+	// Put should fail with an error.
+	entry := &physical.Entry{Key: "foo", Value: []byte("data")}
+	err = b.Put(context.Background(), entry)
+	if err == nil {
+		t.Fatalf("expected put to fail due to missing tables")
+	}
+
+	pg := b.(*PostgreSQLBackend)
+	SetupDatabaseObjects(t, pg)
+
+	logger.Info("Running basic backend tests")
+	physical.ExerciseBackend(t, b)
 }

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -49,8 +49,8 @@ to disable SSL.
   documentation. For example connection string URLs, see the examples section below.
 
 - `table` `(string: "openbao_kv_store")` – Specifies the name of the table in
-  which to write OpenBao data. This table must already exist (OpenBao will not
-  attempt to create it).
+  which to write OpenBao data. OpenBao will attempt to create it if missing and
+  `skip_create_table=false` (the default).
 
 - `max_idle_connections` `(int)` - Default not set. Sets the maximum number of
   connections in the idle connection pool. See
@@ -64,8 +64,8 @@ to disable SSL.
   PostgreSQL 9.5 or later.
 
 - `ha_table` `(string: "openbao_ha_locks")` – Specifies the name of the table to use
-  for storing high availability information. This table must already exist (OpenBao
-  will not attempt to create it).
+  for storing high availability information. OpenBao will attempt to create it
+  if missing and `skip_create_table=false` (the default).
 
 - `upsert_function` `(string: "openbao_kv_put")` – Specifies the name of the
   function to execute for upsert capabilities on PostgreSQL versions earlier
@@ -73,8 +73,8 @@ to disable SSL.
 
 - `skip_create_table` `(string: "true|false", default "false")` - When enabled,
   will not attempt to automatically create database tables if missing. Requires
-  PostgreSQL 9.5 or later. Set to `false` if the database user does not have
-  the required permissions.
+  PostgreSQL 9.5 or later. Set to `true` if the database user does not have
+  the required permissions; otherwise, OpenBao will fail to start.
 
 ## `postgresql` examples
 

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -40,8 +40,68 @@ to disable SSL.
 
 :::
 
-The PostgreSQL storage backend does not automatically create the table. Here is
-some sample SQL to create the schema and indexes.
+## `postgresql` parameters
+
+- `connection_url` `(string: <required>)` – Specifies the connection string to
+  use to authenticate and connect to PostgreSQL. The connection URL can also be
+  set using the `BAO_PG_CONNECTION_URL` environment variable. A full list of supported
+  parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
+  documentation. For example connection string URLs, see the examples section below.
+
+- `table` `(string: "openbao_kv_store")` – Specifies the name of the table in
+  which to write OpenBao data. This table must already exist (OpenBao will not
+  attempt to create it).
+
+- `max_idle_connections` `(int)` - Default not set. Sets the maximum number of
+  connections in the idle connection pool. See
+  [golang docs on SetMaxIdleConns][golang_setmaxidleconns] for more information.
+  Requires OpenBao 1.2 or later.
+
+- `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
+  requests to PostgreSQL.
+
+- `ha_enabled` `(string: "true|false")` – Default not enabled, requires
+  PostgreSQL 9.5 or later.
+
+- `ha_table` `(string: "openbao_ha_locks")` – Specifies the name of the table to use
+  for storing high availability information. This table must already exist (OpenBao
+  will not attempt to create it).
+
+- `upsert_function` `(string: "openbao_kv_put")` – Specifies the name of the
+  function to execute for upsert capabilities on PostgreSQL versions earlier
+  than 9.5. This function must already exist. See above documentation.
+
+- `skip_create_table` `(string: "true|false", default "false")` - When enabled,
+  will not attempt to automatically create database tables if missing. Requires
+  PostgreSQL 9.5 or later. Set to `false` if the database user does not have
+  the required permissions.
+
+## `postgresql` examples
+
+### Custom SSL verification
+
+This example shows connecting to a PostgreSQL cluster using full SSL
+verification (recommended).
+
+```hcl
+storage "postgresql" {
+  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=verify-full"
+}
+```
+
+To disable SSL verification (not recommended), replace `verify-full` with
+`disable`:
+
+```hcl
+storage "postgresql" {
+  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=disable"
+}
+```
+
+## Manually creating tables
+
+OpenBao will attempt to automatically create tables compatible with PostgreSQL
+9.5 or later. However, to manually create tables, use the following schemas:
 
 ```sql
 CREATE TABLE openbao_kv_store (
@@ -95,58 +155,6 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-```
-
-## `postgresql` parameters
-
-- `connection_url` `(string: <required>)` – Specifies the connection string to
-  use to authenticate and connect to PostgreSQL. The connection URL can also be
-  set using the `BAO_PG_CONNECTION_URL` environment variable. A full list of supported
-  parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
-  documentation. For example connection string URLs, see the examples section below.
-
-- `table` `(string: "openbao_kv_store")` – Specifies the name of the table in
-  which to write OpenBao data. This table must already exist (OpenBao will not
-  attempt to create it).
-
-- `max_idle_connections` `(int)` - Default not set. Sets the maximum number of
-  connections in the idle connection pool. See
-  [golang docs on SetMaxIdleConns][golang_setmaxidleconns] for more information.
-  Requires 1.2 or later.
-
-- `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
-  requests to PostgreSQL.
-
-- `ha_enabled` `(string: "true|false")` – Default not enabled, requires 9.5 or later.
-
-- `ha_table` `(string: "openbao_ha_locks")` – Specifies the name of the table to use
-  for storing high availability information. This table must already exist (OpenBao
-  will not attempt to create it).
-
-- `upsert_function` `(string: "openbao_kv_put")` – Specifies the name of the
-  function to execute for upsert capabilities on PostgreSQL versions earlier
-  than 9.5. This function must already exist. See above documentation.
-
-## `postgresql` examples
-
-### Custom SSL verification
-
-This example shows connecting to a PostgreSQL cluster using full SSL
-verification (recommended).
-
-```hcl
-storage "postgresql" {
-  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=verify-full"
-}
-```
-
-To disable SSL verification (not recommended), replace `verify-full` with
-`disable`:
-
-```hcl
-storage "postgresql" {
-  connection_url = "postgres://user:pass@localhost:5432/database?sslmode=disable"
-}
 ```
 
 [golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns


### PR DESCRIPTION
When running in certain environments such as Kubernetes via Helm chart, an operator may not necessarily have direct access to the database to create tables manually. Allow OpenBao to create the tables, which is enabled by default if it detects it does not have its tables present.

In the future, this sets us up to handle potential schema migrations, potentially allowing us to scale across multiple tables based on namespaces or other logical shards.

Resolves: #612