### PR TITLE
Modify audit logging to handle nested structs without panicing

### DIFF
--- a/audit/format.go
+++ b/audit/format.go
@@ -583,11 +583,11 @@ func doElideListResponseDataWithCopy(inputData map[string]interface{}, outputDat
 	for k, v := range inputData {
 		if k == "keys" {
 			if vSlice, ok := v.([]string); ok {
-				outputData[k] = float64(len(vSlice))
+				outputData[k] = len(vSlice)
 			}
 		} else if k == "key_info" {
 			if vMap, ok := v.(map[string]interface{}); ok {
-				outputData[k] = float64(len(vMap))
+				outputData[k] = len(vMap)
 			}
 		}
 	}

--- a/audit/format.go
+++ b/audit/format.go
@@ -576,14 +576,18 @@ func NewTemporaryFormatter(format, prefix string) *AuditFormatter {
 //
 // See the documentation of the controlling option in FormatterConfig for more information on the purpose.
 func doElideListResponseData(data map[string]interface{}) {
-	for k, v := range data {
+	doElideListResponseDataWithCopy(data, data)
+}
+
+func doElideListResponseDataWithCopy(inputData map[string]interface{}, outputData map[string]interface{}) {
+	for k, v := range inputData {
 		if k == "keys" {
 			if vSlice, ok := v.([]string); ok {
-				data[k] = len(vSlice)
+				outputData[k] = float64(len(vSlice))
 			}
 		} else if k == "key_info" {
 			if vMap, ok := v.(map[string]interface{}); ok {
-				data[k] = len(vMap)
+				outputData[k] = float64(len(vMap))
 			}
 		}
 	}

--- a/audit/format_test.go
+++ b/audit/format_test.go
@@ -239,20 +239,19 @@ func fixupInputData(inputData map[string]interface{}) map[string]interface{} {
 	}
 }
 
-// Because the elided real data doesn't get unmarshaled, it doesn't get converted to floats.
-// But when the elided test-data is hashed, it doesn't handle elision and
-// the elided ints get converted to floats. This func corrects the test data, by
-// converting the floats back to ints.
+// Because the elided real data doesn't get unmarshaled, it doesn't
+// get converted to floats.  But when the elided test-data is hashed
+// by the tfw.hashExpectedValueForComparison() method, that method
+// doesn't handle elision and the elided ints get converted to floats.
+//
+// This func corrects the issue with
+// tfw.hashExpectedValueForComparison(), by converting the floats back
+// to ints.
 func fixupElidedTestData(inputData map[string]interface{}) map[string]interface{} {
 	for k, v := range inputData {
-		if k == "keys" {
+		if k == "keys" || k == "key_info" {
 			if f, ok := v.(float64); ok {
-				inputData["keys"] = int(f)
-			}
-		}
-		if k == "key_info" {
-			if f, ok := v.(float64); ok {
-				inputData["key_info"] = int(f)
+				inputData[k] = int(f)
 			}
 		}
 	}

--- a/audit/format_test.go
+++ b/audit/format_test.go
@@ -63,7 +63,7 @@ func (fw *testingFormatWriter) hashExpectedValueForComparison(input map[string]i
 		panic(err)
 	}
 
-	return copiedAsMap
+	return fixupElidedTestData(copiedAsMap)
 }
 
 func TestFormatRequestErrors(t *testing.T) {
@@ -195,8 +195,7 @@ func TestElideListResponses(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
 				formatResponse(t, config, logical.ListOperation, tc.inputData)
-				assert.Equal(t, fixupElidedTestData(tfw.hashExpectedValueForComparison(tc.expectedData)),
-					tfw.lastResponse.Response.Data)
+				assert.Equal(t, tfw.hashExpectedValueForComparison(tc.expectedData), tfw.lastResponse.Response.Data)
 			})
 		}
 	})

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -426,23 +426,24 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 
 }
 
+// get current value from copy to be written to.
 func (w *hashWalker) getValueFromCopy() reflect.Value {
 	size := len(w.cs)
-	newStruct := w.UnmarshalledCopy
+	currentValue := w.UnmarshalledCopy
 	for i := 0; i < size-1; i++ {
 		switch w.loc[2+2*i] {
 		case reflectwalk.MapValue:
-			newStruct = newStruct.MapIndex(w.csKey[i]).Elem()
+			currentValue = currentValue.MapIndex(w.csKey[i]).Elem()
 		case reflectwalk.SliceElem:
 			index := w.csKey[i].Int()
-			newStruct = newStruct.Index(int(index)).Elem()
+			currentValue = currentValue.Index(int(index)).Elem()
 		case reflectwalk.StructField:
-			newStruct = newStruct.MapIndex(w.csKey[i]).Elem()
+			currentValue = currentValue.MapIndex(w.csKey[i]).Elem()
 		default:
 			panic("invalid location")
 		}
 	}
-	return newStruct
+	return currentValue
 }
 
 func (w *hashWalker) elided() bool {

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -69,12 +71,12 @@ func HashRequest(salter *salt.Salt, in *logical.Request, HMACAccessor bool, nonH
 	}
 
 	if req.Data != nil {
-		copy, err := copystructure.Copy(req.Data)
+		copy, err := getUnmarshaledCopy(req.Data)
 		if err != nil {
 			return nil, err
 		}
 
-		err = hashMap(fn, copy.(map[string]interface{}), nonHMACDataKeys)
+		err = hashMap(fn, req.Data, copy.(map[string]interface{}), nonHMACDataKeys, false)
 		if err != nil {
 			return nil, err
 		}
@@ -84,20 +86,8 @@ func HashRequest(salter *salt.Salt, in *logical.Request, HMACAccessor bool, nonH
 	return &req, nil
 }
 
-func hashMap(fn func(string) string, data map[string]interface{}, nonHMACDataKeys []string) error {
-	for k, v := range data {
-		if o, ok := v.(logical.OptMarshaler); ok {
-			marshaled, err := o.MarshalJSONWithOptions(&logical.MarshalOptions{
-				ValueHasher: fn,
-			})
-			if err != nil {
-				return err
-			}
-			data[k] = json.RawMessage(marshaled)
-		}
-	}
-
-	return HashStructure(data, fn, nonHMACDataKeys)
+func hashMap(fn func(string) string, origData map[string]interface{}, data map[string]interface{}, nonHMACDataKeys []string, elideListResponseData bool) error {
+	return HashStructure(origData, data, fn, nonHMACDataKeys, elideListResponseData)
 }
 
 // HashResponse returns a hashed copy of the logical.Request input.
@@ -128,7 +118,7 @@ func HashResponse(
 	}
 
 	if resp.Data != nil {
-		copy, err := copystructure.Copy(resp.Data)
+		copy, err := getUnmarshaledCopy(resp.Data)
 		if err != nil {
 			return nil, err
 		}
@@ -142,10 +132,10 @@ func HashResponse(
 		// - take advantage of the deep copy of resp.Data that was going to be done anyway for hashing
 		// - but elide data before potentially spending time hashing it
 		if elideListResponseData {
-			doElideListResponseData(mapCopy)
+			doElideListResponseDataWithCopy(resp.Data, mapCopy)
 		}
 
-		err = hashMap(fn, mapCopy, nonHMACDataKeys)
+		err = hashMap(fn, resp.Data, mapCopy, nonHMACDataKeys, elideListResponseData)
 		if err != nil {
 			return nil, err
 		}
@@ -161,6 +151,18 @@ func HashResponse(
 	}
 
 	return &resp, nil
+}
+
+func getUnmarshaledCopy(data interface{}) (interface{}, error) {
+	marshaledData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	unmarshaledCopy := map[string]interface{}{}
+	if err := json.Unmarshal(marshaledData, &unmarshaledCopy); err != nil {
+		return nil, err
+	}
+	return unmarshaledCopy, nil
 }
 
 // HashWrapInfo returns a hashed copy of the wrapping.ResponseWrapInfo input.
@@ -189,9 +191,9 @@ func HashWrapInfo(salter *salt.Salt, in *wrapping.ResponseWrapInfo, HMACAccessor
 // the structure. Only _values_ are hashed: keys of objects are not.
 //
 // For the HashCallback, see the built-in HashCallbacks below.
-func HashStructure(s interface{}, cb HashCallback, ignoredKeys []string) error {
-	walker := &hashWalker{Callback: cb, IgnoredKeys: ignoredKeys}
-	return reflectwalk.Walk(s, walker)
+func HashStructure(original interface{}, copy interface{}, cb HashCallback, ignoredKeys []string, elideListResponseData bool) error {
+	walker := &hashWalker{NewMap: reflect.ValueOf(copy), Callback: cb, IgnoredKeys: ignoredKeys, ElideListResponseData: elideListResponseData}
+	return reflectwalk.Walk(original, walker)
 }
 
 // HashCallback is the callback called for HashStructure to hash
@@ -217,14 +219,16 @@ type hashWalker struct {
 	// Enter appends to loc and exit pops loc. The last element of loc is thus
 	// the current location.
 	loc []reflectwalk.Location
-	// Map and Slice append to cs, Exit pops the last element off cs.
+	// Map, Struct and Slice append to cs, Exit pops the last element off cs.
 	// The last element in cs is the most recently entered map or slice.
 	cs []reflect.Value
-	// MapElem and SliceElem append to csKey. The last element in csKey is the
-	// most recently entered map key or slice index. Since Exit pops the last
+	// MapElem, StructField and SliceElem append to csKey. The last element in csKey is the
+	// most recently entered key or slice index. Since Exit pops the last
 	// element of csKey, only nesting to another structure increases the size of
 	// this slice.
-	csKey []reflect.Value
+	csKey                 []reflect.Value
+	NewMap                reflect.Value
+	ElideListResponseData bool
 }
 
 // hashTimeType stores a pre-computed reflect.Type for a time.Time so
@@ -247,6 +251,11 @@ func (w *hashWalker) Exit(loc reflectwalk.Location) error {
 	case reflectwalk.MapValue:
 		w.key = w.key[:len(w.key)-1]
 		w.csKey = w.csKey[:len(w.csKey)-1]
+	case reflectwalk.Struct:
+		w.cs = w.cs[:len(w.cs)-1]
+	case reflectwalk.StructField:
+		w.key = w.key[:len(w.key)-1]
+		w.csKey = w.csKey[:len(w.csKey)-1]
 	case reflectwalk.Slice:
 		w.cs = w.cs[:len(w.cs)-1]
 	case reflectwalk.SliceElem:
@@ -262,10 +271,24 @@ func (w *hashWalker) Map(m reflect.Value) error {
 }
 
 func (w *hashWalker) MapElem(m, k, v reflect.Value) error {
-	w.csKey = append(w.csKey, k)
-	w.key = append(w.key, k.String())
 	w.lastValue = v
-	return nil
+	if _, ok := k.Interface().(string); ok {
+		w.csKey = append(w.csKey, k)
+		w.key = append(w.key, k.String())
+		return nil
+	}
+	if _, ok := k.Interface().(int); ok {
+		kString := strconv.FormatInt(k.Int(), 10)
+		w.csKey = append(w.csKey, reflect.ValueOf(kString))
+		w.key = append(w.key, kString)
+		return nil
+	}
+	if _, ok := k.Interface().(time.Time); ok {
+		w.csKey = append(w.csKey, k)
+		w.key = append(w.key, k.String())
+		return nil
+	}
+	panic("bad type" + k.String())
 }
 
 func (w *hashWalker) Slice(s reflect.Value) error {
@@ -281,6 +304,7 @@ func (w *hashWalker) SliceElem(i int, elem reflect.Value) error {
 func (w *hashWalker) Struct(v reflect.Value) error {
 	// We are looking for time values. If it isn't one, ignore it.
 	if v.Type() != hashTimeType {
+		w.cs = append(w.cs, v)
 		return nil
 	}
 
@@ -301,7 +325,7 @@ func (w *hashWalker) Struct(v reflect.Value) error {
 		strVal := v.Interface().(time.Time).Format(time.RFC3339Nano)
 
 		// Set the map value to the string instead of the time.Time object
-		m := w.cs[len(w.cs)-1]
+		m := w.getValue()
 		mk := w.csKey[len(w.cs)-1]
 		m.SetMapIndex(mk, reflect.ValueOf(strVal))
 	case reflectwalk.SliceElem:
@@ -311,16 +335,29 @@ func (w *hashWalker) Struct(v reflect.Value) error {
 		strVal := v.Interface().(time.Time).Format(time.RFC3339Nano)
 
 		// Set the map value to the string instead of the time.Time object
-		s := w.cs[len(w.cs)-1]
+		s := w.getValue()
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(reflect.ValueOf(strVal))
 	}
 
+	w.cs = append(w.cs, v)
 	// Skip this entry so that we don't walk the struct.
 	return reflectwalk.SkipEntry
 }
 
-func (w *hashWalker) StructField(reflect.StructField, reflect.Value) error {
+func (w *hashWalker) StructField(s reflect.StructField, v reflect.Value) error {
+	if !s.IsExported() {
+		return reflectwalk.SkipEntry
+	}
+	name := s.Name
+	if tag := s.Tag.Get("json"); tag != "" {
+		parts := strings.Split(tag, ",")
+		if parts[0] != "" {
+			name = parts[0]
+		}
+	}
+	w.csKey = append(w.csKey, reflect.ValueOf(name))
+	w.key = append(w.key, name)
 	return nil
 }
 
@@ -336,8 +373,6 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		return nil
 	}
 
-	setV := v
-
 	// We only care about strings
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
@@ -352,6 +387,10 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		return nil
 	}
 
+	if w.elided() {
+		return nil
+	}
+
 	replaceVal := w.Callback(v.String())
 
 	resultVal := reflect.ValueOf(replaceVal)
@@ -359,17 +398,84 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 	case reflectwalk.MapValue:
 		// If we're in a map, then the only way to set a map value is
 		// to set it directly.
-		m := w.cs[len(w.cs)-1]
+		m := w.getValue()
 		mk := w.csKey[len(w.cs)-1]
 		m.SetMapIndex(mk, resultVal)
 	case reflectwalk.SliceElem:
-		s := w.cs[len(w.cs)-1]
+		s := w.getValue()
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
+	case reflectwalk.StructField:
+		m := w.getValue()
+		mk := w.csKey[len(w.cs)-1]
+		m.SetMapIndex(mk, resultVal)
 	default:
-		// Otherwise, we should be addressable
-		setV.Set(resultVal)
+		panic("Found unsupported value.")
 	}
 
 	return nil
+
+}
+
+func (w *hashWalker) getValue() reflect.Value {
+	size := len(w.cs)
+	newStruct := w.NewMap
+	for i := 0; i < size-1; i++ {
+		switch w.loc[2+2*i] {
+		case reflectwalk.MapValue:
+			newStruct = newStruct.MapIndex(w.csKey[i]).Elem()
+		case reflectwalk.SliceElem:
+			index := w.csKey[i].Int()
+			newStruct = newStruct.Index(int(index)).Elem()
+		case reflectwalk.StructField:
+			newStruct = newStruct.MapIndex(w.csKey[i]).Elem()
+		default:
+			panic("invalid location")
+		}
+	}
+	return newStruct
+}
+
+func (w *hashWalker) elided() bool {
+	if !w.ElideListResponseData {
+		return false
+	}
+
+	currentLoc := len(w.loc) - 1
+	currentCs := len(w.cs) - 1
+	currentCsKey := len(w.csKey) - 1
+
+	if currentLoc <= 3 {
+		return false
+	}
+
+	if w.loc[currentLoc-3] != reflectwalk.Map ||
+		w.loc[currentLoc-2] != reflectwalk.MapValue {
+		return false
+	}
+
+	m := w.cs[currentCs-1]
+	mk := w.csKey[currentCsKey-1]
+	k := mk.String()
+	v := m.MapIndex(mk)
+
+	if w.loc[currentLoc-1] == reflectwalk.Slice &&
+		w.loc[currentLoc] == reflectwalk.SliceElem &&
+		k == "keys" {
+		_, vOk := v.Interface().([]string)
+		if vOk {
+			return true
+		}
+	}
+
+	if w.loc[currentLoc-1] == reflectwalk.Map &&
+		w.loc[currentLoc] == reflectwalk.MapValue &&
+		k == "key_info" {
+		_, vOk := v.Interface().(map[string]interface{})
+		if vOk {
+			return true
+		}
+	}
+
+	return false
 }

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -435,14 +435,21 @@ func (w *hashWalker) getValueFromCopy() reflect.Value {
 	for i := 0; i < size-1; i++ {
 		switch w.loc[startKey+(keyFactor*i)] {
 		case reflectwalk.MapValue:
-			currentValue = currentValue.MapIndex(w.csKey[i]).Elem()
+			currentValue = currentValue.MapIndex(w.csKey[i])
 		case reflectwalk.SliceElem:
 			index := w.csKey[i].Int()
-			currentValue = currentValue.Index(int(index)).Elem()
+			currentValue = currentValue.Index(int(index))
 		case reflectwalk.StructField:
-			currentValue = currentValue.MapIndex(w.csKey[i]).Elem()
+			currentValue = currentValue.MapIndex(w.csKey[i])
 		default:
 			panic("invalid location")
+		}
+		if !currentValue.IsValid() {
+			panic("bad field name: " + w.csKey[i].String())
+		}
+		for currentValue.Kind() == reflect.Ptr ||
+			currentValue.Kind() == reflect.Interface {
+			currentValue = currentValue.Elem()
 		}
 	}
 	return currentValue

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -430,8 +430,10 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 func (w *hashWalker) getValueFromCopy() reflect.Value {
 	size := len(w.cs)
 	currentValue := w.UnmarshalledCopy
+	startKey := 2  // First key in w.csKey maps to w.loc[2]
+	keyFactor := 2 // Each key in w.csKey is every other entry in w.loc
 	for i := 0; i < size-1; i++ {
-		switch w.loc[2+2*i] {
+		switch w.loc[startKey+(keyFactor*i)] {
 		case reflectwalk.MapValue:
 			currentValue = currentValue.MapIndex(w.csKey[i]).Elem()
 		case reflectwalk.SliceElem:

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -329,7 +329,7 @@ func (w *hashWalker) Struct(v reflect.Value) error {
 		strVal := v.Interface().(time.Time).Format(time.RFC3339Nano)
 
 		// Set the map value to the string instead of the time.Time object
-		m := w.getValue()
+		m := w.getValueFromCopy()
 		mk := w.csKey[len(w.cs)-1]
 		m.SetMapIndex(mk, reflect.ValueOf(strVal))
 	case reflectwalk.SliceElem:
@@ -339,7 +339,7 @@ func (w *hashWalker) Struct(v reflect.Value) error {
 		strVal := v.Interface().(time.Time).Format(time.RFC3339Nano)
 
 		// Set the map value to the string instead of the time.Time object
-		s := w.getValue()
+		s := w.getValueFromCopy()
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(reflect.ValueOf(strVal))
 	}
@@ -407,15 +407,15 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 	case reflectwalk.MapValue:
 		// If we're in a map, then the only way to set a map value is
 		// to set it directly.
-		m := w.getValue()
+		m := w.getValueFromCopy()
 		mk := w.csKey[len(w.cs)-1]
 		m.SetMapIndex(mk, resultVal)
 	case reflectwalk.SliceElem:
-		s := w.getValue()
+		s := w.getValueFromCopy()
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	case reflectwalk.StructField:
-		m := w.getValue()
+		m := w.getValueFromCopy()
 		mk := w.csKey[len(w.cs)-1]
 		m.SetMapIndex(mk, resultVal)
 	default:
@@ -426,7 +426,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 
 }
 
-func (w *hashWalker) getValue() reflect.Value {
+func (w *hashWalker) getValueFromCopy() reflect.Value {
 	size := len(w.cs)
 	newStruct := w.UnmarshalledCopy
 	for i := 0; i < size-1; i++ {

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -196,7 +196,7 @@ func HashWrapInfo(salter *salt.Salt, in *wrapping.ResponseWrapInfo, HMACAccessor
 //
 // For the HashCallback, see the built-in HashCallbacks below.
 func HashStructure(original interface{}, copy interface{}, cb HashCallback, ignoredKeys []string, elideListResponseData bool) error {
-	walker := &hashWalker{MarshalledCopy: reflect.ValueOf(copy), Callback: cb, IgnoredKeys: ignoredKeys, ElideListResponseData: elideListResponseData}
+	walker := &hashWalker{UnmarshalledCopy: reflect.ValueOf(copy), Callback: cb, IgnoredKeys: ignoredKeys, ElideListResponseData: elideListResponseData}
 	return reflectwalk.Walk(original, walker)
 }
 
@@ -231,7 +231,7 @@ type hashWalker struct {
 	// element of csKey, only nesting to another structure increases the size of
 	// this slice.
 	csKey                 []reflect.Value
-	MarshalledCopy        reflect.Value
+	UnmarshalledCopy      reflect.Value
 	ElideListResponseData bool
 }
 
@@ -428,7 +428,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 
 func (w *hashWalker) getValue() reflect.Value {
 	size := len(w.cs)
-	newStruct := w.MarshalledCopy
+	newStruct := w.UnmarshalledCopy
 	for i := 0; i < size-1; i++ {
 		switch w.loc[2+2*i] {
 		case reflectwalk.MapValue:

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -154,10 +154,9 @@ func HashResponse(
 }
 
 // Creates a deep copy of the data by marshalling to and unmarshalling from json.
-//
-//	This transformation inherently changes all structs to maps, which makes
-//	each of the structs fields addressable through reflection in the copy,
-//	(which is now a map).  This will allow us to write into all fields.
+// This transformation inherently changes all structs to maps, which makes
+// each of the structs fields addressable through reflection in the copy,
+// (which is now a map).  This will allow us to write into all fields.
 func getUnmarshaledCopy(data interface{}) (interface{}, error) {
 	marshaledData, err := json.Marshal(data)
 	if err != nil {
@@ -197,7 +196,7 @@ func HashWrapInfo(salter *salt.Salt, in *wrapping.ResponseWrapInfo, HMACAccessor
 //
 // For the HashCallback, see the built-in HashCallbacks below.
 func HashStructure(original interface{}, copy interface{}, cb HashCallback, ignoredKeys []string, elideListResponseData bool) error {
-	walker := &hashWalker{NewMap: reflect.ValueOf(copy), Callback: cb, IgnoredKeys: ignoredKeys, ElideListResponseData: elideListResponseData}
+	walker := &hashWalker{MarshalledCopy: reflect.ValueOf(copy), Callback: cb, IgnoredKeys: ignoredKeys, ElideListResponseData: elideListResponseData}
 	return reflectwalk.Walk(original, walker)
 }
 
@@ -232,7 +231,7 @@ type hashWalker struct {
 	// element of csKey, only nesting to another structure increases the size of
 	// this slice.
 	csKey                 []reflect.Value
-	NewMap                reflect.Value
+	MarshalledCopy        reflect.Value
 	ElideListResponseData bool
 }
 
@@ -429,7 +428,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 
 func (w *hashWalker) getValue() reflect.Value {
 	size := len(w.cs)
-	newStruct := w.NewMap
+	newStruct := w.MarshalledCopy
 	for i := 0; i < size-1; i++ {
 		switch w.loc[2+2*i] {
 		case reflectwalk.MapValue:

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -275,24 +275,18 @@ func (w *hashWalker) Map(m reflect.Value) error {
 }
 
 func (w *hashWalker) MapElem(m, k, v reflect.Value) error {
-	w.lastValue = v
-	if _, ok := k.Interface().(string); ok {
-		w.csKey = append(w.csKey, k)
-		w.key = append(w.key, k.String())
-		return nil
-	}
+	// Json marshalling converts int keys to strings, so
+	// we need to handle those here.
 	if _, ok := k.Interface().(int); ok {
 		kString := strconv.FormatInt(k.Int(), 10)
 		w.csKey = append(w.csKey, reflect.ValueOf(kString))
 		w.key = append(w.key, kString)
 		return nil
 	}
-	if _, ok := k.Interface().(time.Time); ok {
-		w.csKey = append(w.csKey, k)
-		w.key = append(w.key, k.String())
-		return nil
-	}
-	panic("bad type" + k.String())
+	w.csKey = append(w.csKey, k)
+	w.key = append(w.key, k.String())
+	w.lastValue = v
+	return nil
 }
 
 func (w *hashWalker) Slice(s reflect.Value) error {

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -246,10 +246,11 @@ func TestHashResponse(t *testing.T) {
 		NonHMACDataKeys []string
 		HMACAccessor    bool
 	}{
+		// Confirm nested struct doesn't generate panic
 		{
 			&logical.Response{
 				Data: map[string]interface{}{
-					"foo": testTopicPermission{Write: "abc", Read: "efg"},
+					"foo": testTopicPermission{Write: "bar", Read: "baz"},
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
 					TTL:             60,
@@ -262,8 +263,8 @@ func TestHashResponse(t *testing.T) {
 			&logical.Response{
 				Data: map[string]interface{}{
 					"foo": map[string]interface{}{
-						"write_json": "hmac-sha256:2febde8cad3b3e67067bc8784b1bcf966529c89a999e6c430b9cd536e3a16b52",
-						"read_json":  "efg",
+						"write_json": "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+						"read_json":  "baz",
 					},
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
@@ -275,6 +276,39 @@ func TestHashResponse(t *testing.T) {
 				},
 			},
 			[]string{"read_json"},
+			true,
+		},
+		// Confirm int keys are converted to string keys
+		{
+			&logical.Response{
+				Data: map[string]interface{}{
+					"foo": map[int]interface{}{
+						100: "bar",
+					},
+				},
+				WrapInfo: &wrapping.ResponseWrapInfo{
+					TTL:             60,
+					Token:           "bar",
+					Accessor:        "flimflam",
+					CreationTime:    now,
+					WrappedAccessor: "bar",
+				},
+			},
+			&logical.Response{
+				Data: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"100": "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					},
+				},
+				WrapInfo: &wrapping.ResponseWrapInfo{
+					TTL:             60,
+					Token:           "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					Accessor:        "hmac-sha256:7c9c6fe666d0af73b3ebcfbfabe6885015558213208e6635ba104047b22f6390",
+					CreationTime:    now,
+					WrappedAccessor: "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+				},
+			},
+			[]string{},
 			true,
 		},
 		{

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -235,6 +235,10 @@ func TestHashRequest(t *testing.T) {
 
 func TestHashResponse(t *testing.T) {
 	now := time.Now()
+	type testTopicPermission struct {
+		Write string `json:"write_json"`
+		Read  string `json:"read_json"`
+	}
 
 	cases := []struct {
 		Input           *logical.Response
@@ -242,6 +246,37 @@ func TestHashResponse(t *testing.T) {
 		NonHMACDataKeys []string
 		HMACAccessor    bool
 	}{
+		{
+			&logical.Response{
+				Data: map[string]interface{}{
+					"foo": testTopicPermission{Write: "abc", Read: "efg"},
+				},
+				WrapInfo: &wrapping.ResponseWrapInfo{
+					TTL:             60,
+					Token:           "bar",
+					Accessor:        "flimflam",
+					CreationTime:    now,
+					WrappedAccessor: "bar",
+				},
+			},
+			&logical.Response{
+				Data: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"write_json": "hmac-sha256:2febde8cad3b3e67067bc8784b1bcf966529c89a999e6c430b9cd536e3a16b52",
+						"read_json":  "efg",
+					},
+				},
+				WrapInfo: &wrapping.ResponseWrapInfo{
+					TTL:             60,
+					Token:           "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					Accessor:        "hmac-sha256:7c9c6fe666d0af73b3ebcfbfabe6885015558213208e6635ba104047b22f6390",
+					CreationTime:    now,
+					WrappedAccessor: "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+				},
+			},
+			[]string{"read_json"},
+			true,
+		},
 		{
 			&logical.Response{
 				Data: map[string]interface{}{

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -350,19 +350,6 @@ func TestHashWalker_TimeStructs(t *testing.T) {
 		Input  map[string]interface{}
 		Output map[string]interface{}
 	}{
-		// Should not touch map keys of type time.Time.
-		// {
-		// 	map[string]interface{}{
-		// 		"hello": map[time.Time]struct{}{
-		// 			now: {},
-		// 		},
-		// 	},
-		// 	map[string]interface{}{
-		// 		"hello": map[time.Time]struct{}{
-		// 			now: {},
-		// 		},
-		// 	},
-		// },
 		// Should handle map values of type time.Time.
 		{
 			map[string]interface{}{

--- a/changelog/887.txt
+++ b/changelog/887.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: modify the hashWalker to handle nested structs without panicing
+```


### PR DESCRIPTION
## The Problem
Audit logging uses reflection to write the hashed value of logged fields to a copy of the log data.  That write is inherently problematic.  If the log data contains structs, the struct fields may be "unaddressable" with reflection and the write attempt causes a panic, (as described here): https://github.com/openbao/openbao/issues/478

## The fix in this PR
The fix is to remove all structs by marshalling the data to json and back.  This creates a deep copy where all structs/fields have been converted to maps/keys.

Prior to this fix, the hashing code made a copy of the data structure to be logged, and uses reflection to walk the copy and hash the data.

Because the fix uses the json unmarshalled copy, many of the data types get changed, (like structs to maps).  So the fixed code must walk both the original and the copy.  It walks the original to get the type info and the data to hash, and the copy to get the location to be written to.


## Implications
Because of the type changes caused by the unmarshalling, I've had to modify some of the tests, for example to expect "interface{}"'s instead of strings, and floats instead of ints.

I've removed the "logical.optMarshaler" tests because I was told that feature doesn't need to be maintained, (and is broken by unmarshalling.)

I've had to remove one of the audit.TestHashWalker_TimeStructs() tests because it tested that keys of type time.Time should not be modified.  With the unmarshalling of the data, there is no way to avoid modifying non-string keys.  In json all keys must be strings, so the unmarshalling converts all keys to strings, (including int keys and struct keys.)

## Issues
I'm a little wary of this fix, because it is hard to predict all implications of the type changes implicit in unmarshalling.  (And I'm an openbao newbie and have very little context about those implications may affect openbao.)  So please give that some consideration when evaluating this PR.

Also, https://github.com/openbao/openbao/issues/478 requests that all uses of structs.New() be replaced with custom serializers.  I haven't done that in this PR.  It is complicated enough already and recommend a second PR be created for the custom serializers.


