### PR TITLE
Clean up legacy keyring code

### DIFF
--- a/changelog/750.txt
+++ b/changelog/750.txt
@@ -1,0 +1,4 @@
+```release-note:change
+core/seal: remove support for legacy pre-keyring barrier entries
+core/seal: remove support for legacy (direct) shamir unseal keys
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1679,9 +1679,7 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 		}
 	}
 
-	if core.SealAccess().StoredKeysSupported() != vaultseal.StoredKeysNotSupported {
-		barrierConfig.StoredShares = 1
-	}
+	barrierConfig.StoredShares = 1
 
 	// Initialize it with a basic single key
 	init, err := core.Initialize(ctx, &vault.InitParams{

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -120,7 +120,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 type InitRequest struct {
 	SecretShares      int      `json:"secret_shares"`
 	SecretThreshold   int      `json:"secret_threshold"`
-	StoredShares      int      `json:"stored_shares"`
+	StoredShares      uint     `json:"stored_shares"`
 	PGPKeys           []string `json:"pgp_keys"`
 	RecoveryShares    int      `json:"recovery_shares"`
 	RecoveryThreshold int      `json:"recovery_threshold"`

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -345,7 +345,7 @@ func handleSysRekeyVerifyPut(ctx context.Context, core *vault.Core, recovery boo
 type RekeyRequest struct {
 	SecretShares        int      `json:"secret_shares"`
 	SecretThreshold     int      `json:"secret_threshold"`
-	StoredShares        int      `json:"stored_shares"`
+	StoredShares        uint     `json:"stored_shares"`
 	PGPKeys             []string `json:"pgp_keys"`
 	Backup              bool     `json:"backup"`
 	RequireVerification bool     `json:"require_verification"`

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -34,13 +34,9 @@ var (
 )
 
 const (
-	// barrierInitPath is the path used to store our init sentinel file
-	barrierInitPath = "barrier/init"
-
 	// keyringPath is the location of the keyring data. This is encrypted
 	// by the root key.
-	keyringPath   = "core/keyring"
-	keyringPrefix = "core/"
+	keyringPath = "core/keyring"
 
 	// keyringUpgradePrefix is the path used to store keyring update entries.
 	// When running in HA mode, the active instance will install the new key

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -135,7 +135,7 @@ type SecurityBarrierCore interface {
 	// SetRotationConfig updates the auto-rotation config for the barrier key
 	SetRotationConfig(ctx context.Context, config KeyRotationConfig) error
 
-	// Rekey is used to change the master key used to protect the keyring
+	// Rekey is used to change the root key used to protect the keyring
 	Rekey(context.Context, []byte) error
 
 	// For replication we must send over the keyring, so this must be available

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"go.uber.org/atomic"
@@ -46,12 +44,6 @@ const (
 	AESGCMVersion1 = 0x1
 	AESGCMVersion2 = 0x2
 )
-
-// barrierInit is the JSON encoded value stored
-type barrierInit struct {
-	Version int    // Version is the current format version
-	Key     []byte // Key is the primary encryption key
-}
 
 // Validate AESGCMBarrier satisfies SecurityBarrier interface
 var (
@@ -163,22 +155,14 @@ func (b *AESGCMBarrier) Initialized(ctx context.Context) (bool, error) {
 	}
 
 	// Read the keyring file
-	keys, err := b.backend.List(ctx, keyringPrefix)
+	entry, err := b.backend.Get(ctx, keyringPath)
 	if err != nil {
 		return false, fmt.Errorf("failed to check for initialization: %w", err)
-	}
-	if strutil.StrListContains(keys, "keyring") {
-		b.initialized.Store(true)
-		return true, nil
 	}
 
-	// Fallback, check for the old sentinel file
-	out, err := b.backend.Get(ctx, barrierInitPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to check for initialization: %w", err)
-	}
-	b.initialized.Store(out != nil)
-	return out != nil, nil
+	initialized := entry != nil
+	b.initialized.Store(initialized)
+	return initialized, nil
 }
 
 // Initialize works only if the barrier has not been initialized
@@ -498,39 +482,6 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to check for keyring: %w", err)
 	}
-	if out != nil {
-		// Verify the term is always just one
-		term := binary.BigEndian.Uint32(out.Value[:4])
-		if term != initialKeyTerm {
-			return errors.New("term mis-match")
-		}
-
-		// Decrypt the barrier init key
-		plain, err := b.decrypt(keyringPath, gcm, out.Value)
-		defer memzero(plain)
-		if err != nil {
-			if strings.Contains(err.Error(), "message authentication failed") {
-				return ErrBarrierInvalidKey
-			}
-			return err
-		}
-
-		// Recover the keyring
-		err = b.recoverKeyring(plain)
-		if err != nil {
-			return fmt.Errorf("keyring deserialization failed: %w", err)
-		}
-
-		b.sealed = false
-
-		return nil
-	}
-
-	// Read the barrier initialization key
-	out, err = b.backend.Get(ctx, barrierInitPath)
-	if err != nil {
-		return fmt.Errorf("failed to check for initialization: %w", err)
-	}
 	if out == nil {
 		return ErrBarrierNotInit
 	}
@@ -542,47 +493,21 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	}
 
 	// Decrypt the barrier init key
-	plain, err := b.decrypt(barrierInitPath, gcm, out.Value)
+	plain, err := b.decrypt(keyringPath, gcm, out.Value)
+	defer memzero(plain)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
 			return ErrBarrierInvalidKey
 		}
 		return err
 	}
-	defer memzero(plain)
 
-	// Unmarshal the barrier init
-	var init barrierInit
-	if err := jsonutil.DecodeJSON(plain, &init); err != nil {
-		return fmt.Errorf("failed to unmarshal barrier init file")
-	}
-
-	// Setup a new keyring, this is for backwards compatibility
-	keyringNew := NewKeyring()
-	keyring := keyringNew.SetRootKey(key)
-
-	// AddKey reuses the root, so we are only zeroizing after this call
-	defer keyringNew.Zeroize(false)
-
-	keyring, err = keyring.AddKey(&Key{
-		Term:    1,
-		Version: 1,
-		Value:   init.Key,
-	})
+	// Recover the keyring
+	err = b.recoverKeyring(plain)
 	if err != nil {
-		return fmt.Errorf("failed to create keyring: %w", err)
-	}
-	if err := b.persistKeyring(ctx, keyring); err != nil {
-		return err
+		return fmt.Errorf("keyring deserialization failed: %w", err)
 	}
 
-	// Delete the old barrier entry
-	if err := b.backend.Delete(ctx, barrierInitPath); err != nil {
-		return fmt.Errorf("failed to delete barrier init file: %w", err)
-	}
-
-	// Set the vault as unsealed
-	b.keyring = keyring
 	b.sealed = false
 
 	return nil

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -135,97 +134,6 @@ func TestAESGCMBarrier_Rekey(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	testBarrier_Rekey(t, b.(*TransactionalAESGCMBarrier))
-}
-
-// Test an upgrade from the old (0.1) barrier/init to the new
-// core/keyring style
-func TestAESGCMBarrier_BackwardsCompatible(t *testing.T) {
-	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	sb, err := NewAESGCMBarrier(inm)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	b := sb.(*TransactionalAESGCMBarrier)
-
-	// Generate a barrier/init entry
-	encrypt, _ := b.GenerateKey(rand.Reader)
-	init := &barrierInit{
-		Version: 1,
-		Key:     encrypt,
-	}
-	buf, _ := json.Marshal(init)
-
-	// Protect with master key
-	master, _ := b.GenerateKey(rand.Reader)
-	gcm, _ := b.aeadFromKey(master)
-	value, err := b.encrypt(barrierInitPath, initialKeyTerm, gcm, buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Write to the physical backend
-	pe := &physical.Entry{
-		Key:   barrierInitPath,
-		Value: value,
-	}
-	inm.Put(context.Background(), pe)
-
-	// Create a fake key
-	gcm, _ = b.aeadFromKey(encrypt)
-	value, err = b.encrypt("test/foo", initialKeyTerm, gcm, []byte("test"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	pe = &physical.Entry{
-		Key:   "test/foo",
-		Value: value,
-	}
-	inm.Put(context.Background(), pe)
-
-	// Should still be initialized
-	isInit, err := b.Initialized(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !isInit {
-		t.Fatalf("should be initialized")
-	}
-
-	// Unseal should work and migrate online
-	err = b.Unseal(context.Background(), master)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Check for migration
-	out, err := inm.Get(context.Background(), barrierInitPath)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out != nil {
-		t.Fatalf("should delete old barrier init")
-	}
-
-	// Should have keyring
-	out, err = inm.Get(context.Background(), keyringPath)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("should have keyring file")
-	}
-
-	// Attempt to read encrypted key
-	entry, err := b.Get(context.Background(), "test/foo")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if string(entry.Value) != "test" {
-		t.Fatalf("bad: %#v", entry)
-	}
 }
 
 // Verify data sent through is encrypted

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -21,7 +21,7 @@ import (
 
 var logger = logging.NewVaultLogger(log.Trace)
 
-// mockBarrier returns a physical backend, security barrier, and master key
+// mockBarrier returns a physical backend, security barrier, and root key
 func mockBarrier(t testing.TB) (physical.Backend, SecurityBarrier, []byte) {
 	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -376,7 +376,7 @@ func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Verify the master key
+	// Verify the root key
 	if err := b.VerifyRoot(key); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -388,12 +388,12 @@ func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Verify the old master key
+	// Verify the old root key
 	if err := b.VerifyRoot(key); err != ErrBarrierInvalidKey {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Verify the new master key
+	// Verify the new root key
 	if err := b.VerifyRoot(newKey); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -532,7 +532,7 @@ func testBarrier_Upgrade_Rekey(t *testing.T, b1, b2 SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Reload the master key
+	// Reload the root key
 	err = b2.ReloadRootKey(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/core.go
+++ b/vault/core.go
@@ -305,13 +305,13 @@ type Core struct {
 	unlockInfo *unlockInformation
 
 	// generateRootProgress holds the shares until we reach enough
-	// to verify the master key
+	// to verify the root key
 	generateRootConfig   *GenerateRootConfig
 	generateRootProgress [][]byte
 	generateRootLock     sync.Mutex
 
 	// These variables holds the config and shares we have until we reach
-	// enough to verify the appropriate master key. Note that the same lock is
+	// enough to verify the appropriate root key. Note that the same lock is
 	// used; this isn't time-critical so this shouldn't be a problem.
 	barrierRekeyConfig  *SealConfig
 	recoveryRekeyConfig *SealConfig
@@ -1411,7 +1411,7 @@ func (c *Core) Unseal(key []byte) (bool, error) {
 // and if we don't have enough we return early.  Otherwise we get
 // back the combined key.
 //
-// For shamir the combined key is used to decrypt the master key
+// For shamir the combined key is used to decrypt the root key
 // read from storage.  For autoseal the combined key isn't used
 // except to verify that the stored recovery key matches.
 //
@@ -1493,11 +1493,11 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 	if c.isRaftUnseal() {
 		return c.unsealWithRaft(combinedKey)
 	}
-	masterKey, err := c.unsealKeyToMasterKeyPreUnseal(ctx, sealToUse, combinedKey)
+	rootKey, err := c.unsealKeyToRootKeyPreUnseal(ctx, sealToUse, combinedKey)
 	if err != nil {
 		return err
 	}
-	return c.unsealInternal(ctx, masterKey)
+	return c.unsealInternal(ctx, rootKey)
 }
 
 func (c *Core) unsealWithRaft(combinedKey []byte) error {
@@ -1537,7 +1537,7 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 	}
 
 	go func() {
-		var masterKey []byte
+		var rootKey []byte
 		keyringFound := false
 
 		// Wait until we at least have the keyring before we attempt to
@@ -1553,16 +1553,16 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 					keyringFound = true
 				}
 			}
-			if keyringFound && len(masterKey) == 0 {
+			if keyringFound && len(rootKey) == 0 {
 				var err error
-				masterKey, err = c.unsealKeyToMasterKeyPreUnseal(ctx, c.seal, combinedKey)
+				rootKey, err = c.unsealKeyToRootKeyPreUnseal(ctx, c.seal, combinedKey)
 				if err != nil {
-					c.logger.Error("failed to read master key", "error", err)
+					c.logger.Error("failed to read root key", "error", err)
 					return
 				}
 			}
-			if keyringFound && len(masterKey) > 0 {
-				err := c.unsealInternal(ctx, masterKey)
+			if keyringFound && len(rootKey) > 0 {
+				err := c.unsealInternal(ctx, rootKey)
 				if err != nil {
 					c.logger.Error("failed to unseal", "error", err)
 				}
@@ -1664,7 +1664,7 @@ func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
 // sealMigrated must be called with the stateLock held.  It returns true if
 // the seal configured in HCL and the seal configured in storage match.
 // For the auto->auto same seal migration scenario, it will return false even
-// if the preceding conditions are true but we cannot decrypt the master key
+// if the preceding conditions are true but we cannot decrypt the root key
 // in storage using the configured seal.
 func (c *Core) sealMigrated(ctx context.Context) (bool, error) {
 	if atomic.LoadUint32(c.sealMigrationDone) == 1 {
@@ -1764,7 +1764,7 @@ func (c *Core) migrateSeal(ctx context.Context) error {
 		}
 		err = shamirWrapper.SetAesGcmKeyBytes(recoveryKey)
 		if err != nil {
-			return fmt.Errorf("failed to set master key in seal: %w", err)
+			return fmt.Errorf("failed to set root key in seal: %w", err)
 		}
 
 		barrierKeys, err := c.migrationInfo.seal.GetStoredKeys(ctx)
@@ -1779,25 +1779,25 @@ func (c *Core) migrateSeal(ctx context.Context) error {
 	case c.seal.RecoveryKeySupported():
 		c.logger.Info("migrating from shamir to auto-unseal", "to", c.seal.BarrierType())
 		// Migration is happening from shamir -> auto. In this case use the shamir
-		// combined key that was used to store the master key as the new recovery key.
+		// combined key that was used to store the root key as the new recovery key.
 		if err := c.seal.SetRecoveryKey(ctx, c.migrationInfo.unsealKey); err != nil {
 			return fmt.Errorf("error setting new recovery key information: %w", err)
 		}
 
-		// Generate a new master key
-		newMasterKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+		// Generate a new root key
+		newRootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
 		if err != nil {
-			return fmt.Errorf("error generating new master key: %w", err)
+			return fmt.Errorf("error generating new root key: %w", err)
 		}
 
 		// Rekey the barrier.
-		if err := c.barrier.Rekey(ctx, newMasterKey); err != nil {
+		if err := c.barrier.Rekey(ctx, newRootKey); err != nil {
 			return fmt.Errorf("error rekeying barrier during migration: %w", err)
 		}
 
-		// Store the new master key
-		if err := c.seal.SetStoredKeys(ctx, [][]byte{newMasterKey}); err != nil {
-			return fmt.Errorf("error storing new master key: %w", err)
+		// Store the new root key
+		if err := c.seal.SetStoredKeys(ctx, [][]byte{newRootKey}); err != nil {
+			return fmt.Errorf("error storing new root key: %w", err)
 		}
 
 	default:
@@ -1816,11 +1816,11 @@ func (c *Core) migrateSeal(ctx context.Context) error {
 	return nil
 }
 
-// unsealInternal takes in the master key and attempts to unseal the barrier.
+// unsealInternal takes in the root key and attempts to unseal the barrier.
 // N.B.: This must be called with the state write lock held.
-func (c *Core) unsealInternal(ctx context.Context, masterKey []byte) error {
+func (c *Core) unsealInternal(ctx context.Context, rootKey []byte) error {
 	// Attempt to unlock
-	if err := c.barrier.Unseal(ctx, masterKey); err != nil {
+	if err := c.barrier.Unseal(ctx, rootKey); err != nil {
 		return err
 	}
 
@@ -2740,25 +2740,25 @@ func (c *Core) adjustSealConfigDuringMigration(existBarrierSealConfig, existReco
 }
 
 func (c *Core) unsealKeyToRootKeyPostUnseal(ctx context.Context, combinedKey []byte) ([]byte, error) {
-	return c.unsealKeyToMasterKey(ctx, c.seal, combinedKey, true, false)
+	return c.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
 }
 
-func (c *Core) unsealKeyToMasterKeyPreUnseal(ctx context.Context, seal Seal, combinedKey []byte) ([]byte, error) {
-	return c.unsealKeyToMasterKey(ctx, seal, combinedKey, false, true)
+func (c *Core) unsealKeyToRootKeyPreUnseal(ctx context.Context, seal Seal, combinedKey []byte) ([]byte, error) {
+	return c.unsealKeyToRootKey(ctx, seal, combinedKey, false, true)
 }
 
-// unsealKeyToMasterKey takes a key provided by the user, either a recovery key
+// unsealKeyToRootKey takes a key provided by the user, either a recovery key
 // if using an autoseal or an unseal key with Shamir.  It returns a nil error
-// if the key is valid and an error otherwise. It also returns the master key
+// if the key is valid and an error otherwise. It also returns the root key
 // that can be used to unseal the barrier.
 // If useTestSeal is true, seal will not be modified; this is used when not
 // invoked as part of an unseal process.  Otherwise in the non-legacy shamir
 // case the combinedKey will be set in the seal, which means subsequent attempts
-// to use the seal to read the master key will succeed, assuming combinedKey is
+// to use the seal to read the root key will succeed, assuming combinedKey is
 // valid.
-// If allowMissing is true, a failure to find the master key in storage results
-// in a nil error and a nil master key being returned.
-func (c *Core) unsealKeyToMasterKey(ctx context.Context, seal Seal, combinedKey []byte, useTestSeal bool, allowMissing bool) ([]byte, error) {
+// If allowMissing is true, a failure to find the root key in storage results
+// in a nil error and a nil root key being returned.
+func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []byte, useTestSeal bool, allowMissing bool) ([]byte, error) {
 	switch seal.StoredKeysSupported() {
 	case vaultseal.StoredKeysSupportedGeneric:
 		if err := seal.VerifyRecoveryKey(ctx, combinedKey); err != nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -31,7 +31,6 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/go-uuid"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
@@ -1548,12 +1547,12 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 		// unseal the node.
 		for {
 			if !keyringFound {
-				keys, err := c.underlyingPhysical.List(ctx, keyringPrefix)
+				entry, err := c.underlyingPhysical.Get(ctx, keyringPath)
 				if err != nil {
 					c.logger.Error("failed to list physical keys", "error", err)
 					return
 				}
-				if strutil.StrListContains(keys, "keyring") {
+				if entry != nil {
 					keyringFound = true
 				}
 			}

--- a/vault/external_tests/api/sys_rekey_ext_test.go
+++ b/vault/external_tests/api/sys_rekey_ext_test.go
@@ -20,41 +20,29 @@ import (
 
 func TestSysRekey_Verification(t *testing.T) {
 	testcases := []struct {
-		recovery     bool
-		legacyShamir bool
+		recovery bool
 	}{
-		{recovery: true, legacyShamir: false},
-		{recovery: false, legacyShamir: false},
-		{recovery: false, legacyShamir: true},
+		{recovery: true},
+		{recovery: false},
 	}
 
 	for _, tc := range testcases {
-		recovery, legacy := tc.recovery, tc.legacyShamir
-		t.Run(fmt.Sprintf("recovery=%v,legacyShamir=%v", recovery, legacy), func(t *testing.T) {
+		t.Run(fmt.Sprintf("recovery=%v", tc.recovery), func(t *testing.T) {
 			t.Parallel()
-			testSysRekey_Verification(t, recovery, legacy)
+			testSysRekey_Verification(t, tc.recovery)
 		})
 	}
 }
 
-func testSysRekey_Verification(t *testing.T, recovery bool, legacyShamir bool) {
+func testSysRekey_Verification(t *testing.T, recovery bool) {
 	opts := &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	}
 	switch {
 	case recovery:
-		if legacyShamir {
-			panic("invalid case")
-		}
 		opts.SealFunc = func() vault.Seal {
 			return vault.NewTestSeal(t, &seal.TestSealOpts{
 				StoredKeys: seal.StoredKeysSupportedGeneric,
-			})
-		}
-	case legacyShamir:
-		opts.SealFunc = func() vault.Seal {
-			return vault.NewTestSeal(t, &seal.TestSealOpts{
-				StoredKeys: seal.StoredKeysNotSupported,
 			})
 		}
 	}

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -738,7 +738,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 			Name:   "rotate",
 			Rekey:  false,
 			Rotate: true,
-			// Rotate writes a new master key upgrade using the new term, which
+			// Rotate writes a new root key upgrade using the new term, which
 			// we can no longer decrypt. We must seal here.
 			ShouldSeal: true,
 		},

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -556,7 +556,7 @@ func verifySealConfigTransit(t *testing.T, core *vault.TestClusterCore) {
 }
 
 // verifyBarrierConfig verifies that a barrier configuration is correct.
-func verifyBarrierConfig(t *testing.T, cfg *vault.SealConfig, sealType string, shares, threshold, stored int) {
+func verifyBarrierConfig(t *testing.T, cfg *vault.SealConfig, sealType string, shares, threshold int, stored uint) {
 	t.Helper()
 	if cfg.Type != sealType {
 		t.Fatalf("bad seal config: %#v, expected type=%q", cfg, sealType)

--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
-	c, masterKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Lifecycle_Common(t, c, masterKeys)
+	c, rootKeys, _ := TestCoreUnsealed(t)
+	testCore_GenerateRoot_Lifecycle_Common(t, c, rootKeys)
 }
 
 func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, keys [][]byte) {
@@ -109,14 +109,14 @@ func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core) {
 	}
 }
 
-func TestCore_GenerateRoot_InvalidMasterNonce(t *testing.T) {
-	c, masterKeys, _ := TestCoreUnsealed(t)
-	// Pass in master keys as they'll be invalid
-	masterKeys[0][0]++
-	testCore_GenerateRoot_InvalidMasterNonce_Common(t, c, masterKeys)
+func TestCore_GenerateRoot_InvalidRootNonce(t *testing.T) {
+	c, rootKeys, _ := TestCoreUnsealed(t)
+	// Pass in root keys as they'll be invalid
+	rootKeys[0][0]++
+	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, rootKeys)
 }
 
-func testCore_GenerateRoot_InvalidMasterNonce_Common(t *testing.T, c *Core, keys [][]byte) {
+func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, keys [][]byte) {
 	otp, err := base62.Random(TokenPrefixLength + TokenLength)
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func testCore_GenerateRoot_InvalidMasterNonce_Common(t *testing.T, c *Core, keys
 		t.Fatalf("expected error")
 	}
 
-	// Provide the master (invalid)
+	// Provide the root (invalid)
 	for _, key := range keys {
 		_, err = c.GenerateRootUpdate(namespace.RootContext(nil), key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
 	}
@@ -152,8 +152,8 @@ func testCore_GenerateRoot_InvalidMasterNonce_Common(t *testing.T, c *Core, keys
 }
 
 func TestCore_GenerateRoot_Update_OTP(t *testing.T) {
-	c, masterKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_OTP_Common(t, c, masterKeys)
+	c, rootKeys, _ := TestCoreUnsealed(t)
+	testCore_GenerateRoot_Update_OTP_Common(t, c, rootKeys)
 }
 
 func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byte) {
@@ -239,8 +239,8 @@ func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byt
 }
 
 func TestCore_GenerateRoot_Update_PGP(t *testing.T) {
-	c, masterKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_PGP_Common(t, c, masterKeys)
+	c, rootKeys, _ := TestCoreUnsealed(t)
+	testCore_GenerateRoot_Update_PGP_Common(t, c, rootKeys)
 }
 
 func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byte) {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -974,11 +974,7 @@ func (c *Core) reloadShamirKey(ctx context.Context) error {
 		}
 		shamirKey = entry.Value
 	case seal.StoredKeysNotSupported:
-		keyring, err := c.barrier.Keyring()
-		if err != nil {
-			return fmt.Errorf("failed to update seal access: %w", err)
-		}
-		shamirKey = keyring.rootKey
+		return fmt.Errorf("legacy shamir seals are not supported by OpenBao")
 	}
 	shamirWrapper, err := c.seal.GetShamirWrapper()
 	if err != nil {

--- a/vault/init.go
+++ b/vault/init.go
@@ -27,9 +27,6 @@ type InitParams struct {
 	BarrierConfig   *SealConfig
 	RecoveryConfig  *SealConfig
 	RootTokenPGPKey string
-	// LegacyShamirSeal should only be used in test code, we don't want to
-	// give the user a way to create legacy shamir seals.
-	LegacyShamirSeal bool
 }
 
 // InitResult is used to provide the key parts back after
@@ -182,11 +179,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		}
 	}
 
-	if initParams.LegacyShamirSeal {
-		barrierConfig.StoredShares = 0
-	} else {
-		barrierConfig.StoredShares = 1
-	}
+	barrierConfig.StoredShares = 1
 
 	if len(barrierConfig.PGPKeys) > 0 && len(barrierConfig.PGPKeys) != barrierConfig.SecretShares {
 		return nil, fmt.Errorf("incorrect number of PGP keys")

--- a/vault/init.go
+++ b/vault/init.go
@@ -65,7 +65,7 @@ func (c *Core) InitializeRecovery(ctx context.Context) error {
 }
 
 // Initialized checks if the Vault is already initialized.  This means one of
-// two things: either the barrier has been created (with keyring and master key)
+// two things: either the barrier has been created (with keyring and root key)
 // and the seal config written to storage, or Raft is forming a cluster and a
 // join/bootstrap is in progress.
 func (c *Core) Initialized(ctx context.Context) (bool, error) {

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -46,7 +46,7 @@ type Keyring struct {
 
 // EncodedKeyring is used for serialization of the keyring
 type EncodedKeyring struct {
-	MasterKey      []byte
+	RootKey        []byte `json:"MasterKey"`
 	Keys           []*Key
 	RotationConfig KeyRotationConfig
 }
@@ -191,7 +191,7 @@ func (k *Keyring) RootKey() []byte {
 func (k *Keyring) Serialize() ([]byte, error) {
 	// Create the encoded entry
 	enc := EncodedKeyring{
-		MasterKey:      k.rootKey,
+		RootKey:        k.rootKey,
 		RotationConfig: k.rotationConfig,
 	}
 	for _, key := range k.keys {
@@ -213,7 +213,7 @@ func DeserializeKeyring(buf []byte) (*Keyring, error) {
 
 	// Create a new keyring
 	k := NewKeyring()
-	k.rootKey = enc.MasterKey
+	k.rootKey = enc.RootKey
 	k.rotationConfig = enc.RotationConfig
 	k.rotationConfig.Sanitize()
 	for _, key := range enc.Keys {

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -110,36 +110,36 @@ func TestKeyring(t *testing.T) {
 	}
 }
 
-func TestKeyring_MasterKey(t *testing.T) {
+func TestKeyring_RootKey(t *testing.T) {
 	k := NewKeyring()
-	master := []byte("test")
-	master2 := []byte("test2")
+	root := []byte("test")
+	root2 := []byte("test2")
 
-	// Check no master
+	// Check no root
 	out := k.RootKey()
 	if out != nil {
 		t.Fatalf("bad: %v", out)
 	}
 
-	// Set master
-	k = k.SetRootKey(master)
+	// Set root
+	k = k.SetRootKey(root)
 	out = k.RootKey()
-	if !bytes.Equal(out, master) {
+	if !bytes.Equal(out, root) {
 		t.Fatalf("bad: %v", out)
 	}
 
-	// Update master
-	k = k.SetRootKey(master2)
+	// Update root
+	k = k.SetRootKey(root2)
 	out = k.RootKey()
-	if !bytes.Equal(out, master2) {
+	if !bytes.Equal(out, root2) {
 		t.Fatalf("bad: %v", out)
 	}
 }
 
 func TestKeyring_Serialize(t *testing.T) {
 	k := NewKeyring()
-	master := []byte("test")
-	k = k.SetRootKey(master)
+	root := []byte("test")
+	k = k.SetRootKey(root)
 
 	now := time.Now()
 	testKey := []byte("testing")
@@ -158,7 +158,7 @@ func TestKeyring_Serialize(t *testing.T) {
 	}
 
 	out := k2.RootKey()
-	if !bytes.Equal(out, master) {
+	if !bytes.Equal(out, root) {
 		t.Fatalf("bad: %v", out)
 	}
 

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -326,16 +326,6 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	}
 }
 
-func TestCore_Rekey_Legacy(t *testing.T) {
-	bc := &SealConfig{
-		SecretShares:    1,
-		SecretThreshold: 1,
-	}
-	c, masterKeys, _, root := TestCoreUnsealedWithConfigSealOpts(t, bc, nil,
-		&seal.TestSealOpts{StoredKeys: seal.StoredKeysNotSupported})
-	testCore_Rekey_Update_Common(t, c, masterKeys, root, false)
-}
-
 func TestCore_Rekey_Invalid(t *testing.T) {
 	bc := &SealConfig{
 		SecretShares:    5,

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -26,7 +26,7 @@ func TestCore_Rekey_Lifecycle(t *testing.T) {
 	}
 	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, nil)
 	if len(masterKeys) != 1 {
-		t.Fatalf("expected %d keys, got %d", bc.SecretShares-bc.StoredShares, len(masterKeys))
+		t.Fatalf("expected %d secret shares and %v stored shares for a total of 1 master key, got %d", bc.SecretShares, bc.StoredShares, len(masterKeys))
 	}
 	testCore_Rekey_Lifecycle_Common(t, c, false)
 }

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -24,9 +24,9 @@ func TestCore_Rekey_Lifecycle(t *testing.T) {
 		SecretThreshold: 1,
 		StoredShares:    1,
 	}
-	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, nil)
-	if len(masterKeys) != 1 {
-		t.Fatalf("expected %d secret shares and %v stored shares for a total of 1 master key, got %d", bc.SecretShares, bc.StoredShares, len(masterKeys))
+	c, rootKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, nil)
+	if len(rootKeys) != 1 {
+		t.Fatalf("expected %d secret shares and %v stored shares for a total of 1 root key, got %d", bc.SecretShares, bc.StoredShares, len(rootKeys))
 	}
 	testCore_Rekey_Lifecycle_Common(t, c, false)
 }
@@ -146,8 +146,8 @@ func TestCore_Rekey_Update(t *testing.T) {
 		SecretShares:    1,
 		SecretThreshold: 1,
 	}
-	c, masterKeys, _, root := TestCoreUnsealedWithConfigs(t, bc, nil)
-	testCore_Rekey_Update_Common(t, c, masterKeys, root, false)
+	c, rootKeys, _, root := TestCoreUnsealedWithConfigs(t, bc, nil)
+	testCore_Rekey_Update_Common(t, c, rootKeys, root, false)
 }
 
 func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root string, recovery bool) {
@@ -179,7 +179,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatalf("bad: no rekey config received")
 	}
 
-	// Provide the master/recovery keys
+	// Provide the root/recovery keys
 	var result *RekeyResult
 	for _, key := range keys {
 		result, err = c.RekeyUpdate(context.Background(), key, rkconf.Nonce, recovery)
@@ -272,7 +272,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatalf("bad: no rekey config received")
 	}
 
-	// Provide the parts master
+	// Provide the parts root
 	oldResult := result
 	for i := 0; i < 3; i++ {
 		result, err = c.RekeyUpdate(context.Background(), TestKeyCopy(oldResult.SecretShares[i]), rkconf.Nonce, recovery)
@@ -334,8 +334,8 @@ func TestCore_Rekey_Invalid(t *testing.T) {
 	bc.StoredShares = 0
 	bc.SecretShares = 1
 	bc.SecretThreshold = 1
-	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, nil)
-	testCore_Rekey_Invalid_Common(t, c, masterKeys, false)
+	c, rootKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, nil)
+	testCore_Rekey_Invalid_Common(t, c, rootKeys, false)
 }
 
 func testCore_Rekey_Invalid_Common(t *testing.T, c *Core, keys [][]byte, recovery bool) {
@@ -436,7 +436,7 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		}
 	}
 
-	// Rekey the master key
+	// Rekey the root key
 	newConf := &SealConfig{
 		SecretShares:    1,
 		SecretThreshold: 1,
@@ -473,7 +473,7 @@ func TestCore_Rekey_Standby(t *testing.T) {
 	// Wait for core2 to become active
 	TestWaitActive(t, core2)
 
-	// Rekey the master key again
+	// Rekey the root key again
 	err = core2.RekeyInit(newConf, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -313,7 +313,7 @@ type SealConfig struct {
 	Backup bool `json:"backup" mapstructure:"backup"`
 
 	// How many keys to store, for seals that support storage.  Always 0 or 1.
-	StoredShares int `json:"stored_shares" mapstructure:"stored_shares"`
+	StoredShares uint `json:"stored_shares" mapstructure:"stored_shares"`
 
 	// Stores the progress of the rekey operation (key shares)
 	RekeyProgress [][]byte `json:"-"`

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -133,12 +133,7 @@ func (d *defaultSeal) BarrierType() wrapping.WrapperType {
 }
 
 func (d *defaultSeal) StoredKeysSupported() seal.StoredKeysSupport {
-	switch {
-	case d.LegacySeal():
-		return seal.StoredKeysNotSupported
-	default:
-		return seal.StoredKeysSupportedShamirRoot
-	}
+	return seal.StoredKeysSupportedShamirRoot
 }
 
 func (d *defaultSeal) RecoveryKeySupported() bool {
@@ -146,24 +141,10 @@ func (d *defaultSeal) RecoveryKeySupported() bool {
 }
 
 func (d *defaultSeal) SetStoredKeys(ctx context.Context, keys [][]byte) error {
-	if d.LegacySeal() {
-		return fmt.Errorf("stored keys are not supported")
-	}
 	return writeStoredKeys(ctx, d.core.physical, d.access, keys)
 }
 
-func (d *defaultSeal) LegacySeal() bool {
-	cfg := d.config.Load().(*SealConfig)
-	if cfg == nil {
-		return false
-	}
-	return cfg.StoredShares == 0
-}
-
 func (d *defaultSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {
-	if d.LegacySeal() {
-		return nil, fmt.Errorf("stored keys are not supported")
-	}
 	keys, err := readStoredKeys(ctx, d.core.physical, d.access)
 	return keys, err
 }

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -23,11 +23,9 @@ import (
 	"github.com/openbao/openbao/vault/seal"
 )
 
-// barrierTypeUpgradeCheck checks for backwards compat on barrier type, not
-// applicable in the OSS side
 var (
-	barrierTypeUpgradeCheck     = func(_ wrapping.WrapperType, _ *SealConfig) {}
 	autoSealUnavailableDuration = []string{"seal", "unreachable", "time"}
+
 	// vars for unit testings
 	sealHealthTestIntervalNominal   = 10 * time.Minute
 	sealHealthTestIntervalUnhealthy = 1 * time.Minute
@@ -226,8 +224,6 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 		d.logger.Error("invalid seal configuration", "seal_type", sealType, "error", err)
 		return nil, fmt.Errorf("%q seal validation failed: %w", sealType, err)
 	}
-
-	barrierTypeUpgradeCheck(d.BarrierType(), conf)
 
 	if conf.Type != d.BarrierType().String() {
 		d.logger.Error("barrier seal type does not match loaded type", "seal_type", conf.Type, "loaded_type", d.BarrierType())

--- a/vault/seal_testing.go
+++ b/vault/seal_testing.go
@@ -8,7 +8,6 @@ import (
 
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/openbao/openbao/vault/seal"
-	vaultseal "github.com/openbao/openbao/vault/seal"
 )
 
 func TestCoreUnsealedWithConfigs(t testing.T, barrierConf, recoveryConf *SealConfig) (*Core, [][]byte, [][]byte, string) {
@@ -25,9 +24,8 @@ func TestCoreUnsealedWithConfigSealOpts(t testing.T, barrierConf, recoveryConf *
 	seal := NewTestSeal(t, sealOpts)
 	core := TestCoreWithSeal(t, seal, false)
 	result, err := core.Initialize(context.Background(), &InitParams{
-		BarrierConfig:    barrierConf,
-		RecoveryConfig:   recoveryConf,
-		LegacyShamirSeal: sealOpts.StoredKeys == vaultseal.StoredKeysNotSupported,
+		BarrierConfig:  barrierConf,
+		RecoveryConfig: recoveryConf,
 	})
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/vault/seal_testing_util.go
+++ b/vault/seal_testing_util.go
@@ -31,13 +31,8 @@ func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 		})
 		return newSeal
 	case seal.StoredKeysNotSupported:
-		newSeal := NewDefaultSeal(seal.NewAccess(aeadwrapper.NewShamirWrapper()))
-		newSeal.SetCachedBarrierConfig(&SealConfig{
-			StoredShares:    0,
-			SecretThreshold: 1,
-			SecretShares:    1,
-		})
-		return newSeal
+		t.Fatal("Legacy shamir's seal no longer supported")
+		return nil
 	default:
 		access, _ := seal.NewTestSeal(opts)
 		seal, err := NewAutoSeal(access)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -56,7 +56,6 @@ import (
 	physInmem "github.com/openbao/openbao/sdk/v2/physical/inmem"
 	backendplugin "github.com/openbao/openbao/sdk/v2/plugin"
 	"github.com/openbao/openbao/vault/cluster"
-	"github.com/openbao/openbao/vault/seal"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/net/http2"
 )
@@ -329,12 +328,7 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 		SecretThreshold: 3,
 	}
 
-	switch core.seal.StoredKeysSupported() {
-	case seal.StoredKeysNotSupported:
-		barrierConfig.StoredShares = 0
-	default:
-		barrierConfig.StoredShares = 1
-	}
+	barrierConfig.StoredShares = 1
 
 	recoveryConfig := &SealConfig{
 		SecretShares:    3,
@@ -344,9 +338,6 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 	initParams := &InitParams{
 		BarrierConfig:  barrierConfig,
 		RecoveryConfig: recoveryConfig,
-	}
-	if core.seal.StoredKeysSupported() == seal.StoredKeysNotSupported {
-		initParams.LegacyShamirSeal = true
 	}
 	result, err := core.Initialize(context.Background(), initParams)
 	if err != nil {

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -83,7 +83,7 @@ and starting a new rekey, which will also provide a new nonce.
 
 - `require_verification` `(bool: false)` – This turns on verification
   functionality. When verification is turned on, after successful authorization
-  with the current unseal keys, the new unseal keys are returned but the master
+  with the current unseal keys, the new unseal keys are returned but the root
   key is not actually rotated. The new keys must be provided to authorize the
   actual rotation of the root key. This ensures that the new keys have been
   successfully saved and protects against a risk of the keys being lost after
@@ -199,7 +199,7 @@ for the verification operation.
 
 ### Parameters
 
-- `key` `(string: <required>)` – Specifies a single master share key.
+- `key` `(string: <required>)` – Specifies a single root share key.
 
 - `nonce` `(string: <required>)` – Specifies the nonce of the rekey operation.
 
@@ -310,7 +310,7 @@ $ curl \
 
 This endpoint is used to enter a single new key share to progress the rekey
 verification operation. If the threshold number of new key shares is reached,
-OpenBao will complete the rekey by performing the actual rotation of the master
+OpenBao will complete the rekey by performing the actual rotation of the root
 key. Otherwise, this API must be called multiple times until that threshold is
 met. The nonce must be provided with each call.
 
@@ -324,7 +324,7 @@ below; otherwise the response will be the same as the `GET` method against
 
 ### Parameters
 
-- `key` `(string: <required>)` – Specifies a single master share key from the
+- `key` `(string: <required>)` – Specifies a single root share key from the
   new set of shares.
 
 - `nonce` `(string: <required>)` – Specifies the nonce of the rekey


### PR DESCRIPTION
This cleans up various legacy migrations that should have already occurred by Vault 1.14 (the last Vault release users should've come from).

1. Remove support for pre-keyring barrier encryption
2. Remove support for legacy (direct) Shamir seals.
3. Better enforce that there are only zero or one StoredShares (root keys). 
4. Simplify all references of master->root keys. This was partially renamed but never completed, which makes evaluating the key hierarchy in code much more difficult. 