### PR TITLE
Add -dev-no-store-token to container entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 # # By default you'll get a single-node development server that stores everything
 # # in RAM and bootstraps itself. Don't use this configuration for production.
-CMD ["server", "-dev"]
+CMD ["server", "-dev", "-dev-no-store-token"]
 
 
 
@@ -151,4 +151,4 @@ USER openbao
 
 # # By default you'll get a single-node development server that stores everything
 # # in RAM and bootstraps itself. Don't use this configuration for production.
-CMD ["server", "-dev"]
+CMD ["server", "-dev", "-dev-no-store-token"]

--- a/changelog/826.txt
+++ b/changelog/826.txt
@@ -1,0 +1,3 @@
+```release-note:change
+container: Set -dev-no-store-token in default container images, fixing default read-only containers.
+```


### PR DESCRIPTION
This avoids writing the devroot token, allowing the image to be used from a read-only base.

Resolves: #356
