### PR TITLE
Add pagination_limit to ACL policies

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/armon/go-radix"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/copystructure"
 	"github.com/openbao/openbao/helper/identity"
@@ -63,6 +65,8 @@ type ACLResults struct {
 type SentinelResults struct {
 	GrantingPolicies []logical.PolicyInfo
 }
+
+const limitParameterName = "limit"
 
 // NewACL is used to construct a policy based ACL from a set of policies.
 func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
@@ -254,6 +258,12 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 				existingPerms.MFAMethods = strutil.RemoveDuplicates(existingPerms.MFAMethods, false)
 			}
 
+			// Lowest set pagination limit wins.
+			if pc.Permissions.PaginationLimit > 0 {
+				if existingPerms.PaginationLimit <= 0 || pc.Permissions.PaginationLimit < existingPerms.PaginationLimit {
+					existingPerms.PaginationLimit = pc.Permissions.PaginationLimit
+				}
+			}
 		INSERT:
 			switch {
 			case pc.HasSegmentWildcards:
@@ -365,7 +375,7 @@ func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheck
 		capabilities = permissions.CapabilitiesBitmap
 		goto CHECK
 	}
-	if op == logical.ListOperation {
+	if op == logical.ListOperation || op == logical.ScanOperation {
 		raw, ok = a.exactRules.Get(strings.TrimSuffix(path, "/"))
 		if ok {
 			permissions = raw.(*ACLPermissions)
@@ -374,9 +384,9 @@ func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheck
 		}
 	}
 
-	// List operations need to check without the trailing slash first, because
-	// there could be other rules with trailing wildcards that will match the
-	// path
+	// List and Scan operations need to check without the trailing slash first,
+	// because there could be other rules with trailing wildcards that will
+	// match the path.
 	if op == logical.ListOperation && strings.HasSuffix(path, "/") {
 		permissions = a.CheckAllowedFromNonExactPaths(strings.TrimSuffix(path, "/"), false)
 		if permissions != nil {
@@ -526,6 +536,83 @@ CHECK:
 			// deny
 			if ok && !valueInParameterList(value, valueSlice) {
 				return
+			}
+		}
+	} else if op == logical.ListOperation || op == logical.ScanOperation {
+		if permissions.PaginationLimit > 0 {
+			valRaw, ok := req.Data[limitParameterName]
+			if !ok {
+				// For callers unaware of pagination, deny the request IF
+				// limit is a required parameter; this prevents integrations
+				// from silently continuing to work if they were not expecting
+				// to have pagination while also allowing them to continue
+				// working if the operator just wishes to enable pagination
+				// for them without breakage.
+
+				limitRequiredParameter := false
+				for _, parameter := range permissions.RequiredParameters {
+					if strings.ToLower(parameter) == limitParameterName {
+						limitRequiredParameter = true
+						break
+					}
+				}
+
+				if limitRequiredParameter {
+					return
+				}
+
+				// Otherwise, update our field value to the maximum allowed.
+				req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
+			} else {
+				// Value was provided on the API request and we have a
+				// non-zero limit so we know it was intended to be a limit
+				// operation on a paginated endpoint. Parse the value and
+				// ACL accordingly.
+				val, err := parseutil.SafeParseInt(valRaw)
+				if err != nil {
+					// Unable to parse provided limit as an integer; we assume
+					// the policy author is correct that this is a regular list
+					// endpoint which (optionally) takes a limit. The one
+					// exception is if the user has passed the literal value
+					// "max" to signify the maximum allowed page size, which
+					// works even if the parameter is required (versus leaving
+					// it off).
+					valStr, ok := valRaw.(string)
+					if !ok || valStr != "max" {
+						// Request denied.
+						return
+					}
+
+					// Otherwise, update our field value to the maximum allowed.
+					req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
+				} else {
+					// Deny if we exceed our allotted page size.
+					if val > permissions.PaginationLimit {
+						return
+					}
+				}
+			}
+		} else {
+			// Check if we have the value `max` and set it to 0. This allows
+			// pagination-aware applications to read all data via the same
+			// semantics, without knowing ahead of time whether they are
+			// pagination-limited on a given endpoint: they can call with
+			// after=""&limit=max and then retry with after=<last>&limit=max
+			// and see if any results are returned, repeating until none are.
+
+			valRaw, ok := req.Data[limitParameterName]
+			if ok {
+				// Failure to parse should be ignored in this case. The
+				// operator has not indicated to us that this value of
+				// limit should be an integer limit and it may be some
+				// custom plugin with alternative behavior.
+				valStr, ok := valRaw.(string)
+				if ok && valStr == "max" {
+					// Application has indicated they're aware of the value
+					// of limit and so we should set the limit to zero
+					// (maximum).
+					req.Data[limitParameterName] = "0"
+				}
 			}
 		}
 	}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -122,6 +122,7 @@ type PathRules struct {
 	DeniedParametersHCL   map[string][]interface{} `hcl:"denied_parameters"`
 	RequiredParametersHCL []string                 `hcl:"required_parameters"`
 	MFAMethodsHCL         []string                 `hcl:"mfa_methods"`
+	PaginationLimitHCL    int                      `hcl:"pagination_limit"`
 }
 
 type IdentityFactor struct {
@@ -138,6 +139,7 @@ type ACLPermissions struct {
 	DeniedParameters    map[string][]interface{}
 	RequiredParameters  []string
 	MFAMethods          []string
+	PaginationLimit     int
 	GrantingPoliciesMap map[uint32][]logical.PolicyInfo
 }
 
@@ -147,6 +149,7 @@ func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 		MinWrappingTTL:     p.MinWrappingTTL,
 		MaxWrappingTTL:     p.MaxWrappingTTL,
 		RequiredParameters: p.RequiredParameters[:],
+		PaginationLimit:    p.PaginationLimit,
 	}
 
 	switch {
@@ -320,6 +323,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			"min_wrapping_ttl",
 			"max_wrapping_ttl",
 			"mfa_methods",
+			"pagination_limit",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -434,6 +438,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			pc.Permissions.RequiredParameters = pc.RequiredParametersHCL[:]
 		}
 
+		pc.Permissions.PaginationLimit = pc.PaginationLimitHCL
 	PathFinished:
 		paths = append(paths, &pc)
 	}

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -111,6 +111,13 @@ path "test/+/wildcard/+/*" {
 path "test/+/wildcard/+/end*" {
 	capabilities = ["create", "sudo"]
 }
+path "paginated-kv/metadata" {
+	capabilities = ["list"]
+	pagination_limit = 12345
+}
+path "unpaginated-kv/metadata" {
+	capabilities = ["list"]
+}
 `)
 
 func TestPolicy_Parse(t *testing.T) {
@@ -339,6 +346,22 @@ func TestPolicy_Parse(t *testing.T) {
 				CapabilitiesBitmap: (CreateCapabilityInt | SudoCapabilityInt),
 			},
 			HasSegmentWildcards: true,
+		},
+		{
+			Path:         "paginated-kv/metadata",
+			Capabilities: []string{"list"},
+			Permissions: &ACLPermissions{
+				CapabilitiesBitmap: ListCapabilityInt,
+				PaginationLimit:    12345,
+			},
+			PaginationLimitHCL: 12345,
+		},
+		{
+			Path:         "unpaginated-kv/metadata",
+			Capabilities: []string{"list"},
+			Permissions: &ACLPermissions{
+				CapabilitiesBitmap: ListCapabilityInt,
+			},
 		},
 	}
 

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -592,6 +592,21 @@ path "secret/foo" {
   }
 }
 ```
+
+##### Limiting pagination
+The `pagination_limit` parameter allows policy authors to control the value of
+`limit` on paginated list and scan endpoints. In conjunction with setting
+`required_parameters=["limit"]` on the ACL policy, pagination becomes fully
+required, rejecting the request if the client did not set `limit`; otherwise,
+pagination is optional but, when `limit` is specified, the maximum number of
+results is limited to the value of `pagination_limit`.
+
+It is assumed that the policy author only sets `pagination_limit` on endpoints
+conforming to the [Paginated Lists RFC](/docs/rfcs/paginated-lists/). This
+allows the API to safely translate the value `limit=max` to a numerical value,
+either `limit=0` if no value was set or to the actual limit set by the policy
+author.
+
 ### Required response wrapping TTLs
 
 These parameters can be used to set minimums/maximums on TTLs set by clients

--- a/website/content/docs/rfcs/acl-paginated-lists.mdx
+++ b/website/content/docs/rfcs/acl-paginated-lists.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_label: ACL paginated lists
+description: |-
+  An OpenBao RFC for ACLing paginating lists, restricting the maximum returned values.
+---
+
+# Safely limit pagination via ACL policies
+
+## Summary
+
+Extend our [paginated list RFC](https://openbao.org/docs/rfcs/paginated-lists/) by adding the ability to limit pagination via an ACL policy parameter, `pagination_limit` supplemented by `required_parameters = ["limit"]`.
+
+## Problem Statement
+
+When adding paginated listing, there was no way to enforce that clients should use pagination or restrict them from making non-paginated list calls. Augmented with [list filtering](https://github.com/openbao/openbao/issues/769), it becomes important to allow operators to safely limit the number of returned results.
+
+This should also apply to [SCAN](https://github.com/openbao/openbao/issues/549) if that new operation is accepted.
+
+## User-facing Description
+
+From an operator perspective, we introduce a new parameter, `pagination_limit`, which can be added to an ACL policy for a `list` endpoint which affects whether or not pagination is required. When set to a positive value (1 or more), we enforce limits on the value of the `limit` pagination parameter for both LIST and [future SCAN](https://github.com/openbao/openbao/issues/549#issuecomment-2511881534) operations.
+
+If `required_parameters` contains `limit`, we enforce that all requests contain the limit parameter and are denied otherwise. For requests without `limit` and for which `limit` is not required, we silently update the request to include the maximum allowed limit value. This allows the operator to select the desired behavior: break applications via an explicit request failure or via implicitly setting a limit and not .
+
+An example policy to restrict to 100 items would look like:
+
+```hcl
+path "secret/metadata" {
+  capabilities = ["list"]
+  pagination_limit = 100
+}
+```
+
+For users who do not wish to set an explicit limit but use the maximum allowed value set by an operator, we introduce the transparent value `max`: if the operator has set a maximum value, we update the request to use this value. Otherwise, we translate `max` to 0 to avoid breaking applications.
+
+Operators should only set this option on paths which understand pagination.
+
+## Technical Description
+
+This introduces a new parameter, `pagination_limit`, which needs to be added to the permissions type. This is enforced within `ACL.AllowOperation(...)`, which can update the request value if necessary with the updated value of `limit` and enforce the required parameter for `limit`.
+
+No changes to the typing (from a plugin perspective) are required as the handling of `max` is done transparently to the caller.
+
+However, this will need to be updated in the CLI as well, as it does not permit the value `max` as it is not a valid integer.
+
+## Rationale and Alternatives
+
+This allows operators to safely enforce resource consumption resources on list endpoints with lots of expensive results (e.g., a `ListResponseWithInfo` endpoint).
+
+We could enforce without `max`, however, without substantial modifications to the ACL system to add a reason for rejection, it becomes hard for callers to understand the correct value if they didn't have a particular one in mind.
+
+## Downsides
+
+This has a small potential that, if anyone has a list endpoint which accepts the literal value `max`, we will overwrite this with the value `0`, potentially breaking them. This seems unlikely.
+
+This also has the downside that our [existing SDK pagination API](https://pkg.go.dev/github.com/openbao/openbao/api/v2#Logical.ListPage) does not support string `limit` values and thus doesn't support the `max` helper. This likely requires a new `ListAll` interface, that is aware of pagination and will fetch additional results as required. This would be similar to our [`HandleListPage(...)`](https://github.com/openbao/openbao/blob/acb48ee56577ca8146a05940dad6f76c0b265b57/sdk/logical/storage.go#L169-L182) helper.
+
+Lastly, if a new non-HCL ACL system is introduced in the future, it will need to support translating the `max` value appropriately in requests.
+
+## Security Implications
+
+This improves the security posture of listing, allowing operators to restrict resource consumption via applying strict pagination limits.
+
+## User/Developer Experience
+
+The generic `permission denied` response is slightly unfortunate. However, most applications using pagination will be able to use the value `max` instead, avoiding this problem when the API supports it.
+
+## Unresolved Questions
+
+n/a
+
+## Related Issues
+
+ - Pagination introduction: https://github.com/openbao/openbao/pull/170
+ - LIST to accesisble-only: https://github.com/openbao/openbao/issues/769
+
+## Proof of Concept
+
+https://github.com/cipherboy/openbao/pull/new/acls-limit-pagination

--- a/website/content/docs/rfcs/index.mdx
+++ b/website/content/docs/rfcs/index.mdx
@@ -27,3 +27,6 @@ Steering Committee.
  - [SCAN operation](/docs/rfcs/scan-operation), for supporting recursive
    lists as a native operation and as an ACL capability. This landed in
    [PR #763](https://github.com/openbao/openbao/pull/763).
+ - [Safely limit pagination via ACL policies](/docs/rfcs/acl-paginated-lists),
+   adding a new ACL policy parameter, `pagination_limit`, to restrict the size
+   of list and scan operation requests.

--- a/website/content/docs/rfcs/paginated-lists.mdx
+++ b/website/content/docs/rfcs/paginated-lists.mdx
@@ -8,6 +8,12 @@ description: |-
 
 **Status**: this landed in [PR #170](https://github.com/openbao/openbao/pull/170).
 
+:::info
+
+This RFC was updated by [safely limiting pagination via ACL policies](/docs/rfcs/acl-paginated-lists).
+
+:::
+
 ## Summary
 
 OpenBao's `LIST` Plugin APIs presently only supports returning all keys within a tree, resulting in many performance issues (memory and compute). By implementing pagination, the caller can limit the number of responses and thus reduce both the client's and server's instantaneous resource consumption.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -493,6 +493,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/transactions",
                 "rfcs/split-mount-tables",
                 "rfcs/scan-operation",
+                "rfcs/acl-paginated-lists",
             ],
             FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },


### PR DESCRIPTION
Add pagination_limit to ACL policies

This takes an integer value to limit the maximum value of the page size
(`limit` parameter) in paginated listing requests. This applies to LIST
and SCAN requests. When `limit` is added to `required_parameters` in
conjunction with setting the `pagination_limit` value, the presence of
`limit` is now strictly enforced on requests to this endpoint. However,
`limit` can be silently added if missing from the request (but
`pagination_limit` is present and `required_parameters` does not
include `limit`).

This also adds a helpful value, `max`, which is translated by the ACL
system to the maximum allowed by the operator for this endpoint, or
zero, if no value is defined. This is transparent to the plugin and thus
does not affect typing (it remains an int value).

Resolves: #791