### PR TITLE
Update website metadata

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import path from "path";
 
 const config: Config = {
   title: "OpenBao",
-  tagline: "Manage, store, and distribute sensitive data",
+  tagline: "OpenBao is an open source, community-driven fork of HashiCorp Vault managed by the Linux Foundation to manage, store, and distribute sensitive data.",
   favicon: "img/favicon.svg",
 
   // Set the production url of your site here
@@ -177,6 +177,22 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
       additionalLanguages: ["hcl"],
     },
+    metadata: [
+      {name: 'keywords', content: 'openbao, secrets management, open source, linux foundation, encryption as a service, key management system, pki, transit, ssh, secret vault, database passwords'},
+      {name: 'author', content: 'OpenBao a Series of LF Projects, LLC'},
+      {name: 'twitter:card', content: 'summary_large_image'},
+    ],
+    headTags: [
+      {
+        tagName: 'link',
+        attributes: {
+          rel: 'sitemap',
+          type: 'application/xml',
+          title: 'Sitemap',
+          href: '/sitemap.xml',
+        },
+      },
+    ],
   } satisfies Preset.ThemeConfig,
 };
 

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://openbao.org/sitemap.xml

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -26,7 +26,7 @@ function HomepageHeader() {
               }}
             />
             <Heading as="h1" className="hero__title">
-              {siteConfig.tagline} with {siteConfig.title}
+              Manage, store, and distribute sensitive data with OpenBao
             </Heading>
             <p className="hero__subtitle">
               {siteConfig.title} is an open source, community-driven fork of Vault


### PR DESCRIPTION
This updates various website metadata and adds a robots.txt to link the sitemap to hopefully make it more visible to search engines. 

Sadly I don't think the `<link rel="sitemap" ... />` is actually working though: https://docusaurus.io/docs/api/docusaurus-config#headTags 