### PR TITLE
Allow listing prefixed policies

### DIFF
--- a/changelog/736.txt
+++ b/changelog/736.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/policies: Allow listing policies under a given prefix.
+```

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3745,6 +3745,23 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 					Summary: "Retrieve the policy body for the named policy.",
 				},
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+								"policies": {
+									Type: framework.TypeStringSlice,
+								},
+							},
+						}},
+					},
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handlePoliciesSet(PolicyTypeACL),
 					Responses: map[int][]framework.Response{
@@ -3845,6 +3862,23 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 						}},
 					},
 					Summary: "Retrieve information about the named ACL policy.",
+				},
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+								"policies": {
+									Type: framework.TypeStringSlice,
+								},
+							},
+						}},
+					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handlePoliciesSet(PolicyTypeACL),

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -488,6 +488,10 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 
 // ListPolicies is used to list the available policies
 func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType PolicyType) ([]string, error) {
+	return ps.ListPoliciesWithPrefix(ctx, policyType, "")
+}
+
+func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType PolicyType, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"policy", "list_policies"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -509,7 +513,7 @@ func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType PolicyType) 
 	var keys []string
 	switch policyType {
 	case PolicyTypeACL:
-		keys, err = logical.CollectKeys(ctx, view)
+		keys, err = logical.CollectKeysWithPrefix(ctx, view, prefix)
 	default:
 		return nil, fmt.Errorf("unknown policy type %q", policyType)
 	}

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -10,11 +10,13 @@ The `/sys/policies` endpoints are used to manage ACL, RGP, and EGP policies in O
 
 ## List ACL policies
 
-This endpoint lists all configured ACL policies.
+This endpoint lists all configured ACL policies. This endpoint optionally
+takes a prefix to list policies under.
 
-| Method | Path                |
-| :----- | :------------------ |
-| `LIST` | `/sys/policies/acl` |
+| Method | Path                        |
+| :----- | :-------------------------- |
+| `LIST` | `/sys/policies/acl`         |
+| `LIST` | `/sys/policies/acl/:prefix` |
 
 ### Sample request
 

--- a/website/content/api-docs/system/policy.mdx
+++ b/website/content/api-docs/system/policy.mdx
@@ -8,11 +8,13 @@ The `/sys/policy` endpoint is used to manage ACL policies in OpenBao.
 
 ## List policies
 
-This endpoint lists all configured policies.
+This endpoint lists all configured policies. This endpoint optionally takes a
+prefix to list policies under.
 
-| Method | Path          |
-| :----- | :------------ |
-| `GET`  | `/sys/policy` |
+| Method  | Path                  |
+| :------ | :-------------------- |
+| `GET`   | `/sys/policy`         |
+| `LIST`  | `/sys/policy/:prefix` |
 
 ### Sample request
 


### PR DESCRIPTION
The `sys/policies/acl/*` paths allow arbitrary structuring of policies into paths, e.g., `a/b` and `a/c` may exist. Using path prefixes are useful e.g., when structuring policies into pipelines or projects or tenants. However, policy listing was not capable of only listing policies under a given prefix. So results for `d/e`, `default`, and `root` would also be returned, even if only policies under `a/` were desired by the caller.

Support list operations on prefixes to allow callers to view policies only under some root prefix.