### PR TITLE
Fix cache spamming logs on transaction creation; limit cache size for transactions

### DIFF
--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -113,6 +113,11 @@ func NewCache(b Backend, size int, logger log.Logger, metricSink metrics.MetricS
 	if logger.IsDebug() {
 		logger.Debug("creating LRU cache", "size", size)
 	}
+
+	return newCache(b, size, logger, metricSink)
+}
+
+func newCache(b Backend, size int, logger log.Logger, metricSink metrics.MetricSink) Cache {
 	if size <= 0 {
 		size = DefaultCacheSize
 	}
@@ -274,7 +279,7 @@ func (c *cache) cloneWithStorage(b Backend) *cache {
 	// fresh, localized cache. This is globally sub-optimal (as it starts
 	// with an empty cache), but easiest to implement (as the transaction can
 	// modify its cache as it pleases).
-	cacheCopy := NewCache(b, c.size, c.logger, c.metricSink).(*cache)
+	cacheCopy := newCache(b, c.size, c.logger, c.metricSink).(*cache)
 	cacheCopy.SetEnabled(c.GetEnabled())
 	return cacheCopy
 }

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -19,6 +19,10 @@ const (
 	// DefaultCacheSize is used if no cache size is specified for NewCache
 	DefaultCacheSize = 128 * 1024
 
+	// TransactionCacheFactor is a multiple of cache size to reduce
+	// transactions by, to avoid high memory usage.
+	TransactionCacheFactor = DefaultParallelTransactions
+
 	// refreshCacheCtxKey is a ctx value that denotes the cache should be
 	// refreshed during a Get call.
 	refreshCacheCtxKey = "refresh_cache"
@@ -279,7 +283,7 @@ func (c *cache) cloneWithStorage(b Backend) *cache {
 	// fresh, localized cache. This is globally sub-optimal (as it starts
 	// with an empty cache), but easiest to implement (as the transaction can
 	// modify its cache as it pleases).
-	cacheCopy := newCache(b, c.size, c.logger, c.metricSink).(*cache)
+	cacheCopy := newCache(b, c.size/TransactionCacheFactor, c.logger, c.metricSink).(*cache)
 	cacheCopy.SetEnabled(c.GetEnabled())
 	return cacheCopy
 }


### PR DESCRIPTION
```
commit cebec7772febe00f286b9e3ad4f670d7784b2798 (HEAD -> fix-cache-spam-logs-on-txn, origin/fix-cache-spam-logs-on-txn)
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Sun Oct 13 19:02:38 2024 -0400

    Reduce size of cache for each transaction
    
    While transactions should be short-lived, we wish to prevent leaked
    transactions from consuming too much memory due to excessive cache
    usage. While the cache itself starts empty, a transaction reading and
    writing lots of entries could grow the cache: by decreasing by a factor
    of DefaultParallelTransactions, we can ensure we only grow the total
    memory used by the combined caches by 2x.
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

commit d3aeb49b73f756f5cb1f39b4ee21568a30ad65fc
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Sun Oct 13 19:01:54 2024 -0400

    Prevent spurious logging on transaction creation
    
    Every transaction created would result in details about the cache size
    being printed; this was always the same as the parent's cache and so is
    always extraneous information.
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>
```