### PR TITLE
ui: change sidebar coloring to match OpenBao colors

### DIFF
--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -5,7 +5,7 @@
         <Hds::SideNav::Header>
           <:logo>
             <Sidebar::Header::HomeLink
-              @icon="openbao-white"
+              @icon="openbao"
               @route="vault.cluster"
               @model={{this.currentCluster.cluster.name}}
               @ariaLabel="home link"
@@ -14,6 +14,7 @@
           </:logo>
           <:actions>
             <Hds::SideNav::Header::IconButton
+              class="sidebar-button"
               @icon="terminal-screen"
               @ariaLabel="Console toggle"
               data-test-console-toggle

--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -7,7 +7,7 @@
   as |Dropdown|
 >
   <Dropdown.Trigger data-test-user-menu-trigger>
-    <Hds::SideNav::Header::IconButton @icon="user" @ariaLabel="User menu" />
+    <Hds::SideNav::Header::IconButton @icon="user" @ariaLabel="User menu" class="sidebar-button" />
   </Dropdown.Trigger>
   <Dropdown.Content>
     <Confirm as |c|>

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -20,3 +20,15 @@
 // Font comes from npm package: https://www.npmjs.com/package/text-security
 // We took the font we wanted and moved it into the ui/fonts folder
 @include font-face('text-security-square');
+
+:root {
+  /* Sidebar Foreground Colors */
+  --token-side-nav-color-foreground-primary: #ffffff; /* Primary text color */
+  --token-side-nav-color-foreground-strong: #e0f0eb; /* Strong foreground (e.g., active items) */
+  --token-side-nav-color-foreground-faint: #9db7af; /* Faint foreground (e.g., secondary text) */
+
+  /* Sidebar Background and Interactive Colors */
+  --token-side-nav-color-surface-primary: #336d5c; /* Sidebar primary background */
+  --token-side-nav-color-surface-interactive-hover: #4f8c77; /* Hover state */
+  --token-side-nav-color-surface-interactive-active: #275547; /* Active state */
+}

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -24,3 +24,11 @@
     color: $black;
   }
 }
+
+.sidebar-button {
+  border-color: var(--token-side-nav-color-surface-primary);
+}
+
+.hds-side-nav--is-mobile .hds-side-nav__menu-toggle-button {
+  background-color: var(--token-side-nav-color-surface-interactive-active);
+}


### PR DESCRIPTION
Change the black sidebar to green to match the coloring on our Website
and in the logo.

Signed-off-by: Jan Martens <jan@martens.eu.org>

## Preview
![image](https://github.com/user-attachments/assets/4662fcbb-c524-4a9d-98b7-55b5f7fe5c38)


## Target Release

2.2.0