### PR TITLE
Update to UBI 9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ CMD ["server", "-dev"]
 
 
 #### UBI DOCKERFILE ####
-FROM registry.access.redhat.com/ubi9-minimal:9.4 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.5 as ubi
 
 ARG BIN_NAME
 # PRODUCT_VERSION is the version built dist/$TARGETOS/$TARGETARCH/$BIN_NAME,

--- a/changelog/701.txt
+++ b/changelog/701.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Upgrade RHEL UBI container image to 9.5.
+```


### PR DESCRIPTION
Per https://hub.docker.com/r/redhat/ubi9-minimal/tags, this is now available.