### PR TITLE
Add dependabot for go.mod, container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,42 @@
 version: 2
 
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/api/auth/approle"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/api/auth/kubernetes"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/api/auth/ldap"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/api/auth/userpass"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/api"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/sdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,39 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/api/auth/approle"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/api/auth/kubernetes"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/api/auth/ldap"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/api/auth/userpass"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/sdk"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "npm"
-    directory: "/website"
+    directory: "/ui"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
-    directory: "/ui"
+    directory: "/website"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Resolves: #694 

---

I hadn't realized this would also handle container images, which would be nice for avoiding the issues with our October release. 