### PR TITLE
Compute raft peer bootstrap challenge via HKDF (#690)

### DIFF
--- a/changelog/690.txt
+++ b/changelog/690.txt
@@ -1,0 +1,3 @@
+```release-note:security
+raft: Fix memory exhaustion when processing raft cluster join requests; results in longer challenge/answers. HCSEC-2024-26 / CVE-2024-8185.
+```

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/mapstructure"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/namespace"
@@ -21,7 +21,16 @@ import (
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	"golang.org/x/crypto/hkdf"
 )
+
+// Previously server_id was of unbounded size (capped by max_request_size);
+// because this value is persisted to disk, transited over the network, and
+// used in maps, it makes sense to have _some_ reasonable limit to this, so
+// that a moderate size cluster does not need have megabytes of memory
+// devoted to identifiers. Cap this at 2^14 which should exceed most
+// reasonable values.
+const maxServerIDLength = 1 << 14
 
 // raftStoragePaths returns paths for use when raft is the storage mechanism.
 func (b *SystemBackend) raftStoragePaths() []*framework.Path {
@@ -236,26 +245,49 @@ func (b *SystemBackend) handleRaftRemovePeerUpdate() framework.OperationFunc {
 	}
 }
 
+func (b *SystemBackend) getRaftBootstrapChallengeAnswer(serverID string) []byte {
+	// We take our local key and the given serverID and perform an HKDF
+	// invocation on it. This output is then encrypted using the root key
+	// (which protects our barrier keyring) and the remote peer can
+	// "prove" they're allowed to join by unsealing the challenge answer
+	// and providing it back to us. We assume inverting HKDF is hard (it
+	// is at least as hard as inverting an HMAC) and it is hard for an
+	// attacker to find (serverID, answer) such that:
+	//
+	//     HKDF(challengeKey, serverID) == answer
+	//
+	// The benefit of this is that we only need constant memory (a single
+	// root challenge key) and HKDF is fast and arbitrarily extensible.
+
+	kdf := hkdf.New(sha256.New, b.Core.pendingRaftPeerChallengeKey, []byte("openbao-raft-peer-challenge"), []byte(serverID))
+
+	// hkdf cannot fail on this short of output. While this value was
+	// previously 16 bytes, the root key is 32 bytes so 24 bytes provides
+	// increased safety while still retaining domain safety from the root
+	// key. For SHA-256, the maximum HKDF output is 255*32=8160 bytes.
+	//
+	// See e.g., https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/crypto/tls/key_schedule.go;l=66
+	// for examples where this panic pattern is also used.
+	var answer [24]byte
+	n, err := kdf.Read(answer[:])
+	if err != nil || n != 24 {
+		panic(fmt.Sprintf("hkdf failed on 24 bytes of output: %v", err))
+	}
+
+	return answer[:]
+}
+
 func (b *SystemBackend) handleRaftBootstrapChallengeWrite() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 		serverID := d.Get("server_id").(string)
 		if len(serverID) == 0 {
 			return logical.ErrorResponse("no server id provided"), logical.ErrInvalidRequest
 		}
-
-		var answer []byte
-		answerRaw, ok := b.Core.pendingRaftPeers.Load(serverID)
-		if !ok {
-			var err error
-			answer, err = uuid.GenerateRandomBytes(16)
-			if err != nil {
-				return nil, err
-			}
-			b.Core.pendingRaftPeers.Store(serverID, answer)
-		} else {
-			answer = answerRaw.([]byte)
+		if len(serverID) > maxServerIDLength {
+			return logical.ErrorResponse("server id exceeds max length"), logical.ErrInvalidRequest
 		}
 
+		answer := b.getRaftBootstrapChallengeAnswer(serverID)
 		sealAccess := b.Core.seal.GetAccess()
 
 		eBlob, err := sealAccess.Encrypt(ctx, answer, nil)
@@ -292,6 +324,9 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 		if len(serverID) == 0 {
 			return logical.ErrorResponse("no server_id provided"), logical.ErrInvalidRequest
 		}
+		if len(serverID) > 16384 {
+			return logical.ErrorResponse("server id exceeds max length"), logical.ErrInvalidRequest
+		}
 		answerRaw := d.Get("answer").(string)
 		if len(answerRaw) == 0 {
 			return logical.ErrorResponse("no answer provided"), logical.ErrInvalidRequest
@@ -308,14 +343,8 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 			return logical.ErrorResponse("could not base64 decode answer"), logical.ErrInvalidRequest
 		}
 
-		expectedAnswerRaw, ok := b.Core.pendingRaftPeers.Load(serverID)
-		if !ok {
-			return logical.ErrorResponse("no expected answer for the server id provided"), logical.ErrInvalidRequest
-		}
-
-		b.Core.pendingRaftPeers.Delete(serverID)
-
-		if subtle.ConstantTimeCompare(answer, expectedAnswerRaw.([]byte)) == 0 {
+		expectedAnswer := b.getRaftBootstrapChallengeAnswer(serverID)
+		if subtle.ConstantTimeCompare(answer, expectedAnswer) == 0 {
 			return logical.ErrorResponse("invalid answer given"), logical.ErrInvalidRequest
 		}
 

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -191,8 +191,6 @@ func (c *Core) setupRaftActiveNode(ctx context.Context) error {
 
 	raftBackend.SetupAutopilot(c.activeContext, autopilotConfig, c.raftFollowerStates, disableAutopilot)
 
-	c.pendingRaftPeers = &sync.Map{}
-
 	// Reload the raft TLS keys to ensure we are using the latest version.
 	if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {
 		return err
@@ -213,7 +211,6 @@ func (c *Core) stopRaftActiveNode() {
 		raftBackend.StopAutopilot()
 	}
 
-	c.pendingRaftPeers = nil
 	c.stopPeriodicRaftTLSRotate()
 }
 


### PR DESCRIPTION
* Compute raft peer bootstrap challenge via HKDF

Rather than storing a map of serverID->answer (and generating fully
random challenge answers), use HKDF on the serverID and a secret key
to create challenge answers using only a single constant-space key.
HKDF should be at least as fast as the underlying RNG source and this
ensures we do not incur any additional memory per request to this
un-authenticated endpoint.

See also: https://discuss.hashicorp.com/t/hcsec-2024-26-vault-vulnerable-to-denial-of-service-through-memory-exhaustion-when-processing-raft-cluster-join-requests/71047

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

* Add changelog entry

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

* Refactor limit to constant; clarify panic

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

---------

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>