### PR TITLE
PKI: clarify usage of set-signed command

### DIFF
--- a/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
+++ b/website/content/docs/secrets/pki/quick-start-intermediate-ca.mdx
@@ -109,10 +109,11 @@ serial_number   10:dc:50:0f:b2:88:26:2d:73:13:f8:c4:89:8a:80:1b:55:42:e0:dc
 ```
 
 Now set the intermediate certificate authorities signing certificate to the
-root-signed certificate.
+root-signed certificate. You may pass a bundle of PEM-encoded certificates,
+for example the complete certificate chain.
 
 ```shell-session
-$ bao write pki_int/intermediate/set-signed certificate=@signed_certificate.pem
+$ bao write pki_int/intermediate/set-signed certificate=@cert_bundle.pem
 Success! Data written to: pki_int/intermediate/set-signed
 ```
 


### PR DESCRIPTION
Not only a single certificate, but a bundle of PEM-encoded certificates may be passed

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

2.1.1
