### PR TITLE
[fix][inmem - Occasional logging after test finishes #702] 

### DIFF
--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -606,7 +606,9 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 	// transactions plus a lister outside of transactions (which should still
 	// be atomic relative to the transactions that are occurring). When the
 	// writers are done, signal the readers/listers to finish up.
-	var wg sync.WaitGroup
+	var wgWriters sync.WaitGroup
+	var wgReaders sync.WaitGroup
+	var wgListers sync.WaitGroup
 	var done atomic.Bool
 	var numFiles int = 25
 	var numWriters int = 100
@@ -618,9 +620,9 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 	var listBreak int = 10
 	var numErrors atomic.Int32
 	for i := 1; i <= numWriters; i++ {
-		wg.Add(1)
+		wgWriters.Add(1)
 		go func(worker int) {
-			defer wg.Done()
+			defer wgWriters.Done()
 			for write := 1; write <= numWrites; write++ {
 				time.Sleep(time.Duration(worker) * time.Millisecond)
 
@@ -684,7 +686,9 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 
 	// Validate reads within a transaction are consistent.
 	for i := 1; i <= numReaders; i++ {
+		wgReaders.Add(1)
 		go func(worker int) {
+			defer wgReaders.Done()
 			var read int = 1
 			time.Sleep(time.Duration(worker) * time.Millisecond)
 
@@ -774,7 +778,9 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 
 	// Validate lists outside of a transaction are consistent.
 	for i := 1; i <= numListers; i++ {
+		wgListers.Add(1)
 		go func(worker int) {
+			defer wgListers.Done()
 			var list int = 1
 			time.Sleep(time.Duration(worker) * time.Millisecond)
 
@@ -820,13 +826,23 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 	}
 
 	// Wait for writers to finish
-	wg.Wait()
+	wgWriters.Wait()
 
-	// Give readers additional time to finish before we potentially call
-	// fatal.
-	time.Sleep(100 * time.Millisecond)
+	// Signal readers and listeners to finish
 	done.Store(true)
-	time.Sleep(250 * time.Millisecond)
+
+	// Wait for readers and listers to finish in parallel
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		wgReaders.Wait()
+	}()
+	go func() {
+		defer wg.Done()
+		wgListers.Wait()
+	}()
+	wg.Wait()
 
 	// Handle cleanup
 	if numErrors.Load() > 0 {
@@ -836,7 +852,8 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 
 func testTransactionalMixedWriters(t testing.TB, b TransactionalBackend) {
 	// We have a few readers and writers inside of transactions
-	var wg sync.WaitGroup
+	var wgWriters sync.WaitGroup
+	var wgReaders sync.WaitGroup
 	var done atomic.Bool
 	var numFiles int = 25
 	var numWriters int = 100
@@ -845,9 +862,9 @@ func testTransactionalMixedWriters(t testing.TB, b TransactionalBackend) {
 	var readBreak int = 5
 	var numErrors atomic.Int32
 	for i := 1; i <= numWriters; i++ {
-		wg.Add(1)
+		wgWriters.Add(1)
 		go func(worker int) {
-			defer wg.Done()
+			defer wgWriters.Done()
 			for write := 1; write <= numWrites; write++ {
 				time.Sleep(time.Duration(worker) * time.Millisecond)
 
@@ -917,7 +934,9 @@ func testTransactionalMixedWriters(t testing.TB, b TransactionalBackend) {
 
 	// Validate reads within a transaction are consistent.
 	for i := 1; i <= numReaders; i++ {
+		wgReaders.Add(1)
 		go func(worker int) {
+			defer wgReaders.Done()
 			var read int = 1
 			time.Sleep(time.Duration(worker) * time.Millisecond)
 
@@ -1011,13 +1030,13 @@ func testTransactionalMixedWriters(t testing.TB, b TransactionalBackend) {
 	}
 
 	// Wait for writers to finish
-	wg.Wait()
+	wgWriters.Wait()
 
-	// Give readers additional time to finish before we potentially call
-	// fatal.
-	time.Sleep(100 * time.Millisecond)
+	// Signal readers to stop
 	done.Store(true)
-	time.Sleep(250 * time.Millisecond)
+
+	// Wait for readers to finish
+	wgReaders.Wait()
 
 	// Handle cleanup
 	if numErrors.Load() > 0 {


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

# **Release-note:bug**

## file - sdk/physical/testing.go: 
1. Added Dedicated sync.WaitGroup for Writers, Readers, and Listers:
Purpose: To ensure proper synchronization and orderly completion of all goroutines.
Benefit: This approach ensures that the main test function waits for all writer, reader, and lister goroutines to complete before proceeding, preventing race conditions and ensuring consistent test results.

2. Removed time.Sleep Calls:
Purpose: To eliminate arbitrary delays and rely on proper synchronization mechanisms.
Benefit: This makes the code more efficient and predictable. Using sync.WaitGroup ensures that the test waits for all necessary operations to complete without relying on fixed sleep durations, which can be unreliable and lead to flaky tests.
2.1: The sleep times weren't 100% stable and could cause scenarios where the readers or listers would write to the log after the test completion, leading to the trace mentioned in the original issue.

3. Keep the "done" flag to signal readers and listeners instead of switching to context with cancellation to avoid applying too much of complex changes to something that already works


<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

# Main issue
Resolves [#702](https://github.com/openbao/openbao/issues/702)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.14.7
