### PR TITLE
Move deadlock tests to separate file

### DIFF
--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/version"
-	"github.com/sasha-s/go-deadlock"
 )
 
 // invalidKey is used to test Unseal
@@ -3209,54 +3208,6 @@ func TestCore_ServiceRegistration(t *testing.T) {
 		notifyInitCount:   1,
 	}); diff != nil {
 		t.Fatal(diff)
-	}
-}
-
-func TestDetectedDeadlock(t *testing.T) {
-	testCore, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{DetectDeadlocks: "statelock"})
-	InduceDeadlock(t, testCore, 1)
-}
-
-func TestDefaultDeadlock(t *testing.T) {
-	testCore, _, _ := TestCoreUnsealed(t)
-	InduceDeadlock(t, testCore, 0)
-}
-
-func RestoreDeadlockOpts() func() {
-	opts := deadlock.Opts
-	return func() {
-		deadlock.Opts = opts
-	}
-}
-
-func InduceDeadlock(t *testing.T, vaultcore *Core, expected uint32) {
-	defer RestoreDeadlockOpts()()
-	var deadlocks uint32
-	deadlock.Opts.OnPotentialDeadlock = func() {
-		atomic.AddUint32(&deadlocks, 1)
-	}
-	var mtx deadlock.Mutex
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		vaultcore.expiration.coreStateLock.Lock()
-		mtx.Lock()
-		mtx.Unlock()
-		vaultcore.expiration.coreStateLock.Unlock()
-	}()
-	wg.Wait()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		mtx.Lock()
-		vaultcore.expiration.coreStateLock.RLock()
-		vaultcore.expiration.coreStateLock.RUnlock()
-		mtx.Unlock()
-	}()
-	wg.Wait()
-	if atomic.LoadUint32(&deadlocks) != expected {
-		t.Fatalf("expected 1 deadlock, detected %d", deadlocks)
 	}
 }
 

--- a/vault/deadlock_test.go
+++ b/vault/deadlock_test.go
@@ -1,0 +1,59 @@
+//go:build !race
+
+package vault
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sasha-s/go-deadlock"
+)
+
+func TestDetectedDeadlock(t *testing.T) {
+	testCore, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{DetectDeadlocks: "statelock"})
+	InduceDeadlock(t, testCore, 1)
+}
+
+func TestDefaultDeadlock(t *testing.T) {
+	testCore, _, _ := TestCoreUnsealed(t)
+	InduceDeadlock(t, testCore, 0)
+}
+
+func RestoreDeadlockOpts() func() {
+	opts := deadlock.Opts
+	return func() {
+		deadlock.Opts = opts
+	}
+}
+
+func InduceDeadlock(t *testing.T, vaultcore *Core, expected uint32) {
+	defer RestoreDeadlockOpts()()
+	var deadlocks uint32
+	deadlock.Opts.OnPotentialDeadlock = func() {
+		atomic.AddUint32(&deadlocks, 1)
+	}
+	var mtx deadlock.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		vaultcore.expiration.coreStateLock.Lock()
+		mtx.Lock()
+		mtx.Unlock()
+		vaultcore.expiration.coreStateLock.Unlock()
+	}()
+	wg.Wait()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mtx.Lock()
+		vaultcore.expiration.coreStateLock.RLock()
+		vaultcore.expiration.coreStateLock.RUnlock()
+		mtx.Unlock()
+	}()
+	wg.Wait()
+	if atomic.LoadUint32(&deadlocks) != expected {
+		t.Fatalf("expected 1 deadlock, detected %d", deadlocks)
+	}
+}


### PR DESCRIPTION
This lets us disable the deadlock tests in the race detector, keeping CI clean. Unfortunately, the deadlock library in use does not allow atomic control over these values and doesn't recommend setting them post-startup. While running in tests are serial and nothing else is executing in the process state, it is not ideal but workable. This code is not used in production.