### PR TITLE
Update goreleaser config version to 2 (#709)

### DIFF
--- a/.goreleaser-template.yaml
+++ b/.goreleaser-template.yaml
@@ -6,6 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
+version: 2
+
 project_name: bao
 
 before:

--- a/Makefile
+++ b/Makefile
@@ -350,3 +350,19 @@ release-changelog: $(wildcard changelog/*.txt)
 	@:$(if $(LAST_RELEASE),,$(error please set the LAST_RELEASE environment variable for changelog generation))
 	@:$(if $(THIS_RELEASE),,$(error please set the THIS_RELEASE environment variable for changelog generation))
 	changelog-build -changelog-template changelog/changelog.tmpl -entries-dir changelog -git-dir . -note-template changelog/note.tmpl -last-release $(LAST_RELEASE) -this-release $(THIS_RELEASE)
+
+.PHONY: dev-gorelease
+dev-gorelease: export GORELEASER_PREVIOUS_TAG := $(shell git describe --tags --exclude "api/*" --exclude "sdk/*" --abbrev=0)
+dev-gorelease: export GORELEASER_CURRENT_TAG := $(shell git describe --tags --exclude "api/*" --exclude "sdk/*" )
+dev-gorelease: export GPG_KEY_FILE := /dev/null
+dev-gorelease:
+	@echo GORELEASER_CURRENT_TAG: $(GORELEASER_CURRENT_TAG)
+	@$(SED) 's/REPLACE_WITH_RELEASE_GOOS/linux/g' $(CURDIR)/.goreleaser-template.yaml > $(CURDIR)/.goreleaser.yaml
+	@$(SED) -i 's/^#LINUXONLY#//g' $(CURDIR)/.goreleaser.yaml
+	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@latest release --clean --timeout=60m --verbose --parallelism 2 --snapshot --skip docker,sbom,sign
+
+.PHONY: goreleaser-check
+goreleaser-check:
+	@$(SED) 's/REPLACE_WITH_RELEASE_GOOS/linux/g' $(CURDIR)/.goreleaser-template.yaml > $(CURDIR)/.goreleaser.yaml
+	@$(SED) -i 's/^#LINUXONLY#//g' $(CURDIR)/.goreleaser.yaml
+	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@latest check


### PR DESCRIPTION
This also adds a new Makefile target, `goreleaser-check`, to validate
the configuration is working.

Signed-off-by: Alexander Scheel <ascheel@gitlab.com>