### PR TITLE
fit token to openbao format

### DIFF
--- a/website/content/docs/commands/print.mdx
+++ b/website/content/docs/commands/print.mdx
@@ -12,5 +12,5 @@ Print the current token.
 
 ```shell-session
 $ bao print token
-hvs.CAESICaie3Dm0_Hx001QuMabo1IXnyKkx_FuE14MH7zir_bqGh4KHGh2cy5wQnJsZzZ6WG82b29HUlI3eFdEQ0NPQzQ
+s.CAESICaie3Dm0Hx001QuMabo
 ```


### PR DESCRIPTION
The current version (v2.0.2) of Openbao tokens are expected to match the following regexp: `[sbr]\.[a-zA-Z0-9]{24,}` as documented in [the website](https://openbao.org/docs/concepts/tokens/) and [github source](https://github.com/openbao/openbao/blob/release/2.0.x/website/content/docs/concepts/tokens.mdx)