### PR TITLE
UI: Update documentation links & fix `Doc link renders` test

### DIFF
--- a/ui/lib/core/addon/components/doc-link.js
+++ b/ui/lib/core/addon/components/doc-link.js
@@ -7,14 +7,14 @@ import ExternalLink from './external-link';
 
 /**
  * @module DocLink
- * `DocLink` components are used to render anchor links to relevant Vault documentation at developer.hashicorp.com.
+ * `DocLink` components are used to render anchor links to relevant Vault documentation at openbao.org.
  *
  * @example
  * ```js
     <DocLink @path="/docs/secrets/kv/kv-v2.html">Learn about KV v2</DocLink>
  * ```
  *
- * @param {string} path="/" - The path to documentation on developer.hashicorp.com that the component should link to.
+ * @param {string} path="/" - The path to documentation on openbao.org that the component should link to.
  *
  */
 export default class DocLinkComponent extends ExternalLink {

--- a/ui/lib/core/addon/components/external-link.js
+++ b/ui/lib/core/addon/components/external-link.js
@@ -8,7 +8,7 @@ import Component from '@glimmer/component';
 /**
  * @module ExternalLinkComponent
  * `ExternalLink` components are used to render anchor links to non-cluster links. Automatically opens in a new tab with noopener noreferrer.
- *  To link to developer.hashicorp.com, use DocLink .
+ *  To link to openbao.org, use DocLink .
  *
  * @example
  * ```js

--- a/ui/lib/pki/README.md
+++ b/ui/lib/pki/README.md
@@ -21,10 +21,10 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
   The `pki/action`[adapter](../../app/adapters/pki/action.js) is used to map the desired action to the corresponding endpoint, and the `pki/action` [serializer](../../app/serializers/pki/action.js) includes logic to send the relevant attributes. The following PKI workflows use this model:
 
-  - [Root generation and rotation](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)
-  - [Import CA cert and keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
-  - [Generate intermediate CSR](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-intermediate-csr)
-  - [Sign intermediate](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-intermediate)
+  - [Root generation and rotation](https://openbao.org/api-docs/secret/pki#generate-root)
+  - [Import CA cert and keys](https://openbao.org/api-docs/secret/pki#import-ca-certificates-and-keys)
+  - [Generate intermediate CSR](https://openbao.org/api-docs/secret/pki#generate-intermediate-csr)
+  - [Sign intermediate](https://openbao.org/api-docs/secret/pki#sign-intermediate)
 
 - ### [pki/certificate/base](../../app/models/pki/certificate/base.js)
 
@@ -34,7 +34,7 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
 - ### [pki/tidy](../../app/models/pki/tidy.js)
 
-  This model is used to manage [tidy](https://developer.hashicorp.com/vault/api-docs/secret/pki#tidy) operations in a few different contexts. All of the following endpoints share the same parameters _except_ `enabled` and `interval_duration` which are reserved for auto-tidy operations only.
+  This model is used to manage [tidy](https://openbao.org/api-docs/secret/pki#tidy) operations in a few different contexts. All of the following endpoints share the same parameters _except_ `enabled` and `interval_duration` which are reserved for auto-tidy operations only.
 
   > _`pki/tidy-status` does not use an Ember data model because it is read-only_
 
@@ -48,22 +48,22 @@ If you couldn't tell from the documentation above, PKI is _complex_. As such, th
 
 - ### [pki/issuer](../../app/models/pki/issuer.js)
 
-  > _Issuers are created by the `pki/action` model by either [importing a CA](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys) or [generating a root](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root)_
+  > _Issuers are created by the `pki/action` model by either [importing a CA](https://openbao.org/api-docs/secret/pki#import-ca-certificates-and-keys) or [generating a root](https://openbao.org/api-docs/secret/pki#generate-root)_
 
-  - [update](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
-  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate)
-  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers)
+  - [update](https://openbao.org/api-docs/secret/pki#update-issuer)
+  - [read](https://openbao.org/api-docs/secret/pki#read-issuer-certificate)
+  - [list](https://openbao.org/api-docs/secret/pki#list-issuers)
 
 - ### [pki/role](../../app/models/pki/role.js)
 
-  - [create/update](https://developer.hashicorp.com/vault/api-docs/secret/pki#create-update-role)
-  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-role)
-  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-roles)
+  - [create/update](https://openbao.org/api-docs/secret/pki#createupdate-role)
+  - [read](https://openbao.org/api-docs/secret/pki#read-role)
+  - [list](https://openbao.org/api-docs/secret/pki#list-roles)
 
 - ### [pki/key](../../app/models/pki/key.js)
 
   - `CREATE` has two options:
-    - [generate](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys)
-    - [import](https://developer.hashicorp.com/vault/api-docs/secret/pki#import-key)
-  - [read](https://developer.hashicorp.com/vault/api-docs/secret/pki#read-key)
-  - [list](https://developer.hashicorp.com/vault/api-docs/secret/pki#list-keys)
+    - [generate](https://openbao.org/api-docs/secret/pki#import-ca-certificates-and-keys)
+    - [import](https://openbao.org/api-docs/secret/pki#import-key)
+  - [read](https://openbao.org/api-docs/secret/pki#read-key)
+  - [list](https://openbao.org/api-docs/secret/pki#list-keys)

--- a/ui/tests/integration/components/form-field-label-test.js
+++ b/ui/tests/integration/components/form-field-label-test.js
@@ -44,8 +44,6 @@ module('Integration | Component | form-field-label', function (hooks) {
     assert.dom('a').doesNotExist('docLink hidden when not provided');
     this.set('docLink', '/doc/path');
     assert.dom('.sub-text').includesText('See our documentation for help', 'Doc link text renders');
-    assert
-      .dom('a')
-      .hasAttribute('href', 'https://developer.hashicorp.com' + this.docLink, 'Doc link renders');
+    assert.dom('a').hasAttribute('href', 'https://openbao.org' + this.docLink, 'Doc link renders');
   });
 });


### PR DESCRIPTION
Some links in `README` & code comments was referring to hashicorp documentation.

Small part of #74

Add missing changes in #669
