### PR TITLE
Replace myvault.com with example.com in tests

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -319,7 +319,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 
 	// Sign the intermediate CSR using /pki
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
-		"permitted_dns_domains": ".myvault.com",
+		"permitted_dns_domains": ".example.com",
 		"csr":                   intermediateCSR,
 	})
 	if err != nil {
@@ -337,7 +337,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 
 	// Create a role on the intermediate CA mount
 	_, err = client.Logical().Write("pki2/roles/myvault-dot-com", map[string]interface{}{
-		"allowed_domains":  "myvault.com",
+		"allowed_domains":  "example.com",
 		"allow_subdomains": "true",
 		"max_ttl":          "5m",
 	})
@@ -347,7 +347,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 
 	// Issue a leaf cert using the intermediate CA
 	secret, err = client.Logical().Write("pki2/issue/myvault-dot-com", map[string]interface{}{
-		"common_name": "cert.myvault.com",
+		"common_name": "cert.example.com",
 		"format":      "pem",
 		"ip_sans":     "127.0.0.1",
 	})
@@ -367,7 +367,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 
 	// Set the intermediate CA cert as a trusted certificate in the backend
 	_, err = client.Logical().Write("auth/cert/certs/myvault-dot-com", map[string]interface{}{
-		"display_name": "myvault.com",
+		"display_name": "example.com",
 		"policies":     "default",
 		"certificate":  intermediateCertPEM,
 	})

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -114,7 +114,7 @@ func TestPKI_RequireCN(t *testing.T) {
 	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -191,7 +191,7 @@ func TestPKI_DeviceCert(t *testing.T) {
 	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name":         "myvault.com",
+		"common_name":         "example.com",
 		"not_after":           "9999-12-31T23:59:59Z",
 		"not_before_duration": "2h",
 	})
@@ -265,7 +265,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 	b, s := CreateBackendWithStorage(t)
 
 	_, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"not_after":   "9999-12-31T23:59:59Z",
 		"ttl":         "25h",
 	})
@@ -274,7 +274,7 @@ func TestBackend_InvalidParameter(t *testing.T) {
 	}
 
 	_, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"not_after":   "9999-12-31T23:59:59",
 	})
 	if err == nil {
@@ -2588,7 +2588,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 
 	// This is a change within 1.11, we are no longer idempotent across generate/internal calls.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected ca info")
@@ -2610,7 +2610,7 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 
 	// Calling generate/internal should generate a new CA as well.
 	resp, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp, "expected ca info")
@@ -2735,7 +2735,7 @@ func TestBackend_SignIntermediate_AllowedPastCAValidity(t *testing.T) {
 	// Direct issuing from root
 	_, err = CBWrite(b_root, s_root, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2825,7 +2825,7 @@ func TestBackend_ConsulSignLeafWithLegacyRole(t *testing.T) {
 	// generate root
 	data, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	require.NoError(t, err, "failed generating internal root cert")
 	rootCaPem := data.Data["certificate"].(string)
@@ -3132,7 +3132,7 @@ func TestBackend_OID_SANs(t *testing.T) {
 
 	_, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3355,7 +3355,7 @@ func TestBackend_AllowedSerialNumbers(t *testing.T) {
 
 	_, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3458,7 +3458,7 @@ func TestBackend_URI_SANs(t *testing.T) {
 
 	_, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3614,7 +3614,7 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 	// Generate internal CA.
 	_, err = client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3736,7 +3736,7 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 	// Generate internal CA.
 	_, err = client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -4140,7 +4140,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 
 	// Sign the intermediate CSR using /pki
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
-		"permitted_dns_domains": ".myvault.com",
+		"permitted_dns_domains": ".example.com",
 		"csr":                   intermediateCSR,
 		"ttl":                   "10s",
 	})
@@ -4370,7 +4370,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	var err error
 
 	resp, err := CBWrite(b_root, s_root, "root/generate/exported", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    keyType,
 	})
 	if err != nil {
@@ -4414,7 +4414,7 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	b_int, s_int := CreateBackendWithStorage(t)
 
 	resp, err = CBWrite(b_int, s_int, "intermediate/generate/exported", map[string]interface{}{
-		"common_name": "intermediate myvault.com",
+		"common_name": "intermediate example.com",
 		"key_type":    keyType,
 	})
 	if err != nil {
@@ -4834,7 +4834,7 @@ func TestBackend_Roles_IssuanceRegression(t *testing.T) {
 
 	// We need a RSA key so all signature sizes are valid with it.
 	resp, err := CBWrite(b, s, "root/generate/exported", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"ttl":         "128h",
 		"key_type":    "rsa",
 		"key_bits":    2048,
@@ -4886,7 +4886,7 @@ func RoleKeySizeRegressionHelper(t *testing.T, b *backend, s logical.Storage, in
 		for _, caKeyBits := range test.RoleKeyBits {
 			// Generate a new CA key.
 			resp, err := CBWrite(b, s, "root/generate/exported", map[string]interface{}{
-				"common_name": "myvault.com",
+				"common_name": "example.com",
 				"ttl":         "128h",
 				"key_type":    caKeyType,
 				"key_bits":    caKeyBits,
@@ -5016,7 +5016,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail requests if type is existing, and we specify the key_type param
 	_, err = CBWrite(b, s, "root/generate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 	})
 	require.Error(t, err)
@@ -5024,7 +5024,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail requests if type is existing, and we specify the key_bits param
 	_, err = CBWrite(b, s, "root/generate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_bits":    "2048",
 	})
 	require.Error(t, err)
@@ -5032,7 +5032,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail if the specified key does not exist.
 	_, err = CBWrite(b, s, "issuers/generate/root/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "my-issuer1",
 		"key_ref":     "my-key1",
 	})
@@ -5041,7 +5041,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail if the specified key name is default.
 	_, err = CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "my-issuer1",
 		"key_name":    "Default",
 	})
@@ -5050,7 +5050,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail if the specified issuer name is default.
 	_, err = CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "DEFAULT",
 	})
 	require.Error(t, err)
@@ -5058,7 +5058,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Create the first CA
 	resp, err := CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 		"issuer_name": "my-issuer1",
 	})
@@ -5076,7 +5076,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail if the specified issuer name is re-used.
 	_, err = CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "my-issuer1",
 	})
 	require.Error(t, err)
@@ -5084,7 +5084,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Create the second CA
 	resp, err = CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 		"issuer_name": "my-issuer2",
 		"key_name":    "root-key2",
@@ -5102,7 +5102,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Fail if the specified key name is re-used.
 	_, err = CBWrite(b, s, "issuers/generate/root/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "my-issuer3",
 		"key_name":    "root-key2",
 	})
@@ -5111,7 +5111,7 @@ func TestRootWithExistingKey(t *testing.T) {
 
 	// Create a third CA re-using key from CA 1
 	resp, err = CBWrite(b, s, "issuers/generate/root/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"issuer_name": "my-issuer3",
 		"key_ref":     myKeyId1,
 	})
@@ -5173,7 +5173,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Fail requests if type is existing, and we specify the key_type param
 	_, err = CBWrite(b, s, "intermediate/generate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 	})
 	require.Error(t, err)
@@ -5181,7 +5181,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Fail requests if type is existing, and we specify the key_bits param
 	_, err = CBWrite(b, s, "intermediate/generate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_bits":    "2048",
 	})
 	require.Error(t, err)
@@ -5189,7 +5189,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Fail if the specified key does not exist.
 	_, err = CBWrite(b, s, "issuers/generate/intermediate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_ref":     "my-key1",
 	})
 	require.Error(t, err)
@@ -5197,7 +5197,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Create the first intermediate CA
 	resp, err := CBWrite(b, s, "issuers/generate/intermediate/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 	})
 	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("issuers/generate/intermediate/internal"), logical.UpdateOperation), resp, true)
@@ -5208,7 +5208,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Create the second intermediate CA
 	resp, err = CBWrite(b, s, "issuers/generate/intermediate/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "rsa",
 		"key_name":    "interkey1",
 	})
@@ -5219,7 +5219,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 
 	// Create a third intermediate CA re-using key from intermediate CA 1
 	resp, err = CBWrite(b, s, "issuers/generate/intermediate/existing", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_ref":     myKeyId1,
 	})
 	require.NoError(t, err)
@@ -5912,7 +5912,7 @@ func TestBackend_InitializeCertificateCounts(t *testing.T) {
 	// Set up an Issuer and Role
 	// We need a root certificate to write/revoke certificates with
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -5923,7 +5923,7 @@ func TestBackend_InitializeCertificateCounts(t *testing.T) {
 
 	// Create a role
 	_, err = CBWrite(b, s, "roles/example", map[string]interface{}{
-		"allowed_domains":    "myvault.com",
+		"allowed_domains":    "example.com",
 		"allow_bare_domains": true,
 		"allow_subdomains":   true,
 		"max_ttl":            "2h",
@@ -5937,7 +5937,7 @@ func TestBackend_InitializeCertificateCounts(t *testing.T) {
 	serials := make([]string, 5)
 	for i, cn := range certificates {
 		resp, err = CBWrite(b, s, "issue/example", map[string]interface{}{
-			"common_name": cn + ".myvault.com",
+			"common_name": cn + ".example.com",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -5991,7 +5991,7 @@ func TestBackend_InitializeCertificateCounts(t *testing.T) {
 	dirtyCertificates := []string{"f", "g"}
 	for _, cn := range dirtyCertificates {
 		resp, err = CBWrite(b, s, "issue/example", map[string]interface{}{
-			"common_name": cn + ".myvault.com",
+			"common_name": cn + ".example.com",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -6021,7 +6021,7 @@ func TestBackend_VerifyIssuerUpdateDefaultsMatchCreation(t *testing.T) {
 	b, s := CreateBackendWithStorage(t)
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	requireSuccessNonNilResponse(t, resp, err, "failed generating root issuer")
 
@@ -6987,7 +6987,7 @@ func TestProperAuthing(t *testing.T) {
 	// Setup basic configuration.
 	_, err = client.Logical().WriteWithContext(ctx, "pki/root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -7369,7 +7369,7 @@ func TestGenerateRootCAWithAIA(t *testing.T) {
 
 	// Write a root issuer, this should succeed.
 	resp, err := CBWrite(b_root, s_root, "root/generate/exported", map[string]interface{}{
-		"common_name": "root myvault.com",
+		"common_name": "root example.com",
 		"key_type":    "ec",
 	})
 	requireSuccessNonNilResponse(t, resp, err, "expected root generation to succeed")
@@ -7412,7 +7412,7 @@ func TestPKI_IssueKeyTypeAny(t *testing.T) {
 	}
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"key_type":    "ec",
 	})
 	require.NoError(t, err)

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -29,7 +29,7 @@ func TestBackend_CRL_EnableDisableRoot(t *testing.T) {
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -177,7 +177,7 @@ func TestBackend_CRL_AllKeyTypeSigAlgos(t *testing.T) {
 
 		resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 			"ttl":            "40h",
-			"common_name":    "myvault.com",
+			"common_name":    "example.com",
 			"key_type":       tc.KeyType,
 			"key_bits":       tc.KeyBits,
 			"signature_bits": tc.SigBits,
@@ -220,7 +220,7 @@ func crlEnableDisableIntermediateTestForBackend(t *testing.T, withRoot bool) {
 
 	resp, err := CBWrite(b_root, s_root, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -230,7 +230,7 @@ func crlEnableDisableIntermediateTestForBackend(t *testing.T, withRoot bool) {
 	b_int, s_int := CreateBackendWithStorage(t)
 
 	resp, err = CBWrite(b_int, s_int, "intermediate/generate/internal", map[string]interface{}{
-		"common_name": "intermediate myvault.com",
+		"common_name": "intermediate example.com",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1511,7 +1511,7 @@ func TestRevokeExpiredCert(t *testing.T) {
 	// Generate a root certificate for the PKI.
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"key_type":    "ec",
 	})
 	require.NoError(t, err)

--- a/builtin/logical/pki/path_resign_crls_test.go
+++ b/builtin/logical/pki/path_resign_crls_test.go
@@ -256,7 +256,7 @@ func TestSignRevocationList(t *testing.T) {
 	// Generate internal CA.
 	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
 		"ttl":         "40h",
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 	})
 	require.NoError(t, err)
 	caCert := parseCert(t, resp.Data["certificate"].(string))

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -27,7 +27,7 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
-		"allowed_domains": "myvault.com",
+		"allowed_domains": "example.com",
 		"ttl":             "5h",
 	}
 
@@ -132,7 +132,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
-		"allowed_domains": "myvault.com",
+		"allowed_domains": "example.com",
 		"ttl":             "5h",
 		"key_usage":       []string{"KeyEncipherment", "DigitalSignature"},
 	}
@@ -225,7 +225,7 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
-		"allowed_domains": "myvault.com",
+		"allowed_domains": "example.com",
 		"ttl":             "5h",
 		"ou":              []string{"abc", "123"},
 		"organization":    []string{"org1", "org2"},
@@ -546,7 +546,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	roleData := map[string]interface{}{
-		"allowed_domains": "myvault.com",
+		"allowed_domains": "example.com",
 		"ttl":             "5h",
 	}
 
@@ -591,7 +591,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 	roleReq.Operation = logical.UpdateOperation
 	roleReq.Path = "roles/testrole_nostore"
 	roleReq.Data["no_store"] = true
-	roleReq.Data["allowed_domain"] = "myvault.com"
+	roleReq.Data["allowed_domain"] = "example.com"
 	roleReq.Data["allow_subdomains"] = true
 	roleReq.Data["ttl"] = "5h"
 
@@ -613,7 +613,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 
 	// issue a certificate and test that it's not stored
 	caData := map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"ttl":         "5h",
 		"ip_sans":     "127.0.0.1",
 	}
@@ -629,7 +629,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 	}
 
 	issueData := map[string]interface{}{
-		"common_name": "cert.myvault.com",
+		"common_name": "cert.example.com",
 		"format":      "pem",
 		"ip_sans":     "127.0.0.1",
 		"ttl":         "1h",
@@ -667,7 +667,7 @@ func TestPki_CertsLease(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	caData := map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"ttl":         "5h",
 		"ip_sans":     "127.0.0.1",
 	}
@@ -685,7 +685,7 @@ func TestPki_CertsLease(t *testing.T) {
 	}
 
 	roleData := map[string]interface{}{
-		"allowed_domains":  "myvault.com",
+		"allowed_domains":  "example.com",
 		"allow_subdomains": true,
 		"ttl":              "2h",
 	}
@@ -703,7 +703,7 @@ func TestPki_CertsLease(t *testing.T) {
 	}
 
 	issueData := map[string]interface{}{
-		"common_name": "cert.myvault.com",
+		"common_name": "cert.example.com",
 		"format":      "pem",
 		"ip_sans":     "127.0.0.1",
 	}
@@ -1054,7 +1054,7 @@ func TestPKI_RolePolicyInformation_Flat(t *testing.T) {
 	b, storage := CreateBackendWithStorage(t)
 
 	caData := map[string]interface{}{
-		"common_name": "myvault.com",
+		"common_name": "example.com",
 		"ttl":         "5h",
 		"ip_sans":     "127.0.0.1",
 	}

--- a/command/agent/cert_end_to_end_test.go
+++ b/command/agent/cert_end_to_end_test.go
@@ -368,7 +368,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 	// Sign the intermediate CSR using /pki
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
-		"permitted_dns_domains": ".myvault.com",
+		"permitted_dns_domains": ".example.com",
 		"csr":                   intermediateCSR,
 	})
 	if err != nil {
@@ -386,7 +386,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 	// Create a role on the intermediate CA mount
 	_, err = client.Logical().Write("pki2/roles/myvault-dot-com", map[string]interface{}{
-		"allowed_domains":  "myvault.com",
+		"allowed_domains":  "example.com",
 		"allow_subdomains": "true",
 		"max_ttl":          "5m",
 	})
@@ -396,7 +396,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 	// Issue a leaf cert using the intermediate CA
 	secret, err = client.Logical().Write("pki2/issue/myvault-dot-com", map[string]interface{}{
-		"common_name": "cert.myvault.com",
+		"common_name": "cert.example.com",
 		"format":      "pem",
 		"ip_sans":     "127.0.0.1",
 	})
@@ -458,7 +458,7 @@ func TestCertEndToEnd_CertsInConfig(t *testing.T) {
 
 	// Set the intermediate CA cert as a trusted certificate in the backend
 	_, err = client.Logical().Write("auth/cert/certs/myvault-dot-com", map[string]interface{}{
-		"display_name": "myvault.com",
+		"display_name": "example.com",
 		"policies":     "default",
 		"certificate":  intermediateCertPEM,
 	})

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3455,7 +3455,7 @@ func TestOIDC_Path_OIDC_Provider_List_KeyInfo(t *testing.T) {
 		"p1": map[string]interface{}{
 			"allowed_client_ids": []string{"xyz"},
 			"scopes_supported":   []string{"groups"},
-			"issuer":             "https://myvault.com:8200",
+			"issuer":             "https://example.com:8200",
 		},
 	}
 	for name, p := range providers {


### PR DESCRIPTION
This PR replaces the domain name `myvault.com` with `example.com` in tests as recommended in [RFC2606](https://datatracker.ietf.org/doc/html/rfc2606#section-3). 

> **Reserved Example Second Level Domain Names**
>    The Internet Assigned Numbers Authority (IANA) also currently has the
>    following second level domain names reserved which can be used as
>    examples.
>         example.com
>         example.net
>         example.org

This is grep's output after these changes:
```
/builtin/credential/cert/test-fixtures/generate.txt:3:vault write pki/root/generate/exported common_name=myvault.com ttl=438000h ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:20:vault write pki/root/generate/exported common_name=myvault.com ttl=438000h max_ttl=438000h ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:26:vault write pki/roles/myvault-dot-com allowed_domains=myvault.com allow_subdomains=true ttl=437999h max_ttl=438000h allow_ip_sans=true
./builtin/credential/cert/test-fixtures/generate.txt:28:vault write pki/issue/myvault-dot-com common_name=cert.myvault.com format=pem ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:31:vault write pki/issue/myvault-dot-com common_name=cert.myvault.com format=pem ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:36:vault write pki/issue/myvault-dot-com common_name=cert.myvault.com format=pem ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:39:vault write pki/issue/myvault-dot-com common_name=cert.myvault.com format=pem ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:44:vault write pki/issue/myvault-dot-com common_name=cert.myvault.com format=pem ip_sans=127.0.0.1
./builtin/credential/cert/test-fixtures/generate.txt:56:vault write pki/root/generate/exported common_name=myvault.com ttl=438000h ip_sans=127.0.0.1
```

I'm not sure if I should edit these txt files... 

---
I think this is **pr/no-changelog** since they are no behavioral changes.

Resolves #747 