### PR TITLE
Add pagination to tidy 

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4140,7 +4140,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 
 	// Sign the intermediate CSR using /pki
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
-		"permitted_dns_domains": ".myvault.com",
+		"permitted_dns_domains": ".example.com",
 		"csr":                   intermediateCSR,
 		"ttl":                   "10s",
 	})
@@ -4188,17 +4188,11 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Issue a tidy on /pki
-	_, err = client.Logical().Write("pki/tidy", map[string]interface{}{
+	waitForManualTidy(t, client, map[string]interface{}{
 		"tidy_cert_store":    true,
 		"tidy_revoked_certs": true,
 		"safety_buffer":      "1s",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Sleep a bit to make sure we're past the safety buffer
-	time.Sleep(2 * time.Second)
 
 	// Get CRL and ensure the tidied cert is still in the list after the tidy
 	// operation since it's not past the NotAfter (ttl) value yet.
@@ -4214,21 +4208,27 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 		t.Fatalf("expected: %v, got: %v", intermediateCertSerial, sn)
 	}
 
+	// Check the revoked-count metrics
+	mostRecentInterval2 := inmemSink.Data()[len(inmemSink.Data())-1]
+	expectedGauges := map[string]float32{
+		"secrets.pki.tidy.revoked_cert_total_entries":           1,
+		"secrets.pki.tidy.revoked_cert_total_entries_remaining": 1,
+	}
+	for gauge, value := range expectedGauges {
+		if metric, ok := mostRecentInterval2.Gauges[gauge]; !ok || metric.Value != value {
+			t.Fatalf("Expected gauge %s to have value %f, but got %f", gauge, value, metric.Value)
+		}
+	}
+
 	// Wait for cert to expire
 	time.Sleep(10 * time.Second)
 
 	// Issue a tidy on /pki
-	_, err = client.Logical().Write("pki/tidy", map[string]interface{}{
+	waitForManualTidy(t, client, map[string]interface{}{
 		"tidy_cert_store":    true,
 		"tidy_revoked_certs": true,
 		"safety_buffer":      "1s",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Sleep a bit to make sure we're past the safety buffer
-	time.Sleep(2 * time.Second)
 
 	// Issue a tidy-status on /pki
 	{
@@ -4247,7 +4247,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"tidy_expired_issuers":                  false,
 			"tidy_move_legacy_ca_bundle":            false,
 			"pause_duration":                        "0s",
-			"page_size":                             json.Number("50"),
+			"page_size":                             json.Number("1000"),
 			"state":                                 "Finished",
 			"error":                                 nil,
 			"time_started":                          nil,
@@ -4344,6 +4344,205 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 	revokedCerts = crl.TBSCertList.RevokedCertificates
 	if len(revokedCerts) != 0 {
 		t.Fatal("expected CRL to be empty")
+	}
+}
+
+func TestBackend_RevokePlusTidy_MultipleCerts(t *testing.T) {
+	// Set up metrics and Vault cluster
+	inmemSink := metrics.NewInmemSink(
+		1000000*time.Hour,
+		2000000*time.Hour)
+
+	metricsConf := metrics.DefaultConfig("")
+	metricsConf.EnableHostname = false
+	metricsConf.EnableHostnameLabel = false
+	metricsConf.EnableServiceLabel = false
+	metricsConf.EnableTypePrefix = false
+
+	_, err := metrics.NewGlobal(metricsConf, inmemSink)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable PKI secret engine
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": Factory,
+		},
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+	cores := cluster.Cores
+	core := cores[0]
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	core.StopAutomaticRollbacks()
+
+	// Mount /pki
+	err = client.Sys().Mount("pki", &api.MountInput{
+		Type: "pki",
+		Config: api.MountConfigInput{
+			DefaultLeaseTTL: "16h",
+			MaxLeaseTTL:     "32h",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up Metric Configuration, then restart to enable it
+	_, err = client.Logical().Write("pki/config/auto-tidy", map[string]interface{}{
+		"maintain_stored_certificate_counts":       true,
+		"publish_stored_certificate_count_metrics": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Logical().Write("/sys/plugins/reload/backend", map[string]interface{}{
+		"mounts": "pki/",
+	})
+
+	// Set the cluster's certificate as the root CA in /pki
+	pemBundleRootCA := string(cluster.CACertPEM) + string(cluster.CAKeyPEM)
+	_, err = client.Logical().Write("pki/config/ca", map[string]interface{}{
+		"pem_bundle": pemBundleRootCA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the "test" role
+	_, err = client.Logical().Write("pki/roles/test", map[string]interface{}{
+		"allowed_domains":  "example.com",
+		"allow_subdomains": true,
+		"max_ttl":          "72h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Issue 3 short-lived certificates
+	lastTTL := time.Now()
+	for i := 1; i <= 3; i++ {
+		resp, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+			"common_name": "short-lived.example.com",
+			"ttl":         "1s",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		leafCert := parseCert(t, resp.Data["certificate"].(string))
+		lastTTL = leafCert.NotAfter
+	}
+
+	// Issue 2 long-lived certificates
+	for i := 1; i <= 2; i++ {
+		_, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+			"common_name": "long-lived.example.com",
+			"ttl":         "600s",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for the short-lived certificates to expire
+	time.Sleep(time.Until(lastTTL) + 2*time.Second)
+
+	// Tidy the expired certificates
+	waitForManualTidy(t, client, map[string]interface{}{
+		"tidy_cert_store": true,
+		"safety_buffer":   "1s",
+	})
+
+	// tidy metrics check
+	mostRecentInterval := inmemSink.Data()[len(inmemSink.Data())-1]
+	expectedGauges := map[string]float32{
+		"secrets.pki.tidy.cert_store_total_entries":           5, // All the certs
+		"secrets.pki.tidy.cert_store_total_entries_remaining": 2, // The long-lived certs
+	}
+	for gauge, value := range expectedGauges {
+		if metric, ok := mostRecentInterval.Gauges[gauge]; !ok || metric.Value != value {
+			t.Fatalf("Expected gauge %s to have value %f, but got %f", gauge, value, metric.Value)
+		}
+	}
+
+	// Issue two certificates, a short-lived and a long-lived, then revoke them.
+	cert1Resp, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+		"common_name": "short-lived.example.com",
+		"ttl":         "5s", // Short-lived certificate
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	certSerial1 := cert1Resp.Data["serial_number"].(string)
+	cert1 := parseCert(t, cert1Resp.Data["certificate"].(string))
+
+	cert2, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+		"common_name": "long-lived.example.com",
+		"ttl":         "600s", // Long-lived certificate
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	certSerial2 := cert2.Data["serial_number"].(string)
+
+	_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		"serial_number": certSerial1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+		"serial_number": certSerial2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the short-lived certificate to expire
+	time.Sleep(time.Until(cert1.NotAfter) + 2*time.Second)
+
+	// Tidy the revoked certificates
+	waitForManualTidy(t, client, map[string]interface{}{
+		"tidy_revoked_certs":    true,
+		"revoked_safety_buffer": "1s",
+	})
+
+	// Verify that the revoked short-lived certificate has been tidied
+	crl := getParsedCrl(t, client, "pki")
+	revokedCerts := crl.TBSCertList.RevokedCertificates
+	found := false
+	for _, revoked := range revokedCerts {
+		serial := certutil.GetHexFormatted(revoked.SerialNumber.Bytes(), ":")
+		if serial == certSerial1 {
+			t.Fatalf("Short-lived certificate with serial %s should have been tidied", certSerial1)
+		}
+		if serial == certSerial2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Long-lived certificate with serial %s should still be in the revoked store", certSerial2)
+	}
+
+	// Final tidy metrics check
+	mostRecentInterval2 := inmemSink.Data()[len(inmemSink.Data())-1]
+	expectedGauges2 := map[string]float32{
+		"secrets.pki.tidy.revoked_cert_total_entries":           2, // All the revoked certs
+		"secrets.pki.tidy.revoked_cert_total_entries_remaining": 1, // The revoked long-lived cert
+		"secrets.pki.tidy.cert_store_total_entries":             5, // All the non-revoked certs
+		"secrets.pki.tidy.cert_store_total_entries_remaining":   2, // The non-revoked long-lived certs
+	}
+	for gauge, value := range expectedGauges2 {
+		if metric, ok := mostRecentInterval2.Gauges[gauge]; !ok || metric.Value != value {
+			t.Fatalf("Expected gauge %s to have value %f, but got %f", gauge, value, metric.Value)
+		}
 	}
 }
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4247,6 +4247,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"tidy_expired_issuers":                  false,
 			"tidy_move_legacy_ca_bundle":            false,
 			"pause_duration":                        "0s",
+			"page_size":                             json.Number("50"),
 			"state":                                 "Finished",
 			"error":                                 nil,
 			"time_started":                          nil,

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -547,6 +547,15 @@ after being marked revoked or deactivated.`,
 		Default: int(defaultTidyConfig.AcmeAccountSafetyBuffer / time.Second), // TypeDurationSecond currently requires defaults to be int
 	}
 
+	fields["page_size"] = &framework.FieldSchema{
+		Type: framework.TypeInt,
+		Description: `The number of certificates to process per page during list pagination. 
+This setting enables tidy to handle certificates in smaller increments, rather than loading 
+the entire set into memory at once. 
+Defaults to 50 certificates, with a minimum of 5 certificates per page.`,
+		Default: int(defaultTidyConfig.PageSize),
+	}
+
 	fields["pause_duration"] = &framework.FieldSchema{
 		Type: framework.TypeString,
 		Description: `The amount of time to wait between processing

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -549,10 +549,11 @@ after being marked revoked or deactivated.`,
 
 	fields["page_size"] = &framework.FieldSchema{
 		Type: framework.TypeInt,
-		Description: `The number of certificates to process per page during list pagination. 
-This setting enables tidy to handle certificates in smaller increments, rather than loading 
-the entire set into memory at once. 
-Defaults to 50 certificates, with a minimum of 5 certificates per page.`,
+		Description: `The number of certificates to process per page during list 
+pagination. This setting enables tidy to handle certificates in smaller increments,
+rather than loading the entire set into memory at once. 
+Defaults to 1000 certificates, with a minimum of 5 certificates per page. To 
+revert to the old behavior, set page size to any value less than zero.`,
 		Default: int(defaultTidyConfig.PageSize),
 	}
 

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -49,6 +49,9 @@ type tidyStatus struct {
 	tidyAcme           bool
 	pauseDuration      string
 
+	// Page size for list pagination
+	pageSize int
+
 	// Status
 	state        tidyStatusState
 	err          error
@@ -89,6 +92,9 @@ type tidyConfig struct {
 	AcmeAccountSafetyBuffer time.Duration  `json:"acme_account_safety_buffer"`
 	PauseDuration           time.Duration  `json:"pause_duration"`
 
+	// Page size for list pagination
+	PageSize int `json:"page_size"`
+
 	// Metrics.
 	MaintainCount  bool `json:"maintain_stored_certificate_counts"`
 	PublishMetrics bool `json:"publish_stored_certificate_count_metrics"`
@@ -116,6 +122,7 @@ var defaultTidyConfig = tidyConfig{
 	IssuerSafetyBuffer:      365 * 24 * time.Hour,
 	AcmeAccountSafetyBuffer: 30 * 24 * time.Hour,
 	PauseDuration:           0 * time.Second,
+	PageSize:                50,
 	MaintainCount:           false,
 	PublishMetrics:          false,
 }
@@ -217,6 +224,11 @@ func pathTidyCancel(b *backend) *framework.Path {
 							"pause_duration": {
 								Type:        framework.TypeString,
 								Description: `Duration to pause between tidying certificates`,
+								Required:    false,
+							},
+							"page_size": {
+								Type:        framework.TypeInt,
+								Description: `The number of certificates per page for list pagination`,
 								Required:    false,
 							},
 							"state": {
@@ -383,6 +395,11 @@ func pathTidyStatus(b *backend) *framework.Path {
 								Type:        framework.TypeString,
 								Description: `Duration to pause between tidying certificates`,
 								Required:    true,
+							},
+							"page_size": {
+								Type:        framework.TypeInt,
+								Description: `The number of certificates per page for list pagination`,
+								Required:    false,
 							},
 							"state": {
 								Type:        framework.TypeString,
@@ -584,6 +601,11 @@ available on the tidy-status endpoint.`,
 								Description: `Duration to pause between tidying certificates`,
 								Required:    true,
 							},
+							"page_size": {
+								Type:        framework.TypeInt,
+								Description: `The number of certificates per page for list pagination`,
+								Required:    false,
+							},
 							"tidy_move_legacy_ca_bundle": {
 								Type:     framework.TypeBool,
 								Required: true,
@@ -675,6 +697,11 @@ available on the tidy-status endpoint.`,
 								Description: `Duration to pause between tidying certificates`,
 								Required:    true,
 							},
+							"page_size": {
+								Type:        framework.TypeInt,
+								Description: `The number of certificates per page for list pagination`,
+								Required:    false,
+							},
 							"tidy_move_legacy_ca_bundle": {
 								Type:     framework.TypeBool,
 								Required: true,
@@ -717,6 +744,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 	tidyBackupBundle := d.Get("tidy_move_legacy_ca_bundle").(bool)
 	issuerSafetyBuffer := d.Get("issuer_safety_buffer").(int)
 	pauseDurationStr := d.Get("pause_duration").(string)
+	pageSize := d.Get("page_size").(int)
 	pauseDuration := 0 * time.Second
 	tidyAcme := d.Get("tidy_acme").(bool)
 	acmeAccountSafetyBuffer := d.Get("acme_account_safety_buffer").(int)
@@ -749,6 +777,10 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}
 
+	if pageSize < 5 {
+		return logical.ErrorResponse("page_size must be greater than five"), nil
+	}
+
 	bufferDuration := time.Duration(safetyBuffer) * time.Second
 	revokedBufferDuration := time.Duration(revokedSafetyBuffer) * time.Second
 	issuerBufferDuration := time.Duration(issuerSafetyBuffer) * time.Second
@@ -768,6 +800,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 		RevokedSafetyBuffer:     &revokedBufferDuration,
 		IssuerSafetyBuffer:      issuerBufferDuration,
 		PauseDuration:           pauseDuration,
+		PageSize:                pageSize,
 		TidyAcme:                tidyAcme,
 		AcmeAccountSafetyBuffer: acmeAccountSafetyBufferDuration,
 	}
@@ -905,122 +938,136 @@ func (b *backend) startTidyOperation(req *logical.Request, config *tidyConfig) {
 }
 
 func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, logger hclog.Logger, config *tidyConfig) (uint, error) {
-	serials, err := req.Storage.List(ctx, "certs/")
-	if err != nil {
-		return 0, fmt.Errorf("error fetching list of certs: %w", err)
-	}
-
-	revokedSafetyBuffer := config.SafetyBuffer
-	if config.RevokedSafetyBuffer != nil {
-		revokedSafetyBuffer = *config.RevokedSafetyBuffer
-	}
-
-	haveWarned := false
-	serialCount := len(serials)
-	metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_total_entries"}, float32(serialCount))
-
+	var after string
+	var serialCount uint
 	var revokedDeleted uint
-	for i, serial := range serials {
-		b.tidyStatusMessage(fmt.Sprintf("Tidying certificate store: checking entry %d of %d", i, serialCount))
-		metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_current_entry"}, float32(i))
+	haveWarned := false
 
-		// Check for cancel before continuing.
-		if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
-			return 0, tidyCancelledError
-		}
-
-		// Check for pause duration to reduce resource consumption.
-		if config.PauseDuration > (0 * time.Second) {
-			time.Sleep(config.PauseDuration)
-		}
-
-		certEntry, err := req.Storage.Get(ctx, "certs/"+serial)
+	for {
+		// Fetch the next batch of certificate serials using pagination
+		serials, err := req.Storage.ListPage(ctx, "certs/", after, config.PageSize)
 		if err != nil {
-			return 0, fmt.Errorf("error fetching certificate %q: %w", serial, err)
+			return 0, fmt.Errorf("error fetching list of certs: %w", err)
 		}
 
-		if certEntry == nil {
-			logger.Warn("certificate entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
-			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return 0, fmt.Errorf("error deleting nil entry with serial %s: %w", serial, err)
-			}
-			b.tidyStatusIncCertStoreCount()
-			continue
+		// If no serials are returned, we've reached the end of the cert list
+		if len(serials) == 0 {
+			break
 		}
 
-		if certEntry.Value == nil || len(certEntry.Value) == 0 {
-			logger.Warn("certificate entry has no value; tidying up since it is no longer useful for any server operations", "serial", serial)
-			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return 0, fmt.Errorf("error deleting entry with nil value with serial %s: %w", serial, err)
-			}
-			b.tidyStatusIncCertStoreCount()
-			continue
+		serialCount += uint(len(serials))
+
+		revokedSafetyBuffer := config.SafetyBuffer
+		if config.RevokedSafetyBuffer != nil {
+			revokedSafetyBuffer = *config.RevokedSafetyBuffer
 		}
 
-		cert, err := x509.ParseCertificate(certEntry.Value)
-		if err != nil {
-			// only log warning once
-			if !haveWarned {
-				msg := "Unable to parse stored certificate. Other invalid certificates may exist; "
-				if config.InvalidCerts {
-					msg += "tidying up since it is not usable."
-				} else {
-					msg += "tidy by enabling tidy_invalid_certs=true."
-				}
-				logger.Warn(msg, "serial", serial, "err", err)
-				haveWarned = true
+		for i, serial := range serials {
+			// Set the `after` variable for the next ListPage call
+			after = serial
+
+			b.tidyStatusMessage(fmt.Sprintf("Tidying certificate store: checking entry %d of %d on current page; total certs checked: %d", i, config.PageSize, int(serialCount)+i))
+			metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_current_entry"}, float32(serialCount)+float32(i))
+
+			// Check for cancel before continuing.
+			if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
+				return 0, tidyCancelledError
 			}
 
-			// if tidy_invalid_certs enabled, delete invalid cert. Because
-			// we're cleaning up revoked certs later by virtue of
-			// config.InvalidCerts=true, we can skip deleting revoked certs
-			// here.
-			if config.InvalidCerts {
+			// Check for pause duration to reduce resource consumption.
+			if config.PauseDuration > (0 * time.Second) {
+				time.Sleep(config.PauseDuration)
+			}
+
+			certEntry, err := req.Storage.Get(ctx, "certs/"+serial)
+			if err != nil {
+				return 0, fmt.Errorf("error fetching certificate %q: %w", serial, err)
+			}
+
+			if certEntry == nil {
+				logger.Warn("certificate entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
 				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-					return 0, fmt.Errorf("error deleting invalid certificate %s: %w", serial, err)
+					return 0, fmt.Errorf("error deleting nil entry with serial %s: %w", serial, err)
+				}
+				b.tidyStatusIncCertStoreCount()
+				continue
+			}
+
+			if certEntry.Value == nil || len(certEntry.Value) == 0 {
+				logger.Warn("certificate entry has no value; tidying up since it is no longer useful for any server operations", "serial", serial)
+				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+					return 0, fmt.Errorf("error deleting entry with nil value with serial %s: %w", serial, err)
+				}
+				b.tidyStatusIncCertStoreCount()
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(certEntry.Value)
+			if err != nil {
+				// only log warning once
+				if !haveWarned {
+					msg := "Unable to parse stored certificate. Other invalid certificates may exist; "
+					if config.InvalidCerts {
+						msg += "tidying up since it is not usable."
+					} else {
+						msg += "tidy by enabling tidy_invalid_certs=true."
+					}
+					logger.Warn(msg, "serial", serial, "err", err)
+					haveWarned = true
+				}
+
+				// if tidy_invalid_certs enabled, delete invalid cert. Because
+				// we're cleaning up revoked certs later by virtue of
+				// config.InvalidCerts=true, we can skip deleting revoked certs
+				// here.
+				if config.InvalidCerts {
+					if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+						return 0, fmt.Errorf("error deleting invalid certificate %s: %w", serial, err)
+					}
+					b.tidyStatusIncCertStoreCount()
+				}
+
+				continue
+			}
+
+			// We could be exclusively looking for invalid certificates; skip
+			// fetching a known-good revocation entry here if so. This also lets
+			// us avoid guarding each deletion check below.
+			if !config.CertStore {
+				continue
+			}
+
+			// Check if a revocation entry exists for this cert; if so, use the
+			// appropriate entry.
+			revokedResp, err := req.Storage.Get(ctx, "revoked/"+serial)
+			if err != nil {
+				return 0, fmt.Errorf("error fetching revocation status of serial %q from storage: %w", serial, err)
+			}
+
+			if revokedResp == nil && time.Since(cert.NotAfter) > config.SafetyBuffer {
+				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+					return 0, fmt.Errorf("error deleting serial %q from storage: %w", serial, err)
+				}
+				b.tidyStatusIncCertStoreCount()
+			} else if revokedResp != nil && time.Since(cert.NotAfter) > revokedSafetyBuffer {
+				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+					return 0, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
+				}
+				// Only tidy revoked certs if requested.
+				if config.RevokedCerts {
+					if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+						return 0, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
+					}
+					revokedDeleted += 1
+					b.tidyStatusIncRevokedCertCount()
 				}
 				b.tidyStatusIncCertStoreCount()
 			}
-
-			continue
-		}
-
-		// We could be exclusively looking for invalid certificates; skip
-		// fetching a known-good revocation entry here if so. This also lets
-		// us avoid guarding each deletion check below.
-		if !config.CertStore {
-			continue
-		}
-
-		// Check if a revocation entry exists for this cert; if so, use the
-		// appropriate entry.
-		revokedResp, err := req.Storage.Get(ctx, "revoked/"+serial)
-		if err != nil {
-			return 0, fmt.Errorf("error fetching revocation status of serial %q from storage: %w", serial, err)
-		}
-
-		if revokedResp == nil && time.Since(cert.NotAfter) > config.SafetyBuffer {
-			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return 0, fmt.Errorf("error deleting serial %q from storage: %w", serial, err)
-			}
-			b.tidyStatusIncCertStoreCount()
-		} else if revokedResp != nil && time.Since(cert.NotAfter) > revokedSafetyBuffer {
-			if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-				return 0, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
-			}
-			// Only tidy revoked certs if requested.
-			if config.RevokedCerts {
-				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-					return 0, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
-				}
-				revokedDeleted += 1
-				b.tidyStatusIncRevokedCertCount()
-			}
-			b.tidyStatusIncCertStoreCount()
 		}
 	}
 
 	b.tidyStatusLock.RLock()
+	metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_total_entries"}, float32(serialCount))
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "cert_store_total_entries_remaining"}, float32(uint(serialCount)-b.tidyStatus.certStoreDeletedCount))
 	b.tidyStatusLock.RUnlock()
 
@@ -1038,151 +1085,162 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 		return false, err
 	}
 
-	rebuildCRL := false
-
-	revokedSerials, err := req.Storage.List(ctx, "revoked/")
-	if err != nil {
-		return false, fmt.Errorf("error fetching list of revoked certs: %w", err)
-	}
-
+	var after string
+	var revokedSerialsCount uint
 	haveWarned := false
-	revokedSerialsCount := len(revokedSerials) + int(revokedDeleted)
-	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_total_entries"}, float32(revokedSerialsCount))
-
+	rebuildCRL := false
 	fixedIssuers := 0
 
-	revokedSafetyBuffer := config.SafetyBuffer
-	if config.RevokedSafetyBuffer != nil {
-		revokedSafetyBuffer = *config.RevokedSafetyBuffer
-	}
-
-	var revInfo revocationInfo
-	for i, serial := range revokedSerials {
-		b.tidyStatusMessage(fmt.Sprintf("Tidying revoked certificates: checking certificate %d of %d", i, len(revokedSerials)))
-		metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_current_entry"}, float32(i))
-
-		// Check for cancel before continuing.
-		if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
-			return false, tidyCancelledError
-		}
-
-		// Check for pause duration to reduce resource consumption.
-		if config.PauseDuration > (0 * time.Second) {
-			b.revokeStorageLock.Unlock()
-			time.Sleep(config.PauseDuration)
-			b.revokeStorageLock.Lock()
-		}
-
-		revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)
+	for {
+		revokedSerials, err := req.Storage.ListPage(ctx, "revoked/", after, config.PageSize)
 		if err != nil {
-			return false, fmt.Errorf("unable to fetch revoked cert with serial %q: %w", serial, err)
+			return false, fmt.Errorf("error fetching list of revoked certs: %w", err)
 		}
 
-		if revokedEntry == nil {
-			if !haveWarned {
-				logger.Warn("Revoked entry is nil. Other invalid entries may exist; tidying up since it is no longer useful for any server operations.", "serial", serial)
-			}
-			if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-				return false, fmt.Errorf("error deleting nil revoked entry with serial %s: %w", serial, err)
-			}
-			b.tidyStatusIncRevokedCertCount()
-			continue
+		// If no revokedSerials are returned, we've reached the end of the list
+		if len(revokedSerials) == 0 {
+			break
 		}
 
-		if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
-			if !haveWarned {
-				logger.Warn("Revoked entry has nil value. Other invalid entries may exist; tidying up since it is no longer useful for any server operations", "serial", serial)
-			}
-			if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-				return false, fmt.Errorf("error deleting revoked entry with nil value with serial %s: %w", serial, err)
-			}
-			b.tidyStatusIncRevokedCertCount()
-			continue
+		revokedSerialsCount += uint(len(revokedSerials) + int(revokedDeleted))
+
+		revokedSafetyBuffer := config.SafetyBuffer
+		if config.RevokedSafetyBuffer != nil {
+			revokedSafetyBuffer = *config.RevokedSafetyBuffer
 		}
 
-		err = revokedEntry.DecodeJSON(&revInfo)
-		if err != nil {
-			return false, fmt.Errorf("error decoding revocation entry for serial %q: %w", serial, err)
-		}
+		var revInfo revocationInfo
+		for i, serial := range revokedSerials {
+			// Set the `after` variable for the next ListPage call
+			after = serial
 
-		revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
-		if err != nil {
-			// only log warning once
-			if !haveWarned {
-				msg := "Unable to parse revoked certificate. Other invalid certificates may exist; "
+			b.tidyStatusMessage(fmt.Sprintf("Tidying revoked certificates: checking certificate %d of %d on current page; total revoked certs checked: %d", i, config.PageSize, int(revokedSerialsCount)+i))
+			metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_current_entry"}, float32(i))
+
+			// Check for cancel before continuing.
+			if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
+				return false, tidyCancelledError
+			}
+
+			// Check for pause duration to reduce resource consumption.
+			if config.PauseDuration > (0 * time.Second) {
+				b.revokeStorageLock.Unlock()
+				time.Sleep(config.PauseDuration)
+				b.revokeStorageLock.Lock()
+			}
+
+			revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)
+			if err != nil {
+				return false, fmt.Errorf("unable to fetch revoked cert with serial %q: %w", serial, err)
+			}
+
+			if revokedEntry == nil {
+				if !haveWarned {
+					logger.Warn("Revoked entry is nil. Other invalid entries may exist; tidying up since it is no longer useful for any server operations.", "serial", serial)
+				}
+				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+					return false, fmt.Errorf("error deleting nil revoked entry with serial %s: %w", serial, err)
+				}
+				b.tidyStatusIncRevokedCertCount()
+				continue
+			}
+
+			if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
+				if !haveWarned {
+					logger.Warn("Revoked entry has nil value. Other invalid entries may exist; tidying up since it is no longer useful for any server operations", "serial", serial)
+				}
+				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+					return false, fmt.Errorf("error deleting revoked entry with nil value with serial %s: %w", serial, err)
+				}
+				b.tidyStatusIncRevokedCertCount()
+				continue
+			}
+
+			err = revokedEntry.DecodeJSON(&revInfo)
+			if err != nil {
+				return false, fmt.Errorf("error decoding revocation entry for serial %q: %w", serial, err)
+			}
+
+			revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
+			if err != nil {
+				// only log warning once
+				if !haveWarned {
+					msg := "Unable to parse revoked certificate. Other invalid certificates may exist; "
+					if config.InvalidCerts {
+						msg += "tidying up since it is not usable."
+					} else {
+						msg += "tidy by enabling tidy_invalid_certs=true."
+					}
+					logger.Warn(msg, "serial", serial, "err", err)
+					haveWarned = true
+				}
+
+				// If tidy_invalid_certs enabled, delete invalid revoked cert.
+				// We know we've already deleted the invalid cert entry via
+				// doTidyCertStore(...) earlier so don't bother deleting that
+				// too.
 				if config.InvalidCerts {
-					msg += "tidying up since it is not usable."
-				} else {
-					msg += "tidy by enabling tidy_invalid_certs=true."
+					if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+						return false, fmt.Errorf("error deleting invalid revoked certificate %s: %w", serial, err)
+					}
+					b.tidyStatusIncRevokedCertCount()
 				}
-				logger.Warn(msg, "serial", serial, "err", err)
-				haveWarned = true
+
+				continue
 			}
 
-			// If tidy_invalid_certs enabled, delete invalid revoked cert.
-			// We know we've already deleted the invalid cert entry via
-			// doTidyCertStore(...) earlier so don't bother deleting that
-			// too.
-			if config.InvalidCerts {
-				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-					return false, fmt.Errorf("error deleting invalid revoked certificate %s: %w", serial, err)
-				}
-				b.tidyStatusIncRevokedCertCount()
-			}
-
-			continue
-		}
-
-		// Tidy operations over revoked certs should execute prior to
-		// tidyRevokedCerts as that may remove the entry. If that happens,
-		// we won't persist the revInfo changes (as it was deleted instead).
-		var storeCert bool = false
-		if config.IssuerAssocs {
-			if !isRevInfoIssuerValid(&revInfo, issuerIDCertMap) {
-				b.tidyStatusIncMissingIssuerCertCount()
-				revInfo.CertificateIssuer = issuerID("")
-				storeCert = true
-				if associateRevokedCertWithIsssuer(&revInfo, revokedCert, issuerIDCertMap) {
-					fixedIssuers += 1
+			// Tidy operations over revoked certs should execute prior to
+			// tidyRevokedCerts as that may remove the entry. If that happens,
+			// we won't persist the revInfo changes (as it was deleted instead).
+			var storeCert bool = false
+			if config.IssuerAssocs {
+				if !isRevInfoIssuerValid(&revInfo, issuerIDCertMap) {
+					b.tidyStatusIncMissingIssuerCertCount()
+					revInfo.CertificateIssuer = issuerID("")
+					storeCert = true
+					if associateRevokedCertWithIsssuer(&revInfo, revokedCert, issuerIDCertMap) {
+						fixedIssuers += 1
+					}
 				}
 			}
-		}
 
-		if config.RevokedCerts {
-			// Only remove the entries from revoked/ and certs/ if we're
-			// past its NotAfter value. This is because we use the
-			// information on revoked/ to build the CRL and the
-			// information on certs/ for lookup.
+			if config.RevokedCerts {
+				// Only remove the entries from revoked/ and certs/ if we're
+				// past its NotAfter value. This is because we use the
+				// information on revoked/ to build the CRL and the
+				// information on certs/ for lookup.
 
-			if time.Since(revokedCert.NotAfter) > revokedSafetyBuffer {
-				if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-					return false, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
+				if time.Since(revokedCert.NotAfter) > revokedSafetyBuffer {
+					if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
+						return false, fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
+					}
+					if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
+						return false, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
+					}
+					rebuildCRL = true
+					storeCert = false
+					b.tidyStatusIncRevokedCertCount()
 				}
-				if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-					return false, fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
-				}
-				rebuildCRL = true
-				storeCert = false
-				b.tidyStatusIncRevokedCertCount()
-			}
-		}
-
-		// If the entry wasn't removed but was otherwise modified,
-		// go ahead and write it back out.
-		if storeCert {
-			revokedEntry, err = logical.StorageEntryJSON("revoked/"+serial, revInfo)
-			if err != nil {
-				return false, fmt.Errorf("error building entry to persist changes to serial %v from revoked list: %w", serial, err)
 			}
 
-			err = req.Storage.Put(ctx, revokedEntry)
-			if err != nil {
-				return false, fmt.Errorf("error persisting changes to serial %v from revoked list: %w", serial, err)
+			// If the entry wasn't removed but was otherwise modified,
+			// go ahead and write it back out.
+			if storeCert {
+				revokedEntry, err = logical.StorageEntryJSON("revoked/"+serial, revInfo)
+				if err != nil {
+					return false, fmt.Errorf("error building entry to persist changes to serial %v from revoked list: %w", serial, err)
+				}
+
+				err = req.Storage.Put(ctx, revokedEntry)
+				if err != nil {
+					return false, fmt.Errorf("error persisting changes to serial %v from revoked list: %w", serial, err)
+				}
 			}
 		}
 	}
 
 	b.tidyStatusLock.RLock()
+	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_total_entries"}, float32(revokedSerialsCount))
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_total_entries_remaining"}, float32(uint(revokedSerialsCount)-b.tidyStatus.revokedCertDeletedCount))
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_entries_incorrect_issuers"}, float32(b.tidyStatus.missingIssuerCertCount))
 	metrics.SetGauge([]string{"secrets", "pki", "tidy", "revoked_cert_entries_fixed_issuers"}, float32(fixedIssuers))
@@ -1396,34 +1454,48 @@ func (b *backend) doTidyAcme(ctx context.Context, req *logical.Request, logger h
 	defer b.acmeAccountLock.Unlock()
 
 	sc := b.makeStorageContext(ctx, req.Storage)
-	thumbprints, err := sc.Storage.List(ctx, acmeThumbprintPrefix)
-	if err != nil {
-		return err
+	var after string
+	var thumbprintsCount uint
+
+	for {
+		thumbprints, err := sc.Storage.ListPage(ctx, acmeThumbprintPrefix, after, config.PageSize)
+		if err != nil {
+			return err
+		}
+
+		// If no thumbprints are returned, we've reached the end of the list
+		if len(thumbprints) == 0 {
+			break
+		}
+
+		thumbprintsCount += uint(len(thumbprints))
+
+		for _, thumbprint := range thumbprints {
+			// Set the `after` variable for the next ListPage call
+			after = thumbprint
+
+			err := b.tidyAcmeAccountByThumbprint(b.acmeState, sc, thumbprint, config.SafetyBuffer, config.AcmeAccountSafetyBuffer)
+			if err != nil {
+				logger.Warn("error tidying account %v: %v", thumbprint, err.Error())
+			}
+
+			// Check for cancel before continuing.
+			if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
+				return tidyCancelledError
+			}
+
+			// Check for pause duration to reduce resource consumption.
+			if config.PauseDuration > (0 * time.Second) {
+				b.acmeAccountLock.Unlock() // Correct the Lock
+				time.Sleep(config.PauseDuration)
+				b.acmeAccountLock.Lock()
+			}
+		}
 	}
 
 	b.tidyStatusLock.Lock()
-	b.tidyStatus.acmeAccountsCount = uint(len(thumbprints))
+	b.tidyStatus.acmeAccountsCount = uint(thumbprintsCount)
 	b.tidyStatusLock.Unlock()
-
-	for _, thumbprint := range thumbprints {
-		err := b.tidyAcmeAccountByThumbprint(b.acmeState, sc, thumbprint, config.SafetyBuffer, config.AcmeAccountSafetyBuffer)
-		if err != nil {
-			logger.Warn("error tidying account %v: %v", thumbprint, err.Error())
-		}
-
-		// Check for cancel before continuing.
-		if atomic.CompareAndSwapUint32(b.tidyCancelCAS, 1, 0) {
-			return tidyCancelledError
-		}
-
-		// Check for pause duration to reduce resource consumption.
-		if config.PauseDuration > (0 * time.Second) {
-			b.acmeAccountLock.Unlock() // Correct the Lock
-			time.Sleep(config.PauseDuration)
-			b.acmeAccountLock.Lock()
-		}
-
-	}
 
 	// Clean up any unused EAB
 	eabIds, err := b.acmeState.ListEabIds(sc)
@@ -1505,6 +1577,7 @@ func (b *backend) pathTidyStatusRead(_ context.Context, _ *logical.Request, _ *f
 			"tidy_move_legacy_ca_bundle":            nil,
 			"tidy_acme":                             nil,
 			"pause_duration":                        nil,
+			"page_size":                             nil,
 			"state":                                 "Inactive",
 			"error":                                 nil,
 			"time_started":                          nil,
@@ -1553,6 +1626,7 @@ func (b *backend) pathTidyStatusRead(_ context.Context, _ *logical.Request, _ *f
 	resp.Data["tidy_move_legacy_ca_bundle"] = b.tidyStatus.tidyBackupBundle
 	resp.Data["tidy_acme"] = b.tidyStatus.tidyAcme
 	resp.Data["pause_duration"] = b.tidyStatus.pauseDuration
+	resp.Data["page_size"] = b.tidyStatus.pageSize
 	resp.Data["time_started"] = b.tidyStatus.timeStarted
 	resp.Data["message"] = b.tidyStatus.message
 	resp.Data["cert_store_deleted_count"] = b.tidyStatus.certStoreDeletedCount
@@ -1660,6 +1734,13 @@ func (b *backend) pathConfigAutoTidyWrite(ctx context.Context, req *logical.Requ
 		}
 	}
 
+	if PageSizeRaw, ok := d.GetOk("page_size"); ok {
+		config.PageSize = PageSizeRaw.(int)
+		if config.PageSize < 5 {
+			return logical.ErrorResponse("page_size must be at least 5"), nil
+		}
+	}
+
 	if expiredIssuers, ok := d.GetOk("tidy_expired_issuers"); ok {
 		config.ExpiredIssuers = expiredIssuers.(bool)
 	}
@@ -1732,6 +1813,7 @@ func (b *backend) tidyStatusStart(config *tidyConfig) {
 		tidyBackupBundle:        config.BackupBundle,
 		tidyAcme:                config.TidyAcme,
 		pauseDuration:           config.PauseDuration.String(),
+		pageSize:                config.PageSize,
 
 		state:       tidyStatusStarted,
 		timeStarted: time.Now(),
@@ -1894,6 +1976,8 @@ The result includes the following fields:
 * 'tidy_move_legacy_ca_bundle': the value of this parameter when initiating the tidy operation
 * 'tidy_acme': the value of this parameter when initiating the tidy operation
 * 'acme_account_safety_buffer': the value of this parameter when initiating the tidy operation
+* 'pause_duration: the value of this parameter when initiating the tidy operation
+* 'page_size': the value of this parameter when initiating the tidy operation
 * 'total_acme_account_count': the total number of acme accounts in the list to be iterated over
 * 'acme_account_deleted_count': the number of revoked acme accounts deleted during the operation
 * 'acme_account_revoked_count': the number of acme accounts revoked during the operation
@@ -1935,6 +2019,7 @@ func getTidyConfigData(config tidyConfig) map[string]interface{} {
 		"issuer_safety_buffer":                     int(config.IssuerSafetyBuffer / time.Second),
 		"acme_account_safety_buffer":               int(config.AcmeAccountSafetyBuffer / time.Second),
 		"pause_duration":                           config.PauseDuration.String(),
+		"page_size":                                config.PageSize,
 		"publish_stored_certificate_count_metrics": config.PublishMetrics,
 		"maintain_stored_certificate_counts":       config.MaintainCount,
 	}

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -523,6 +523,7 @@ func TestTidyIssuerConfig(t *testing.T) {
 	defaultConfigMap["safety_buffer"] = int(time.Duration(defaultConfigMap["safety_buffer"].(float64)) / time.Second)
 	defaultConfigMap["revoked_safety_buffer"] = int(defaultConfigMap["safety_buffer"].(int))
 	defaultConfigMap["pause_duration"] = time.Duration(defaultConfigMap["pause_duration"].(float64)).String()
+	defaultConfigMap["page_size"] = int(defaultConfigMap["page_size"].(float64))
 	defaultConfigMap["acme_account_safety_buffer"] = int(time.Duration(defaultConfigMap["acme_account_safety_buffer"].(float64)) / time.Second)
 
 	require.Equal(t, defaultConfigMap, resp.Data)
@@ -1293,6 +1294,46 @@ func waitForAutoTidyToFinish(t *testing.T, client *api.Client) {
 	}
 }
 
+func waitForManualTidy(t *testing.T, client *api.Client, tidyConfig map[string]interface{}) {
+	status, err := client.Logical().Read("pki/tidy-status")
+	require.NoError(t, err, "got error reading initial tidy status")
+
+	t.Logf("initial status resp: %v", status)
+
+	_, err = client.Logical().Write("pki/tidy", tidyConfig)
+	require.NoError(t, err, "got error starting tidy")
+
+	timeoutChan := time.After(120 * time.Second)
+
+	for {
+		select {
+		case <-timeoutChan:
+			t.Fatalf("expected manual tidy to run before timeout")
+		default:
+			time.Sleep(50 * time.Millisecond)
+
+			newStatus, err := client.Logical().Read("pki/tidy-status")
+			require.NoError(t, err, "got error reading subsequent tidy status")
+
+			if newStatus.Data["state"].(string) == "Finished" {
+				thisStart, err := time.Parse(time.RFC3339, newStatus.Data["time_started"].(string))
+				require.NoError(t, err, "failed to parse time")
+				lastStartRaw, ok := status.Data["time_started"]
+				if !ok || lastStartRaw == nil {
+					return
+				}
+
+				lastStart, err := time.Parse(time.RFC3339, lastStartRaw.(string))
+				require.NoError(t, err, "failed to parse time")
+
+				if thisStart.After(lastStart) {
+					return
+				}
+			}
+		}
+	}
+}
+
 func TestTidyWithInvalidCertInStore(t *testing.T) {
 	t.Parallel()
 	b, s := CreateBackendWithStorage(t)
@@ -1650,4 +1691,158 @@ func TestSafetyBufferVsRevokedSafetyBuffer(t *testing.T) {
 	resp, err = client.Logical().Read("pki/cert/" + lastLeafSerial)
 	require.Nil(t, err)
 	require.Nil(t, resp)
+}
+
+func TestTidyPaginationConfig(t *testing.T) {
+	t.Parallel()
+
+	b, s := CreateBackendWithStorage(t)
+
+	// Verify that the default of page_size is 1000
+	resp, err := CBWrite(b, s, "config/auto-tidy", map[string]interface{}{})
+	resp, err = CBRead(b, s, "config/auto-tidy")
+	requireSuccessNonNilResponse(t, resp, err, "expected to read auto-tidy config")
+	require.Equal(t, 1000, resp.Data["page_size"].(int), "expected page_size to be defaulted to 1000")
+
+	// Verify that page_size can be explicitly set
+	pageSize := 75
+	resp, err = CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
+		"page_size": pageSize,
+	})
+	requireSuccessNonNilResponse(t, resp, err, "expected to be able to set page_size")
+
+	resp, err = CBRead(b, s, "config/auto-tidy")
+	requireSuccessNonNilResponse(t, resp, err, "expected to read auto-tidy config")
+	require.Equal(t, pageSize, resp.Data["page_size"].(int), "expected page_size to be set to pageSize")
+
+	// Expect an error when setting page_size to less than 5
+	pageSizeInvalid := 4
+	resp, err = CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
+		"page_size": pageSizeInvalid,
+	})
+	require.Error(t, err, "expected error when setting page_size less than 5")
+	require.Contains(t, err.Error(), "page_size must be at least 5", "page_size must be greater than five")
+
+	// Check page size is still the previous value
+	resp, err = CBRead(b, s, "config/auto-tidy")
+	requireSuccessNonNilResponse(t, resp, err, "expected to read auto-tidy config")
+	require.Equal(t, pageSize, resp.Data["page_size"].(int), "expected page_size to be set to pageSize")
+}
+
+func TestTidyPagination(t *testing.T) {
+	t.Parallel()
+
+	// Short interval duration to trigger frequent auto-tidy runs
+	newPeriod := 1 * time.Second
+
+	// Set up the test cluster
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": Factory,
+		},
+		EnableRaw:      true,
+		RollbackPeriod: newPeriod,
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+	client := cluster.Cores[0].Client
+
+	// Mount PKI
+	err := client.Sys().Mount("pki", &api.MountInput{
+		Type: "pki",
+		Config: api.MountConfigInput{
+			DefaultLeaseTTL: "10m",
+			MaxLeaseTTL:     "60m",
+		},
+	})
+	require.NoError(t, err)
+
+	// Generate a root certificate
+	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+		"ttl":         "40h",
+		"common_name": "Root X1",
+		"key_type":    "ec",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data)
+	rootSerial := resp.Data["serial_number"].(string)
+
+	// Run tidy so status is not empty when we run it later
+	_, err = client.Logical().Write("pki/tidy", map[string]interface{}{
+		"tidy_revoked_certs": true,
+	})
+	require.NoError(t, err)
+
+	// Set up a role for testing
+	_, err = client.Logical().Write("pki/roles/local-testing", map[string]interface{}{
+		"allow_any_name":    true,
+		"enforce_hostnames": false,
+		"key_type":          "ec",
+	})
+	require.NoError(t, err)
+
+	// Configure auto-tidy
+	_, err = client.Logical().Write("pki/config/auto-tidy", map[string]interface{}{
+		"enabled":               true,
+		"interval_duration":     "1s",
+		"tidy_cert_store":       true,
+		"tidy_revoked_certs":    true,
+		"page_size":             5,
+		"safety_buffer":         "1s",
+		"revoked_safety_buffer": "1s",
+	})
+	require.NoError(t, err)
+
+	// Issue 27 leaf certificates to populate the cert store.
+	// This number is chosen to ensure that the tidy operation can process multiple pages,
+	// even when the page size limit is set below the total number of certificates.
+	for i := 0; i < 26; i++ {
+		_, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+			"common_name": "example.com",
+			"ttl":         "1s",
+		})
+		require.NoError(t, err)
+	}
+	// the last leaf cert being issued
+	resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+		"common_name": "last.com",
+		"ttl":         "1s",
+	})
+	require.NoError(t, err)
+	lastCert := parseCert(t, resp.Data["certificate"].(string))
+
+	// Issue another 4 leaf certificates then revoke them. This is done to ensure that
+	// the tidy operation can process certificates less than its the page size.
+	for i := 0; i < 4; i++ {
+		resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
+			"common_name": fmt.Sprintf("revoked.com"),
+			"ttl":         "1s",
+		})
+		require.NoError(t, err)
+		revokedSerial := resp.Data["serial_number"].(string)
+
+		_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+			"serial_number": revokedSerial,
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for the last certificate to expire, revoked safety buffer and safety buffer to elapse
+	time.Sleep(time.Until(lastCert.NotAfter) + 3*time.Second)
+
+	// Wait for auto-tidy to run afterwards.
+	waitForAutoTidyToFinish(t, client)
+
+	// List remaining certificates in the cert store
+	resp, err = client.Logical().List("pki/certs/")
+	require.NoError(t, err, "unable to list certificates in store")
+
+	// Check that only the root certificate remains
+	certKeys := resp.Data["keys"].([]interface{})
+	require.Len(t, certKeys, 1, "expected only root cert to remain in the store")
+	require.Contains(t, certKeys, rootSerial, "expected only root cert to remain in the store")
 }

--- a/changelog/678.txt
+++ b/changelog/678.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/pki: Add pagination to `tidy` operations for improved scalability in large certificate stores.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -4555,6 +4555,12 @@ to stop a running operation after the sleep period is over.
 
 :::
 
+- `page_size` `(int: 1000)` - The number of certificates to process per page 
+during list pagination in tidy. This setting enables tidy to handle certificates 
+in smaller increments, rather than loading the entire set into memory at once. 
+Defaults to 1000 certificates, with a minimum of 5 certificates per page. To 
+revert to the old behavior, set page size to any value less than zero.
+
 - `revocation_queue_safety_buffer` `(string: "")` - Specifies a duration
   after which cross-cluster revocation requests will be removed as expired.
   This should be set high enough that, if a cluster disappears for a while
@@ -4630,6 +4636,7 @@ $ curl \
     "issuer_safety_buffer": 31536000,
     "maintain_stored_certificate_counts": false,
     "pause_duration": "0s",
+    "page_size": 50,
     "publish_stored_certificate_count_metrics": false,
     "revocation_queue_safety_buffer": 172800,
     "safety_buffer": 259200,
@@ -4739,6 +4746,7 @@ The result includes the following fields:
 * `cross_revoked_cert_deleted_count`: the number of cross-cluster revoked certificate entries deleted
 * `revocation_queue_safety_buffer`: the value of this parameter when initiating the tidy operation
 * `pause_duration`: the value of this parameter when initiating the tidy operation
+* `page_size`: the value of this parameter when initiating the tidy operation
 * `last_auto_tidy_finished`: the time when the last auto-tidy operation finished; may be different than `time_finished` especially if the last operation was a manually executed tidy operation. Set to current time at mount time to delay the initial auto-tidy operation; not persisted.
 
 


### PR DESCRIPTION
This PR modifies the tidy process to use pagination, allowing certificates to be processed in increments rather than loading the entire set into memory at once. This would be particularly helpful when the cert store contains millions of certs. The default page size is 1000 certificates but custom page sizes can be specified via a flag `page_size`. Minimum page size is 5 and to default to previous behavior, i.e., skip out on pagination, set `page_size=-1` or any negative int.

Partly resolves #271

## Target Release

1.14.7

---
### TO DO

- [X] Add pagination to tidy cert store.
- [X] Add pagination to all tidy functions.
- [X] Add flag to allow user to define page size with minimum size 5 and defaults to 1000.
- [X] Create pagination test.
- [X] Add docs.