### PR TITLE
Create plugin authors guide

### DIFF
--- a/website/content/docs/plugins/plugin-authors-guide.mdx
+++ b/website/content/docs/plugins/plugin-authors-guide.mdx
@@ -1,0 +1,42 @@
+---
+sidebar_label: Plugin Author Guide
+description: OpenBao's plugin authors guide.
+---
+
+# Plugin Author Guide
+
+This page is a guide for developers interested in creating, managing, and enhancing 
+plugins for OpenBao.
+
+## Table of contents
+
+- [List pagination](#list-pagination)
+
+## List pagination
+
+When implementing listing, it is recommended to use pagination so that items are 
+processed in increments rather than loading the entire set into memory at once. 
+Learn more in [rfcs/paginated-lists](https://openbao.org/docs/rfcs/paginated-lists/). 
+`HandleListPage(...)` is a helper introduced in [PR #781](https://github.com/openbao/openbao/pull/781) 
+to streamline list pagination across implementations. It supports both item-level 
+and batch-level callbacks for flexibility:
+
+- **`itemCallback(...)`**: Processes individual entries within a page.
+   - **Parameters**:
+     - `page` (int): The index of the current page.
+     - `index` (int): The index of the entry within the current page.
+     - `entry` (*logical.StorageEntry): The current storage entry being processed.
+   - **Returns**:
+     - `cont` (bool): Whether to continue processing further entries.
+     - `err` (error): An error, if encountered.
+
+- **`batchCallback(...)`**: Executes after processing all entries in a page.
+   - **Parameters**:
+     - `page` (int): The index of the current page.
+     - `entries` ([]*logical.StorageEntry): All entries in the current batch.
+   - **Returns**:
+     - `cont` (bool): Whether to continue processing further pages.
+     - `err` (error): An error, if encountered.
+
+The callbacks are executed sequentially, with `itemCallback` processing each entry individually,
+followed by `batchCallback` handling the entire batch.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -393,9 +393,10 @@ const sidebars: SidebarsConfig = {
                 "audit/socket",
             ],
             Plugins: [
-                "plugins/index",
-                "plugins/plugin-architecture",
+                "plugins/index",                
+                "plugins/plugin-architecture",                
                 "plugins/plugin-development",
+                "plugins/plugin-authors-guide",
                 "plugins/plugin-management",
             ],
             Platforms: [

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -393,8 +393,8 @@ const sidebars: SidebarsConfig = {
                 "audit/socket",
             ],
             Plugins: [
-                "plugins/index",                
-                "plugins/plugin-architecture",                
+                "plugins/index",
+                "plugins/plugin-architecture",
                 "plugins/plugin-development",
                 "plugins/plugin-authors-guide",
                 "plugins/plugin-management",


### PR DESCRIPTION
This PR adds a Plugin Author Guide to the website under docs/plugins. 

The guide is intended to:
- Document the reasoning behind certain design decisions and behaviors in plugins.
- Provide a clear understanding of the design logic for current and future plugin authors.
- Assist new contributors in getting up to speed quickly.
- Ensure consistency and clarity in contributions to the project.

Resolves #749 