### PR TITLE
Ignore overlapping -config file/dir options passed to server

### DIFF
--- a/changelog/816.txt
+++ b/changelog/816.txt
@@ -1,0 +1,3 @@
+```release-note:change
+command/server: Prevent and warn about loading of duplicate config file from config directory.
+```

--- a/command/server/config_custom_response_headers_test.go
+++ b/command/server/config_custom_response_headers_test.go
@@ -60,7 +60,7 @@ func TestCustomResponseHeadersConfigs(t *testing.T) {
 		"400":     customHeader400,
 	}
 
-	config, err := LoadConfigFile("./test-fixtures/config_custom_response_headers_1.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config_custom_response_headers_1.hcl", nil)
 	if err != nil {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
@@ -79,7 +79,7 @@ func TestCustomResponseHeadersConfigsMultipleListeners(t *testing.T) {
 		"400":     customHeader400,
 	}
 
-	config, err := LoadConfigFile("./test-fixtures/config_custom_response_headers_multiple_listeners.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config_custom_response_headers_multiple_listeners.hcl", nil)
 	if err != nil {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}

--- a/command/server/config_telemetry_test.go
+++ b/command/server/config_telemetry_test.go
@@ -31,7 +31,7 @@ func TestMetricFilterConfigs(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			config, err := LoadConfigFile(tc.configFile)
+			config, err := LoadConfigFile(tc.configFile, nil)
 			if err != nil {
 				t.Fatalf("Error encountered when loading config %+v", err)
 			}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -30,7 +30,7 @@ func boolPointer(x bool) *bool {
 }
 
 func testConfigRaftRetryJoin(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/raft_retry_join.hcl")
+	config, err := LoadConfigFile("./test-fixtures/raft_retry_join.hcl", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func testConfigRaftRetryJoin(t *testing.T) {
 }
 
 func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
-	config, err := LoadConfigFile("./test-fixtures/config2.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config2.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -175,7 +175,7 @@ func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
 }
 
 func testLoadConfigFile_json2(t *testing.T, entropy *configutil.Entropy) {
-	config, err := LoadConfigFile("./test-fixtures/config2.hcl.json")
+	config, err := LoadConfigFile("./test-fixtures/config2.hcl.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -275,7 +275,7 @@ func testLoadConfigFileIntegerAndBooleanValuesJson(t *testing.T) {
 }
 
 func testLoadConfigFileIntegerAndBooleanValuesCommon(t *testing.T, path string) {
-	config, err := LoadConfigFile(path)
+	config, err := LoadConfigFile(path, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -322,7 +322,7 @@ func testLoadConfigFileIntegerAndBooleanValuesCommon(t *testing.T, path string) 
 }
 
 func testLoadConfigFile(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -421,7 +421,7 @@ func testLoadConfigFile(t *testing.T) {
 }
 
 func testUnknownFieldValidationStorageAndListener(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/storage-listener-config.json")
+	config, err := LoadConfigFile("./test-fixtures/storage-listener-config.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -431,7 +431,7 @@ func testUnknownFieldValidationStorageAndListener(t *testing.T) {
 }
 
 func testUnknownFieldValidation(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -483,7 +483,7 @@ func testUnknownFieldValidation(t *testing.T) {
 // errors. Prior to VAULT-8519, it reported errors even with a valid config that was
 // parsed properly.
 func testUnknownFieldValidationJson(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config_small.json")
+	config, err := LoadConfigFile("./test-fixtures/config_small.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -499,7 +499,7 @@ func testUnknownFieldValidationJson(t *testing.T) {
 // with a valid config that was parsed properly.
 // In short, this ensures the same for HCL as we test in testUnknownFieldValidationJson
 func testUnknownFieldValidationHcl(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config_small.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config_small.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -512,7 +512,7 @@ func testUnknownFieldValidationHcl(t *testing.T) {
 
 // testConfigWithAdministrativeNamespaceJson tests that a config with a valid administrative namespace path is correctly validated and loaded.
 func testConfigWithAdministrativeNamespaceJson(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config_with_valid_admin_ns.json")
+	config, err := LoadConfigFile("./test-fixtures/config_with_valid_admin_ns.json", nil)
 	require.NoError(t, err)
 
 	configErrors := config.Validate("./test-fixtures/config_with_valid_admin_ns.json")
@@ -523,7 +523,7 @@ func testConfigWithAdministrativeNamespaceJson(t *testing.T) {
 
 // testConfigWithAdministrativeNamespaceHcl tests that a config with a valid administrative namespace path is correctly validated and loaded.
 func testConfigWithAdministrativeNamespaceHcl(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config_with_valid_admin_ns.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config_with_valid_admin_ns.hcl", nil)
 	require.NoError(t, err)
 
 	configErrors := config.Validate("./test-fixtures/config_with_valid_admin_ns.hcl")
@@ -533,7 +533,7 @@ func testConfigWithAdministrativeNamespaceHcl(t *testing.T) {
 }
 
 func testLoadConfigFile_json(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config.hcl.json")
+	config, err := LoadConfigFile("./test-fixtures/config.hcl.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -682,7 +682,7 @@ func testLoadConfigDir(t *testing.T) {
 }
 
 func testConfig_Sanitized(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config3.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config3.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1018,7 +1018,7 @@ ha_storage "consul" {
 }
 
 func testParseSeals(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config_seals.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config_seals.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1081,7 +1081,7 @@ func testParseSeals(t *testing.T) {
 }
 
 func testLoadConfigFileLeaseMetrics(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config5.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config5.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1172,7 +1172,7 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 }
 
 func testConfigRaftAutopilot(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/raft_autopilot.hcl")
+	config, err := LoadConfigFile("./test-fixtures/raft_autopilot.hcl", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/server/listener_test.go
+++ b/command/server/listener_test.go
@@ -93,7 +93,7 @@ func testListenerImpl(t *testing.T, ln net.Listener, connFn testListenerConnFn, 
 }
 
 func TestProfilingUnauthenticatedInFlightAccess(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/unauth_in_flight_access.hcl")
+	config, err := LoadConfigFile("./test-fixtures/unauth_in_flight_access.hcl", nil)
 	if err != nil {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}


### PR DESCRIPTION
When using the official container image with no arguments, OpenBao automatically invokes the server as:

```
$ bao server -config=/openbao/config "$@"
```

A user might reasonably expect to mount their configuration into /openbao/config, perhaps using a filename ending in .hcl or .json, and pass -config=/openbao/config/my-config.hcl, not expecting it to be auto-loaded. When this occurs, a strange error such as:

> bind: cannot assign requested address

occurs, because there are two identical listener configurations with the same address: one from loading the configuration file as a directory and one from adding it as a config file.

We opt to not entirely deduplicate arguments, but do warn if a server uses both a config directory and a config path.

This is a potentially breaking change: while ideal for listeners, if a user has a layout such as:

 - `config/00-ui-enable.hcl`
 - `config/01-ui-disable.hcl`

and invokes the CLI as:

```
$ bao server -config=config/ -config=00-ui-enable.hcl
```

before this change, the UI would be enabled (due to the last version winning), but after this change, the UI would be disabled. It is suggested admins update the configuration for clarity.

---

> ```
> $ podman run --replace --name vault  --mount=type=bind,src=./config.hcl,dst=/openbao/config/config.hcl,chown=true,relabel=shared --mount=type=bind,src=/home/cipherboy/GitHub/cipherboy/openbao/bin/bao,dst=/bin/bao,chown=true,relabel=shared   openbao/openbao:latest   server -config=/openbao/config/config.hcl 
> WARNING: ignoring duplicate configuration found in directory: /openbao/config/config.hcl
> ...
> ```