### PR TITLE
Compute raft peer bootstrap challenge via HKDF

### DIFF
--- a/changelog/690.txt
+++ b/changelog/690.txt
@@ -1,0 +1,3 @@
+```release-note:security
+raft: Fix memory exhaustion when processing raft cluster join requests; results in longer challenge/answers. HCSEC-2024-26 / CVE-2024-8185.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -555,8 +555,11 @@ type Core struct {
 	raftFollowerStates *raft.FollowerStates
 	// Stop channel for raft TLS rotations
 	raftTLSRotationStopCh chan struct{}
-	// Stores the pending peers we are waiting to give answers
-	pendingRaftPeers *sync.Map
+
+	// Stores the root key for generating challenges for pending peers we are
+	// waiting to give answers. This is constant size unlike the earlier
+	// sync.Map implementation.
+	pendingRaftPeerChallengeKey []byte
 
 	// rawConfig stores the config as-is from the provided server configuration.
 	rawConfig *atomic.Value
@@ -939,6 +942,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		postUnsealStarted:              new(uint32),
 		raftInfo:                       new(atomic.Value),
 		raftJoinDoneCh:                 make(chan struct{}),
+		pendingRaftPeerChallengeKey:    make([]byte, 32),
 		clusterHeartbeatInterval:       clusterHeartbeatInterval,
 		keyRotateGracePeriod:           new(int64),
 		numExpirationWorkers:           conf.NumExpirationWorkers,
@@ -986,6 +990,12 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	atomic.StoreInt64(c.keyRotateGracePeriod, int64(2*time.Minute))
 
 	c.raftInfo.Store((*raftInformation)(nil))
+
+	// Create a random key for raft peer challenges.
+	_, err := io.ReadFull(rand.Reader, c.pendingRaftPeerChallengeKey)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing pending raft peer challenge key: %w", err)
+	}
 
 	switch conf.ClusterCipherSuites {
 	case "tls13", "tls12":

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -191,8 +191,6 @@ func (c *Core) setupRaftActiveNode(ctx context.Context) error {
 
 	raftBackend.SetupAutopilot(c.activeContext, autopilotConfig, c.raftFollowerStates, disableAutopilot)
 
-	c.pendingRaftPeers = &sync.Map{}
-
 	// Reload the raft TLS keys to ensure we are using the latest version.
 	if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {
 		return err
@@ -213,7 +211,6 @@ func (c *Core) stopRaftActiveNode() {
 		raftBackend.StopAutopilot()
 	}
 
-	c.pendingRaftPeers = nil
 	c.stopPeriodicRaftTLSRotate()
 }
 


### PR DESCRIPTION
Rather than storing a map of serverID->answer (and generating fully random challenge answers), use HKDF on the serverID and a secret key to create challenge answers using only a single constant-space key. HKDF should be at least as fast as the underlying RNG source and this ensures we do not incur any additional memory per request to this un-authenticated endpoint.

See also: https://discuss.hashicorp.com/t/hcsec-2024-26-vault-vulnerable-to-denial-of-service-through-memory-exhaustion-when-processing-raft-cluster-join-requests/71047