### PR TITLE
Nit: Put not_before in bullet point format.

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -677,7 +677,7 @@ field if `format=pem_bundle` parameter is specified.
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
 
- `not_before` `(string)` - Specifies the Not Before field of the certificate with
+- `not_before` `(string)` - Specifies the Not Before field of the certificate with
   specified date value. The value format should be given in UTC format
   `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.


### PR DESCRIPTION
Nit in the pki docs. The parameter `not_before` is not formatted to be part of a list even though points before and after are in list format.

![image](https://github.com/user-attachments/assets/c19bc0ff-4ada-4de9-b2a1-fdc0bc9e9704)