### PR TITLE
Add UI label to /ui dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     directory: "/ui"
     schedule:
       interval: "weekly"
+    labels:
+      - dependencies
+      - javascript
+      - ui
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:


### PR DESCRIPTION
This adds the `ui` label to dependabot updates, so that `/ui` updates are properly tagged and tested. Otherwise, errors like https://github.com/openbao/openbao/pull/821 are missed: this PR broke `main`, because while the `ui` tag was added, the tests were not re-run.

