### PR TITLE
Bump sdk to api/v2@v2.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/openbao/openbao-template v1.0.0
 	github.com/openbao/openbao/api/auth/approle/v2 v2.0.0
 	github.com/openbao/openbao/api/auth/userpass/v2 v2.0.0
-	github.com/openbao/openbao/api/v2 v2.0.1
+	github.com/openbao/openbao/api/v2 v2.1.0
 	github.com/openbao/openbao/sdk/v2 v2.0.1
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0
 	github.com/openbao/go-kms-wrapping/v2 v2.2.0
-	github.com/openbao/openbao/api/v2 v2.0.1
+	github.com/openbao/openbao/api/v2 v2.1.0
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
~This replace directive meant that anyone consuming our SDK would have to include a similar replace directive in their own go module. This is an unfortunate side-effect of how modules work and undesirable in general; remove this.~


This may be incorrect, see: https://github.com/openbao/openbao/pull/705#pullrequestreview-2435486904