### PR TITLE
Remove usage of deprecated .Subjects() in test files

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
@@ -401,7 +402,7 @@ func TestClientEnvSettings(t *testing.T) {
 	}
 
 	tlsConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
-	if len(tlsConfig.RootCAs.Subjects()) == 0 {
+	if x509.NewCertPool().Equal(tlsConfig.RootCAs) {
 		t.Fatalf("bad: expected a cert pool with at least one subject")
 	}
 	if tlsConfig.GetClientCertificate == nil {

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -219,8 +219,7 @@ func TLSErrorChecks(leafCerts, interCerts, rootCerts []*x509.Certificate) error 
 		}
 	}
 
-	rootSubjs := rootPool.Subjects()
-	if len(rootSubjs) == 0 && len(leafCerts) > 0 {
+	if x509.NewCertPool().Equal(rootPool) && len(leafCerts) > 0 {
 		// this is a self signed server certificate, or the root is just not provided. In any
 		// case, we need to bypass the root verification step by adding the leaf itself to the
 		// root pool.


### PR DESCRIPTION

`tlsConfig.RootCAs.Subjects` deprecated and removed from test files.


```
./sdk/helper/certutil/certutil_test.go:                 if len(tlsConfig.ClientCAs.Subjects()) != 1 || bytes.Compare(tlsConfig.ClientCAs.Subjects()[0], pcbut.CAChain[0].Certificate.RawSubject) != 0 {
./sdk/helper/certutil/certutil_test.go:                 if len(tlsConfig.RootCAs.Subjects()) != 1 || bytes.Compare(tlsConfig.RootCAs.Subjects()[0], pcbut.CAChain[0].Certificate.RawSubject) != 0 {
./sdk/helper/certutil/certutil_test.go:                 if len(tlsConfig.ClientCAs.Subjects()) != 1 || bytes.Compare(tlsConfig.ClientCAs.Subjects()[0], pcbut.CAChain[0].Certificate.RawSubject) != 0 {
./sdk/helper/certutil/certutil_test.go:                 if len(tlsConfig.RootCAs.Subjects()) != 1 || bytes.Compare(tlsConfig.RootCAs.Subjects()[0], pcbut.CAChain[0].Certificate.RawSubject) != 0 {
```
In **certutil_test.go**, it was replaced by verifying if the leaf certs could be verified against the ClientCAs or RootCAs or both.

```
./api/client_test.go:   if len(tlsConfig.RootCAs.Subjects()) == 0 {
./vault/diagnose/tls_verification.go:   rootSubjs := rootPool.Subjects()
```
In these test files which were checking that the cert pools are not empty, I replaced them by checking the cert pool is not equal to an empty cert pool: `x509.NewCertPool().Equal(tlsConfig.RootCAs) `

Resolves #575 

## Target Release

1.14.7
