### PR TITLE
Get current time in each JWT leeway subtest

### DIFF
--- a/builtin/credential/jwt/path_login_test.go
+++ b/builtin/credential/jwt/path_login_test.go
@@ -928,7 +928,7 @@ func TestLogin_Leeways(t *testing.T) {
 }
 
 func testLogin_ExpiryClaims(t *testing.T, jwks bool) {
-	tests := []struct {
+	type params struct {
 		Context       string
 		Valid         bool
 		JWKS          bool
@@ -937,59 +937,8 @@ func testLogin_ExpiryClaims(t *testing.T, jwks bool) {
 		Expiration    time.Time
 		DefaultLeeway int
 		ExpLeeway     int
-	}{
-		// iat, auto clock_skew_leeway (60s), auto expiration leeway (150s)
-		{"auto expire leeway using iat with auto clock_skew_leeway", true, jwks, time.Now().Add(-205 * time.Second), time.Time{}, time.Time{}, 0, 0},
-		{"expired auto expire leeway using iat with auto clock_skew_leeway", false, jwks, time.Now().Add(-215 * time.Second), time.Time{}, time.Time{}, 0, 0},
-
-		// iat, clock_skew_leeway (10s), auto expiration leeway (150s)
-		{"auto expire leeway using iat with custom clock_skew_leeway", true, jwks, time.Now().Add(-150 * time.Second), time.Time{}, time.Time{}, 10, 0},
-		{"expired auto expire leeway using iat with custom clock_skew_leeway", false, jwks, time.Now().Add(-165 * time.Second), time.Time{}, time.Time{}, 10, 0},
-
-		// iat, no clock_skew_leeway (0s), auto expiration leeway (150s)
-		{"auto expire leeway using iat with no clock_skew_leeway", true, jwks, time.Now().Add(-145 * time.Second), time.Time{}, time.Time{}, -1, 0},
-		{"expired auto expire leeway using iat with no clock_skew_leeway", false, jwks, time.Now().Add(-155 * time.Second), time.Time{}, time.Time{}, -1, 0},
-
-		// nbf, auto clock_skew_leeway (60s), auto expiration leeway (150s)
-		{"auto expire leeway using nbf with auto clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-205 * time.Second), time.Time{}, 0, 0},
-		{"expired auto expire leeway using nbf with auto clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-215 * time.Second), time.Time{}, 0, 0},
-
-		// nbf, clock_skew_leeway (10s), auto expiration leeway (150s)
-		{"auto expire leeway using nbf with custom clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-145 * time.Second), time.Time{}, 10, 0},
-		{"expired auto expire leeway using nbf with custom clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-165 * time.Second), time.Time{}, 10, 0},
-
-		// nbf, no clock_skew_leeway (0s), auto expiration leeway (150s)
-		{"auto expire leeway using nbf with no clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-145 * time.Second), time.Time{}, -1, 0},
-		{"expired auto expire leeway using nbf with no clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-155 * time.Second), time.Time{}, -1, 0},
-
-		// iat, auto clock_skew_leeway (60s), custom expiration leeway (10s)
-		{"custom expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-65 * time.Second), time.Time{}, time.Time{}, 0, 10},
-		{"expired custom expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-75 * time.Second), time.Time{}, time.Time{}, 0, 10},
-
-		// iat, clock_skew_leeway (10s), custom expiration leeway (10s)
-		{"custom expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-5 * time.Second), time.Time{}, time.Time{}, 10, 10},
-		{"expired custom expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-25 * time.Second), time.Time{}, time.Time{}, 10, 10},
-
-		// iat, clock_skew_leeway (10s), no expiration leeway (10s)
-		{"no expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-5 * time.Second), time.Time{}, time.Time{}, 10, -1},
-		{"expired no expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-15 * time.Second), time.Time{}, time.Time{}, 10, -1},
-
-		// nbf, default clock_skew_leeway (60s), custom expiration leeway (10s)
-		{"custom expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-65 * time.Second), time.Time{}, 0, 10},
-		{"expired custom expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-75 * time.Second), time.Time{}, 0, 10},
-
-		// nbf, clock_skew_leeway (10s), custom expiration leeway (0s)
-		{"custom expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-5 * time.Second), time.Time{}, 10, 10},
-		{"expired custom expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-25 * time.Second), time.Time{}, 10, 10},
-
-		// nbf, clock_skew_leeway (10s), no expiration leeway (0s)
-		{"no expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-5 * time.Second), time.Time{}, 10, -1},
-		{"no expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-5 * time.Second), time.Time{}, 10, -100},
-		{"expired no expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-15 * time.Second), time.Time{}, 10, -1},
-		{"expired no expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-15 * time.Second), time.Time{}, 10, -100},
 	}
-
-	for i, tt := range tests {
+	test := func(tt params) {
 		cfg := testConfig{
 			audience:      true,
 			jwks:          tt.JWKS,
@@ -1008,16 +957,64 @@ func testLogin_ExpiryClaims(t *testing.T, jwks bool) {
 		}
 
 		if tt.Valid && resp.IsError() {
-			t.Fatalf("[test %d: %s jws: %v] unexpected error: %s", i, tt.Context, tt.JWKS, resp.Error())
+			t.Fatalf("[test: %s jws: %v] unexpected error: %s", tt.Context, tt.JWKS, resp.Error())
 		} else if !tt.Valid && !resp.IsError() {
-			t.Fatalf("[test %d: %s jws: %v] expected token expired error, got : %v", i, tt.Context, tt.JWKS, *resp)
+			t.Fatalf("[test: %s jws: %v] expected token expired error, got : %v", tt.Context, tt.JWKS, *resp)
 		}
 		b.closeServerFunc()
 	}
+
+	// iat, auto clock_skew_leeway (60s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using iat with auto clock_skew_leeway", true, jwks, time.Now().Add(-205 * time.Second), time.Time{}, time.Time{}, 0, 0})
+	test(params{"expired auto expire leeway using iat with auto clock_skew_leeway", false, jwks, time.Now().Add(-215 * time.Second), time.Time{}, time.Time{}, 0, 0})
+
+	// iat, clock_skew_leeway (10s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using iat with custom clock_skew_leeway", true, jwks, time.Now().Add(-150 * time.Second), time.Time{}, time.Time{}, 10, 0})
+	test(params{"expired auto expire leeway using iat with custom clock_skew_leeway", false, jwks, time.Now().Add(-165 * time.Second), time.Time{}, time.Time{}, 10, 0})
+
+	// iat, no clock_skew_leeway (0s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using iat with no clock_skew_leeway", true, jwks, time.Now().Add(-145 * time.Second), time.Time{}, time.Time{}, -1, 0})
+	test(params{"expired auto expire leeway using iat with no clock_skew_leeway", false, jwks, time.Now().Add(-155 * time.Second), time.Time{}, time.Time{}, -1, 0})
+
+	// nbf, auto clock_skew_leeway (60s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using nbf with auto clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-205 * time.Second), time.Time{}, 0, 0})
+	test(params{"expired auto expire leeway using nbf with auto clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-215 * time.Second), time.Time{}, 0, 0})
+
+	// nbf, clock_skew_leeway (10s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using nbf with custom clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-145 * time.Second), time.Time{}, 10, 0})
+	test(params{"expired auto expire leeway using nbf with custom clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-165 * time.Second), time.Time{}, 10, 0})
+
+	// nbf, no clock_skew_leeway (0s), auto expiration leeway (150s)
+	test(params{"auto expire leeway using nbf with no clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-145 * time.Second), time.Time{}, -1, 0})
+	test(params{"expired auto expire leeway using nbf with no clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-155 * time.Second), time.Time{}, -1, 0})
+
+	// iat, auto clock_skew_leeway (60s), custom expiration leeway (10s)
+	test(params{"custom expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-65 * time.Second), time.Time{}, time.Time{}, 0, 10})
+	test(params{"expired custom expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-75 * time.Second), time.Time{}, time.Time{}, 0, 10})
+
+	// iat, clock_skew_leeway (10s), custom expiration leeway (10s)
+	test(params{"custom expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-5 * time.Second), time.Time{}, time.Time{}, 10, 10})
+	test(params{"expired custom expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-25 * time.Second), time.Time{}, time.Time{}, 10, 10})
+
+	// iat, clock_skew_leeway (10s), no expiration leeway (10s)
+	test(params{"no expire leeway using iat with clock_skew_leeway", true, jwks, time.Now().Add(-5 * time.Second), time.Time{}, time.Time{}, 10, -1})
+	test(params{"expired no expire leeway using iat with clock_skew_leeway", false, jwks, time.Now().Add(-15 * time.Second), time.Time{}, time.Time{}, 10, -1})
+
+	// nbf, default clock_skew_leeway (60s), custom expiration leeway (10s)
+	test(params{"custom expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-65 * time.Second), time.Time{}, 0, 10})
+	test(params{"expired custom expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-75 * time.Second), time.Time{}, 0, 10})
+
+	// nbf, clock_skew_leeway (10s), custom expiration leeway (0s)
+	test(params{"custom expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-5 * time.Second), time.Time{}, 10, 10})
+	test(params{"expired custom expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-25 * time.Second), time.Time{}, 10, 10})
+
+	// nbf, clock_skew_leeway (10s), no expiration leeway (0s)
+	test(params{"no expire leeway using nbf with clock_skew_leeway", true, jwks, time.Time{}, time.Now().Add(-5 * time.Second), time.Time{}, 10, -1})
+	test(params{"expired no expire leeway using nbf with clock_skew_leeway", false, jwks, time.Time{}, time.Now().Add(-15 * time.Second), time.Time{}, 10, -1})
 }
 
 func testLogin_NotBeforeClaims(t *testing.T, jwks bool) {
-	tests := []struct {
+	type params struct {
 		Context       string
 		Valid         bool
 		JWKS          bool
@@ -1026,47 +1023,8 @@ func testLogin_NotBeforeClaims(t *testing.T, jwks bool) {
 		Expiration    time.Time
 		DefaultLeeway int
 		NBFLeeway     int
-	}{
-		// iat, auto clock_skew_leeway (60s), no nbf leeway (0)
-		{"no nbf leeway using iat with auto clock_skew_leeway", true, jwks, time.Now().Add(55 * time.Second), time.Time{}, time.Now(), 0, -1},
-		{"not yet valid no nbf leeway using iat with auto clock_skew_leeway", false, jwks, time.Now().Add(65 * time.Second), time.Time{}, time.Now(), 0, -1},
-
-		// iat, clock_skew_leeway (10s), no nbf leeway (0s)
-		{"no nbf leeway using iat with custom clock_skew_leeway", true, jwks, time.Now().Add(5 * time.Second), time.Time{}, time.Time{}, 10, -1},
-		{"not yet valid no nbf leeway using iat with custom clock_skew_leeway", false, jwks, time.Now().Add(15 * time.Second), time.Time{}, time.Time{}, 10, -1},
-
-		// iat, no clock_skew_leeway (0s), nbf leeway (5s)
-		{"nbf leeway using iat with no clock_skew_leeway", true, jwks, time.Now(), time.Time{}, time.Time{}, -1, 5},
-		{"not yet valid nbf leeway using iat with no clock_skew_leeway", false, jwks, time.Now().Add(6 * time.Second), time.Time{}, time.Time{}, -1, 5},
-
-		// exp, auto clock_skew_leeway (60s), auto nbf leeway (150s)
-		{"auto nbf leeway using exp with auto clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(205 * time.Second), 0, 0},
-		{"not yet valid auto nbf leeway using exp with auto clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(215 * time.Second), 0, 0},
-
-		// exp, clock_skew_leeway (10s), auto nbf leeway (150s)
-		{"auto nbf leeway using exp with custom clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(150 * time.Second), 10, 0},
-		{"not yet valid auto nbf leeway using exp with custom clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(165 * time.Second), 10, 0},
-
-		// exp, no clock_skew_leeway (0s), auto nbf leeway (150s)
-		{"auto nbf leeway using exp with no clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(145 * time.Second), -1, 0},
-		{"not yet valid auto nbf leeway using exp with no clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(152 * time.Second), -1, 0},
-
-		// exp, auto clock_skew_leeway (60s), custom nbf leeway (10s)
-		{"custom nbf leeway using exp with auto clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(65 * time.Second), 0, 10},
-		{"not yet valid custom nbf leeway using exp with auto clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(75 * time.Second), 0, 10},
-
-		// exp, clock_skew_leeway (10s), custom nbf leeway (10s)
-		{"custom nbf leeway using exp with custom clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(15 * time.Second), 10, 10},
-		{"not yet valid custom nbf leeway using exp with custom clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(25 * time.Second), 10, 10},
-
-		// exp, no clock_skew_leeway (0s), custom nbf leeway (5s)
-		{"custom nbf leeway using exp with no clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(3 * time.Second), -1, 5},
-		{"custom nbf leeway using exp with no clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(3 * time.Second), -100, 5},
-		{"not yet valid custom nbf leeway using exp with no clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(70 * time.Second), -1, 5},
-		{"not yet valid custom nbf leeway using exp with no clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(70 * time.Second), -100, 5},
 	}
-
-	for i, tt := range tests {
+	test := func(tt params) {
 		cfg := testConfig{
 			audience:      true,
 			jwks:          tt.JWKS,
@@ -1086,12 +1044,48 @@ func testLogin_NotBeforeClaims(t *testing.T, jwks bool) {
 		}
 
 		if tt.Valid && resp.IsError() {
-			t.Fatalf("[test %d: %s] unexpected error: %s", i, tt.Context, resp.Error())
+			t.Fatalf("[test: %s] unexpected error: %s", tt.Context, resp.Error())
 		} else if !tt.Valid && !resp.IsError() {
-			t.Fatalf("[test %d: %s jws: %v] expected token not valid yet error, got : %v", i, tt.Context, *resp, tt.JWKS)
+			t.Fatalf("[test: %s jws: %v] expected token not valid yet error, got : %v", tt.Context, *resp, tt.JWKS)
 		}
 		b.closeServerFunc()
 	}
+
+	// iat, auto clock_skew_leeway (60s), no nbf leeway (0)
+	test(params{"no nbf leeway using iat with auto clock_skew_leeway", true, jwks, time.Now().Add(55 * time.Second), time.Time{}, time.Now(), 0, -1})
+	test(params{"not yet valid no nbf leeway using iat with auto clock_skew_leeway", false, jwks, time.Now().Add(65 * time.Second), time.Time{}, time.Now(), 0, -1})
+
+	// iat, clock_skew_leeway (10s), no nbf leeway (0s)
+	test(params{"no nbf leeway using iat with custom clock_skew_leeway", true, jwks, time.Now().Add(5 * time.Second), time.Time{}, time.Time{}, 10, -1})
+	test(params{"not yet valid no nbf leeway using iat with custom clock_skew_leeway", false, jwks, time.Now().Add(15 * time.Second), time.Time{}, time.Time{}, 10, -1})
+
+	// iat, no clock_skew_leeway (0s), nbf leeway (5s)
+	test(params{"nbf leeway using iat with no clock_skew_leeway", true, jwks, time.Now(), time.Time{}, time.Time{}, -1, 5})
+	test(params{"not yet valid nbf leeway using iat with no clock_skew_leeway", false, jwks, time.Now().Add(6 * time.Second), time.Time{}, time.Time{}, -1, 5})
+
+	// exp, auto clock_skew_leeway (60s), auto nbf leeway (150s)
+	test(params{"auto nbf leeway using exp with auto clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(205 * time.Second), 0, 0})
+	test(params{"not yet valid auto nbf leeway using exp with auto clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(215 * time.Second), 0, 0})
+
+	// exp, clock_skew_leeway (10s), auto nbf leeway (150s)
+	test(params{"auto nbf leeway using exp with custom clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(150 * time.Second), 10, 0})
+	test(params{"not yet valid auto nbf leeway using exp with custom clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(165 * time.Second), 10, 0})
+
+	// exp, no clock_skew_leeway (0s), auto nbf leeway (150s)
+	test(params{"auto nbf leeway using exp with no clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(145 * time.Second), -1, 0})
+	test(params{"not yet valid auto nbf leeway using exp with no clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(152 * time.Second), -1, 0})
+
+	// exp, auto clock_skew_leeway (60s), custom nbf leeway (10s)
+	test(params{"custom nbf leeway using exp with auto clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(65 * time.Second), 0, 10})
+	test(params{"not yet valid custom nbf leeway using exp with auto clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(75 * time.Second), 0, 10})
+
+	// exp, clock_skew_leeway (10s), custom nbf leeway (10s)
+	test(params{"custom nbf leeway using exp with custom clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(15 * time.Second), 10, 10})
+	test(params{"not yet valid custom nbf leeway using exp with custom clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(25 * time.Second), 10, 10})
+
+	// exp, no clock_skew_leeway (0s), custom nbf leeway (5s)
+	test(params{"custom nbf leeway using exp with no clock_skew_leeway", true, jwks, time.Time{}, time.Time{}, time.Now().Add(3 * time.Second), -1, 5})
+	test(params{"not yet valid custom nbf leeway using exp with no clock_skew_leeway", false, jwks, time.Time{}, time.Time{}, time.Now().Add(70 * time.Second), -1, 5})
 }
 
 func TestLogin_JWTSupportedAlgs(t *testing.T) {


### PR DESCRIPTION
This PR continues from #698, which did not fully resolve the CI time sensitivity issue.

In this change, I've "unrolled" the table-driven test so that each sub-test now uses the current time at the beginning of each-sub-test. This replaces the previous approach where tests ran relative to the time during table initialization at the start of the whole test case, which caused frequent failures due to strict timing sensitivity.

The diff looks larger than the actual changes. Although I (mostly) kept the formatting of the table and only added the function calls, it's showing as if the entire section was modified.  I made one change that might be hard to spot in the diff: I removed [this](https://github.com/openbao/openbao/blob/758e24181d71c93a75dc36cd0d17ab55d485c475/builtin/credential/jwt/path_login_test.go#L989) and [this](https://github.com/openbao/openbao/blob/758e24181d71c93a75dc36cd0d17ab55d485c475/builtin/credential/jwt/path_login_test.go#L1066) test, which ran the same test as the line above, but with default leeway of -100 instead of -1. When troubleshooting, the duplicate test names were confused, and I did not find what is the point to test with several different negative values since they all fall under [this single if branch](https://github.com/hashicorp/cap/blob/8c4d3db5ad15bc5a19dc1b35fed4d07e00b549a2/jwt/jwt.go#L226-L227) in github.com/hashicorp/cap - therefore I think it should be ok to test only -1, like it was done in all other sub-tests.

As previously, this PR can be tagged with "pr/no-changelog" label.