### PR TITLE
Allow Nodes to Join the Raft Cluster as Non-Voters

### DIFF
--- a/changelog/741.txt
+++ b/changelog/741.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+raft: Added support for nodes to join the Raft cluster as non-voters.
+```

--- a/command/operator_raft_join.go
+++ b/command/operator_raft_join.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -18,6 +19,7 @@ var (
 )
 
 type OperatorRaftJoinCommand struct {
+	flagNonVoter         bool
 	flagRetry            bool
 	flagLeaderCACert     string
 	flagLeaderClientCert string
@@ -113,6 +115,13 @@ func (c *OperatorRaftJoinCommand) Flags() *FlagSets {
 		Usage:   "Continuously retry joining the Raft cluster upon failures.",
 	})
 
+	f.BoolVar(&BoolVar{
+		Name:    "non-voter",
+		Target:  &c.flagNonVoter,
+		Default: false,
+		Usage:   "Join the Raft cluster as non-voter.",
+	})
+
 	return set
 }
 
@@ -179,6 +188,7 @@ func (c *OperatorRaftJoinCommand) Run(args []string) int {
 		LeaderClientCert: leaderClientCert,
 		LeaderClientKey:  leaderClientKey,
 		Retry:            c.flagRetry,
+		NonVoter:         c.flagNonVoter,
 	}
 
 	if strings.Contains(leaderInfo, "provider=") {

--- a/http/util.go
+++ b/http/util.go
@@ -33,7 +33,7 @@ var (
 
 	additionalRoutes = func(mux *http.ServeMux, core *vault.Core) {}
 
-	nonVotersAllowed = false
+	nonVotersAllowed = true
 
 	adjustResponse = func(core *vault.Core, w http.ResponseWriter, req *logical.Request) {}
 )

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -52,6 +53,9 @@ const (
 	// EnvVaultRaftNonVoter is used to override the non_voter config option, telling Vault to join as a non-voter (i.e. read replica).
 	EnvVaultRaftNonVoter  = "BAO_RAFT_RETRY_JOIN_AS_NON_VOTER"
 	raftNonVoterConfigKey = "retry_join_as_non_voter"
+
+	// NodeNonVoter is a custom node type for non-voters
+	NodeNonVoter = autopilot.NodeType("non-voter")
 )
 
 var getMmapFlags = func(string) int { return 0 }
@@ -155,6 +159,10 @@ type RaftBackend struct {
 	// autopilot features. This will be instantiated in both leader and followers.
 	// However, only active node will have a "running" autopilot.
 	autopilot *autopilot.Autopilot
+
+	// delegate is the autopilot delegate that will be used to interact with the
+	// autopilot library.
+	delegate *Delegate
 
 	// autopilotConfig represents the configuration required to instantiate autopilot.
 	autopilotConfig *AutopilotConfig
@@ -990,14 +998,6 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 			return fmt.Errorf("raft recovery failed to parse peers.json: %w", err)
 		}
 
-		// Non-voting servers are only allowed in enterprise. If Suffrage is disabled,
-		// error out to indicate that it isn't allowed.
-		for idx := range recoveryConfig.Servers {
-			if recoveryConfig.Servers[idx].Suffrage == raft.Nonvoter {
-				return fmt.Errorf("raft recovery failed to parse configuration for node %q: setting `non_voter` not supported in OpenBao", recoveryConfig.Servers[idx].ID)
-			}
-		}
-
 		b.logger.Info("raft recovery found new config", "config", recoveryConfig)
 
 		err = raft.RecoverCluster(raftConfig, b.fsm, b.logStore, b.stableStore, b.snapStore, b.raftTransport, recoveryConfig)
@@ -1309,7 +1309,7 @@ func (b *RaftBackend) GetConfiguration(ctx context.Context) (*RaftConfigurationR
 }
 
 // AddPeer adds a new server to the raft cluster
-func (b *RaftBackend) AddPeer(ctx context.Context, peerID, clusterAddr string) error {
+func (b *RaftBackend) AddPeer(ctx context.Context, peerID, clusterAddr string, voter bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -1322,7 +1322,13 @@ func (b *RaftBackend) AddPeer(ctx context.Context, peerID, clusterAddr string) e
 			return errors.New("raft storage is not initialized")
 		}
 		b.logger.Trace("adding server to raft", "id", peerID)
-		future := b.raft.AddVoter(raft.ServerID(peerID), raft.ServerAddress(clusterAddr), 0, 0)
+		var future raft.IndexFuture
+		if voter {
+			future = b.raft.AddVoter(raft.ServerID(peerID), raft.ServerAddress(clusterAddr), 0, 0)
+		} else {
+			future = b.raft.AddNonvoter(raft.ServerID(peerID), raft.ServerAddress(clusterAddr), 0, 0)
+		}
+
 		return future.Error()
 	}
 
@@ -1330,13 +1336,27 @@ func (b *RaftBackend) AddPeer(ctx context.Context, peerID, clusterAddr string) e
 		return errors.New("raft storage autopilot is not initialized")
 	}
 
-	b.logger.Trace("adding server to raft via autopilot", "id", peerID)
+	var nodeType autopilot.NodeType
+	if voter {
+		nodeType = autopilot.NodeVoter
+	} else {
+		nodeType = NodeNonVoter
+	}
+
+	b.logger.Debug("adding server to raft via autopilot", "id", peerID)
+	if !voter {
+		b.logger.Debug("adding non-voter to raft via autopilot", "id", peerID)
+		err := b.delegate.AddNonVoter(raft.ServerID(peerID))
+		if err != nil {
+			return err
+		}
+	}
 	return b.autopilot.AddServer(&autopilot.Server{
 		ID:          raft.ServerID(peerID),
 		Name:        peerID,
 		Address:     raft.ServerAddress(clusterAddr),
 		RaftVersion: raft.ProtocolVersionMax,
-		NodeType:    autopilot.NodeVoter,
+		NodeType:    nodeType,
 	})
 }
 

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -473,6 +473,7 @@ func autopilotToAPIState(state *autopilot.State) (*AutopilotState, error) {
 		FailureTolerance: state.FailureTolerance,
 		Leader:           string(state.Leader),
 		Voters:           stringIDs(state.Voters),
+		NonVoters:        []string{},
 		Servers:          make(map[string]*AutopilotServer),
 	}
 
@@ -482,6 +483,10 @@ func autopilotToAPIState(state *autopilot.State) (*AutopilotState, error) {
 			return nil, err
 		}
 		out.Servers[string(id)] = aps
+
+		if aps.NodeType == "non-voter" {
+			out.NonVoters = append(out.NonVoters, string(id))
+		}
 	}
 
 	return out, nil

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -15,7 +16,6 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/mitchellh/mapstructure"
@@ -29,6 +29,9 @@ const (
 	CleanupDeadServersUnset CleanupDeadServersValue = 0
 	CleanupDeadServersTrue  CleanupDeadServersValue = 1
 	CleanupDeadServersFalse CleanupDeadServersValue = 2
+
+	// NonVoterPath is the path to the non-voters in the storage.
+	NonVoterPath = "autopilot/non-voters"
 )
 
 func (c CleanupDeadServersValue) Value() bool {
@@ -251,236 +254,6 @@ func (s *FollowerStates) MinIndex() uint64 {
 	}
 
 	return min
-}
-
-// Ensure that the Delegate implements the ApplicationIntegration interface
-var _ autopilot.ApplicationIntegration = (*Delegate)(nil)
-
-// Delegate is an implementation of autopilot.ApplicationIntegration interface.
-// This is used by the autopilot library to retrieve information and to have
-// application specific tasks performed.
-type Delegate struct {
-	*RaftBackend
-
-	// dl is a lock dedicated for guarding delegate's fields
-	dl               sync.RWMutex
-	inflightRemovals map[raft.ServerID]bool
-	emptyVersionLogs map[raft.ServerID]struct{}
-}
-
-func NewDelegate(b *RaftBackend) *Delegate {
-	return &Delegate{
-		RaftBackend:      b,
-		inflightRemovals: make(map[raft.ServerID]bool),
-		emptyVersionLogs: make(map[raft.ServerID]struct{}),
-	}
-}
-
-// AutopilotConfig is called by the autopilot library to know the desired
-// autopilot configuration.
-func (d *Delegate) AutopilotConfig() *autopilot.Config {
-	d.l.RLock()
-	config := &autopilot.Config{
-		CleanupDeadServers:      d.autopilotConfig.CleanupDeadServers,
-		LastContactThreshold:    d.autopilotConfig.LastContactThreshold,
-		MaxTrailingLogs:         d.autopilotConfig.MaxTrailingLogs,
-		MinQuorum:               d.autopilotConfig.MinQuorum,
-		ServerStabilizationTime: d.autopilotConfig.ServerStabilizationTime,
-		Ext:                     nil,
-	}
-	d.l.RUnlock()
-	return config
-}
-
-// NotifyState is called by the autopilot library whenever there is a state
-// change. We update a few metrics when this happens.
-func (d *Delegate) NotifyState(state *autopilot.State) {
-	if d.raft.State() == raft.Leader {
-		metrics.SetGauge([]string{"autopilot", "failure_tolerance"}, float32(state.FailureTolerance))
-		if state.Healthy {
-			metrics.SetGauge([]string{"autopilot", "healthy"}, 1)
-		} else {
-			metrics.SetGauge([]string{"autopilot", "healthy"}, 0)
-		}
-
-		for id, state := range state.Servers {
-			labels := []metrics.Label{
-				{
-					Name:  "node_id",
-					Value: string(id),
-				},
-			}
-			if state.Health.Healthy {
-				metrics.SetGaugeWithLabels([]string{"autopilot", "node", "healthy"}, 1, labels)
-			} else {
-				metrics.SetGaugeWithLabels([]string{"autopilot", "node", "healthy"}, 0, labels)
-			}
-		}
-	}
-}
-
-// FetchServerStats is called by the autopilot library to retrieve information
-// about all the nodes in the raft cluster.
-func (d *Delegate) FetchServerStats(ctx context.Context, servers map[raft.ServerID]*autopilot.Server) map[raft.ServerID]*autopilot.ServerStats {
-	ret := make(map[raft.ServerID]*autopilot.ServerStats)
-
-	d.l.RLock()
-	followerStates := d.followerStates
-	d.l.RUnlock()
-
-	followerStates.l.RLock()
-	defer followerStates.l.RUnlock()
-
-	now := time.Now()
-	for id, followerState := range followerStates.followers {
-		ret[raft.ServerID(id)] = &autopilot.ServerStats{
-			LastContact: now.Sub(followerState.LastHeartbeat),
-			LastTerm:    followerState.LastTerm,
-			LastIndex:   followerState.AppliedIndex,
-		}
-	}
-
-	leaderState, _ := d.fsm.LatestState()
-	ret[raft.ServerID(d.localID)] = &autopilot.ServerStats{
-		LastTerm:  leaderState.Term,
-		LastIndex: leaderState.Index,
-	}
-
-	return ret
-}
-
-// KnownServers is called by the autopilot library to know the status of each
-// node in the raft cluster. If the application thinks that certain nodes left,
-// it is here that we let the autopilot library know of the same.
-func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
-	d.l.RLock()
-	defer d.l.RUnlock()
-	future := d.raft.GetConfiguration()
-	if err := future.Error(); err != nil {
-		d.logger.Error("failed to get raft configuration when computing known servers", "error", err)
-		return nil
-	}
-
-	apServerStates := d.autopilot.GetState().Servers
-	servers := future.Configuration().Servers
-	serverIDs := make([]string, 0, len(servers))
-	for _, server := range servers {
-		serverIDs = append(serverIDs, string(server.ID))
-	}
-
-	d.followerStates.l.RLock()
-	defer d.followerStates.l.RUnlock()
-
-	ret := make(map[raft.ServerID]*autopilot.Server)
-	for id, state := range d.followerStates.followers {
-		// If the server is not in raft configuration, even if we received a follower
-		// heartbeat, it shouldn't be a known server for autopilot.
-		if !strutil.StrListContains(serverIDs, id) {
-			continue
-		}
-
-		// If version isn't found in the state, fake it using the version from the leader so that autopilot
-		// doesn't demote the node to a non-voter, just because of a missed heartbeat.
-		currentServerID := raft.ServerID(id)
-		followerVersion := state.Version
-		leaderVersion := d.effectiveSDKVersion
-		d.dl.Lock()
-		if followerVersion == "" {
-			if _, ok := d.emptyVersionLogs[currentServerID]; !ok {
-				d.logger.Trace("received empty Vault version in heartbeat state. faking it with the leader version for now", "id", id, "leader version", leaderVersion)
-				d.emptyVersionLogs[currentServerID] = struct{}{}
-			}
-			followerVersion = leaderVersion
-		} else {
-			delete(d.emptyVersionLogs, currentServerID)
-		}
-		d.dl.Unlock()
-
-		server := &autopilot.Server{
-			ID:          currentServerID,
-			Name:        id,
-			RaftVersion: raft.ProtocolVersionMax,
-			Meta:        nil,
-			Version:     followerVersion,
-			Ext:         nil,
-		}
-
-		// As KnownServers is a delegate called by autopilot let's check if we already
-		// had this data in the correct format and use it. If we don't (which sounds a
-		// bit sad, unless this ISN'T a voter) then as a fail-safe, let's try what we've
-		// done elsewhere in code to check the desired suffrage and manually set NodeType
-		// based on whether that's a voter or not. If we don't  do either of these
-		// things, NodeType isn't set which means technically it's not a voter.
-		// It shouldn't be a voter and end up in this state.
-		if apServerState, found := apServerStates[raft.ServerID(id)]; found && apServerState.Server.NodeType != "" {
-			server.NodeType = apServerState.Server.NodeType
-		} else if state.DesiredSuffrage == "voter" {
-			server.NodeType = autopilot.NodeVoter
-		}
-
-		switch state.IsDead.Load() {
-		case true:
-			d.logger.Debug("informing autopilot that the node left", "id", id)
-			server.NodeStatus = autopilot.NodeLeft
-		default:
-			server.NodeStatus = autopilot.NodeAlive
-		}
-
-		ret[raft.ServerID(id)] = server
-	}
-
-	// Add the leader
-	ret[raft.ServerID(d.localID)] = &autopilot.Server{
-		ID:          raft.ServerID(d.localID),
-		Name:        d.localID,
-		RaftVersion: raft.ProtocolVersionMax,
-		NodeStatus:  autopilot.NodeAlive,
-		NodeType:    autopilot.NodeVoter, // The leader must be a voter
-		Meta:        nil,
-		Version:     d.effectiveSDKVersion,
-		Ext:         nil,
-		IsLeader:    true,
-	}
-
-	return ret
-}
-
-// RemoveFailedServer is called by the autopilot library when it desires a node
-// to be removed from the raft configuration. This function removes the node
-// from the raft cluster and stops tracking its information in follower states.
-// This function needs to return quickly. Hence removal is performed in a
-// goroutine.
-func (d *Delegate) RemoveFailedServer(server *autopilot.Server) {
-	go func() {
-		added := false
-		defer func() {
-			if added {
-				d.dl.Lock()
-				delete(d.inflightRemovals, server.ID)
-				d.dl.Unlock()
-			}
-		}()
-
-		d.dl.Lock()
-		_, ok := d.inflightRemovals[server.ID]
-		if ok {
-			d.logger.Info("removal of dead server is already initiated", "id", server.ID)
-			d.dl.Unlock()
-			return
-		}
-
-		added = true
-		d.inflightRemovals[server.ID] = true
-		d.dl.Unlock()
-
-		d.logger.Info("removing dead server from raft configuration", "id", server.ID)
-		if future := d.raft.RemoveServer(server.ID, 0, 0); future.Error() != nil {
-			d.logger.Error("failed to remove server", "server_id", server.ID, "server_address", server.Address, "server_name", server.Name, "error", future.Error())
-			return
-		}
-
-		d.followerStates.Delete(string(server.ID))
-	}()
 }
 
 // SetFollowerStates sets the followerStates field in the backend to track peers
@@ -781,10 +554,13 @@ func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *Autopil
 	// Merge the setting provided over the API
 	b.autopilotConfig.Merge(storageConfig)
 
+	// Create the autopilot delegate
+	b.delegate = NewDelegate(b)
+
 	// Create the autopilot instance
 	options := []autopilot.Option{
 		autopilot.WithLogger(b.logger),
-		autopilot.WithPromoter(autopilot.DefaultPromoter()),
+		autopilot.WithPromoter(&CustomPromoter{}),
 	}
 	if b.autopilotReconcileInterval != 0 {
 		options = append(options, autopilot.WithReconcileInterval(b.autopilotReconcileInterval))
@@ -792,7 +568,7 @@ func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *Autopil
 	if b.autopilotUpdateInterval != 0 {
 		options = append(options, autopilot.WithUpdateInterval(b.autopilotUpdateInterval))
 	}
-	b.autopilot = autopilot.New(b.raft, NewDelegate(b), options...)
+	b.autopilot = autopilot.New(b.raft, b.delegate, options...)
 	b.followerStates = followerStates
 	b.followerHeartbeatTicker = time.NewTicker(1 * time.Second)
 

--- a/physical/raft/raft_autopilot_delegate.go
+++ b/physical/raft/raft_autopilot_delegate.go
@@ -1,0 +1,354 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+// Ensure that the Delegate implements the ApplicationIntegration interface
+var _ autopilot.ApplicationIntegration = (*Delegate)(nil)
+
+// Delegate is an implementation of autopilot.ApplicationIntegration interface.
+// This is used by the autopilot library to retrieve information and to have
+// application specific tasks performed.
+type Delegate struct {
+	*RaftBackend
+
+	// dl is a lock dedicated for guarding delegate's fields
+	dl               sync.RWMutex
+	inflightRemovals map[raft.ServerID]bool
+	emptyVersionLogs map[raft.ServerID]struct{}
+	// added in OpenBao 2.2 to support permanent non-voters
+	permanentNonVoters map[raft.ServerID]bool
+}
+
+func NewDelegate(b *RaftBackend) *Delegate {
+	return &Delegate{
+		RaftBackend:        b,
+		inflightRemovals:   make(map[raft.ServerID]bool),
+		emptyVersionLogs:   make(map[raft.ServerID]struct{}),
+		permanentNonVoters: make(map[raft.ServerID]bool),
+	}
+}
+
+// AutopilotConfig is called by the autopilot library to know the desired
+// autopilot configuration.
+func (d *Delegate) AutopilotConfig() *autopilot.Config {
+	// Always fetch non-voters before returning the config
+	err := d.FetchNonVoters()
+	if err != nil {
+		d.logger.Error("failed to fetch non-voters", "error", err)
+	}
+	// Get read lock for autopilot config
+	d.l.RLock()
+	defer d.l.RUnlock()
+	// Get read lock for delegate's fields
+	d.dl.RLock()
+	defer d.dl.RUnlock()
+	config := &autopilot.Config{
+		CleanupDeadServers:      d.autopilotConfig.CleanupDeadServers,
+		LastContactThreshold:    d.autopilotConfig.LastContactThreshold,
+		MaxTrailingLogs:         d.autopilotConfig.MaxTrailingLogs,
+		MinQuorum:               d.autopilotConfig.MinQuorum,
+		ServerStabilizationTime: d.autopilotConfig.ServerStabilizationTime,
+		Ext:                     d.permanentNonVoters,
+	}
+	return config
+}
+
+// NotifyState is called by the autopilot library whenever there is a state
+// change. We update a few metrics when this happens.
+func (d *Delegate) NotifyState(state *autopilot.State) {
+	if d.raft.State() == raft.Leader {
+		metrics.SetGauge([]string{"autopilot", "failure_tolerance"}, float32(state.FailureTolerance))
+		if state.Healthy {
+			metrics.SetGauge([]string{"autopilot", "healthy"}, 1)
+		} else {
+			metrics.SetGauge([]string{"autopilot", "healthy"}, 0)
+		}
+
+		for id, state := range state.Servers {
+			labels := []metrics.Label{
+				{
+					Name:  "node_id",
+					Value: string(id),
+				},
+			}
+			if state.Health.Healthy {
+				metrics.SetGaugeWithLabels([]string{"autopilot", "node", "healthy"}, 1, labels)
+			} else {
+				metrics.SetGaugeWithLabels([]string{"autopilot", "node", "healthy"}, 0, labels)
+			}
+		}
+	}
+}
+
+// FetchServerStats is called by the autopilot library to retrieve information
+// about all the nodes in the raft cluster.
+func (d *Delegate) FetchServerStats(ctx context.Context, servers map[raft.ServerID]*autopilot.Server) map[raft.ServerID]*autopilot.ServerStats {
+	ret := make(map[raft.ServerID]*autopilot.ServerStats)
+
+	d.l.RLock()
+	followerStates := d.followerStates
+	d.l.RUnlock()
+
+	followerStates.l.RLock()
+	defer followerStates.l.RUnlock()
+
+	now := time.Now()
+	for id, followerState := range followerStates.followers {
+		ret[raft.ServerID(id)] = &autopilot.ServerStats{
+			LastContact: now.Sub(followerState.LastHeartbeat),
+			LastTerm:    followerState.LastTerm,
+			LastIndex:   followerState.AppliedIndex,
+		}
+	}
+
+	leaderState, _ := d.fsm.LatestState()
+	ret[raft.ServerID(d.localID)] = &autopilot.ServerStats{
+		LastTerm:  leaderState.Term,
+		LastIndex: leaderState.Index,
+	}
+
+	return ret
+}
+
+// KnownServers is called by the autopilot library to know the status of each
+// node in the raft cluster. If the application thinks that certain nodes left,
+// it is here that we let the autopilot library know of the same.
+func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
+	d.l.RLock()
+	defer d.l.RUnlock()
+	future := d.raft.GetConfiguration()
+	if err := future.Error(); err != nil {
+		d.logger.Error("failed to get raft configuration when computing known servers", "error", err)
+		return nil
+	}
+
+	apServerStates := d.autopilot.GetState().Servers
+	servers := future.Configuration().Servers
+	serverIDs := make([]string, 0, len(servers))
+	for _, server := range servers {
+		serverIDs = append(serverIDs, string(server.ID))
+	}
+
+	d.followerStates.l.RLock()
+	defer d.followerStates.l.RUnlock()
+
+	ret := make(map[raft.ServerID]*autopilot.Server)
+	for id, state := range d.followerStates.followers {
+		// If the server is not in raft configuration, even if we received a follower
+		// heartbeat, it shouldn't be a known server for autopilot.
+		if !strutil.StrListContains(serverIDs, id) {
+			continue
+		}
+
+		// If version isn't found in the state, fake it using the version from the leader so that autopilot
+		// doesn't demote the node to a non-voter, just because of a missed heartbeat.
+		currentServerID := raft.ServerID(id)
+		followerVersion := state.Version
+		leaderVersion := d.effectiveSDKVersion
+		d.dl.Lock()
+		if followerVersion == "" {
+			if _, ok := d.emptyVersionLogs[currentServerID]; !ok {
+				d.logger.Trace("received empty Vault version in heartbeat state. faking it with the leader version for now", "id", id, "leader version", leaderVersion)
+				d.emptyVersionLogs[currentServerID] = struct{}{}
+			}
+			followerVersion = leaderVersion
+		} else {
+			delete(d.emptyVersionLogs, currentServerID)
+		}
+		d.dl.Unlock()
+
+		server := &autopilot.Server{
+			ID:          currentServerID,
+			Name:        id,
+			RaftVersion: raft.ProtocolVersionMax,
+			Meta:        nil,
+			Version:     followerVersion,
+			Ext:         nil,
+		}
+
+		// As KnownServers is a delegate called by autopilot let's check if we already
+		// had this data in the correct format and use it. If we don't (which sounds a
+		// bit sad, unless this ISN'T a voter) then as a fail-safe, let's try what we've
+		// done elsewhere in code to check the desired suffrage and manually set NodeType
+		// based on whether that's a voter or not. If we don't  do either of these
+		// things, NodeType isn't set which means technically it's not a voter.
+		// It shouldn't be a voter and end up in this state.
+		if apServerState, found := apServerStates[raft.ServerID(id)]; found && apServerState.Server.NodeType != "" {
+			server.NodeType = apServerState.Server.NodeType
+		} else if d.IsNonVoter(raft.ServerID(id)) {
+			server.NodeType = NodeNonVoter
+		} else if state.DesiredSuffrage == "voter" {
+			server.NodeType = autopilot.NodeVoter
+		}
+
+		switch state.IsDead.Load() {
+		case true:
+			d.logger.Debug("informing autopilot that the node left", "id", id)
+			server.NodeStatus = autopilot.NodeLeft
+		default:
+			server.NodeStatus = autopilot.NodeAlive
+		}
+
+		ret[raft.ServerID(id)] = server
+	}
+
+	// Add the leader
+	ret[raft.ServerID(d.localID)] = &autopilot.Server{
+		ID:          raft.ServerID(d.localID),
+		Name:        d.localID,
+		RaftVersion: raft.ProtocolVersionMax,
+		NodeStatus:  autopilot.NodeAlive,
+		NodeType:    autopilot.NodeVoter, // The leader must be a voter
+		Meta:        nil,
+		Version:     d.effectiveSDKVersion,
+		Ext:         nil,
+		IsLeader:    true,
+	}
+
+	return ret
+}
+
+// RemoveFailedServer is called by the autopilot library when it desires a node
+// to be removed from the raft configuration. This function removes the node
+// from the raft cluster and stops tracking its information in follower states.
+// This function needs to return quickly. Hence removal is performed in a
+// goroutine.
+func (d *Delegate) RemoveFailedServer(server *autopilot.Server) {
+	go func() {
+		added := false
+		defer func() {
+			if added {
+				d.dl.Lock()
+				delete(d.inflightRemovals, server.ID)
+				d.dl.Unlock()
+			}
+		}()
+
+		d.dl.Lock()
+		_, ok := d.inflightRemovals[server.ID]
+		if ok {
+			d.logger.Info("removal of dead server is already initiated", "id", server.ID)
+			d.dl.Unlock()
+			return
+		}
+
+		added = true
+		d.inflightRemovals[server.ID] = true
+		d.dl.Unlock()
+
+		d.logger.Info("removing dead server from raft configuration", "id", server.ID)
+		if future := d.raft.RemoveServer(server.ID, 0, 0); future.Error() != nil {
+			d.logger.Error("failed to remove server", "server_id", server.ID, "server_address", server.Address, "server_name", server.Name, "error", future.Error())
+			return
+		}
+
+		// remove failed server from non-voters
+		err := d.RemoveNonVoter(server.ID)
+		if err != nil {
+			d.logger.Error("failed to remove server from non-voters", "server_id", server.ID, "error", err)
+		}
+		d.followerStates.Delete(string(server.ID))
+	}()
+}
+
+// AddNonVoter mark a node as permanent non-voter
+func (d *Delegate) AddNonVoter(id raft.ServerID) error {
+	d.dl.Lock()
+	d.permanentNonVoters[id] = true
+	d.dl.Unlock()
+
+	return d.StoreNonVoters()
+}
+
+// IsNonVoter check if a node is a permanent non-voter
+func (d *Delegate) IsNonVoter(id raft.ServerID) bool {
+	d.dl.RLock()
+	defer d.dl.RUnlock()
+	if _, ok := d.permanentNonVoters[id]; ok {
+		return ok
+	}
+	return false
+}
+
+// RemoveNonVoter remove a node from permanent non-voter list
+func (d *Delegate) RemoveNonVoter(id raft.ServerID) error {
+	d.dl.Lock()
+	delete(d.permanentNonVoters, id)
+	d.dl.Unlock()
+
+	return d.StoreNonVoters()
+}
+
+// NonVoters returns the list of permanent non-voters
+func (d *Delegate) NonVoters() []raft.ServerID {
+	d.dl.RLock()
+	defer d.dl.RUnlock()
+	nonVoters := make([]raft.ServerID, 0, len(d.permanentNonVoters))
+	for id := range d.permanentNonVoters {
+		nonVoters = append(nonVoters, id)
+	}
+	return nonVoters
+}
+
+// StoreNonVoters stores the permanent non-voters in the physical store
+func (d *Delegate) StoreNonVoters() error {
+	d.dl.RLock()
+	defer d.dl.RUnlock()
+	d.logger.Debug("updating non-voters", "non_voters", d.permanentNonVoters)
+	v, err := json.Marshal(d.permanentNonVoters)
+	if err != nil {
+		return err
+	}
+	e := physical.Entry{
+		Key:   NonVoterPath,
+		Value: v,
+	}
+
+	return d.Put(context.Background(), &e)
+}
+
+// FetchNonVoters fetches the permanent non-voters from the physical store
+func (d *Delegate) FetchNonVoters() error {
+	e, err := d.Get(context.Background(), NonVoterPath)
+	if err != nil {
+		d.logger.Error("failed to fetch non voters", "error", err)
+		return err
+	}
+
+	if e == nil {
+		d.logger.Debug("no non-voters")
+		return nil
+	}
+
+	var nonVoters map[raft.ServerID]bool
+	if err := json.Unmarshal(e.Value, &nonVoters); err != nil {
+		d.logger.Error("failed to unmarshal non-voters", "error", err)
+		return err
+	}
+
+	d.dl.RLock()
+	nV := d.permanentNonVoters
+	d.dl.RUnlock()
+	if !maps.Equal(nV, nonVoters) {
+		d.dl.Lock()
+		d.permanentNonVoters = nonVoters
+		d.dl.Unlock()
+	}
+	return nil
+}

--- a/physical/raft/raft_autopilot_promoter.go
+++ b/physical/raft/raft_autopilot_promoter.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"time"
+
+	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
+)
+
+// Ensure that the CustomPromoter implements the autopilot.Promoter interface
+var _ autopilot.Promoter = (*CustomPromoter)(nil)
+
+type CustomPromoter struct {
+	autopilot.StablePromoter
+}
+
+// GetNodeTypes will return a map of node types for each server in the cluster. This particular interface implementation
+// will mark all servers as voters except for those that are marked as non-voters in the configuration.
+func (_ *CustomPromoter) GetNodeTypes(c *autopilot.Config, s *autopilot.State) map[raft.ServerID]autopilot.NodeType {
+	types := make(map[raft.ServerID]autopilot.NodeType)
+	nonVoters := c.Ext.(map[raft.ServerID]bool)
+	for id := range s.Servers {
+		// If the server is a non-voter, mark it as such
+		if _, ok := nonVoters[id]; ok {
+			types[id] = NodeNonVoter
+		} else {
+			types[id] = autopilot.NodeVoter
+		}
+	}
+	return types
+}
+
+// CalculatePromotionsAndDemotions will return a list of all promotions and demotions to be done as well as the server id of
+// the desired leader. This particular interface implementation maintains a stable leader and will promote healthy servers
+// to voting status if they are not marked as permanent non-voters. It will never change the leader ID nor will it perform demotions.
+func (_ *CustomPromoter) CalculatePromotionsAndDemotions(c *autopilot.Config, s *autopilot.State) autopilot.RaftChanges {
+	var changes autopilot.RaftChanges
+
+	now := time.Now()
+	minStableDuration := s.ServerStabilizationTime(c)
+	nonVoters := c.Ext.(map[raft.ServerID]bool)
+	for id, server := range s.Servers {
+		// Ignore non-voters
+		if _, ok := nonVoters[id]; ok {
+			continue
+		}
+		// If the server is healthy and stable, promote it to a voter
+		if server.State == autopilot.RaftNonVoter && server.Health.IsStable(now, minStableDuration) {
+			changes.Promotions = append(changes.Promotions, id)
+		}
+	}
+
+	return changes
+}

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -33,7 +34,7 @@ func (a *idAddr) String() string  { return a.id }
 
 func addPeer(t *testing.T, leader, follower *RaftBackend) {
 	t.Helper()
-	if err := leader.AddPeer(context.Background(), follower.NodeID(), follower.NodeID()); err != nil {
+	if err := leader.AddPeer(context.Background(), follower.NodeID(), follower.NodeID(), true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2024 OpenBao a Series of LF Projects, LLC
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -375,9 +376,9 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 
 		switch nonVoter {
 		case true:
-			err = errors.New("adding non voting peer is not allowed")
+			err = raftBackend.AddPeer(ctx, serverID, clusterAddr, false)
 		default:
-			err = raftBackend.AddPeer(ctx, serverID, clusterAddr)
+			err = raftBackend.AddPeer(ctx, serverID, clusterAddr, true)
 		}
 		if err != nil {
 			if added {

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -52,6 +52,19 @@ leader node.
 
 - `auto_join_port` `(int: 8200)` - Port to be used for `auto_join`.
 
+- `non_voter` `(bool: false)` - If set, will make the server not
+  participate in the Raft quorum, and have it only receive the data replication
+  stream. This can be used to add read scalability to a cluster in cases where a
+  high volume of reads to servers are needed. The default is false.
+
+:::warning
+
+Adding a large number of non-voters to a cluster will impact application
+latency. Make sure to tune the [Raft settings](/docs/configuration/storage/raft/#raft-parameters)
+for your intended use case.
+
+:::
+
 ### Sample payload
 
 ```json

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -236,7 +236,7 @@ and how many nodes could fail before the cluster becomes unhealthy ("Failure Tol
 State includes a list of all servers by nodeID and IP address. Last Index
 indicates how close the state on each node is to the leader's.
 
-A node can have a status of "leader" or "voter".
+A node can have a status of "leader", "voter" or "non-voter".
 
 ```text
 Usage: bao operator raft autopilot state
@@ -256,6 +256,8 @@ Voters:
    raft1
    raft2
    raft3
+Non Voters:
+   raft4
 Servers:
    raft1
       Name:            raft1

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -74,6 +74,21 @@ The following flags are available for the `operator raft join` command.
 
 - `-leader-client-key` `(string: "")` - Client key to authenticate to Raft leader.
 
+- `-non-voter` `(bool: false)` - This flag is used to make the
+  server not participate in the Raft quorum, and have it only receive the data
+  replication stream. This can be used to add read scalability to a cluster in
+  cases where a high volume of reads to servers are needed. The default is false.
+  See [`retry_join_as_non_voter`](/docs/configuration/storage/raft#retry_join_as_non_voter)
+  for the equivalent config option when using `retry_join` stanzas instead.
+
+:::warning
+
+Adding a large number of non-voters to a cluster will impact application
+latency. Make sure to tune the [Raft settings](/docs/configuration/storage/raft/#raft-parameters)
+for your intended use case.
+
+:::
+
 - `-retry` `(bool: false)` - Continuously retry joining the Raft cluster upon
   failures. The default is false.
 

--- a/website/content/docs/concepts/integrated-storage/index.mdx
+++ b/website/content/docs/concepts/integrated-storage/index.mdx
@@ -135,6 +135,17 @@ active node's API address will need to be specified:
 $ bao operator raft join https://node1.openbao.local:8200
 ```
 
+#### Non-Voting nodes
+
+Nodes that are joined to a cluster can be specified as non-voters. A non-voting
+node has all of OpenBao's data replicated to it, but does not contribute to the
+quorum count. This can be used to add read scalability to
+a cluster in cases where a high volume of reads to servers are needed.
+
+```shell-session
+$ bao operator raft join -non-voter https://node1.openbao.local:8200
+```
+
 ### Removing peers
 
 Removing a peer node is a necessary step when you no longer want the node in the


### PR DESCRIPTION
#### Summary
This PR reimplements a previous enterprise feature to allow nodes to join a Raft cluster as non-voting members. Nodes can now be configured as non-voters by either using the new `-non-voter` flag in the `operator raft join` command or by setting the existing configuration option `retry_join_as_non_voter`.

#### Key Changes
- Introduced a `-non-voter` flag to the `operator raft join` command.
- Enhanced join logic to support both the `-non-voter` flag and the pre-existing `retry_join_as_non_voter` configuration option.
- Updated relevant Raft implementation files and improved the handling of non-voter joins.
- Added documentation updates to reflect these changes.

Closes: #578