### PR TITLE
Update goreleaser config version to 2

### DIFF
--- a/.goreleaser-template.yaml
+++ b/.goreleaser-template.yaml
@@ -6,6 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
+version: 2
+
 project_name: bao
 
 before:

--- a/Makefile
+++ b/Makefile
@@ -359,4 +359,10 @@ dev-gorelease:
 	@echo GORELEASER_CURRENT_TAG: $(GORELEASER_CURRENT_TAG)
 	@$(SED) 's/REPLACE_WITH_RELEASE_GOOS/linux/g' $(CURDIR)/.goreleaser-template.yaml > $(CURDIR)/.goreleaser.yaml
 	@$(SED) -i 's/^#LINUXONLY#//g' $(CURDIR)/.goreleaser.yaml
-	goreleaser release --clean --timeout=60m --verbose --parallelism 2 --snapshot --skip docker,sbom,sign
+	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@latest release --clean --timeout=60m --verbose --parallelism 2 --snapshot --skip docker,sbom,sign
+
+.PHONY: goreleaser-check
+goreleaser-check:
+	@$(SED) 's/REPLACE_WITH_RELEASE_GOOS/linux/g' $(CURDIR)/.goreleaser-template.yaml > $(CURDIR)/.goreleaser.yaml
+	@$(SED) -i 's/^#LINUXONLY#//g' $(CURDIR)/.goreleaser.yaml
+	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@latest check


### PR DESCRIPTION
This also adds a new Makefile target, `goreleaser-check`, to validate the configuration is working.