### PR TITLE
added warning for ui on helm chart

### DIFF
--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -154,6 +154,13 @@ The OpenBao UI is enabled but NOT exposed as service for security reasons. The
 OpenBao UI can also be exposed via port-forwarding or through a [`ui`
 configuration value](/docs/platform/k8s/helm/configuration/#ui).
 
+:::warning
+
+The UI for OpenBao needs to be built from the source (https://github.com/openbao/openbao) 
+The Helm chart does not come with the UI ready at the moment.
+
+:::
+
 Expose the OpenBao UI with port-forwarding:
 
 ```shell-session


### PR DESCRIPTION
Added a warning before the port forwarding section for the UI that the UI needs to be built from the source code and is not available on the helm chart.

This section of the docs is a 1:1 copy of the vault documentation while the expectation is that we build our own ui from source to use. (which is fine) Its not mentioned here in any manner and its easy to just think that everything will work just like vault I think its important to at least make the information that its not the case at the moment easily readable