### PR TITLE
Revoked safety documentation, minor fixes

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -791,10 +791,16 @@ func (b *backend) startTidyOperation(req *logical.Request, config *tidyConfig) {
 		logger := b.Logger().Named("tidy")
 
 		doTidy := func() error {
+			var revokedDeleted uint
+			var rebuildCRL bool
+
 			if config.CertStore {
-				if err := b.doTidyCertStore(ctx, req, logger, config); err != nil {
+				deleted, err := b.doTidyCertStore(ctx, req, logger, config)
+				if err != nil {
 					return err
 				}
+				rebuildCRL = rebuildCRL || (deleted > 0)
+				revokedDeleted = deleted
 			}
 
 			// Check for cancel before continuing.
@@ -803,7 +809,20 @@ func (b *backend) startTidyOperation(req *logical.Request, config *tidyConfig) {
 			}
 
 			if config.RevokedCerts || config.IssuerAssocs {
-				if err := b.doTidyRevocationStore(ctx, req, logger, config); err != nil {
+				rebuild, err := b.doTidyRevocationStore(ctx, req, logger, config, revokedDeleted)
+				if err != nil {
+					return err
+				}
+				rebuildCRL = rebuildCRL || rebuild
+			}
+
+			// Check for cancel before continuing.
+			if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
+				return tidyCancelledError
+			}
+
+			if rebuildCRL {
+				if err := b.doTidyRebuildCRL(ctx, req, logger, config); err != nil {
 					return err
 				}
 			}
@@ -860,21 +879,28 @@ func (b *backend) startTidyOperation(req *logical.Request, config *tidyConfig) {
 	}()
 }
 
-func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig) error {
+func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig) (uint, error) {
 	serials, err := req.Storage.List(ctx, "certs/")
 	if err != nil {
-		return fmt.Errorf("error fetching list of certs: %w", err)
+		return 0, fmt.Errorf("error fetching list of certs: %w", err)
+	}
+
+	revokedSafetyBuffer := config.SafetyBuffer
+	if config.RevokedSafetyBuffer != nil {
+		revokedSafetyBuffer = *config.RevokedSafetyBuffer
 	}
 
 	serialCount := len(serials)
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_total_entries"}, float32(serialCount))
+
+	var revokedDeleted uint
 	for i, serial := range serials {
 		b.tidyStatusMessage(fmt.Sprintf("Tidying certificate store: checking entry %d of %d", i, serialCount))
 		metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_current_entry"}, float32(i))
 
 		// Check for cancel before continuing.
 		if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
-			return tidyCancelledError
+			return 0, tidyCancelledError
 		}
 
 		// Check for pause duration to reduce resource consumption.
@@ -884,13 +910,13 @@ func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, log
 
 		certEntry, err := req.Storage.Get(ctx, "certs/"+serial)
 		if err != nil {
-			return fmt.Errorf("error fetching certificate %q: %w", serial, err)
+			return 0, fmt.Errorf("error fetching certificate %q: %w", serial, err)
 		}
 
 		if certEntry == nil {
 			logger.Warn("certificate entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
 			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return fmt.Errorf("error deleting nil entry with serial %s: %w", serial, err)
+				return 0, fmt.Errorf("error deleting nil entry with serial %s: %w", serial, err)
 			}
 			b.tidyStatusIncCertStoreCount()
 			continue
@@ -899,7 +925,7 @@ func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, log
 		if certEntry.Value == nil || len(certEntry.Value) == 0 {
 			logger.Warn("certificate entry has no value; tidying up since it is no longer useful for any server operations", "serial", serial)
 			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return fmt.Errorf("error deleting entry with nil value with serial %s: %w", serial, err)
+				return 0, fmt.Errorf("error deleting entry with nil value with serial %s: %w", serial, err)
 			}
 			b.tidyStatusIncCertStoreCount()
 			continue
@@ -907,12 +933,32 @@ func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, log
 
 		cert, err := x509.ParseCertificate(certEntry.Value)
 		if err != nil {
-			return fmt.Errorf("unable to parse stored certificate with serial %q: %w", serial, err)
+			return 0, fmt.Errorf("unable to parse stored certificate with serial %q: %w", serial, err)
 		}
 
-		if time.Since(cert.NotAfter) > config.SafetyBuffer {
+		// Check if a revocation entry exists for this cert; if so, use the
+		// appropriate entry.
+		revokedResp, err := req.Storage.Get(ctx, "revoked/"+serial)
+		if err != nil {
+			return 0, fmt.Errorf("error fetching revocation status of serial %q from storage: %w", serial, err)
+		}
+
+		if revokedResp == nil && time.Since(cert.NotAfter) > config.SafetyBuffer {
 			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return fmt.Errorf("error deleting serial %q from storage: %w", serial, err)
+				return 0, fmt.Errorf("error deleting serial %q from storage: %w", serial, err)
+			}
+			b.tidyStatusIncCertStoreCount()
+		} else if revokedResp != nil && time.Since(cert.NotAfter) > revokedSafetyBuffer {
+			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+				return 0, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
+			}
+			// Only tidy revoked certs if requested.
+			if config.RevokedCerts {
+				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+					return 0, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
+				}
+				revokedDeleted += 1
+				b.tidyStatusIncRevokedCertCount()
 			}
 			b.tidyStatusIncCertStoreCount()
 		}
@@ -922,10 +968,10 @@ func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, log
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_total_entries_remaining"}, float32(uint(serialCount)-b.tidyStatus.certStoreDeletedCount))
 	b.tidyStatusLock.RUnlock()
 
-	return nil
+	return revokedDeleted, nil
 }
 
-func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig) error {
+func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig, revokedDeleted uint) (bool, error) {
 	b.revokeStorageLock.Lock()
 	defer b.revokeStorageLock.Unlock()
 
@@ -933,20 +979,25 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 	sc := b.makeStorageContext(ctx, req.Storage)
 	issuerIDCertMap, err := fetchIssuerMapForRevocationChecking(sc)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	rebuildCRL := false
 
 	revokedSerials, err := req.Storage.List(ctx, "revoked/")
 	if err != nil {
-		return fmt.Errorf("error fetching list of revoked certs: %w", err)
+		return false, fmt.Errorf("error fetching list of revoked certs: %w", err)
 	}
 
-	revokedSerialsCount := len(revokedSerials)
+	revokedSerialsCount := len(revokedSerials) + int(revokedDeleted)
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_total_entries"}, float32(revokedSerialsCount))
 
 	fixedIssuers := 0
+
+	revokedSafetyBuffer := config.SafetyBuffer
+	if config.RevokedSafetyBuffer != nil {
+		revokedSafetyBuffer = *config.RevokedSafetyBuffer
+	}
 
 	var revInfo revocationInfo
 	for i, serial := range revokedSerials {
@@ -955,7 +1006,7 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 
 		// Check for cancel before continuing.
 		if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
-			return tidyCancelledError
+			return false, tidyCancelledError
 		}
 
 		// Check for pause duration to reduce resource consumption.
@@ -967,13 +1018,13 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 
 		revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)
 		if err != nil {
-			return fmt.Errorf("unable to fetch revoked cert with serial %q: %w", serial, err)
+			return false, fmt.Errorf("unable to fetch revoked cert with serial %q: %w", serial, err)
 		}
 
 		if revokedEntry == nil {
 			logger.Warn("revoked entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
 			if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-				return fmt.Errorf("error deleting nil revoked entry with serial %s: %w", serial, err)
+				return false, fmt.Errorf("error deleting nil revoked entry with serial %s: %w", serial, err)
 			}
 			b.tidyStatusIncRevokedCertCount()
 			continue
@@ -982,7 +1033,7 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 		if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
 			logger.Warn("revoked entry has nil value; tidying up since it is no longer useful for any server operations", "serial", serial)
 			if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-				return fmt.Errorf("error deleting revoked entry with nil value with serial %s: %w", serial, err)
+				return false, fmt.Errorf("error deleting revoked entry with nil value with serial %s: %w", serial, err)
 			}
 			b.tidyStatusIncRevokedCertCount()
 			continue
@@ -990,12 +1041,12 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 
 		err = revokedEntry.DecodeJSON(&revInfo)
 		if err != nil {
-			return fmt.Errorf("error decoding revocation entry for serial %q: %w", serial, err)
+			return false, fmt.Errorf("error decoding revocation entry for serial %q: %w", serial, err)
 		}
 
 		revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
 		if err != nil {
-			return fmt.Errorf("unable to parse stored revoked certificate with serial %q: %w", serial, err)
+			return false, fmt.Errorf("unable to parse stored revoked certificate with serial %q: %w", serial, err)
 		}
 
 		// Tidy operations over revoked certs should execute prior to
@@ -1019,17 +1070,12 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 			// information on revoked/ to build the CRL and the
 			// information on certs/ for lookup.
 
-			revokedSafetyBuffer := config.SafetyBuffer
-			if config.RevokedSafetyBuffer != nil {
-				revokedSafetyBuffer = *config.RevokedSafetyBuffer
-			}
-
 			if time.Since(revokedCert.NotAfter) > revokedSafetyBuffer {
 				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-					return fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
+					return false, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
 				}
 				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-					return fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
+					return false, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
 				}
 				rebuildCRL = true
 				storeCert = false
@@ -1042,12 +1088,12 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 		if storeCert {
 			revokedEntry, err = logical.StorageEntryJSON("revoked/"+serial, revInfo)
 			if err != nil {
-				return fmt.Errorf("error building entry to persist changes to serial %v from revoked list: %w", serial, err)
+				return false, fmt.Errorf("error building entry to persist changes to serial %v from revoked list: %w", serial, err)
 			}
 
 			err = req.Storage.Put(ctx, revokedEntry)
 			if err != nil {
-				return fmt.Errorf("error persisting changes to serial %v from revoked list: %w", serial, err)
+				return false, fmt.Errorf("error persisting changes to serial %v from revoked list: %w", serial, err)
 			}
 		}
 	}
@@ -1058,28 +1104,31 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_entries_fixed_issuers"}, float32(fixedIssuers))
 	b.tidyStatusLock.RUnlock()
 
-	if rebuildCRL {
-		// Expired certificates isn't generally an important
-		// reason to trigger a CRL rebuild for. Check if
-		// automatic CRL rebuilds have been enabled and defer
-		// the rebuild if so.
-		config, err := sc.getRevocationConfig()
+	return rebuildCRL, nil
+}
+
+func (b *backend) doTidyRebuildCRL(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig) error {
+	// Expired certificates isn't generally an important
+	// reason to trigger a CRL rebuild for. Check if
+	// automatic CRL rebuilds have been enabled and defer
+	// the rebuild if so.
+	sc := b.makeStorageContext(ctx, req.Storage)
+	crlConfig, err := sc.getRevocationConfig()
+	if err != nil {
+		return err
+	}
+
+	if !crlConfig.AutoRebuild {
+		warnings, err := b.crlBuilder.rebuild(sc, false)
 		if err != nil {
 			return err
 		}
-
-		if !config.AutoRebuild {
-			warnings, err := b.crlBuilder.rebuild(sc, false)
-			if err != nil {
-				return err
+		if len(warnings) > 0 {
+			msg := "During rebuild of CRL for tidy, got the following warnings:"
+			for index, warning := range warnings {
+				msg = fmt.Sprintf("%v\n %d. %v", msg, index+1, warning)
 			}
-			if len(warnings) > 0 {
-				msg := "During rebuild of CRL for tidy, got the following warnings:"
-				for index, warning := range warnings {
-					msg = fmt.Sprintf("%v\n %d. %v", msg, index+1, warning)
-				}
-				b.Logger().Warn(msg)
-			}
+			b.Logger().Warn(msg)
 		}
 	}
 

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -1405,7 +1405,7 @@ func TestSafetyBufferVsRevokedSafetyBuffer(t *testing.T) {
 		"tidy_cert_store":       true,
 		"tidy_revoked_certs":    true,
 		"safety_buffer":         "2s",
-		"revoked_safety_buffer": "10s",
+		"revoked_safety_buffer": "15s",
 	})
 	require.NoError(t, err)
 
@@ -1425,11 +1425,23 @@ func TestSafetyBufferVsRevokedSafetyBuffer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	revokedSerial := resp.Data["serial_number"].(string)
+	revokedCert := parseCert(t, resp.Data["certificate"].(string))
 
 	_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
 		"serial_number": revokedSerial,
 	})
 	require.NoError(t, err)
+
+	// Issue a certificate that expires after the revoked
+	// certificate. This expiration needs to be longer than
+	// revoked_safety_buffer+revoked.ttl.
+	resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+		"common_name": "example.com",
+		"ttl":         "35s",
+	})
+	require.NoError(t, err)
+	lastLeafSerial := resp.Data["serial_number"].(string)
+	lastLeafCert := parseCert(t, resp.Data["certificate"].(string))
 
 	// Wait for the first certificate to expire and the safety buffer to elapse
 	time.Sleep(time.Until(leafCert.NotAfter) + 3*time.Second)
@@ -1443,16 +1455,35 @@ func TestSafetyBufferVsRevokedSafetyBuffer(t *testing.T) {
 	require.Nil(t, resp)
 
 	// Ensure the revoked certificate is not tidied before revoked_safety_buffer has passed
-	time.Sleep(2 * time.Second) // Check midway
+	time.Sleep(time.Until(revokedCert.NotAfter) + 3*time.Second)
+	waitForAutoTidyToFinish(t, client)
+
+	// The revoked certificate should still be present: we've not passed
+	// revoked_safety_buffer, only safety_buffer.
 	resp, err = client.Logical().Read("pki/cert/" + revokedSerial)
 	require.NoError(t, err)
+	require.NotNil(t, resp)
 	require.NotNil(t, resp.Data["certificate"], "Revoked certificate should not be tidied before revoked_safety_buffer")
 
 	// Wait for the revoked_safety_buffer to pass
-	time.Sleep(10 * time.Second)
+	time.Sleep(time.Until(revokedCert.NotAfter) + 16*time.Second)
+	waitForAutoTidyToFinish(t, client)
 
 	// Confirm the revoked certificate has been tidied
 	resp, err = client.Logical().Read("pki/cert/" + revokedSerial)
+	require.Nil(t, err)
+	require.Nil(t, resp)
+
+	// Confirm the final certificate has not been tidied.
+	resp, err = client.Logical().Read("pki/cert/" + lastLeafSerial)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Ensure it is cleaned up afterwards.
+	time.Sleep(time.Until(lastLeafCert.NotAfter) + 3*time.Second)
+	waitForAutoTidyToFinish(t, client)
+
+	resp, err = client.Logical().Read("pki/cert/" + lastLeafSerial)
 	require.Nil(t, err)
 	require.Nil(t, resp)
 }

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -4518,6 +4518,16 @@ past the `issuer_safety_buffer` specified.
   still be considered valid on other hosts. For a certificate to be expunged,
   the time must be after the expiration time of the certificate (according to
   the local clock) plus the duration of `safety_buffer`. Defaults to `72h`.
+  This value applies to both expired and revoked certificates unless
+  `revoked_safety_buffer` has been set, in which case `safety_buffer` only
+  applies to expired, non-revoked certificates.
+
+- `revoked_safety_buffer` `(string: "")` - Specifies a duration using
+  [duration format strings](/docs/concepts/duration-format) used as a
+  safety buffer for revoked, expired certificates to ensure they are not
+  expunged prematurely. This value takes precedence over `safety_buffer`
+  when set; otherwise, `safety_buffer` applies to revoked, expired
+  certificates as well when unset.
 
 - `issuer_safety_buffer` `(string: "")` - Specifies a duration that issuers
   should be kept for, past their `NotAfter` validity period. Defaults to
@@ -4703,6 +4713,7 @@ operation, or the most recent if none are currently running.
 The result includes the following fields:
 
 * `safety_buffer`: the value of this parameter when initiating the tidy operation
+* `revoked_safety_buffer`: the calculated value of this parameter when initiating the tidy operation
 * `tidy_cert_store`: the value of this parameter when initiating the tidy operation
 * `tidy_revoked_certs`: the value of this parameter when initiating the tidy operation
 * `state`: one of *Inactive*, *Running*, *Finished*, *Error*, *Cancelling*, or *Cancelled*


### PR DESCRIPTION
- Adds web docs for `revoked_safety_buffer`.
- Refactor of auto-tidy to better handle revoked vs non-revoked certificates.
- Fix test case to better handle differences in timing.

This is a follow-up to #653. :-) 

/cc: @fatima2003 