### PR TITLE
Add download link to v2.1.0 blog post

### DIFF
--- a/website/content/blog/2024-11-29-release-v2-1-0.md
+++ b/website/content/blog/2024-11-29-release-v2-1-0.md
@@ -8,7 +8,7 @@ tags: [release, announcement, release]
 
 ![openbao-logo](https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-text-color.svg)
 
-We are thrilled to announce the availability of [OpenBao v2.1.0](https://openbao.org/docs/release-notes/2-1-0/), focused on safety and scalability improvements!
+We are thrilled to announce [the availability](https://openbao.org/downloads/?version=v2.1.0) of [OpenBao v2.1.0](https://openbao.org/docs/release-notes/2-1-0/), focused on safety and scalability improvements!
 
 This release spent some time laying the groundwork for safety and scalability improvements for releases to come. With the help of the community, OpenBao will now take advantage of transactional storage semantics from its underlying data store, giving operators and plugin developers confidence in the consistency of storage writes. This storage safety allows us to focus on alternative storage layouts for improving scalability, for instance, increasing the maximum number of mount table entries past the single-entry limit.
 


### PR DESCRIPTION
This will make it a little easier to find installation instructions for anyone hitting the blog post. 