### PR TITLE
Don't override conf files in OpenBao binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           sed "s/REPLACE_WITH_RELEASE_GOOS/${{ matrix.release_os }}/g" .goreleaser-template.yaml > .goreleaser.yaml
+          sed -i "s/^#OTHERARCH#//g" .goreleaser.yaml
           [ "${{ matrix.release_os }}" == "linux" ] && sed -i "s/^#LINUXONLY#//g" .goreleaser.yaml || true
 
       - name: "GoReleaser: Release"

--- a/.goreleaser-template.yaml
+++ b/.goreleaser-template.yaml
@@ -33,11 +33,11 @@ builds:
       - REPLACE_WITH_RELEASE_GOOS
     goarch:
       - amd64
-      - arm
-      - arm64
-      - ppc64le
-      - riscv64
-      - s390x
+#OTHERARCH#      - arm
+#OTHERARCH#      - arm64
+#OTHERARCH#      - ppc64le
+#OTHERARCH#      - riscv64
+#OTHERARCH#      - s390x
     goarm:
       - "6"
     ignore:
@@ -190,14 +190,17 @@ report_sizes: true
 #LINUXONLY#          mode: 0644
 #LINUXONLY#      - src: ./.release/linux/package/etc/openbao/openbao.env
 #LINUXONLY#        dst: /etc/openbao/openbao.env
+#LINUXONLY#        type: config|noreplace
 #LINUXONLY#        file_info:
 #LINUXONLY#          mode: 0644
 #LINUXONLY#      - src: ./.release/linux/package/etc/openbao/openbao.hcl
 #LINUXONLY#        dst: /etc/openbao/openbao.hcl
+#LINUXONLY#        type: config|noreplace
 #LINUXONLY#        file_info:
 #LINUXONLY#          mode: 0644
 #LINUXONLY#      - src: ./.release/linux/package/usr/lib/systemd/system/openbao.service
 #LINUXONLY#        dst: /usr/lib/systemd/system/openbao.service
+#LINUXONLY#        type: config|noreplace
 #LINUXONLY#        file_info:
 #LINUXONLY#          mode: 0644
 #LINUXONLY#    scripts:

--- a/changelog/639.txt
+++ b/changelog/639.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+rpm: Fix packaging to properly annotate configs entries for noreplace
+```


### PR DESCRIPTION
Fixing https://github.com/openbao/openbao/issues/599

Fix : 
1. Make the conf files as `type: config` in .goreleaser-template.yaml so the files are not overwritten during rpm upgrade.
2. Add a new target in makefile to build rpm locally
