### PR TITLE
Split mount tables with transactions

### DIFF
--- a/changelog/622.txt
+++ b/changelog/622.txt
@@ -1,0 +1,7 @@
+```release-note:feature
+**Remove Mount Table Limits**: Using transactional storage, we've split the
+auth and secret mount tables into separate storage entires, removing the
+requirement that the entire table fit into a single storage entry limited by
+`max_entry_size`. This allows potentially hundreds of thousands of mounts on
+a single scaled-up server.
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -189,7 +190,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	newTable := c.auth.shallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		if err := c.persistAuth(ctx, newTable, &entry.Local); err != nil {
+		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -339,7 +340,7 @@ func (c *Core) removeCredEntry(ctx context.Context, path string, updateStorage b
 
 	if updateStorage {
 		// Update the auth table
-		if err := c.persistAuth(ctx, newTable, &entry.Local); err != nil {
+		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -419,7 +420,7 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	srcMatch.Path = strings.TrimPrefix(dst.MountPath, credentialRoutePrefix)
 
 	// Update the mount table
-	if err := c.persistAuth(ctx, c.auth, &srcMatch.Local); err != nil {
+	if err := c.persistAuth(ctx, nil, c.auth, &srcMatch.Local, srcMatch.UUID); err != nil {
 		srcMatch.Path = srcPath
 		srcMatch.Tainted = true
 		c.authLock.Unlock()
@@ -489,7 +490,7 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 
 	if updateStorage {
 		// Update the auth table
-		if err := c.persistAuth(ctx, c.auth, &entry.Local); err != nil {
+		if err := c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -499,50 +500,201 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 
 // loadCredentials is invoked as part of postUnseal to load the auth table
 func (c *Core) loadCredentials(ctx context.Context) error {
-	// Load the existing mount table
-	raw, err := c.barrier.Get(ctx, coreAuthConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read auth table", "error", err)
-		return errLoadAuthFailed
-	}
-	rawLocal, err := c.barrier.Get(ctx, coreLocalAuthConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read local auth table", "error", err)
-		return errLoadAuthFailed
-	}
-
+	// Previously, this lock would be held after attempting to read the
+	// storage entries. While we could never read corrupted entries,
+	// we now need to ensure we can gracefully failover from legacy to
+	// transactional auth mount table structure. This means holding the locks
+	// for longer.
+	//
+	// Note that this lock is used for consistency with other code during
+	// system operation (when mounting and unmounting auth engines), but
+	// is not strictly necessary here as unseal(...) is serial and blocks
+	// startup until finished.
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
+
+	// Start with an empty mount table.
+	c.auth = nil
+
+	// Migrating auth mounts from the previous single-entry to a transactional
+	// variant requires careful surgery that should only be done in the
+	// event the backend is transactionally aware. Otherwise, we'll continue
+	// to use the legacy storage format indefinitely.
+	//
+	// This does mean that going backwards (from a transaction-aware storage
+	// to not) is not possible without manual reconstruction.
+	txnableBarrier, ok := c.barrier.(logical.TransactionalStorage)
+	if !ok {
+		_, err := c.loadLegacyCredentials(ctx, c.barrier)
+		return err
+	}
+
+	// Create a write transaction in case we need to persist the initial
+	// table or migrate from the old format.
+	txn, err := txnableBarrier.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Defer rolling back: we may commit the transaction anyways, but we
+	// need to ensure the transaction is cleaned up in the event of an
+	// error.
+	defer txn.Rollback(ctx)
+
+	legacy, err := c.loadLegacyCredentials(ctx, txn)
+	if err != nil {
+		return fmt.Errorf("failed to load legacy auth mounts in transaction: %w", err)
+	}
+
+	// If we have legacy auth mounts, migration was handled by the above. Otherwise,
+	// we need to fetch the new auth mount table.
+	if !legacy {
+		c.logger.Info("reading transactional auth mount table")
+		if err := c.loadTransactionalCredentials(ctx, txn); err != nil {
+			return fmt.Errorf("failed to load transactional auth mount table: %w", err)
+		}
+	}
+
+	// Finally, persist our changes.
+	if err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit auth table changes: %w", err)
+	}
+
+	return nil
+}
+
+// This function reads the transactional split auth (credential) table.
+func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical.Storage) error {
+	globalEntries, err := barrier.List(ctx, coreAuthConfigPath+"/")
+	if err != nil {
+		return fmt.Errorf("failed listing core auth mounts: %w", err)
+	}
+
+	localEntries, err := barrier.List(ctx, coreLocalAuthConfigPath+"/")
+	if err != nil {
+		return fmt.Errorf("failed listing core local auth mounts: %w", err)
+	}
+
+	var needPersist bool
+	if len(globalEntries) == 0 {
+		c.logger.Info("no auth mounts in transactional auth mount table; adding default auth mount table")
+		c.auth = c.defaultAuthTable()
+		needPersist = true
+	} else {
+		c.auth = &MountTable{
+			Type: credentialTableType,
+		}
+
+		for index, uuid := range globalEntries {
+			entry, err := c.fetchAndDecodeMountTableEntry(ctx, barrier, coreAuthConfigPath, uuid)
+			if err != nil {
+				return fmt.Errorf("error loading auth mount table entry (%v/%v): %w", index, uuid, err)
+			}
+
+			if entry != nil {
+				c.auth.Entries = append(c.auth.Entries, entry)
+			}
+		}
+	}
+
+	if len(localEntries) > 0 {
+		for index, uuid := range localEntries {
+			entry, err := c.fetchAndDecodeMountTableEntry(ctx, barrier, coreLocalAuthConfigPath, uuid)
+			if err != nil {
+				return fmt.Errorf("error loading local auth mount table entry (%v/%v): %w", index, uuid, err)
+			}
+
+			if entry != nil {
+				c.auth.Entries = append(c.auth.Entries, entry)
+			}
+		}
+	}
+
+	err = c.runCredentialUpdates(ctx, barrier, needPersist)
+	if err != nil {
+		c.logger.Error("failed to run legacy auth mount table upgrades", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// This function reads the legacy, single-entry combined auth mount table,
+// returning true if it was used. This will let us know (if we're inside
+// a transaction) if we need to do an upgrade.
+func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storage) (bool, error) {
+	// Load the existing auth mount table
+	raw, err := barrier.Get(ctx, coreAuthConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read auth table", "error", err)
+		return false, errLoadAuthFailed
+	}
+	rawLocal, err := barrier.Get(ctx, coreLocalAuthConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read local auth table", "error", err)
+		return false, errLoadAuthFailed
+	}
 
 	if raw != nil {
 		authTable, err := c.decodeMountTable(ctx, raw.Value)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the auth table", "error", err)
-			return err
+			return false, err
 		}
 		c.auth = authTable
 	}
 
 	var needPersist bool
 	if c.auth == nil {
+		// In the event we are inside a transaction, we do not yet know if
+		// we have a transactional mount table; exit early and load the new format.
+		if _, ok := barrier.(logical.Transaction); ok {
+			return false, nil
+		}
+		c.logger.Info("no mounts in legacy auth table; adding default mount table")
 		c.auth = c.defaultAuthTable()
 		needPersist = true
 	} else {
-		// only record tableMetrics if we have loaded something from storge
-		c.tableMetrics(len(c.auth.Entries), false, true, raw.Value)
+		if _, ok := barrier.(logical.Transaction); ok {
+			// We know we have legacy mount table entries, so force a migration.
+			c.logger.Info("migrating legacy mount table to transactional layout")
+			needPersist = true
+		}
+		c.tableMetrics(len(c.auth.Entries), false, true, len(raw.Value))
 	}
 	if rawLocal != nil {
 		localAuthTable, err := c.decodeMountTable(ctx, rawLocal.Value)
 		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the local mount table", "error", err)
-			return err
+			c.logger.Error("failed to decompress and/or decode the legacy local auth mount table", "error", err)
+			return false, err
 		}
 		if localAuthTable != nil && len(localAuthTable.Entries) > 0 {
 			c.auth.Entries = append(c.auth.Entries, localAuthTable.Entries...)
-			c.tableMetrics(len(localAuthTable.Entries), true, true, rawLocal.Value)
+			c.tableMetrics(len(localAuthTable.Entries), true, true, len(rawLocal.Value))
 		}
 	}
 
+	// Here, we must call runCredentialUpdates:
+	//
+	// 1. We may be without any auth mount table and need to create the legacy
+	//    table format because we don't have a transaction aware storage
+	//    backend.
+	// 2. We may have had a legacy auth mount table and need to upgrade into the
+	//    new format. runCredentialUpdates will handle this for us.
+	err = c.runCredentialUpdates(ctx, barrier, needPersist)
+	if err != nil {
+		c.logger.Error("failed to run legacy auth mount table upgrades", "error", err)
+		return false, err
+	}
+
+	// We loaded a legacy auth mount table and successfully migrated it, if
+	// necessary.
+	return true, nil
+}
+
+// Note that this is only designed to work with singletons, as it checks by
+// type only.
+func (c *Core) runCredentialUpdates(ctx context.Context, barrier logical.Storage, needPersist bool) error {
 	// Upgrade to typed auth table
 	if c.auth.Type == "" {
 		c.auth.Type = credentialTableType
@@ -572,7 +724,7 @@ func (c *Core) loadCredentials(ctx context.Context) error {
 			needPersist = true
 		}
 
-		// Don't store built-in version in the mount table, to make upgrades smoother.
+		// Don't store built-in version in the auth mount table, to make upgrades smoother.
 		if versions.IsBuiltinVersion(entry.Version) {
 			entry.Version = ""
 			needPersist = true
@@ -599,7 +751,7 @@ func (c *Core) loadCredentials(ctx context.Context) error {
 		return nil
 	}
 
-	if err := c.persistAuth(ctx, c.auth, nil); err != nil {
+	if err := c.persistAuth(ctx, barrier, c.auth, nil, ""); err != nil {
 		c.logger.Error("failed to persist auth table", "error", err)
 		return errLoadAuthFailed
 	}
@@ -608,7 +760,31 @@ func (c *Core) loadCredentials(ctx context.Context) error {
 }
 
 // persistAuth is used to persist the auth table after modification
-func (c *Core) persistAuth(ctx context.Context, table *MountTable, local *bool) error {
+func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
+	// Sometimes we may not want to explicitly pass barrier; fetch it if
+	// necessary.
+	if barrier == nil {
+		barrier = c.barrier
+	}
+
+	// Gracefully handle a transaction-aware backend, if a transaction
+	// wasn't created for us. This is safe as we do not support nested
+	// transactions.
+	needTxnCommit := false
+	if txnBarrier, ok := barrier.(logical.TransactionalStorage); ok {
+		var err error
+		barrier, err = txnBarrier.BeginTx(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction to persist auth mounts: %w", err)
+		}
+
+		needTxnCommit = true
+
+		// In the event of an unexpected error, rollback this transaction.
+		// A rollback of a committed transaction does not impact the commit.
+		defer barrier.(logical.Transaction).Rollback(ctx)
+	}
+
 	if table.Type != credentialTableType {
 		c.logger.Error("given table to persist has wrong type", "actual_type", table.Type, "expected_type", credentialTableType)
 		return fmt.Errorf("invalid table type given, not persisting")
@@ -633,14 +809,19 @@ func (c *Core) persistAuth(ctx context.Context, table *MountTable, local *bool) 
 		} else {
 			nonLocalAuth.Entries = append(nonLocalAuth.Entries, entry)
 		}
+
+		// We potentially modified the auth mount table entry so update the
+		// map accordingly.
+		entry.SyncCache()
 	}
 
-	writeTable := func(mt *MountTable, path string) ([]byte, error) {
-		// Encode the mount table into JSON and compress it (lzw).
+	// Handle writing the legacy auth mount table by default.
+	writeTable := func(mt *MountTable, path string) (int, error) {
+		// Encode the auth mount table into JSON and compress it (lzw).
 		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mt, nil)
 		if err != nil {
 			c.logger.Error("failed to encode or compress auth mount table", "error", err)
-			return nil, err
+			return -1, err
 		}
 
 		// Create an entry
@@ -652,43 +833,123 @@ func (c *Core) persistAuth(ctx context.Context, table *MountTable, local *bool) 
 		// Write to the physical backend
 		if err := c.barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist auth mount table", "error", err)
-			return nil, err
+			return -1, err
 		}
-		return compressedBytes, nil
+		return len(compressedBytes), nil
+	}
+
+	if _, ok := barrier.(logical.Transaction); ok {
+		// Write a transactional-aware mount table series instead.
+		writeTable = func(mt *MountTable, prefix string) (int, error) {
+			var size int
+			var found bool
+			currentEntries := make(map[string]struct{}, len(mt.Entries))
+			for index, mtEntry := range mt.Entries {
+				if mount != "" && mtEntry.UUID != mount {
+					continue
+				}
+
+				found = true
+				currentEntries[mtEntry.UUID] = struct{}{}
+
+				// Encode the mount table into JSON. There is little value in
+				// compressing short entries.
+				path := path.Join(prefix, mtEntry.UUID)
+				encoded, err := jsonutil.EncodeJSON(mtEntry)
+				if err != nil {
+					c.logger.Error("failed to encode auth mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
+					return -1, err
+				}
+
+				// Create a storage entry.
+				sEntry := &logical.StorageEntry{
+					Key:   path,
+					Value: encoded,
+				}
+
+				// Write to the backend.
+				if err := barrier.Put(ctx, sEntry); err != nil {
+					c.logger.Error("failed to persist auth mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
+					return -1, err
+				}
+
+				size += len(encoded)
+			}
+
+			if mount != "" && !found {
+				// Delete this component if it exists. This signifies that
+				// we're removing this mount.
+				path := path.Join(prefix, mount)
+				if err := barrier.Delete(ctx, path); err != nil {
+					return -1, fmt.Errorf("requested removal of auth mount but failed: %w", err)
+				}
+			}
+
+			if mount == "" {
+				// List all entries and remove any deleted ones.
+				presentEntries, err := barrier.List(ctx, prefix+"/")
+				if err != nil {
+					return -1, fmt.Errorf("failed to list entries for removal: %w", err)
+				}
+
+				for index, presentEntry := range presentEntries {
+					if _, present := currentEntries[presentEntry]; present {
+						continue
+					}
+
+					if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						return -1, fmt.Errorf("failed to remove deleted mount %v (%d): %w", presentEntry, index, err)
+					}
+				}
+			}
+
+			// Finally, delete the legacy entries, if any.
+			if err := barrier.Delete(ctx, prefix); err != nil {
+				return -1, err
+			}
+
+			return size, nil
+		}
 	}
 
 	var err error
-	var compressedBytes []byte
+	var compressedBytesLen int
 	switch {
 	case local == nil:
 		// Write non-local mounts
-		compressedBytes, err := writeTable(nonLocalAuth, coreAuthConfigPath)
+		compressedBytesLen, err = writeTable(nonLocalAuth, coreAuthConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(nonLocalAuth.Entries), false, true, compressedBytes)
+		c.tableMetrics(len(nonLocalAuth.Entries), false, true, compressedBytesLen)
 
 		// Write local mounts
-		compressedBytes, err = writeTable(localAuth, coreLocalAuthConfigPath)
+		compressedBytesLen, err = writeTable(localAuth, coreLocalAuthConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(localAuth.Entries), true, true, compressedBytes)
+		c.tableMetrics(len(localAuth.Entries), true, true, compressedBytesLen)
 	case *local:
-		compressedBytes, err = writeTable(localAuth, coreLocalAuthConfigPath)
+		compressedBytesLen, err = writeTable(localAuth, coreLocalAuthConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(localAuth.Entries), true, true, compressedBytes)
+		c.tableMetrics(len(localAuth.Entries), true, true, compressedBytesLen)
 	default:
-		compressedBytes, err = writeTable(nonLocalAuth, coreAuthConfigPath)
+		compressedBytesLen, err = writeTable(nonLocalAuth, coreAuthConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(nonLocalAuth.Entries), false, true, compressedBytes)
+		c.tableMetrics(len(nonLocalAuth.Entries), false, true, compressedBytesLen)
 	}
 
-	return err
+	if needTxnCommit {
+		if err := barrier.(logical.Transaction).Commit(ctx); err != nil {
+			return fmt.Errorf("failed to persist mounts inside transaction: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // setupCredentials is invoked after we've loaded the auth table to

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -350,7 +350,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 	}
 
 	c.auth.Entries[1].Local = true
-	if err := c.persistAuth(context.Background(), c.auth, nil); err != nil {
+	if err := c.persistAuth(context.Background(), nil, c.auth, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -53,6 +53,10 @@ func TestMountTableMetrics(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
+	if nonlocalLogicalMountsize <= 0 {
+		t.Fatalf("expected non-zero value for nonlocalLogicalMountsize: %v", nonlocalLogicalMountsize)
+	}
+
 	// Mount new kv
 	if err = client.Sys().Mount("kv", &api.MountInput{
 		Type: "kv",
@@ -68,13 +72,15 @@ func TestMountTableMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Notably, the gauge only reports the size of the new table entry; it
+	// does not report the total size on a transactional storage backend.
 	nonlocalLogicalMountsizeAfterMount, err := gaugeSearchHelper(data, 4)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	if nonlocalLogicalMountsizeAfterMount <= nonlocalLogicalMountsize {
-		t.Errorf("Mount size does not change after new mount is mounted")
+	if nonlocalLogicalMountsizeAfterMount <= 0 {
+		t.Fatalf("expected non-zero value for nonlocalLogicalMountsizeAfterMount: %v", nonlocalLogicalMountsizeAfterMount)
 	}
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1723,9 +1723,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		if len(userLockoutConfigMap) > 0 {
 			switch {
 			case strings.HasPrefix(path, "auth/"):
-				err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+				err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 			default:
-				err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+				err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 			}
 			if err != nil {
 				mountEntry.Config.UserLockoutConfig.LockoutCounterReset = oldUserLockoutCounterReset
@@ -1750,9 +1750,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Description = oldDesc
@@ -1787,9 +1787,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		// Update the mount table
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Version = oldVersion
@@ -1810,9 +1810,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.AuditNonHMACRequestKeys = oldVal
@@ -1836,9 +1836,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.AuditNonHMACResponseKeys = oldVal
@@ -1867,9 +1867,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.ListingVisibility = oldVal
@@ -1909,7 +1909,7 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		mountEntry.Config.TokenType = tokenType
 
 		// Update the mount table
-		if err := b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local); err != nil {
+		if err := b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
 			mountEntry.Config.TokenType = oldVal
 			return handleError(err)
 		}
@@ -1929,9 +1929,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.PassthroughRequestHeaders = oldVal
@@ -1954,9 +1954,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.AllowedResponseHeaders = oldVal
@@ -1980,9 +1980,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		var err error
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Config.AllowedManagedKeys = oldVal
@@ -2061,9 +2061,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		mountEntry.Options = newOptions
 		switch {
 		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+			err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+			err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 		}
 		if err != nil {
 			mountEntry.Options = oldVal

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -68,9 +68,9 @@ func (b *SystemBackend) tuneMountTTLs(ctx context.Context, path string, me *Moun
 	var err error
 	switch {
 	case strings.HasPrefix(path, credentialRoutePrefix):
-		err = b.Core.persistAuth(ctx, b.Core.auth, &me.Local)
+		err = b.Core.persistAuth(ctx, nil, b.Core.auth, &me.Local, me.UUID)
 	default:
-		err = b.Core.persistMounts(ctx, b.Core.mounts, &me.Local)
+		err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &me.Local, me.UUID)
 	}
 	if err != nil {
 		me.Config.MaxLeaseTTL = origMax

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2593,7 +2593,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -2606,7 +2606,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 			true,
 		)
 
-		if !strings.HasPrefix(resp.Data["value"].(string), `{"type":"mounts"`) {
+		if !strings.HasPrefix(resp.Data["value"].(string), `{"type":"audit"`) {
 			t.Fatalf("bad: %v", resp)
 		}
 	})
@@ -2614,7 +2614,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 	t.Run("base64", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"encoding": "base64",
 		}
@@ -2627,7 +2627,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 			t.Fatalf("value is a not an array of bytes, it is %T", resp.Data["value"])
 		}
 
-		if !strings.HasPrefix(string(resp.Data["value"].([]byte)), `{"type":"mounts"`) {
+		if !strings.HasPrefix(string(resp.Data["value"].([]byte)), `{"type":"audit"`) {
 			t.Fatalf("bad: %v", resp)
 		}
 	})
@@ -2635,7 +2635,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 	t.Run("invalid_encoding", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"encoding": "invalid_encoding",
 		}
@@ -2652,7 +2652,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 	t.Run("compressed_false", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"compressed": false,
 		}
@@ -2673,7 +2673,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 	t.Run("compressed_false_base64", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"compressed": false,
 			"encoding":   "base64",
@@ -2790,7 +2790,8 @@ func TestSystemBackend_rawReadWrite(t *testing.T) {
 
 func TestSystemBackend_rawWrite_ExistanceCheck(t *testing.T) {
 	b := testSystemBackendRaw(t)
-	req := logical.TestRequest(t, logical.CreateOperation, "raw/core/mounts")
+
+	req := logical.TestRequest(t, logical.CreateOperation, "raw/core/audit")
 	_, exist, err := b.HandleExistenceCheck(namespace.RootContext(nil), req)
 	if err != nil {
 		t.Fatalf("err: #{err}")
@@ -2886,14 +2887,14 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 	t.Run("use_existing_compression", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		mounts := resp.Data["value"].(string)
-		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"value":            mounts,
 			"compression_type": compressutil.CompressionTypeGzip,
@@ -2911,7 +2912,7 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 		)
 
 		// Read back and check gzip was applied by looking for prefix byte
-		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"compressed": false,
 			"encoding":   "base64",
@@ -2934,14 +2935,14 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 	t.Run("compression_type_matches_existing_compression", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		mounts := resp.Data["value"].(string)
-		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"value": mounts,
 		}
@@ -2951,7 +2952,7 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 		}
 
 		// Read back and check gzip was applied by looking for prefix byte
-		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"compressed": false,
 			"encoding":   "base64",
@@ -2973,14 +2974,14 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 	t.Run("write_uncompressed_over_existing_compressed", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		mounts := resp.Data["value"].(string)
-		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"value":            mounts,
 			"compression_type": "",
@@ -2991,7 +2992,7 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 		}
 
 		// Read back and check gzip was not applied by looking for prefix byte
-		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"compressed": false,
 			"encoding":   "base64",
@@ -3006,7 +3007,7 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 			t.Fatalf("value is a not an array of bytes, it is %T", resp.Data["value"])
 		}
 
-		if !strings.HasPrefix(string(resp.Data["value"].([]byte)), `{"type":"mounts"`) {
+		if !strings.HasPrefix(string(resp.Data["value"].([]byte)), `{"type":"audit"`) {
 			t.Fatalf("bad: %v", resp)
 		}
 	})
@@ -3014,14 +3015,14 @@ func TestSystemBackend_rawReadWrite_Compressed(t *testing.T) {
 	t.Run("invalid_compression_type", func(t *testing.T) {
 		b := testSystemBackendRaw(t)
 
-		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+		req := logical.TestRequest(t, logical.ReadOperation, "raw/core/audit")
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		mounts := resp.Data["value"].(string)
-		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/mounts")
+		req = logical.TestRequest(t, logical.UpdateOperation, "raw/core/audit")
 		req.Data = map[string]interface{}{
 			"value":            mounts,
 			"compression_type": "invalid_type",
@@ -5903,9 +5904,16 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 			t.Fatal()
 		}
 		mountEntry.Version = nonExistentBuiltinVersion
-		err = core.persistMounts(ctx, nil, core.mounts, &mountEntry.Local, mountEntry.UUID)
-		if err != nil {
-			t.Fatal(err)
+		if tc.mountTable == "mounts" {
+			err = core.persistMounts(ctx, nil, core.mounts, &mountEntry.Local, mountEntry.UUID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			err = core.persistAuth(ctx, nil, core.auth, &mountEntry.Local, mountEntry.UUID)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		config = readMountConfig(tc.pluginName, tc.mountTable)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3872,6 +3872,7 @@ func TestSystemBackend_InternalUIMounts(t *testing.T) {
 		},
 	}
 	if diff := deep.Equal(resp.Data, exp); diff != nil {
+		t.Logf("resp.Data[secret][sys/] = %#v", ((resp.Data["secret"]).(map[string]interface{}))["sys/"])
 		t.Fatal(diff)
 	}
 
@@ -5902,7 +5903,7 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 			t.Fatal()
 		}
 		mountEntry.Version = nonExistentBuiltinVersion
-		err = core.persistMounts(ctx, core.mounts, &mountEntry.Local)
+		err = core.persistMounts(ctx, nil, core.mounts, &mountEntry.Local, mountEntry.UUID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -179,7 +180,7 @@ type MountMigrationInfo struct {
 // preserves plaintext size, adding a constant of 30 bytes of
 // padding, which is negligable and subject to change, and thus
 // not accounted for.
-func (c *Core) tableMetrics(entryCount int, isLocal bool, isAuth bool, compressedTable []byte) {
+func (c *Core) tableMetrics(entryCount int, isLocal bool, isAuth bool, compressedTableLen int) {
 	if c.metricsHelper == nil {
 		// do nothing if metrics are not initialized
 		return
@@ -207,13 +208,13 @@ func (c *Core) tableMetrics(entryCount int, isLocal bool, isAuth bool, compresse
 		})
 
 	c.metricSink.SetGaugeWithLabels(metricsutil.PhysicalTableSizeName,
-		float32(len(compressedTable)), []metrics.Label{
+		float32(compressedTableLen), []metrics.Label{
 			typeAuthLabelMap[isAuth],
 			typeLocalLabelMap[isLocal],
 		})
 
 	c.metricsHelper.AddGaugeLoopMetric(metricsutil.PhysicalTableSizeName,
-		float32(len(compressedTable)), []metrics.Label{
+		float32(compressedTableLen), []metrics.Label{
 			typeAuthLabelMap[isAuth],
 			typeLocalLabelMap[isLocal],
 		})
@@ -549,6 +550,44 @@ func (c *Core) decodeMountTable(ctx context.Context, raw []byte) (*MountTable, e
 	}, nil
 }
 
+func (c *Core) fetchAndDecodeMountTableEntry(ctx context.Context, barrier logical.Storage, prefix string, uuid string) (*MountEntry, error) {
+	path := path.Join(prefix, uuid)
+	sEntry, err := barrier.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if sEntry == nil {
+		return nil, fmt.Errorf("unexpected empty storage entry for mount")
+	}
+
+	entry := new(MountEntry)
+	if err := jsonutil.DecodeJSON(sEntry.Value, entry); err != nil {
+		return nil, err
+	}
+
+	if entry.UUID == "" {
+		entry.UUID = uuid
+	} else if entry.UUID != uuid {
+		return nil, fmt.Errorf("mismatch between mount entry uuid in path (%v) and value (%v)", uuid, entry.UUID)
+	}
+
+	if entry.NamespaceID == "" {
+		entry.NamespaceID = namespace.RootNamespaceID
+	}
+	ns, err := NamespaceByID(ctx, entry.NamespaceID, c)
+	if err != nil {
+		return nil, err
+	}
+	if ns == nil {
+		c.logger.Error("namespace on mount entry not found", "table", prefix, "uuid", uuid, "namespace_id", entry.NamespaceID, "mount_path", entry.Path, "mount_description", entry.Description)
+		return nil, nil
+	}
+
+	entry.namespace = ns
+
+	return entry, nil
+}
+
 // Mount is used to mount a new backend to the mount table.
 func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 	// Ensure we end the path in a slash
@@ -692,7 +731,7 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	newTable := c.mounts.shallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		if err := c.persistMounts(ctx, newTable, &entry.Local); err != nil {
+		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to update mount table", "error", err)
 			return logical.CodedError(500, "failed to update mount table")
 		}
@@ -896,7 +935,7 @@ func (c *Core) removeMountEntry(ctx context.Context, path string, updateStorage 
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, newTable, &entry.Local); err != nil {
+		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to remove entry from mounts table", "error", err)
 			return logical.CodedError(500, "failed to remove entry from mounts table")
 		}
@@ -929,7 +968,7 @@ func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, upda
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, c.mounts, &entry.Local); err != nil {
+		if err := c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to taint entry in mounts table", "error", err)
 			return logical.CodedError(500, "failed to taint entry in mounts table")
 		}
@@ -1092,7 +1131,7 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	srcMatch.Path = dst.MountPath
 
 	// Update the mount table
-	if err := c.persistMounts(ctx, c.mounts, &srcMatch.Local); err != nil {
+	if err := c.persistMounts(ctx, nil, c.mounts, &srcMatch.Local, srcMatch.UUID); err != nil {
 		srcMatch.Path = srcPath
 		srcMatch.Tainted = true
 		c.mountsLock.Unlock()
@@ -1131,83 +1170,203 @@ func (c *Core) splitNamespaceAndMountFromPath(currNs, path string) namespace.Mou
 
 // loadMounts is invoked as part of postUnseal to load the mount table
 func (c *Core) loadMounts(ctx context.Context) error {
-	// Load the existing mount table
-	raw, err := c.barrier.Get(ctx, coreMountConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read mount table", "error", err)
-		return errLoadMountsFailed
-	}
-	rawLocal, err := c.barrier.Get(ctx, coreLocalMountConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read local mount table", "error", err)
-		return errLoadMountsFailed
-	}
-
+	// Previously, this lock would be held after attempting to read the
+	// storage entries. While we could never read corrupted entries,
+	// we now need to ensure we can gracefully failover from legacy to
+	// transactional mount table structure. This means holding the locks
+	// for longer.
+	//
+	// Note that this lock is used for consistency with other code during
+	// system operation (when mounting and unmounting secret engines), but
+	// is not strictly necessary here as unseal(...) is serial and blocks
+	// startup until finished.
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
+	// Start with an empty mount table.
+	c.mounts = nil
+
+	// Migrating mounts from the previous single-entry to a transactional
+	// variant requires careful surgery that should only be done in the
+	// event the backend is transactionally aware. Otherwise, we'll continue
+	// to use the legacy storage format indefinitely.
+	//
+	// This does mean that going backwards (from a transaction-aware storage
+	// to not) is not possible without manual reconstruction.
+	txnableBarrier, ok := c.barrier.(logical.TransactionalStorage)
+	if !ok {
+		_, err := c.loadLegacyMounts(ctx, c.barrier)
+		return err
+	}
+
+	// Create a write transaction in case we need to persist the initial
+	// table or migrate from the old format.
+	txn, err := txnableBarrier.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Defer rolling back: we may commit the transaction anyways, but we
+	// need to ensure the transaction is cleaned up in the event of an
+	// error.
+	defer txn.Rollback(ctx)
+
+	legacy, err := c.loadLegacyMounts(ctx, txn)
+	if err != nil {
+		return fmt.Errorf("failed to load legacy mounts in transaction: %w", err)
+	}
+
+	// If we have legacy mounts, migration was handled by the above. Otherwise,
+	// we need to fetch the new mount table.
+	if !legacy {
+		c.logger.Info("reading transactional mount table")
+		if err := c.loadTransactionalMounts(ctx, txn); err != nil {
+			return fmt.Errorf("failed to load transactional mount table: %w", err)
+		}
+	}
+
+	// Finally, persist our changes.
+	if err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit mount table changes: %w", err)
+	}
+
+	return nil
+}
+
+// This function reads the transactional split mount table.
+func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Storage) error {
+	globalEntries, err := barrier.List(ctx, coreMountConfigPath+"/")
+	if err != nil {
+		return fmt.Errorf("failed listing core mounts: %w", err)
+	}
+
+	localEntries, err := barrier.List(ctx, coreLocalMountConfigPath+"/")
+	if err != nil {
+		return fmt.Errorf("failed listing core local mounts: %w", err)
+	}
+
+	var needPersist bool
+	if len(globalEntries) == 0 {
+		c.logger.Info("no mounts in transactional mount table; adding default mount table")
+		c.mounts = c.defaultMountTable()
+		needPersist = true
+	} else {
+		c.mounts = &MountTable{
+			Type: mountTableType,
+		}
+
+		for index, uuid := range globalEntries {
+			entry, err := c.fetchAndDecodeMountTableEntry(ctx, barrier, coreMountConfigPath, uuid)
+			if err != nil {
+				return fmt.Errorf("error loading mount table entry (%v/%v): %w", index, uuid, err)
+			}
+
+			if entry != nil {
+				c.mounts.Entries = append(c.mounts.Entries, entry)
+			}
+		}
+	}
+
+	if len(localEntries) > 0 {
+		for index, uuid := range localEntries {
+			entry, err := c.fetchAndDecodeMountTableEntry(ctx, barrier, coreLocalMountConfigPath, uuid)
+			if err != nil {
+				return fmt.Errorf("error loading local mount table entry (%v/%v): %w", index, uuid, err)
+			}
+
+			if entry != nil {
+				c.mounts.Entries = append(c.mounts.Entries, entry)
+			}
+		}
+	}
+
+	err = c.runMountUpdates(ctx, barrier, needPersist)
+	if err != nil {
+		c.logger.Error("failed to run legacy mount table upgrades", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// This function reads the legacy, single-entry combined mount table,
+// returning true if it was used. This will let us know (if we're inside
+// a transaction) if we need to do an upgrade.
+func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage) (bool, error) {
+	// Load the existing mount table
+	raw, err := barrier.Get(ctx, coreMountConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read legacy mount table", "error", err)
+		return false, errLoadMountsFailed
+	}
+	rawLocal, err := barrier.Get(ctx, coreLocalMountConfigPath)
+	if err != nil {
+		c.logger.Error("failed to read legacy local mount table", "error", err)
+		return false, errLoadMountsFailed
+	}
+
 	if raw != nil {
-		// Check if the persisted value has canary in the beginning. If
-		// yes, decompress the table and then JSON decode it. If not,
-		// simply JSON decode it.
 		mountTable, err := c.decodeMountTable(ctx, raw.Value)
 		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the mount table", "error", err)
-			return err
+			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
+			return false, err
 		}
-		c.tableMetrics(len(mountTable.Entries), false, false, raw.Value)
+		c.tableMetrics(len(mountTable.Entries), false, false, len(raw.Value))
 		c.mounts = mountTable
 	}
 
 	var needPersist bool
 	if c.mounts == nil {
-		c.logger.Info("no mounts; adding default mount table")
+		// In the event we are inside a transaction, we do not yet know if
+		// we have a transactional mount table; exit early and load the new format.
+		if _, ok := barrier.(logical.Transaction); ok {
+			return false, nil
+		}
+		c.logger.Info("no mounts in legacy mount table; adding default mount table")
 		c.mounts = c.defaultMountTable()
 		needPersist = true
+	} else {
+		if _, ok := barrier.(logical.Transaction); ok {
+			// We know we have legacy mount table entries, so force a migration.
+			c.logger.Info("migrating legacy mount table to transactional layout")
+			needPersist = true
+		}
+		c.tableMetrics(len(c.mounts.Entries), false, false, len(raw.Value))
 	}
 
 	if rawLocal != nil {
 		localMountTable, err := c.decodeMountTable(ctx, rawLocal.Value)
 		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the local mount table", "error", err)
-			return err
+			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
+			return false, err
 		}
 		if localMountTable != nil && len(localMountTable.Entries) > 0 {
-			c.tableMetrics(len(localMountTable.Entries), true, false, rawLocal.Value)
+			c.tableMetrics(len(localMountTable.Entries), true, false, len(rawLocal.Value))
 			c.mounts.Entries = append(c.mounts.Entries, localMountTable.Entries...)
 		}
 	}
 
-	// If this node is a performance standby we do not want to attempt to
-	// upgrade the mount table, this will be the active node's responsibility.
-	err = c.runMountUpdates(ctx, needPersist)
+	// Here, we must call runMountUpdates:
+	//
+	// 1. We may be without any mount table and need to create the legacy
+	//    table format because we don't have a transaction aware storage
+	//    backend.
+	// 2. We may have had a legacy mount table and need to upgrade into the
+	//    new format. runMountUpdates will handle this for us.
+	err = c.runMountUpdates(ctx, barrier, needPersist)
 	if err != nil {
-		c.logger.Error("failed to run mount table upgrades", "error", err)
-		return err
+		c.logger.Error("failed to run legacy mount table upgrades", "error", err)
+		return false, err
 	}
 
-	for _, entry := range c.mounts.Entries {
-		if entry.NamespaceID == "" {
-			entry.NamespaceID = namespace.RootNamespaceID
-		}
-		ns, err := NamespaceByID(ctx, entry.NamespaceID, c)
-		if err != nil {
-			return err
-		}
-		if ns == nil {
-			return namespace.ErrNoNamespace
-		}
-		entry.namespace = ns
-
-		// Sync values to the cache
-		entry.SyncCache()
-	}
-	return nil
+	// We loaded a legacy mount table and successfully migrated it, if
+	// necessary.
+	return true, nil
 }
 
 // Note that this is only designed to work with singletons, as it checks by
 // type only.
-func (c *Core) runMountUpdates(ctx context.Context, needPersist bool) error {
+func (c *Core) runMountUpdates(ctx context.Context, barrier logical.Storage, needPersist bool) error {
 	// Upgrade to typed mount table
 	if c.mounts.Type == "" {
 		c.mounts.Type = mountTableType
@@ -1220,6 +1379,10 @@ func (c *Core) runMountUpdates(ctx context.Context, needPersist bool) error {
 			if coreMount.Type == requiredMount.Type {
 				foundRequired = true
 				coreMount.Config = requiredMount.Config
+
+				// Since we're potentially updating the config here, sync the
+				// cache.
+				coreMount.SyncCache()
 				break
 			}
 		}
@@ -1273,11 +1436,23 @@ func (c *Core) runMountUpdates(ctx context.Context, needPersist bool) error {
 			needPersist = true
 		}
 
+		ns, err := NamespaceByID(ctx, entry.NamespaceID, c)
+		if err != nil {
+			return err
+		}
+		if ns == nil {
+			return namespace.ErrNoNamespace
+		}
+		entry.namespace = ns
+
 		// Don't store built-in version in the mount table, to make upgrades smoother.
 		if versions.IsBuiltinVersion(entry.Version) {
 			entry.Version = ""
 			needPersist = true
 		}
+
+		// Sync values to the cache
+		entry.SyncCache()
 	}
 	// Done if we have restored the mount table and we don't need
 	// to persist
@@ -1286,15 +1461,39 @@ func (c *Core) runMountUpdates(ctx context.Context, needPersist bool) error {
 	}
 
 	// Persist both mount tables
-	if err := c.persistMounts(ctx, c.mounts, nil); err != nil {
+	if err := c.persistMounts(ctx, barrier, c.mounts, nil, ""); err != nil {
 		c.logger.Error("failed to persist mount table", "error", err)
 		return errLoadMountsFailed
 	}
 	return nil
 }
 
-// persistMounts is used to persist the mount table after modification
-func (c *Core) persistMounts(ctx context.Context, table *MountTable, local *bool) error {
+// persistMounts is used to persist the mount table after modification.
+func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
+	// Sometimes we may not want to explicitly pass barrier; fetch it if
+	// necessary.
+	if barrier == nil {
+		barrier = c.barrier
+	}
+
+	// Gracefully handle a transaction-aware backend, if a transaction
+	// wasn't created for us. This is safe as we do not support nested
+	// transactions.
+	needTxnCommit := false
+	if txnBarrier, ok := barrier.(logical.TransactionalStorage); ok {
+		var err error
+		barrier, err = txnBarrier.BeginTx(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction to persist mounts: %w", err)
+		}
+
+		needTxnCommit = true
+
+		// In the event of an unexpected error, rollback this transaction.
+		// A rollback of a committed transaction does not impact the commit.
+		defer barrier.(logical.Transaction).Rollback(ctx)
+	}
+
 	if table.Type != mountTableType {
 		c.logger.Error("given table to persist has wrong type", "actual_type", table.Type, "expected_type", mountTableType)
 		return fmt.Errorf("invalid table type given, not persisting")
@@ -1319,14 +1518,19 @@ func (c *Core) persistMounts(ctx context.Context, table *MountTable, local *bool
 		} else {
 			nonLocalMounts.Entries = append(nonLocalMounts.Entries, entry)
 		}
+
+		// We potentially modified the mount table entry so update the map
+		// accordingly.
+		entry.SyncCache()
 	}
 
-	writeTable := func(mt *MountTable, path string) ([]byte, error) {
+	// Handle writing the legacy mount table by default.
+	writeTable := func(mt *MountTable, path string) (int, error) {
 		// Encode the mount table into JSON and compress it (lzw).
 		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mt, nil)
 		if err != nil {
 			c.logger.Error("failed to encode or compress mount table", "error", err)
-			return nil, err
+			return -1, err
 		}
 
 		// Create an entry
@@ -1336,45 +1540,125 @@ func (c *Core) persistMounts(ctx context.Context, table *MountTable, local *bool
 		}
 
 		// Write to the physical backend
-		if err := c.barrier.Put(ctx, entry); err != nil {
+		if err := barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist mount table", "error", err)
-			return nil, err
+			return -1, err
 		}
-		return compressedBytes, nil
+		return len(compressedBytes), nil
+	}
+
+	if _, ok := barrier.(logical.Transaction); ok {
+		// Write a transactional-aware mount table series instead.
+		writeTable = func(mt *MountTable, prefix string) (int, error) {
+			var size int
+			var found bool
+			currentEntries := make(map[string]struct{}, len(mt.Entries))
+			for index, mtEntry := range mt.Entries {
+				if mount != "" && mtEntry.UUID != mount {
+					continue
+				}
+
+				found = true
+				currentEntries[mtEntry.UUID] = struct{}{}
+
+				// Encode the mount table into JSON. There is little value in
+				// compressing short entries.
+				path := path.Join(prefix, mtEntry.UUID)
+				encoded, err := jsonutil.EncodeJSON(mtEntry)
+				if err != nil {
+					c.logger.Error("failed to encode mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
+					return -1, err
+				}
+
+				// Create a storage entry.
+				sEntry := &logical.StorageEntry{
+					Key:   path,
+					Value: encoded,
+				}
+
+				// Write to the backend.
+				if err := barrier.Put(ctx, sEntry); err != nil {
+					c.logger.Error("failed to persist mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
+					return -1, err
+				}
+
+				size += len(encoded)
+			}
+
+			if mount != "" && !found {
+				// Delete this component if it exists. This signifies that
+				// we're removing this mount.
+				path := path.Join(prefix, mount)
+				if err := barrier.Delete(ctx, path); err != nil {
+					return -1, fmt.Errorf("requested removal of mount but failed: %w", err)
+				}
+			}
+
+			if mount == "" {
+				// List all entries and remove any deleted ones.
+				presentEntries, err := barrier.List(ctx, prefix+"/")
+				if err != nil {
+					return -1, fmt.Errorf("failed to list entries for removal: %w", err)
+				}
+
+				for index, presentEntry := range presentEntries {
+					if _, present := currentEntries[presentEntry]; present {
+						continue
+					}
+
+					if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						return -1, fmt.Errorf("failed to remove deleted mount %v (%d): %w", presentEntry, index, err)
+					}
+				}
+			}
+
+			// Finally, delete the legacy entries, if any.
+			if err := barrier.Delete(ctx, prefix); err != nil {
+				return -1, err
+			}
+
+			return size, nil
+		}
 	}
 
 	var err error
-	var compressedBytes []byte
+	var compressedBytesLen int
 	switch {
 	case local == nil:
 		// Write non-local mounts
-		compressedBytes, err := writeTable(nonLocalMounts, coreMountConfigPath)
+		compressedBytesLen, err = writeTable(nonLocalMounts, coreMountConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(nonLocalMounts.Entries), false, false, compressedBytes)
+		c.tableMetrics(len(nonLocalMounts.Entries), false, false, compressedBytesLen)
 
 		// Write local mounts
-		compressedBytes, err = writeTable(localMounts, coreLocalMountConfigPath)
+		compressedBytesLen, err = writeTable(localMounts, coreLocalMountConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(localMounts.Entries), true, false, compressedBytes)
+		c.tableMetrics(len(localMounts.Entries), true, false, compressedBytesLen)
 
 	case *local:
 		// Write local mounts
-		compressedBytes, err = writeTable(localMounts, coreLocalMountConfigPath)
+		compressedBytesLen, err = writeTable(localMounts, coreLocalMountConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(localMounts.Entries), true, false, compressedBytes)
+		c.tableMetrics(len(localMounts.Entries), true, false, compressedBytesLen)
 	default:
 		// Write non-local mounts
-		compressedBytes, err = writeTable(nonLocalMounts, coreMountConfigPath)
+		compressedBytesLen, err = writeTable(nonLocalMounts, coreMountConfigPath)
 		if err != nil {
 			return err
 		}
-		c.tableMetrics(len(nonLocalMounts.Entries), false, false, compressedBytes)
+		c.tableMetrics(len(nonLocalMounts.Entries), false, false, compressedBytesLen)
+	}
+
+	if needTxnCommit {
+		if err := barrier.(logical.Transaction).Commit(ctx); err != nil {
+			return fmt.Errorf("failed to persist mounts inside transaction: %w", err)
+		}
 	}
 
 	return nil

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -303,19 +303,30 @@ func TestCore_Mount_Local(t *testing.T) {
 		t.Fatalf("expected two entries, got %d", len(c.mounts.Entries))
 	}
 
-	rawLocal, err := c.barrier.Get(context.Background(), coreLocalMountConfigPath)
+	localEntries, err := c.barrier.List(context.Background(), coreLocalMountConfigPath+"/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rawLocal == nil {
-		t.Fatal("expected non-nil local mounts")
+	if len(localEntries) != 1 {
+		t.Fatalf("expected one entry in local mount table, got %#v", localEntries)
 	}
-	localMountsTable := &MountTable{}
-	if err := jsonutil.DecodeJSON(rawLocal.Value, localMountsTable); err != nil {
-		t.Fatal(err)
-	}
-	if len(localMountsTable.Entries) != 1 || localMountsTable.Entries[0].Type != "cubbyhole" {
-		t.Fatalf("expected only cubbyhole entry in local mount table, got %#v", localMountsTable)
+	for _, localEntry := range localEntries {
+		rawLocal, err := c.barrier.Get(context.Background(), coreLocalMountConfigPath+"/"+localEntry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rawLocal == nil {
+			t.Fatal("expected non-nil local mounts")
+		}
+
+		localMountEntry := &MountEntry{}
+		if err := jsonutil.DecodeJSON(rawLocal.Value, localMountEntry); err != nil {
+			t.Fatal(err)
+		}
+
+		if localMountEntry.Type != "cubbyhole" {
+			t.Fatalf("expected only cubbyhole entry in local mount table, got %#v at %v", localMountEntry, coreLocalMountConfigPath+"/"+localEntry)
+		}
 	}
 
 	c.mounts.Entries[1].Local = true
@@ -323,23 +334,33 @@ func TestCore_Mount_Local(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawLocal, err = c.barrier.Get(context.Background(), coreLocalMountConfigPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rawLocal == nil {
-		t.Fatal("expected non-nil local mount")
-	}
-	localMountsTable = &MountTable{}
-	if err := jsonutil.DecodeJSON(rawLocal.Value, localMountsTable); err != nil {
-		t.Fatal(err)
-	}
 	// This requires some explanation: because we're directly munging the mount
 	// table, the table initially when core unseals contains cubbyhole as per
 	// above, but then we overwrite it with our own table with one local entry,
 	// so we should now only expect the noop2 entry
-	if len(localMountsTable.Entries) != 1 || localMountsTable.Entries[0].Path != "noop2/" {
-		t.Fatalf("expected one entry in local mount table, got %#v", localMountsTable)
+	localEntries, err = c.barrier.List(context.Background(), coreLocalMountConfigPath+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(localEntries) != 1 {
+		t.Fatalf("expected one entry in local mount table, got %#v", localEntries)
+	}
+	for _, localEntry := range localEntries {
+		rawLocal, err := c.barrier.Get(context.Background(), coreLocalMountConfigPath+"/"+localEntry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rawLocal == nil {
+			t.Fatal("expected non-nil local mounts")
+		}
+
+		localMountEntry := &MountEntry{}
+		if err := jsonutil.DecodeJSON(rawLocal.Value, localMountEntry); err != nil {
+			t.Fatal(err)
+		}
+		if localMountEntry.Path != "noop2/" {
+			t.Fatalf("expected only noop2/ entry in local mount table, got %#v at %v", localMountEntry, coreLocalMountConfigPath+"/"+localEntry)
+		}
 	}
 
 	oldMounts := c.mounts
@@ -360,7 +381,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	if len(c.mounts.Entries) != 2 {
-		t.Fatalf("expected two mount entries, got %#v", localMountsTable)
+		t.Fatalf("expected two mount entries, got %#v", c.mounts.Entries)
 	}
 }
 
@@ -777,7 +798,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	}
 
 	// We filter out local entries here since the logic is rather dumb
-	// (straight JSON comparison) and doesn't seal well with the separate
+	// (straight JSON comparison) and doesn't deal well with the separate
 	// locations
 	newEntries := mt.Entries[:0]
 	for _, entry := range mt.Entries {
@@ -808,6 +829,23 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		t.Fatalf("bad: values here should be different")
 	}
 
+	// Remove any transactional storage entries: we want to replace the mount
+	// table with a pre-transactional variant to force upgrades to be run.
+	if _, ok := c.barrier.(logical.TransactionalStorage); ok && testType != "audits" {
+		postTxnEntries, err := c.barrier.List(context.Background(), path+"/")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, txnEntry := range postTxnEntries {
+			t.Logf("removing entry: %v", path+"/"+txnEntry)
+			if err := c.barrier.Delete(context.Background(), path+"/"+txnEntry); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Write the pre-typed version
 	entry := &logical.StorageEntry{
 		Key:   path,
 		Value: raw,
@@ -843,26 +881,85 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		t.Fatal(err)
 	}
 
-	entry, err = c.barrier.Get(context.Background(), path)
-	if err != nil {
+	// If we are using a transactional backend, validate the migrated path.
+	var actual []byte
+	if _, ok := c.barrier.(logical.TransactionalStorage); ok && testType != "audits" {
+		// Assume we got the outer, implicit type correct.
+		postTxnEntries, err := c.barrier.List(context.Background(), path+"/")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mapEntries := make(map[string]string)
+		for _, txnEntry := range postTxnEntries {
+			entry, err = c.barrier.Get(context.Background(), path+"/"+txnEntry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if entry == nil {
+				t.Fatal("nil value")
+			}
+
+			mapEntries[txnEntry] = strings.TrimSpace(string(entry.Value))
+		}
+
+		// Reconstruct them in the correct order.
+		var entries string
+		for _, entry := range mt.Entries {
+			if _, present := mapEntries[entry.UUID]; !present {
+				continue
+			}
+
+			if len(entries) > 0 {
+				entries += ","
+			}
+			entries += mapEntries[entry.UUID]
+		}
+
+		// Assume we would've gotten the outer type correct.
+		actual = []byte(`{"type":"` + mt.Type + `","entries":[` + entries + `]}`)
+
+		// Read the old mount table entry and ensure it was deleted.
+		entry, err = c.barrier.Get(context.Background(), path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entry != nil && len(entry.Value) > 0 {
+			t.Fatalf("expected empty entry at non-transactional mount table path: %v\n\tentry: %#v", path, string(entry.Value))
+		}
+	} else {
+		entry, err = c.barrier.Get(context.Background(), path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entry == nil {
+			t.Fatal("nil value")
+		}
+
+		decompressedBytes, uncompressed, err := compressutil.Decompress(entry.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actual = decompressedBytes
+		if uncompressed {
+			actual = entry.Value
+		}
+	}
+
+	// Decode actual and expected and compare.
+	var expectedDecoded map[string]interface{}
+	var actualDecoded map[string]interface{}
+
+	if err := json.Unmarshal(goodJson, &expectedDecoded); err != nil {
 		t.Fatal(err)
 	}
-	if entry == nil {
-		t.Fatal("nil value")
-	}
-
-	decompressedBytes, uncompressed, err := compressutil.Decompress(entry.Value)
-	if err != nil {
+	if err := json.Unmarshal(actual, &actualDecoded); err != nil {
 		t.Fatal(err)
 	}
 
-	actual := decompressedBytes
-	if uncompressed {
-		actual = entry.Value
-	}
-
-	if strings.TrimSpace(string(actual)) != strings.TrimSpace(string(goodJson)) {
-		t.Fatalf("bad: expected\n%s\nactual\n%s\n", string(goodJson), string(actual))
+	if diff := deep.Equal(actualDecoded, expectedDecoded); len(diff) > 0 {
+		t.Fatalf("bad: expected\n%s\nactual\n%s\n\n\tdiff: %#v", string(goodJson), string(actual), diff)
 	}
 
 	// Now try saving invalid versions

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -319,7 +319,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	c.mounts.Entries[1].Local = true
-	if err := c.persistMounts(context.Background(), c.mounts, nil); err != nil {
+	if err := c.persistMounts(context.Background(), nil, c.mounts, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -816,7 +816,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		t.Fatal(err)
 	}
 
-	var persistFunc func(context.Context, *MountTable, *bool) error
+	var persistFunc func(context.Context, logical.Storage, *MountTable, *bool, string) error
 
 	// It should load successfully and be upgraded and persisted
 	switch testType {
@@ -830,7 +830,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		mt = c.auth
 	case "audits":
 		err = c.loadAudits(context.Background())
-		persistFunc = func(ctx context.Context, mt *MountTable, b *bool) error {
+		persistFunc = func(ctx context.Context, barrier logical.Storage, mt *MountTable, b *bool, mount string) error {
 			if b == nil {
 				b = new(bool)
 				*b = false
@@ -868,19 +868,19 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	// Now try saving invalid versions
 	origTableType := mt.Type
 	mt.Type = "foo"
-	if err := persistFunc(context.Background(), mt, nil); err == nil {
+	if err := persistFunc(context.Background(), nil, mt, nil, ""); err == nil {
 		t.Fatal("expected error")
 	}
 
 	if len(mt.Entries) > 0 {
 		mt.Type = origTableType
 		mt.Entries[0].Table = "bar"
-		if err := persistFunc(context.Background(), mt, nil); err == nil {
+		if err := persistFunc(context.Background(), nil, mt, nil, ""); err == nil {
 			t.Fatal("expected error")
 		}
 
 		mt.Entries[0].Table = mt.Type
-		if err := persistFunc(context.Background(), mt, nil); err != nil {
+		if err := persistFunc(context.Background(), nil, mt, nil, ""); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -203,12 +203,12 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 	// update the mount table since we changed the runningSha
 	if oldSha != entry.RunningSha256 && MountTableUpdateStorage {
 		if isAuth {
-			err = c.persistAuth(ctx, c.auth, &entry.Local)
+			err = c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = c.persistMounts(ctx, c.mounts, &entry.Local)
+			err = c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID)
 			if err != nil {
 				return err
 			}

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -121,7 +121,7 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(context.Background(), newTable, &mountEntry.Local))
+			require.NoError(t, core.persistMounts(context.Background(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 
@@ -204,7 +204,7 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(context.Background(), newTable, &mountEntry.Local))
+			require.NoError(t, core.persistMounts(context.Background(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 

--- a/website/content/docs/rfcs/split-mount-tables.mdx
+++ b/website/content/docs/rfcs/split-mount-tables.mdx
@@ -1,0 +1,203 @@
+---
+sidebar_label: Split mount tables
+description: |-
+  Split the auth and secret mount tables using transactional storage to remove
+  limits around the maximum number of mounted plugins.
+---
+
+# Split the mount table using transactional storage
+
+## Summary
+
+OpenBao inherits a problem from upstream Vault: because the mount table is stored as a single entry, it is constrained by the size of a storage entry, not system memory. We wish to split this table into separate entries using transactional storage so that this limit can be raised much higher.
+
+## Problem Statement
+
+OpenBao's [default `max_entry_size`](https://openbao.org/docs/configuration/storage/raft/) is 1MB, which [with compression](https://github.com/openbao/openbao/blob/7d3a5f4b45cd0718eb2f3c97bcd9b90a563f2ce9/sdk/helper/jsonutil/json.go#L30-L53), usually works out to about [14k mounts due](https://openbao.org/docs/internals/limits/#mount-point-limits) to storing all mounts in a [single entry](https://github.com/openbao/openbao/blob/7d3a5f4b45cd0718eb2f3c97bcd9b90a563f2ce9/vault/mount.go#L1324-L1344). Upstream has opted to [create a second tunable](https://developer.hashicorp.com/vault/docs/release-notes/1.17.0#enterprise-updates), [`max_mount_and_namespace_table_entry_size`](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#max_mount_and_namespace_table_entry_size), letting this entry grow larger than other entries. With [transactional storage](https://github.com/openbao/openbao/issues/296), we can make a better tradeoff: split the mount table into a pieces, one per mount entry, and use transactions to do atomic updates to it. This ensures we do not hit this limit and thus do not need to re-implement the new tunable.
+
+As currently proposed, transactions will still have a size limit (about [8 times larger than `max_entry_size` currently](https://github.com/openbao/openbao/pull/292/files#diff-e7a3b01e6748f4e31a9293348fb545117ed1138c2e6e274d5f30bb07cf9a114cR76)), which means we might still err out. Because we can now atomically update just a portion of the mount table however, the types of operations that cause this will be rarer: this would mostly be the initial migration to the new format (if `max_entry_size` was raised but `max_transaction_size` was not) and any operations which involve scans across the entire mount table (due to adding reads to the transaction to verify they don't conflict).
+
+## User-facing description
+
+Users will now be able to create mounts in excess of the 14k soft limit previously caused by `max_entry_size`. They may decrease this value if they do not have other storage entries currently exceeding the default size in the future.
+
+Further, we'll only support an upgrade from the legacy->transactional mount table and not downgrades from transactional->legacy. This upgrade will happen automatically on the first startup with a transactional storage backend. As long as a non-transactional backend is used, it will continue to use the old mount table format.
+
+## Technical Description
+
+
+This change will apply for both auth and secret engine mounts.
+
+OpenBao's storage semantics mean that entries can both be a directory and a file at the same time. This means we can write individual mount entries from `coreMountConfigPath` into `coreMountConfigPath/{uuid}` and treat the latter (`coreMountConfigPath/`) as a listable directory of mounts. Any modification to individual mounts can be done without impacting other mounts once the UUID is known. By wrapping all updates in a transaction, we can ensure modifications to the mount table are consistent. Further, because the mount table is kept in memory, we will rarely need to load the entire mount table from disk except when invalidating the legacy single-entry table.
+
+More precisely, we have the following places where the mount table is potentially adjusted:
+
+ - When starting up and loading the mount table. This will handle the migration from legacy to standard if necessary.
+ - When an invalidation occurs and we trigger a reload of the core (e.g., leadership changed).
+ - When [mounting](https://openbao.org/api-docs/system/mounts/#enable-secrets-engine) a new secrets engine.
+ - When [tuning](https://openbao.org/api-docs/system/mounts/#tune-mount-configuration) a secrets engine.
+
+Of these, the first two use the common `loadMounts`; only the latter require special care. However, all four of these paths call the common `c.persistMounts` helper, so modifying that will be sufficient for our needs. Further, an extra pair of parameters (`barrier`, to optionally work within an existing transaction) and `uuid` (to persist only a specific mount) will increase performance in these cases.
+
+## Rationale and alternatives
+
+This helps OpenBao's scalability and is a great use for the new transactional storage system.
+
+[@remilapeyre](https://github.com/remilapeyre)'s approach (linked below) uses a similar structure, but because upstream Vault lacks transactions, it must use a pseudo-transactional update mechanism. Entries are encoded together but written in separate segments and the legacy mount table configuration is rewritten to include a list of all segments, before old segments are deleted. Due to this, modifying a single mount table entry still requires modifying several structures (due to compression of the table, which means several shards may update). This is less desirable and transactional storage gets us cleaner semantics.
+
+## Downsides
+
+This would be a breaking change w.r.t. storage and divergence from upstream Vault. Users would be unable to downgrade to non-transactional storage (including to Vault) without having to manually reconstruct their mount table. This new mount table may exceed the size of a storage entry. Note however that [our policy](https://openbao.org/docs/policies/migration/#proposal) is aiming for API compatibility and drop-in binary _upgrades_ from Vault to OpenBao, not supporting the reverse. Thus, this only impacts customers which need to revert this upgrade. In that case, using a backup (such as a snapshot) and restoring afterwards should address this.
+
+## Security Implications
+
+No new security implications are expected as a result of this change.
+
+## User/Developer Experience
+
+Users will be able to have a higher mount count, but otherwise will not be negatively impacted by this change. Adding new mounts might actually be more performant.
+
+## Unresolved Questions
+
+n/a
+
+## Related Issues
+
+OpenBao issues:
+
+ - https://github.com/openbao/openbao/296
+
+Upstream issues:
+
+ - https://github.com/hashicorp/vault/pull/16025
+
+
+## Proof of Concept
+
+WIP: https://github.com/cipherboy/openbao/commits/split-mount-table
+
+Using this code:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/openbao/openbao/api/v2"
+)
+
+func main() {
+    addr := "http://localhost:8200"
+    token := "devroot"
+    mountType := "transit"
+    count := 360000
+
+    client, err := api.NewClient(&api.Config{
+        Address: addr,
+    })
+    if err != nil {
+        panic(fmt.Sprintf("failed to create client: %v", err))
+    }
+
+    client.SetToken(token)
+
+    for i := 0; i < count; i++ {
+        if err := client.Sys().Mount(fmt.Sprintf("%v-%v", mountType, i), &api.MountInput{
+            Type: mountType,
+        }); err != nil {
+            panic(fmt.Sprintf("failed to mount %v instance: %v", mountType, err))
+        }
+    }
+}
+```
+
+on a [raft backend](https://github.com/cipherboy/devbao) node, I got:
+
+```
+$ time go run ./main.go
+panic: failed to mount transit instance: Error making API request.
+
+URL: POST http://localhost:8200/v1/sys/mounts/transit-288826
+Code: 400. Errors:
+
+* invalid backend version: 2 errors occurred:
+	* Error retrieving cache size from storage: context canceled
+	* Error retrieving cache size from storage: context canceled
+
+
+
+goroutine 1 [running]:
+main.main()
+	/home/cipherboy/GitHub/cipherboy/testbed/openbao-mounts/main.go:28 +0x1ed
+exit status 2
+
+real	120m38.046s
+user	0m39.741s
+sys	0m33.142s
+```
+
+and OpenBao was consuming 36GB of memory. This error was caused [by storage being slow](https://github.com/openbao/openbao/blob/5372ce8429ac8b26d861d266841ffcd1771bf7d4/builtin/logical/transit/backend.go#L92-L96) while the Transit mount was starting up. On a subsequent run, using `ssh` instead (as it does no storage operations on mount):
+
+```
+$ time go run ./main.go
+
+real	159m50.839s
+user	0m50.784s
+sys	0m32.350s
+```
+
+all 360k mounts were created:
+
+```
+$ bao list sys/raw/core/mounts | wc -l
+360002
+$ bao list sys/raw/core/mounts | head -n 10
+Keys
+----
+000009e0-123e-72b4-ed66-cf9a454535e6
+00004caf-b55d-0bed-5bc6-6b006ae9dc50
+00009443-ee00-1443-9d71-c79070eaf825
+0000e52a-2c79-a695-cca5-810b78e7e161
+00013fd2-abbc-0d41-3a4b-71b1aeef1a65
+00015884-79c2-3120-953a-0c475e89456b
+0001593f-b031-9bc9-4938-b20667692667
+00017b32-b7af-52ea-6dbd-fca3e29fb6a8
+$ bao read sys/raw/core/mounts/000009e0-123e-72b4-ed66-cf9a454535e6
+Key      Value
+---      -----
+value    {"table":"mounts","path":"ssh-129154/","type":"ssh","description":"","uuid":"000009e0-123e-72b4-ed66-cf9a454535e6","backend_aware_uuid":"fbb54766-47bd-f2d2-f115-e94b07b5ef7c","accessor":"ssh_46768b9a","config":{},"options":null,"local":false,"seal_wrap":false,"namespace_id":"root","running_plugin_version":"v2.0.0+builtin.bao"}
+```
+
+When attempting to use all of these mounts, I seem to be limited by storage speed:
+
+![image](https://github.com/user-attachments/assets/54ab0920-adf7-49ac-8141-036116265cb7)
+
+```go
+    var wg sync.WaitGroup
+
+    for proc := 0; proc < procs; proc++ {
+        wg.Add(1)
+        go func(us int) {
+            for i := us * (count / procs); i < (us+1)*(count/procs); i++ {
+                if _, err := client.Logical().Write(fmt.Sprintf("%v-%v/config/ca", mountType, i), map[string]interface{}{
+                    "generate_signing_key": true,
+                    "key_type":             "ssh-ed25519",
+                }); err != nil {
+                    // fmt.Fprintf(os.Stderr, "failed to mount %v instance: %v", mountType, err)
+                }
+            }
+            wg.Done()
+        }(proc)
+    }
+
+    wg.Wait()
+```
+
+And I'm roughly getting ~180 SSH CA certs/second.
+
+```
+$ bao list sys/raw/logical/ | wc -l ; sleep 10 ; bao list sys/raw/logical/ | wc -l
+45658
+47083
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -491,6 +491,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/mlock-removal",
                 "rfcs/signed-commits",
                 "rfcs/transactions",
+                "rfcs/split-mount-tables",
             ],
             FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },


### PR DESCRIPTION
OpenBao has an implicit limit on the number of mounts much lower than can theoretically fit in memory: the maximum Raft storage entry size. In practice, the use of compression (after applying JSON encoding to the table) lets us achieve a higher than expected limit. Large deployments can still hit this limit.

By relying on the newly introduced transactional storage, we can split the mount table into separate entries (one per mount), which is performant due to reuse of the bbolt transaction. This lets us avoid the lower entry limit at the risk of hitting the higher transaction limit in the future.

However, this also makes updates scoped: only reading or writing a large number of entries (combining path + hash) and then committing will hit this limit; individual mount additions or modifications will not trigger re-writing all entries and thus becomes safer.

We introduce this change for both auth and secret mounts, but not for audit mounts as audit mounts are not used as extensively as auth and secrets engines in practice. This lets us avoid unnecessary complexity there.

Note that this change cannot be retroactively reverted: users must take a snapshot before upgrading if they wish to later downgrade to the old (non-transactional) storage layout.

---

TODO:

 - [x] Add changelog entry
 - [x] Add RFC
 - [x] Add tests for the migration in particular