### PR TITLE
Add scan operation for recursive listing

### DIFF
--- a/builtin/logical/kv/backend.go
+++ b/builtin/logical/kv/backend.go
@@ -182,6 +182,8 @@ func pathInvalid(b *versionedKVBackend) []*framework.Path {
 			subCommand = "get"
 		case logical.ListOperation:
 			subCommand = "list"
+		case logical.ScanOperation:
+			subCommand = "scan"
 		case logical.DeleteOperation:
 			subCommand = "delete"
 		}
@@ -200,6 +202,7 @@ func pathInvalid(b *versionedKVBackend) []*framework.Path {
 				logical.ReadOperation:   &framework.PathOperation{Callback: handler, Unpublished: true},
 				logical.DeleteOperation: &framework.PathOperation{Callback: handler, Unpublished: true},
 				logical.ListOperation:   &framework.PathOperation{Callback: handler, Unpublished: true},
+				logical.ScanOperation:   &framework.PathOperation{Callback: handler, Unpublished: true},
 			},
 
 			HelpDescription: pathInvalidHelp,

--- a/changelog/763.txt
+++ b/changelog/763.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Scanning**: introduce the ability to recursively list (scan) within plugins, adding a separate `scan` ACL capability, operation type, HTTP verb (`SCAN` with `GET` fallback via `?scan=true`), API, and CLI support. This also adds support to the KVv1 and KVv2 engines.
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -578,6 +578,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"scan": func() (cli.Command, error) {
+			return &ScanCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"secrets": func() (cli.Command, error) {
 			return &SecretsCommand{
 				BaseCommand: getBaseCommand(),
@@ -775,6 +780,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 		},
 		"kv metadata delete": func() (cli.Command, error) {
 			return &KVMetadataDeleteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"kv scan": func() (cli.Command, error) {
+			return &KVScanCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/kv_scan.go
+++ b/command/kv_scan.go
@@ -1,0 +1,179 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*KVScanCommand)(nil)
+	_ cli.CommandAutocomplete = (*KVScanCommand)(nil)
+)
+
+type KVScanCommand struct {
+	*BaseCommand
+	flagMount string
+}
+
+func (c *KVScanCommand) Synopsis() string {
+	return "Scan data or secrets"
+}
+
+func (c *KVScanCommand) Help() string {
+	helpText := `
+
+Usage: bao kv scan [options] PATH
+
+  Scans data from OpenBao's key-value store at the given path.
+
+  Scan values under the "my-app" folder of the key-value store:
+
+      $ bao kv scan secret/my-app/
+
+  Additional flags and more advanced use cases are detailed below.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *KVScanCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	// Common Options
+	f := set.NewFlagSet("Common Options")
+
+	f.StringVar(&StringVar{
+		Name:    "mount",
+		Target:  &c.flagMount,
+		Default: "", // no default, because the handling of the next arg is determined by whether this flag has a value
+		Usage: `Specifies the path where the KV backend is mounted. If specified, 
+		the next argument will be interpreted as the secret path. If this flag is 
+		not specified, the next argument will be interpreted as the combined mount 
+		path and secret path, with /data/ automatically appended between KV 
+		v2 secrets.`,
+	})
+
+	return set
+}
+
+func (c *KVScanCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultFolders()
+}
+
+func (c *KVScanCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *KVScanCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		if c.flagMount == "" {
+			c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+			return 1
+		}
+		args = []string{""}
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	// If true, we're working with "-mount=secret foo" syntax.
+	// If false, we're using "secret/foo" syntax.
+	mountFlagSyntax := c.flagMount != ""
+
+	var (
+		mountPath   string
+		partialPath string
+		v2          bool
+	)
+
+	// Parse the paths and grab the KV version
+	if mountFlagSyntax {
+		// In this case, this arg is the secret path (e.g. "foo").
+		partialPath = sanitizePath(args[0])
+		mountPath, v2, err = isKVv2(sanitizePath(c.flagMount), client)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 2
+		}
+
+		if v2 {
+			partialPath = path.Join(mountPath, partialPath)
+		}
+	} else {
+		// In this case, this arg is a path-like combination of mountPath/secretPath.
+		// (e.g. "secret/foo")
+		partialPath = sanitizePath(args[0])
+		mountPath, v2, err = isKVv2(partialPath, client)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 2
+		}
+	}
+
+	// Add /metadata to v2 paths only
+	var fullPath string
+	if v2 {
+		fullPath = addPrefixToKVPath(partialPath, mountPath, "metadata", false)
+	} else {
+		// v1
+		if mountFlagSyntax {
+			fullPath = path.Join(mountPath, partialPath)
+		} else {
+			fullPath = partialPath
+		}
+	}
+
+	secret, err := client.Logical().Scan(fullPath)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error scanning %s: %s", fullPath, err))
+		return 2
+	}
+
+	// If the secret is wrapped, return the wrapped response.
+	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+		return OutputSecret(c.UI, secret)
+	}
+
+	_, ok := extractListData(secret)
+	if Format(c.UI) != "table" {
+		if secret == nil || secret.Data == nil || !ok {
+			OutputData(c.UI, map[string]interface{}{})
+			return 2
+		}
+	}
+
+	if secret == nil || secret.Data == nil {
+		c.UI.Error(fmt.Sprintf("No value found at %s", fullPath))
+		return 2
+	}
+
+	if !ok {
+		c.UI.Error(fmt.Sprintf("No entries found at %s", fullPath))
+		return 2
+	}
+
+	return OutputList(c.UI, secret)
+}

--- a/command/scan.go
+++ b/command/scan.go
@@ -1,0 +1,161 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*ScanCommand)(nil)
+	_ cli.CommandAutocomplete = (*ScanCommand)(nil)
+)
+
+type ScanCommand struct {
+	*BaseCommand
+
+	flagAfter string
+	flagLimit int
+}
+
+func (c *ScanCommand) Synopsis() string {
+	return "Scan (recursively list) data or secrets"
+}
+
+func (c *ScanCommand) Help() string {
+	helpText := `
+
+Usage: bao scan [options] PATH
+
+  Scans data from Vault at the given path. This can be used to scan keys in a
+  given secret engine. Scanning amounts to a recursive listing on all entries.
+
+  Scan values under the "my-app" folder of the generic secret engine:
+
+      $ bao scan secret/my-app/
+
+  Some paths support paginated scanning. Use the -after and -limit flags to
+  control the return of data:
+
+      $ bao scan -after=last-serial -limit=50 pki/certs
+
+  Some paths may support returning additional information about items;
+  use the -detailed flag to see this info:
+
+      $ bao scan -detailed secret/detailed-metadata/foo
+
+  For a full list of examples and paths, please see the documentation that
+  corresponds to the secret engine in use. Not all engines support scanning.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ScanCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat | FlagSetOutputDetailed)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:    "after",
+		Target:  &c.flagAfter,
+		Default: "",
+		Usage: "Last seen key on applicable endpoints; the next key" +
+			"alphabetically will be the first returned.",
+	})
+
+	f.IntVar(&IntVar{
+		Name:    "limit",
+		Target:  &c.flagLimit,
+		Default: -1,
+		Usage:   "Limits the number of scan responses on applicable endpoints.",
+	})
+
+	return set
+}
+
+func (c *ScanCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultFolders()
+}
+
+func (c *ScanCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *ScanCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	path := sanitizePath(args[0])
+
+	// Only dispatch a ScanPage operation if flags were given; this avoids
+	// a warning from the server about unrecognized parameters if the scan
+	// endpoint doesn't understand pagination.
+	var secret *api.Secret
+	if c.flagAfter == "" && c.flagLimit <= 0 {
+		secret, err = client.Logical().Scan(path)
+	} else {
+		secret, err = client.Logical().ScanPage(path, c.flagAfter, c.flagLimit)
+	}
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error scanning %s: %s", path, err))
+		return 2
+	}
+
+	// If the secret is wrapped, return the wrapped response.
+	if secret != nil && secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+		return OutputSecret(c.UI, secret)
+	}
+
+	_, ok := extractListData(secret)
+	if Format(c.UI) != "table" {
+		if secret == nil || secret.Data == nil || !ok {
+			OutputData(c.UI, map[string]interface{}{})
+			return 2
+		}
+	}
+
+	if secret == nil {
+		c.UI.Error(fmt.Sprintf("No value found at %s", path))
+		return 2
+	}
+	if secret.Data == nil {
+		// If secret wasn't nil, we have warnings, so output them anyways. We
+		// may also have non-keys info.
+		return OutputSecret(c.UI, secret)
+	}
+
+	if !ok {
+		c.UI.Error(fmt.Sprintf("No entries found at %s", path))
+		return 2
+	}
+
+	return OutputList(c.UI, secret)
+}

--- a/command/scan_test.go
+++ b/command/scan_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testScanCommand(tb testing.TB) (*cli.MockUi, *ScanCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &ScanCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestScanCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"not_found",
+			[]string{"nope/not/once/never"},
+			"",
+			2,
+		},
+		{
+			"default",
+			[]string{"secret/scan"},
+			"bar\nbaz\nfoo",
+			0,
+		},
+		{
+			"default_slash",
+			[]string{"secret/scan/"},
+			"bar\nbaz\nfoo",
+			0,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				keys := []string{
+					"secret/scan/foo",
+					"secret/scan/bar",
+					"secret/scan/baz",
+				}
+				for _, k := range keys {
+					if _, err := client.Logical().Write(k, map[string]interface{}{
+						"foo": "bar",
+					}); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				ui, cmd := testScanCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testScanCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"secret/scan",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error scanning secret/scan: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testScanCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/http/cors.go
+++ b/http/cors.go
@@ -19,6 +19,7 @@ var allowedMethods = []string{
 	http.MethodPost,
 	http.MethodPut,
 	"LIST", // LIST is not an official HTTP method, but Vault supports it.
+	"SCAN", // SCAN is not an official HTTP method, but Vault supports it.
 }
 
 func wrapCORSHandler(h http.Handler, core *vault.Core) http.Handler {

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -443,6 +443,138 @@ func TestLogical_ListWithQueryParameters(t *testing.T) {
 	}
 }
 
+func TestLogical_ScanSuffix(t *testing.T) {
+	core, _, rootToken := vault.TestCoreUnsealed(t)
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:8200/v1/secret/foo", nil)
+	req = req.WithContext(namespace.RootContext(nil))
+	req.Header.Add(consts.AuthHeaderName, rootToken)
+
+	lreq, _, status, err := buildLogicalRequest(core, nil, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("got status %d", status)
+	}
+	if strings.HasSuffix(lreq.Path, "/") {
+		t.Fatal("trailing slash found on path")
+	}
+
+	req, _ = http.NewRequest("GET", "http://127.0.0.1:8200/v1/secret/foo?scan=true", nil)
+	req = req.WithContext(namespace.RootContext(nil))
+	req.Header.Add(consts.AuthHeaderName, rootToken)
+
+	lreq, _, status, err = buildLogicalRequest(core, nil, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("got status %d", status)
+	}
+	if !strings.HasSuffix(lreq.Path, "/") {
+		t.Fatal("trailing slash not found on path")
+	}
+
+	req, _ = http.NewRequest("SCAN", "http://127.0.0.1:8200/v1/secret/foo", nil)
+	req = req.WithContext(namespace.RootContext(nil))
+	req.Header.Add(consts.AuthHeaderName, rootToken)
+
+	_, _, status, err = buildLogicalRequestNoAuth(nil, req)
+	if err != nil || status != 0 {
+		t.Fatal(err)
+	}
+
+	lreq, _, status, err = buildLogicalRequest(core, nil, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("got status %d", status)
+	}
+	if !strings.HasSuffix(lreq.Path, "/") {
+		t.Fatal("trailing slash not found on path")
+	}
+}
+
+func TestLogical_ScanWithQueryParameters(t *testing.T) {
+	core, _, rootToken := vault.TestCoreUnsealed(t)
+
+	tests := []struct {
+		name          string
+		requestMethod string
+		url           string
+		expectedData  map[string]interface{}
+	}{
+		{
+			name:          "SCAN request method parses query parameter",
+			requestMethod: "SCAN",
+			url:           "http://127.0.0.1:8200/v1/secret/foo?key1=value1",
+			expectedData: map[string]interface{}{
+				"key1": "value1",
+			},
+		},
+		{
+			name:          "SCAN request method parses query multiple parameters",
+			requestMethod: "SCAN",
+			url:           "http://127.0.0.1:8200/v1/secret/foo?key1=value1&key2=value2",
+			expectedData: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name:          "GET request method with scan=true parses query parameter",
+			requestMethod: "GET",
+			url:           "http://127.0.0.1:8200/v1/secret/foo?scan=true&key1=value1",
+			expectedData: map[string]interface{}{
+				"key1": "value1",
+			},
+		},
+		{
+			name:          "GET request method with scan=true parses multiple query parameters",
+			requestMethod: "GET",
+			url:           "http://127.0.0.1:8200/v1/secret/foo?scan=true&key1=value1&key2=value2",
+			expectedData: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name:          "GET request method with alternate order scan=true parses multiple query parameters",
+			requestMethod: "GET",
+			url:           "http://127.0.0.1:8200/v1/secret/foo?key1=value1&scan=true&key2=value2",
+			expectedData: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.requestMethod, tc.url, nil)
+			req = req.WithContext(namespace.RootContext(nil))
+			req.Header.Add(consts.AuthHeaderName, rootToken)
+
+			lreq, _, status, err := buildLogicalRequest(core, nil, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status != 0 {
+				t.Fatalf("got status %d", status)
+			}
+			if !strings.HasSuffix(lreq.Path, "/") {
+				t.Fatal("trailing slash not found on path")
+			}
+			if lreq.Operation != logical.ScanOperation {
+				t.Fatalf("expected logical.ScanOperation, got %v", lreq.Operation)
+			}
+			if !reflect.DeepEqual(tc.expectedData, lreq.Data) {
+				t.Fatalf("expected query parameter data %v, got %v", tc.expectedData, lreq.Data)
+			}
+		})
+	}
+}
+
 func TestLogical_RespondWithStatusCode(t *testing.T) {
 	resp := &logical.Response{
 		Data: map[string]interface{}{

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -418,11 +418,28 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 					In:          "query",
 					Schema:      &OASSchema{Type: "string", Enum: []interface{}{"true"}},
 				})
+			} else if opType == logical.ScanOperation {
+				// Only accepts List (due to the above skipping of ListOperations that also have ReadOperations)
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "scan",
+					Description: "Must be set to `true`",
+					Required:    true,
+					In:          "query",
+					Schema:      &OASSchema{Type: "string", Enum: []interface{}{"true"}},
+				})
 			} else if opType == logical.ReadOperation && operations[logical.ListOperation] != nil {
 				// Accepts both Read and List
 				op.Parameters = append(op.Parameters, OASParameter{
 					Name:        "list",
 					Description: "Return a list if `true`",
+					In:          "query",
+					Schema:      &OASSchema{Type: "string"},
+				})
+			} else if opType == logical.ReadOperation && operations[logical.ScanOperation] != nil {
+				// Accepts both Read and List
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "scan",
+					Description: "Return a recursive list if `true`",
 					In:          "query",
 					Schema:      &OASSchema{Type: "string"},
 				})

--- a/sdk/helper/stepwise/stepwise.go
+++ b/sdk/helper/stepwise/stepwise.go
@@ -28,6 +28,7 @@ const (
 	ReadOperation             = "read"
 	DeleteOperation           = "delete"
 	ListOperation             = "list"
+	ScanOperation             = "scan"
 	HelpOperation             = "help"
 )
 

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -356,6 +356,7 @@ const (
 	PatchOperation                    = "patch"
 	DeleteOperation                   = "delete"
 	ListOperation                     = "list"
+	ScanOperation                     = "scan"
 	HelpOperation                     = "help"
 	AliasLookaheadOperation           = "alias-lookahead"
 	ResolveRoleOperation              = "resolve-role"

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -302,6 +302,9 @@ func (a *ACL) Capabilities(ctx context.Context, path string) (pathCapabilities [
 	if capabilities&PatchCapabilityInt > 0 {
 		pathCapabilities = append(pathCapabilities, PatchCapability)
 	}
+	if capabilities&ScanCapabilityInt > 0 {
+		pathCapabilities = append(pathCapabilities, ScanCapability)
+	}
 
 	// If "deny" is explicitly set or if the path has no capabilities at all,
 	// set the path capabilities to "deny"
@@ -427,6 +430,9 @@ CHECK:
 	case logical.PatchOperation:
 		operationAllowed = capabilities&PatchCapabilityInt > 0
 		grantingPolicies = permissions.GrantingPoliciesMap[PatchCapabilityInt]
+	case logical.ScanOperation:
+		operationAllowed = capabilities&ScanCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[ScanCapabilityInt]
 
 	// These three re-use UpdateCapabilityInt since that's the most appropriate
 	// capability/operation mapping

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -247,6 +247,10 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 		{logical.PatchOperation, "baz/quux", true, false},
 		{logical.ListOperation, "baz/quux", false, false},
 		{logical.UpdateOperation, "baz/quux", false, false},
+		{logical.ScanOperation, "baz/quux", false, false},
+
+		{logical.ScanOperation, "asdf/fdsa", true, false},
+		{logical.ListOperation, "asdf/fdsa", false, false},
 
 		// Path segment wildcards
 		{logical.ReadOperation, "test/foo/bar/segment", false, false},
@@ -1039,6 +1043,9 @@ path "1/2/+" {
 }
 path "1/2/+/+" {
 	capabilities = ["update"]
+}
+path "asdf/fdsa" {
+	capabilities = ["scan"]
 }
 `
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3920,7 +3920,8 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 			perms.CapabilitiesBitmap&ReadCapabilityInt > 0,
 			perms.CapabilitiesBitmap&SudoCapabilityInt > 0,
 			perms.CapabilitiesBitmap&UpdateCapabilityInt > 0,
-			perms.CapabilitiesBitmap&PatchCapabilityInt > 0:
+			perms.CapabilitiesBitmap&PatchCapabilityInt > 0,
+			perms.CapabilitiesBitmap&ScanCapabilityInt > 0:
 
 			aclCapabilitiesGiven = true
 
@@ -4254,6 +4255,9 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 		}
 		if perms.CapabilitiesBitmap&PatchCapabilityInt > 0 {
 			capabilities = append(capabilities, PatchCapability)
+		}
+		if perms.CapabilitiesBitmap&ScanCapabilityInt > 0 {
+			capabilities = append(capabilities, ScanCapability)
 		}
 
 		// If "deny" is explicitly set or if the path has no capabilities at all,

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -31,6 +31,7 @@ const (
 	SudoCapability   = "sudo"
 	RootCapability   = "root"
 	PatchCapability  = "patch"
+	ScanCapability   = "scan"
 
 	// Backwards compatibility
 	OldDenyPathPolicy  = "deny"
@@ -48,6 +49,7 @@ const (
 	ListCapabilityInt
 	SudoCapabilityInt
 	PatchCapabilityInt
+	ScanCapabilityInt
 )
 
 type PolicyType uint32
@@ -77,6 +79,7 @@ var cap2Int = map[string]uint32{
 	ListCapability:   ListCapabilityInt,
 	SudoCapability:   SudoCapabilityInt,
 	PatchCapability:  PatchCapabilityInt,
+	ScanCapability:   ScanCapabilityInt,
 }
 
 // Policy is used to represent the policy specified by an ACL configuration.
@@ -384,7 +387,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				pc.Capabilities = []string{DenyCapability}
 				pc.Permissions.CapabilitiesBitmap = DenyCapabilityInt
 				goto PathFinished
-			case CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability, PatchCapability:
+			case CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability, PatchCapability, ScanCapability:
 				pc.Permissions.CapabilitiesBitmap |= cap2Int[cap]
 			default:
 				return fmt.Errorf("path %q: invalid capability %q", key, cap)

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -89,6 +89,9 @@ path "test/req" {
 path "test/patch" {
 	capabilities = ["patch"]
 }
+path "test/scan" {
+	capabilities = ["scan"]
+}
 path "test/mfa" {
 	capabilities = ["create", "sudo"]
 	mfa_methods = ["my_totp", "my_totp2"]
@@ -255,6 +258,13 @@ func TestPolicy_Parse(t *testing.T) {
 			Capabilities: []string{"patch"},
 			Permissions: &ACLPermissions{
 				CapabilitiesBitmap: (PatchCapabilityInt),
+			},
+		},
+		{
+			Path:         "test/scan",
+			Capabilities: []string{"scan"},
+			Permissions: &ACLPermissions{
+				CapabilitiesBitmap: (ScanCapabilityInt),
 			},
 		},
 		{

--- a/website/content/api-docs/secret/kv/kv-v1.mdx
+++ b/website/content/api-docs/secret/kv/kv-v1.mdx
@@ -69,9 +69,12 @@ value. Note that no policy-based filtering is performed on keys; do not encode
 sensitive information in key names. The values themselves are not accessible via
 this API.
 
+This endpoint also supports recursive listing (scanning).
+
 | Method | Path            |
 | :----- | :-------------- |
 | `LIST` | `/secret/:path` |
+| `SCAN` | `/secret/:path` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -508,9 +508,12 @@ value. Note that no policy-based filtering is performed on keys; do not encode
 sensitive information in key names. The values themselves are not accessible via
 this command.
 
+This endpoint also supports recursive listing (scanning).
+
 | Method | Path                                 |
 |:-------|:-------------------------------------|
 | `LIST` | `/:secret-mount-path/metadata/:path` |
+| `SCAN` | `/:secret-mount-path/metadata/:path` |
 
 ### Parameters
 

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -102,7 +102,7 @@ Here is a more detailed policy, and it is documented inline:
 # This section grants all access on "secret/*". further restrictions can be
 # applied to this broad policy, as shown below.
 path "secret/*" {
-  capabilities = ["create", "read", "update", "patch", "delete", "list"]
+  capabilities = ["create", "read", "update", "patch", "delete", "list", "scan"]
 }
 
 # Even though we allowed secret/*, this line explicitly denies
@@ -200,9 +200,9 @@ It _is not a regular expression_ and is only supported **as the last character o
 
 :::
 
-When providing `list` capability, it is important to note that since listing
-always operates on a prefix, policies must operate on a prefix because OpenBao
-will sanitize request paths to be prefixes.
+When providing `list` or `scan` capabilities, it is important to note that
+since listing always operates on a prefix, policies must operate on a prefix
+because OpenBao will sanitize request paths to be prefixes.
 
 ### Capabilities
 
@@ -234,6 +234,11 @@ The list of capabilities include the following:
 - `list` (`LIST`) - Allows listing values at the given path. Note that the
   keys returned by a `list` operation are _not_ filtered by policies. Do not
   encode sensitive information in key names. Not all backends support listing.
+
+- `scan` (`SCAN`) - Allows recursively listing ("scanning") values at the
+  given path. Note that the keys returned by a `list` operation are _not_
+  filtered by policies. Do not encode sensitive information in key names. Not
+  all backends support listing.
 
 In the list above, the associated HTTP verbs are shown in parenthesis next to
 the capability. When authoring policy, it is usually helpful to look at the HTTP

--- a/website/content/docs/rfcs/index.mdx
+++ b/website/content/docs/rfcs/index.mdx
@@ -24,3 +24,6 @@ Steering Committee.
    storage semantics in `physical.Backend` and `logical.Storage` for use
    by Core and plugins. This landed in several parts concluding in
    [PR #292](https://github.com/openbao/openbao/pull/292).
+ - [SCAN operation](/docs/rfcs/scan-operation), for supporting recursive
+   lists as a native operation and as an ACL capability. This landed in
+   [PR #763](https://github.com/openbao/openbao/pull/763).

--- a/website/content/docs/rfcs/scan-operation.mdx
+++ b/website/content/docs/rfcs/scan-operation.mdx
@@ -1,0 +1,80 @@
+---
+sidebar_label: SCAN operation
+description: |-
+  An OpenBao RFC to add a recursive list (SCAN) operation and ACL capability.
+---
+
+# SCAN operation
+
+## Summary
+
+Introduce a new ACL capability, `scan`, and operation type, under the `SCAN` HTTP verb or `GET` with `?scan=true`, to safely support recursive listing of entries under a given path.
+
+## Problem Statement
+
+Many users operate a K/V mount with a nested, hierarchical entry layout. While the total number of [visible entries](https://github.com/openbao/openbao/issues/769) may not be that many, it may be difficult to navigate even a shallow hierarchy to find the correct entries. This makes supporting a recursive list operation, especially in conjunction with [pruning of non-accessible results](https://github.com/openbao/openbao/issues/769) attractive for a flatter layout.
+
+Similarly, applications operating over larger datasets (say, for compliance) may want a point-in-time snapshot of all entries within a mount, say, to enqueue auditing of `custom_metadata` with company policies for structure.
+
+OpenBao has lacked recursive listing of entries from an API perspective, but has had an underlying implementation of this in certain areas via the `logical.ScanView(...)` helper. With the combination of pagination and transactional storage, this becomes consistent and resource constrainable that makes implementing worthwhile.
+
+## User-facing Description
+
+For users, OpenBao is introducing a new operation type, under the `SCAN` HTTP verb or `GET` with `?scan=true`, that plugins can implement to indicate that their lists are recursive, if they support hierarchical storage (e.g., of K/V entries versus the flat role list of PKI). Like LIST, this returns all entries within the mount, recursively. The exact implementation details are left up to plugins; please see their documentation for more information. Like LIST, in places where `ListResponseWithInfo(...)` is used, `SCAN` can use the same response format to attach detailed metadata to list entries.
+
+For operators, OpenBao will allow safely constraining these values by adding a new ACL capability, `scan`, to support limiting users' ability to call these types of endpoints. Like all capabilities, we default to deny behavior and thus users will not get access to these endpoints automatically.
+
+## Technical Description
+
+`SCAN` behaves like `LIST` in that it returns all entries within the mount. Presuambly `SCAN` would only be used in plugins which support a `LIST` parameterized with a `:prefix` parameter usually in the URL for ACLing. SCAN would, like LIST, return all entries (albeit, recursively) even if they were not necessarily visible to the caller. The operator would grant explicit access to SCAN results, giving intent to recursively list all entries below the given path.
+
+However, access to a given prefix's SCAN does not necessarily mean READ access was granted nor that SCAN was granted on sub-paths. E.g., if an operator had an ACL like:
+
+```hcl
+path "secrets/metadata" {
+   capabilities = ["scan"]
+}
+```
+
+the user would be able to see all entries in the K/V mount. However, they would not be able to call `SCAN secrets/metadata/subpath/` (even though these would show up in the results for `SCAN secrets/metadata/`) or `READ secrets/metadata/some-key`.
+
+SCAN thus behaves exactly like LIST in that regard.
+
+Because SCAN is recursive, it will presumably not include directories in its output as there is no need to explicitly call out directories, unlike with LIST. For example, given `a/b` and `c/d`, the output would be `keys: ["a/b", "c/d"]` and not `keys: ["a/", "a/b", "c/", "c/d"]`.
+
+## Rationale and Alternatives
+
+One alternative was supporting a `recurse=true` parameter. However, many endpoints which would support a recurse operation already support `LIST` and would require different implementations `storage.List(...)` versus a `logical.ScanView(...)`. This means a separate operation would be more ideal than reusing the existing `LIST` operation. Using a new verb and capability also allows for easier, clearer ACL policies: allowing `list` (without a `denied_parameters=["recurse"]`) would allow recursion, which is not ideal.
+
+A similar argument goes for pushing this onto plugin developers via separate endpoints. An operator could accidentally grant LIST with recursion on an alternative endpoint without fully understanding the resource implications of it.
+
+## Downsides
+
+SCAN is a more expensive operation. However, with `required_parameters=limit` (and potential future improvements to allow policy authors to numerically constrain this value), operators should be able to achieve comparable performance to limited LISTs.
+
+## Security Implications
+
+The security implications are mostly the same as LIST, with the extra overhead of recursion. However, this is mitigated by adding a new ACL capability and placing them on unique operation handlers and by potential future work to enforce numericial `limit` constraints.
+
+## User/Developer Experience
+
+This helps certain use cases as enumeated above, especially when humans or automated systems are directly interacting with OpenBao.
+
+For consumers of OpenAPI generation, this will [have some impact](https://github.com/orgs/openbao/discussions/656) where `LIST`, `GET`, and `SCAN` are used at the same time, but a similar workaround to the existing LIST workaround would suffice here. However, due to the `GET` fallback, this should otherwise be accessible everywhere `LIST` is.
+
+## Unresolved Questions
+
+n/a
+
+## Related Issues
+
+ - https://github.com/openbao/openbao/issues/769 implements response filtering for this.
+ - https://github.com/openbao/openbao/issues/549 is a feature request asking for this for K/V.
+
+Upstream:
+
+ - https://github.com/hashicorp/vault/issues/5275
+
+## Proof of Concept
+
+https://github.com/openbao/openbao/pull/763 is the open pull request for this change.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -492,6 +492,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/signed-commits",
                 "rfcs/transactions",
                 "rfcs/split-mount-tables",
+                "rfcs/scan-operation",
             ],
             FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },


### PR DESCRIPTION
This introduces support for recursive listing (scans):

 - A new `SCAN` operation (including handler type, HTTP verb, and `GET` fallback via `?scan=true`) for notating APIs which return all data.
 - A new `SCAN` capability, allowing operators to selectively allow the above (due to the default-deny policy).
 - `SCAN` operation support within KV, recursively listing all entries under the given prefix.
 - `SCAN` support in the API and CLI. 

Resolves: #549

---

/cc @dirsigler