### PR TITLE
PKI - Allow revocation of expired certificates

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -6268,6 +6268,7 @@ func TestPKI_EmptyCRLConfigUpgraded(t *testing.T) {
 	require.Equal(t, resp.Data["auto_rebuild_grace_period"], defaultCrlConfig.AutoRebuildGracePeriod)
 	require.Equal(t, resp.Data["enable_delta"], defaultCrlConfig.EnableDelta)
 	require.Equal(t, resp.Data["delta_rebuild_interval"], defaultCrlConfig.DeltaRebuildInterval)
+	require.Equal(t, resp.Data["allow_expired_cert_revocation"], defaultCrlConfig.AllowExpiredCertRevocation)
 }
 
 func TestPKI_ListRevokedCerts(t *testing.T) {

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1502,3 +1502,119 @@ func TestCRLIssuerRemoval(t *testing.T) {
 	}
 	require.Equal(t, len(afterCRLList), len(crlList))
 }
+
+func TestRevokeExpiredCert(t *testing.T) {
+	t.Parallel()
+
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": Factory,
+		},
+		EnableRaw: true,
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+	client := cluster.Cores[0].Client
+
+	err := client.Sys().Mount("pki", &api.MountInput{
+		Type: "pki",
+		Config: api.MountConfigInput{
+			DefaultLeaseTTL: "16h",
+			MaxLeaseTTL:     "60h",
+		},
+	})
+	require.NoError(t, err)
+
+	// Generate a root certificate for the PKI.
+	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+		"ttl":         "40h",
+		"common_name": "Root X1",
+		"key_type":    "ec",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data)
+	require.NotEmpty(t, resp.Data["issuer_id"])
+
+	// Create a role in the PKI backend for issuing certificates.
+	_, err = client.Logical().Write("pki/roles/local-testing", map[string]interface{}{
+		"allow_any_name":    true,
+		"enforce_hostnames": false,
+		"key_type":          "ec",
+	})
+	require.NoError(t, err)
+
+	// Ensure that the CRL config returns default values before being set.
+	resp, err = client.Logical().Read("pki/config/crl")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	// Check that the default CRL configuration values are returned correctly.
+	require.Equal(t, resp.Data["expiry"], defaultCrlConfig.Expiry)
+	require.Equal(t, resp.Data["disable"], defaultCrlConfig.Disable)
+	require.Equal(t, resp.Data["ocsp_disable"], defaultCrlConfig.OcspDisable)
+	require.Equal(t, resp.Data["auto_rebuild"], defaultCrlConfig.AutoRebuild)
+	require.Equal(t, resp.Data["auto_rebuild_grace_period"], defaultCrlConfig.AutoRebuildGracePeriod)
+	require.Equal(t, resp.Data["enable_delta"], defaultCrlConfig.EnableDelta)
+	require.Equal(t, resp.Data["delta_rebuild_interval"], defaultCrlConfig.DeltaRebuildInterval)
+	require.Equal(t, resp.Data["allow_expired_cert_revocation"], defaultCrlConfig.AllowExpiredCertRevocation)
+
+	// Issue a short-lived certificate and revoke it after it expires whilst allow_expired_cert_revocation is false.
+	resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+		"ttl":         "1s",
+		"common_name": "example.com",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.NotEmpty(t, resp.Data["serial_number"])
+	leafSerial := resp.Data["serial_number"].(string)
+
+	// Wait for 1 second to ensure the certificate expires before revocation.
+	time.Sleep(1 * time.Second)
+
+	// Revoke the issued certificate.
+	resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		"serial_number": leafSerial,
+	})
+	require.NoError(t, err)
+	require.Contains(t, resp.Warnings[0], fmt.Sprintf("certificate with serial %s already expired; refusing to add to CRL. Enable 'AllowExpiredCertRevocation' to allow revoking expired certificates.", leafSerial))
+
+	// Check that CRL does NOT contain any certificates
+	defaultCrlPath := "/v1/pki/crl"
+	crl := getParsedCrlAtPath(t, client, defaultCrlPath).TBSCertList
+	require.True(t, len(crl.RevokedCertificates) == 0)
+
+	// Enable expired certification revocation
+	_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
+		"allow_expired_cert_revocation": true,
+	})
+	require.NoError(t, err)
+
+	// Issue a short-lived certificate and revoke it after it expires whilst allow_expired_cert_revocation is true.
+	resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+		"ttl":         "1s",
+		"common_name": "example.com",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.NotEmpty(t, resp.Data["serial_number"])
+	newLeafSerial := resp.Data["serial_number"].(string)
+
+	// Wait for 2 seconds to ensure the certificate expires before revocation.
+	time.Sleep(2 * time.Second)
+
+	// Revoke the expired certificate.
+	resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		"serial_number": newLeafSerial,
+	})
+	require.NoError(t, err)
+
+	// Ensure that the certificate is in the CRL
+	crl = getParsedCrlAtPath(t, client, defaultCrlPath).TBSCertList
+	requireSerialNumberInCRL(t, crl, newLeafSerial)
+}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -584,9 +584,9 @@ func revokeCert(sc *storageContext, config *crlConfig, cert *x509.Certificate) (
 
 	// Add a little wiggle room because leases are stored with a second
 	// granularity
-	if cert.NotAfter.Before(time.Now().Add(2 * time.Second)) {
+	if cert.NotAfter.Before(time.Now().Add(2*time.Second)) && !config.AllowExpiredCertRevocation {
 		response := &logical.Response{}
-		response.AddWarning(fmt.Sprintf("certificate with serial %s already expired; refusing to add to CRL", colonSerial))
+		response.AddWarning(fmt.Sprintf("certificate with serial %s already expired; refusing to add to CRL. Enable 'AllowExpiredCertRevocation' to allow revoking expired certificates.", colonSerial))
 		return response, nil
 	}
 

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -14,6 +14,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 
@@ -86,6 +87,10 @@ hyphen-separated octal`,
 				Description: `Certificate to revoke in PEM format; must be
 signed by an issuer in this mount.`,
 			},
+			"allow_expired_cert_revocation": {
+				Type:        framework.TypeBool,
+				Description: `Optional flag to allow revocation of expired certificates.`,
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -150,6 +155,11 @@ signed by an issuer in this mount.`,
 				Type: framework.TypeString,
 				Description: `Key to use to verify revocation permission; must
 be in PEM format.`,
+			},
+			"allow_expired_cert_revocation": {
+				Type:        framework.TypeBool,
+				Description: `Optional flag to allow revocation of expired certificates.`,
+				Default:     false,
 			},
 		},
 
@@ -465,6 +475,7 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 	rawSerial, haveSerial := data.GetOk("serial_number")
 	rawCertificate, haveCert := data.GetOk("certificate")
 	sc := b.makeStorageContext(ctx, req.Storage)
+	allowExpiredRevocation, _ := data.GetOk("allow_expired_cert_revocation")
 
 	if !haveSerial && !haveCert {
 		return logical.ErrorResponse("The serial number or certificate to revoke must be provided."), nil
@@ -527,6 +538,11 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 
 	if cert == nil {
 		return logical.ErrorResponse(fmt.Sprintf("certificate with serial %s not found.", serial)), nil
+	}
+
+	// Check if expired certificates can be revoked based on the flag
+	if cert.NotAfter.Before(time.Now()) && allowExpiredRevocation != nil && !allowExpiredRevocation.(bool) {
+		return logical.ErrorResponse("Cannot revoke expired certificate without the allow_expired_cert_revocation flag."), nil
 	}
 
 	// Before we write the certificate, we've gotta verify the request in

--- a/changelog/638.txt
+++ b/changelog/638.txt
@@ -1,4 +1,3 @@
 ```release-note:improvement
 secret/pki: Support revoking expired certificates with the `allow_expired_cert_revocation` CRL configuration.
-secret/pki: Add `revoked_safety_buffer` to control retention on revoked certificates separately from expired certificates. 
 ```

--- a/changelog/638.txt
+++ b/changelog/638.txt
@@ -1,0 +1,7 @@
+```release-note:feature
+**PKI Secret Engine**: Added support for revoking expired certificates by introducing the 
+`allow_expired_cert_revocation` flag. 
+**PKI Secret Engine**: Added a new field `revoked_safety_buffer` to the CRL configuration, 
+allowing differentiation between retention times for revoked certificates and 
+expired-but-not-revoked certificates.
+```

--- a/changelog/638.txt
+++ b/changelog/638.txt
@@ -1,7 +1,4 @@
 ```release-note:improvement
-**PKI Secret Engine**: Added support for revoking expired certificates by introducing the 
-`allow_expired_cert_revocation` flag. 
-**PKI Secret Engine**: Added a new field `revoked_safety_buffer` to the CRL configuration, 
-allowing differentiation between retention times for revoked certificates and 
-expired-but-not-revoked certificates.
+secret/pki: Support revoking expired certificates iwth the `allow_expired_cert_revocation` CRL configuration.
+secret/pki: Add `revoked_safety_buffer` to control retention on revoked certificates separately from expired certificates. 
 ```

--- a/changelog/638.txt
+++ b/changelog/638.txt
@@ -1,4 +1,4 @@
-```release-note:feature
+```release-note:improvement
 **PKI Secret Engine**: Added support for revoking expired certificates by introducing the 
 `allow_expired_cert_revocation` flag. 
 **PKI Secret Engine**: Added a new field `revoked_safety_buffer` to the CRL configuration, 

--- a/changelog/638.txt
+++ b/changelog/638.txt
@@ -1,4 +1,4 @@
 ```release-note:improvement
-secret/pki: Support revoking expired certificates iwth the `allow_expired_cert_revocation` CRL configuration.
+secret/pki: Support revoking expired certificates with the `allow_expired_cert_revocation` CRL configuration.
 secret/pki: Add `revoked_safety_buffer` to control retention on revoked certificates separately from expired certificates. 
 ```


### PR DESCRIPTION
This PR introduces the ability to revoke expired certificates by adding an `allow_expired_cert_revocation` field to the CRL configuration. This field can be globally enabled by the operator in the `config/crl` endpoint, allowing expired certificates to be revoked across the system. The feature is a global setting to ensure deliberate use and avoid unnecessary overhead or arbitrary certificate revocations.

Resolves #459 Vault #27609

## Target Release

1.14.7

___
**TO DO LIST**

- [X] Add `allow_expired_cert_revocation` field and check there's no issues parsing.
- [X] Update revocation behavior.
- [X] Create tests for revoking expired-but-not-revoked certificates.