### PR TITLE
Move to faster golang-lru/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/hcl v1.0.1-vault-5
 	github.com/hashicorp/hcl/v2 v2.16.2
 	github.com/hashicorp/raft v1.3.10
@@ -258,6 +258,7 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.3.0 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 // indirect

--- a/go.sum
+++ b/go.sum
@@ -579,6 +579,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/hcl v1.0.1-vault-5
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
@@ -72,6 +72,7 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -127,6 +127,8 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J+x6AzmKuVM/JWCQwkWm6GW/MUR6I=

--- a/sdk/helper/keysutil/encrypted_key_storage.go
+++ b/sdk/helper/keysutil/encrypted_key_storage.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -96,7 +96,7 @@ func NewEncryptedKeyStorageWrapper(config EncryptedKeyStorageConfig) (*Encrypted
 		size = DefaultCacheSize
 	}
 
-	cache, err := lru.New2Q(size)
+	cache, err := lru.New2Q[string, string](size)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func NewEncryptedKeyStorageWrapper(config EncryptedKeyStorageConfig) (*Encrypted
 
 type EncryptedKeyStorageWrapper struct {
 	policy *Policy
-	lru    *lru.TwoQueueCache
+	lru    *lru.TwoQueueCache[string, string]
 	prefix string
 }
 
@@ -136,7 +136,7 @@ func (f *EncryptedKeyStorageWrapper) Wrap(s logical.Storage) logical.Storage {
 type encryptedKeyStorage struct {
 	policy *Policy
 	s      logical.Storage
-	lru    *lru.TwoQueueCache
+	lru    *lru.TwoQueueCache[string, string]
 
 	prefix string
 }
@@ -199,7 +199,7 @@ func (s *encryptedKeyStorage) ListPage(ctx context.Context, prefix string, after
 		raw, ok := s.lru.Get(k)
 		if ok {
 			// cache HIT, we can bail early and skip the decode & decrypt operations.
-			decryptedKeys[i] = raw.(string)
+			decryptedKeys[i] = raw
 			continue
 		}
 

--- a/sdk/helper/keysutil/transit_lru.go
+++ b/sdk/helper/keysutil/transit_lru.go
@@ -3,28 +3,28 @@
 
 package keysutil
 
-import lru "github.com/hashicorp/golang-lru"
+import lru "github.com/hashicorp/golang-lru/v2"
 
 type TransitLRU struct {
 	size int
-	lru  *lru.TwoQueueCache
+	lru  *lru.TwoQueueCache[string, interface{}]
 }
 
 func NewTransitLRU(size int) (*TransitLRU, error) {
-	lru, err := lru.New2Q(size)
+	lru, err := lru.New2Q[string, interface{}](size)
 	return &TransitLRU{lru: lru, size: size}, err
 }
 
 func (c *TransitLRU) Delete(key interface{}) {
-	c.lru.Remove(key)
+	c.lru.Remove(key.(string))
 }
 
 func (c *TransitLRU) Load(key interface{}) (value interface{}, ok bool) {
-	return c.lru.Get(key)
+	return c.lru.Get(key.(string))
 }
 
 func (c *TransitLRU) Store(key, value interface{}) {
-	c.lru.Add(key, value)
+	c.lru.Add(key.(string), value)
 }
 
 func (c *TransitLRU) Size() int {

--- a/sdk/helper/ocsp/ocsp_test.go
+++ b/sdk/helper/ocsp/ocsp_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-retryablehttp"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ocsp"
 )
@@ -47,7 +47,7 @@ func TestOCSP(t *testing.T) {
 	}
 
 	for _, tgt := range targetURL {
-		c.ocspResponseCache, _ = lru.New2Q(10)
+		c.ocspResponseCache, _ = lru.New2Q[certIDKey, *ocspCachedResponse](10)
 		for _, tr := range transports {
 			c := &http.Client{
 				Transport: tr,


### PR DESCRIPTION
This moves to the faster, maintained `golang-lru/v2`. We'll want to be on `v2` if we want to contribute a warm-cache implementation to fix benchmarks in transactions (see #624). 

So far I haven't seen many performance improvements with a warm cache; a later PR will introduce the performance improvements I wanted to see (thanks to Jan for identifying them!).

I will note we don't have many uses of generics in OpenBao so far, but many of these caches are heavily used so I'm inclined to take the faster implementation for them.