### PR TITLE
Fix root namespace permission elevation (#695)

### DIFF
--- a/changelog/695.txt
+++ b/changelog/695.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/identity: fix root namespace privilege escalation via entity modification. HCSEC-2024-21 / CVE-2024-9180.
+```

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -925,7 +925,7 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 					}
 
 					// Fetch the associated entity and add the alias to that too.
-					entity, err := i.MemDBEntityByIDInTxn(txn, alias.CanonicalID, false)
+					entity, err := i.MemDBEntityByIDInTxn(txn, alias.CanonicalID, true)
 					if err != nil {
 						i.logger.Error("failed to fetch entity during local alias invalidation", "error", err)
 						return

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -329,7 +329,7 @@ func (i *IdentityStore) handleEntityUpdateCommon() framework.OperationFunc {
 		// Get the name
 		entityName := d.Get("name").(string)
 		if entityName != "" {
-			entityByName, err := i.MemDBEntityByName(ctx, entityName, false)
+			entityByName, err := i.MemDBEntityByName(ctx, entityName, true)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
* Clone entity on modifications

When modifying an entity, ensure we clone the MemDB copy so that we do
not accidentally modify the value stored in the underlying MemDB. This
ensures we can use it as a staging area and only persist changes on
explicit upsert.

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

* Clone entity on invalidations

While the invalidation should only be triggered when storage is
writable, if we have an alias invalidation on an entity, we should
only modify the in-memory entity on upsert, not when the alias is
added to the entity. This ensures failures to upsert do not cause a
modified entity to be present in memory.

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

* Add changelog entry

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

---------

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>