### PR TITLE
Prune dependabot to only handle main module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,30 +13,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/api/auth/approle"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/api/auth/kubernetes"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/api/auth/ldap"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/api/auth/userpass"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/api"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/sdk"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:


### PR DESCRIPTION
This is because API and SDK updates should be synchronized via `make sync-deps` and not done directly. 