### PR TITLE
Improve raft transaction application performance

### DIFF
--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -133,6 +133,9 @@ type FSM struct {
 	localID         string
 	desiredSuffrage string
 	unknownOpTypes  sync.Map
+
+	// tracker for fast application of transactions
+	fastTxnTracker *fsmTxnCommitIndexTracker
 }
 
 // NewFSM constructs a FSM using the given directory
@@ -157,6 +160,7 @@ func NewFSM(path string, localID string, logger log.Logger) (*FSM, error) {
 		// setup if this is already part of a cluster with a desired suffrage.
 		desiredSuffrage: "voter",
 		localID:         localID,
+		fastTxnTracker:  FsmTxnCommitIndexTracker(),
 	}
 
 	f.chunker = raftchunking.NewChunkingBatchingFSM(f, &FSMChunkStorage{
@@ -633,6 +637,126 @@ func listPageInner(ctx context.Context, tx *bolt.Tx, prefix string, after string
 	return keys, nil
 }
 
+// Within ApplyBatch, applies non-transactional operations.
+func (f *FSM) applyBatchNonTxOps(b *bolt.Bucket, txnState *fsmTxnCommitIndexApplicationState, command *LogData) error {
+	for _, op := range command.Operations {
+		var err error
+		switch op.OpType {
+		case putOp:
+			err = b.Put([]byte(op.Key), op.Value)
+			if err == nil {
+				// This log occurs directly to the state tracker, so we
+				// want to ensure we only track it when the write succeeded.
+				txnState.logWrite(op.Key)
+			}
+		case deleteOp:
+			err = b.Delete([]byte(op.Key))
+			if err == nil {
+				// See note above.
+				txnState.logWrite(op.Key)
+			}
+		case restoreCallbackOp:
+			if f.restoreCb != nil {
+				// Kick off the restore callback function in a go routine
+				go f.restoreCb(context.Background())
+			}
+		default:
+			if _, ok := f.unknownOpTypes.Load(op.OpType); !ok {
+				f.logger.Error("unsupported transaction operation", "op", op.OpType)
+				f.unknownOpTypes.Store(op.OpType, struct{}{})
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Within ApplyBatch, applies a transaction within the broader context of the
+// batch's transaction.
+func (f *FSM) applyBatchTxOps(tx *bolt.Tx, b *bolt.Bucket, txnState *fsmTxnCommitIndexApplicationState, command *LogData) error {
+	txnState.setInTx()
+
+	// First we verify the transaction can apply correctly before doing any
+	// write operations. This allows us to safely ignore it if it conflicts
+	// with previous writes.
+	//
+	// This assumes that the transaction is constructed so that all verify
+	// operations are relative to the initial state of storage and not the
+	// in-transaction updated state.
+	var err error
+	for index, op := range command.Operations {
+		switch op.OpType {
+		case beginTxOp, commitTxOp:
+			// Ensure a well-formed transaction.
+			if command.Operations[0].OpType != beginTxOp || command.Operations[len(command.Operations)-1].OpType != commitTxOp || (index != 0 && index != len(command.Operations)-1) {
+				return fmt.Errorf("unsupported transaction: saw beginTxOp/commitTxOp mixed inside other operations: %w", physical.ErrTransactionCommitFailure)
+			}
+
+			if op.OpType == beginTxOp {
+				s, err := parseBeginTxOpValue(op.Value)
+				if err != nil {
+					return err
+				}
+				txnState.setStartIndex(s.Index)
+			}
+		case putOp:
+			// ignore
+		case deleteOp:
+			// ignore
+		case verifyReadOp:
+			err = txnState.doVerifyRead(b, op)
+		case verifyListOp:
+			err = txnState.doVerifyList(tx, b, op)
+		default:
+			if _, ok := f.unknownOpTypes.Load(op.OpType); !ok {
+				f.logger.Error("unsupported transaction operation", "op", op.OpType)
+				f.unknownOpTypes.Store(op.OpType, struct{}{})
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// Now we apply the write operations since the verification succeeded.
+	for _, op := range command.Operations {
+		switch op.OpType {
+		case beginTxOp, commitTxOp:
+			// ignore
+		case putOp:
+			err = b.Put([]byte(op.Key), op.Value)
+			txnState.logWrite(op.Key)
+		case deleteOp:
+			err = b.Delete([]byte(op.Key))
+			txnState.logWrite(op.Key)
+		case verifyReadOp:
+			// ignore
+		case verifyListOp:
+			// ignore
+		default:
+			if _, ok := f.unknownOpTypes.Load(op.OpType); !ok {
+				f.logger.Error("unsupported transaction operation", "op", op.OpType)
+				f.unknownOpTypes.Store(op.OpType, struct{}{})
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// Record the transaction as having been applied and merge state back into
+	// the central fast application tracking.
+	txnState.finishTxn()
+
+	return nil
+}
+
 // ApplyBatch will apply a set of logs to the FSM. This is called from the raft
 // library.
 func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
@@ -697,118 +821,79 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 		f.applyCallback()
 	}
 
-	// This loop and subsequent f.db.Update call were reordered from upstream,
-	// to enable one transaction per command. Raft chunking will already be
-	// applied, so if logs are split across multiple operations, we'll see
-	// only a single call here. This ensures that our transaction really will
-	// apply at the bolt level, independent of the other operations occurring,
-	// and lets us back out just the changes in the transaction if they fail
-	// to apply.
-	for _, commandRaw := range commands {
-		inTx := false
-		entrySlice := make([]*FSMEntry, 0)
-		err = f.db.Update(func(tx *bolt.Tx) error {
-			b := tx.Bucket(dataBucketName)
+	// One would think that this f.db.Update(...) and the following loop over
+	// commands should be in the opposite order, as we want transactions to be
+	// applied atomically. Indeed, 2c154ad516162dcb8b15ad270cd6a15516f2ce59 had
+	// this ordered that way. It has two issues though:
+	//
+	// 1. It is slower, as each bbolt transaction incurs additional storage
+	//    writes.
+	// 2. Technically, Raft expects the entire batch to succeed or fail as a
+	//    unit; thus, we don't want to commit partial state from a previous
+	//    log entry (that succeeded) when a later log entry fails.
+	//
+	// Hence, keep the original upstream ordering of Update w.r.t. batch
+	// application and switch to pre-verifying transactions prior to
+	// performing any writes in them.
+	err = f.db.Update(func(tx *bolt.Tx) error {
+		var err error
+		b := tx.Bucket(dataBucketName)
+		configB := tx.Bucket(configBucketName)
+		latestIndex := atomic.LoadUint64(f.latestIndex)
+
+		for commandIndex, commandRaw := range commands {
+			entrySlice := make([]*FSMEntry, 0, 1)
+
 			switch command := commandRaw.(type) {
 			case *LogData:
-				for index, op := range command.Operations {
-					var err error
-					switch op.OpType {
-					case beginTxOp, commitTxOp:
-						inTx = true
-						if command.Operations[0].OpType != beginTxOp || command.Operations[len(command.Operations)-1].OpType != commitTxOp || (index != 0 && index != len(command.Operations)-1) {
-							return fmt.Errorf("unsupported transaction: saw beginTxOp/commitTxOp mixed inside other operations: %w", physical.ErrTransactionCommitFailure)
-						}
-					case putOp:
-						err = b.Put([]byte(op.Key), op.Value)
-					case deleteOp:
-						err = b.Delete([]byte(op.Key))
-					case getOp:
-						fsmEntry := &FSMEntry{
-							Key: op.Key,
-						}
-						val := b.Get([]byte(op.Key))
-						if len(val) > 0 {
-							newVal := make([]byte, len(val))
-							copy(newVal, val)
-							fsmEntry.Value = newVal
-						}
-						entrySlice = append(entrySlice, fsmEntry)
-					case restoreCallbackOp:
-						if f.restoreCb != nil {
-							// Kick off the restore callback function in a go routine
-							go f.restoreCb(context.Background())
-						}
-					case verifyReadOp:
-						val := b.Get([]byte(op.Key))
-						err = doVerifyEntry(op.Key, val, op.Value)
-					case verifyListOp:
-						var params *verifyListOpParams
-						params, err = parseListVerifyParams(op.Key)
+				txnState := f.fastTxnTracker.applyState(latestIndex, commandIndex, logs[commandIndex].Index)
 
-						if err == nil {
-							var keys []string
-							keys, err = listPageInner(context.Background(), tx, params.Prefix, params.After, params.Limit)
-							if err == nil {
-								err = doVerifyList(op.Key, keys, op.Value)
-							}
-						}
-					default:
-						if _, ok := f.unknownOpTypes.Load(op.OpType); !ok {
-							f.logger.Error("unsupported transaction operation", "op", op.OpType)
-							f.unknownOpTypes.Store(op.OpType, struct{}{})
-						}
-					}
-					if err != nil {
-						// If we're in a transaction, we want to err out of
-						// this f.db.Update call, but we also need a way of
-						// informing the applyLog(...) caller that the
-						// transaction failed (instead of panic(...)ing below
-						// like we do for non-transaction operations).
-						//
-						// Create a special FSMEntry to send back the error
-						// message, that applyLog(...) will look for if it
-						// sent a transaction.
-						if inTx && errors.Is(err, physical.ErrTransactionCommitFailure) {
-							entrySlice = append(entrySlice, &FSMEntry{
-								Key:   fsmEntryTxErrorKey,
-								Value: []byte(err.Error()),
-							})
-						}
-
-						return err
-					}
+				if len(command.Operations) == 0 || command.Operations[0].OpType != beginTxOp {
+					err = f.applyBatchNonTxOps(b, txnState, command)
+				} else {
+					err = f.applyBatchTxOps(tx, b, txnState, command)
 				}
 
+				if err != nil {
+					// If we're in a transaction, we do not want to err the
+					// global f.db.Update call unless this is a critical error
+					// worthy of a panic(...).
+					//
+					// Create a special FSMEntry to send back the error
+					// message, that applyLog(...) will look for if it
+					// sent a transaction.
+					if txnState.getInTx() && errors.Is(err, physical.ErrTransactionCommitFailure) {
+						entrySlice = append(entrySlice, &FSMEntry{
+							Key:   fsmEntryTxErrorKey,
+							Value: []byte(err.Error()),
+						})
+
+						// Process other events; this transaction failure was handled
+						// appropriately already in applyBatchTxOps.
+						err = nil
+					}
+				}
 			case *ConfigurationValue:
-				b := tx.Bucket(configBucketName)
 				configBytes, err := proto.Marshal(command)
 				if err != nil {
 					return err
 				}
-				if err := b.Put(latestConfigKey, configBytes); err != nil {
+				if err := configB.Put(latestConfigKey, configBytes); err != nil {
 					return err
 				}
 			}
 
-			return nil
-		})
+			entrySlices = append(entrySlices, entrySlice)
 
-		entrySlices = append(entrySlices, entrySlice)
-
-		if err != nil && inTx && errors.Is(err, physical.ErrTransactionCommitFailure) {
-			// Process other events; this transaction failure was handled
-			// appropriately.
-			err = nil
-			continue
+			if err != nil {
+				break
+			}
 		}
 
-		if err != nil {
-			// Unknown error type or non-transactional error; exit and panic.
-			break
-		}
-	}
+		return err
+	})
 
+	// If we had no error, update our last applied log.
 	if err == nil {
 		err = f.db.Update(func(tx *bolt.Tx) error {
 			if len(logIndex) > 0 {

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1669,24 +1669,7 @@ func (b *RaftBackend) applyLog(ctx context.Context, command *LogData) error {
 		return errors.New("entries on FSM response were empty")
 	}
 
-	if !isTx {
-		for i, logOp := range command.Operations {
-			if logOp.OpType == getOp {
-				fsmEntry := fsmar.EntrySlice[i]
-
-				// this should always be true because the entries in the slice were created in the same order as
-				// the command operations.
-				if logOp.Key == fsmEntry.Key {
-					if len(fsmEntry.Value) > 0 {
-						logOp.Value = fsmEntry.Value
-					}
-				} else {
-					// this shouldn't happen
-					return errors.New("entries in FSM response were out of order")
-				}
-			}
-		}
-	} else {
+	if isTx {
 		// There should be at most one EntrySlice entry.
 		if len(fsmar.EntrySlice) > 1 {
 			return fmt.Errorf("multiple responses in entry slice: %v", len(fsmar.EntrySlice))

--- a/physical/raft/transaction.go
+++ b/physical/raft/transaction.go
@@ -15,9 +15,10 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/openbao/openbao/sdk/v2/physical"
-	"go.etcd.io/bbolt"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -35,6 +36,31 @@ var defaultVerifyHash = sha384VerifyHash
 // Bytes of overhead a single Put entry has versus a transaction, excluding
 // the size of the path. Verified by TestRaft_Backend_PutTxnMargin.
 const maxEntrySizeMultipleTxnOverhead = 11
+
+// Parameters to send on the beginTxOp
+type beginTxOpParams struct {
+	// Index prior to start of the underlying transaction: this allows fast
+	// application of transactions if no subsequent WAL entries modified any
+	// entries verified by this transaction.
+	Index uint64 `json:"i"`
+}
+
+func createBeginTxOpValue(index uint64) ([]byte, error) {
+	s := beginTxOpParams{
+		Index: index,
+	}
+	return json.Marshal(s)
+}
+
+func parseBeginTxOpValue(data []byte) (*beginTxOpParams, error) {
+	var s beginTxOpParams
+
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal begin tx op value: %w", err)
+	}
+
+	return &s, nil
+}
 
 type verifyListOpParams struct {
 	Prefix string `json:"p"`
@@ -141,18 +167,22 @@ func cloneBytes(val []byte) []byte {
 
 type raftTxnUpdateRecord struct {
 	// If this record exists but Contents is nil, the entry was deleted.
+	OpType   uint32
 	Contents *physical.Entry
 }
 
 type RaftTransaction struct {
 	b              *RaftBackend
 	l              sync.Mutex
-	tx             *bbolt.Tx
+	tx             *bolt.Tx
 	updates        map[string]*raftTxnUpdateRecord
-	log            *LogData
+	reads          map[string]*LogOperation
+	lists          map[string]map[string]map[int]*LogOperation
 	writable       bool
 	haveWritten    bool
 	haveFinishedTx bool
+	index          uint64
+	started        time.Time
 }
 
 var _ physical.Transaction = &RaftTransaction{}
@@ -165,6 +195,13 @@ func (b *RaftBackend) newTransaction(ctx context.Context, writable bool) (*RaftT
 	b.txnPermitPool.Acquire()
 	b.fsm.l.RLock()
 
+	// Grab the last seen WAL index prior to starting the transaction for
+	// correctness: this ensures everything in this WAL is seen in the
+	// underlying transaction, versus the other ordering (in which, the
+	// WAL could be incremented and we could be missing items not present
+	// in the transaction).
+	index := b.AppliedIndex()
+
 	// All underlying bbolt transactions are read-only; this gives us a
 	// consistent view of storage but means we need to track writes ourselves.
 	tx, err := b.fsm.db.Begin(false)
@@ -172,24 +209,26 @@ func (b *RaftBackend) newTransaction(ctx context.Context, writable bool) (*RaftT
 		return nil, fmt.Errorf("failed to start underlying bbolt transaction: %w", err)
 	}
 
+	if writable {
+		b.fsm.fastTxnTracker.trackTransaction(index)
+	}
+
 	return &RaftTransaction{
-		b:       b,
-		tx:      tx,
-		updates: make(map[string]*raftTxnUpdateRecord),
-		log: &LogData{
-			Operations: []*LogOperation{
-				{
-					OpType: beginTxOp,
-				},
-			},
-		},
+		b:        b,
+		tx:       tx,
+		updates:  make(map[string]*raftTxnUpdateRecord),
+		reads:    make(map[string]*LogOperation),
+		lists:    make(map[string]map[string]map[int]*LogOperation),
 		writable: writable,
+		index:    index,
+		started:  time.Now(),
 	}, nil
 }
 
 func (t *RaftTransaction) Put(ctx context.Context, entry *physical.Entry) error {
 	t.l.Lock()
 	defer t.l.Unlock()
+
 	if !t.writable {
 		return physical.ErrTransactionReadOnly
 	}
@@ -213,40 +252,41 @@ func (t *RaftTransaction) Put(ctx context.Context, entry *physical.Entry) error 
 	// If we haven't modified this entry within the scope of this
 	// transaction, read the value of this entry so we can hash it.
 	if _, present := t.updates[entry.Key]; !present {
-		// It is safe to go to the underlying transaction here as we
-		// hold an exclusive write lock here and so there's no parallel
-		// writers to the same key.
-		value := t.tx.Bucket(dataBucketName).Get([]byte(entry.Key))
-		contentsHash, err := createVerificationEntry(entry.Key, value)
-		if err != nil {
-			return err
-		}
+		// We could've alternatively performed a read on this entry before
+		// attempting to update it; don't create a verification entry if
+		// we have.
+		if _, present := t.reads[entry.Key]; !present {
+			// It is safe to go to the underlying transaction here as we
+			// hold an exclusive write lock here and so there's no parallel
+			// writers to the same key.
+			value := t.tx.Bucket(dataBucketName).Get([]byte(entry.Key))
+			contentsHash, err := createVerificationEntry(entry.Key, value)
+			if err != nil {
+				return err
+			}
 
-		// Verify the entry prior to updating it, when it comes time for raft
-		// application.
-		t.log.Operations = append(t.log.Operations, &LogOperation{
-			OpType: verifyReadOp,
-			Key:    entry.Key,
-			Value:  contentsHash,
-		})
+			// Add it to the list of reads to be performed when it comes time
+			// to generate the Raft log.
+			t.reads[entry.Key] = &LogOperation{
+				OpType: verifyReadOp,
+				Key:    entry.Key,
+				Value:  contentsHash,
+			}
+		}
 	}
 
+	// Do the update in the transaction, adding it to updates for when we
+	// generate the log.
 	update := &raftTxnUpdateRecord{
 		// Caller may mutate their entry after we accept it, so create a new
 		// one for the cache.
+		OpType: putOp,
 		Contents: &physical.Entry{
 			Key:   entry.Key,
 			Value: cloneBytes(entry.Value),
 		},
 	}
-
-	// Do the update in the transaction, adding it to the future raft log.
 	t.updates[entry.Key] = update
-	t.log.Operations = append(t.log.Operations, &LogOperation{
-		OpType: putOp,
-		Key:    entry.Key,
-		Value:  entry.Value,
-	})
 
 	return nil
 }
@@ -283,19 +323,21 @@ func (t *RaftTransaction) Get(ctx context.Context, key string) (*physical.Entry,
 	// Otherwise, ask the underlying transaction for this value.
 	value := t.tx.Bucket(dataBucketName).Get([]byte(key))
 
-	// Hash the contents so that we can add a verify operation.
-	contentsHash, err := createVerificationEntry(key, value)
-	if err != nil {
-		return nil, err
-	}
+	if _, present := t.reads[key]; !present {
+		// Hash the contents so that we can add a verify operation.
+		contentsHash, err := createVerificationEntry(key, value)
+		if err != nil {
+			return nil, err
+		}
 
-	// Add the read to the verification log, to ensure nobody else has written
-	// to it while the transaction was operating.
-	t.log.Operations = append(t.log.Operations, &LogOperation{
-		OpType: verifyReadOp,
-		Key:    key,
-		Value:  contentsHash,
-	})
+		// Add it to the list of reads to be performed when it comes time
+		// to generate the Raft log.
+		t.reads[key] = &LogOperation{
+			OpType: verifyReadOp,
+			Key:    key,
+			Value:  contentsHash,
+		}
+	}
 
 	// If we have no value, return nil.
 	if value == nil {
@@ -323,31 +365,32 @@ func (t *RaftTransaction) Delete(ctx context.Context, key string) error {
 	// If we haven't modified this entry within the scope of this
 	// transaction, read the value of this entry so we can hash it.
 	if _, present := t.updates[key]; !present {
-		// See notes above in Put(...) for why this is safe.
-		value := t.tx.Bucket(dataBucketName).Get([]byte(key))
-		contentsHash, err := createVerificationEntry(key, value)
-		if err != nil {
-			return err
-		}
+		// We could've alternatively performed a read on this entry before
+		// attempting to update it; don't create a verification entry if
+		// we have.
+		if _, present := t.reads[key]; !present {
+			// See notes above in Put(...) for why this is safe.
+			value := t.tx.Bucket(dataBucketName).Get([]byte(key))
+			contentsHash, err := createVerificationEntry(key, value)
+			if err != nil {
+				return err
+			}
 
-		// Verify the entry prior to deleting it, when it comes time for raft
-		// application.
-		t.log.Operations = append(t.log.Operations, &LogOperation{
-			OpType: verifyReadOp,
-			Key:    key,
-			Value:  contentsHash,
-		})
+			// Verify the entry prior to deleting it, when it comes time for raft
+			// application.
+			t.reads[key] = &LogOperation{
+				OpType: verifyReadOp,
+				Key:    key,
+				Value:  contentsHash,
+			}
+		}
 	}
 
-	// Empty Contents signifies delete.
-	update := &raftTxnUpdateRecord{}
-
 	// Do the delete in the transaction, adding it to the future raft log.
-	t.updates[key] = update
-	t.log.Operations = append(t.log.Operations, &LogOperation{
+	update := &raftTxnUpdateRecord{
 		OpType: deleteOp,
-		Key:    key,
-	})
+	}
+	t.updates[key] = update
 
 	return nil
 }
@@ -433,23 +476,36 @@ func (t *RaftTransaction) ListPage(ctx context.Context, prefix string, after str
 		}
 	}
 
+	// We do verifications off of the contents actually in the underlying
+	// storage, not from pre-commit writes. This means we need two entries:
+	//
+	// 1. Things we've seen in the course of this list.
+	// 2. The immediate next list entry, if any.
+	var presentKeys []string
+	var nextPresentEntry string
+
 	// Iterate through the results of list and see if the underlying data
 	// store already had entries for this list operation. Merge in any
 	// updated keys in the process.
 	var keys []string
 	for k, _ := c.Seek(seekPrefix); k != nil && bytes.HasPrefix(k, prefixBytes); k, _ = c.Next() {
+		key := string(k)
+		entry, isFolder, shouldVisit := listShouldIncludeEntry(prefix, after, key)
+
 		if limit > 0 && len(keys) >= limit {
 			// We've seen enough entries; exit.
+			nextPresentEntry = entry
 			break
 		}
 
-		key := string(k)
 		if _, deleted := deletions[key]; deleted {
-			// This key was deleted; we don't need to include it in our list.
+			// This key was deleted; we don't need to include it in our list,
+			// but because it was deleted, it will show up in our underlying
+			// list.
+			presentKeys = append(presentKeys, key)
 			continue
 		}
 
-		entry, isFolder, shouldVisit := listShouldIncludeEntry(prefix, after, key)
 		if !shouldVisit {
 			// Skip this entry.
 			continue
@@ -475,11 +531,15 @@ func (t *RaftTransaction) ListPage(ctx context.Context, prefix string, after str
 
 		if isFolder && len(keys) > 0 && lastKey == entry {
 			// This folder was already seen; don't revisit it.
+			if len(presentKeys) > 0 && presentKeys[len(presentKeys)-1] != key {
+				presentKeys = append(presentKeys, key)
+			}
 			continue
 		}
 
 		// Otherwise, include the entry.
 		keys = append(keys, entry)
+		presentKeys = append(presentKeys, entry)
 		delete(updates, entry)
 	}
 
@@ -506,20 +566,43 @@ func (t *RaftTransaction) ListPage(ctx context.Context, prefix string, after str
 		keys = keys[:limit]
 	}
 
-	// Now that we have our result, save the operation in the log
-	// for verification. To do so, we hash the results.
-	listParams, contentsHash, err := createListVerificationEntry(prefix, after, limit, keys)
+	// Now that we have the results, create a fake version for verification:
+	// we append the next key (in storage) to the iterated list for iteration,
+	// to ensure we didn't miss any entries. This is guaranteed to be at most
+	// one more than the requested entries, if no writes occurred within this
+	// transaction.
+	if nextPresentEntry != "" {
+		presentKeys = append(presentKeys, nextPresentEntry)
+	}
+	verifyLimit := len(presentKeys)
+	listParams, contentsHash, err := createListVerificationEntry(prefix, after, verifyLimit, presentKeys)
 	if err != nil {
 		return nil, err
 	}
 
 	// Add the list to the verification log, to ensure nobody else has written
-	// to it while the transaction was operating.
-	t.log.Operations = append(t.log.Operations, &LogOperation{
-		OpType: verifyListOp,
-		Key:    listParams,
-		Value:  contentsHash,
-	})
+	// to it while the transaction was operating. While it is technically
+	// possible to collapse operations across values for after (sharing the
+	// same prefix), we only collapse to a single log operation if we have
+	// a higher limit than the existing entry.
+	if _, present := t.lists[prefix]; !present {
+		t.lists[prefix] = make(map[string]map[int]*LogOperation, 1)
+		t.lists[prefix][after] = make(map[int]*LogOperation, 1)
+	} else if _, present := t.lists[prefix][after]; !present {
+		t.lists[prefix][after] = make(map[int]*LogOperation, 1)
+	}
+	existingLimit := -1
+	for existingVerifyLimit := range t.lists[prefix][after] {
+		existingLimit = existingVerifyLimit
+	}
+	if verifyLimit > existingLimit {
+		delete(t.lists[prefix][after], existingLimit)
+		t.lists[prefix][after][verifyLimit] = &LogOperation{
+			OpType: verifyListOp,
+			Key:    listParams,
+			Value:  contentsHash,
+		}
+	}
 
 	return keys, nil
 }
@@ -532,24 +615,29 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 		return physical.ErrTransactionAlreadyCommitted
 	}
 
+	commitRuntimeStart := time.Now()
+
 	// The transaction is done; release the permit pool entry now that we're
 	// mostly done with the underlying transaction.
 	//
 	// Also unlock the read lock on the underlying fsm.
 	defer func() {
+		if t.writable {
+			t.b.fsm.fastTxnTracker.completeTransaction(t.index)
+		}
+
 		t.b.fsm.l.RUnlock()
 		t.b.txnPermitPool.Release()
 		t.haveFinishedTx = true
 
-		// Restore ourselves to the initial state.
+		// Clear our state.
 		t.updates = make(map[string]*raftTxnUpdateRecord)
-		t.log = &LogData{
-			Operations: []*LogOperation{
-				{
-					OpType: beginTxOp,
-				},
-			},
-		}
+		t.reads = make(map[string]*LogOperation)
+		t.lists = make(map[string]map[string]map[int]*LogOperation)
+
+		// Emit a metric for the duration of the transaction.
+		metrics.MeasureSince([]string{"raft-storage", "txn-commit"}, t.started)
+		metrics.MeasureSince([]string{"raft-storage", "txn-commit-runtime"}, commitRuntimeStart)
 	}()
 
 	// Always rollback the underlying transaction.
@@ -566,8 +654,55 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 		return nil
 	}
 
-	// Append the commit message to the log.
-	t.log.Operations = append(t.log.Operations, &LogOperation{
+	// Build the log from its component parts. This is:
+	//
+	// 1. The initial header containing the index.
+	// 2. Any read verifications
+	// 3. Any list verifications
+	// 4. All writes
+	// 5. The final sentinel
+	beginValue, err := createBeginTxOpValue(t.index)
+	if err != nil {
+		return err
+	}
+
+	log := &LogData{
+		// While list operations may contribute more (if the list was issued
+		// with the same prefix with different after and limit values), this
+		// is a good approximation as to the size of the operation log and
+		// saves us from continually allocating in future appends.
+		Operations: make([]*LogOperation, 0, 2+len(t.reads)+len(t.lists)+len(t.updates)),
+	}
+	log.Operations = append(log.Operations, &LogOperation{
+		OpType: beginTxOp,
+		Value:  beginValue,
+	})
+	for _, op := range t.reads {
+		log.Operations = append(log.Operations, op)
+	}
+	for _, afterLimitMap := range t.lists {
+		for _, limits := range afterLimitMap {
+			for _, op := range limits {
+				log.Operations = append(log.Operations, op)
+			}
+		}
+	}
+	for key, updateInfo := range t.updates {
+		switch updateInfo.OpType {
+		case deleteOp:
+			log.Operations = append(log.Operations, &LogOperation{
+				OpType: deleteOp,
+				Key:    key,
+			})
+		case putOp:
+			log.Operations = append(log.Operations, &LogOperation{
+				OpType: putOp,
+				Key:    key,
+				Value:  updateInfo.Contents.Value,
+			})
+		}
+	}
+	log.Operations = append(log.Operations, &LogOperation{
 		OpType: commitTxOp,
 	})
 
@@ -580,7 +715,7 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 	// the transaction application in Raft, applyLog will gather it for us
 	// and return it as a proper error.
 	t.b.l.RLock()
-	err := t.b.applyLog(ctx, t.log)
+	err = t.b.applyLog(ctx, log)
 	t.b.l.RUnlock()
 
 	return err
@@ -599,20 +734,21 @@ func (t *RaftTransaction) Rollback(ctx context.Context) error {
 	//
 	// Also unlock the read lock on the underlying fsm.
 	defer func() {
+		if t.writable {
+			t.b.fsm.fastTxnTracker.completeTransaction(t.index)
+		}
+
 		t.b.fsm.l.RUnlock()
 		t.b.txnPermitPool.Release()
-
 		t.haveFinishedTx = true
 
-		// Restore ourselves to the initial state.
+		// Clear our state.
 		t.updates = make(map[string]*raftTxnUpdateRecord)
-		t.log = &LogData{
-			Operations: []*LogOperation{
-				{
-					OpType: beginTxOp,
-				},
-			},
-		}
+		t.reads = make(map[string]*LogOperation)
+		t.lists = make(map[string]map[string]map[int]*LogOperation)
+
+		// Emit a metric for the duration of the transaction.
+		metrics.MeasureSince([]string{"raft-storage", "txn-rollback"}, t.started)
 	}()
 
 	// Rollback the underlying transaction.
@@ -621,4 +757,296 @@ func (t *RaftTransaction) Rollback(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// fsmTxnCommitIndexTracker allows fast application of transactions by
+// tracking certain state about outstanding and finished operations:
+// which entries transactions started at and all modifications which
+// were applied by subsequent indices.
+type fsmTxnCommitIndexTracker struct {
+	l sync.Mutex
+
+	// sourceIndexMap tracks the number of write transactions started at a given
+	// application log index, so we can keep track of writes between them.
+	sourceIndexMap map[uint64]int
+
+	// indexModifiedMap keeps track of which storage entries were modified at
+	// given points, letting us fast commit additional entries if the new
+	// transaction's verified reads and lists do not conflict with earlier
+	// writes. This is slightly non-trivial to track as we need to ensure that
+	// verified list operations correctly invalidate on writes to subkeys
+	// which are net-new to a list.
+	//
+	// For example, on an empty storage tree, writing to /foo/bar/fud should
+	// invalidate the list on /foo (as it adds /bar in). Luckily, we can use
+	// paginated lists to see if bar is contained in foo/'s tree already.
+	indexModifiedMap map[uint64]map[string]struct{}
+}
+
+func FsmTxnCommitIndexTracker() *fsmTxnCommitIndexTracker {
+	return &fsmTxnCommitIndexTracker{
+		sourceIndexMap:   make(map[uint64]int, physical.DefaultParallelTransactions),
+		indexModifiedMap: make(map[uint64]map[string]struct{}, physical.DefaultParallelTransactions),
+	}
+}
+
+func (t *fsmTxnCommitIndexTracker) trackTransaction(index uint64) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	t.sourceIndexMap[index] += 1
+}
+
+func (t *fsmTxnCommitIndexTracker) completeTransaction(index uint64) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	existing := t.sourceIndexMap[index]
+	if existing > 1 {
+		t.sourceIndexMap[index] -= 1
+	} else {
+		delete(t.sourceIndexMap, index)
+	}
+
+	if existing == 1 {
+		// See if we invalidated the smallest entry; if so, find the next
+		// smallest entry and invalidate all earlier indexModifiedMap
+		// entries as a result.
+		minIndex := index
+		for key := range t.sourceIndexMap {
+			if key < minIndex {
+				minIndex = key
+			}
+		}
+
+		if minIndex < index {
+			return
+		}
+
+		deletedIndices := make([]uint64, 0, physical.DefaultParallelTransactions/2)
+		for key := range t.indexModifiedMap {
+			if key <= minIndex {
+				deletedIndices = append(deletedIndices, key)
+			}
+		}
+
+		for _, index := range deletedIndices {
+			delete(t.indexModifiedMap, index)
+		}
+	}
+}
+
+// Logs a single, non-transactional write.
+func (t *fsmTxnCommitIndexTracker) logWrite(index uint64, key string) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	t.indexModifiedMap[index] = make(map[string]struct{}, 1)
+	t.indexModifiedMap[index][key] = struct{}{}
+}
+
+// Logs all writes occurring in a transaction.
+func (t *fsmTxnCommitIndexTracker) logTxnWrites(index uint64, writes map[string]struct{}) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	t.indexModifiedMap[index] = writes
+}
+
+// Checks whether a given entry was modified within the transaction window.
+func (t *fsmTxnCommitIndexTracker) hasModifiedEntry(minIndex uint64, maxIndex uint64, key string) (uint64, bool) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	for index, modifications := range t.indexModifiedMap {
+		if index <= minIndex {
+			continue
+		}
+
+		if index > maxIndex {
+			// Raft WALs should be strictly monotonic and thus this shouldn't
+			// trigger.
+			panic(fmt.Sprintf("saw later index in fast txn cache: %v > %v\n%#v", index, maxIndex, t))
+		}
+
+		if _, ok := modifications[key]; ok {
+			return index, true
+		}
+	}
+
+	return 0, false
+}
+
+// Checks whether any child of key was modified within the transaction window.
+func (t *fsmTxnCommitIndexTracker) hasModifiedListEntry(minIndex uint64, maxIndex uint64, key string) (uint64, bool) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	normKey := key
+	if len(key) > 0 && key[len(key)-1] != '/' {
+		normKey += "/"
+	}
+
+	for index, modifications := range t.indexModifiedMap {
+		if index <= minIndex {
+			continue
+		}
+
+		if index > maxIndex {
+			// Raft WALs should be strictly monotonic and thus this shouldn't
+			// trigger.
+			panic(fmt.Sprintf("saw later index in entry: %v > %v\n%#v", index, maxIndex, t))
+		}
+
+		for modified := range modifications {
+			if key == "" || key == "/" {
+				return index, true
+			}
+
+			if strings.HasPrefix(modified, normKey) {
+				return index, true
+			}
+		}
+	}
+
+	return 0, false
+}
+
+// fsmTxnCommitIndexApplicationState is created by fsmTxnCommitIndexTracker,
+// to handle the application of a single WAL entry to storage. This allows
+// us to check if the transaction satisfies fast application rules and batch
+// updates to the committer.
+type fsmTxnCommitIndexApplicationState struct {
+	// parent access
+	parent *fsmTxnCommitIndexTracker
+
+	// Last index applied prior to stating batch application.
+	latestAppliedIndex uint64
+
+	// Index of this transaction within the batch.
+	commandOffset int
+
+	// Actual index of this transaction within the full Raft log.
+	commandIndex uint64
+
+	// Latest applied index at the time of this transaction.
+	txnStartIndex uint64
+
+	// Whether we're in a transaction
+	inTx bool
+
+	// List of writes from this transaction.
+	modifiedMap map[string]struct{}
+}
+
+func (t *fsmTxnCommitIndexTracker) applyState(latestAppliedIndex uint64, commandOffset int, commandIndex uint64) *fsmTxnCommitIndexApplicationState {
+	return &fsmTxnCommitIndexApplicationState{
+		parent:             t,
+		latestAppliedIndex: latestAppliedIndex,
+		commandOffset:      commandOffset,
+		commandIndex:       commandIndex,
+		inTx:               false,
+		modifiedMap:        make(map[string]struct{}, 1),
+	}
+}
+
+func (s *fsmTxnCommitIndexApplicationState) setStartIndex(index uint64) {
+	s.txnStartIndex = index
+}
+
+func (s *fsmTxnCommitIndexApplicationState) setInTx() {
+	s.inTx = true
+}
+
+func (s *fsmTxnCommitIndexApplicationState) getInTx() bool {
+	return s.inTx
+}
+
+func (s *fsmTxnCommitIndexApplicationState) logWrite(key string) {
+	if s.inTx {
+		s.modifiedMap[key] = struct{}{}
+	} else {
+		s.parent.logWrite(s.commandIndex, key)
+	}
+}
+
+func (s *fsmTxnCommitIndexApplicationState) finishTxn() {
+	s.parent.logTxnWrites(s.commandIndex, s.modifiedMap)
+}
+
+// canFastWrite holds true if this is the first entry in a batch of logs and
+// the index when we started the transaction was the same as the index when
+// we applied the WAL: nothing has happened in storage.
+func (s *fsmTxnCommitIndexApplicationState) canFastWrite() bool {
+	return s.inTx && s.commandOffset == 0 && s.latestAppliedIndex == s.txnStartIndex
+}
+
+func (s *fsmTxnCommitIndexApplicationState) indexDelta() uint64 {
+	return s.latestAppliedIndex - s.txnStartIndex
+}
+
+// canFastWriteBypassRead holds true if no subsequent WALs (from when the
+// transaction was started) modified this entry. All WALs did not affect
+// this verified read operation.
+//
+// Note that having a counter example is not sufficient to conflict the
+// transaction: it only states that it might have been modified, but the
+// modification could be reverted in a later WAL or it could have been a
+// write of the same value.
+func (s *fsmTxnCommitIndexApplicationState) canFastWriteBypassRead(key string) bool {
+	// If we found a modifying entry, we can't fast-write: we need to
+	// validate that the corresponding write didn't modify our entry
+	// and cause the verification to fail.
+	_, found := s.parent.hasModifiedEntry(s.txnStartIndex, s.commandIndex, key)
+	return !found
+}
+
+// canFastWriteBypassList holds true if no subsequent WALs (from when the
+// transaction was started) modified any child entries which might have
+// affected this list operation.
+//
+// Note that having a counter example is not sufficient to conflict the
+// transaction: it only states that the list results might have been modified,
+// but the modification could be reverted in a later WAL or it could have been
+// a write of an existing storage entry already visible in the list.
+func (s *fsmTxnCommitIndexApplicationState) canFastWriteBypassList(key string) bool {
+	_, found := s.parent.hasModifiedListEntry(s.txnStartIndex, s.commandIndex, key)
+	return !found
+}
+
+func (s *fsmTxnCommitIndexApplicationState) doVerifyRead(b *bolt.Bucket, op *LogOperation) error {
+	if s.canFastWrite() || s.canFastWriteBypassRead(op.Key) {
+		metrics.IncrCounter([]string{"raft-storage", "txn_fast_apply_read_hit"}, 1)
+		return nil
+	}
+
+	metrics.AddSample([]string{"raft-storage", "txn_applied_index_delta"}, float32(s.indexDelta()))
+	metrics.IncrCounter([]string{"raft-storage", "txn_fast_apply_miss"}, 1)
+	val := b.Get([]byte(op.Key))
+	err := doVerifyEntry(op.Key, val, op.Value)
+
+	return err
+}
+
+func (s *fsmTxnCommitIndexApplicationState) doVerifyList(tx *bolt.Tx, b *bolt.Bucket, op *LogOperation) error {
+	params, err := parseListVerifyParams(op.Key)
+	if err != nil {
+		return err
+	}
+
+	if s.canFastWrite() || s.canFastWriteBypassList(params.Prefix) {
+		metrics.IncrCounter([]string{"raft-storage", "txn_fast_apply_list_hit"}, 1)
+		return nil
+	}
+
+	metrics.AddSample([]string{"raft-storage", "txn_applied_index_delta"}, float32(s.indexDelta()))
+	metrics.IncrCounter([]string{"raft-storage", "txn_fast_apply_miss"}, 1)
+
+	var keys []string
+	keys, err = listPageInner(context.Background(), tx, params.Prefix, params.After, params.Limit)
+	if err == nil {
+		err = doVerifyList(op.Key, keys, op.Value)
+	}
+
+	return err
 }


### PR DESCRIPTION
I was benchmarking Raft's performance today before and after transactions and noticed that our new implementation was nearly 2.5x slower. This ultimately came down to the `f.db.Update(...)` ordering change in #436. On slower disks, I think the first item is also worthwhile as we can skip several reads from disk. However, on SSDs, this change is much less noticeable.

I still want to do some more testing of this PR before it is ready for general review and also add a few new tests. 

---

```
commit 49092f1fda17ded29919528a8d626298db2b40e8 (HEAD -> track-raft-last-state, origin/track-raft-last-state)
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Mon Oct 14 19:19:45 2024 -0400

    Remove support for legacy getOps
    
    getOps was an operation used by the legacy one-shot transaction; we
    leave it in the ordering of operations (as existing log messages may
    use it and we need to continue to be able to parse them), but we don't
    need to support newly sending it any more.
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

commit d1e1edc0addfeaa3e02d346e1a94133a1220bc9d
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Sun Oct 13 23:31:07 2024 -0400

    Improve Raft transaction performance
    
    This makes two major improvements to Raft transaction performance:
    
    1. When committing a transaction, send along the state index at the
       start of the transaction. This lets us track changes since the
       transaction was started and quickly tell if we have no conflicts
       (on the basis of no conflicting writes) or if we'll have to fall
       back to checking verifying read operations anyways.
    
       This was inspired by a conversation with Sami Hiltunen at GitLab,
       about Gitaly's own implementation of transactions on top of the
       Dragonboat Raft library.
    
    2. Restore original ordering of f.db.Update(...) versus batch log
       application. The new ordering had two problems (big thanks to Jan
       Martens for pointing out the first):
    
       1. It is slower, as each bbolt transaction incurs additional storage
          writes. This results in us having to spend more time in syscalls
          as even with transactions, Raft will frequently batch operations
          together in benchmarking.
    
       2. Technically, Raft expects the entire batch to succeed or fail as
          a unit; thus, we don't want to commit partial state from a
          previous log entry (that succeeded) when a later log entry fails.
    
          This correctness bug never manifested in practice as it would be
          fairly rare for a write operation to fail.
    
       This restores the performance in K/V benchmarks.
    
    See also: https://handbook.gitlab.com/handbook/engineering/architecture/design-documents/gitaly_transaction_management/
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>
```