### PR TITLE
Go 1.24 fixes

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -32,7 +33,7 @@ func (c *Client) Auth() *Auth {
 // automatically renewing the token.
 func (a *Auth) Login(ctx context.Context, authMethod AuthMethod) (*Secret, error) {
 	if authMethod == nil {
-		return nil, fmt.Errorf("no auth method provided for login")
+		return nil, errors.New("no auth method provided for login")
 	}
 	return a.login(ctx, authMethod)
 }
@@ -63,7 +64,7 @@ func (a *Auth) MFALogin(ctx context.Context, authMethod AuthMethod, creds ...str
 // automatically renewing the token.
 func (a *Auth) MFAValidate(ctx context.Context, mfaSecret *Secret, payload map[string]interface{}) (*Secret, error) {
 	if mfaSecret == nil || mfaSecret.Auth == nil || mfaSecret.Auth.MFARequirement == nil {
-		return nil, fmt.Errorf("secret does not contain MFARequirements")
+		return nil, errors.New("secret does not contain MFARequirements")
 	}
 
 	s, err := a.c.Sys().MFAValidateWithContext(ctx, mfaSecret.Auth.MFARequirement.MFARequestID, payload)
@@ -95,7 +96,7 @@ func (a *Auth) twoPhaseMFALogin(ctx context.Context, authMethod AuthMethod) (*Se
 		if s != nil {
 			s.Warnings = append(s.Warnings, "expected secret to contain MFARequirements")
 		}
-		return s, fmt.Errorf("assumed two-phase MFA login, returned secret is missing MFARequirements")
+		return s, errors.New("assumed two-phase MFA login, returned secret is missing MFARequirements")
 	}
 
 	return s, nil
@@ -106,7 +107,7 @@ func (a *Auth) checkAndSetToken(s *Secret) (*Secret, error) {
 		if s != nil {
 			s.Warnings = append(s.Warnings, "expected secret to contain ClientToken")
 		}
-		return s, fmt.Errorf("response did not return ClientToken, client token not set")
+		return s, errors.New("response did not return ClientToken, client token not set")
 	}
 
 	a.c.SetToken(s.Auth.ClientToken)

--- a/api/auth/approle/approle.go
+++ b/api/auth/approle/approle.go
@@ -5,6 +5,7 @@ package approle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,11 +59,11 @@ const (
 // Supported options: WithMountPath, WithWrappingToken
 func NewAppRoleAuth(roleID string, secretID *SecretID, opts ...LoginOption) (*AppRoleAuth, error) {
 	if roleID == "" {
-		return nil, fmt.Errorf("no role ID provided for login")
+		return nil, errors.New("no role ID provided for login")
 	}
 
 	if secretID == nil {
-		return nil, fmt.Errorf("no secret ID provided for login")
+		return nil, errors.New("no secret ID provided for login")
 	}
 
 	err := secretID.validate()
@@ -184,24 +185,24 @@ func (a *AppRoleAuth) readSecretIDFromFile() (string, error) {
 
 func (secretID *SecretID) validate() error {
 	if secretID.FromFile == "" && secretID.FromEnv == "" && secretID.FromString == "" {
-		return fmt.Errorf("secret ID for AppRole must be provided with a source file, environment variable, or plaintext string")
+		return errors.New("secret ID for AppRole must be provided with a source file, environment variable, or plaintext string")
 	}
 
 	if secretID.FromFile != "" {
 		if secretID.FromEnv != "" || secretID.FromString != "" {
-			return fmt.Errorf("only one source for the secret ID should be specified")
+			return errors.New("only one source for the secret ID should be specified")
 		}
 	}
 
 	if secretID.FromEnv != "" {
 		if secretID.FromFile != "" || secretID.FromString != "" {
-			return fmt.Errorf("only one source for the secret ID should be specified")
+			return errors.New("only one source for the secret ID should be specified")
 		}
 	}
 
 	if secretID.FromString != "" {
 		if secretID.FromFile != "" || secretID.FromEnv != "" {
-			return fmt.Errorf("only one source for the secret ID should be specified")
+			return errors.New("only one source for the secret ID should be specified")
 		}
 	}
 	return nil

--- a/api/auth/approle/approle_test.go
+++ b/api/auth/approle/approle_test.go
@@ -105,7 +105,7 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with secret ID from file: %v", err)
 	}
 	if loginRespFromFile.Auth == nil || loginRespFromFile.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login")
+		t.Fatal("no authentication info returned by login")
 	}
 
 	authFromEnv, err := NewAppRoleAuth(allowedRoleID, &SecretID{FromEnv: secretIDEnvVar})
@@ -118,7 +118,7 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with secret ID from env var: %v", err)
 	}
 	if loginRespFromEnv.Auth == nil || loginRespFromEnv.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with secret ID from env var")
+		t.Fatal("no authentication info returned by login with secret ID from env var")
 	}
 
 	authFromStr, err := NewAppRoleAuth(allowedRoleID, &SecretID{FromString: allowedSecretID})
@@ -131,6 +131,6 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with string: %v", err)
 	}
 	if loginRespFromStr.Auth == nil || loginRespFromStr.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with secret ID from string")
+		t.Fatal("no authentication info returned by login with secret ID from string")
 	}
 }

--- a/api/auth/kubernetes/kubernetes.go
+++ b/api/auth/kubernetes/kubernetes.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -40,7 +41,7 @@ const (
 // Supported options: WithMountPath, WithServiceAccountTokenPath, WithServiceAccountTokenEnv, WithServiceAccountToken
 func NewKubernetesAuth(roleName string, opts ...LoginOption) (*KubernetesAuth, error) {
 	if roleName == "" {
-		return nil, fmt.Errorf("no role name was provided")
+		return nil, errors.New("no role name was provided")
 	}
 
 	a := &KubernetesAuth{
@@ -120,7 +121,7 @@ func WithServiceAccountTokenEnv(envVar string) LoginOption {
 	return func(a *KubernetesAuth) error {
 		token := os.Getenv(envVar)
 		if token == "" {
-			return fmt.Errorf("service account token was specified with an environment variable with an empty value")
+			return errors.New("service account token was specified with an environment variable with an empty value")
 		}
 		a.serviceAccountToken = token
 		return nil

--- a/api/auth/ldap/ldap.go
+++ b/api/auth/ldap/ldap.go
@@ -5,6 +5,7 @@ package ldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,11 +45,11 @@ const (
 // Supported options: WithMountPath
 func NewLDAPAuth(username string, password *Password, opts ...LoginOption) (*LDAPAuth, error) {
 	if username == "" {
-		return nil, fmt.Errorf("no user name provided for login")
+		return nil, errors.New("no user name provided for login")
 	}
 
 	if password == nil {
-		return nil, fmt.Errorf("no password provided for login")
+		return nil, errors.New("no password provided for login")
 	}
 
 	err := password.validate()
@@ -102,7 +103,7 @@ func (a *LDAPAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, 
 	} else if a.passwordEnv != "" {
 		passwordValue := os.Getenv(a.passwordEnv)
 		if passwordValue == "" {
-			return nil, fmt.Errorf("password was specified with an environment variable with an empty value")
+			return nil, errors.New("password was specified with an environment variable with an empty value")
 		}
 		loginData["password"] = passwordValue
 	} else {
@@ -145,24 +146,24 @@ func (a *LDAPAuth) readPasswordFromFile() (string, error) {
 
 func (password *Password) validate() error {
 	if password.FromFile == "" && password.FromEnv == "" && password.FromString == "" {
-		return fmt.Errorf("password for LDAP auth must be provided with a source file, environment variable, or plaintext string")
+		return errors.New("password for LDAP auth must be provided with a source file, environment variable, or plaintext string")
 	}
 
 	if password.FromFile != "" {
 		if password.FromEnv != "" || password.FromString != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 
 	if password.FromEnv != "" {
 		if password.FromFile != "" || password.FromString != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 
 	if password.FromString != "" {
 		if password.FromFile != "" || password.FromEnv != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 	return nil

--- a/api/auth/ldap/ldap_test.go
+++ b/api/auth/ldap/ldap_test.go
@@ -106,7 +106,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	if loginRespFromFile.Auth == nil || loginRespFromFile.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login")
+		t.Fatal("no authentication info returned by login")
 	}
 
 	// Password fromEnv Test
@@ -121,7 +121,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	if loginRespFromEnv.Auth == nil || loginRespFromEnv.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with password from env var")
+		t.Fatal("no authentication info returned by login with password from env var")
 	}
 
 	// Password fromStr test
@@ -136,7 +136,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	if loginRespFromStr.Auth == nil || loginRespFromStr.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with password from string")
+		t.Fatal("no authentication info returned by login with password from string")
 	}
 
 	// Empty User Test

--- a/api/auth/userpass/userpass.go
+++ b/api/auth/userpass/userpass.go
@@ -5,6 +5,7 @@ package userpass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,11 +47,11 @@ const (
 // Supported options: WithMountPath
 func NewUserpassAuth(username string, password *Password, opts ...LoginOption) (*UserpassAuth, error) {
 	if username == "" {
-		return nil, fmt.Errorf("no user name provided for login")
+		return nil, errors.New("no user name provided for login")
 	}
 
 	if password == nil {
-		return nil, fmt.Errorf("no password provided for login")
+		return nil, errors.New("no password provided for login")
 	}
 
 	err := password.validate()
@@ -106,7 +107,7 @@ func (a *UserpassAuth) Login(ctx context.Context, client *api.Client) (*api.Secr
 	} else if a.passwordEnv != "" {
 		passwordValue := os.Getenv(a.passwordEnv)
 		if passwordValue == "" {
-			return nil, fmt.Errorf("password was specified with an environment variable with an empty value")
+			return nil, errors.New("password was specified with an environment variable with an empty value")
 		}
 		loginData["password"] = passwordValue
 	} else {
@@ -149,24 +150,24 @@ func (a *UserpassAuth) readPasswordFromFile() (string, error) {
 
 func (password *Password) validate() error {
 	if password.FromFile == "" && password.FromEnv == "" && password.FromString == "" {
-		return fmt.Errorf("password for Userpass auth must be provided with a source file, environment variable, or plaintext string")
+		return errors.New("password for Userpass auth must be provided with a source file, environment variable, or plaintext string")
 	}
 
 	if password.FromFile != "" {
 		if password.FromEnv != "" || password.FromString != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 
 	if password.FromEnv != "" {
 		if password.FromFile != "" || password.FromString != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 
 	if password.FromString != "" {
 		if password.FromFile != "" || password.FromEnv != "" {
-			return fmt.Errorf("only one source for the password should be specified")
+			return errors.New("only one source for the password should be specified")
 		}
 	}
 	return nil

--- a/api/auth/userpass/userpass_test.go
+++ b/api/auth/userpass/userpass_test.go
@@ -104,7 +104,7 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with password from file: %v", err)
 	}
 	if loginRespFromFile.Auth == nil || loginRespFromFile.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login")
+		t.Fatal("no authentication info returned by login")
 	}
 
 	authFromEnv, err := NewUserpassAuth("my-role-id", &Password{FromEnv: passwordEnvVar})
@@ -117,7 +117,7 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with password from env var: %v", err)
 	}
 	if loginRespFromEnv.Auth == nil || loginRespFromEnv.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with password from env var")
+		t.Fatal("no authentication info returned by login with password from env var")
 	}
 
 	authFromStr, err := NewUserpassAuth("my-role-id", &Password{FromString: allowedPassword})
@@ -130,6 +130,6 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("error logging in with string: %v", err)
 	}
 	if loginRespFromStr.Auth == nil || loginRespFromStr.Auth.ClientToken == "" {
-		t.Fatalf("no authentication info returned by login with password from string")
+		t.Fatal("no authentication info returned by login with password from string")
 	}
 }

--- a/api/client.go
+++ b/api/client.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -287,7 +288,7 @@ func (c *Config) configureTLS(t *TLSConfig) error {
 		c.curlClientCert = t.ClientCert
 		c.curlClientKey = t.ClientKey
 	case t.ClientCert != "" || t.ClientKey != "":
-		return fmt.Errorf("both client cert and client key must be provided")
+		return errors.New("both client cert and client key must be provided")
 	}
 
 	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {
@@ -519,7 +520,7 @@ func (c *Config) ParseAddress(address string) (*url.URL, error) {
 			u.Host = "localhost"
 			u.Path = ""
 		} else {
-			return nil, fmt.Errorf("attempting to specify unix:// address with non-transport transport")
+			return nil, errors.New("attempting to specify unix:// address with non-transport transport")
 		}
 	} else if strings.HasPrefix(c.Address, "unix://") {
 		// When the address being set does not begin with unix:// but the previous
@@ -572,7 +573,7 @@ type Client struct {
 func NewClient(c *Config) (*Client, error) {
 	def := DefaultConfig()
 	if def == nil {
-		return nil, fmt.Errorf("could not create/read default configuration")
+		return nil, errors.New("could not create/read default configuration")
 	}
 	if def.Error != nil {
 		return nil, errwrap.Wrapf("error encountered setting up default configuration: {{err}}", def.Error)
@@ -1297,7 +1298,7 @@ START:
 		return nil, err
 	}
 	if req == nil {
-		return nil, fmt.Errorf("nil request created")
+		return nil, errors.New("nil request created")
 	}
 
 	if outputCurlString {
@@ -1364,7 +1365,7 @@ START:
 
 		// Ensure a protocol downgrade doesn't happen
 		if req.URL.Scheme == "https" && respLoc.Scheme != "https" {
-			return result, fmt.Errorf("redirect would cause protocol downgrade")
+			return result, errors.New("redirect would cause protocol downgrade")
 		}
 
 		// Update the request
@@ -1430,10 +1431,10 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 
 	// OutputCurlString and OutputPolicy logic rely on the request type to be retryable.Request
 	if outputCurlString {
-		return nil, fmt.Errorf("output-curl-string is not implemented for this request")
+		return nil, errors.New("output-curl-string is not implemented for this request")
 	}
 	if outputPolicy {
-		return nil, fmt.Errorf("output-policy is not implemented for this request")
+		return nil, errors.New("output-policy is not implemented for this request")
 	}
 
 	req.URL.User = r.URL.User
@@ -1493,7 +1494,7 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 
 		// Ensure a protocol downgrade doesn't happen
 		if req.URL.Scheme == "https" && respLoc.Scheme != "https" {
-			return result, fmt.Errorf("redirect would cause protocol downgrade")
+			return result, errors.New("redirect would cause protocol downgrade")
 		}
 
 		// Update the request
@@ -1579,7 +1580,7 @@ func validateToken(t string) error {
 		return !unicode.IsPrint(c)
 	})
 	if idx != -1 {
-		return fmt.Errorf("configured Vault token contains non-printable characters and cannot be used")
+		return errors.New("configured Vault token contains non-printable characters and cannot be used")
 	}
 	return nil
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -314,7 +315,7 @@ func TestDefaulRetryPolicy(t *testing.T) {
 		expectErr error
 	}{
 		"retry on error": {
-			err:    fmt.Errorf("error"),
+			err:    errors.New("error"),
 			expect: true,
 		},
 		"don't retry on 200": {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -203,7 +203,7 @@ func TestClientBadToken(t *testing.T) {
 	client.SetToken("foo\u007f")
 	_, err = client.RawRequest(client.NewRequest(http.MethodPut, "/"))
 	if err == nil || !strings.Contains(err.Error(), "printable") {
-		t.Fatalf("expected error due to bad token")
+		t.Fatal("expected error due to bad token")
 	}
 }
 
@@ -404,10 +404,10 @@ func TestClientEnvSettings(t *testing.T) {
 
 	tlsConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
 	if x509.NewCertPool().Equal(tlsConfig.RootCAs) {
-		t.Fatalf("bad: expected a cert pool with at least one subject")
+		t.Fatal("bad: expected a cert pool with at least one subject")
 	}
 	if tlsConfig.GetClientCertificate == nil {
-		t.Fatalf("bad: expected client tls config to have a certificate getter")
+		t.Fatal("bad: expected client tls config to have a certificate getter")
 	}
 	if tlsConfig.InsecureSkipVerify != true {
 		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
@@ -662,7 +662,7 @@ func TestClone(t *testing.T) {
 			}
 			if tt.config.CloneToken {
 				if tt.token == "" {
-					t.Fatalf("test requires a non-empty token")
+					t.Fatal("test requires a non-empty token")
 				}
 				if parent.config.CloneToken != clone.config.CloneToken {
 					t.Fatalf("config.CloneToken doesn't match: %v vs %v", parent.config.CloneToken, clone.config.CloneToken)
@@ -911,7 +911,7 @@ func TestVaultProxy(t *testing.T) {
 				t.Fatalf("Expected no error resolving proxy, found error %v", err)
 			}
 			if proxyUrl == nil || proxyUrl.String() == "" {
-				t.Fatalf("Expected proxy to be resolved but no proxy returned")
+				t.Fatal("Expected proxy to be resolved but no proxy returned")
 			}
 			if tc.expectedResolvedProxyUrl != "" && proxyUrl.String() != tc.expectedResolvedProxyUrl {
 				t.Fatalf("Expected resolved proxy URL to be %v but was %v", tc.expectedResolvedProxyUrl, proxyUrl.String())

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -465,7 +465,7 @@ func (kv *KVv2) Rollback(ctx context.Context, secretPath string, toVersion int) 
 
 	// Verify metadata found
 	if latest.VersionMetadata == nil {
-		return nil, fmt.Errorf("no metadata found; rollback can only be used on existing data")
+		return nil, errors.New("no metadata found; rollback can only be used on existing data")
 	}
 
 	// Now run it again and read the version we want to roll back to
@@ -516,7 +516,7 @@ func extractDataAndVersionMetadata(secret *Secret) (*KVSecret, error) {
 	if secret.Data != nil {
 		dataInterface, ok := secret.Data["data"]
 		if !ok {
-			return nil, fmt.Errorf("missing expected 'data' element")
+			return nil, errors.New("missing expected 'data' element")
 		}
 
 		if dataInterface != nil {
@@ -630,26 +630,26 @@ func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
 func validateRollbackVersion(rollbackVersion *KVSecret) error {
 	// Make sure a value already exists
 	if rollbackVersion == nil || rollbackVersion.Data == nil {
-		return fmt.Errorf("no secret found")
+		return errors.New("no secret found")
 	}
 
 	// Verify metadata found
 	if rollbackVersion.VersionMetadata == nil {
-		return fmt.Errorf("no version metadata found; rollback only works on existing data")
+		return errors.New("no version metadata found; rollback only works on existing data")
 	}
 
 	// Verify it hasn't been deleted
 	if !rollbackVersion.VersionMetadata.DeletionTime.IsZero() {
-		return fmt.Errorf("cannot roll back to a version that has been deleted")
+		return errors.New("cannot roll back to a version that has been deleted")
 	}
 
 	if rollbackVersion.VersionMetadata.Destroyed {
-		return fmt.Errorf("cannot roll back to a version that has been destroyed")
+		return errors.New("cannot roll back to a version that has been destroyed")
 	}
 
 	// Verify old data found
 	if rollbackVersion.Data == nil {
-		return fmt.Errorf("no data found; rollback only works on existing data")
+		return errors.New("no data found; rollback only works on existing data")
 	}
 
 	return nil

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -133,7 +132,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			renew: func(_ string, _ int) (*Secret, error) {
 				if caseOneErrorCount == 0 {
 					caseOneErrorCount++
-					return nil, fmt.Errorf("renew failure")
+					return nil, errors.New("renew failure")
 				}
 				return renewedSecret, nil
 			},
@@ -150,7 +149,7 @@ func TestLifetimeWatcher(t *testing.T) {
 					return renewedSecret, nil
 				}
 				caseManyErrorsCount++
-				return nil, fmt.Errorf("renew failure")
+				return nil, errors.New("renew failure")
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -161,7 +160,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			leaseDurationSeconds: 15,
 			incrementSeconds:     15,
 			renew: func(_ string, _ int) (*Secret, error) {
-				return nil, fmt.Errorf("renew failure")
+				return nil, errors.New("renew failure")
 			},
 			expectError:   nil,
 			expectRenewal: false,

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -203,7 +203,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			for {
 				select {
 				case <-time.After(tc.maxTestTime):
-					t.Fatalf("renewal didn't happen")
+					t.Fatal("renewal didn't happen")
 				case r := <-v.RenewCh():
 					if !tc.expectRenewal {
 						t.Fatal("expected no renewals")
@@ -233,7 +233,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			}
 
 			if tc.expectRenewal && !receivedRenewal {
-				t.Fatalf("expected at least one renewal, got none.")
+				t.Fatal("expected at least one renewal, got none.")
 			}
 		})
 	}

--- a/api/secret.go
+++ b/api/secret.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -60,7 +61,7 @@ func (s *Secret) TokenID() (string, error) {
 
 	id, ok := s.Data["id"].(string)
 	if !ok {
-		return "", fmt.Errorf("token found but in the wrong format")
+		return "", errors.New("token found but in the wrong format")
 	}
 
 	return id, nil
@@ -84,7 +85,7 @@ func (s *Secret) TokenAccessor() (string, error) {
 
 	accessor, ok := s.Data["accessor"].(string)
 	if !ok {
-		return "", fmt.Errorf("token found but in the wrong format")
+		return "", errors.New("token found but in the wrong format")
 	}
 
 	return accessor, nil
@@ -134,7 +135,7 @@ func (s *Secret) TokenPolicies() ([]string, error) {
 
 		list, ok := s.Data["policies"].([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("unable to convert token policies to expected format")
+			return nil, errors.New("unable to convert token policies to expected format")
 		}
 		for _, v := range list {
 			p, ok := v.(string)
@@ -163,7 +164,7 @@ TOKEN_DONE:
 
 		list, ok := s.Data["identity_policies"].([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("unable to convert identity policies to expected format")
+			return nil, errors.New("unable to convert identity policies to expected format")
 		}
 		for _, v := range list {
 			p, ok := v.(string)
@@ -209,7 +210,7 @@ func (s *Secret) TokenMetadata() (map[string]string, error) {
 	if !ok {
 		data, ok = s.Data["meta"].(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("unable to convert metadata field to expected format")
+			return nil, errors.New("unable to convert metadata field to expected format")
 		}
 	}
 

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -155,7 +156,7 @@ func ParseSSHHelperConfig(contents string) (*SSHHelperConfig, error) {
 
 	list, ok := root.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing config: file doesn't contain a root object")
+		return nil, errors.New("error parsing config: file doesn't contain a root object")
 	}
 
 	valid := []string{

--- a/api/sys_mfa.go
+++ b/api/sys_mfa.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -41,7 +42,7 @@ func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payl
 	}
 
 	if secret == nil {
-		return nil, fmt.Errorf("data from server response is empty")
+		return nil, errors.New("data from server response is empty")
 	}
 
 	return secret, nil

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -82,7 +82,7 @@ func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, er
 		return policyRaw.(string), nil
 	}
 
-	return "", fmt.Errorf("no policy found in response")
+	return "", errors.New("no policy found in response")
 }
 
 func (c *Sys) PutPolicy(name, rules string) error {

--- a/audit/format.go
+++ b/audit/format.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -37,15 +38,15 @@ var _ Formatter = (*AuditFormatter)(nil)
 
 func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config FormatterConfig, in *logical.LogInput) error {
 	if in == nil || in.Request == nil {
-		return fmt.Errorf("request to request-audit a nil request")
+		return errors.New("request to request-audit a nil request")
 	}
 
 	if w == nil {
-		return fmt.Errorf("writer for audit request is nil")
+		return errors.New("writer for audit request is nil")
 	}
 
 	if f.AuditFormatWriter == nil {
-		return fmt.Errorf("no format writer specified")
+		return errors.New("no format writer specified")
 	}
 
 	salt, err := f.Salt(ctx)
@@ -171,15 +172,15 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 
 func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config FormatterConfig, in *logical.LogInput) error {
 	if in == nil || in.Request == nil {
-		return fmt.Errorf("request to response-audit a nil request")
+		return errors.New("request to response-audit a nil request")
 	}
 
 	if w == nil {
-		return fmt.Errorf("writer for audit request is nil")
+		return errors.New("writer for audit request is nil")
 	}
 
 	if f.AuditFormatWriter == nil {
-		return fmt.Errorf("no format writer specified")
+		return errors.New("no format writer specified")
 	}
 
 	salt, err := f.Salt(ctx)

--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -6,7 +6,7 @@ package audit
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/openbao/openbao/sdk/v2/helper/salt"
@@ -21,7 +21,7 @@ type JSONFormatWriter struct {
 
 func (f *JSONFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) error {
 	if req == nil {
-		return fmt.Errorf("request entry was nil, cannot encode")
+		return errors.New("request entry was nil, cannot encode")
 	}
 
 	if len(f.Prefix) > 0 {
@@ -37,7 +37,7 @@ func (f *JSONFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) err
 
 func (f *JSONFormatWriter) WriteResponse(w io.Writer, resp *AuditResponseEntry) error {
 	if resp == nil {
-		return fmt.Errorf("response entry was nil, cannot encode")
+		return errors.New("response entry was nil, cannot encode")
 	}
 
 	if len(f.Prefix) > 0 {

--- a/audit/format_jsonx.go
+++ b/audit/format_jsonx.go
@@ -6,7 +6,7 @@ package audit
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/jefferai/jsonx"
@@ -22,7 +22,7 @@ type JSONxFormatWriter struct {
 
 func (f *JSONxFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) error {
 	if req == nil {
-		return fmt.Errorf("request entry was nil, cannot encode")
+		return errors.New("request entry was nil, cannot encode")
 	}
 
 	if len(f.Prefix) > 0 {
@@ -48,7 +48,7 @@ func (f *JSONxFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) er
 
 func (f *JSONxFormatWriter) WriteResponse(w io.Writer, resp *AuditResponseEntry) error {
 	if resp == nil {
-		return fmt.Errorf("response entry was nil, cannot encode")
+		return errors.New("response entry was nil, cannot encode")
 	}
 
 	if len(f.Prefix) > 0 {

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -113,7 +113,7 @@ func TestHashString(t *testing.T) {
 	}
 	out := HashString(localSalt, "foo")
 	if out != "hmac-sha256:08ba357e274f528065766c770a639abf6809b39ccfd37c2a3157c7f51954da0a" {
-		t.Fatalf("err: HashString output did not match expected")
+		t.Fatal("err: HashString output did not match expected")
 	}
 }
 

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -6,6 +6,7 @@ package file
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,17 +23,17 @@ import (
 
 func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, error) {
 	if conf.SaltConfig == nil {
-		return nil, fmt.Errorf("nil salt config")
+		return nil, errors.New("nil salt config")
 	}
 	if conf.SaltView == nil {
-		return nil, fmt.Errorf("nil salt view")
+		return nil, errors.New("nil salt view")
 	}
 
 	path, ok := conf.Config["file_path"]
 	if !ok {
 		path, ok = conf.Config["path"]
 		if !ok {
-			return nil, fmt.Errorf("file_path is required")
+			return nil, errors.New("file_path is required")
 		}
 	}
 

--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -49,28 +49,28 @@ func TestAuditFile_fileModeNew(t *testing.T) {
 
 	info, err := os.Stat(file)
 	if err != nil {
-		t.Fatalf("Cannot retrieve file mode from `Stat`")
+		t.Fatal("Cannot retrieve file mode from `Stat`")
 	}
 	if info.Mode() != os.FileMode(mode) {
-		t.Fatalf("File mode does not match.")
+		t.Fatal("File mode does not match.")
 	}
 }
 
 func TestAuditFile_fileModeExisting(t *testing.T) {
 	f, err := os.CreateTemp("", "test")
 	if err != nil {
-		t.Fatalf("Failure to create test file.")
+		t.Fatal("Failure to create test file.")
 	}
 	defer os.Remove(f.Name())
 
 	err = os.Chmod(f.Name(), 0o777)
 	if err != nil {
-		t.Fatalf("Failure to chmod temp file for testing.")
+		t.Fatal("Failure to chmod temp file for testing.")
 	}
 
 	err = f.Close()
 	if err != nil {
-		t.Fatalf("Failure to close temp file for test.")
+		t.Fatal("Failure to close temp file for test.")
 	}
 
 	config := map[string]string{
@@ -88,10 +88,10 @@ func TestAuditFile_fileModeExisting(t *testing.T) {
 
 	info, err := os.Stat(f.Name())
 	if err != nil {
-		t.Fatalf("cannot retrieve file mode from `Stat`")
+		t.Fatal("cannot retrieve file mode from `Stat`")
 	}
 	if info.Mode() != os.FileMode(0o600) {
-		t.Fatalf("File mode does not match.")
+		t.Fatal("File mode does not match.")
 	}
 }
 
@@ -131,7 +131,7 @@ func TestAuditFile_fileMode0000(t *testing.T) {
 		t.Fatalf("cannot retrieve file mode from `Stat`. The error is %v", err)
 	}
 	if info.Mode() != os.FileMode(0o777) {
-		t.Fatalf("File mode does not match.")
+		t.Fatal("File mode does not match.")
 	}
 }
 

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -6,6 +6,7 @@ package socket
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -21,15 +22,15 @@ import (
 
 func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, error) {
 	if conf.SaltConfig == nil {
-		return nil, fmt.Errorf("nil salt config")
+		return nil, errors.New("nil salt config")
 	}
 	if conf.SaltView == nil {
-		return nil, fmt.Errorf("nil salt view")
+		return nil, errors.New("nil salt view")
 	}
 
 	address, ok := conf.Config["address"]
 	if !ok {
-		return nil, fmt.Errorf("address is required")
+		return nil, errors.New("address is required")
 	}
 
 	socketType, ok := conf.Config["socket_type"]

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -6,6 +6,7 @@ package syslog
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -18,10 +19,10 @@ import (
 
 func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, error) {
 	if conf.SaltConfig == nil {
-		return nil, fmt.Errorf("nil salt config")
+		return nil, errors.New("nil salt config")
 	}
 	if conf.SaltView == nil {
-		return nil, fmt.Errorf("nil salt view")
+		return nil, errors.New("nil salt view")
 	}
 
 	// Get facility or default to AUTH

--- a/builtin/credential/approle/backend_test.go
+++ b/builtin/credential/approle/backend_test.go
@@ -23,7 +23,7 @@ func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
 		t.Fatal(err)
 	}
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 	err = b.Backend.Setup(context.Background(), config)
 	if err != nil {
@@ -151,7 +151,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 		}
 		if resp.Auth == nil {
-			t.Fatalf("failed to perform login")
+			t.Fatal("failed to perform login")
 		}
 
 		// Destroy secret ID accessor
@@ -181,7 +181,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error due to invalid secret ID")
+			t.Fatal("expected error due to invalid secret ID")
 		}
 
 		// Generate another secret ID
@@ -210,7 +210,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 		}
 		if resp.Auth == nil {
-			t.Fatalf("failed to perform login")
+			t.Fatal("failed to perform login")
 		}
 
 		// Destroy the secret ID
@@ -240,7 +240,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error due to invalid secret ID")
+			t.Fatal("expected error due to invalid secret ID")
 		}
 
 		// Generate another secret ID
@@ -269,7 +269,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 		}
 		if resp.Auth == nil {
-			t.Fatalf("failed to perform login")
+			t.Fatal("failed to perform login")
 		}
 
 		// Destroy the secret ID using lower cased role name
@@ -299,7 +299,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error due to invalid secret ID")
+			t.Fatal("expected error due to invalid secret ID")
 		}
 
 		// Generate another secret ID
@@ -328,7 +328,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 		}
 		if resp.Auth == nil {
-			t.Fatalf("failed to perform login")
+			t.Fatal("failed to perform login")
 		}
 
 		// Destroy the secret ID using upper cased role name
@@ -358,7 +358,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error due to invalid secret ID")
+			t.Fatal("expected error due to invalid secret ID")
 		}
 
 		// Generate another secret ID
@@ -387,7 +387,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 		}
 		if resp.Auth == nil {
-			t.Fatalf("failed to perform login")
+			t.Fatal("failed to perform login")
 		}
 
 		// Destroy the secret ID using mixed case name
@@ -417,7 +417,7 @@ func TestAppRole_RoleNameCaseSensitivity(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error due to invalid secret ID")
+			t.Fatal("expected error due to invalid secret ID")
 		}
 	}
 

--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -5,6 +5,7 @@ package approle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -74,7 +75,7 @@ func pathLogin(b *backend) *framework.Path {
 func (b *backend) pathLoginUpdateAliasLookahead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	roleID := strings.TrimSpace(data.Get("role_id").(string))
 	if roleID == "" {
-		return nil, fmt.Errorf("missing role_id")
+		return nil, errors.New("missing role_id")
 	}
 
 	return &logical.Response{
@@ -239,7 +240,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 			// source IP complies to it
 			if len(entry.CIDRList) != 0 {
 				if req.Connection == nil || req.Connection.RemoteAddr == "" {
-					return nil, fmt.Errorf("failed to get connection information")
+					return nil, errors.New("failed to get connection information")
 				}
 
 				belongs, err := cidrutil.IPBelongsToCIDRBlocksSlice(req.Connection.RemoteAddr, entry.CIDRList)
@@ -314,7 +315,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 			// source IP complies to it
 			if len(entry.CIDRList) != 0 {
 				if req.Connection == nil || req.Connection.RemoteAddr == "" {
-					return nil, fmt.Errorf("failed to get connection information")
+					return nil, errors.New("failed to get connection information")
 				}
 
 				belongs, err := cidrutil.IPBelongsToCIDRBlocksSlice(req.Connection.RemoteAddr, entry.CIDRList)
@@ -334,7 +335,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 
 	if len(role.SecretIDBoundCIDRs) != 0 {
 		if req.Connection == nil || req.Connection.RemoteAddr == "" {
-			return nil, fmt.Errorf("failed to get connection information")
+			return nil, errors.New("failed to get connection information")
 		}
 		belongs, err := cidrutil.IPBelongsToCIDRBlocksSlice(req.Connection.RemoteAddr, role.SecretIDBoundCIDRs)
 		if err != nil || !belongs {
@@ -391,7 +392,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	roleName := req.Auth.InternalData["role_name"].(string)
 	if roleName == "" {
-		return nil, fmt.Errorf("failed to fetch role_name during renewal")
+		return nil, errors.New("failed to fetch role_name during renewal")
 	}
 
 	lock := b.roleLock(roleName)

--- a/builtin/credential/approle/path_login_test.go
+++ b/builtin/credential/approle/path_login_test.go
@@ -153,11 +153,11 @@ func TestAppRole_RoleLogin(t *testing.T) {
 	}
 
 	if loginResp.Auth == nil {
-		t.Fatalf("expected a non-nil auth object in the response")
+		t.Fatal("expected a non-nil auth object in the response")
 	}
 
 	if loginResp.Auth.Metadata == nil {
-		t.Fatalf("expected a non-nil metadata object in the response")
+		t.Fatal("expected a non-nil metadata object in the response")
 	}
 
 	if val := loginResp.Auth.Metadata["role_name"]; val != "role1" {
@@ -165,7 +165,7 @@ func TestAppRole_RoleLogin(t *testing.T) {
 	}
 
 	if loginResp.Auth.Alias.Metadata == nil {
-		t.Fatalf("expected a non-nil alias metadata object in the response")
+		t.Fatal("expected a non-nil alias metadata object in the response")
 	}
 
 	if val := loginResp.Auth.Alias.Metadata["role_name"]; val != "role1" {
@@ -229,7 +229,7 @@ func TestAppRole_RoleLogin(t *testing.T) {
 	}
 
 	if loginResp.Auth == nil {
-		t.Fatalf("expected a non-nil auth object in the response")
+		t.Fatal("expected a non-nil auth object in the response")
 	}
 
 	renewReq = generateRenewRequest(storage, loginResp.Auth)

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -1324,7 +1324,7 @@ Overrides secret_id_ttl role option when supplied. May not be longer than role's
 func (b *backend) pathRoleExistenceCheck(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
 	roleName := data.Get("role_name").(string)
 	if roleName == "" {
-		return false, fmt.Errorf("missing role_name")
+		return false, errors.New("missing role_name")
 	}
 
 	lock := b.roleLock(roleName)
@@ -1423,7 +1423,7 @@ func (b *backend) pathRoleSecretIDList(ctx context.Context, req *logical.Request
 			return nil, err
 		} else if entry == nil {
 			secretIDLock.RUnlock()
-			return nil, fmt.Errorf("storage entry for SecretID is present but no content found at the index")
+			return nil, errors.New("storage entry for SecretID is present but no content found at the index")
 		} else if err := entry.DecodeJSON(&result); err != nil {
 			secretIDLock.RUnlock()
 			return nil, err
@@ -1439,7 +1439,7 @@ func (b *backend) pathRoleSecretIDList(ctx context.Context, req *logical.Request
 // enabled.
 func validateRoleConstraints(role *roleStorageEntry) error {
 	if role == nil {
-		return fmt.Errorf("nil role")
+		return errors.New("nil role")
 	}
 
 	// At least one constraint should be enabled on the role
@@ -1449,7 +1449,7 @@ func validateRoleConstraints(role *roleStorageEntry) error {
 	case len(role.SecretIDBoundCIDRs) != 0:
 	case len(role.TokenBoundCIDRs) != 0:
 	default:
-		return fmt.Errorf("at least one constraint should be enabled on the role")
+		return errors.New("at least one constraint should be enabled on the role")
 	}
 
 	return nil
@@ -1459,11 +1459,11 @@ func validateRoleConstraints(role *roleStorageEntry) error {
 // name.
 func (b *backend) setRoleEntry(ctx context.Context, s logical.Storage, roleName string, role *roleStorageEntry, previousRoleID string) error {
 	if roleName == "" {
-		return fmt.Errorf("missing role name")
+		return errors.New("missing role name")
 	}
 
 	if role == nil {
-		return fmt.Errorf("nil role")
+		return errors.New("nil role")
 	}
 
 	// Check if role constraints are properly set
@@ -1488,7 +1488,7 @@ func (b *backend) setRoleEntry(ctx context.Context, s logical.Storage, roleName 
 
 	// If the entry exists, make sure that it belongs to the current role
 	if roleIDIndex != nil && roleIDIndex.Name != roleName {
-		return fmt.Errorf("role_id already in use")
+		return errors.New("role_id already in use")
 	}
 
 	// When role_id is getting updated, delete the old index before
@@ -1519,7 +1519,7 @@ func (b *backend) setRoleEntry(ctx context.Context, s logical.Storage, roleName 
 // roleEntry reads the role from storage
 func (b *backend) roleEntry(ctx context.Context, s logical.Storage, roleName string) (*roleStorageEntry, error) {
 	if roleName == "" {
-		return nil, fmt.Errorf("missing role_name")
+		return nil, errors.New("missing role_name")
 	}
 
 	var role roleStorageEntry
@@ -3190,7 +3190,7 @@ func (b *backend) setRoleIDEntry(ctx context.Context, s logical.Storage, roleID 
 // roleIDEntry is used to read the storage entry that maps RoleID to Role
 func (b *backend) roleIDEntry(ctx context.Context, s logical.Storage, roleID string) (*roleIDStorageEntry, error) {
 	if roleID == "" {
-		return nil, fmt.Errorf("missing role id")
+		return nil, errors.New("missing role id")
 	}
 
 	lock := b.roleIDLock(roleID)
@@ -3220,7 +3220,7 @@ func (b *backend) roleIDEntry(ctx context.Context, s logical.Storage, roleID str
 // RoleID to the Role itself.
 func (b *backend) roleIDEntryDelete(ctx context.Context, s logical.Storage, roleID string) error {
 	if roleID == "" {
-		return fmt.Errorf("missing role id")
+		return errors.New("missing role id")
 	}
 
 	lock := b.roleIDLock(roleID)

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -53,7 +53,7 @@ func TestAppRole_LocalSecretIDsRead(t *testing.T) {
 	})
 
 	if !resp.Data["local_secret_ids"].(bool) {
-		t.Fatalf("expected local_secret_ids to be returned")
+		t.Fatal("expected local_secret_ids to be returned")
 	}
 }
 
@@ -101,7 +101,7 @@ func TestAppRole_LocalNonLocalSecretIDs(t *testing.T) {
 	})
 
 	if len(resp.Data["keys"].([]string)) != count {
-		t.Fatalf("failed to list secret IDs")
+		t.Fatal("failed to list secret IDs")
 	}
 
 	// Create secret IDs on testrole1
@@ -120,7 +120,7 @@ func TestAppRole_LocalNonLocalSecretIDs(t *testing.T) {
 	})
 
 	if len(resp.Data["keys"].([]string)) != count {
-		t.Fatalf("failed to list secret IDs")
+		t.Fatal("failed to list secret IDs")
 	}
 }
 
@@ -148,7 +148,7 @@ func TestAppRole_UpgradeSecretIDPrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 	if role.SecretIDPrefix == "" {
-		t.Fatalf("expected SecretIDPrefix to be set")
+		t.Fatal("expected SecretIDPrefix to be set")
 	}
 
 	// Ensure that the API response contains local_secret_ids
@@ -160,7 +160,7 @@ func TestAppRole_UpgradeSecretIDPrefix(t *testing.T) {
 
 	_, ok := resp.Data["local_secret_ids"]
 	if !ok {
-		t.Fatalf("expected local_secret_ids to be present in the response")
+		t.Fatal("expected local_secret_ids to be present in the response")
 	}
 }
 
@@ -196,7 +196,7 @@ func TestAppRole_LocalSecretIDImmutability(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error since local_secret_ids can't be overwritten")
+		t.Fatal("expected an error since local_secret_ids can't be overwritten")
 	}
 }
 
@@ -270,7 +270,7 @@ func TestAppRole_UpgradeBoundCIDRList(t *testing.T) {
 	})
 
 	if resp.Data["secret_id"].(string) == "" {
-		t.Fatalf("failed to generate secret-id")
+		t.Fatal("failed to generate secret-id")
 	}
 
 	// Check that the backwards compatibility for the string type is not broken
@@ -284,7 +284,7 @@ func TestAppRole_UpgradeBoundCIDRList(t *testing.T) {
 	})
 
 	if resp.Data["secret_id"].(string) == "" {
-		t.Fatalf("failed to generate secret-id")
+		t.Fatal("failed to generate secret-id")
 	}
 }
 
@@ -349,7 +349,7 @@ func TestAppRole_RoleNameLowerCasing(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Delete the role and create it again. This time don't directly persist
@@ -410,7 +410,7 @@ func TestAppRole_RoleNameLowerCasing(t *testing.T) {
 	})
 
 	if resp == nil {
-		t.Fatalf("failed to lookup secret IDs")
+		t.Fatal("failed to lookup secret IDs")
 	}
 
 	// Listing of secret IDs should work in case-insensitive manner
@@ -421,7 +421,7 @@ func TestAppRole_RoleNameLowerCasing(t *testing.T) {
 	})
 
 	if len(resp.Data["keys"].([]string)) != 1 {
-		t.Fatalf("failed to list secret IDs")
+		t.Fatal("failed to list secret IDs")
 	}
 }
 
@@ -466,7 +466,7 @@ func TestAppRole_RoleReadSetIndex(t *testing.T) {
 
 	// Check if the warning is being returned
 	if !strings.Contains(resp.Warnings[0], "Role identifier was missing an index back to role name.") {
-		t.Fatalf("bad: expected a warning in the response")
+		t.Fatal("bad: expected a warning in the response")
 	}
 
 	roleIDIndex, err := b.roleIDEntry(context.Background(), storage, roleID)
@@ -476,7 +476,7 @@ func TestAppRole_RoleReadSetIndex(t *testing.T) {
 
 	// Check if the index has been successfully created
 	if roleIDIndex == nil || roleIDIndex.Name != "testrole" {
-		t.Fatalf("bad: expected role to have an index")
+		t.Fatal("bad: expected role to have an index")
 	}
 
 	roleReq.Operation = logical.UpdateOperation
@@ -628,7 +628,7 @@ func TestAppRole_RoleConstraints(t *testing.T) {
 		t.Fatalf("err:%v, resp:%#v", err, resp)
 	}
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -687,7 +687,7 @@ func TestAppRole_RoleIDUpdate(t *testing.T) {
 	resp = b.requestNoErr(t, loginReq)
 
 	if resp.Auth == nil {
-		t.Fatalf("expected a non-nil auth object in the response")
+		t.Fatal("expected a non-nil auth object in the response")
 	}
 }
 
@@ -900,7 +900,7 @@ func TestAppRole_RoleSecretIDAccessorReadDelete(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -1015,13 +1015,13 @@ func TestAppRole_RoleSecretIDWithoutFields(t *testing.T) {
 	resp = b.requestNoErr(t, roleSecretIDReq)
 
 	if resp.Data["secret_id"].(string) == "" {
-		t.Fatalf("failed to generate secret_id")
+		t.Fatal("failed to generate secret_id")
 	}
 	if resp.Data["secret_id_ttl"].(int64) != int64(roleData["secret_id_ttl"].(int)) {
-		t.Fatalf("secret_id_ttl has not defaulted to the role's secret id ttl")
+		t.Fatal("secret_id_ttl has not defaulted to the role's secret id ttl")
 	}
 	if resp.Data["secret_id_num_uses"].(int) != roleData["secret_id_num_uses"].(int) {
-		t.Fatalf("secret_id_num_uses has not defaulted to the role's secret id num_uses")
+		t.Fatal("secret_id_num_uses has not defaulted to the role's secret id num_uses")
 	}
 
 	roleSecretIDReq.Path = "role/role1/custom-secret-id"
@@ -1032,13 +1032,13 @@ func TestAppRole_RoleSecretIDWithoutFields(t *testing.T) {
 	resp = b.requestNoErr(t, roleSecretIDReq)
 
 	if resp.Data["secret_id"] != "abcd123" {
-		t.Fatalf("failed to set specific secret_id to role")
+		t.Fatal("failed to set specific secret_id to role")
 	}
 	if resp.Data["secret_id_ttl"].(int64) != int64(roleData["secret_id_ttl"].(int)) {
-		t.Fatalf("secret_id_ttl has not defaulted to the role's secret id ttl")
+		t.Fatal("secret_id_ttl has not defaulted to the role's secret id ttl")
 	}
 	if resp.Data["secret_id_num_uses"].(int) != roleData["secret_id_num_uses"].(int) {
-		t.Fatalf("secret_id_num_uses has not defaulted to the role's secret id num_uses")
+		t.Fatal("secret_id_num_uses has not defaulted to the role's secret id num_uses")
 	}
 }
 
@@ -1099,13 +1099,13 @@ func TestAppRole_RoleSecretIDWithValidFields(t *testing.T) {
 			resp = b.requestNoErr(t, roleSecretIDReq)
 
 			if resp.Data["secret_id"].(string) == "" {
-				t.Fatalf("failed to generate secret_id")
+				t.Fatal("failed to generate secret_id")
 			}
 			if resp.Data["secret_id_ttl"].(int64) != int64(tc.payload["ttl"].(int)) {
-				t.Fatalf("secret_id_ttl has not been set by the 'ttl' field")
+				t.Fatal("secret_id_ttl has not been set by the 'ttl' field")
 			}
 			if resp.Data["secret_id_num_uses"].(int) != tc.payload["num_uses"].(int) {
-				t.Fatalf("secret_id_num_uses has not been set by the 'num_uses' field")
+				t.Fatal("secret_id_num_uses has not been set by the 'num_uses' field")
 			}
 
 			roleSecretIDReq.Path = "role/role1/custom-secret-id"
@@ -1113,13 +1113,13 @@ func TestAppRole_RoleSecretIDWithValidFields(t *testing.T) {
 			resp = b.requestNoErr(t, roleSecretIDReq)
 
 			if resp.Data["secret_id"] != tc.payload["secret_id"] {
-				t.Fatalf("failed to set specific secret_id to role")
+				t.Fatal("failed to set specific secret_id to role")
 			}
 			if resp.Data["secret_id_ttl"].(int64) != int64(tc.payload["ttl"].(int)) {
-				t.Fatalf("secret_id_ttl has not been set by the 'ttl' field")
+				t.Fatal("secret_id_ttl has not been set by the 'ttl' field")
 			}
 			if resp.Data["secret_id_num_uses"].(int) != tc.payload["num_uses"].(int) {
-				t.Fatalf("secret_id_num_uses has not been set by the 'num_uses' field")
+				t.Fatal("secret_id_num_uses has not been set by the 'num_uses' field")
 			}
 		})
 	}
@@ -1392,7 +1392,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if !resp.Data["bind_secret_id"].(bool) {
-		t.Fatalf("expected the default value of 'true' to be set")
+		t.Fatal("expected the default value of 'true' to be set")
 	}
 
 	// RUD for policies field
@@ -1447,7 +1447,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["secret_id_num_uses"].(int) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for secret_id_ttl field
@@ -1472,7 +1472,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["secret_id_ttl"].(time.Duration) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for secret-id-num-uses field
@@ -1502,7 +1502,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["token_num_uses"].(int) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for 'period' field
@@ -1527,7 +1527,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["token_period"].(time.Duration) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for token_ttl field
@@ -1552,7 +1552,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["token_ttl"].(time.Duration) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for token_max_ttl field
@@ -1577,7 +1577,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if resp.Data["token_max_ttl"].(time.Duration) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// Delete test for role
@@ -1592,7 +1592,7 @@ func TestAppRole_RoleCRUD(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -1718,7 +1718,7 @@ func TestAppRole_RoleWithTokenBoundCIDRsCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if len(resp.Data["secret_id_bound_cidrs"].([]string)) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// RUD for token-bound-cidrs field
@@ -1753,7 +1753,7 @@ func TestAppRole_RoleWithTokenBoundCIDRsCRUD(t *testing.T) {
 	resp = b.requestNoErr(t, roleReq)
 
 	if len(resp.Data["token_bound_cidrs"].([]*sockaddr.SockAddrMarshaler)) != 0 {
-		t.Fatalf("expected value to be reset")
+		t.Fatal("expected value to be reset")
 	}
 
 	// Delete test for role
@@ -1767,7 +1767,7 @@ func TestAppRole_RoleWithTokenBoundCIDRsCRUD(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -1883,7 +1883,7 @@ func TestAppRole_RoleWithTokenTypeCRUD(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -1945,7 +1945,7 @@ func TestAppRole_TokenutilUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 	if err := b.Setup(ctx, config); err != nil {
 		t.Fatal(err)
@@ -2050,7 +2050,7 @@ func TestAppRole_SecretID_WithTTL(t *testing.T) {
 			// Extract the "ttl" value from the response data if it exists
 			ttlRaw, okTTL := resp.Data["secret_id_ttl"]
 			if !okTTL {
-				t.Fatalf("expected TTL value in response")
+				t.Fatal("expected TTL value in response")
 			}
 
 			var (
@@ -2129,6 +2129,6 @@ func TestAppRole_RoleSecretIDAccessorCrossDelete(t *testing.T) {
 	})
 
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }

--- a/builtin/credential/approle/validation.go
+++ b/builtin/credential/approle/validation.go
@@ -8,6 +8,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -110,7 +111,7 @@ const maxHmacInputLength = 4096
 // a hex encoded string.
 func createHMAC(key, value string) (string, error) {
 	if key == "" {
-		return "", fmt.Errorf("invalid HMAC key")
+		return "", errors.New("invalid HMAC key")
 	}
 
 	if len(value) > maxHmacInputLength {
@@ -160,11 +161,11 @@ func decodeSecretIDStorageEntry(entry *logical.StorageEntry) (*secretIDStorageEn
 // the storage entry. Locks need to be acquired before calling this method.
 func (b *backend) nonLockedSecretIDStorageEntry(ctx context.Context, s logical.Storage, roleSecretIDPrefix, roleNameHMAC, secretIDHMAC string) (*secretIDStorageEntry, error) {
 	if secretIDHMAC == "" {
-		return nil, fmt.Errorf("missing secret ID HMAC")
+		return nil, errors.New("missing secret ID HMAC")
 	}
 
 	if roleNameHMAC == "" {
-		return nil, fmt.Errorf("missing role name HMAC")
+		return nil, errors.New("missing role name HMAC")
 	}
 
 	// Prepare the storage index at which the secret ID will be stored
@@ -213,18 +214,18 @@ func (b *backend) nonLockedSecretIDStorageEntry(ctx context.Context, s logical.S
 // this method.
 func (b *backend) nonLockedSetSecretIDStorageEntry(ctx context.Context, s logical.Storage, roleSecretIDPrefix, roleNameHMAC, secretIDHMAC string, secretEntry *secretIDStorageEntry) error {
 	if roleSecretIDPrefix == "" {
-		return fmt.Errorf("missing secret ID prefix")
+		return errors.New("missing secret ID prefix")
 	}
 	if secretIDHMAC == "" {
-		return fmt.Errorf("missing secret ID HMAC")
+		return errors.New("missing secret ID HMAC")
 	}
 
 	if roleNameHMAC == "" {
-		return fmt.Errorf("missing role name HMAC")
+		return errors.New("missing role name HMAC")
 	}
 
 	if secretEntry == nil {
-		return fmt.Errorf("nil secret entry")
+		return errors.New("nil secret entry")
 	}
 
 	entryIndex := fmt.Sprintf("%s%s/%s", roleSecretIDPrefix, roleNameHMAC, secretIDHMAC)
@@ -259,7 +260,7 @@ func (b *backend) registerSecretIDEntry(ctx context.Context, s logical.Storage, 
 	}
 	if entry != nil {
 		lock.RUnlock()
-		return nil, fmt.Errorf("SecretID is already registered")
+		return nil, errors.New("SecretID is already registered")
 	}
 
 	// If there isn't an entry for the secretID already, switch the read lock
@@ -274,7 +275,7 @@ func (b *backend) registerSecretIDEntry(ctx context.Context, s logical.Storage, 
 		return nil, err
 	}
 	if entry != nil {
-		return nil, fmt.Errorf("SecretID is already registered")
+		return nil, errors.New("SecretID is already registered")
 	}
 
 	//
@@ -320,7 +321,7 @@ func (b *backend) deriveSecretIDTTL(secretIDTTL time.Duration) time.Duration {
 // accessor to a secret_id.
 func (b *backend) secretIDAccessorEntry(ctx context.Context, s logical.Storage, secretIDAccessor, roleSecretIDPrefix string) (*secretIDAccessorStorageEntry, error) {
 	if secretIDAccessor == "" {
-		return nil, fmt.Errorf("missing secretIDAccessor")
+		return nil, errors.New("missing secretIDAccessor")
 	}
 
 	var result secretIDAccessorStorageEntry

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -461,7 +461,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 		t.Fatal(err)
 	}
 	if secret.Auth == nil || secret.Auth.ClientToken == "" {
-		t.Fatalf("expected a successful authentication")
+		t.Fatal("expected a successful authentication")
 	}
 
 	// testing pathLoginRenew for cert auth
@@ -476,7 +476,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 	}
 
 	if secret.Auth == nil || secret.Auth.ClientToken != "" || secret.Auth.LeaseDuration != 3600 || secret.Auth.Accessor != oldAccessor {
-		t.Fatalf("unexpected accessor renewal")
+		t.Fatal("unexpected accessor renewal")
 	}
 }
 
@@ -612,7 +612,7 @@ path "kv/ext/{{identity.entity.aliases.%s.metadata.2-1-1-1}}" {
 		t.Fatal(err)
 	}
 	if secret.Auth == nil || secret.Auth.ClientToken == "" {
-		t.Fatalf("expected a successful authentication")
+		t.Fatal("expected a successful authentication")
 	}
 
 	// Check paths guarded by ACL policy
@@ -662,7 +662,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 	// Set IP SAN
 	parsedIP := net.ParseIP("127.0.0.1")
 	if parsedIP == nil {
-		t.Fatalf("failed to create parsed IP")
+		t.Fatal("failed to create parsed IP")
 	}
 	template.IPAddresses = []net.IP{parsedIP}
 
@@ -854,7 +854,7 @@ func TestBackend_NonCAExpiry(t *testing.T) {
 	// Login attempt after certificate expiry should fail
 	resp, err = b.HandleRequest(context.Background(), loginReq)
 	if err == nil {
-		t.Fatalf("expected error due to expired certificate")
+		t.Fatal("expected error due to expired certificate")
 	}
 }
 
@@ -952,7 +952,7 @@ func TestBackend_RegisteredNonCA_CRL(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected failure due to revoked certificate")
+		t.Fatal("expected failure due to revoked certificate")
 	}
 }
 
@@ -1049,7 +1049,7 @@ func TestBackend_CRLs(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected failure due to revoked certificate")
+		t.Fatal("expected failure due to revoked certificate")
 	}
 
 	// Register a different client CA certificate.
@@ -1093,7 +1093,7 @@ func TestBackend_CRLs(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected failure due to revoked certificate")
+		t.Fatal("expected failure due to revoked certificate")
 	}
 }
 
@@ -1709,7 +1709,7 @@ func testAccStepReadCRL(t *testing.T, connState tls.ConnectionState) logicaltest
 				t.Fatalf("bad: expected CRL with length 1, got %d", len(crlInfo.Serials))
 			}
 			if _, ok := crlInfo.Serials["637101449987587619778072672905061040630001617053"]; !ok {
-				t.Fatalf("bad: expected serial number not found in CRL")
+				t.Fatal("bad: expected serial number not found in CRL")
 			}
 			return nil
 		},
@@ -1743,12 +1743,12 @@ func testAccStepReadConfig(t *testing.T, conf config, connState tls.ConnectionSt
 		Check: func(resp *logical.Response) error {
 			value, ok := resp.Data["enable_identity_alias_metadata"]
 			if !ok {
-				t.Fatalf("enable_identity_alias_metadata not found in response")
+				t.Fatal("enable_identity_alias_metadata not found in response")
 			}
 
 			b, ok := value.(bool)
 			if !ok {
-				t.Fatalf("bad: expected enable_identity_alias_metadata to be a bool")
+				t.Fatal("bad: expected enable_identity_alias_metadata to be a bool")
 			}
 
 			if b != conf.EnableIdentityAliasMetadata {
@@ -2303,7 +2303,7 @@ func TestBackend_CertUpgrade(t *testing.T) {
 
 	b := Backend()
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 	if err := b.Setup(ctx, config); err != nil {
 		t.Fatal(err)
@@ -2685,6 +2685,6 @@ func TestBackend_RegressionDifferentTrustedLeaf(t *testing.T) {
 		t.Fatal(err)
 	}
 	if secret.Auth == nil || secret.Auth.ClientToken == "" {
-		t.Fatalf("expected a successful authentication")
+		t.Fatal("expected a successful authentication")
 	}
 }

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -426,7 +427,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				// This can of course be overridden per-test by using its own client
-				return fmt.Errorf("redirects not allowed in these tests")
+				return errors.New("redirects not allowed in these tests")
 			},
 		}
 		config := api.DefaultConfig()
@@ -575,7 +576,7 @@ path "kv/ext/{{identity.entity.aliases.%s.metadata.2-1-1-1}}" {
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				// This can of course be overridden per-test by using its own client
-				return fmt.Errorf("redirects not allowed in these tests")
+				return errors.New("redirects not allowed in these tests")
 			},
 		}
 		config := api.DefaultConfig()
@@ -1885,13 +1886,13 @@ func testAccStepListCerts(
 			Path:      "certs",
 			Check: func(resp *logical.Response) error {
 				if resp == nil {
-					return fmt.Errorf("nil response")
+					return errors.New("nil response")
 				}
 				if resp.Data == nil {
-					return fmt.Errorf("nil data")
+					return errors.New("nil data")
 				}
 				if resp.Data["keys"] == interface{}(nil) {
-					return fmt.Errorf("nil keys")
+					return errors.New("nil keys")
 				}
 				keys := resp.Data["keys"].([]string)
 				if !reflect.DeepEqual(keys, certs) {
@@ -1904,13 +1905,13 @@ func testAccStepListCerts(
 			Path:      "certs/",
 			Check: func(resp *logical.Response) error {
 				if resp == nil {
-					return fmt.Errorf("nil response")
+					return errors.New("nil response")
 				}
 				if resp.Data == nil {
-					return fmt.Errorf("nil data")
+					return errors.New("nil data")
 				}
 				if resp.Data["keys"] == interface{}(nil) {
-					return fmt.Errorf("nil keys")
+					return errors.New("nil keys")
 				}
 				keys := resp.Data["keys"].([]string)
 				if !reflect.DeepEqual(keys, certs) {
@@ -1963,7 +1964,7 @@ func testAccStepCertWithExtraParams(t *testing.T, name string, cert []byte, poli
 		Data:      data,
 		Check: func(resp *logical.Response) error {
 			if resp == nil && expectError {
-				return fmt.Errorf("expected error but received nil")
+				return errors.New("expected error but received nil")
 			}
 			return nil
 		},
@@ -1978,7 +1979,7 @@ func testAccStepReadCertPolicy(t *testing.T, name string, expectError bool, expe
 		Data:      nil,
 		Check: func(resp *logical.Response) error {
 			if (resp == nil || len(resp.Data) == 0) && expectError {
-				return fmt.Errorf("expected error but received nil")
+				return errors.New("expected error but received nil")
 			}
 			for key, expectedValue := range expected {
 				actualValue := resp.Data[key]
@@ -2637,7 +2638,7 @@ func TestBackend_RegressionDifferentTrustedLeaf(t *testing.T) {
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				// This can of course be overridden per-test by using its own client
-				return fmt.Errorf("redirects not allowed in these tests")
+				return errors.New("redirects not allowed in these tests")
 			},
 		}
 		config := api.DefaultConfig()

--- a/builtin/credential/cert/cli.go
+++ b/builtin/credential/cert/cli.go
@@ -4,6 +4,7 @@
 package cert
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -35,7 +36,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		return nil, err
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("empty response from credential provider")
+		return nil, errors.New("empty response from credential provider")
 	}
 
 	return secret, nil

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -91,11 +91,11 @@ func (b *backend) pathLoginResolveRole(ctx context.Context, req *logical.Request
 
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	if req.Connection == nil || req.Connection.ConnState == nil {
-		return nil, fmt.Errorf("tls connection not found")
+		return nil, errors.New("tls connection not found")
 	}
 	clientCerts := req.Connection.ConnState.PeerCertificates
 	if len(clientCerts) == 0 {
-		return nil, fmt.Errorf("no client certificate found")
+		return nil, errors.New("no client certificate found")
 	}
 
 	return &logical.Response{
@@ -218,7 +218,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 		// Certificate should not only match a registered certificate policy.
 		// Also, the identity of the certificate presented should match the identity of the certificate used during login
 		if req.Auth.InternalData["subject_key_id"] != skid && req.Auth.InternalData["authority_key_id"] != akid {
-			return nil, fmt.Errorf("client identity during renewal not matching client identity used during login")
+			return nil, errors.New("client identity during renewal not matching client identity used during login")
 		}
 
 	}
@@ -233,7 +233,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if !policyutil.EquivalentPolicies(cert.TokenPolicies, req.Auth.TokenPolicies) {
-		return nil, fmt.Errorf("policies have changed, not renewing")
+		return nil, errors.New("policies have changed, not renewing")
 	}
 
 	resp := &logical.Response{Auth: req.Auth}

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -219,7 +219,7 @@ func (b *jwtAuthBackend) configDeviceAuthURL(ctx context.Context, s logical.Stor
 
 	if config.OIDCDeviceAuthURL != "" {
 		if config.OIDCDeviceAuthURL == "N/A" {
-			return fmt.Errorf("no device auth endpoint url discovered")
+			return errors.New("no device auth endpoint url discovered")
 		}
 		return nil
 	}
@@ -244,7 +244,7 @@ func (b *jwtAuthBackend) configDeviceAuthURL(ctx context.Context, s logical.Stor
 	err = json.Unmarshal(body, &daj)
 	if err != nil || daj.DeviceAuthURL == "" {
 		b.cachedConfig.OIDCDeviceAuthURL = "N/A"
-		return fmt.Errorf("no device auth endpoint url discovered")
+		return errors.New("no device auth endpoint url discovered")
 	}
 
 	b.cachedConfig.OIDCDeviceAuthURL = daj.DeviceAuthURL

--- a/builtin/credential/jwt/path_role_test.go
+++ b/builtin/credential/jwt/path_role_test.go
@@ -134,7 +134,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if resp.Error().Error() != "a user claim must be defined on the role" {
 			t.Fatalf("unexpected err: %v", resp)
@@ -161,7 +161,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if !strings.HasPrefix(resp.Error().Error(), "must have at least one bound constraint") {
 			t.Fatalf("unexpected err: %v", resp)
@@ -189,7 +189,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && resp.IsError() {
-			t.Fatalf("did not expect error")
+			t.Fatal("did not expect error")
 		}
 	})
 
@@ -215,7 +215,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && resp.IsError() {
-			t.Fatalf("did not expect error")
+			t.Fatal("did not expect error")
 		}
 	})
 
@@ -241,7 +241,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && resp.IsError() {
-			t.Fatalf("did not expect error")
+			t.Fatal("did not expect error")
 		}
 	})
 
@@ -269,7 +269,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && resp.IsError() {
-			t.Fatalf("did not expect error")
+			t.Fatal("did not expect error")
 		}
 	})
 
@@ -442,7 +442,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if resp.Error().Error() != "invalid 'bound_claims_type': invalid" {
 			t.Fatalf("unexpected err: %v", resp)
@@ -477,7 +477,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if resp.Error().Error() != "claim is not a string or list: 25" {
 			t.Fatalf("unexpected err: %v", resp)
@@ -511,7 +511,7 @@ func TestPath_Create(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if resp.Error().Error() != "claim is not a string: 10" {
 			t.Fatalf("unexpected err: %v", resp)
@@ -644,7 +644,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if !strings.Contains(resp.Error().Error(), `metadata key "role" is reserved`) {
 			t.Fatalf("unexpected err: %v", resp)
@@ -690,7 +690,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp != nil && !resp.IsError() {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 		if !strings.Contains(resp.Error().Error(), `multiple keys are mapped to metadata key "a"`) {
 			t.Fatalf("unexpected err: %v", resp)

--- a/builtin/credential/jwt/provider_config.go
+++ b/builtin/credential/jwt/provider_config.go
@@ -5,6 +5,7 @@ package jwtauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"golang.org/x/oauth2"
@@ -45,7 +46,7 @@ func NewProviderConfig(ctx context.Context, jc *jwtConfig, providerMap map[strin
 	}
 	provider, ok := jc.ProviderConfig["provider"].(string)
 	if !ok {
-		return nil, fmt.Errorf("'provider' field not found in provider_config")
+		return nil, errors.New("'provider' field not found in provider_config")
 	}
 	newCustomProvider, ok := providerMap[provider]
 	if !ok {

--- a/builtin/credential/jwt/provider_config_test.go
+++ b/builtin/credential/jwt/provider_config_test.go
@@ -5,7 +5,7 @@ package jwtauth
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +18,7 @@ type testProviderConfig struct {
 
 func (t *testProviderConfig) Initialize(_ context.Context, jc *jwtConfig) error {
 	if t.throwError {
-		return fmt.Errorf("i'm throwing an error")
+		return errors.New("i'm throwing an error")
 	}
 	t.initialized = jc.ProviderConfig["initialized_value"].(string)
 	return nil

--- a/builtin/credential/kubernetes/backend_test.go
+++ b/builtin/credential/kubernetes/backend_test.go
@@ -321,7 +321,7 @@ func Test_kubeAuthBackend_initialize(t *testing.T) {
 			b.tlsMu.RLock()
 			if b.tlsConfigUpdaterRunning {
 				b.tlsMu.RUnlock()
-				t.Fatalf("tlsConfigUpdater started before initialize()")
+				t.Fatal("tlsConfigUpdater started before initialize()")
 			}
 			b.tlsMu.RUnlock()
 
@@ -349,7 +349,7 @@ func Test_kubeAuthBackend_initialize(t *testing.T) {
 			b.tlsMu.RLock()
 			if !b.tlsConfigUpdaterRunning {
 				b.tlsMu.RUnlock()
-				t.Fatalf("tlsConfigUpdater not started from initialize()")
+				t.Fatal("tlsConfigUpdater not started from initialize()")
 			}
 			b.tlsMu.RUnlock()
 		})
@@ -444,7 +444,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 			b.tlsMu.RLock()
 			if b.tlsConfigUpdaterRunning {
 				b.tlsMu.RUnlock()
-				t.Fatalf("tlsConfigUpdater already started")
+				t.Fatal("tlsConfigUpdater already started")
 			}
 			b.tlsMu.RUnlock()
 
@@ -467,7 +467,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 			b.tlsMu.RLock()
 			if !b.tlsConfigUpdaterRunning {
 				b.tlsMu.RUnlock()
-				t.Fatalf("tlsConfigUpdater not started")
+				t.Fatal("tlsConfigUpdater not started")
 			}
 			b.tlsMu.RUnlock()
 
@@ -488,7 +488,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 
 						time.Sleep(tt.horizon * 2)
 						if b.tlsConfig == nil {
-							t.Fatalf("runTLSConfigUpdater(), expected tlsConfig initialization")
+							t.Fatal("runTLSConfigUpdater(), expected tlsConfig initialization")
 						}
 
 						b.tlsMu.RLock()
@@ -499,7 +499,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 				}
 			} else {
 				if b.tlsConfig != nil {
-					t.Errorf("runTLSConfigUpdater(), unexpected tlsConfig initialization")
+					t.Error("runTLSConfigUpdater(), unexpected tlsConfig initialization")
 				}
 			}
 
@@ -508,7 +508,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 			b.tlsMu.RLock()
 			if b.tlsConfigUpdaterRunning {
 				b.tlsMu.RUnlock()
-				t.Fatalf("tlsConfigUpdater did not shutdown cleanly")
+				t.Fatal("tlsConfigUpdater did not shutdown cleanly")
 			}
 			b.tlsMu.RUnlock()
 		})
@@ -544,7 +544,7 @@ func getTestCertPool(t *testing.T, cert string) *x509.CertPool {
 
 	pool := x509.NewCertPool()
 	if ok := pool.AppendCertsFromPEM([]byte(cert)); !ok {
-		t.Fatalf("test certificate contains no valid certificates")
+		t.Fatal("test certificate contains no valid certificates")
 	}
 	return pool
 }

--- a/builtin/credential/kubernetes/namespace_validator.go
+++ b/builtin/credential/kubernetes/namespace_validator.go
@@ -110,7 +110,7 @@ func makeLabelSelector(selector string) (*metav1.LabelSelector, error) {
 
 func makeNsLabelSelector(namespaceSelector string) (*metav1.LabelSelector, error) {
 	if namespaceSelector == "" {
-		return nil, fmt.Errorf("namespace selector is empty")
+		return nil, errors.New("namespace selector is empty")
 	}
 
 	labelSelector, err := makeLabelSelector(namespaceSelector)
@@ -119,7 +119,7 @@ func makeNsLabelSelector(namespaceSelector string) (*metav1.LabelSelector, error
 	}
 
 	if labelSelector.MatchExpressions != nil {
-		return nil, fmt.Errorf("label selector match expressions are not supported")
+		return nil, errors.New("label selector match expressions are not supported")
 	}
 
 	return labelSelector, nil

--- a/builtin/credential/kubernetes/path_login.go
+++ b/builtin/credential/kubernetes/path_login.go
@@ -212,7 +212,7 @@ func (b *kubeAuthBackend) getAliasName(role *roleStorageEntry, serviceAccount *s
 	case aliasNameSourceSAName:
 		ns, name := serviceAccount.namespace(), serviceAccount.name()
 		if ns == "" || name == "" {
-			return "", fmt.Errorf("service account namespace and name must be set")
+			return "", errors.New("service account namespace and name must be set")
 		}
 		return fmt.Sprintf("%s/%s", ns, name), nil
 	default:
@@ -490,7 +490,7 @@ func (b *kubeAuthBackend) pathLoginRenew() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		roleName := req.Auth.InternalData["role"].(string)
 		if roleName == "" {
-			return nil, fmt.Errorf("failed to fetch role_name during renewal")
+			return nil, errors.New("failed to fetch role_name during renewal")
 		}
 
 		b.l.RLock()

--- a/builtin/credential/kubernetes/path_login_test.go
+++ b/builtin/credential/kubernetes/path_login_test.go
@@ -1264,7 +1264,7 @@ func TestAliasLookAheadProjectedToken(t *testing.T) {
 }
 
 func Test_kubeAuthBackend_getAliasName(t *testing.T) {
-	expectedErr := fmt.Errorf("service account namespace and name must be set")
+	expectedErr := errors.New("service account namespace and name must be set")
 	issuerDefault := "kubernetes/serviceaccount"
 	issuerProjected := "https://kubernetes.default.svc.cluster.local"
 

--- a/builtin/credential/kubernetes/path_login_test.go
+++ b/builtin/credential/kubernetes/path_login_test.go
@@ -396,7 +396,7 @@ func TestLogin(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
-		t.Fatalf("Expected error")
+		t.Fatal("Expected error")
 	} else if !errors.Is(err, logical.ErrPermissionDenied) {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -700,7 +700,7 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
-		t.Fatalf("Expected error")
+		t.Fatal("Expected error")
 	} else if !errors.Is(logical.ErrPermissionDenied, err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -824,7 +824,7 @@ func TestLoginSvcAcctNamespaceSelector(t *testing.T) {
 				} else if resp != nil && resp.IsError() {
 					actual = resp.Error()
 				} else {
-					t.Fatalf("expected error")
+					t.Fatal("expected error")
 				}
 
 				if tc.expectedErrCode != 0 {
@@ -931,7 +931,7 @@ func TestAliasLookAhead(t *testing.T) {
 				} else if resp != nil && resp.IsError() {
 					actual = resp.Error()
 				} else {
-					t.Fatalf("expected error")
+					t.Fatal("expected error")
 				}
 
 				if tc.wantErr.Error() != actual.Error() {

--- a/builtin/credential/kubernetes/path_role.go
+++ b/builtin/credential/kubernetes/path_role.go
@@ -5,6 +5,7 @@ package kubeauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -280,7 +281,7 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	if role == nil && req.Operation == logical.CreateOperation {
 		role = &roleStorageEntry{}
 	} else if role == nil {
-		return nil, fmt.Errorf("role entry not found during update operation")
+		return nil, errors.New("role entry not found during update operation")
 	}
 
 	if err := role.ParseTokenFields(req, data); err != nil {

--- a/builtin/credential/kubernetes/path_role_test.go
+++ b/builtin/credential/kubernetes/path_role_test.go
@@ -288,7 +288,7 @@ func TestPath_Create(t *testing.T) {
 				} else if resp != nil && resp.IsError() {
 					actual = resp.Error()
 				} else {
-					t.Fatalf("expected error")
+					t.Fatal("expected error")
 				}
 
 				if tc.wantErr.Error() != actual.Error() {
@@ -581,7 +581,7 @@ func TestPath_Update(t *testing.T) {
 				} else if resp != nil && resp.IsError() {
 					actual = resp.Error()
 				} else {
-					t.Fatalf("expected error")
+					t.Fatal("expected error")
 				}
 
 				if tc.wantErr.Error() != actual.Error() {

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -5,6 +5,7 @@ package ldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -919,7 +920,7 @@ func testAccStepConfigUrlWarningCheck(t *testing.T, cfg *ldaputil.ConfigEntry, o
 		},
 		Check: func(response *logical.Response) error {
 			if len(response.Warnings) == 0 {
-				return fmt.Errorf("expected warnings, got none")
+				return errors.New("expected warnings, got none")
 			}
 
 			if !strutil.StrListSubset(response.Warnings, warnings) {

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -32,7 +32,7 @@ func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
 
 	b := Backend()
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 
 	err := b.Backend.Setup(context.Background(), config)

--- a/builtin/credential/ldap/cli.go
+++ b/builtin/credential/ldap/cli.go
@@ -4,6 +4,7 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -24,7 +25,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 	if !ok {
 		username = usernameFromEnv()
 		if username == "" {
-			return nil, fmt.Errorf("'username' not supplied and neither 'LOGNAME' nor 'USER' env vars set")
+			return nil, errors.New("'username' not supplied and neither 'LOGNAME' nor 'USER' env vars set")
 		}
 	}
 	password, ok := m["password"]
@@ -32,7 +33,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		password = passwordFromEnv()
 		if password == "" {
 			if nonInteractive {
-				return nil, fmt.Errorf("'password' not supplied and refusing to pull from stdin")
+				return nil, errors.New("'password' not supplied and refusing to pull from stdin")
 			}
 
 			fmt.Fprintf(os.Stderr, "Password (will be hidden): ")
@@ -55,7 +56,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		return nil, err
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("empty response from credential provider")
+		return nil, errors.New("empty response from credential provider")
 	}
 
 	return secret, nil

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -5,6 +5,7 @@ package ldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -51,7 +52,7 @@ func pathLogin(b *backend) *framework.Path {
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := d.Get("username").(string)
 	if username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	return &logical.Response{
@@ -152,7 +153,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if !policyutil.EquivalentPolicies(finalPolicies, req.Auth.TokenPolicies) {
-		return nil, fmt.Errorf("policies have changed, not renewing")
+		return nil, errors.New("policies have changed, not renewing")
 	}
 
 	resp.Auth = req.Auth

--- a/builtin/credential/radius/path_login.go
+++ b/builtin/credential/radius/path_login.go
@@ -5,6 +5,7 @@ package radius
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -64,7 +65,7 @@ func pathLogin(b *backend) *framework.Path {
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := d.Get("username").(string)
 	if username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	return &logical.Response{
@@ -173,7 +174,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if !policyutil.EquivalentPolicies(finalPolicies, req.Auth.TokenPolicies) {
-		return nil, fmt.Errorf("policies have changed, not renewing")
+		return nil, errors.New("policies have changed, not renewing")
 	}
 
 	req.Auth.Period = cfg.TokenPeriod

--- a/builtin/credential/radius/path_users.go
+++ b/builtin/credential/radius/path_users.go
@@ -5,7 +5,7 @@ package radius
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -105,7 +105,7 @@ func (b *backend) userExistenceCheck(ctx context.Context, req *logical.Request, 
 
 func (b *backend) user(ctx context.Context, s logical.Storage, username string) (*UserEntry, error) {
 	if username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	entry, err := s.Get(ctx, "user/"+strings.ToLower(username))

--- a/builtin/credential/token/cli.go
+++ b/builtin/credential/token/cli.go
@@ -4,6 +4,7 @@
 package token
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,7 +45,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		}
 
 		if nonInteractive {
-			return nil, fmt.Errorf("'token' not supplied and refusing to pull from stdin")
+			return nil, errors.New("'token' not supplied and refusing to pull from stdin")
 		}
 
 		// No arguments given, read the token from user input
@@ -55,7 +56,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 
 		if err != nil {
 			if err == password.ErrInterrupted {
-				return nil, fmt.Errorf("user interrupted")
+				return nil, errors.New("user interrupted")
 			}
 
 			return nil, fmt.Errorf("An error occurred attempting to "+
@@ -96,7 +97,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		return nil, fmt.Errorf("error looking up token: %w", err)
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("empty response from lookup-self")
+		return nil, errors.New("empty response from lookup-self")
 	}
 
 	// Return an auth struct that "looks" like the response from an auth method.

--- a/builtin/credential/userpass/backend_test.go
+++ b/builtin/credential/userpass/backend_test.go
@@ -41,7 +41,7 @@ func TestBackend_CRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 
 	localhostSockAddr, err := sockaddr.NewSockAddr("127.0.0.1")
@@ -75,7 +75,7 @@ func TestBackend_CRUD(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 	if resp.Data["token_ttl"].(int64) != 5 && resp.Data["token_max_ttl"].(int64) != 10 {
-		t.Fatalf("bad: token_ttl and token_max_ttl are not set correctly")
+		t.Fatal("bad: token_ttl and token_max_ttl are not set correctly")
 	}
 	if diff := deep.Equal(resp.Data["token_policies"], []string{"foo"}); diff != nil {
 		t.Fatal(diff)
@@ -115,10 +115,10 @@ func TestBackend_CRUD(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 	if resp.Data["ttl"].(int64) != 300 && resp.Data["max_ttl"].(int64) != 600 {
-		t.Fatalf("bad: ttl and max_ttl are not set correctly")
+		t.Fatal("bad: ttl and max_ttl are not set correctly")
 	}
 	if resp.Data["token_ttl"].(int64) != 300 && resp.Data["token_max_ttl"].(int64) != 600 {
-		t.Fatalf("bad: token_ttl and token_max_ttl are not set correctly")
+		t.Fatal("bad: token_ttl and token_max_ttl are not set correctly")
 	}
 	if diff := deep.Equal(resp.Data["policies"], []string{"bar"}); diff != nil {
 		t.Fatal(diff)
@@ -374,7 +374,7 @@ func TestBackend_UserUpgrade(t *testing.T) {
 
 	b := Backend()
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 	if err := b.Setup(ctx, config); err != nil {
 		t.Fatal(err)

--- a/builtin/credential/userpass/cli.go
+++ b/builtin/credential/userpass/cli.go
@@ -4,6 +4,7 @@
 package userpass
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,11 +29,11 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 	}
 
 	if data.Username == "" {
-		return nil, fmt.Errorf("'username' must be specified")
+		return nil, errors.New("'username' must be specified")
 	}
 	if data.Password == "" {
 		if nonInteractive {
-			return nil, fmt.Errorf("'password' must be specified and refusing to pull from stdin")
+			return nil, errors.New("'password' must be specified and refusing to pull from stdin")
 		}
 
 		fmt.Fprintf(os.Stderr, "Password (will be hidden): ")
@@ -57,7 +58,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string, nonInteractive boo
 		return nil, err
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("empty response from credential provider")
+		return nil, errors.New("empty response from credential provider")
 	}
 
 	return secret, nil

--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -5,6 +5,7 @@ package userpass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -53,7 +54,7 @@ func pathLogin(b *backend) *framework.Path {
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := d.Get("username").(string)
 	if username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	return &logical.Response{
@@ -70,7 +71,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 
 	password := d.Get("password").(string)
 	if password == "" {
-		return nil, fmt.Errorf("missing password")
+		return nil, errors.New("missing password")
 	}
 
 	// Get the user and validate auth
@@ -83,7 +84,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	// to bcrypt.
 	if user != nil && userError == nil {
 		if len(user.PasswordHash) == 0 {
-			return nil, fmt.Errorf("invalid user entry: refusing to process pre-Vault v0.2 record")
+			return nil, errors.New("invalid user entry: refusing to process pre-Vault v0.2 record")
 		}
 
 		userPassword = user.PasswordHash
@@ -152,7 +153,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if !policyutil.EquivalentPolicies(user.TokenPolicies, req.Auth.TokenPolicies) {
-		return nil, fmt.Errorf("policies have changed, not renewing")
+		return nil, errors.New("policies have changed, not renewing")
 	}
 
 	resp := &logical.Response{Auth: req.Auth}

--- a/builtin/credential/userpass/path_user_password.go
+++ b/builtin/credential/userpass/path_user_password.go
@@ -5,7 +5,7 @@ package userpass
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -60,7 +60,7 @@ func (b *backend) pathUserPasswordUpdate(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 	if userEntry == nil {
-		return nil, fmt.Errorf("username does not exist")
+		return nil, errors.New("username does not exist")
 	}
 
 	userErr, intErr := b.updateUserPassword(req, d, userEntry)
@@ -84,7 +84,7 @@ func (b *backend) pathUserPasswordUpdate(ctx context.Context, req *logical.Reque
 func (b *backend) updateUserPassword(req *logical.Request, d *framework.FieldData, userEntry *UserEntry) (error, error) {
 	password := d.Get("password").(string)
 	if password == "" {
-		return fmt.Errorf("missing password"), nil
+		return errors.New("missing password"), nil
 	}
 	// Generate a hash of the password
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/builtin/credential/userpass/path_user_policies.go
+++ b/builtin/credential/userpass/path_user_policies.go
@@ -5,7 +5,7 @@ package userpass
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/policyutil"
@@ -67,7 +67,7 @@ func (b *backend) pathUserPoliciesUpdate(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 	if userEntry == nil {
-		return nil, fmt.Errorf("username does not exist")
+		return nil, errors.New("username does not exist")
 	}
 
 	policiesRaw, ok := d.GetOk("token_policies")

--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -5,7 +5,7 @@ package userpass
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"time"
 
@@ -134,7 +134,7 @@ func (b *backend) userExistenceCheck(ctx context.Context, req *logical.Request, 
 
 func (b *backend) user(ctx context.Context, s logical.Storage, username string) (*UserEntry, error) {
 	if username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	entry, err := s.Get(ctx, "user/"+strings.ToLower(username))

--- a/builtin/credential/userpass/stepwise_test.go
+++ b/builtin/credential/userpass/stepwise_test.go
@@ -4,6 +4,7 @@
 package userpass
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -64,7 +65,7 @@ func testAccStepwiseReadUser(t *testing.T, name string, policies string) stepwis
 					return nil
 				}
 
-				return fmt.Errorf("unexpected nil response")
+				return errors.New("unexpected nil response")
 			}
 
 			var d struct {

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -350,7 +350,7 @@ func TestBackend_BadConnectionString(t *testing.T) {
 		}
 		err = resp.Error()
 		if strings.Contains(err.Error(), "localhost") {
-			t.Fatalf("error should not contain connection info")
+			t.Fatal("error should not contain connection info")
 		}
 	}
 
@@ -502,7 +502,7 @@ func TestBackend_basic(t *testing.T) {
 			t.Fatalf("unexpected TTL of %d", credsResp.Secret.TTL)
 		}
 		if !testCredsExist(t, credsResp, connURL) {
-			t.Fatalf("Creds should exist")
+			t.Fatal("Creds should exist")
 		}
 
 		// Revoke creds
@@ -522,7 +522,7 @@ func TestBackend_basic(t *testing.T) {
 		}
 
 		if testCredsExist(t, credsResp, connURL) {
-			t.Fatalf("Creds should not exist")
+			t.Fatal("Creds should not exist")
 		}
 	}
 
@@ -540,7 +540,7 @@ func TestBackend_basic(t *testing.T) {
 			t.Fatalf("err:%s resp:%#v\n", err, credsResp)
 		}
 		if !testCredsExist(t, credsResp, connURL) {
-			t.Fatalf("Creds should exist")
+			t.Fatal("Creds should exist")
 		}
 
 		// Delete role, forcing us to rely on embedded data
@@ -573,7 +573,7 @@ func TestBackend_basic(t *testing.T) {
 		}
 
 		if testCredsExist(t, credsResp, connURL) {
-			t.Fatalf("Creds should not exist")
+			t.Fatal("Creds should not exist")
 		}
 	}
 }
@@ -734,7 +734,7 @@ func TestBackend_connectionCrud(t *testing.T) {
 		"password": "secret",
 	})
 	if !testCredsExist(t, credsResp, credCheckURL) {
-		t.Fatalf("Creds should exist")
+		t.Fatal("Creds should exist")
 	}
 
 	// Delete Connection
@@ -1128,7 +1128,7 @@ func TestBackend_allowedRoles(t *testing.T) {
 	}
 
 	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatalf("Creds should exist")
+		t.Fatal("Creds should exist")
 	}
 
 	// update connection with * allowed roles connection
@@ -1162,7 +1162,7 @@ func TestBackend_allowedRoles(t *testing.T) {
 	}
 
 	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatalf("Creds should exist")
+		t.Fatal("Creds should exist")
 	}
 
 	// update connection with allowed roles
@@ -1209,7 +1209,7 @@ func TestBackend_allowedRoles(t *testing.T) {
 	}
 
 	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatalf("Creds should exist")
+		t.Fatal("Creds should exist")
 	}
 }
 
@@ -1417,7 +1417,7 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 					t.Fatal(err)
 				}
 				if pp, _ := p.User.Password(); pp == tt.password {
-					t.Fatalf("password was not redacted by URL.Redacted()")
+					t.Fatal("password was not redacted by URL.Redacted()")
 				}
 			}
 		})

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -351,7 +351,7 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 			if len(tc.expected) > 0 {
 				// verify a password is returned, but we don't care what it's value is
 				if actual["password"] == "" {
-					t.Fatalf("expected result to contain password, but none found")
+					t.Fatal("expected result to contain password, but none found")
 				}
 				if v, ok := actual["last_vault_rotation"].(time.Time); !ok {
 					t.Fatalf("expected last_vault_rotation to be set to time.Time type, got: %#v", v)
@@ -670,7 +670,7 @@ func TestBackend_StaticRole_Role_name_check(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error, got none")
+		t.Fatal("expected error, got none")
 	}
 
 	// repeat, with a static role first
@@ -716,7 +716,7 @@ func TestBackend_StaticRole_Role_name_check(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error, got none")
+		t.Fatal("expected error, got none")
 	}
 }
 

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -88,12 +89,12 @@ func (b *databaseBackend) pathRotateRootCredentialsUpdate() framework.OperationF
 
 		rootUsername, ok := config.ConnectionDetails["username"].(string)
 		if !ok || rootUsername == "" {
-			return nil, fmt.Errorf("unable to rotate root credentials: no username in configuration")
+			return nil, errors.New("unable to rotate root credentials: no username in configuration")
 		}
 
 		rootPassword, ok := config.ConnectionDetails["password"].(string)
 		if !ok || rootPassword == "" {
-			return nil, fmt.Errorf("unable to rotate root credentials: no password in configuration")
+			return nil, errors.New("unable to rotate root credentials: no password in configuration")
 		}
 
 		dbi, err := b.GetConnection(ctx, req.Storage, name)

--- a/builtin/logical/database/rollback_test.go
+++ b/builtin/logical/database/rollback_test.go
@@ -125,7 +125,7 @@ func TestBackend_RotateRootCredentials_WAL_rollback(t *testing.T) {
 	// Reading credentials should no longer work
 	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
 	if err == nil {
-		t.Fatalf("expected authentication to fail when reading credentials")
+		t.Fatal("expected authentication to fail when reading credentials")
 	}
 
 	// Put a WAL entry that will be used for rolling back the database password

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -277,7 +277,7 @@ func TestBackend_StaticRole_Rotate_NonStaticError(t *testing.T) {
 	// expect resp to be an error
 	resp, _ = b.HandleRequest(namespace.RootContext(nil), req)
 	if !resp.IsError() {
-		t.Fatalf("expected error rotating non-static role")
+		t.Fatal("expected error rotating non-static role")
 	}
 
 	if resp.Error().Error() != "no static role found for role name" {
@@ -654,7 +654,7 @@ func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) 
 
 	password := resp.Data["password"].(string)
 	if password == walPassword {
-		t.Fatalf("expected password to not be changed by WAL, but was")
+		t.Fatal("expected password to not be changed by WAL, but was")
 	}
 }
 

--- a/builtin/logical/database/secret_creds.go
+++ b/builtin/logical/database/secret_creds.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -31,7 +32,7 @@ func (b *databaseBackend) secretCredsRenew() framework.OperationFunc {
 		// Get the username from the internal data
 		usernameRaw, ok := req.Secret.InternalData["username"]
 		if !ok {
-			return nil, fmt.Errorf("secret is missing username internal data")
+			return nil, errors.New("secret is missing username internal data")
 		}
 		username, ok := usernameRaw.(string)
 
@@ -95,7 +96,7 @@ func (b *databaseBackend) secretCredsRevoke() framework.OperationFunc {
 		// Get the username from the internal data
 		usernameRaw, ok := req.Secret.InternalData["username"]
 		if !ok {
-			return nil, fmt.Errorf("secret is missing username internal data")
+			return nil, errors.New("secret is missing username internal data")
 		}
 		username, ok := usernameRaw.(string)
 
@@ -103,7 +104,7 @@ func (b *databaseBackend) secretCredsRevoke() framework.OperationFunc {
 
 		roleNameRaw, ok := req.Secret.InternalData["role"]
 		if !ok {
-			return nil, fmt.Errorf("no role name was provided")
+			return nil, errors.New("no role name was provided")
 		}
 
 		var dbName string

--- a/builtin/logical/database/version_wrapper.go
+++ b/builtin/logical/database/version_wrapper.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	log "github.com/hashicorp/go-hclog"
@@ -62,7 +63,7 @@ func newDatabaseWrapper(ctx context.Context, pluginName string, pluginVersion st
 // Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) Initialize(ctx context.Context, req v5.InitializeRequest) (v5.InitializeResponse, error) {
 	if !d.isV5() && !d.isV4() {
-		return v5.InitializeResponse{}, fmt.Errorf("no underlying database specified")
+		return v5.InitializeResponse{}, errors.New("no underlying database specified")
 	}
 
 	// v5 Database
@@ -88,7 +89,7 @@ func (d databaseVersionWrapper) Initialize(ctx context.Context, req v5.Initializ
 // Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) NewUser(ctx context.Context, req v5.NewUserRequest) (resp v5.NewUserResponse, password string, err error) {
 	if !d.isV5() && !d.isV4() {
-		return v5.NewUserResponse{}, "", fmt.Errorf("no underlying database specified")
+		return v5.NewUserResponse{}, "", errors.New("no underlying database specified")
 	}
 
 	// v5 Database
@@ -122,7 +123,7 @@ func (d databaseVersionWrapper) NewUser(ctx context.Context, req v5.NewUserReque
 // Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) UpdateUser(ctx context.Context, req v5.UpdateUserRequest, isRootUser bool) (saveConfig map[string]interface{}, err error) {
 	if !d.isV5() && !d.isV4() {
-		return nil, fmt.Errorf("no underlying database specified")
+		return nil, errors.New("no underlying database specified")
 	}
 
 	// v5 Database
@@ -133,12 +134,12 @@ func (d databaseVersionWrapper) UpdateUser(ctx context.Context, req v5.UpdateUse
 
 	// v4 Database
 	if req.Password == nil && req.Expiration == nil {
-		return nil, fmt.Errorf("missing change to be sent to the database")
+		return nil, errors.New("missing change to be sent to the database")
 	}
 	if req.Password != nil && req.Expiration != nil {
 		// We could support this, but it would require handling partial
 		// errors which I'm punting on since we don't need it for now
-		return nil, fmt.Errorf("cannot specify both password and expiration change at the same time")
+		return nil, errors.New("cannot specify both password and expiration change at the same time")
 	}
 
 	// Change password
@@ -196,7 +197,7 @@ func (d databaseVersionWrapper) changeRootUserPasswordLegacy(ctx context.Context
 // DeleteUser in the underlying database. Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) DeleteUser(ctx context.Context, req v5.DeleteUserRequest) (v5.DeleteUserResponse, error) {
 	if !d.isV5() && !d.isV4() {
-		return v5.DeleteUserResponse{}, fmt.Errorf("no underlying database specified")
+		return v5.DeleteUserResponse{}, errors.New("no underlying database specified")
 	}
 
 	// v5 Database
@@ -215,7 +216,7 @@ func (d databaseVersionWrapper) DeleteUser(ctx context.Context, req v5.DeleteUse
 // Type of the underlying database. Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) Type() (string, error) {
 	if !d.isV5() && !d.isV4() {
-		return "", fmt.Errorf("no underlying database specified")
+		return "", errors.New("no underlying database specified")
 	}
 
 	// v5 Database
@@ -230,7 +231,7 @@ func (d databaseVersionWrapper) Type() (string, error) {
 // Close the underlying database. Errors if the wrapper does not contain an underlying database.
 func (d databaseVersionWrapper) Close() error {
 	if !d.isV5() && !d.isV4() {
-		return fmt.Errorf("no underlying database specified")
+		return errors.New("no underlying database specified")
 	}
 	// v5 Database
 	if d.isV5() {

--- a/builtin/logical/database/version_wrapper_test.go
+++ b/builtin/logical/database/version_wrapper_test.go
@@ -24,7 +24,7 @@ func TestInitDatabase_missingDB(t *testing.T) {
 	req := v5.InitializeRequest{}
 	resp, err := dbw.Initialize(context.Background(), req)
 	if err == nil {
-		t.Fatalf("err expected, got nil")
+		t.Fatal("err expected, got nil")
 	}
 
 	expectedResp := v5.InitializeResponse{}
@@ -94,7 +94,7 @@ func TestInitDatabase_newDB(t *testing.T) {
 
 			resp, err := dbw.Initialize(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -165,7 +165,7 @@ func TestInitDatabase_legacyDB(t *testing.T) {
 
 			resp, err := dbw.Initialize(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -184,7 +184,7 @@ func TestNewUser_missingDB(t *testing.T) {
 	req := v5.NewUserRequest{}
 	resp, pass, err := dbw.NewUser(context.Background(), req)
 	if err == nil {
-		t.Fatalf("err expected, got nil")
+		t.Fatal("err expected, got nil")
 	}
 
 	expectedResp := v5.NewUserResponse{}
@@ -251,7 +251,7 @@ func TestNewUser_newDB(t *testing.T) {
 
 			resp, password, err := dbw.NewUser(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -324,7 +324,7 @@ func TestNewUser_legacyDB(t *testing.T) {
 
 			resp, password, err := dbw.NewUser(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -347,7 +347,7 @@ func TestUpdateUser_missingDB(t *testing.T) {
 	req := v5.UpdateUserRequest{}
 	resp, err := dbw.UpdateUser(context.Background(), req, false)
 	if err == nil {
-		t.Fatalf("err expected, got nil")
+		t.Fatal("err expected, got nil")
 	}
 
 	expectedConfig := map[string]interface{}(nil)
@@ -398,7 +398,7 @@ func TestUpdateUser_newDB(t *testing.T) {
 
 			_, err := dbw.UpdateUser(context.Background(), test.req, false)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -632,7 +632,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 
 			newConfig, err := dbw.UpdateUser(context.Background(), test.req, test.isRootUser)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -651,7 +651,7 @@ func TestDeleteUser_missingDB(t *testing.T) {
 	req := v5.DeleteUserRequest{}
 	_, err := dbw.DeleteUser(context.Background(), req)
 	if err == nil {
-		t.Fatalf("err expected, got nil")
+		t.Fatal("err expected, got nil")
 	}
 }
 
@@ -701,7 +701,7 @@ func TestDeleteUser_newDB(t *testing.T) {
 
 			_, err := dbw.DeleteUser(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -756,7 +756,7 @@ func TestDeleteUser_legacyDB(t *testing.T) {
 
 			_, err := dbw.DeleteUser(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -847,7 +847,7 @@ func TestStoreConfig(t *testing.T) {
 			defer cancel()
 			err := storeConfig(ctx, storage, "testconfig", test.config)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/builtin/logical/database/version_wrapper_test.go
+++ b/builtin/logical/database/version_wrapper_test.go
@@ -5,7 +5,7 @@ package database
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -74,7 +74,7 @@ func TestInitDatabase_newDB(t *testing.T) {
 				VerifyConnection: true,
 			},
 			newInitResp:  v5.InitializeResponse{},
-			newInitErr:   fmt.Errorf("test error"),
+			newInitErr:   errors.New("test error"),
 			newInitCalls: 1,
 			expectedResp: v5.InitializeResponse{},
 			expectErr:    true,
@@ -145,7 +145,7 @@ func TestInitDatabase_legacyDB(t *testing.T) {
 				},
 				VerifyConnection: true,
 			},
-			initErr:      fmt.Errorf("test error"),
+			initErr:      errors.New("test error"),
 			initCalls:    1,
 			expectedResp: v5.InitializeResponse{},
 			expectErr:    true,
@@ -230,7 +230,7 @@ func TestNewUser_newDB(t *testing.T) {
 				Password: "new_password",
 			},
 
-			newUserErr:   fmt.Errorf("test error"),
+			newUserErr:   errors.New("test error"),
 			newUserCalls: 1,
 
 			expectedResp: v5.NewUserResponse{},
@@ -303,7 +303,7 @@ func TestNewUser_legacyDB(t *testing.T) {
 				Password: "new_password",
 			},
 
-			createUserErr:   fmt.Errorf("test error"),
+			createUserErr:   errors.New("test error"),
 			createUserCalls: 1,
 
 			expectedResp: v5.NewUserResponse{},
@@ -379,7 +379,7 @@ func TestUpdateUser_newDB(t *testing.T) {
 			req: v5.UpdateUserRequest{
 				Username: "existing_user",
 			},
-			updateUserErr:   fmt.Errorf("test error"),
+			updateUserErr:   errors.New("test error"),
 			updateUserCalls: 1,
 			expectErr:       true,
 		},
@@ -479,7 +479,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			},
 			isRootUser: false,
 
-			setCredentialsErr:   fmt.Errorf("set credentials failed"),
+			setCredentialsErr:   errors.New("set credentials failed"),
 			setCredentialsCalls: 1,
 			rotateRootCalls:     0,
 			renewUserCalls:      0,
@@ -565,7 +565,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			setCredentialsErr:   status.Error(codes.Unimplemented, "SetCredentials is not implemented"),
 			setCredentialsCalls: 1,
 
-			rotateRootErr:   fmt.Errorf("rotate root failed"),
+			rotateRootErr:   errors.New("rotate root failed"),
 			rotateRootCalls: 1,
 			renewUserCalls:  0,
 
@@ -603,7 +603,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			setCredentialsCalls: 0,
 			rotateRootCalls:     0,
 
-			renewUserErr:   fmt.Errorf("test error"),
+			renewUserErr:   errors.New("test error"),
 			renewUserCalls: 1,
 
 			expectedConfig: nil,
@@ -681,7 +681,7 @@ func TestDeleteUser_newDB(t *testing.T) {
 				Username: "existing_user",
 			},
 
-			deleteUserErr:   fmt.Errorf("test error"),
+			deleteUserErr:   errors.New("test error"),
 			deleteUserCalls: 1,
 
 			expectErr: true,
@@ -736,7 +736,7 @@ func TestDeleteUser_legacyDB(t *testing.T) {
 				Username: "existing_user",
 			},
 
-			revokeUserErr:   fmt.Errorf("test error"),
+			revokeUserErr:   errors.New("test error"),
 			revokeUserCalls: 1,
 
 			expectErr: true,
@@ -768,7 +768,7 @@ func TestDeleteUser_legacyDB(t *testing.T) {
 type badValue struct{}
 
 func (badValue) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("this value cannot be marshalled to JSON")
+	return nil, errors.New("this value cannot be marshalled to JSON")
 }
 
 var _ logical.Storage = fakeStorage{}
@@ -822,7 +822,7 @@ func TestStoreConfig(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			putErr:    fmt.Errorf("failed to store config"),
+			putErr:    errors.New("failed to store config"),
 			expectErr: true,
 		},
 		"happy path": {

--- a/builtin/logical/database/versioning_large_test.go
+++ b/builtin/logical/database/versioning_large_test.go
@@ -492,7 +492,7 @@ func assertNoRespData(t *testing.T, resp *logical.Response) {
 func assertRespHasData(t *testing.T, resp *logical.Response) {
 	t.Helper()
 	if resp == nil || len(resp.Data) == 0 {
-		t.Fatalf("Response didn't have any data when some was expected")
+		t.Fatal("Response didn't have any data when some was expected")
 	}
 }
 

--- a/builtin/logical/kubernetes/backend.go
+++ b/builtin/logical/kubernetes/backend.go
@@ -5,7 +5,7 @@ package kubesecrets
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -65,7 +65,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 
 	if conf == nil {
-		return nil, fmt.Errorf("configuration passed into backend is nil")
+		return nil, errors.New("configuration passed into backend is nil")
 	}
 
 	if err := b.Setup(ctx, conf); err != nil {

--- a/builtin/logical/kubernetes/client_test.go
+++ b/builtin/logical/kubernetes/client_test.go
@@ -4,7 +4,7 @@
 package kubesecrets
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,12 +42,12 @@ func Test_makeRules(t *testing.T) {
 		"bad YAML": {
 			rules:    badYAMLRules,
 			expected: nil,
-			wantErr:  fmt.Errorf("error converting YAML to JSON: yaml: line 3: found character that cannot start any token"),
+			wantErr:  errors.New("error converting YAML to JSON: yaml: line 3: found character that cannot start any token"),
 		},
 		"bad JSON": {
 			rules:    badJSONRules,
 			expected: nil,
-			wantErr:  fmt.Errorf("error converting YAML to JSON: yaml: line 4: did not find expected ',' or '}'"),
+			wantErr:  errors.New("error converting YAML to JSON: yaml: line 4: did not find expected ',' or '}'"),
 		},
 	}
 	for name, tc := range testCases {

--- a/builtin/logical/kubernetes/integrationtest/wal_rollback_test.go
+++ b/builtin/logical/kubernetes/integrationtest/wal_rollback_test.go
@@ -5,6 +5,7 @@ package integrationtest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -247,7 +248,7 @@ func checkRoleExists(k8sClient kubernetes.Interface, listOptions metav1.ListOpti
 			return false, err
 		}
 		if roles == nil {
-			return false, fmt.Errorf("roles list response was nil")
+			return false, errors.New("roles list response was nil")
 		}
 		return len(roles.Items) > 0, nil
 	case "clusterrole":
@@ -256,7 +257,7 @@ func checkRoleExists(k8sClient kubernetes.Interface, listOptions metav1.ListOpti
 			return false, err
 		}
 		if roles == nil {
-			return false, fmt.Errorf("cluster roles list response was nil")
+			return false, errors.New("cluster roles list response was nil")
 		}
 		return len(roles.Items) > 0, nil
 	}
@@ -271,7 +272,7 @@ func checkRoleBindingExists(k8sClient kubernetes.Interface, listOptions metav1.L
 			return false, err
 		}
 		if clusterBindings == nil {
-			return false, fmt.Errorf("cluster role bindings list response was nil")
+			return false, errors.New("cluster role bindings list response was nil")
 		}
 		return len(clusterBindings.Items) > 0, nil
 	} else {
@@ -280,7 +281,7 @@ func checkRoleBindingExists(k8sClient kubernetes.Interface, listOptions metav1.L
 			return false, err
 		}
 		if bindings == nil {
-			return false, fmt.Errorf("role bindings list response was nil")
+			return false, errors.New("role bindings list response was nil")
 		}
 		return len(bindings.Items) > 0, nil
 	}
@@ -292,7 +293,7 @@ func checkServiceAccountExists(k8sClient kubernetes.Interface, listOptions metav
 		return false, err
 	}
 	if acct == nil {
-		return false, fmt.Errorf("service account list response was nil")
+		return false, errors.New("service account list response was nil")
 	}
 	return len(acct.Items) > 0, nil
 }

--- a/builtin/logical/kubernetes/path_creds.go
+++ b/builtin/logical/kubernetes/path_creds.go
@@ -5,6 +5,7 @@ package kubesecrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -149,7 +150,7 @@ func (b *backend) isValidKubernetesNamespace(ctx context.Context, req *logical.R
 			return true, nil
 		}
 
-		return false, fmt.Errorf("'kubernetes_namespace' is required unless the OpenBao role has a single namespace specified")
+		return false, errors.New("'kubernetes_namespace' is required unless the OpenBao role has a single namespace specified")
 	}
 
 	if strutil.StrListContains(role.K8sNamespaces, "*") || strutil.StrListContains(role.K8sNamespaces, request.Namespace) {
@@ -307,7 +308,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 		createdK8sRoleBinding = genName
 
 	default:
-		return nil, fmt.Errorf("one of service_account_name, kubernetes_role_name, or generated_role_rules must be set")
+		return nil, errors.New("one of service_account_name, kubernetes_role_name, or generated_role_rules must be set")
 	}
 
 	resp := b.Secret(kubeTokenType).Response(map[string]interface{}{

--- a/builtin/logical/kubernetes/path_roles.go
+++ b/builtin/logical/kubernetes/path_roles.go
@@ -5,6 +5,7 @@ package kubesecrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -350,7 +351,7 @@ func onlyOneSet(vars ...string) bool {
 
 func getRole(ctx context.Context, s logical.Storage, name string) (*roleEntry, error) {
 	if name == "" {
-		return nil, fmt.Errorf("missing role name")
+		return nil, errors.New("missing role name")
 	}
 
 	entry, err := s.Get(ctx, rolesPath+name)

--- a/builtin/logical/kv/passthrough.go
+++ b/builtin/logical/kv/passthrough.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -104,7 +105,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 	}
 
 	if conf == nil {
-		return nil, fmt.Errorf("Configuation passed into backend is nil")
+		return nil, errors.New("Configuation passed into backend is nil")
 	}
 	backend.Setup(ctx, conf)
 	b.Backend = backend

--- a/builtin/logical/kv/passthrough_test.go
+++ b/builtin/logical/kv/passthrough_test.go
@@ -56,7 +56,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("failed to write to view")
+			t.Fatal("failed to write to view")
 		}
 	}
 	b := testPassthroughBackend()

--- a/builtin/logical/kv/path_metadata_test.go
+++ b/builtin/logical/kv/path_metadata_test.go
@@ -1016,7 +1016,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 
 	if resp.Data["cas_required"] != false {
-		t.Fatalf("expected cas_required to be set to false despite warning")
+		t.Fatal("expected cas_required to be set to false despite warning")
 	}
 }
 
@@ -1312,7 +1312,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 
 	if maxVersions := resp.Data["max_versions"].(uint32); maxVersions != 10 {
-		t.Fatalf("expected max_versions to be 10")
+		t.Fatal("expected max_versions to be 10")
 	}
 
 	req = &logical.Request{
@@ -1343,6 +1343,6 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 
 	if maxVersions := resp.Data["max_versions"].(uint32); maxVersions != 0 {
-		t.Fatalf("expected max_versions to be unset to zero value")
+		t.Fatal("expected max_versions to be unset to zero value")
 	}
 }

--- a/builtin/logical/openldap/backend_test.go
+++ b/builtin/logical/openldap/backend_test.go
@@ -6,7 +6,6 @@ package openldap
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/go-ldap/ldif"
@@ -86,7 +85,7 @@ func (f *fakeLdapClient) UpdateDNPassword(_ *client.Config, _ string, _ string) 
 }
 
 func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) (err error) {
-	return fmt.Errorf("not implemented")
+	return errors.New("not implemented")
 }
 
 const validCertificate = `

--- a/builtin/logical/openldap/checkout_handler_test.go
+++ b/builtin/logical/openldap/checkout_handler_test.go
@@ -5,7 +5,6 @@ package openldap
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestCheckOutHandlerStorageLayer(t *testing.T) {
 		t.Fatal("storedCheckOut should not be nil")
 	}
 	if !reflect.DeepEqual(checkOut, storedCheckOut) {
-		t.Fatalf(fmt.Sprintf(`expected %+v to be equal to %+v`, checkOut, storedCheckOut))
+		t.Fatalf(`expected %+v to be equal to %+v`, checkOut, storedCheckOut)
 	}
 
 	// If we try to check something out that's already checked out, we should

--- a/builtin/logical/openldap/client/client.go
+++ b/builtin/logical/openldap/client/client.go
@@ -238,7 +238,7 @@ func (c *Client) Execute(cfg *Config, entries []*ldif.Entry, continueOnFailure b
 		case entry.Del != nil:
 			err = errorf("failed to run DelRequest: %w", conn.Del(entry.Del))
 		default:
-			err = fmt.Errorf("unrecognized or missing LDIF command")
+			err = errors.New("unrecognized or missing LDIF command")
 		}
 
 		if err != nil {

--- a/builtin/logical/openldap/dynamic_role.go
+++ b/builtin/logical/openldap/dynamic_role.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"time"
@@ -44,7 +45,7 @@ func retrieveDynamicRole(ctx context.Context, s logical.Storage, roleName string
 
 func storeDynamicRole(ctx context.Context, s logical.Storage, role *dynamicRole) error {
 	if role.Name == "" {
-		return fmt.Errorf("missing role name")
+		return errors.New("missing role name")
 	}
 	entry, err := logical.StorageEntryJSON(path.Join(dynamicRolePath, role.Name), role)
 	if err != nil {
@@ -60,7 +61,7 @@ func storeDynamicRole(ctx context.Context, s logical.Storage, role *dynamicRole)
 
 func deleteDynamicRole(ctx context.Context, s logical.Storage, roleName string) error {
 	if roleName == "" {
-		return fmt.Errorf("missing role name")
+		return errors.New("missing role name")
 	}
 	return s.Delete(ctx, path.Join(dynamicRolePath, roleName))
 }

--- a/builtin/logical/openldap/path_checkout_sets.go
+++ b/builtin/logical/openldap/path_checkout_sets.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,11 +28,11 @@ type librarySet struct {
 // a way that makes sense, and that there's at least one service account.
 func (l *librarySet) Validate() error {
 	if len(l.ServiceAccountNames) < 1 {
-		return fmt.Errorf("at least one service account must be configured")
+		return errors.New("at least one service account must be configured")
 	}
 	for _, name := range l.ServiceAccountNames {
 		if name == "" {
-			return fmt.Errorf("service account name must not be empty")
+			return errors.New("service account name must not be empty")
 		}
 	}
 	if l.MaxTTL > 0 {

--- a/builtin/logical/openldap/path_checkouts.go
+++ b/builtin/logical/openldap/path_checkouts.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -258,7 +259,7 @@ func (b *backend) operationCheckIn(overrideCheckInEnforcement bool) framework.Op
 			return nil, err
 		}
 		if config == nil {
-			return nil, fmt.Errorf("missing LDAP configuration")
+			return nil, errors.New("missing LDAP configuration")
 		}
 
 		set, err := readSet(ctx, req.Storage, setName)

--- a/builtin/logical/openldap/path_config.go
+++ b/builtin/logical/openldap/path_config.go
@@ -173,7 +173,7 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 
 	if passPolicy != "" && hasPassLen {
 		// If both a password policy and a password length are set, we can't figure out what to do
-		return nil, fmt.Errorf("cannot set both 'password_policy' and 'length'")
+		return nil, errors.New("cannot set both 'password_policy' and 'length'")
 	}
 
 	staticSkip := fieldData.Get("skip_static_role_import_rotation").(bool)

--- a/builtin/logical/openldap/path_config_test.go
+++ b/builtin/logical/openldap/path_config_test.go
@@ -224,7 +224,7 @@ func TestConfig_Create(t *testing.T) {
 
 			resp, err := b.configCreateUpdateOperation(context.Background(), req, test.createData)
 			if test.createExpectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.createExpectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/builtin/logical/openldap/path_dynamic_creds.go
+++ b/builtin/logical/openldap/path_dynamic_creds.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -65,7 +66,7 @@ func (b *backend) pathDynamicCredsRead(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 	if config == nil {
-		return nil, fmt.Errorf("missing LDAP configuration")
+		return nil, errors.New("missing LDAP configuration")
 	}
 
 	// Generate dynamic data
@@ -176,7 +177,7 @@ func (b *backend) secretCredsRenew() framework.OperationFunc {
 		// Retrieve the role to ensure it still exists. If it doesn't, this will reject the renewal request.
 		roleNameRaw, ok := req.Secret.InternalData["name"]
 		if !ok {
-			return nil, fmt.Errorf("missing role name")
+			return nil, errors.New("missing role name")
 		}
 
 		roleName := roleNameRaw.(string)
@@ -185,7 +186,7 @@ func (b *backend) secretCredsRenew() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to retrieve dynamic role: %w", err)
 		}
 		if dRole == nil {
-			return nil, fmt.Errorf("unable to renew: role does not exist")
+			return nil, errors.New("unable to renew: role does not exist")
 		}
 
 		// Update the default TTL & MaxTTL to the latest from the role in the event the role definition has changed
@@ -207,7 +208,7 @@ func (b *backend) secretCredsRevoke() framework.OperationFunc {
 			return nil, err
 		}
 		if config == nil {
-			return nil, fmt.Errorf("missing LDAP configuration")
+			return nil, errors.New("missing LDAP configuration")
 		}
 
 		deletionTemplate, err := getString(req.Secret.InternalData, "deletion_ldif")
@@ -216,7 +217,7 @@ func (b *backend) secretCredsRevoke() framework.OperationFunc {
 		}
 
 		if deletionTemplate == "" {
-			return nil, fmt.Errorf("broken internal data: missing deletion_ldif")
+			return nil, errors.New("broken internal data: missing deletion_ldif")
 		}
 
 		var templateData dynamicTemplateData
@@ -297,7 +298,7 @@ func encodeUTF16LE(str string) (string, error) {
 
 func getString(m map[string]interface{}, key string) (string, error) {
 	if m == nil {
-		return "", fmt.Errorf("nil map")
+		return "", errors.New("nil map")
 	}
 
 	val, exists := m[key]

--- a/builtin/logical/openldap/path_dynamic_creds_test.go
+++ b/builtin/logical/openldap/path_dynamic_creds_test.go
@@ -5,7 +5,7 @@ package openldap
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"path"
 	"reflect"
 	"strconv"
@@ -26,7 +26,7 @@ func TestDynamicCredsRead_failures(t *testing.T) {
 
 		storage := new(mockStorage)
 		storage.On("Get", mock.Anything, path.Join(dynamicRolePath, roleName)).
-			Return((*logical.StorageEntry)(nil), fmt.Errorf("test error")).Once()
+			Return((*logical.StorageEntry)(nil), errors.New("test error")).Once()
 		defer storage.AssertExpectations(t)
 
 		client := new(mockLDAPClient)
@@ -65,7 +65,7 @@ func TestDynamicCredsRead_failures(t *testing.T) {
 			Return(roleStorageResp, nil).
 			Once()
 		storage.On("Get", mock.Anything, configPath).
-			Return((*logical.StorageEntry)(nil), fmt.Errorf("test error")).
+			Return((*logical.StorageEntry)(nil), errors.New("test error")).
 			Once()
 		defer storage.AssertExpectations(t)
 
@@ -155,7 +155,7 @@ func TestDynamicCredsRead_failures(t *testing.T) {
 
 		client := new(mockLDAPClient)
 		client.On("Execute", mock.Anything, mock.Anything, mock.Anything).
-			Return(fmt.Errorf("test error")).
+			Return(errors.New("test error")).
 			Once()
 
 		b := Backend(client)
@@ -394,7 +394,7 @@ func TestSecretCredsRenew(t *testing.T) {
 				},
 			},
 			storageResp:  nil,
-			storageErr:   fmt.Errorf("test error"),
+			storageErr:   errors.New("test error"),
 			expectedResp: nil,
 			expectErr:    true,
 		},
@@ -504,7 +504,7 @@ func TestSecretCredsRevoke(t *testing.T) {
 		storage := new(mockStorage)
 
 		storage.On("Get", mock.Anything, configPath).
-			Return((*logical.StorageEntry)(nil), fmt.Errorf("test error")).
+			Return((*logical.StorageEntry)(nil), errors.New("test error")).
 			Once()
 		defer storage.AssertExpectations(t)
 
@@ -636,7 +636,7 @@ func TestSecretCredsRevoke(t *testing.T) {
 
 		client := new(mockLDAPClient)
 		client.On("Execute", mock.Anything, mock.Anything, mock.Anything).
-			Return(fmt.Errorf("test error")).
+			Return(errors.New("test error")).
 			Once()
 		defer client.AssertExpectations(t)
 

--- a/builtin/logical/openldap/path_dynamic_creds_test.go
+++ b/builtin/logical/openldap/path_dynamic_creds_test.go
@@ -487,7 +487,7 @@ func TestSecretCredsRenew(t *testing.T) {
 
 			resp, err := b.secretCredsRenew()(ctx, test.req, data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -875,7 +875,7 @@ expirationTimeSeconds: ` + expSecondsStr,
 		t.Run(name, func(t *testing.T) {
 			actual, err := applyTemplate(test.template, test.data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -917,7 +917,7 @@ func getStringSlice(t *testing.T, m map[string]interface{}, key string) []string
 	for _, rawVal := range iSlice {
 		str, ok := rawVal.(string)
 		if !ok {
-			t.Fatalf("Unable to coerce value within slice to string")
+			t.Fatal("Unable to coerce value within slice to string")
 		}
 		strSlice = append(strSlice, str)
 	}

--- a/builtin/logical/openldap/path_dynamic_roles.go
+++ b/builtin/logical/openldap/path_dynamic_roles.go
@@ -6,6 +6,7 @@ package openldap
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"path"
 	"time"
@@ -140,7 +141,7 @@ func (b *backend) pathDynamicRoleCreateUpdate(ctx context.Context, req *logical.
 	}
 	if dRole == nil {
 		if req.Operation == logical.UpdateOperation {
-			return nil, fmt.Errorf("unable to update role: role does not exist")
+			return nil, errors.New("unable to update role: role does not exist")
 		}
 		dRole = &dynamicRole{}
 	}
@@ -168,11 +169,11 @@ func (b *backend) pathDynamicRoleCreateUpdate(ctx context.Context, req *logical.
 
 func validateDynamicRole(dRole *dynamicRole) error {
 	if dRole.CreationLDIF == "" {
-		return fmt.Errorf("missing creation_ldif")
+		return errors.New("missing creation_ldif")
 	}
 
 	if dRole.DeletionLDIF == "" {
-		return fmt.Errorf("missing deletion_ldif")
+		return errors.New("missing deletion_ldif")
 	}
 
 	err := assertValidLDIFTemplate(dRole.CreationLDIF)
@@ -255,7 +256,7 @@ func assertValidLDIFTemplate(rawTemplate string) error {
 	}
 
 	if len(entries.Entries) == 0 {
-		return fmt.Errorf("must specify at least one LDIF entry")
+		return errors.New("must specify at least one LDIF entry")
 	}
 
 	return nil

--- a/builtin/logical/openldap/path_dynamic_roles_test.go
+++ b/builtin/logical/openldap/path_dynamic_roles_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"path"
 	"reflect"
 	"testing"
@@ -186,7 +186,7 @@ func TestDynamicRoleCreateUpdate(t *testing.T) {
 				"deletion_ldif": ldifDeleteTemplate,
 			}),
 
-			putErr:   fmt.Errorf("test error"),
+			putErr:   errors.New("test error"),
 			putTimes: 1,
 
 			expectErr: true,
@@ -867,7 +867,7 @@ func TestDynamicRoleRead(t *testing.T) {
 	tests := map[string]testCase{
 		"storage failure": {
 			storageResp:  nil,
-			storageErr:   fmt.Errorf("test error"),
+			storageErr:   errors.New("test error"),
 			expectedResp: nil,
 			expectErr:    true,
 		},
@@ -952,7 +952,7 @@ func TestDynamicRoleList(t *testing.T) {
 	tests := map[string]testCase{
 		"storage failure": {
 			storageResp:  nil,
-			storageErr:   fmt.Errorf("test error"),
+			storageErr:   errors.New("test error"),
 			expectedResp: nil,
 			expectErr:    true,
 		},
@@ -1023,7 +1023,7 @@ func TestDynamicRoleExistenceCheck(t *testing.T) {
 	tests := map[string]testCase{
 		"storage failure": {
 			storageResp:    nil,
-			storageErr:     fmt.Errorf("test error"),
+			storageErr:     errors.New("test error"),
 			expectedExists: false,
 			expectErr:      true,
 		},

--- a/builtin/logical/openldap/path_dynamic_roles_test.go
+++ b/builtin/logical/openldap/path_dynamic_roles_test.go
@@ -259,7 +259,7 @@ func TestDynamicRoleCreateUpdate(t *testing.T) {
 
 			_, err := b.pathDynamicRoleCreateUpdate(ctx, req, test.createData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -839,7 +839,7 @@ changetype: delete`,
 			}
 			resp, err = b.pathDynamicRoleCreateUpdate(ctx, req, updateData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -928,7 +928,7 @@ func TestDynamicRoleRead(t *testing.T) {
 
 			resp, err := b.pathDynamicRoleRead(ctx, req, data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -997,7 +997,7 @@ func TestDynamicRoleList(t *testing.T) {
 
 			resp, err := b.pathDynamicRoleList(ctx, req, data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -1079,17 +1079,17 @@ userPassword: {{.Password}}`,
 
 			exists, err := b.pathDynamicRoleExistenceCheck(ctx, req, data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
 
 			if test.expectedExists && !exists {
-				t.Fatalf("expected role to exist, did not")
+				t.Fatal("expected role to exist, did not")
 			}
 			if !test.expectedExists && exists {
-				t.Fatalf("did not expect role to exist, but did")
+				t.Fatal("did not expect role to exist, but did")
 			}
 		})
 	}
@@ -1216,7 +1216,7 @@ func TestConvertToDuration(t *testing.T) {
 			data := test.input // The original map is being modified so let's make this an explicit variable
 			err := convertToDuration(data, test.keysToConvert...)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/builtin/logical/openldap/path_rotate.go
+++ b/builtin/logical/openldap/path_rotate.go
@@ -192,7 +192,7 @@ func (b *backend) rollBackPassword(ctx context.Context, config *config, oldPassw
 		case <-timer.C:
 		case <-ctx.Done():
 			// Outer environment is closing.
-			return fmt.Errorf("unable to roll back password because enclosing environment is shutting down")
+			return errors.New("unable to roll back password because enclosing environment is shutting down")
 		}
 		if err = b.client.UpdateDNPassword(config.LDAP, config.LDAP.BindDN, oldPassword); err == nil {
 			// Success.

--- a/builtin/logical/pki/acme_authorizations.go
+++ b/builtin/logical/pki/acme_authorizations.go
@@ -4,7 +4,7 @@
 package pki
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -44,11 +44,11 @@ func (ai *ACMEIdentifier) MaybeParseWildcard() (bool, string, error) {
 		// > of a single asterisk character followed by a single full stop
 		// > character ("*.") followed by a domain name as defined for use in the
 		// > Subject Alternate Name Extension by [RFC5280].
-		return true, "", fmt.Errorf("wildcard must be entire left-most label")
+		return true, "", errors.New("wildcard must be entire left-most label")
 	}
 
 	if reducedName == "" {
-		return true, "", fmt.Errorf("wildcard must not be entire domain name; need at least two domain labels")
+		return true, "", errors.New("wildcard must not be entire domain name; need at least two domain labels")
 	}
 
 	// Parsing was indeed successful, so update our reduced name.

--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -238,7 +239,7 @@ func (ace *ACMEChallengeEngine) _run(b *backend, state *acmeState) error {
 		ace.ValidationLock.Unlock()
 	}
 
-	return fmt.Errorf("unexpectedly exited from ACMEChallengeEngine._run()")
+	return errors.New("unexpectedly exited from ACMEChallengeEngine._run()")
 }
 
 func (ace *ACMEChallengeEngine) AcceptChallenge(sc *storageContext, account string, authz *ACMEAuthorization, challenge *ACMEChallenge, thumbprint string) error {

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -352,7 +352,7 @@ func (a *acmeState) LoadJWK(ac *acmeContext, keyId string) ([]byte, error) {
 	}
 
 	if len(key.Jwk) == 0 {
-		return nil, fmt.Errorf("malformed key entry lacks JWK")
+		return nil, errors.New("malformed key entry lacks JWK")
 	}
 
 	return key.Jwk, nil
@@ -360,7 +360,7 @@ func (a *acmeState) LoadJWK(ac *acmeContext, keyId string) ([]byte, error) {
 
 func (a *acmeState) LoadAuthorization(ac *acmeContext, userCtx *jwsCtx, authId string) (*ACMEAuthorization, error) {
 	if authId == "" {
-		return nil, fmt.Errorf("malformed authorization identifier")
+		return nil, errors.New("malformed authorization identifier")
 	}
 
 	authorizationPath := getAuthorizationPath(userCtx.Kid, authId)
@@ -403,11 +403,11 @@ func (a *acmeState) SaveAuthorization(ac *acmeContext, authz *ACMEAuthorization)
 
 func saveAuthorizationAtPath(sc *storageContext, path string, authz *ACMEAuthorization) error {
 	if authz.Id == "" {
-		return fmt.Errorf("invalid authorization, missing id")
+		return errors.New("invalid authorization, missing id")
 	}
 
 	if authz.AccountId == "" {
-		return fmt.Errorf("invalid authorization, missing account id")
+		return errors.New("invalid authorization, missing account id")
 	}
 
 	json, err := logical.StorageEntryJSON(path, authz)
@@ -514,11 +514,11 @@ func (a *acmeState) LoadOrder(ac *acmeContext, userCtx *jwsCtx, orderId string) 
 
 func (a *acmeState) SaveOrder(ac *acmeContext, order *acmeOrder) error {
 	if order.OrderId == "" {
-		return fmt.Errorf("invalid order, missing order id")
+		return errors.New("invalid order, missing order id")
 	}
 
 	if order.AccountId == "" {
-		return fmt.Errorf("invalid order, missing account id")
+		return errors.New("invalid order, missing account id")
 	}
 	path := getOrderPath(order.AccountId, order.OrderId)
 	json, err := logical.StorageEntryJSON(path, order)
@@ -585,7 +585,7 @@ func (a *acmeState) GetIssuedCert(ac *acmeContext, accountId string, serial stri
 	}
 
 	if entry == nil {
-		return nil, fmt.Errorf("no certificate with this serial was issued for this account")
+		return nil, errors.New("no certificate with this serial was issued for this account")
 	}
 
 	var cert acmeCertEntry

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -261,7 +262,7 @@ func getBasePathFromClusterConfig(sc *storageContext) (*url.URL, error) {
 	}
 
 	if cfg.Path == "" {
-		return nil, fmt.Errorf("ACME feature requires local cluster 'path' field configuration to be set")
+		return nil, errors.New("ACME feature requires local cluster 'path' field configuration to be set")
 	}
 
 	baseUrl, err := url.Parse(cfg.Path)

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2312,7 +2312,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")
@@ -2502,7 +2502,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -149,7 +149,7 @@ func TestPKI_RequireCN(t *testing.T) {
 	// common name. It should error out.
 	_, err = CBWrite(b, s, "issue/example", map[string]interface{}{})
 	if err == nil {
-		t.Fatalf("expected an error due to missing common_name")
+		t.Fatal("expected an error due to missing common_name")
 	}
 
 	// Modify the role to make the common name optional
@@ -172,7 +172,7 @@ func TestPKI_RequireCN(t *testing.T) {
 	}
 
 	if resp.Data["certificate"] == "" {
-		t.Fatalf("expected a cert to be generated")
+		t.Fatal("expected a cert to be generated")
 	}
 
 	// Issue a cert with require_cn set to false and with a common name. It
@@ -183,7 +183,7 @@ func TestPKI_RequireCN(t *testing.T) {
 	}
 
 	if resp.Data["certificate"] == "" {
-		t.Fatalf("expected a cert to be generated")
+		t.Fatal("expected a cert to be generated")
 	}
 }
 
@@ -1920,7 +1920,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 		t.Fatalf("failed read ca_chain, %#v", resp)
 	}
 	if strings.Count(string(resp.Data[logical.HTTPRawBody].([]byte)), rootCaAsPem) != 1 {
-		t.Fatalf("expected raw chain to contain the root cert")
+		t.Fatal("expected raw chain to contain the root cert")
 	}
 
 	// The ca/pem should return us the actual CA...
@@ -1938,7 +1938,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 	}
 	// check the raw cert matches the response body
 	if !bytes.Equal(resp.Data[logical.HTTPRawBody].([]byte), []byte(rootCaAsPem)) {
-		t.Fatalf("failed to get raw cert")
+		t.Fatal("failed to get raw cert")
 	}
 
 	_, err = b.HandleRequest(context.Background(), &logical.Request{
@@ -1994,7 +1994,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 		t.Fatalf("failed to get raw cert for serial number: %s", expectedSerial)
 	}
 	if resp.Data[logical.HTTPContentType] != "application/pkix-cert" {
-		t.Fatalf("failed to get raw cert content-type")
+		t.Fatal("failed to get raw cert content-type")
 	}
 
 	// get pem
@@ -2012,10 +2012,10 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 
 	// check the pem cert matches the response body
 	if !bytes.Equal(resp.Data[logical.HTTPRawBody].([]byte), expectedCert) {
-		t.Fatalf("failed to get pem cert")
+		t.Fatal("failed to get pem cert")
 	}
 	if resp.Data[logical.HTTPContentType] != "application/pem-certificate-chain" {
-		t.Fatalf("failed to get raw cert content-type")
+		t.Fatal("failed to get raw cert content-type")
 	}
 }
 
@@ -2135,7 +2135,7 @@ func TestBackend_PathFetchCertList(t *testing.T) {
 	}
 	// check that the root and 9 additional certs are all listed
 	if len(resp.Data["keys"].([]string)) != 10 {
-		t.Fatalf("failed to list all 10 certs")
+		t.Fatal("failed to list all 10 certs")
 	}
 
 	// list certs/
@@ -2153,7 +2153,7 @@ func TestBackend_PathFetchCertList(t *testing.T) {
 	}
 	// check that the root and 9 additional certs are all listed
 	if len(resp.Data["keys"].([]string)) != 10 {
-		t.Fatalf("failed to list all 10 certs")
+		t.Fatal("failed to list all 10 certs")
 	}
 }
 
@@ -2339,7 +2339,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	}
 
 	if cert.BasicConstraintsValid {
-		t.Fatalf("By default, sign-verbatim must not issue certificates containing the x509 Basic Constraints extension")
+		t.Fatal("By default, sign-verbatim must not issue certificates containing the x509 Basic Constraints extension")
 	}
 
 	// Test the Basic Constraints extension: when the option is explicitly specified (as an explicit option or in a role), the issued certificate must be generated with the Basic Constraints extension.
@@ -2383,7 +2383,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	}
 
 	if cert.IsCA {
-		t.Fatalf("The certificate issued with sign-verbatim cannot be a CA certificate")
+		t.Fatal("The certificate issued with sign-verbatim cannot be a CA certificate")
 	}
 
 	// Test the Basic Constraints extension with a role: when the option is explicitly specified in a role, the issued certificate must be generated with the Basic Constraints extension.
@@ -2446,7 +2446,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	}
 
 	if cert.IsCA {
-		t.Fatalf("The certificate issued with sign-verbatim cannot be a CA certificate")
+		t.Fatal("The certificate issued with sign-verbatim cannot be a CA certificate")
 	}
 
 	// Test the Basic Constraints parameter specified in the API call takes priority and overwrites the value set in the role.
@@ -2485,7 +2485,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 	cert = certs[0]
 
 	if cert.BasicConstraintsValid {
-		t.Fatalf("The Basic Constraints parameter specified in the sign-verbatim API call must take priority and overwrite the value set in the role")
+		t.Fatal("The Basic Constraints parameter specified in the sign-verbatim API call must take priority and overwrite the value set in the role")
 	}
 
 	// Now check signing a certificate using the not_after input using the Y10K value
@@ -7423,7 +7423,7 @@ func TestProperAuthing(t *testing.T) {
 	}
 
 	if !validatedPath {
-		t.Fatalf("Expected to have validated at least one path.")
+		t.Fatal("Expected to have validated at least one path.")
 	}
 }
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -252,11 +253,11 @@ func TestPKI_DeviceCert(t *testing.T) {
 	cert = parsedCertBundle.Certificate
 	notAfter = cert.NotAfter.Format(time.RFC3339)
 	if notAfter != "9999-12-31T23:59:59Z" {
-		t.Fatal(fmt.Errorf("not after from certificate  is not matching with input parameter"))
+		t.Fatal(errors.New("not after from certificate  is not matching with input parameter"))
 	}
 	notBefore := cert.NotBefore.Format(time.RFC3339)
 	if notBefore != "1900-01-01T00:00:00Z" {
-		t.Fatal(fmt.Errorf("not before from certificate  is not matching with input parameter"))
+		t.Fatal(errors.New("not before from certificate  is not matching with input parameter"))
 	}
 }
 
@@ -431,13 +432,13 @@ func checkCertsAndPrivateKey(keyType string, key crypto.Signer, usage x509.KeyUs
 
 	switch {
 	case parsedCertBundle.Certificate == nil:
-		return nil, fmt.Errorf("did not find a certificate in the cert bundle")
+		return nil, errors.New("did not find a certificate in the cert bundle")
 	case len(parsedCertBundle.CAChain) == 0 || parsedCertBundle.CAChain[0].Certificate == nil:
-		return nil, fmt.Errorf("did not find a CA in the cert bundle")
+		return nil, errors.New("did not find a CA in the cert bundle")
 	case parsedCertBundle.PrivateKey == nil:
-		return nil, fmt.Errorf("did not find a private key in the cert bundle")
+		return nil, errors.New("did not find a private key in the cert bundle")
 	case parsedCertBundle.PrivateKeyType == certutil.UnknownPrivateKey:
-		return nil, fmt.Errorf("could not figure out type of private key")
+		return nil, errors.New("could not figure out type of private key")
 	}
 
 	switch {
@@ -446,7 +447,7 @@ func checkCertsAndPrivateKey(keyType string, key crypto.Signer, usage x509.KeyUs
 	case parsedCertBundle.PrivateKeyType == certutil.RSAPrivateKey && keyType != "rsa":
 		fallthrough
 	case parsedCertBundle.PrivateKeyType == certutil.ECPrivateKey && keyType != "ec":
-		return nil, fmt.Errorf("given key type does not match type found in bundle")
+		return nil, errors.New("given key type does not match type found in bundle")
 	}
 
 	cert := parsedCertBundle.Certificate
@@ -463,19 +464,19 @@ func checkCertsAndPrivateKey(keyType string, key crypto.Signer, usage x509.KeyUs
 	switch extUsage {
 	case x509.ExtKeyUsageEmailProtection:
 		if cert.ExtKeyUsage[0] != x509.ExtKeyUsageEmailProtection {
-			return nil, fmt.Errorf("bad extended key usage")
+			return nil, errors.New("bad extended key usage")
 		}
 	case x509.ExtKeyUsageServerAuth:
 		if cert.ExtKeyUsage[0] != x509.ExtKeyUsageServerAuth {
-			return nil, fmt.Errorf("bad extended key usage")
+			return nil, errors.New("bad extended key usage")
 		}
 	case x509.ExtKeyUsageClientAuth:
 		if cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
-			return nil, fmt.Errorf("bad extended key usage")
+			return nil, errors.New("bad extended key usage")
 		}
 	case x509.ExtKeyUsageCodeSigning:
 		if cert.ExtKeyUsage[0] != x509.ExtKeyUsageCodeSigning {
-			return nil, fmt.Errorf("bad extended key usage")
+			return nil, errors.New("bad extended key usage")
 		}
 	}
 
@@ -540,7 +541,7 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			},
 			Check: func(resp *logical.Response) error {
 				if resp.Secret != nil && resp.Secret.LeaseID != "" {
-					return fmt.Errorf("root returned with a lease")
+					return errors.New("root returned with a lease")
 				}
 				return nil
 			},
@@ -562,7 +563,7 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Path:      "config/urls",
 			Check: func(resp *logical.Response) error {
 				if resp.Data == nil {
-					return fmt.Errorf("no data returned")
+					return errors.New("no data returned")
 				}
 				var entries certutil.URLEntries
 				err := mapstructure.Decode(resp.Data, &entries)
@@ -588,7 +589,7 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			ErrorOk: true,
 			Check: func(resp *logical.Response) error {
 				if !resp.IsError() {
-					return fmt.Errorf("expected an error response but did not get one")
+					return errors.New("expected an error response but did not get one")
 				}
 				if !strings.Contains(resp.Data["error"].(string), "2048") {
 					return fmt.Errorf("received an error but not about a 1024-bit key, error was: %s", resp.Data["error"].(string))
@@ -613,10 +614,10 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Check: func(resp *logical.Response) error {
 				certString := resp.Data["certificate"].(string)
 				if certString == "" {
-					return fmt.Errorf("no certificate returned")
+					return errors.New("no certificate returned")
 				}
 				if resp.Secret != nil && resp.Secret.LeaseID != "" {
-					return fmt.Errorf("signed intermediate returned with a lease")
+					return errors.New("signed intermediate returned with a lease")
 				}
 				certBytes, _ := base64.StdEncoding.DecodeString(certString)
 				certs, err := x509.ParseCertificates(certBytes)
@@ -667,10 +668,10 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Check: func(resp *logical.Response) error {
 				certString := resp.Data["certificate"].(string)
 				if certString == "" {
-					return fmt.Errorf("no certificate returned")
+					return errors.New("no certificate returned")
 				}
 				if resp.Secret != nil && resp.Secret.LeaseID != "" {
-					return fmt.Errorf("signed intermediate returned with a lease")
+					return errors.New("signed intermediate returned with a lease")
 				}
 				certBytes, _ := base64.StdEncoding.DecodeString(certString)
 				certs, err := x509.ParseCertificates(certBytes)
@@ -761,7 +762,7 @@ func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Check: func(resp *logical.Response) error {
 				certString := resp.Data["certificate"].(string)
 				if certString == "" {
-					return fmt.Errorf("no certificate returned")
+					return errors.New("no certificate returned")
 				}
 				certBytes, _ := base64.StdEncoding.DecodeString(certString)
 				certs, err := x509.ParseCertificates(certBytes)
@@ -826,7 +827,7 @@ func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Check: func(resp *logical.Response) error {
 				certString := resp.Data["certificate"].(string)
 				if certString == "" {
-					return fmt.Errorf("no certificate returned")
+					return errors.New("no certificate returned")
 				}
 				certBytes, _ := base64.StdEncoding.DecodeString(certString)
 				certs, err := x509.ParseCertificates(certBytes)
@@ -842,7 +843,7 @@ func generateCSRSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 					return fmt.Errorf("max path length of %d does not match the requested of 3", cert.MaxPathLen)
 				}
 				if !cert.MaxPathLenZero {
-					return fmt.Errorf("max path length zero is not set")
+					return errors.New("max path length zero is not set")
 				}
 
 				// We need to set these as they are filled in with unparsed values in the final cert
@@ -956,7 +957,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		if resp.IsError() {
 			return nil
 		}
-		return fmt.Errorf("expected an error, but did not seem to get one")
+		return errors.New("expected an error, but did not seem to get one")
 	}
 
 	// Adds tests with the currently configured issue/role information
@@ -1760,17 +1761,17 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		Path:      "roles/",
 		Check: func(resp *logical.Response) error {
 			if resp.Data == nil {
-				return fmt.Errorf("nil data")
+				return errors.New("nil data")
 			}
 
 			keysRaw, ok := resp.Data["keys"]
 			if !ok {
-				return fmt.Errorf("no keys found")
+				return errors.New("no keys found")
 			}
 
 			keys, ok := keysRaw.([]string)
 			if !ok {
-				return fmt.Errorf("could not convert keys to a string list")
+				return errors.New("could not convert keys to a string list")
 			}
 
 			if len(keys) != 1 {
@@ -2535,7 +2536,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 
 	notAfter := cert.NotAfter.Format(time.RFC3339)
 	if notAfter != "9999-12-31T23:59:59Z" {
-		t.Fatal(fmt.Errorf("not after from certificate is not matching with input parameter"))
+		t.Fatal(errors.New("not after from certificate is not matching with input parameter"))
 	}
 
 	// now check that if we set generate-lease it takes it from the role and the TTLs match

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -309,11 +309,11 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 				expected += "\n"
 				_, present := resp.Data["issuer_id"]
 				if !present {
-					t.Fatalf("expected issuer/default/json to include issuer_id")
+					t.Fatal("expected issuer/default/json to include issuer_id")
 				}
 				_, present = resp.Data["issuer_name"]
 				if !present {
-					t.Fatalf("expected issuer/default/json to include issuer_name")
+					t.Fatal("expected issuer/default/json to include issuer_name")
 				}
 			}
 			if diff := deep.Equal(resp.Data["certificate"].(string), expected); diff != nil {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -206,7 +206,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 
 		if serial == deltaCRLPath {
 			if sc.Backend.useLegacyBundleCaStorage() {
-				return nil, fmt.Errorf("refusing to serve delta CRL with legacy CA bundle")
+				return nil, errors.New("refusing to serve delta CRL with legacy CA bundle")
 			}
 
 			path += deltaCRLPathSuffix
@@ -363,7 +363,7 @@ func validateWildcardDomain(name string) (string, string, error) {
 	if strings.Count(name, "*") > 1 {
 		// As mentioned above, only one wildcard character is permitted
 		// under RFC 6125 semantics.
-		return wildcardLabel, reducedName, fmt.Errorf("expected only one wildcard identifier in the given domain name")
+		return wildcardLabel, reducedName, errors.New("expected only one wildcard identifier in the given domain name")
 	}
 
 	// Split the Common Name into two parts: a left-most label and the
@@ -393,7 +393,7 @@ func validateWildcardDomain(name string) (string, string, error) {
 		wildcardLabel = splitLabels[0]
 		reducedName = splitLabels[1]
 		if strings.Contains(reducedName, "*") {
-			return wildcardLabel, reducedName, fmt.Errorf("expected wildcard to only be present in left-most domain label")
+			return wildcardLabel, reducedName, errors.New("expected wildcard to only be present in left-most domain label")
 		}
 	}
 
@@ -1087,7 +1087,7 @@ func (oraw *otherNameRaw) extractUTF8String() (*otherNameUtf8, error) {
 	if read && outTag == asn1.TagUTF8String {
 		return &otherNameUtf8{oid: oraw.TypeID.String(), value: string(val)}, nil
 	}
-	return nil, fmt.Errorf("no UTF-8 string found in OtherName")
+	return nil, errors.New("no UTF-8 string found in OtherName")
 }
 
 func (o otherNameUtf8) String() string {
@@ -1147,7 +1147,7 @@ func forEachSAN(extension []byte, callback func(tag int, data []byte) error) err
 	if err != nil {
 		return err
 	} else if len(rest) != 0 {
-		return fmt.Errorf("x509: trailing data after X.509 extension")
+		return errors.New("x509: trailing data after X.509 extension")
 	}
 	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
 		return asn1.StructuralError{Msg: "bad SAN sequence"}
@@ -1674,7 +1674,7 @@ func convertRespToPKCS8(resp *logical.Response) error {
 	}
 	priv, ok := privRaw.(string)
 	if !ok {
-		return fmt.Errorf("error converting response to pkcs8: could not parse original value as string")
+		return errors.New("error converting response to pkcs8: could not parse original value as string")
 	}
 
 	privKeyTypeRaw, ok := resp.Data["private_key_type"]
@@ -1683,7 +1683,7 @@ func convertRespToPKCS8(resp *logical.Response) error {
 	}
 	privKeyType, ok := privKeyTypeRaw.(certutil.PrivateKeyType)
 	if !ok {
-		return fmt.Errorf("error converting response to pkcs8: could not parse original type value as string")
+		return errors.New("error converting response to pkcs8: could not parse original type value as string")
 	}
 
 	var keyData []byte

--- a/builtin/logical/pki/chain_test.go
+++ b/builtin/logical/pki/chain_test.go
@@ -573,7 +573,7 @@ func (c CBIssueLeaf) RevokeLeaf(t testing.TB, b *backend, s logical.Storage, kno
 				t.Fatalf("failed to read default issuer config: %v", err)
 			}
 			if resp == nil {
-				t.Fatalf("failed to read default issuer config: nil response")
+				t.Fatal("failed to read default issuer config: nil response")
 			}
 			defaultID := resp.Data["default"].(issuerID).String()
 			c.Issuer = defaultID
@@ -635,7 +635,7 @@ func (c CBIssueLeaf) Run(t testing.TB, b *backend, s logical.Storage, knownKeys 
 		t.Fatalf("failed to read default issuer config: %v", err)
 	}
 	if resp == nil {
-		t.Fatalf("failed to read default issuer config: nil response")
+		t.Fatal("failed to read default issuer config: nil response")
 	}
 	defaultID := resp.Data["default"].(issuerID).String()
 
@@ -1614,7 +1614,7 @@ func Test_CAChainBuilding(t *testing.T) {
 			testStep.Run(t, b, s, knownKeys, knownCerts)
 		}
 
-		t.Logf("Checking stable ordering of chains...")
+		t.Log("Checking stable ordering of chains...")
 		ensureStableOrderingOfChains(t, b, s, knownKeys, knownCerts)
 	}
 }

--- a/builtin/logical/pki/chain_util.go
+++ b/builtin/logical/pki/chain_util.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"bytes"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -438,7 +439,7 @@ func (sc *storageContext) rebuildIssuersChains(referenceCert *issuerEntry /* opt
 		}
 	}
 	if len(msg) > 0 {
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 
 	// Finally, write all issuers to disk.

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -880,7 +880,7 @@ func TestIssuerRevocation(t *testing.T) {
 	requireSerialNumberInCRL(t, crl.TBSCertList, intCertSerial)
 	crl = getParsedCrlFromBackend(t, b, s, "issuer/root/crl/delta/der")
 	if requireSerialNumberInCRL(nil, crl.TBSCertList, intCertSerial) {
-		t.Fatalf("expected intermediate serial NOT to appear on root's delta CRL, but did")
+		t.Fatal("expected intermediate serial NOT to appear on root's delta CRL, but did")
 	}
 
 	// Ensure we can still revoke the issued leaf.
@@ -1083,7 +1083,7 @@ func TestAutoRebuild(t *testing.T) {
 			t.Fatalf("expected newly generated certificate with serial %v not to appear on this CRL but it did, prematurely: %v", newLeafSerial, crl)
 		}
 
-		t.Fatalf("shouldn't be here")
+		t.Fatal("shouldn't be here")
 	}
 
 	// This serial should exist in the delta WAL section for the mount...

--- a/builtin/logical/pki/path_acme_eab.go
+++ b/builtin/logical/pki/path_acme_eab.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -274,7 +275,7 @@ func (b *backend) pathAcmeDeleteEab(ctx context.Context, r *logical.Request, d *
 
 	_, err := uuid.ParseUUID(keyId)
 	if err != nil {
-		return nil, fmt.Errorf("badly formatted key_id field")
+		return nil, errors.New("badly formatted key_id field")
 	}
 
 	deleted, err := b.acmeState.DeleteEab(sc, keyId)

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -174,7 +175,7 @@ func (b *backend) acmeFetchCertOrderHandler(ac *acmeContext, _ *logical.Request,
 	}
 
 	if len(order.IssuerId) == 0 || len(order.CertificateSerialNumber) == 0 {
-		return nil, fmt.Errorf("order is missing required fields to load certificate")
+		return nil, errors.New("order is missing required fields to load certificate")
 	}
 
 	certEntry, err := fetchCertBySerial(ac.sc, "certs/", order.CertificateSerialNumber)

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1160,7 +1160,7 @@ func TestAcmeWithCsrIncludingBasicConstraintExtension(t *testing.T) {
 	for _, ext := range acmeCert.Extensions {
 		if ext.Id.Equal(certutil.ExtensionBasicConstraintsOID) {
 			// We shouldn't have this extension in our cert
-			t.Fatalf("acme csr contained a basic constraints extension")
+			t.Fatal("acme csr contained a basic constraints extension")
 		}
 	}
 }
@@ -1223,14 +1223,14 @@ func markAuthorizationSuccess(t *testing.T, client *api.Client, acmeClient *acme
 				// Our order seems to be in the proper status, should be safe-ish to go ahead now
 				break
 			} else {
-				t.Logf("order status was not ready, retrying")
+				t.Log("order status was not ready, retrying")
 			}
 		} else {
-			t.Logf("new challenge entries appeared after deletion, retrying")
+			t.Log("new challenge entries appeared after deletion, retrying")
 		}
 
 		if i > 5 {
-			t.Fatalf("We are constantly deleting cv entries or order status is not changing, something is wrong")
+			t.Fatal("We are constantly deleting cv entries or order status is not changing, something is wrong")
 		}
 
 		i++

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -14,6 +14,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1457,7 +1458,7 @@ func TestAcmeValidationError(t *testing.T) {
 		}
 
 		if challenge.Error == nil {
-			return fmt.Errorf("no error set in challenge yet")
+			return errors.New("no error set in challenge yet")
 		}
 
 		acmeError, ok := challenge.Error.(*acme.Error)

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -5,6 +5,7 @@ package pki
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -198,7 +199,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 	if allowedRolesRaw, ok := d.GetOk("allowed_roles"); ok {
 		config.AllowedRoles = allowedRolesRaw.([]string)
 		if len(config.AllowedRoles) == 0 {
-			return nil, fmt.Errorf("allowed_roles must take a non-zero length value; specify '*' as the value to allow anything or specify enabled=false to disable ACME entirely")
+			return nil, errors.New("allowed_roles must take a non-zero length value; specify '*' as the value to allow anything or specify enabled=false to disable ACME entirely")
 		}
 	}
 
@@ -213,7 +214,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 	if allowedIssuersRaw, ok := d.GetOk("allowed_issuers"); ok {
 		config.AllowedIssuers = allowedIssuersRaw.([]string)
 		if len(config.AllowedIssuers) == 0 {
-			return nil, fmt.Errorf("allowed_issuers must take a non-zero length value; specify '*' as the value to allow anything or specify enabled=false to disable ACME entirely")
+			return nil, errors.New("allowed_issuers must take a non-zero length value; specify '*' as the value to allow anything or specify enabled=false to disable ACME entirely")
 		}
 	}
 
@@ -225,10 +226,10 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 				return nil, fmt.Errorf("failed to parse DNS resolver address: %w", err)
 			}
 			if addr == "" {
-				return nil, fmt.Errorf("failed to parse DNS resolver address: got empty address")
+				return nil, errors.New("failed to parse DNS resolver address: got empty address")
 			}
 			if net.ParseIP(addr) == nil {
-				return nil, fmt.Errorf("failed to parse DNS resolver address: expected IPv4/IPv6 address, likely got hostname")
+				return nil, errors.New("failed to parse DNS resolver address: expected IPv4/IPv6 address, likely got hostname")
 			}
 		}
 	}

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -5,6 +5,7 @@ package pki
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -201,7 +202,7 @@ func writeURLs(ctx context.Context, storage logical.Storage, entries *aiaConfigE
 		return err
 	}
 	if entry == nil {
-		return fmt.Errorf("unable to marshal entry into JSON")
+		return errors.New("unable to marshal entry into JSON")
 	}
 
 	err = storage.Put(ctx, entry)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -532,7 +533,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	var resp *logical.Response
 	switch {
 	case role.GenerateLease == nil:
-		return nil, fmt.Errorf("generate lease in role is nil")
+		return nil, errors.New("generate lease in role is nil")
 	case !*role.GenerateLease:
 		// If lease generation is disabled do not populate `Secret` field in
 		// the response

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -130,7 +130,7 @@ func TestOcsp_MalformedRequests(t *testing.T) {
 			case "post":
 				resp, err = sendOcspPostRequest(b, s, badReq)
 			default:
-				t.Fatalf("bad request type")
+				t.Fatal("bad request type")
 			}
 			require.NoError(t, err)
 			requireFieldsSetInResp(t, resp, "http_content_type", "http_status_code", "http_raw_body")
@@ -446,7 +446,7 @@ func TestOcsp_HigherLevel(t *testing.T) {
 	urlEncoded := base64.StdEncoding.EncodeToString(ocspReq)
 	if strings.Contains(urlEncoded, "//") {
 		// workaround known redirect bug that is difficult to fix
-		t.Skipf("VAULT-13630 - Skipping GET OCSP test with encoded issuer cert containing // triggering redirection bug")
+		t.Skip("VAULT-13630 - Skipping GET OCSP test with encoded issuer cert containing // triggering redirection bug")
 	}
 
 	ocspGetReq := client.NewRequest(http.MethodGet, "/v1/pki/ocsp/"+urlEncoded)

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -12,6 +12,7 @@ import (
 	"crypto/subtle"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -328,7 +329,7 @@ func (b *backend) pathRevokeWriteHandleCertificate(ctx context.Context, req *log
 			// Here we refuse the import with an error because the two certs
 			// are unequal but we would've otherwise overwritten the existing
 			// copy.
-			return serial, false, nil, fmt.Errorf("certificate with same serial but unequal value already present in this cluster's storage; refusing to revoke")
+			return serial, false, nil, errors.New("certificate with same serial but unequal value already present in this cluster's storage; refusing to revoke")
 		} else {
 			// Otherwise, we can return without an error as we've already
 			// imported this certificate, likely when we issued it. We don't
@@ -379,7 +380,7 @@ func (b *backend) pathRevokeWriteHandleKey(req *logical.Request, certReference *
 		// The only way to get here should be via the /revoke endpoint;
 		// validate the path one more time and return an error if necessary.
 		if req.Path != "revoke" {
-			return fmt.Errorf("must have private key to revoke via the /revoke-with-key path")
+			return errors.New("must have private key to revoke via the /revoke-with-key path")
 		}
 
 		// Otherwise, we don't need to validate the key and thus can return

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -1622,17 +1623,17 @@ func checkCNValidations(validations []string) ([]string, error) {
 		switch strings.ToLower(validation) {
 		case "disabled":
 			if haveDisabled {
-				return nil, fmt.Errorf("cn_validations value incorrect: `disabled` specified multiple times")
+				return nil, errors.New("cn_validations value incorrect: `disabled` specified multiple times")
 			}
 			haveDisabled = true
 		case "email":
 			if haveEmail {
-				return nil, fmt.Errorf("cn_validations value incorrect: `email` specified multiple times")
+				return nil, errors.New("cn_validations value incorrect: `email` specified multiple times")
 			}
 			haveEmail = true
 		case "hostname":
 			if haveHostname {
-				return nil, fmt.Errorf("cn_validations value incorrect: `hostname` specified multiple times")
+				return nil, errors.New("cn_validations value incorrect: `hostname` specified multiple times")
 			}
 			haveHostname = true
 		default:
@@ -1643,11 +1644,11 @@ func checkCNValidations(validations []string) ([]string, error) {
 	}
 
 	if !haveDisabled && !haveEmail && !haveHostname {
-		return nil, fmt.Errorf("cn_validations value incorrect: must specify a value (`email` and/or `hostname`) or `disabled`")
+		return nil, errors.New("cn_validations value incorrect: must specify a value (`email` and/or `hostname`) or `disabled`")
 	}
 
 	if haveDisabled && (haveEmail || haveHostname) {
-		return nil, fmt.Errorf("cn_validations value incorrect: cannot specify `disabled` along with `email` or `hostname`")
+		return nil, errors.New("cn_validations value incorrect: cannot specify `disabled` along with `email` or `hostname`")
 	}
 
 	return result, nil

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -54,12 +54,12 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 	// creation or has to be filled in by the upgrade code
 	generateLease := resp.Data["generate_lease"].(*bool)
 	if generateLease == nil {
-		t.Fatalf("generate_lease should not be nil")
+		t.Fatal("generate_lease should not be nil")
 	}
 
 	// By default, generate_lease should be `false`
 	if *generateLease {
-		t.Fatalf("generate_lease should not be set by default")
+		t.Fatal("generate_lease should not be set by default")
 	}
 
 	// To test upgrade of generate_lease, we read the storage entry,
@@ -92,12 +92,12 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 
 	generateLease = resp.Data["generate_lease"].(*bool)
 	if generateLease == nil {
-		t.Fatalf("generate_lease should not be nil")
+		t.Fatal("generate_lease should not be nil")
 	}
 
 	// Upgrade should set generate_lease to `true`
 	if !*generateLease {
-		t.Fatalf("generate_lease should be set after an upgrade")
+		t.Fatal("generate_lease should be set after an upgrade")
 	}
 
 	// Make sure that setting generate_lease to `true` works properly
@@ -118,10 +118,10 @@ func TestPki_RoleGenerateLease(t *testing.T) {
 
 	generateLease = resp.Data["generate_lease"].(*bool)
 	if generateLease == nil {
-		t.Fatalf("generate_lease should not be nil")
+		t.Fatal("generate_lease should not be nil")
 	}
 	if !*generateLease {
-		t.Fatalf("generate_lease should have been set")
+		t.Fatal("generate_lease should have been set")
 	}
 }
 
@@ -159,7 +159,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 
 	keyUsage := resp.Data["key_usage"].([]string)
 	if len(keyUsage) != 2 {
-		t.Fatalf("key_usage should have 2 values")
+		t.Fatal("key_usage should have 2 values")
 	}
 
 	// To test the upgrade of KeyUsageOld into KeyUsage, we read
@@ -194,7 +194,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 
 	keyUsage = resp.Data["key_usage"].([]string)
 	if len(keyUsage) != 2 {
-		t.Fatalf("key_usage should have 2 values")
+		t.Fatal("key_usage should have 2 values")
 	}
 
 	// Read back from storage to ensure upgrade
@@ -203,7 +203,7 @@ func TestPki_RoleKeyUsage(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("role should not be nil")
+		t.Fatal("role should not be nil")
 	}
 	var result roleEntry
 	if err := entry.DecodeJSON(&result); err != nil {
@@ -251,11 +251,11 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 
 	ou := resp.Data["ou"].([]string)
 	if len(ou) != 2 {
-		t.Fatalf("ou should have 2 values")
+		t.Fatal("ou should have 2 values")
 	}
 	organization := resp.Data["organization"].([]string)
 	if len(organization) != 2 {
-		t.Fatalf("organization should have 2 values")
+		t.Fatal("organization should have 2 values")
 	}
 
 	// To test upgrade of O/OU, we read the storage entry, modify it to set
@@ -290,11 +290,11 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 
 	ou = resp.Data["ou"].([]string)
 	if len(ou) != 2 {
-		t.Fatalf("ou should have 2 values")
+		t.Fatal("ou should have 2 values")
 	}
 	organization = resp.Data["organization"].([]string)
 	if len(organization) != 2 {
-		t.Fatalf("organization should have 2 values")
+		t.Fatal("organization should have 2 values")
 	}
 
 	// Read back from storage to ensure upgrade
@@ -303,7 +303,7 @@ func TestPki_RoleOUOrganizationUpgrade(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("role should not be nil")
+		t.Fatal("role should not be nil")
 	}
 	var result roleEntry
 	if err := entry.DecodeJSON(&result); err != nil {
@@ -355,7 +355,7 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 
 	allowedDomains := resp.Data["allowed_domains"].([]string)
 	if len(allowedDomains) != 2 {
-		t.Fatalf("allowed_domains should have 2 values")
+		t.Fatal("allowed_domains should have 2 values")
 	}
 
 	// To test upgrade of allowed_domains, we read the storage entry,
@@ -388,7 +388,7 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 
 	allowedDomains = resp.Data["allowed_domains"].([]string)
 	if len(allowedDomains) != 2 {
-		t.Fatalf("allowed_domains should have 2 values")
+		t.Fatal("allowed_domains should have 2 values")
 	}
 
 	// Read back from storage to ensure upgrade
@@ -397,7 +397,7 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("role should not be nil")
+		t.Fatal("role should not be nil")
 	}
 	var result roleEntry
 	if err := entry.DecodeJSON(&result); err != nil {
@@ -443,7 +443,7 @@ func TestPki_RoleAllowedURISANs(t *testing.T) {
 
 	allowedURISANs := resp.Data["allowed_uri_sans"].([]string)
 	if len(allowedURISANs) != 2 {
-		t.Fatalf("allowed_uri_sans should have 2 values")
+		t.Fatal("allowed_uri_sans should have 2 values")
 	}
 }
 
@@ -485,57 +485,57 @@ func TestPki_RolePkixFields(t *testing.T) {
 	origCountry := roleData["country"].([]string)
 	respCountry := resp.Data["country"].([]string)
 	if !strutil.StrListSubset(origCountry, respCountry) {
-		t.Fatalf("country did not match values set in role")
+		t.Fatal("country did not match values set in role")
 	} else if len(origCountry) != len(respCountry) {
-		t.Fatalf("country did not have same number of values set in role")
+		t.Fatal("country did not have same number of values set in role")
 	}
 
 	origOU := roleData["ou"].([]string)
 	respOU := resp.Data["ou"].([]string)
 	if !strutil.StrListSubset(origOU, respOU) {
-		t.Fatalf("ou did not match values set in role")
+		t.Fatal("ou did not match values set in role")
 	} else if len(origOU) != len(respOU) {
-		t.Fatalf("ou did not have same number of values set in role")
+		t.Fatal("ou did not have same number of values set in role")
 	}
 
 	origOrganization := roleData["organization"].([]string)
 	respOrganization := resp.Data["organization"].([]string)
 	if !strutil.StrListSubset(origOrganization, respOrganization) {
-		t.Fatalf("organization did not match values set in role")
+		t.Fatal("organization did not match values set in role")
 	} else if len(origOrganization) != len(respOrganization) {
-		t.Fatalf("organization did not have same number of values set in role")
+		t.Fatal("organization did not have same number of values set in role")
 	}
 
 	origLocality := roleData["locality"].([]string)
 	respLocality := resp.Data["locality"].([]string)
 	if !strutil.StrListSubset(origLocality, respLocality) {
-		t.Fatalf("locality did not match values set in role")
+		t.Fatal("locality did not match values set in role")
 	} else if len(origLocality) != len(respLocality) {
-		t.Fatalf("locality did not have same number of values set in role: ")
+		t.Fatal("locality did not have same number of values set in role: ")
 	}
 
 	origProvince := roleData["province"].([]string)
 	respProvince := resp.Data["province"].([]string)
 	if !strutil.StrListSubset(origProvince, respProvince) {
-		t.Fatalf("province did not match values set in role")
+		t.Fatal("province did not match values set in role")
 	} else if len(origProvince) != len(respProvince) {
-		t.Fatalf("province did not have same number of values set in role")
+		t.Fatal("province did not have same number of values set in role")
 	}
 
 	origStreetAddress := roleData["street_address"].([]string)
 	respStreetAddress := resp.Data["street_address"].([]string)
 	if !strutil.StrListSubset(origStreetAddress, respStreetAddress) {
-		t.Fatalf("street_address did not match values set in role")
+		t.Fatal("street_address did not match values set in role")
 	} else if len(origStreetAddress) != len(respStreetAddress) {
-		t.Fatalf("street_address did not have same number of values set in role")
+		t.Fatal("street_address did not have same number of values set in role")
 	}
 
 	origPostalCode := roleData["postal_code"].([]string)
 	respPostalCode := resp.Data["postal_code"].([]string)
 	if !strutil.StrListSubset(origPostalCode, respPostalCode) {
-		t.Fatalf("postal_code did not match values set in role")
+		t.Fatal("postal_code did not match values set in role")
 	} else if len(origPostalCode) != len(respPostalCode) {
-		t.Fatalf("postal_code did not have same number of values set in role")
+		t.Fatal("postal_code did not have same number of values set in role")
 	}
 }
 
@@ -572,19 +572,19 @@ func TestPki_RoleNoStore(t *testing.T) {
 	// By default, no_store should be `false`
 	noStore := resp.Data["no_store"].(bool)
 	if noStore {
-		t.Fatalf("no_store should not be set by default")
+		t.Fatal("no_store should not be set by default")
 	}
 
 	// By default, allowed_domains_template should be `false`
 	allowedDomainsTemplate := resp.Data["allowed_domains_template"].(bool)
 	if allowedDomainsTemplate {
-		t.Fatalf("allowed_domains_template should not be set by default")
+		t.Fatal("allowed_domains_template should not be set by default")
 	}
 
 	// By default, allowed_uri_sans_template should be `false`
 	allowedURISANsTemplate := resp.Data["allowed_uri_sans_template"].(bool)
 	if allowedURISANsTemplate {
-		t.Fatalf("allowed_uri_sans_template should not be set by default")
+		t.Fatal("allowed_uri_sans_template should not be set by default")
 	}
 
 	// Make sure that setting no_store to `true` works properly
@@ -608,7 +608,7 @@ func TestPki_RoleNoStore(t *testing.T) {
 
 	noStore = resp.Data["no_store"].(bool)
 	if !noStore {
-		t.Fatalf("no_store should have been set to true")
+		t.Fatal("no_store should have been set to true")
 	}
 
 	// issue a certificate and test that it's not stored
@@ -720,7 +720,7 @@ func TestPki_CertsLease(t *testing.T) {
 	}
 
 	if resp.Secret != nil {
-		t.Fatalf("expected a response that does not contain a secret")
+		t.Fatal("expected a response that does not contain a secret")
 	}
 
 	// Turn on the lease generation and issue a certificate. The response
@@ -738,7 +738,7 @@ func TestPki_CertsLease(t *testing.T) {
 	}
 
 	if resp.Secret == nil {
-		t.Fatalf("expected a response that contains a secret")
+		t.Fatal("expected a response that contains a secret")
 	}
 }
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -612,7 +612,7 @@ func (b *backend) pathIssuerSignSelfIssued(ctx context.Context, req *logical.Req
 		return nil, fmt.Errorf("error signing self-issued certificate: %w", err)
 	}
 	if len(newCert) == 0 {
-		return nil, fmt.Errorf("nil cert was created when signing self-issued certificate")
+		return nil, errors.New("nil cert was created when signing self-issued certificate")
 	}
 	pemCert := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -1241,7 +1241,7 @@ func waitForTidyToFinish(t *testing.T, client *api.Client, mount string) *api.Se
 			return fmt.Errorf("failed reading path: %s: %w", tidyStatusPath, err)
 		}
 		if state, ok := statusResp.Data["state"]; !ok || state == "Running" {
-			return fmt.Errorf("tidy status state is still running")
+			return errors.New("tidy status state is still running")
 		}
 
 		if errorOccurred, ok := statusResp.Data["error"]; !ok || !(errorOccurred == nil || errorOccurred == "") {

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -639,11 +639,11 @@ func TestCertStorageMetrics(t *testing.T) {
 	mostRecentInterval := stableMetric[len(stableMetric)-1]
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_revoked_certificates_stored"]
 	if ok {
-		t.Fatalf("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
+		t.Fatal("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
 	}
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_certificates_stored"]
 	if ok {
-		t.Fatalf("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
+		t.Fatal("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
 	}
 
 	// Write the auto-tidy config.
@@ -680,11 +680,11 @@ func TestCertStorageMetrics(t *testing.T) {
 	mostRecentInterval = stableMetric[len(stableMetric)-1]
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_revoked_certificates_stored"]
 	if ok {
-		t.Fatalf("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
+		t.Fatal("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
 	}
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_certificates_stored"]
 	if ok {
-		t.Fatalf("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
+		t.Fatal("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
 	}
 
 	// But since certificate counting is on, the metrics should exist on tidyStatus endpoint:
@@ -696,14 +696,14 @@ func TestCertStorageMetrics(t *testing.T) {
 	// "current_cert_store_count", "current_revoked_cert_count"
 	certStoreCount, ok := tidyStatus.Data["current_cert_store_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
 	}
 	if certStoreCount != json.Number("1") {
 		t.Fatalf("Only created one certificate, but a got a certificate count of %v", certStoreCount)
 	}
 	revokedCertCount, ok := tidyStatus.Data["current_revoked_cert_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
 	}
 	if revokedCertCount != json.Number("0") {
 		t.Fatalf("Have not yet revoked a certificate, but got a revoked cert store count of %v", revokedCertCount)
@@ -752,7 +752,7 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	for _, warning := range revokeResp.Warnings {
 		if strings.Contains(warning, "already expired; refusing to add to CRL") {
-			t.Skipf("Skipping test as we missed the revocation window of our leaf cert")
+			t.Skip("Skipping test as we missed the revocation window of our leaf cert")
 		}
 	}
 
@@ -767,14 +767,14 @@ func TestCertStorageMetrics(t *testing.T) {
 	backendUUID = tidyStatus.Data["internal_backend_uuid"].(string)
 	certStoreCount, ok = tidyStatus.Data["current_cert_store_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
 	}
 	if certStoreCount != json.Number("2") {
 		t.Fatalf("Created root and leaf certificate, but a got a certificate count of %v", certStoreCount)
 	}
 	revokedCertCount, ok = tidyStatus.Data["current_revoked_cert_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
 	}
 	if revokedCertCount != json.Number("1") {
 		t.Fatalf("Revoked one certificate, but got a revoked cert store count of %v\n:%v", revokedCertCount, tidyStatus)
@@ -823,14 +823,14 @@ func TestCertStorageMetrics(t *testing.T) {
 	// "current_cert_store_count", "current_revoked_cert_count"
 	certStoreCount, ok = tidyStatus.Data["current_cert_store_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
 	}
 	if certStoreCount != json.Number("1") {
 		t.Fatalf("Created root and leaf certificate, deleted leaf, but a got a certificate count of %v", certStoreCount)
 	}
 	revokedCertCount, ok = tidyStatus.Data["current_revoked_cert_count"]
 	if !ok {
-		t.Fatalf("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
 	}
 	if revokedCertCount != json.Number("0") {
 		t.Fatalf("Revoked certificate has been tidied, but got a revoked cert store count of %v", revokedCertCount)
@@ -1139,7 +1139,7 @@ func backDateAcmeAccountSys(t *testing.T, testContext context.Context, client *a
 	require.NoError(t, err, "failed listing orders")
 
 	if ordersRaw == nil {
-		t.Logf("skipping backdating orders as there are none")
+		t.Log("skipping backdating orders as there are none")
 		return
 	}
 
@@ -1308,7 +1308,7 @@ func waitForManualTidy(t *testing.T, client *api.Client, tidyConfig map[string]i
 	for {
 		select {
 		case <-timeoutChan:
-			t.Fatalf("expected manual tidy to run before timeout")
+			t.Fatal("expected manual tidy to run before timeout")
 		default:
 			time.Sleep(50 * time.Millisecond)
 

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -41,12 +42,12 @@ reference`,
 
 func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	if req.Secret == nil {
-		return nil, fmt.Errorf("secret is nil in request")
+		return nil, errors.New("secret is nil in request")
 	}
 
 	serialInt, ok := req.Secret.InternalData["serial_number"]
 	if !ok {
-		return nil, fmt.Errorf("could not find serial in internal secret data")
+		return nil, errors.New("could not find serial in internal secret data")
 	}
 
 	b.revokeStorageLock.Lock()

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -231,14 +231,14 @@ func (c *aiaConfigEntry) toURLEntries(sc *storageContext, issuer issuerID) (*cer
 			templated := make([]string, len(*source))
 			for index, uri := range *source {
 				if strings.Contains(uri, "{{cluster_path}}") && len(cfg.Path) == 0 {
-					return nil, fmt.Errorf("unable to template AIA URLs as we lack local cluster address information (path)")
+					return nil, errors.New("unable to template AIA URLs as we lack local cluster address information (path)")
 				}
 				if strings.Contains(uri, "{{cluster_aia_path}}") && len(cfg.AIAPath) == 0 {
-					return nil, fmt.Errorf("unable to template AIA URLs as we lack local cluster address information (aia_path)")
+					return nil, errors.New("unable to template AIA URLs as we lack local cluster address information (aia_path)")
 				}
 				if strings.Contains(uri, "{{issuer_id}}") && len(issuer) == 0 {
 					// Elide issuer AIA info as we lack an issuer_id.
-					return nil, fmt.Errorf("unable to template AIA URLs as we lack an issuer_id for this operation")
+					return nil, errors.New("unable to template AIA URLs as we lack an issuer_id for this operation")
 				}
 
 				uri = strings.ReplaceAll(uri, "{{cluster_path}}", cfg.Path)
@@ -618,7 +618,7 @@ func (sc *storageContext) resolveKeyReference(reference string) (keyID, error) {
 			return keyID("config-error"), err
 		}
 		if len(config.DefaultKeyId) == 0 {
-			return KeyRefNotFound, fmt.Errorf("no default key currently configured")
+			return KeyRefNotFound, errors.New("no default key currently configured")
 		}
 
 		return config.DefaultKeyId, nil
@@ -1125,7 +1125,7 @@ func (sc *storageContext) resolveIssuerReference(reference string) (issuerID, er
 			return issuerID("config-error"), err
 		}
 		if len(config.DefaultIssuerId) == 0 {
-			return IssuerRefNotFound, fmt.Errorf("no default issuer currently configured")
+			return IssuerRefNotFound, errors.New("no default issuer currently configured")
 		}
 
 		return config.DefaultIssuerId, nil

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -180,7 +180,7 @@ func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *pkix.Cer
 		t.Fatalf("err: %s", err)
 	}
 	if len(crlBytes) == 0 {
-		t.Fatalf("expected CRL in response body")
+		t.Fatal("expected CRL in response body")
 	}
 
 	crl, err := x509.ParseDERCRL(crlBytes)
@@ -313,7 +313,7 @@ func getCRLNumber(t *testing.T, crl pkix.TBSCertificateList) int {
 		}
 	}
 
-	t.Fatalf("failed to find crl number extension")
+	t.Fatal("failed to find crl number extension")
 	return 0
 }
 
@@ -332,7 +332,7 @@ func getCrlReferenceFromDelta(t *testing.T, crl pkix.TBSCertificateList) int {
 		}
 	}
 
-	t.Fatalf("failed to find delta crl indicator extension")
+	t.Fatal("failed to find delta crl indicator extension")
 	return 0
 }
 

--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -406,7 +406,7 @@ func CheckWithGo(t *testing.T, rootCert string, clientCert string, clientChain [
 }
 
 func RunNginxRootTest(t *testing.T, caKeyType string, caKeyBits int, caUsePSS bool, roleKeyType string, roleKeyBits int, roleUsePSS bool) {
-	t.Skipf("flaky in CI")
+	t.Skip("flaky in CI")
 
 	b, s := pki.CreateBackendWithStorage(t)
 

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -1041,7 +1041,7 @@ func SubtestACMEStepDownNode(t *testing.T, cluster *VaultPkiCluster) {
 		t.Logf("Node: %v Raft AutoPilotState: %v\n", previousActiveNode.NodeID, state)
 
 		if !state.Healthy {
-			return fmt.Errorf("raft auto pilot state is not healthy")
+			return errors.New("raft auto pilot state is not healthy")
 		}
 
 		// Make sure that we have at least one node that can take over prior to sealing the current active node.

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -1106,7 +1106,7 @@ func SubtestACMEStepDownNode(t *testing.T, cluster *VaultPkiCluster) {
 
 func getDockerLog(t *testing.T) (func(s string), *pkiext.LogConsumerWriter, *pkiext.LogConsumerWriter) {
 	logConsumer := func(s string) {
-		t.Logf(s)
+		t.Log(s)
 	}
 
 	logStdout := &pkiext.LogConsumerWriter{logConsumer}

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -1054,12 +1054,12 @@ func SubtestACMEStepDownNode(t *testing.T, cluster *VaultPkiCluster) {
 		return nil
 	})
 
-	t.Logf("Sealing active node")
+	t.Log("Sealing active node")
 	err = previousActiveNode.APIClient().Sys().Seal()
 	require.NoError(t, err, "failed stepping down node")
 
 	// Add our DNS records now
-	t.Logf("Adding DNS records")
+	t.Log("Adding DNS records")
 	for dnsHost, dnsValue := range dnsTxtRecordsToAdd {
 		err = pki.AddDNSRecord(dnsHost, "TXT", dnsValue)
 		require.NoError(t, err, "failed adding DNS record: %s:%s", dnsHost, dnsValue)

--- a/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
+++ b/builtin/logical/pkiext/pkiext_binary/pki_cluster.go
@@ -5,6 +5,7 @@ package pkiext_binary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -145,7 +146,7 @@ func (vpc *VaultPkiCluster) AddNameToHostFiles(hostname, ip string) error {
 
 func (vpc *VaultPkiCluster) AddDNSRecord(hostname, recordType, ip string) error {
 	if vpc.Dns == nil {
-		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to provision custom records")
+		return errors.New("no DNS server was provisioned on this cluster group; unable to provision custom records")
 	}
 
 	vpc.Dns.AddRecord(hostname, recordType, ip)
@@ -155,7 +156,7 @@ func (vpc *VaultPkiCluster) AddDNSRecord(hostname, recordType, ip string) error 
 
 func (vpc *VaultPkiCluster) RemoveDNSRecord(domain string, record string, value string) error {
 	if vpc.Dns == nil {
-		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to remove specific record")
+		return errors.New("no DNS server was provisioned on this cluster group; unable to remove specific record")
 	}
 
 	vpc.Dns.RemoveRecord(domain, record, value)
@@ -164,7 +165,7 @@ func (vpc *VaultPkiCluster) RemoveDNSRecord(domain string, record string, value 
 
 func (vpc *VaultPkiCluster) RemoveDNSRecordsOfTypeForDomain(domain string, record string) error {
 	if vpc.Dns == nil {
-		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to remove all records of type")
+		return errors.New("no DNS server was provisioned on this cluster group; unable to remove all records of type")
 	}
 
 	vpc.Dns.RemoveRecordsOfTypeForDomain(domain, record)
@@ -173,7 +174,7 @@ func (vpc *VaultPkiCluster) RemoveDNSRecordsOfTypeForDomain(domain string, recor
 
 func (vpc *VaultPkiCluster) RemoveDNSRecordsForDomain(domain string) error {
 	if vpc.Dns == nil {
-		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to remove records for domain")
+		return errors.New("no DNS server was provisioned on this cluster group; unable to remove records for domain")
 	}
 
 	vpc.Dns.RemoveRecordsForDomain(domain)
@@ -182,7 +183,7 @@ func (vpc *VaultPkiCluster) RemoveDNSRecordsForDomain(domain string) error {
 
 func (vpc *VaultPkiCluster) RemoveAllDNSRecords() error {
 	if vpc.Dns == nil {
-		return fmt.Errorf("no DNS server was provisioned on this cluster group; unable to remove all records")
+		return errors.New("no DNS server was provisioned on this cluster group; unable to remove all records")
 	}
 
 	vpc.Dns.RemoveAllRecords()
@@ -249,7 +250,7 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 		return nil, fmt.Errorf("failed generating root internal: %w", err)
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return nil, fmt.Errorf("failed generating root internal: nil or empty response but no error")
+		return nil, errors.New("failed generating root internal: nil or empty response but no error")
 	}
 
 	resp, err = pki.GenerateIntermediateInternal(map[string]interface{}{
@@ -265,7 +266,7 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 		return nil, fmt.Errorf("failed generating int csr: %w", err)
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return nil, fmt.Errorf("failed generating int csr: nil or empty response but no error")
+		return nil, errors.New("failed generating int csr: nil or empty response but no error")
 	}
 
 	resp, err = pki.SignIntermediary("default", resp.Data["csr"], map[string]interface{}{
@@ -280,7 +281,7 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 		return nil, fmt.Errorf("failed signing int csr: %w", err)
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return nil, fmt.Errorf("failed signing int csr: nil or empty response but no error")
+		return nil, errors.New("failed signing int csr: nil or empty response but no error")
 	}
 	intCert := resp.Data["certificate"].(string)
 
@@ -289,7 +290,7 @@ func (vpc *VaultPkiCluster) CreateAcmeMount(mountName string) (*VaultPkiMount, e
 		return nil, fmt.Errorf("failed importing signed cert: %w", err)
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return nil, fmt.Errorf("failed importing signed cert: nil or empty response but no error")
+		return nil, errors.New("failed importing signed cert: nil or empty response but no error")
 	}
 
 	err = pki.UpdateDefaultIssuer(resp.Data["imported_issuers"].([]interface{})[0].(string), nil)

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -5,6 +5,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -107,7 +108,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		Tags:     []string{role.Tags},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a new user with the generated credentials")
+		return nil, errors.New("failed to create a new user with the generated credentials")
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {

--- a/builtin/logical/rabbitmq/path_role_create_test.go
+++ b/builtin/logical/rabbitmq/path_role_create_test.go
@@ -76,12 +76,12 @@ func TestBackend_RoleCreate_DefaultUsernameTemplate(t *testing.T) {
 		t.Fatal("missing creds response")
 	}
 	if resp.Data == nil {
-		t.Fatalf("missing creds data")
+		t.Fatal("missing creds data")
 	}
 
 	username, exists := resp.Data["username"]
 	if !exists {
-		t.Fatalf("missing username in response")
+		t.Fatal("missing username in response")
 	}
 
 	require.Regexp(t, `^token-[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$`, username)
@@ -152,12 +152,12 @@ func TestBackend_RoleCreate_CustomUsernameTemplate(t *testing.T) {
 		t.Fatal("missing creds response")
 	}
 	if resp.Data == nil {
-		t.Fatalf("missing creds data")
+		t.Fatal("missing creds data")
 	}
 
 	username, exists := resp.Data["username"]
 	if !exists {
-		t.Fatalf("missing username in response")
+		t.Fatal("missing username in response")
 	}
 
 	require.Regexp(t, `^foo-token$`, username)

--- a/builtin/logical/rabbitmq/secret_creds.go
+++ b/builtin/logical/rabbitmq/secret_creds.go
@@ -5,6 +5,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -54,7 +55,7 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, d
 	// Get the username from the internal data
 	usernameRaw, ok := req.Secret.InternalData["username"]
 	if !ok {
-		return nil, fmt.Errorf("secret is missing username internal data")
+		return nil, errors.New("secret is missing username internal data")
 	}
 	username := usernameRaw.(string)
 

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -439,7 +439,7 @@ func TestBackend_DefaultUserTemplateFalse_AllowedUsersTemplateTrue(t *testing.T)
 		"public_key": testCAPublicKey,
 	})
 	if err == nil {
-		t.Errorf("signing request should fail when default_user is not in the allowed_users list, because allowed_users_template is true and default_user_template is not")
+		t.Error("signing request should fail when default_user is not in the allowed_users list, because allowed_users_template is true and default_user_template is not")
 	}
 
 	expectedErrStr := "{{identity.entity.metadata.ssh_username}} is not a valid value for valid_principals"
@@ -2763,7 +2763,7 @@ func TestProperAuthing(t *testing.T) {
 	}
 
 	if len(openAPIResp.Data["paths"].(map[string]interface{})) == 0 {
-		t.Fatalf("expected to get response from OpenAPI; got empty path list")
+		t.Fatal("expected to get response from OpenAPI; got empty path list")
 	}
 
 	validatedPath := false
@@ -2811,12 +2811,12 @@ func TestProperAuthing(t *testing.T) {
 
 		if handler == shouldBeUnauthedReadList {
 			if hasPost || hasDelete {
-				t.Fatalf("Unauthed read-only endpoints should not have POST/DELETE capabilities")
+				t.Fatal("Unauthed read-only endpoints should not have POST/DELETE capabilities")
 			}
 		}
 	}
 
 	if !validatedPath {
-		t.Fatalf("Expected to have validated at least one path.")
+		t.Fatal("Expected to have validated at least one path.")
 	}
 }

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -939,7 +939,7 @@ cKumubUxOfFdy1ZvAAAAEm5jY0BtYnAudWJudC5sb2NhbA==
 
 					err = testSSH(testUserName, sshAddress, ssh.PublicKeys(certSigner), "date")
 					if expectError && err == nil {
-						return fmt.Errorf("expected error but got none")
+						return errors.New("expected error but got none")
 					}
 					if !expectError && err != nil {
 						return err
@@ -1125,7 +1125,7 @@ func TestBackend_AbleToAutoGenerateSigningKeys(t *testing.T) {
 				Path:      "config/ca",
 				Check: func(resp *logical.Response) error {
 					if resp.Data["public_key"].(string) == "" {
-						return fmt.Errorf("public_key empty")
+						return errors.New("public_key empty")
 					}
 					expectedPublicKey = resp.Data["public_key"].(string)
 					return nil
@@ -2282,7 +2282,7 @@ func testVerifyWrite(t *testing.T, data map[string]interface{}, expected map[str
 			}
 
 			if !reflect.DeepEqual(ac, ex) {
-				return fmt.Errorf("invalid response")
+				return errors.New("invalid response")
 			}
 			return nil
 		},
@@ -2296,7 +2296,7 @@ func testLookupRead(t *testing.T, data map[string]interface{}, expected []string
 		Data:      data,
 		Check: func(resp *logical.Response) error {
 			if resp.Data == nil || resp.Data["roles"] == nil {
-				return fmt.Errorf("missing roles information")
+				return errors.New("missing roles information")
 			}
 			if !reflect.DeepEqual(resp.Data["roles"].([]string), expected) {
 				return fmt.Errorf("Invalid response: \nactual:%#v\nexpected:%#v", resp.Data["roles"].([]string), expected)
@@ -2320,10 +2320,10 @@ func testRoleList(t *testing.T, expected map[string]interface{}) logicaltest.Tes
 		Path:      "roles",
 		Check: func(resp *logical.Response) error {
 			if resp == nil {
-				return fmt.Errorf("nil response")
+				return errors.New("nil response")
 			}
 			if resp.Data == nil {
-				return fmt.Errorf("nil data")
+				return errors.New("nil data")
 			}
 			if !reflect.DeepEqual(resp.Data, expected) {
 				return fmt.Errorf("Invalid response:\nactual:%#v\nexpected is %#v", resp.Data, expected)
@@ -2376,10 +2376,10 @@ func testCredsWrite(t *testing.T, roleName string, data map[string]interface{}, 
 		ErrorOk:   expectError,
 		Check: func(resp *logical.Response) error {
 			if resp == nil {
-				return fmt.Errorf("response is nil")
+				return errors.New("response is nil")
 			}
 			if resp.Data == nil {
-				return fmt.Errorf("data is nil")
+				return errors.New("data is nil")
 			}
 			if expectError {
 				var e struct {
@@ -2389,7 +2389,7 @@ func testCredsWrite(t *testing.T, roleName string, data map[string]interface{}, 
 					return err
 				}
 				if len(e.Error) == 0 {
-					return fmt.Errorf("expected error, but write succeeded")
+					return errors.New("expected error, but write succeeded")
 				}
 				return nil
 			}
@@ -2401,22 +2401,22 @@ func testCredsWrite(t *testing.T, roleName string, data map[string]interface{}, 
 					return err
 				}
 				if d.Key == "" {
-					return fmt.Errorf("generated key is an empty string")
+					return errors.New("generated key is an empty string")
 				}
 				// Checking only for a parsable key
 				privKey, err := ssh.ParsePrivateKey([]byte(d.Key))
 				if err != nil {
-					return fmt.Errorf("generated key is invalid")
+					return errors.New("generated key is invalid")
 				}
 				if err := testSSH(data["username"].(string), address, ssh.PublicKeys(privKey), "date"); err != nil {
 					return fmt.Errorf("unable to SSH with new key (%s): %w", d.Key, err)
 				}
 			} else {
 				if resp.Data["key_type"] != KeyTypeOTP {
-					return fmt.Errorf("incorrect key_type")
+					return errors.New("incorrect key_type")
 				}
 				if resp.Data["key"] == nil {
-					return fmt.Errorf("invalid key")
+					return errors.New("invalid key")
 				}
 			}
 			return nil

--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -242,7 +242,7 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 	}
 
 	if publicKey == "" || privateKey == "" {
-		return nil, fmt.Errorf("failed to generate or parse the keys")
+		return nil, errors.New("failed to generate or parse the keys")
 	}
 
 	publicKeyEntry, err := caKey(ctx, req.Storage, caPublicKey)

--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -42,7 +42,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if privateKeyEntry == nil || privateKeyEntry.Key == "" {
-		t.Fatalf("failed to read the stored private key")
+		t.Fatal("failed to read the stored private key")
 	}
 
 	entry, err := config.StorageView.Get(context.Background(), caPrivateKeyStoragePathDeprecated)
@@ -50,7 +50,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entry != nil {
-		t.Fatalf("bad: expected a nil entry after upgrade")
+		t.Fatal("bad: expected a nil entry after upgrade")
 	}
 
 	entry, err = config.StorageView.Get(context.Background(), caPrivateKeyStoragePath)
@@ -58,7 +58,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entry == nil {
-		t.Fatalf("bad: expected a non-nil entry after upgrade")
+		t.Fatal("bad: expected a non-nil entry after upgrade")
 	}
 
 	// Store at an older path
@@ -76,7 +76,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if publicKeyEntry == nil || publicKeyEntry.Key == "" {
-		t.Fatalf("failed to read the stored public key")
+		t.Fatal("failed to read the stored public key")
 	}
 
 	entry, err = config.StorageView.Get(context.Background(), caPublicKeyStoragePathDeprecated)
@@ -84,7 +84,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entry != nil {
-		t.Fatalf("bad: expected a nil entry after upgrade")
+		t.Fatal("bad: expected a nil entry after upgrade")
 	}
 
 	entry, err = config.StorageView.Get(context.Background(), caPublicKeyStoragePath)
@@ -92,7 +92,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entry == nil {
-		t.Fatalf("bad: expected a non-nil entry after upgrade")
+		t.Fatal("bad: expected a non-nil entry after upgrade")
 	}
 }
 

--- a/builtin/logical/ssh/path_creds_create.go
+++ b/builtin/logical/ssh/path_creds_create.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -149,9 +150,9 @@ func (b *backend) pathCredsCreateWrite(ctx context.Context, req *logical.Request
 			"otp": otp,
 		})
 	} else if role.KeyType == KeyTypeDynamic {
-		return nil, fmt.Errorf("dynamic key types have been removed")
+		return nil, errors.New("dynamic key types have been removed")
 	} else {
-		return nil, fmt.Errorf("key type unknown")
+		return nil, errors.New("key type unknown")
 	}
 
 	return result, nil
@@ -228,7 +229,7 @@ func validateIP(ip, roleName, cidrList, excludeCidrList string, zeroAddressRoles
 		return err
 	}
 	if !ipMatched {
-		return fmt.Errorf("IP does not belong to role")
+		return errors.New("IP does not belong to role")
 	}
 
 	if len(excludeCidrList) == 0 {
@@ -241,7 +242,7 @@ func validateIP(ip, roleName, cidrList, excludeCidrList string, zeroAddressRoles
 		return err
 	}
 	if ipMatched {
-		return fmt.Errorf("IP does not belong to role")
+		return errors.New("IP does not belong to role")
 	}
 
 	return nil
@@ -251,7 +252,7 @@ func validateIP(ip, roleName, cidrList, excludeCidrList string, zeroAddressRoles
 // allowed users registered which creation of role.
 func validateUsername(username, allowedUsers string) error {
 	if allowedUsers == "" {
-		return fmt.Errorf("username not in allowed users list")
+		return errors.New("username not in allowed users list")
 	}
 
 	// Role was explicitly configured to allow any username.
@@ -266,7 +267,7 @@ func validateUsername(username, allowedUsers string) error {
 		}
 	}
 
-	return fmt.Errorf("username not in allowed users list")
+	return errors.New("username not in allowed users list")
 }
 
 const pathCredsCreateHelpSyn = `

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -192,7 +192,7 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 	switch {
 	case len(parsedPrincipals) == 0:
 		if !role.AllowEmptyPrincipals && principalsAllowedByRole != "*" {
-			return nil, fmt.Errorf("refusing to issue unsafe, globally-valid certificate with no principals specified; set valid_principals or default_user")
+			return nil, errors.New("refusing to issue unsafe, globally-valid certificate with no principals specified; set valid_principals or default_user")
 		}
 
 		// There is nothing to process
@@ -200,7 +200,7 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 	case len(allowedPrincipals) == 0:
 		// User has requested principals to be set, but role is not configured
 		// with any principals
-		return nil, fmt.Errorf("role is not configured to allow any principals")
+		return nil, errors.New("role is not configured to allow any principals")
 	default:
 		// Role was explicitly configured to allow any principal.
 		if principalsAllowedByRole == "*" {
@@ -258,7 +258,7 @@ func (b *backend) calculateKeyID(data *framework.FieldData, req *logical.Request
 
 	if reqID != "" {
 		if !role.AllowUserKeyIDs {
-			return "", fmt.Errorf("setting key_id is not allowed by role")
+			return "", errors.New("setting key_id is not allowed by role")
 		}
 		return reqID, nil
 	}
@@ -499,7 +499,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 
 	sshAlgorithmSigner, ok := b.Signer.(ssh.AlgorithmSigner)
 	if !ok {
-		return nil, fmt.Errorf("failed to generate signed SSH key: signer is not an AlgorithmSigner")
+		return nil, errors.New("failed to generate signed SSH key: signer is not an AlgorithmSigner")
 	}
 
 	// prepare certificate for signing

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -732,7 +733,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 			"not_before_duration":         int64(role.NotBeforeDuration.Seconds()),
 		}
 	case KeyTypeDynamic:
-		return nil, fmt.Errorf("dynamic key type roles are no longer supported")
+		return nil, errors.New("dynamic key type roles are no longer supported")
 	default:
 		return nil, fmt.Errorf("invalid key type: %v", role.KeyType)
 	}

--- a/builtin/logical/ssh/secret_otp.go
+++ b/builtin/logical/ssh/secret_otp.go
@@ -5,7 +5,7 @@ package ssh
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -30,11 +30,11 @@ func secretOTP(b *backend) *framework.Secret {
 func (b *backend) secretOTPRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	otpRaw, ok := req.Secret.InternalData["otp"]
 	if !ok {
-		return nil, fmt.Errorf("secret is missing internal data")
+		return nil, errors.New("secret is missing internal data")
 	}
 	otp, ok := otpRaw.(string)
 	if !ok {
-		return nil, fmt.Errorf("secret is missing internal data")
+		return nil, errors.New("secret is missing internal data")
 	}
 
 	salt, err := b.Salt(ctx)

--- a/builtin/logical/ssh/util.go
+++ b/builtin/logical/ssh/util.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -44,11 +45,11 @@ func generateRSAKeys(keyBits int) (publicKeyRsa string, privateKeyRsa string, er
 // of CIDR blocks belonging to the role.
 func roleContainsIP(ctx context.Context, s logical.Storage, roleName string, ip string) (bool, error) {
 	if roleName == "" {
-		return false, fmt.Errorf("missing role name")
+		return false, errors.New("missing role name")
 	}
 
 	if ip == "" {
-		return false, fmt.Errorf("missing ip")
+		return false, errors.New("missing ip")
 	}
 
 	roleEntry, err := s.Get(ctx, fmt.Sprintf("roles/%s", roleName))
@@ -75,7 +76,7 @@ func roleContainsIP(ctx context.Context, s logical.Storage, roleName string, ip 
 // separated CIDR blocks
 func cidrListContainsIP(ip, cidrList string) (bool, error) {
 	if len(cidrList) == 0 {
-		return false, fmt.Errorf("IP does not belong to role")
+		return false, errors.New("IP does not belong to role")
 	}
 	for _, item := range strings.Split(cidrList, ",") {
 		_, cidrIPNet, err := net.ParseCIDR(item)

--- a/builtin/logical/totp/backend_test.go
+++ b/builtin/logical/totp/backend_test.go
@@ -1052,7 +1052,7 @@ func testAccStepCreateKey(t *testing.T, name string, keyData map[string]interfac
 			// Check to see if barcode and url were returned if exported is false
 			if !keyData["exported"].(bool) {
 				if resp != nil {
-					t.Fatalf("data was returned when exported was set to false")
+					t.Fatal("data was returned when exported was set to false")
 				}
 				return nil
 			}
@@ -1060,7 +1060,7 @@ func testAccStepCreateKey(t *testing.T, name string, keyData map[string]interfac
 			// Check to see if a barcode was returned when qr_size is zero
 			if keyData["qr_size"].(int) == 0 {
 				if _, exists := resp.Data["barcode"]; exists {
-					t.Fatalf("a barcode was returned when qr_size was set to zero")
+					t.Fatal("a barcode was returned when qr_size was set to zero")
 				}
 				return nil
 			}
@@ -1076,11 +1076,11 @@ func testAccStepCreateKey(t *testing.T, name string, keyData map[string]interfac
 
 			// Check to see if barcode and url are returned
 			if d.Barcode == "" {
-				t.Fatalf("a barcode was not returned for a generated key")
+				t.Fatal("a barcode was not returned for a generated key")
 			}
 
 			if d.Url == "" {
-				t.Fatalf("a url was not returned for a generated key")
+				t.Fatal("a url was not returned for a generated key")
 			}
 
 			// Parse url
@@ -1144,7 +1144,7 @@ func testAccStepReadCreds(t *testing.T, b logical.Backend, s logical.Storage, na
 			})
 
 			if !valid {
-				t.Fatalf("generated code isn't valid")
+				t.Fatal("generated code isn't valid")
 			}
 
 			return nil

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -50,7 +50,7 @@ func createBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 
 	b, _ := Backend(context.Background(), config)
 	if b == nil {
-		t.Fatalf("failed to create backend")
+		t.Fatal("failed to create backend")
 	}
 	err := b.Backend.Setup(context.Background(), config)
 	if err != nil {
@@ -206,7 +206,7 @@ func testTransit_RSA(t *testing.T, keyType string) {
 	ciphertext2 := resp.Data["ciphertext"].(string)
 
 	if ciphertext1 == ciphertext2 {
-		t.Fatalf("expected different ciphertexts")
+		t.Fatal("expected different ciphertexts")
 	}
 
 	// See if the older ciphertext can still be decrypted
@@ -259,7 +259,7 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
 	}
 	if !resp.Data["valid"].(bool) {
-		t.Fatalf("failed to verify the RSA signature")
+		t.Fatal("failed to verify the RSA signature")
 	}
 
 	signReq.Data = map[string]interface{}{
@@ -290,7 +290,7 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
 	}
 	if resp.Data["valid"].(bool) {
-		t.Fatalf("expected validation to fail")
+		t.Fatal("expected validation to fail")
 	}
 
 	verifyReq.Data = map[string]interface{}{
@@ -303,7 +303,7 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
 	}
 	if !resp.Data["valid"].(bool) {
-		t.Fatalf("failed to verify the RSA signature")
+		t.Fatal("failed to verify the RSA signature")
 	}
 
 	// Take a random hash and sign it using PKCSv1_5_NoOID.
@@ -332,7 +332,7 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
 	}
 	if !resp.Data["valid"].(bool) {
-		t.Fatalf("failed to verify the RSA signature")
+		t.Fatal("failed to verify the RSA signature")
 	}
 }
 
@@ -1225,7 +1225,7 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext3, ciphertext4)
 	}
 	if ciphertext1 == ciphertext3 {
-		t.Fatalf("expected different ciphertexts")
+		t.Fatal("expected different ciphertexts")
 	}
 
 	// ...and a different context value
@@ -1264,10 +1264,10 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext5, ciphertext6)
 	}
 	if ciphertext1 == ciphertext5 {
-		t.Fatalf("expected different ciphertexts")
+		t.Fatal("expected different ciphertexts")
 	}
 	if ciphertext3 == ciphertext5 {
-		t.Fatalf("expected different ciphertexts")
+		t.Fatal("expected different ciphertexts")
 	}
 
 	// If running version 2, check upgrade handling
@@ -1337,10 +1337,10 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 			t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext7, ciphertext8)
 		}
 		if ciphertext6 == ciphertext7 {
-			t.Fatalf("expected different ciphertexts")
+			t.Fatal("expected different ciphertexts")
 		}
 		if ciphertext3 == ciphertext7 {
-			t.Fatalf("expected different ciphertexts")
+			t.Fatal("expected different ciphertexts")
 		}
 	}
 
@@ -2120,7 +2120,7 @@ func testTransit_SignWithImportedPublicKey(t *testing.T, keyType string) {
 
 	_, err = b.HandleRequest(context.Background(), signReq)
 	if err == nil {
-		t.Fatalf("expected error, should have failed to sign input")
+		t.Fatal("expected error, should have failed to sign input")
 	}
 }
 

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -502,17 +503,17 @@ func testAccStepListPolicy(t *testing.T, name string, expectNone bool) logicalte
 		Path:      "keys",
 		Check: func(resp *logical.Response) error {
 			if resp == nil {
-				return fmt.Errorf("missing response")
+				return errors.New("missing response")
 			}
 			if expectNone {
 				keysRaw, ok := resp.Data["keys"]
 				if ok || keysRaw != nil {
-					return fmt.Errorf("response data when expecting none")
+					return errors.New("response data when expecting none")
 				}
 				return nil
 			}
 			if len(resp.Data) == 0 {
-				return fmt.Errorf("no data returned")
+				return errors.New("no data returned")
 			}
 
 			var d struct {
@@ -586,12 +587,12 @@ func testAccStepDeleteNotDisabledPolicy(t *testing.T, name string) logicaltest.T
 		ErrorOk:   true,
 		Check: func(resp *logical.Response) error {
 			if resp == nil {
-				return fmt.Errorf("got nil response instead of error")
+				return errors.New("got nil response instead of error")
 			}
 			if resp.IsError() {
 				return nil
 			}
-			return fmt.Errorf("expected error but did not get one")
+			return errors.New("expected error but did not get one")
 		},
 	}
 }
@@ -606,10 +607,10 @@ func testAccStepReadPolicyWithVersions(t *testing.T, name string, expectNone, de
 		Path:      "keys/" + name,
 		Check: func(resp *logical.Response) error {
 			if resp == nil && !expectNone {
-				return fmt.Errorf("missing response")
+				return errors.New("missing response")
 			} else if expectNone {
 				if resp != nil {
-					return fmt.Errorf("response when expecting none")
+					return errors.New("response when expecting none")
 				}
 				return nil
 			}
@@ -683,7 +684,7 @@ func testAccStepEncrypt(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
 			return nil
@@ -708,7 +709,7 @@ func testAccStepEncryptUpsert(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
 			return nil
@@ -734,7 +735,7 @@ func testAccStepEncryptContext(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
 			decryptData["context"] = base64.StdEncoding.EncodeToString([]byte(context))
@@ -787,7 +788,7 @@ func testAccStepRewrap(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			splitStrings := strings.Split(d.Ciphertext, ":")
 			verString := splitStrings[1][1:]
@@ -796,7 +797,7 @@ func testAccStepRewrap(
 				return fmt.Errorf("error pulling out version from verString %q, ciphertext was %s", verString, d.Ciphertext)
 			}
 			if ver != expectedVer {
-				return fmt.Errorf("did not get expected version")
+				return errors.New("did not get expected version")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
 			return nil
@@ -822,7 +823,7 @@ func testAccStepEncryptVX(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			splitStrings := strings.Split(d.Ciphertext, ":")
 			splitStrings[1] = "v" + strconv.Itoa(ver)
@@ -861,7 +862,7 @@ func testAccStepDecryptExpectFailure(
 		ErrorOk:   true,
 		Check: func(resp *logical.Response) error {
 			if !resp.IsError() {
-				return fmt.Errorf("expected error")
+				return errors.New("expected error")
 			}
 			return nil
 		},
@@ -900,11 +901,11 @@ func testAccStepWriteDatakey(t *testing.T, name string,
 				return err
 			}
 			if noPlaintext && len(d.Plaintext) != 0 {
-				return fmt.Errorf("received plaintxt when we disabled it")
+				return errors.New("received plaintxt when we disabled it")
 			}
 			if !noPlaintext {
 				if len(d.Plaintext) == 0 {
-					return fmt.Errorf("did not get plaintext when we expected it")
+					return errors.New("did not get plaintext when we expected it")
 				}
 				dataKeyInfo["plaintext"] = d.Plaintext
 				plainBytes, err := base64.StdEncoding.DecodeString(d.Plaintext)
@@ -912,7 +913,7 @@ func testAccStepWriteDatakey(t *testing.T, name string,
 					return fmt.Errorf("could not base64 decode plaintext string %q", d.Plaintext)
 				}
 				if len(plainBytes)*8 != bits {
-					return fmt.Errorf("returned key does not have correct bit length")
+					return errors.New("returned key does not have correct bit length")
 				}
 			}
 			dataKeyInfo["ciphertext"] = d.Ciphertext

--- a/builtin/logical/transit/path_backup_test.go
+++ b/builtin/logical/transit/path_backup_test.go
@@ -137,7 +137,7 @@ func testBackupRestore(t *testing.T, keyType, feature string) {
 		t.Fatalf("resp: %#v\nerr: %v", resp, err)
 	}
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	plaintextB64 := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"

--- a/builtin/logical/transit/path_byok.go
+++ b/builtin/logical/transit/path_byok.go
@@ -79,7 +79,7 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 		return nil, err
 	}
 	if dstP == nil {
-		return nil, fmt.Errorf("no such destination key to export to")
+		return nil, errors.New("no such destination key to export to")
 	}
 	if !b.System().CachingDisabled() {
 		dstP.Lock(false)
@@ -98,7 +98,7 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 		return nil, err
 	}
 	if srcP == nil {
-		return nil, fmt.Errorf("no such source key for export")
+		return nil, errors.New("no such source key for export")
 	}
 	if !b.System().CachingDisabled() {
 		srcP.Lock(false)

--- a/builtin/logical/transit/path_cache_config_test.go
+++ b/builtin/logical/transit/path_cache_config_test.go
@@ -38,7 +38,7 @@ func TestTransit_CacheConfig(t *testing.T) {
 	validateResponse := func(resp *logical.Response, expectedCacheSize int, expectedWarning bool) {
 		actualCacheSize, ok := resp.Data["size"].(int)
 		if !ok {
-			t.Fatalf("No size returned")
+			t.Fatal("No size returned")
 		}
 		if expectedCacheSize != actualCacheSize {
 			t.Fatalf("testAccReadCacheConfig expected: %d got: %d", expectedCacheSize, actualCacheSize)

--- a/builtin/logical/transit/path_certificates_test.go
+++ b/builtin/logical/transit/path_certificates_test.go
@@ -281,14 +281,14 @@ func testTransit_Certificates_ImportCertChain(t *testing.T, apiClient *api.Clien
 	require.NotNil(t, resp)
 	keys, ok := resp.Data["keys"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("could not cast Keys value")
+		t.Fatal("could not cast Keys value")
 	}
 	keyData, ok := keys["1"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("could not cast key version 1 from keys")
+		t.Fatal("could not cast key version 1 from keys")
 	}
 	_, present := keyData["certificate_chain"]
 	if !present {
-		t.Fatalf("certificate chain not present in key version 1")
+		t.Fatal("certificate chain not present in key version 1")
 	}
 }

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
+	"errors"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
@@ -140,7 +140,7 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 	}
 
 	if ciphertext == "" {
-		return nil, fmt.Errorf("empty ciphertext returned")
+		return nil, errors.New("empty ciphertext returned")
 	}
 
 	keyVersion := ver

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -596,7 +596,7 @@ func TestTransit_BatchEncryptionCase10(t *testing.T) {
 	}
 	_, err = b.HandleRequest(context.Background(), batchReq)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -647,7 +647,7 @@ func TestTransit_BatchEncryptionCase12(t *testing.T) {
 	}
 	_, err = b.HandleRequest(context.Background(), batchReq)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -202,7 +202,7 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 			src = key.Key
 		}
 		if format == "der" || format == "pem" {
-			return "", fmt.Errorf("unknown format for HMAC key; supported values are `` or `raw`")
+			return "", errors.New("unknown format for HMAC key; supported values are `` or `raw`")
 		}
 
 		return strings.TrimSpace(base64.StdEncoding.EncodeToString(src)), nil
@@ -210,7 +210,7 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 		switch policy.Type {
 		case keysutil.KeyType_AES128_GCM96, keysutil.KeyType_AES256_GCM96, keysutil.KeyType_ChaCha20_Poly1305, keysutil.KeyType_XChaCha20_Poly1305:
 			if format == "der" || format == "pem" {
-				return "", fmt.Errorf("unknown format for HMAC key; supported values are `` or `raw`")
+				return "", errors.New("unknown format for HMAC key; supported values are `` or `raw`")
 			}
 
 			return strings.TrimSpace(base64.StdEncoding.EncodeToString(key.Key)), nil
@@ -301,7 +301,7 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 
 func encodeRSAPrivateKey(key *keysutil.KeyEntry, format string) (string, error) {
 	if format == "raw" {
-		return "", fmt.Errorf("unknown key format for rsa key; supported values are ``, `der`, or `pem`")
+		return "", errors.New("unknown key format for rsa key; supported values are ``, `der`, or `pem`")
 	}
 
 	if key == nil {
@@ -341,7 +341,7 @@ func encodeRSAPrivateKey(key *keysutil.KeyEntry, format string) (string, error) 
 
 func encodeRSAPublicKey(key *keysutil.KeyEntry, format string) (string, error) {
 	if format == "raw" {
-		return "", fmt.Errorf("unknown key format for rsa key; supported values are ``, `der`, or `pem`")
+		return "", errors.New("unknown key format for rsa key; supported values are ``, `der`, or `pem`")
 	}
 
 	if key == nil {
@@ -375,7 +375,7 @@ func encodeRSAPublicKey(key *keysutil.KeyEntry, format string) (string, error) {
 	}
 	pemBytes := pem.EncodeToMemory(pemBlock)
 	if pemBytes == nil || len(pemBytes) == 0 {
-		return "", fmt.Errorf("failed to PEM-encode RSA public key")
+		return "", errors.New("failed to PEM-encode RSA public key")
 	}
 
 	return string(pemBytes), nil
@@ -383,7 +383,7 @@ func encodeRSAPublicKey(key *keysutil.KeyEntry, format string) (string, error) {
 
 func keyEntryToECPrivateKey(k *keysutil.KeyEntry, curve elliptic.Curve, format string) (string, error) {
 	if format == "raw" {
-		return "", fmt.Errorf("unknown key format for ec key; supported values are ``, `der`, or `pem`")
+		return "", errors.New("unknown key format for ec key; supported values are ``, `der`, or `pem`")
 	}
 
 	if k == nil {
@@ -433,7 +433,7 @@ func keyEntryToECPrivateKey(k *keysutil.KeyEntry, curve elliptic.Curve, format s
 
 func keyEntryToECPublicKey(k *keysutil.KeyEntry, curve elliptic.Curve, format string) (string, error) {
 	if format == "raw" {
-		return "", fmt.Errorf("unknown key format for ec key; supported values are ``, `der`, or `pem`")
+		return "", errors.New("unknown key format for ec key; supported values are ``, `der`, or `pem`")
 	}
 
 	if k == nil {

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -689,6 +689,6 @@ func testTransit_Export_CertificateChain(t *testing.T, apiClient *api.Client, ke
 	exportedCertChainPEM := exportedKeys["1"].(string)
 
 	if exportedCertChainPEM != leafCertPEM {
-		t.Fatalf("expected exported cert chain to match with imported value")
+		t.Fatal("expected exported cert chain to match with imported value")
 	}
 }

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -362,7 +363,7 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 		}
 		if key == nil {
 			response[i].Error = ""
-			response[i].err = fmt.Errorf("HMAC key value could not be computed")
+			response[i].err = errors.New("HMAC key value could not be computed")
 			continue
 		}
 

--- a/builtin/logical/transit/path_hmac_test.go
+++ b/builtin/logical/transit/path_hmac_test.go
@@ -198,7 +198,7 @@ func TestTransit_HMAC(t *testing.T) {
 			t.Fatal("expected non-nil response")
 		}
 		if resp.Data["valid"].(bool) {
-			t.Fatalf("expected error validating hmac")
+			t.Fatal("expected error validating hmac")
 		}
 
 		// Set min decryption version, attempt to verify

--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -333,7 +333,7 @@ func (b *backend) decryptImportedKey(ctx context.Context, storage logical.Storag
 		return nil, err
 	}
 	if wrappingKey == nil {
-		return nil, fmt.Errorf("error importing key: wrapping key was nil")
+		return nil, errors.New("error importing key: wrapping key was nil")
 	}
 
 	privWrappingKey := wrappingKey.Keys[strconv.Itoa(wrappingKey.LatestVersion)].RSAKey

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -8,6 +8,7 @@ import (
 	"crypto/elliptic"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -310,7 +311,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		return nil, err
 	}
 	if p == nil {
-		return nil, fmt.Errorf("error generating key: returned policy was nil")
+		return nil, errors.New("error generating key: returned policy was nil")
 	}
 	if !b.System().CachingDisabled() {
 		p.Lock(false)

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -210,7 +210,7 @@ func TestTransit_Restore(t *testing.T) {
 				t.Fatalf("resp: %#v\nerr: %v", resp, err)
 			}
 			if err == nil && tc.ExpectedErr != nil {
-				t.Fatalf("expected an error, but got none")
+				t.Fatal("expected an error, but got none")
 			}
 			if err != nil && tc.ExpectedErr == nil {
 				t.Fatalf("unexpected error:%s", err)

--- a/builtin/logical/transit/path_rewrap_test.go
+++ b/builtin/logical/transit/path_rewrap_test.go
@@ -101,7 +101,7 @@ func TestTransit_BatchRewrapCase1(t *testing.T) {
 	}
 
 	if ciphertext.(string) == resp.Data["ciphertext"].(string) {
-		t.Fatalf("bad: ciphertexts are same before and after rewrap")
+		t.Fatal("bad: ciphertexts are same before and after rewrap")
 	}
 
 	if !strings.HasPrefix(resp.Data["ciphertext"].(string), "vault:v2") {
@@ -206,7 +206,7 @@ func TestTransit_BatchRewrapCase2(t *testing.T) {
 	}
 
 	if ciphertext.(string) == resp.Data["ciphertext"].(string) {
-		t.Fatalf("bad: ciphertexts are same before and after rewrap")
+		t.Fatal("bad: ciphertexts are same before and after rewrap")
 	}
 
 	if !strings.HasPrefix(resp.Data["ciphertext"].(string), "vault:v2") {
@@ -298,7 +298,7 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 		}
 
 		if eItem.Ciphertext == rItem.Ciphertext {
-			t.Fatalf("bad: rewrap input and output are the same")
+			t.Fatal("bad: rewrap input and output are the same")
 		}
 
 		if !strings.HasPrefix(rItem.Ciphertext, "vault:v2") {

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -449,7 +450,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 			}
 			response[i].err = err
 		} else if sig == nil {
-			response[i].err = fmt.Errorf("signature could not be computed")
+			response[i].err = errors.New("signature could not be computed")
 		} else {
 			keyVersion := ver
 			if keyVersion == 0 {

--- a/builtin/logical/transit/path_trim_test.go
+++ b/builtin/logical/transit/path_trim_test.go
@@ -221,7 +221,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 	doReq(t, req)
 	if p.MinEncryptionVersion != 10 {
-		t.Fatalf("failed to set min encryption version")
+		t.Fatal("failed to set min encryption version")
 	}
 
 	// Set min decryption version to 9
@@ -230,7 +230,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 	doReq(t, req)
 	if p.MinDecryptionVersion != 9 {
-		t.Fatalf("failed to set min encryption version")
+		t.Fatal("failed to set min encryption version")
 	}
 
 	// Reduce the min decryption version to 8
@@ -239,7 +239,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 	doReq(t, req)
 	if p.MinDecryptionVersion != 8 {
-		t.Fatalf("failed to set min encryption version")
+		t.Fatal("failed to set min encryption version")
 	}
 
 	// Reduce the min encryption version to 8
@@ -248,7 +248,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 	doReq(t, req)
 	if p.MinDecryptionVersion != 8 {
-		t.Fatalf("failed to set min decryption version")
+		t.Fatal("failed to set min decryption version")
 	}
 
 	// Read the key to ensure that the keys are properly copied from the

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -51,7 +52,7 @@ func (b *backend) pathWrappingKeyRead(ctx context.Context, req *logical.Request,
 	}
 	pemBytes := pem.EncodeToMemory(pemBlock)
 	if pemBytes == nil || len(pemBytes) == 0 {
-		return nil, fmt.Errorf("failed to PEM-encode RSA public key")
+		return nil, errors.New("failed to PEM-encode RSA public key")
 	}
 
 	publicKeyString := string(pemBytes)
@@ -82,7 +83,7 @@ func (b *backend) getWrappingKey(ctx context.Context, storage logical.Storage) (
 		return nil, err
 	}
 	if p == nil {
-		return nil, fmt.Errorf("error retrieving wrapping key: returned policy was nil")
+		return nil, errors.New("error retrieving wrapping key: returned policy was nil")
 	}
 	if b.System().CachingDisabled() {
 		p.Unlock()

--- a/builtin/logical/transit/stepwise_test.go
+++ b/builtin/logical/transit/stepwise_test.go
@@ -5,6 +5,7 @@ package transit
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -61,10 +62,10 @@ func testAccStepwiseListPolicy(t *testing.T, name string, expectNone bool) stepw
 		Path:      "keys",
 		Assert: func(resp *api.Secret, err error) error {
 			if (resp == nil || len(resp.Data) == 0) && !expectNone {
-				return fmt.Errorf("missing response")
+				return errors.New("missing response")
 			}
 			if expectNone && resp != nil {
-				return fmt.Errorf("response data when expecting none")
+				return errors.New("response data when expecting none")
 			}
 
 			if expectNone && resp == nil {
@@ -78,7 +79,7 @@ func testAccStepwiseListPolicy(t *testing.T, name string, expectNone bool) stepw
 				return err
 			}
 			if len(d.Keys) == 0 {
-				return fmt.Errorf("missing keys")
+				return errors.New("missing keys")
 			}
 			if len(d.Keys) > 1 {
 				return fmt.Errorf("only 1 key expected, %d returned", len(d.Keys))
@@ -104,10 +105,10 @@ func testAccStepwiseReadPolicyWithVersions(t *testing.T, name string, expectNone
 		Assert: func(resp *api.Secret, err error) error {
 			t.Helper()
 			if resp == nil && !expectNone {
-				return fmt.Errorf("missing response")
+				return errors.New("missing response")
 			} else if expectNone {
 				if resp != nil {
-					return fmt.Errorf("response when expecting none")
+					return errors.New("response when expecting none")
 				}
 				return nil
 			}
@@ -139,10 +140,10 @@ func testAccStepwiseReadPolicyWithVersions(t *testing.T, name string, expectNone
 			}
 			// Should NOT get a key back
 			if d.Key != nil {
-				return fmt.Errorf("unexpected key found")
+				return errors.New("unexpected key found")
 			}
 			if d.Keys == nil {
-				return fmt.Errorf("no keys found")
+				return errors.New("no keys found")
 			}
 			if d.MinDecryptionVersion != minDecryptionVersion {
 				return fmt.Errorf("minimum decryption version mismatch, expected (%#v), found (%#v)", minEncryptionVersion, d.MinDecryptionVersion)
@@ -151,7 +152,7 @@ func testAccStepwiseReadPolicyWithVersions(t *testing.T, name string, expectNone
 				return fmt.Errorf("minimum encryption version mismatch, expected (%#v), found (%#v)", minEncryptionVersion, d.MinDecryptionVersion)
 			}
 			if d.DeletionAllowed {
-				return fmt.Errorf("expected DeletionAllowed to be false, but got true")
+				return errors.New("expected DeletionAllowed to be false, but got true")
 			}
 			if d.Derived != derived {
 				return fmt.Errorf("derived mismatch, expected (%t), got (%t)", derived, d.Derived)
@@ -182,7 +183,7 @@ func testAccStepwiseEncryptContext(
 				return err
 			}
 			if d.Ciphertext == "" {
-				return fmt.Errorf("missing ciphertext")
+				return errors.New("missing ciphertext")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
 			decryptData["context"] = base64.StdEncoding.EncodeToString([]byte(context))

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/rpc"
 	"reflect"
@@ -21,8 +22,8 @@ import (
 )
 
 var (
-	ErrMismatchType  = fmt.Errorf("mismatch on mounted backend and plugin backend type")
-	ErrMismatchPaths = fmt.Errorf("mismatch on mounted backend and plugin backend special paths")
+	ErrMismatchType  = errors.New("mismatch on mounted backend and plugin backend type")
+	ErrMismatchPaths = errors.New("mismatch on mounted backend and plugin backend special paths")
 )
 
 // Factory returns a configured plugin logical.Backend.
@@ -30,7 +31,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	merr := &multierror.Error{}
 	_, ok := conf.Config["plugin_name"]
 	if !ok {
-		return nil, fmt.Errorf("plugin_name not provided")
+		return nil, errors.New("plugin_name not provided")
 	}
 	b, err := v5.Backend(ctx, conf)
 	if err == nil {

--- a/builtin/plugin/backend_lazyLoad_test.go
+++ b/builtin/plugin/backend_lazyLoad_test.go
@@ -26,10 +26,10 @@ func TestBackend_lazyLoad(t *testing.T) {
 		return nil
 	})
 	if invocations != 1 {
-		t.Fatalf("expected 1 invocation")
+		t.Fatal("expected 1 invocation")
 	}
 	if b.canary != "" {
-		t.Fatalf("expected empty canary")
+		t.Fatal("expected empty canary")
 	}
 
 	// load with plugin shutdown
@@ -42,10 +42,10 @@ func TestBackend_lazyLoad(t *testing.T) {
 		return nil
 	})
 	if invocations != 2 {
-		t.Fatalf("expected 2 invocations")
+		t.Fatal("expected 2 invocations")
 	}
 	if b.canary == "" {
-		t.Fatalf("expected canary")
+		t.Fatal("expected canary")
 	}
 }
 
@@ -79,31 +79,31 @@ func testLazyLoad(t *testing.T, methodWrapper func() error) *PluginBackend {
 		t.Fatal(err)
 	}
 	if !b.loaded {
-		t.Fatalf("not loaded")
+		t.Fatal("not loaded")
 	}
 
 	// make sure dummy plugin was handled properly
 	ob := orig.(*testBackend)
 	if !ob.cleaned {
-		t.Fatalf("not cleaned")
+		t.Fatal("not cleaned")
 	}
 	if ob.setup {
-		t.Fatalf("setup")
+		t.Fatal("setup")
 	}
 	if ob.initialized {
-		t.Fatalf("initialized")
+		t.Fatal("initialized")
 	}
 
 	// make sure our newly initialized plugin was handled properly
 	nb := b.Backend.(*testBackend)
 	if nb.cleaned {
-		t.Fatalf("cleaned")
+		t.Fatal("cleaned")
 	}
 	if !nb.setup {
-		t.Fatalf("not setup")
+		t.Fatal("not setup")
 	}
 	if !nb.initialized {
-		t.Fatalf("not initialized")
+		t.Fatal("not initialized")
 	}
 
 	return b

--- a/command/agent.go
+++ b/command/agent.go
@@ -1014,7 +1014,7 @@ func (c *AgentCommand) handleMetrics() http.Handler {
 			w.WriteHeader(status)
 			w.Write(v)
 		default:
-			logical.RespondError(w, http.StatusInternalServerError, fmt.Errorf("wrong response returned"))
+			logical.RespondError(w, http.StatusInternalServerError, errors.New("wrong response returned"))
 		}
 	})
 }
@@ -1041,7 +1041,7 @@ func (c *AgentCommand) handleQuit(enabled bool) http.Handler {
 // newLogger creates a logger based on parsed config field on the Agent Command struct.
 func (c *AgentCommand) newLogger() (hclog.InterceptLogger, error) {
 	if c.config == nil {
-		return nil, fmt.Errorf("cannot create logger, no config")
+		return nil, errors.New("cannot create logger, no config")
 	}
 
 	var errs *multierror.Error

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -352,7 +352,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil {
-			t.Fatalf("failed to use the auto-auth token to perform lookup-self")
+			t.Fatal("failed to use the auto-auth token to perform lookup-self")
 		}
 	}
 
@@ -414,7 +414,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp == nil || resp.Data["id"] != client.Token() {
-			t.Fatalf("failed to use the cluster client token to perform lookup-self")
+			t.Fatal("failed to use the cluster client token to perform lookup-self")
 		}
 	}
 }

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -295,7 +295,7 @@ func (c *Config) ValidateConfig() error {
 	if c.APIProxy != nil && c.Cache != nil {
 		if c.Cache.UseAutoAuthTokenRaw != nil {
 			if c.APIProxy.UseAutoAuthTokenRaw != nil {
-				return fmt.Errorf("use_auto_auth_token defined in both api_proxy and cache config. Please remove this configuration from the cache block")
+				return errors.New("use_auto_auth_token defined in both api_proxy and cache config. Please remove this configuration from the cache block")
 			} else {
 				c.APIProxy.ForceAutoAuthToken = c.Cache.ForceAutoAuthToken
 			}
@@ -304,30 +304,30 @@ func (c *Config) ValidateConfig() error {
 
 	if c.Cache != nil {
 		if len(c.Listeners) < 1 && len(c.Templates) < 1 && len(c.EnvTemplates) < 1 {
-			return fmt.Errorf("enabling the cache requires at least 1 template or 1 listener to be defined")
+			return errors.New("enabling the cache requires at least 1 template or 1 listener to be defined")
 		}
 
 		if c.Cache.UseAutoAuthToken {
 			if c.AutoAuth == nil {
-				return fmt.Errorf("cache.use_auto_auth_token is true but auto_auth not configured")
+				return errors.New("cache.use_auto_auth_token is true but auto_auth not configured")
 			}
 			if c.AutoAuth != nil && c.AutoAuth.Method != nil && c.AutoAuth.Method.WrapTTL > 0 {
-				return fmt.Errorf("cache.use_auto_auth_token is true and auto_auth uses wrapping")
+				return errors.New("cache.use_auto_auth_token is true and auto_auth uses wrapping")
 			}
 		}
 	}
 
 	if c.APIProxy != nil {
 		if len(c.Listeners) < 1 {
-			return fmt.Errorf("configuring the api_proxy requires at least 1 listener to be defined")
+			return errors.New("configuring the api_proxy requires at least 1 listener to be defined")
 		}
 
 		if c.APIProxy.UseAutoAuthToken {
 			if c.AutoAuth == nil {
-				return fmt.Errorf("api_proxy.use_auto_auth_token is true but auto_auth not configured")
+				return errors.New("api_proxy.use_auto_auth_token is true but auto_auth not configured")
 			}
 			if c.AutoAuth != nil && c.AutoAuth.Method != nil && c.AutoAuth.Method.WrapTTL > 0 {
-				return fmt.Errorf("api_proxy.use_auto_auth_token is true and auto_auth uses wrapping")
+				return errors.New("api_proxy.use_auto_auth_token is true and auto_auth uses wrapping")
 			}
 		}
 	}
@@ -337,12 +337,12 @@ func (c *Config) ValidateConfig() error {
 			(c.APIProxy == nil || !c.APIProxy.UseAutoAuthToken) &&
 			len(c.Templates) == 0 &&
 			len(c.EnvTemplates) == 0 {
-			return fmt.Errorf("auto_auth requires at least one sink or at least one template or api_proxy.use_auto_auth_token=true")
+			return errors.New("auto_auth requires at least one sink or at least one template or api_proxy.use_auto_auth_token=true")
 		}
 	}
 
 	if c.AutoAuth == nil && c.Cache == nil && len(c.Listeners) == 0 {
-		return fmt.Errorf("no auto_auth, cache, or listener block found in config")
+		return errors.New("no auto_auth, cache, or listener block found in config")
 	}
 
 	return c.validateEnvTemplateConfig()
@@ -355,23 +355,23 @@ func (c *Config) validateEnvTemplateConfig() error {
 	}
 
 	if c.Exec == nil {
-		return fmt.Errorf("a top-level 'exec' element must be specified with 'env_template' entries")
+		return errors.New("a top-level 'exec' element must be specified with 'env_template' entries")
 	}
 
 	if len(c.EnvTemplates) == 0 {
-		return fmt.Errorf("must specify at least one 'env_template' element with a top-level 'exec' element")
+		return errors.New("must specify at least one 'env_template' element with a top-level 'exec' element")
 	}
 
 	if c.APIProxy != nil {
-		return fmt.Errorf("'api_proxy' cannot be specified with 'env_template' entries")
+		return errors.New("'api_proxy' cannot be specified with 'env_template' entries")
 	}
 
 	if len(c.Templates) > 0 {
-		return fmt.Errorf("'template' cannot be specified with 'env_template' entries")
+		return errors.New("'template' cannot be specified with 'env_template' entries")
 	}
 
 	if len(c.Exec.Command) == 0 {
-		return fmt.Errorf("'exec' requires a non-empty 'command' field")
+		return errors.New("'exec' requires a non-empty 'command' field")
 	}
 
 	if !slices.Contains([]string{"always", "never"}, c.Exec.RestartOnSecretChanges) {
@@ -393,7 +393,7 @@ func (c *Config) validateEnvTemplateConfig() error {
 		//   - function_denylist / function_blacklist
 
 		if template.MapToEnvironmentVariable == nil {
-			return fmt.Errorf("env_template: an environment variable name is required")
+			return errors.New("env_template: an environment variable name is required")
 		}
 
 		key := *template.MapToEnvironmentVariable
@@ -564,7 +564,7 @@ func LoadConfigFile(path string) (*Config, error) {
 	}
 
 	if fi.IsDir() {
-		return nil, fmt.Errorf("location is a directory, not a file")
+		return nil, errors.New("location is a directory, not a file")
 	}
 
 	// Read the file
@@ -607,7 +607,7 @@ func LoadConfigFile(path string) (*Config, error) {
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	if err := parseAutoAuth(result, list); err != nil {
@@ -938,7 +938,7 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 		return fmt.Errorf("error parsing 'method': %w", err)
 	}
 	if a.Method == nil {
-		return fmt.Errorf("no 'method' block found")
+		return errors.New("no 'method' block found")
 	}
 
 	if err := parseSinks(result, subList); err != nil {
@@ -947,11 +947,11 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 
 	if result.AutoAuth.Method.WrapTTL > 0 {
 		if len(result.AutoAuth.Sinks) != 1 {
-			return fmt.Errorf("error parsing auto_auth: wrapping enabled on auth method and 0 or many sinks defined")
+			return errors.New("error parsing auto_auth: wrapping enabled on auth method and 0 or many sinks defined")
 		}
 
 		if result.AutoAuth.Sinks[0].WrapTTL > 0 {
-			return fmt.Errorf("error parsing auto_auth: wrapping enabled both on auth method and sink")
+			return errors.New("error parsing auto_auth: wrapping enabled both on auth method and sink")
 		}
 	}
 

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -667,7 +667,7 @@ func TestLoadConfigFile_Bad_AgentCache_ForceAutoAuthNoMethod(t *testing.T) {
 func TestLoadConfigFile_Bad_AgentCache_NoListeners(t *testing.T) {
 	_, err := LoadConfigFile("./test-fixtures/bad-config-cache-no-listeners.hcl")
 	if err != nil {
-		t.Fatalf("LoadConfigFile should return an error for this config")
+		t.Fatal("LoadConfigFile should return an error for this config")
 	}
 }
 
@@ -695,7 +695,7 @@ func TestLoadConfigFile_Bad_AutoAuth_Nosinks_Nocache_Notemplates(t *testing.T) {
 func TestLoadConfigFile_Bad_AutoAuth_Both_Wrapping_Types(t *testing.T) {
 	_, err := LoadConfigFile("./test-fixtures/bad-config-method-wrapping-and-sink-wrapping.hcl")
 	if err == nil {
-		t.Fatalf("LoadConfigFile should return an error for this config")
+		t.Fatal("LoadConfigFile should return an error for this config")
 	}
 }
 
@@ -2102,7 +2102,7 @@ func TestLoadConfigFile_EnvTemplates_Simple(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected environment variable name to be populated")
+		t.Fatal("expected environment variable name to be populated")
 	}
 }
 
@@ -2155,7 +2155,7 @@ func TestLoadConfigFile_EnvTemplates_WithSource(t *testing.T) {
 func TestLoadConfigFile_EnvTemplates_NoName(t *testing.T) {
 	_, err := LoadConfigFile("./test-fixtures/bad-config-env-templates-no-name.hcl")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 
@@ -2163,7 +2163,7 @@ func TestLoadConfigFile_EnvTemplates_NoName(t *testing.T) {
 func TestLoadConfigFile_EnvTemplates_ExecInvalidSignal(t *testing.T) {
 	_, err := LoadConfigFile("./test-fixtures/bad-config-env-templates-invalid-signal.hcl")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -321,7 +321,7 @@ func TestExecServer_Run(t *testing.T) {
 
 			case err := <-testAppStartedCh:
 				if testCase.expectedError == nil && err != nil {
-					t.Fatalf("test app could not be started")
+					t.Fatal("test app could not be started")
 				}
 
 				t.Log("test app started successfully")
@@ -348,7 +348,7 @@ func TestExecServer_Run(t *testing.T) {
 			}
 
 			// verify the environment variables
-			t.Logf("verifying test-app's environment variables")
+			t.Log("verifying test-app's environment variables")
 
 			resp, err := retryablehttp.Get(testAppAddr)
 			if err != nil {

--- a/command/agent/internal/ctmanager/runner_config.go
+++ b/command/agent/internal/ctmanager/runner_config.go
@@ -1,7 +1,7 @@
 package ctmanager
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"strings"
 
@@ -69,7 +69,7 @@ func NewConfig(mc ManagerConfig, templates ctconfig.TemplateConfigs) (*ctconfig.
 	// Use the cache if available or fallback to the Vault server values.
 	if mc.AgentConfig.Cache != nil {
 		if mc.AgentConfig.Cache.InProcDialer == nil {
-			return nil, fmt.Errorf("missing in-process dialer configuration")
+			return nil, errors.New("missing in-process dialer configuration")
 		}
 		if conf.Vault.Transport == nil {
 			conf.Vault.Transport = &ctconfig.TransportConfig{}

--- a/command/agent_generate_config.go
+++ b/command/agent_generate_config.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -336,14 +337,14 @@ func constructTemplatesFromSecret(ctx context.Context, client *api.Client, path,
 		return nil, fmt.Errorf("error querying: %w", err)
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("secret not found")
+		return nil, errors.New("secret not found")
 	}
 
 	var data map[string]interface{}
 	if v2 {
 		internal, ok := resp.Data["data"]
 		if !ok {
-			return nil, fmt.Errorf("secret.Data not found")
+			return nil, errors.New("secret.Data not found")
 		}
 		data = internal.(map[string]interface{})
 	} else {

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -392,7 +392,7 @@ listener "tcp" {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// defer agent shutdown
@@ -426,7 +426,7 @@ listener "tcp" {
 	req = agentClient.NewRequest("GET", "/v1/sys/health")
 	resp, err := agentClient.RawRequest(req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("expected status code %d, not %d", http.StatusPreconditionFailed, resp.StatusCode)
@@ -441,7 +441,7 @@ listener "tcp" {
 	req = agentClient.NewRequest("GET", "/v1/sys/health")
 	resp, err = agentClient.RawRequest(req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("expected status code %d, not %d", http.StatusPreconditionFailed, resp.StatusCode)
@@ -608,7 +608,7 @@ auto_auth {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// We need to shut down the Agent command
@@ -814,7 +814,7 @@ auto_auth {
 			select {
 			case <-cmd.startedCh:
 			case <-time.After(5 * time.Second):
-				t.Errorf("timeout")
+				t.Error("timeout")
 			}
 
 			// if using exit_after_auth, then the command will have returned at the
@@ -1092,7 +1092,7 @@ auto_auth {
 			select {
 			case <-cmd.startedCh:
 			case <-time.After(5 * time.Second):
-				t.Errorf("timeout")
+				t.Error("timeout")
 			}
 
 			defer func() {
@@ -1270,7 +1270,7 @@ exit_after_auth = true
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	wg.Wait()
@@ -1593,7 +1593,7 @@ template_config {
 			select {
 			case <-cmd.startedCh:
 			case <-time.After(5 * time.Second):
-				t.Errorf("timeout")
+				t.Error("timeout")
 			}
 
 			verify := func() error {
@@ -1822,7 +1822,7 @@ api_proxy {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// Validate that the auto-auth token has been correctly attained
@@ -1913,7 +1913,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	agentClient, err := api.NewClient(api.DefaultConfig())
@@ -2005,7 +2005,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	agentClient, err := api.NewClient(api.DefaultConfig())
@@ -2081,7 +2081,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	agentClient, err := api.NewClient(api.DefaultConfig())
@@ -2127,7 +2127,7 @@ vault {
 	token2 := secret.Auth.ClientToken
 
 	if token != token2 {
-		t.Fatalf("token create response not cached when it should have been, as tokens differ")
+		t.Fatal("token create response not cached when it should have been, as tokens differ")
 	}
 
 	close(cmd.ShutdownCh)
@@ -2253,7 +2253,7 @@ vault {
 			select {
 			case <-cmd.startedCh:
 			case <-time.After(5 * time.Second):
-				t.Errorf("timeout")
+				t.Error("timeout")
 			}
 
 			client, err := api.NewClient(api.DefaultConfig())
@@ -2578,7 +2578,7 @@ vault {
 				}
 			case code == 0 && err == nil && !tc.expectError:
 				if exitedEarly {
-					t.Fatalf("did not expect program to exit before verify completes")
+					t.Fatal("did not expect program to exit before verify completes")
 				}
 			default:
 				if code != 0 {
@@ -2643,7 +2643,7 @@ listener "tcp" {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// defer agent shutdown
@@ -2750,7 +2750,7 @@ cache {}
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 	client, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
@@ -2766,7 +2766,7 @@ cache {}
 	// First try on listener 1 where the API should be disabled.
 	resp, err := client.RawRequest(client.NewRequest(http.MethodPost, "/agent/v1/quit"))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 	if resp != nil && resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected %d but got: %d", http.StatusNotFound, resp.StatusCode)
@@ -2786,7 +2786,7 @@ cache {}
 	select {
 	case <-cmd.ShutdownCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	wg.Wait()
@@ -2979,7 +2979,7 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("foo.example.com"); err != nil {
@@ -3010,7 +3010,7 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("bar.example.com"); err != nil {
@@ -3081,7 +3081,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// Reload
@@ -3089,7 +3089,7 @@ vault {
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	close(cmd.ShutdownCh)

--- a/command/agentproxyshared/auth/token-file/token_file_test.go
+++ b/command/agentproxyshared/auth/token-file/token_file_test.go
@@ -33,7 +33,7 @@ func TestNewTokenFileEmptyFilePath(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatalf("Expected error when giving empty file path")
+		t.Fatal("Expected error when giving empty file path")
 	}
 }
 

--- a/command/agentproxyshared/cache/api_proxy.go
+++ b/command/agentproxyshared/cache/api_proxy.go
@@ -5,7 +5,7 @@ package cache
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	gohttp "net/http"
 	"sync"
 
@@ -39,7 +39,7 @@ type APIProxyConfig struct {
 
 func NewAPIProxy(config *APIProxyConfig) (Proxier, error) {
 	if config.Client == nil {
-		return nil, fmt.Errorf("nil API client")
+		return nil, errors.New("nil API client")
 	}
 	return &APIProxy{
 		client:                  config.Client,

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -107,7 +107,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 		t.Fatal(err)
 	}
 	if secret.Data["id"] != nil || secret.Data["accessor"] != nil || secret.Data["request"].(string) != "lookup-self" {
-		t.Fatalf("failed to strip off auto-auth token on lookup-self")
+		t.Fatal("failed to strip off auto-auth token on lookup-self")
 	}
 
 	secret, err = testClient.Auth().Token().Lookup("")
@@ -115,7 +115,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 		t.Fatal(err)
 	}
 	if secret.Data["id"] != nil || secret.Data["accessor"] != nil || secret.Data["request"].(string) != "lookup" {
-		t.Fatalf("failed to strip off auto-auth token on lookup")
+		t.Fatal("failed to strip off auto-auth token on lookup")
 	}
 
 	secret, err = testClient.Auth().Token().RenewSelf(1)
@@ -127,7 +127,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 		t.Fatalf("Expected secret to have Auth but was %s", secretJson)
 	}
 	if secret.Auth.ClientToken != "" || secret.Auth.Accessor != "" {
-		t.Fatalf("failed to strip off auto-auth token on renew-self")
+		t.Fatal("failed to strip off auto-auth token on renew-self")
 	}
 
 	secret, err = testClient.Auth().Token().Renew("testid", 1)
@@ -139,7 +139,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 		t.Fatalf("Expected secret to have Auth but was %s", secretJson)
 	}
 	if secret.Auth.ClientToken != "" || secret.Auth.Accessor != "" {
-		t.Fatalf("failed to strip off auto-auth token on renew")
+		t.Fatal("failed to strip off auto-auth token on renew")
 	}
 }
 
@@ -196,7 +196,7 @@ func TestCache_AutoAuthClientTokenProxyStripping(t *testing.T) {
 		t.Fatal(err)
 	}
 	if leaseCache.currentToken != realToken {
-		t.Fatalf("failed to use real token from auto-auth")
+		t.Fatal("failed to use real token from auto-auth")
 	}
 }
 

--- a/command/agentproxyshared/cache/cachememdb/cache_memdb.go
+++ b/command/agentproxyshared/cache/cachememdb/cache_memdb.go
@@ -198,7 +198,7 @@ func (c *CacheMemDB) GetByPrefix(indexName string, indexValues ...interface{}) (
 		}
 		index, ok := obj.(*Index)
 		if !ok {
-			return nil, fmt.Errorf("failed to cast cached index")
+			return nil, errors.New("failed to cast cached index")
 		}
 
 		indexes = append(indexes, index)

--- a/command/agentproxyshared/cache/keymanager/passthrough.go
+++ b/command/agentproxyshared/cache/keymanager/passthrough.go
@@ -6,6 +6,7 @@ package keymanager
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
@@ -64,7 +65,7 @@ func (w *PassthroughKeyManager) Wrapper() wrapping.Wrapper {
 // this key.
 func (w *PassthroughKeyManager) RetrievalToken(ctx context.Context) ([]byte, error) {
 	if w.wrapper == nil {
-		return nil, fmt.Errorf("unable to get wrapper for token retrieval")
+		return nil, errors.New("unable to get wrapper for token retrieval")
 	}
 
 	return w.wrapper.KeyBytes(ctx)

--- a/command/agentproxyshared/cache/keymanager/passthrough_test.go
+++ b/command/agentproxyshared/cache/keymanager/passthrough_test.go
@@ -45,7 +45,7 @@ func TestKeyManager_PassthrougKeyManager(t *testing.T) {
 			require.NoError(t, err)
 
 			if w := m.Wrapper(); w == nil {
-				t.Fatalf("expected non-nil wrapper from the key manager")
+				t.Fatal("expected non-nil wrapper from the key manager")
 			}
 
 			token, err := m.RetrievalToken(ctx)

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -137,7 +137,7 @@ func NewLeaseCache(conf *LeaseCacheConfig) (*LeaseCache, error) {
 	}
 
 	if conf.Client == nil {
-		return nil, fmt.Errorf("nil API client")
+		return nil, errors.New("nil API client")
 	}
 
 	db, err := cachememdb.New()
@@ -766,11 +766,11 @@ func (c *LeaseCache) handleRevocationRequest(ctx context.Context, req *SendReque
 		}
 		tokenRaw, ok := jsonBody["token"]
 		if !ok {
-			return false, fmt.Errorf("failed to get token from request body")
+			return false, errors.New("failed to get token from request body")
 		}
 		token, ok := tokenRaw.(string)
 		if !ok {
-			return false, fmt.Errorf("expected token in the request body to be string")
+			return false, errors.New("expected token in the request body to be string")
 		}
 
 		// Clear the cache entry associated with the token and all the other
@@ -801,11 +801,11 @@ func (c *LeaseCache) handleRevocationRequest(ctx context.Context, req *SendReque
 		}
 		accessorRaw, ok := jsonBody["accessor"]
 		if !ok {
-			return false, fmt.Errorf("failed to get accessor from request body")
+			return false, errors.New("failed to get accessor from request body")
 		}
 		accessor, ok := accessorRaw.(string)
 		if !ok {
-			return false, fmt.Errorf("expected accessor in the request body to be string")
+			return false, errors.New("expected accessor in the request body to be string")
 		}
 
 		in := &cacheClearInput{
@@ -823,11 +823,11 @@ func (c *LeaseCache) handleRevocationRequest(ctx context.Context, req *SendReque
 		}
 		tokenRaw, ok := jsonBody["token"]
 		if !ok {
-			return false, fmt.Errorf("failed to get token from request body")
+			return false, errors.New("failed to get token from request body")
 		}
 		token, ok := tokenRaw.(string)
 		if !ok {
-			return false, fmt.Errorf("expected token in the request body to be string")
+			return false, errors.New("expected token in the request body to be string")
 		}
 
 		// Kill the lifetime watchers of all the leases attached to the revoked
@@ -878,11 +878,11 @@ func (c *LeaseCache) handleRevocationRequest(ctx context.Context, req *SendReque
 		}
 		leaseIDRaw, ok := jsonBody["lease_id"]
 		if !ok {
-			return false, fmt.Errorf("failed to get lease_id from request body")
+			return false, errors.New("failed to get lease_id from request body")
 		}
 		leaseID, ok := leaseIDRaw.(string)
 		if !ok {
-			return false, fmt.Errorf("expected lease_id the request body to be string")
+			return false, errors.New("expected lease_id the request body to be string")
 		}
 		in := &cacheClearInput{
 			Type:  "lease",

--- a/command/agentproxyshared/cache/lease_cache_test.go
+++ b/command/agentproxyshared/cache/lease_cache_test.go
@@ -106,7 +106,7 @@ func TestLeaseCache_EmptyToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non empty response")
+		t.Fatal("expected a non empty response")
 	}
 }
 
@@ -156,7 +156,7 @@ func TestLeaseCache_SendCacheable(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cachedItem == nil {
-		t.Fatalf("expected token entry from cache")
+		t.Fatal("expected token entry from cache")
 	}
 	if cachedItem.TokenParent != "autoauthtoken" {
 		t.Fatalf("unexpected value for tokenparent: %s", cachedItem.TokenParent)

--- a/command/agentproxyshared/helpers.go
+++ b/command/agentproxyshared/helpers.go
@@ -130,7 +130,7 @@ func AddPersistentStorageToLeaseCache(ctx context.Context, leaseCache *cache.Lea
 		if err := leaseCache.Restore(ctx, ps); err != nil {
 			logger.Error(fmt.Sprintf("error restoring in-memory cache from persisted file: %v", err))
 			if persistConfig.ExitOnErr {
-				return nil, "", fmt.Errorf("exiting with error as exit_on_err is set to true")
+				return nil, "", errors.New("exiting with error as exit_on_err is set to true")
 			}
 		}
 		logger.Info("loaded memcache from persistent storage")
@@ -140,7 +140,7 @@ func AddPersistentStorageToLeaseCache(ctx context.Context, leaseCache *cache.Lea
 		if err != nil {
 			logger.Error(fmt.Sprintf("error in fetching previous auto-auth token: %v", err))
 			if persistConfig.ExitOnErr {
-				return nil, "", fmt.Errorf("exiting with error as exit_on_err is set to true")
+				return nil, "", errors.New("exiting with error as exit_on_err is set to true")
 			}
 		}
 		var previousToken string
@@ -149,7 +149,7 @@ func AddPersistentStorageToLeaseCache(ctx context.Context, leaseCache *cache.Lea
 			if err != nil {
 				logger.Error(fmt.Sprintf("error in deserializing previous auto-auth token cache entryn: %v", err))
 				if persistConfig.ExitOnErr {
-					return nil, "", fmt.Errorf("exiting with error as exit_on_err is set to true")
+					return nil, "", errors.New("exiting with error as exit_on_err is set to true")
 				}
 			}
 			previousToken = oldToken.Token
@@ -168,7 +168,7 @@ func AddPersistentStorageToLeaseCache(ctx context.Context, leaseCache *cache.Lea
 			if err := os.Remove(dbFile); err != nil {
 				logger.Error(fmt.Sprintf("failed to remove persistent storage file %s: %v", dbFile, err))
 				if persistConfig.ExitOnErr {
-					return nil, "", fmt.Errorf("exiting with error as exit_on_err is set to true")
+					return nil, "", errors.New("exiting with error as exit_on_err is set to true")
 				}
 			}
 			return nil, previousToken, nil

--- a/command/agentproxyshared/sink/file/file_sink.go
+++ b/command/agentproxyshared/sink/file/file_sink.go
@@ -54,7 +54,7 @@ func NewFileSink(conf *sink.SinkConfig) (sink.Sink, error) {
 		}
 
 		if !os.FileMode(mode).IsRegular() {
-			return nil, fmt.Errorf("file mode does not represent a regular file")
+			return nil, errors.New("file mode does not represent a regular file")
 		}
 
 		f.logger.Debug("overriding default file sink", "mode", mode)

--- a/command/audit_enable_test.go
+++ b/command/audit_enable_test.go
@@ -117,7 +117,7 @@ func TestAuditEnableCommand_Run(t *testing.T) {
 
 		auditInfo, ok := audits["audit_enable_integration/"]
 		if !ok {
-			t.Fatalf("expected audit to exist")
+			t.Fatal("expected audit to exist")
 		}
 		if exp := "file"; auditInfo.Type != exp {
 			t.Errorf("expected %q to be %q", auditInfo.Type, exp)

--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -115,7 +115,7 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 
 		authInfo, ok := auths["auth_integration/"]
 		if !ok {
-			t.Fatalf("expected mount to exist")
+			t.Fatal("expected mount to exist")
 		}
 		if exp := "userpass"; authInfo.Type != exp {
 			t.Errorf("expected %q to be %q", authInfo.Type, exp)

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -139,7 +139,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 
 			mountInfo, ok = auths["my-auth/"]
 			if !ok {
-				t.Fatalf("expected auth to exist")
+				t.Fatal("expected auth to exist")
 			}
 			if exp := "new description"; mountInfo.Description != exp {
 				t.Errorf("expected %q to be %q", mountInfo.Description, exp)
@@ -208,7 +208,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 
 				mountInfo, ok := auths["my-auth/"]
 				if !ok {
-					t.Fatalf("expected auth to exist")
+					t.Fatal("expected auth to exist")
 				}
 				if exp := "initial description"; mountInfo.Description != exp {
 					t.Errorf("expected %q to be %q", mountInfo.Description, exp)
@@ -251,7 +251,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 
 				mountInfo, ok := auths["my-auth/"]
 				if !ok {
-					t.Fatalf("expected auth to exist")
+					t.Fatal("expected auth to exist")
 				}
 				if exp := ""; mountInfo.Description != exp {
 					t.Errorf("expected %q to be %q", mountInfo.Description, exp)

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -336,7 +336,7 @@ func generateFlagErrors(f *FlagSets, opts ...ParseOptions) error {
 		}
 
 		if !canUseRaw {
-			return fmt.Errorf("This command does not support the -format=raw option.")
+			return errors.New("This command does not support the -format=raw option.")
 		}
 	}
 

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -85,7 +86,7 @@ func ParseConfig(contents string) (*DefaultConfig, error) {
 	// Top-level item should be the object list
 	list, ok := root.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("failed to parse config; does not contain a root object")
+		return nil, errors.New("failed to parse config; does not contain a root object")
 	}
 
 	valid := []string{

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -836,7 +836,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			// check permissions of the parent debug directory
 			err = isValidFilePermissions(stat.Mode(), stat.Name())
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 
 			// check permissions of the files within the parent directory
@@ -872,7 +872,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 				err = filepath.Walk(bundlePath, func(path string, info os.FileInfo, err error) error {
 					err = isValidFilePermissions(info.Mode(), info.Name())
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 					return nil
 				})

--- a/command/format.go
+++ b/command/format.go
@@ -134,7 +134,7 @@ type RawFormatter struct{}
 func (r RawFormatter) Format(data interface{}) ([]byte, error) {
 	byte_data, ok := data.([]byte)
 	if !ok {
-		return nil, fmt.Errorf("This command does not support the -format=raw option; only `vault read` does.")
+		return nil, errors.New("This command does not support the -format=raw option; only `vault read` does.")
 	}
 
 	return byte_data, nil

--- a/command/healthcheck/pki.go
+++ b/command/healthcheck/pki.go
@@ -6,6 +6,7 @@ package healthcheck
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -23,7 +24,7 @@ func pkiFetchIssuersList(e *Executor, versionError func()) (bool, *PathFetch, []
 		}
 
 		if issuersRet.Is404NotFound() {
-			return true, issuersRet, nil, fmt.Errorf("this mount lacks any configured issuers, limiting health check usefulness")
+			return true, issuersRet, nil, errors.New("this mount lacks any configured issuers, limiting health check usefulness")
 		}
 
 		return true, issuersRet, nil, nil
@@ -44,7 +45,7 @@ func parsePEM(contents string) ([]byte, error) {
 	// Need to parse out the issuer from its PEM format.
 	pemBlock, _ := pem.Decode([]byte(contents))
 	if pemBlock == nil {
-		return nil, fmt.Errorf("invalid PEM block")
+		return nil, errors.New("invalid PEM block")
 	}
 
 	return pemBlock.Bytes, nil

--- a/command/healthcheck/pki_enable_acme_issuance.go
+++ b/command/healthcheck/pki_enable_acme_issuance.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -113,7 +114,7 @@ func doesMountContainOnlyRootIssuers(e *Executor) (int, int, error) {
 func isAcmeEnabled(fetcher *PathFetch) (bool, error) {
 	isEnabledRaw, ok := fetcher.Secret.Data["enabled"]
 	if !ok {
-		return false, fmt.Errorf("enabled configuration field missing from acme config")
+		return false, errors.New("enabled configuration field missing from acme config")
 	}
 
 	parseBool, err := parseutil.ParseBool(isEnabledRaw)
@@ -127,7 +128,7 @@ func isAcmeEnabled(fetcher *PathFetch) (bool, error) {
 func verifyLocalPathUrl(h *EnableAcmeIssuance) error {
 	localPathRaw, ok := h.ClusterConfigFetcher.Secret.Data["path"]
 	if !ok {
-		return fmt.Errorf("'path' field missing from config")
+		return errors.New("'path' field missing from config")
 	}
 
 	localPath, err := parseutil.ParseString(localPathRaw)
@@ -136,7 +137,7 @@ func verifyLocalPathUrl(h *EnableAcmeIssuance) error {
 	}
 
 	if localPath == "" {
-		return fmt.Errorf("'path' field not configured within /{{mount}}/config/cluster")
+		return errors.New("'path' field not configured within /{{mount}}/config/cluster")
 	}
 
 	parsedUrl, err := url.Parse(localPath)
@@ -145,7 +146,7 @@ func verifyLocalPathUrl(h *EnableAcmeIssuance) error {
 	}
 
 	if parsedUrl.Scheme != "https" {
-		return fmt.Errorf("the configured 'path' field in /{{mount}}/config/cluster was not using an https scheme")
+		return errors.New("the configured 'path' field in /{{mount}}/config/cluster was not using an https scheme")
 	}
 
 	// Avoid issues with SSL certificates for this check, we just want to validate that we would

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -1511,7 +1511,7 @@ func TestPadEqualSigns(t *testing.T) {
 
 			signs := strings.Split(padded, fmt.Sprintf(" %s ", header))
 			if len(signs[0]) != len(signs[1]) {
-				t.Fatalf("expected an equal number of equal signs on both sides")
+				t.Fatal("expected an equal number of equal signs on both sides")
 			}
 			for _, sign := range signs {
 				count := strings.Count(sign, "=")

--- a/command/login.go
+++ b/command/login.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -356,14 +357,14 @@ func (c *LoginCommand) Run(args []string) int {
 func (c *LoginCommand) extractToken(client *api.Client, secret *api.Secret, unwrap bool) (*api.Secret, bool, error) {
 	switch {
 	case secret == nil:
-		return nil, false, fmt.Errorf("empty response from auth helper")
+		return nil, false, errors.New("empty response from auth helper")
 
 	case secret.Auth != nil:
 		return secret, false, nil
 
 	case secret.WrapInfo != nil:
 		if secret.WrapInfo.WrappedAccessor == "" {
-			return nil, false, fmt.Errorf("wrapped response does not contain a token")
+			return nil, false, errors.New("wrapped response does not contain a token")
 		}
 
 		if !unwrap {
@@ -378,7 +379,7 @@ func (c *LoginCommand) extractToken(client *api.Client, secret *api.Secret, unwr
 		return c.extractToken(client, secret, unwrap)
 
 	default:
-		return nil, false, fmt.Errorf("no auth or wrapping info in response")
+		return nil, false, errors.New("no auth or wrapping info in response")
 	}
 }
 

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -608,7 +608,7 @@ func TestLoginMFATwoPhaseNonInteractiveMethodName(t *testing.T) {
 		}
 
 		if secret.Auth == nil || secret.Auth.ClientToken == "" {
-			t.Fatalf("mfa validation did not return a client token")
+			t.Fatal("mfa validation did not return a client token")
 		}
 	}
 

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -548,7 +549,7 @@ func compareResult(exp *diagnose.Result, act *diagnose.Result) error {
 		for _, c := range act.Children {
 			errStrings = append(errStrings, fmt.Sprintf("%+v", c))
 		}
-		return fmt.Errorf(strings.Join(errStrings, ","))
+		return errors.New(strings.Join(errStrings, ","))
 	}
 
 	if len(exp.Children) > 0 {

--- a/command/operator_init_test.go
+++ b/command/operator_init_test.go
@@ -331,7 +331,7 @@ func TestOperatorInitCommand_Run(t *testing.T) {
 		reToken := regexp.MustCompile(`Root Token: (.+)`)
 		match = reToken.FindAllStringSubmatch(output, -1)
 		if len(match) < 1 || len(match[0]) < 2 {
-			t.Fatalf("no match")
+			t.Fatal("no match")
 		}
 		root := match[0][1]
 		decryptedRoot := testPGPDecrypt(t, pgpkeys.TestPrivKey1, root)

--- a/command/operator_migrate.go
+++ b/command/operator_migrate.go
@@ -322,7 +322,7 @@ func (c *OperatorMigrateCommand) loadMigratorConfig(path string) (*migratorConfi
 	}
 
 	if fi.IsDir() {
-		return nil, fmt.Errorf("location is a directory, not a file")
+		return nil, errors.New("location is a directory, not a file")
 	}
 
 	d, err := os.ReadFile(path)
@@ -342,7 +342,7 @@ func (c *OperatorMigrateCommand) loadMigratorConfig(path string) (*migratorConfi
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	// Look for storage_* stanzas

--- a/command/operator_seal_test.go
+++ b/command/operator_seal_test.go
@@ -91,7 +91,7 @@ func TestOperatorSealCommand_Run(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !sealStatus.Sealed {
-			t.Errorf("expected to be sealed")
+			t.Error("expected to be sealed")
 		}
 	})
 

--- a/command/pgp_test.go
+++ b/command/pgp_test.go
@@ -204,7 +204,7 @@ func parseDecryptAndTestUnsealKeys(t *testing.T,
 				t.Fatalf("Error using unseal key %s: %s", unsealKey, err)
 			}
 			if i >= 2 && !unsealed {
-				t.Fatalf("Error: Provided two unseal keys but core is not unsealed")
+				t.Fatal("Error: Provided two unseal keys but core is not unsealed")
 			}
 		}
 	}

--- a/command/pki_reissue_intermediate.go
+++ b/command/pki_reissue_intermediate.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -179,7 +180,7 @@ func parseTemplateCertificate(certificate x509.Certificate, useExistingKey bool,
 	if useExistingKey {
 		templateData["skid"] = hex.EncodeToString(certificate.SubjectKeyId) // TODO: Double Check this with someone
 		if keyRef == "" {
-			return nil, fmt.Errorf("unable to create certificate template for existing key without a key_id")
+			return nil, errors.New("unable to create certificate template for existing key without a key_id")
 		}
 		templateData["key_ref"] = keyRef
 	} else {

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -6,6 +6,7 @@ package command
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -911,7 +912,7 @@ func (c *ProxyCommand) handleMetrics() http.Handler {
 			w.WriteHeader(status)
 			w.Write(v)
 		default:
-			logical.RespondError(w, http.StatusInternalServerError, fmt.Errorf("wrong response returned"))
+			logical.RespondError(w, http.StatusInternalServerError, errors.New("wrong response returned"))
 		}
 	})
 }
@@ -938,7 +939,7 @@ func (c *ProxyCommand) handleQuit(enabled bool) http.Handler {
 // newLogger creates a logger based on parsed config field on the Proxy Command struct.
 func (c *ProxyCommand) newLogger() (log.InterceptLogger, error) {
 	if c.config == nil {
-		return nil, fmt.Errorf("cannot create logger, no config")
+		return nil, errors.New("cannot create logger, no config")
 	}
 
 	var errors error

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -220,21 +220,21 @@ func (c *Config) Merge(c2 *Config) *Config {
 func (c *Config) ValidateConfig() error {
 	if c.Cache != nil {
 		if len(c.Listeners) < 1 {
-			return fmt.Errorf("enabling the cache requires at least 1 listener to be defined")
+			return errors.New("enabling the cache requires at least 1 listener to be defined")
 		}
 	}
 
 	if c.APIProxy != nil {
 		if len(c.Listeners) < 1 {
-			return fmt.Errorf("configuring the api_proxy requires at least 1 listener to be defined")
+			return errors.New("configuring the api_proxy requires at least 1 listener to be defined")
 		}
 
 		if c.APIProxy.UseAutoAuthToken {
 			if c.AutoAuth == nil {
-				return fmt.Errorf("api_proxy.use_auto_auth_token is true but auto_auth not configured")
+				return errors.New("api_proxy.use_auto_auth_token is true but auto_auth not configured")
 			}
 			if c.AutoAuth != nil && c.AutoAuth.Method != nil && c.AutoAuth.Method.WrapTTL > 0 {
-				return fmt.Errorf("api_proxy.use_auto_auth_token is true and auto_auth uses wrapping")
+				return errors.New("api_proxy.use_auto_auth_token is true and auto_auth uses wrapping")
 			}
 		}
 	}
@@ -242,12 +242,12 @@ func (c *Config) ValidateConfig() error {
 	if c.AutoAuth != nil {
 		if len(c.AutoAuth.Sinks) == 0 &&
 			(c.APIProxy == nil || !c.APIProxy.UseAutoAuthToken) {
-			return fmt.Errorf("auto_auth requires at least one sink or api_proxy.use_auto_auth_token=true")
+			return errors.New("auto_auth requires at least one sink or api_proxy.use_auto_auth_token=true")
 		}
 	}
 
 	if c.AutoAuth == nil && c.Cache == nil && len(c.Listeners) == 0 {
-		return fmt.Errorf("no auto_auth, cache, or listener block found in config")
+		return errors.New("no auto_auth, cache, or listener block found in config")
 	}
 
 	return nil
@@ -349,7 +349,7 @@ func LoadConfigFile(path string) (*Config, error) {
 	}
 
 	if fi.IsDir() {
-		return nil, fmt.Errorf("location is a directory, not a file")
+		return nil, errors.New("location is a directory, not a file")
 	}
 
 	// Read the file
@@ -392,7 +392,7 @@ func LoadConfigFile(path string) (*Config, error) {
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	if err := parseAutoAuth(result, list); err != nil {
@@ -677,7 +677,7 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 		return fmt.Errorf("error parsing 'method': %w", err)
 	}
 	if a.Method == nil {
-		return fmt.Errorf("no 'method' block found")
+		return errors.New("no 'method' block found")
 	}
 
 	if err := parseSinks(result, subList); err != nil {
@@ -686,11 +686,11 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 
 	if result.AutoAuth.Method.WrapTTL > 0 {
 		if len(result.AutoAuth.Sinks) != 1 {
-			return fmt.Errorf("error parsing auto_auth: wrapping enabled on auth method and 0 or many sinks defined")
+			return errors.New("error parsing auto_auth: wrapping enabled on auth method and 0 or many sinks defined")
 		}
 
 		if result.AutoAuth.Sinks[0].WrapTTL > 0 {
-			return fmt.Errorf("error parsing auto_auth: wrapping enabled both on auth method and sink")
+			return errors.New("error parsing auto_auth: wrapping enabled both on auth method and sink")
 		}
 	}
 

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -372,7 +372,7 @@ api_proxy {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// Validate that the auto-auth token has been correctly attained
@@ -463,7 +463,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	proxyClient, err := api.NewClient(api.DefaultConfig())
@@ -555,7 +555,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	proxyClient, err := api.NewClient(api.DefaultConfig())
@@ -633,7 +633,7 @@ vault {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	proxyClient, err := api.NewClient(api.DefaultConfig())
@@ -679,7 +679,7 @@ vault {
 	token2 := secret.Auth.ClientToken
 
 	if token != token2 {
-		t.Fatalf("token create response not cached when it should have been, as tokens differ")
+		t.Fatal("token create response not cached when it should have been, as tokens differ")
 	}
 
 	close(cmd.ShutdownCh)
@@ -805,7 +805,7 @@ vault {
 			select {
 			case <-cmd.startedCh:
 			case <-time.After(5 * time.Second):
-				t.Errorf("timeout")
+				t.Error("timeout")
 			}
 
 			client, err := api.NewClient(api.DefaultConfig())
@@ -887,7 +887,7 @@ listener "tcp" {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	// defer proxy shutdown
@@ -988,7 +988,7 @@ cache {}
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 	client, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
@@ -1004,7 +1004,7 @@ cache {}
 	// First try on listener 1 where the API should be disabled.
 	resp, err := client.RawRequest(client.NewRequest(http.MethodPost, "/proxy/v1/quit"))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 	if resp != nil && resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected %d but got: %d", http.StatusNotFound, resp.StatusCode)
@@ -1024,7 +1024,7 @@ cache {}
 	select {
 	case <-cmd.ShutdownCh:
 	case <-time.After(5 * time.Second):
-		t.Errorf("timeout")
+		t.Error("timeout")
 	}
 
 	wg.Wait()
@@ -1226,7 +1226,7 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("foo.example.com"); err != nil {
@@ -1257,7 +1257,7 @@ func TestProxy_Config_ReloadTls(t *testing.T) {
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("bar.example.com"); err != nil {

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -139,7 +139,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 
 		mountInfo, ok := mounts["mount_integration/"]
 		if !ok {
-			t.Fatalf("expected mount to exist")
+			t.Fatal("expected mount to exist")
 		}
 		if exp := "pki"; mountInfo.Type != exp {
 			t.Errorf("expected %q to be %q", mountInfo.Type, exp)

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -101,7 +101,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 
 		mountInfo, ok := mounts["kv/"]
 		if !ok {
-			t.Fatalf("expected mount to exist")
+			t.Fatal("expected mount to exist")
 		}
 		if exp := "kv"; mountInfo.Type != exp {
 			t.Errorf("expected %q to be %q", mountInfo.Type, exp)
@@ -136,7 +136,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 
 		mountInfo, ok = mounts["kv/"]
 		if !ok {
-			t.Fatalf("expected mount to exist")
+			t.Fatal("expected mount to exist")
 		}
 		if exp := "2"; mountInfo.Options["version"] != exp {
 			t.Errorf("expected %q to be %q", mountInfo.Options["version"], exp)
@@ -174,7 +174,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 			}
 			mountInfo, ok := mounts["mount_tune_integration/"]
 			if !ok {
-				t.Fatalf("expected mount to exist")
+				t.Fatal("expected mount to exist")
 			}
 
 			if exp := ""; mountInfo.PluginVersion != exp {
@@ -214,7 +214,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 
 			mountInfo, ok = mounts["mount_tune_integration/"]
 			if !ok {
-				t.Fatalf("expected mount to exist")
+				t.Fatal("expected mount to exist")
 			}
 			if exp := "new description"; mountInfo.Description != exp {
 				t.Errorf("expected %q to be %q", mountInfo.Description, exp)
@@ -286,7 +286,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 
 				mountInfo, ok := mounts["mount_tune_integration/"]
 				if !ok {
-					t.Fatalf("expected mount to exist")
+					t.Fatal("expected mount to exist")
 				}
 				if exp := "initial description"; mountInfo.Description != exp {
 					t.Errorf("expected %q to be %q", mountInfo.Description, exp)
@@ -329,7 +329,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 
 				mountInfo, ok := mounts["mount_tune_integration/"]
 				if !ok {
-					t.Fatalf("expected mount to exist")
+					t.Fatal("expected mount to exist")
 				}
 				if exp := ""; mountInfo.Description != exp {
 					t.Errorf("expected %q to be %q", mountInfo.Description, exp)

--- a/command/server.go
+++ b/command/server.go
@@ -813,7 +813,7 @@ func (c *ServerCommand) InitListeners(config *server.Config, disableClustering b
 			} else {
 				tcpAddr, ok := ln.Addr().(*net.TCPAddr)
 				if !ok {
-					errMsg = fmt.Errorf("Failed to parse tcp listener")
+					errMsg = errors.New("Failed to parse tcp listener")
 					return 1, nil, nil, errMsg
 				}
 				clusterAddr := &net.TCPAddr{
@@ -1707,7 +1707,7 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 			return nil, err
 		}
 		if !unsealed {
-			return nil, fmt.Errorf("failed to unseal Vault for dev mode")
+			return nil, errors.New("failed to unseal Vault for dev mode")
 		}
 	}
 
@@ -2353,11 +2353,11 @@ func initHaBackend(c *ServerCommand, config *server.Config, coreConfig *vault.Co
 	var ok bool
 	if config.HAStorage != nil {
 		if config.Storage.Type == storageTypeRaft && config.HAStorage.Type == storageTypeRaft {
-			return false, fmt.Errorf("Raft cannot be set both as 'storage' and 'ha_storage'. Setting 'storage' to 'raft' will automatically set it up for HA operations as well")
+			return false, errors.New("Raft cannot be set both as 'storage' and 'ha_storage'. Setting 'storage' to 'raft' will automatically set it up for HA operations as well")
 		}
 
 		if config.Storage.Type == storageTypeRaft {
-			return false, fmt.Errorf("HA storage cannot be declared when Raft is the storage type")
+			return false, errors.New("HA storage cannot be declared when Raft is the storage type")
 		}
 
 		factory, exists := c.PhysicalBackends[config.HAStorage.Type]
@@ -2373,18 +2373,18 @@ func initHaBackend(c *ServerCommand, config *server.Config, coreConfig *vault.Co
 		}
 
 		if coreConfig.HAPhysical, ok = habackend.(physical.HABackend); !ok {
-			return false, fmt.Errorf("Specified HA storage does not support HA")
+			return false, errors.New("Specified HA storage does not support HA")
 		}
 
 		if !coreConfig.HAPhysical.HAEnabled() {
-			return false, fmt.Errorf("Specified HA storage has HA support disabled; please consult documentation")
+			return false, errors.New("Specified HA storage has HA support disabled; please consult documentation")
 		}
 
 		coreConfig.RedirectAddr = config.HAStorage.RedirectAddr
 		disableClustering := config.HAStorage.DisableClustering
 
 		if config.HAStorage.Type == storageTypeRaft && disableClustering {
-			return disableClustering, fmt.Errorf("Disable clustering cannot be set to true when Raft is the HA storage type")
+			return disableClustering, errors.New("Disable clustering cannot be set to true when Raft is the HA storage type")
 		}
 
 		if !disableClustering {
@@ -2396,7 +2396,7 @@ func initHaBackend(c *ServerCommand, config *server.Config, coreConfig *vault.Co
 			disableClustering := config.Storage.DisableClustering
 
 			if (config.Storage.Type == storageTypeRaft) && disableClustering {
-				return disableClustering, fmt.Errorf("Disable clustering cannot be set to true when Raft is the storage type")
+				return disableClustering, errors.New("Disable clustering cannot be set to true when Raft is the storage type")
 			}
 
 			if !disableClustering {
@@ -2436,7 +2436,7 @@ func determineRedirectAddr(c *ServerCommand, coreConfig *vault.CoreConfig, confi
 		if err != nil {
 			retErr = fmt.Errorf("Error detecting api address: %s", err)
 		} else if redirect == "" {
-			retErr = fmt.Errorf("Failed to detect api address")
+			retErr = errors.New("Failed to detect api address")
 		} else {
 			coreConfig.RedirectAddr = redirect
 		}
@@ -2754,7 +2754,7 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config, lns []listenerutil.Listener) error {
 	for _, ln := range lns {
 		if ln.Config == nil {
-			return fmt.Errorf("Found nil listener config after parsing")
+			return errors.New("Found nil listener config after parsing")
 		}
 
 		if err := config2.IsValidListener(ln.Config); err != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -682,7 +682,7 @@ func ParseConfig(d, source string) (*Config, error) {
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	// Look for storage but still support old backend

--- a/command/server/config_custom_response_headers_test.go
+++ b/command/server/config_custom_response_headers_test.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -65,7 +64,7 @@ func TestCustomResponseHeadersConfigs(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }
 
@@ -84,29 +83,29 @@ func TestCustomResponseHeadersConfigsMultipleListeners(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[1].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader["default"], config.Listeners[1].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[2].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[2].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[3].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[3].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -824,11 +824,11 @@ listener "tcp" {
 	configutil.ParseListeners(config.SharedConfig, objList)
 	listeners := config.Listeners
 	if len(listeners) == 0 {
-		t.Fatalf("expected at least one listener in the config")
+		t.Fatal("expected at least one listener in the config")
 	}
 	listener := listeners[0]
 	if listener.Type != "tcp" {
-		t.Fatalf("expected tcp listener in the config")
+		t.Fatal("expected tcp listener in the config")
 	}
 
 	expected := &Config{

--- a/command/server/listener_test.go
+++ b/command/server/listener_test.go
@@ -52,7 +52,7 @@ func testListenerImpl(t *testing.T, ln net.Listener, connFn testListenerConnFn, 
 			t.Fatalf("expected version %d, got %d", expectedVersion, tlsConn.ConnectionState().Version)
 		}
 		if len(tlsConn.ConnectionState().PeerCertificates) != 1 {
-			t.Fatalf("err: number of certs too long")
+			t.Fatal("err: number of certs too long")
 		}
 		peerName := tlsConn.ConnectionState().PeerCertificates[0].Subject.CommonName
 		if peerName != certName {
@@ -98,6 +98,6 @@ func TestProfilingUnauthenticatedInFlightAccess(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if !config.Listeners[0].InFlightRequestLogging.UnauthenticatedInFlightAccess {
-		t.Fatalf("failed to read UnauthenticatedInFlightAccess")
+		t.Fatal("failed to read UnauthenticatedInFlightAccess")
 	}
 }

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -166,7 +166,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	select {
 	case <-cmd.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("foo.example.com"); err != nil {
@@ -184,7 +184,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatalf("timeout")
+		t.Fatal("timeout")
 	}
 
 	if err := testCertificateName("bar.example.com"); err != nil {

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -661,7 +661,7 @@ func (c *SSHCommand) generateCredential(username, ip string) (*api.Secret, *SSHC
 		return nil, nil, errors.Wrap(err, "failed to get credentials")
 	}
 	if secret == nil || secret.Data == nil {
-		return nil, nil, fmt.Errorf("vault returned empty credentials")
+		return nil, nil, errors.New("vault returned empty credentials")
 	}
 
 	// Port comes back as a json.Number which mapstructure doesn't like, so
@@ -678,7 +678,7 @@ func (c *SSHCommand) generateCredential(username, ip string) (*api.Secret, *SSHC
 
 	// Check for an empty key response
 	if len(resp.Key) == 0 {
-		return nil, nil, fmt.Errorf("vault returned an invalid key")
+		return nil, nil, errors.New("vault returned an invalid key")
 	}
 
 	return secret, &resp, nil

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -230,6 +230,6 @@ func TestSSHCommandOmitFlagWarning(t *testing.T) {
 
 	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 	if strings.Contains(combined, "Command flags must be provided before positional arguments. The following arguments will not be parsed as flags") {
-		t.Fatalf("ssh command displayed flag warnings")
+		t.Fatal("ssh command displayed flag warnings")
 	}
 }

--- a/command/token/helper_external.go
+++ b/command/token/helper_external.go
@@ -5,6 +5,7 @@ package token
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,7 +35,7 @@ func ExternalTokenHelperPath(path string) (string, error) {
 	}
 
 	if _, err := os.Stat(path); err != nil {
-		return "", fmt.Errorf("unknown error getting the external helper path")
+		return "", errors.New("unknown error getting the external helper path")
 	}
 
 	return path, nil

--- a/helper/fairshare/fairshare_testing_util.go
+++ b/helper/fairshare/fairshare_testing_util.go
@@ -28,10 +28,10 @@ func (t *testJob) OnFailure(err error) {
 func newTestJob(t *testing.T, id string, ex func(string) error, onFail func(error)) testJob {
 	t.Helper()
 	if ex == nil {
-		t.Errorf("ex cannot be nil")
+		t.Error("ex cannot be nil")
 	}
 	if onFail == nil {
-		t.Errorf("onFail cannot be nil")
+		t.Error("onFail cannot be nil")
 	}
 
 	return testJob{

--- a/helper/fairshare/workerpool_test.go
+++ b/helper/fairshare/workerpool_test.go
@@ -4,6 +4,7 @@
 package fairshare
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -350,7 +351,7 @@ func TestFairshare_dispatch(t *testing.T) {
 
 func TestFairshare_jobFailure(t *testing.T) {
 	numJobs := 10
-	testErr := fmt.Errorf("test error")
+	testErr := errors.New("test error")
 	var wg sync.WaitGroup
 
 	ex := func(_ string) error {

--- a/helper/flag-slice/flag_test.go
+++ b/helper/flag-slice/flag_test.go
@@ -13,7 +13,7 @@ func TestStringFlag_implements(t *testing.T) {
 	var raw interface{}
 	raw = new(StringFlag)
 	if _, ok := raw.(flag.Value); !ok {
-		t.Fatalf("StringFlag should be a Value")
+		t.Fatal("StringFlag should be a Value")
 	}
 }
 

--- a/helper/hostutil/hostinfo_openbsd.go
+++ b/helper/hostutil/hostinfo_openbsd.go
@@ -7,7 +7,7 @@ package hostutil
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -21,9 +21,9 @@ type HostInfo struct {
 }
 
 func CollectHostInfo(ctx context.Context) (*HostInfo, error) {
-	return nil, fmt.Errorf("host info not supported on this platform")
+	return nil, errors.New("host info not supported on this platform")
 }
 
 func CollectHostMemory(ctx context.Context) (*VirtualMemoryStat, error) {
-	return nil, fmt.Errorf("host info not supported on this platform")
+	return nil, errors.New("host info not supported on this platform")
 }

--- a/helper/identity/identity.go
+++ b/helper/identity/identity.go
@@ -4,6 +4,7 @@
 package identity
 
 import (
+	"errors"
 	"fmt"
 
 	proto "github.com/golang/protobuf/proto"
@@ -12,7 +13,7 @@ import (
 
 func (g *Group) Clone() (*Group, error) {
 	if g == nil {
-		return nil, fmt.Errorf("nil group")
+		return nil, errors.New("nil group")
 	}
 
 	marshaledGroup, err := proto.Marshal(g)
@@ -31,7 +32,7 @@ func (g *Group) Clone() (*Group, error) {
 
 func (e *Entity) Clone() (*Entity, error) {
 	if e == nil {
-		return nil, fmt.Errorf("nil entity")
+		return nil, errors.New("nil entity")
 	}
 
 	marshaledEntity, err := proto.Marshal(e)
@@ -60,7 +61,7 @@ func (e *Entity) UpsertAlias(alias *Alias) {
 
 func (p *Alias) Clone() (*Alias, error) {
 	if p == nil {
-		return nil, fmt.Errorf("nil alias")
+		return nil, errors.New("nil alias")
 	}
 
 	marshaledAlias, err := proto.Marshal(p)

--- a/helper/identity/mfa/mfa.go
+++ b/helper/identity/mfa/mfa.go
@@ -4,6 +4,7 @@
 package mfa
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
@@ -11,7 +12,7 @@ import (
 
 func (c *Config) Clone() (*Config, error) {
 	if c == nil {
-		return nil, fmt.Errorf("nil config")
+		return nil, errors.New("nil config")
 	}
 
 	marshaledConfig, err := proto.Marshal(c)
@@ -30,7 +31,7 @@ func (c *Config) Clone() (*Config, error) {
 
 func (c *MFAEnforcementConfig) Clone() (*MFAEnforcementConfig, error) {
 	if c == nil {
-		return nil, fmt.Errorf("nil config")
+		return nil, errors.New("nil config")
 	}
 
 	marshaledConfig, err := proto.Marshal(c)

--- a/helper/logging/logger.go
+++ b/helper/logging/logger.go
@@ -109,12 +109,12 @@ func parseFullPath(fullPath string) (directory, fileName string, err error) {
 
 	globChars := "*?["
 	if strings.ContainsAny(directory, globChars) {
-		err = multierror.Append(err, fmt.Errorf("directory contains glob character"))
+		err = multierror.Append(err, errors.New("directory contains glob character"))
 	}
 	if fileName == "" {
 		fileName = "bao.log"
 	} else if strings.ContainsAny(fileName, globChars) {
-		err = multierror.Append(err, fmt.Errorf("file name contains globbing character"))
+		err = multierror.Append(err, errors.New("file name contains globbing character"))
 	}
 
 	return directory, fileName, err
@@ -218,6 +218,6 @@ func TranslateLoggerLevel(logger hclog.Logger) (string, error) {
 	case hclog.Trace, hclog.Debug, hclog.Info, hclog.Warn, hclog.Error:
 		return logLevel.String(), nil
 	default:
-		return "", fmt.Errorf("unknown log level")
+		return "", errors.New("unknown log level")
 	}
 }

--- a/helper/monitor/monitor.go
+++ b/helper/monitor/monitor.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,7 +63,7 @@ func NewMonitor(buf int, logger log.InterceptLogger, opts *log.LoggerOptions) (M
 
 func newMonitor(buf int, logger log.InterceptLogger, opts *log.LoggerOptions) (*monitor, error) {
 	if buf <= 0 {
-		return nil, fmt.Errorf("buf must be greater than zero")
+		return nil, errors.New("buf must be greater than zero")
 	}
 
 	sw := &monitor{

--- a/helper/osutil/fileinfo.go
+++ b/helper/osutil/fileinfo.go
@@ -4,6 +4,7 @@
 package osutil
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -43,7 +44,7 @@ func FilePermissionsMatch(info fs.FileInfo, path string, permissions int) error 
 // OwnerPermissionsMatch checks if vault user is the owner and permissions are secure for input path
 func OwnerPermissionsMatch(path string, uid int, permissions int) error {
 	if path == "" {
-		return fmt.Errorf("could not verify permissions for path. No path provided ")
+		return errors.New("could not verify permissions for path. No path provided ")
 	}
 
 	info, err := os.Stat(path)

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -77,7 +77,7 @@ func TestCheckPathInfo(t *testing.T) {
 			t.Errorf("invalid result. expected error")
 		}
 		if !tc.expectError && err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		err = os.RemoveAll("testFile")

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -74,7 +74,7 @@ func TestCheckPathInfo(t *testing.T) {
 
 		err = checkPathInfo(info, "testFile", tc.uid, int(tc.permissions))
 		if tc.expectError && err == nil {
-			t.Errorf("invalid result. expected error")
+			t.Error("invalid result. expected error")
 		}
 		if !tc.expectError && err != nil {
 			t.Error(err.Error())
@@ -141,7 +141,7 @@ func TestOwnerPermissionsMatchFile_OtherUser(t *testing.T) {
 	}
 
 	if err := OwnerPermissionsMatchFile(f, int(uid)+1, int(info.Mode())); err == nil {
-		t.Fatalf("expected error but none")
+		t.Fatal("expected error but none")
 	}
 }
 

--- a/helper/pgpkeys/encrypt_decrypt.go
+++ b/helper/pgpkeys/encrypt_decrypt.go
@@ -6,6 +6,7 @@ package pgpkeys
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -20,7 +21,7 @@ import (
 // thoroughly tested in the init and rekey command unit tests
 func EncryptShares(input [][]byte, pgpKeys []string) ([]string, [][]byte, error) {
 	if len(input) != len(pgpKeys) {
-		return nil, nil, fmt.Errorf("mismatch between number items to encrypt and number of PGP keys")
+		return nil, nil, errors.New("mismatch between number items to encrypt and number of PGP keys")
 	}
 	encryptedShares := make([][]byte, 0, len(pgpKeys))
 	entities, err := GetEntities(pgpKeys)

--- a/helper/pgpkeys/flag_test.go
+++ b/helper/pgpkeys/flag_test.go
@@ -22,7 +22,7 @@ func TestPubKeyFilesFlag_implements(t *testing.T) {
 	var raw interface{}
 	raw = new(PubKeyFilesFlag)
 	if _, ok := raw.(flag.Value); !ok {
-		t.Fatalf("PubKeysFilesFlag should be a Value")
+		t.Fatal("PubKeysFilesFlag should be a Value")
 	}
 }
 
@@ -67,7 +67,7 @@ func TestPubKeyFilesFlagSetBinary(t *testing.T) {
 
 	err = pkf.Set(tempDir + "/pubkey3")
 	if err == nil {
-		t.Fatalf("err: should not have been able to set a second value")
+		t.Fatal("err: should not have been able to set a second value")
 	}
 
 	expected := []string{strings.ReplaceAll(pubKey1, "\n", ""), strings.ReplaceAll(pubKey2, "\n", "")}
@@ -104,7 +104,7 @@ func TestPubKeyFilesFlagSetB64(t *testing.T) {
 
 	err = pkf.Set(tempDir + "/pubkey3")
 	if err == nil {
-		t.Fatalf("err: should not have been able to set a second value")
+		t.Fatal("err: should not have been able to set a second value")
 	}
 
 	expected := []string{pubKey1, pubKey2}
@@ -143,7 +143,7 @@ func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
 			t.Fatalf("bad: %v", err)
 		}
 		if entity == nil {
-			t.Fatalf("nil entity encountered")
+			t.Fatal("nil entity encountered")
 		}
 		fingerprints = append(fingerprints, hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
 	}

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -6,6 +6,7 @@ package pgpkeys
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -26,7 +27,7 @@ const (
 func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 	client := cleanhttp.DefaultClient()
 	if client == nil {
-		return nil, fmt.Errorf("unable to create an http client")
+		return nil, errors.New("unable to create an http client")
 	}
 
 	if len(input) == 0 {

--- a/helper/proxyutil/proxyutil.go
+++ b/helper/proxyutil/proxyutil.go
@@ -76,7 +76,7 @@ func WrapInProxyProto(listener net.Listener, config *ProxyProtoConfig) (net.List
 			},
 		}
 	default:
-		return listener, fmt.Errorf("unknown behavior type for proxy proto config")
+		return listener, errors.New("unknown behavior type for proxy proto config")
 	}
 
 	return newLn, nil

--- a/helper/random/parser.go
+++ b/helper/random/parser.go
@@ -4,6 +4,7 @@
 package random
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"unicode/utf8"
@@ -131,7 +132,7 @@ func getRuleInfo(rule map[string]interface{}) (data ruleInfo, err error) {
 		}
 
 		if len(slice) == 0 {
-			return data, fmt.Errorf("rule info cannot be empty")
+			return data, errors.New("rule info cannot be empty")
 		}
 
 		data = ruleInfo{
@@ -140,7 +141,7 @@ func getRuleInfo(rule map[string]interface{}) (data ruleInfo, err error) {
 		}
 		return data, nil
 	}
-	return data, fmt.Errorf("rule is empty")
+	return data, errors.New("rule is empty")
 }
 
 // stringToRunesFunc converts a string to a []rune for use in the mapstructure library
@@ -152,7 +153,7 @@ func stringToRunesFunc(from reflect.Kind, to reflect.Kind, data interface{}) (in
 	raw := data.(string)
 
 	if !utf8.ValidString(raw) {
-		return nil, fmt.Errorf("invalid UTF8 string")
+		return nil, errors.New("invalid UTF8 string")
 	}
 	return []rune(raw), nil
 }

--- a/helper/random/parser_test.go
+++ b/helper/random/parser_test.go
@@ -53,7 +53,7 @@ func TestParsePolicy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual, err := ParsePolicy(test.rawConfig)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -321,7 +321,7 @@ func TestParser_ParsePolicy(t *testing.T) {
 
 			actual, err := parser.ParsePolicy(test.rawConfig)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -415,7 +415,7 @@ func TestParseRules(t *testing.T) {
 
 			actualRules, err := parseRules(registry, test.rawRules)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -487,7 +487,7 @@ func TestGetMapSlice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actualSlice, err := getMapSlice(test.input, test.key)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -547,7 +547,7 @@ func TestGetRuleInfo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actualInfo, err := getRuleInfo(test.rule)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/helper/random/registry_test.go
+++ b/helper/random/registry_test.go
@@ -88,7 +88,7 @@ func TestParseRule(t *testing.T) {
 
 			actualRule, err := reg.parseRule(test.ruleType, test.ruleData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/helper/random/registry_test.go
+++ b/helper/random/registry_test.go
@@ -4,7 +4,7 @@
 package random
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -23,7 +23,7 @@ func newTestRule(data map[string]interface{}) (rule Rule, err error) {
 	tr := &testCharsetRule{}
 	err = mapstructure.Decode(data, tr)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode test rule")
+		return nil, errors.New("unable to decode test rule")
 	}
 	return *tr, nil
 }

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -6,6 +6,7 @@ package random
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -103,7 +104,7 @@ LOOP:
 	for {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timed out generating string")
+			return "", errors.New("timed out generating string")
 		default:
 			str, err = g.generate(rng)
 			if err != nil {
@@ -150,13 +151,13 @@ const (
 // combine bytes into a larger integer using binary.BigEndian.Uint16() function.
 func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, err error) {
 	if len(charset) == 0 {
-		return nil, fmt.Errorf("no charset specified")
+		return nil, errors.New("no charset specified")
 	}
 	if len(charset) > maxCharsetLen {
 		return nil, fmt.Errorf("charset is too long: limited to %d characters", math.MaxUint8)
 	}
 	if length <= 0 {
-		return nil, fmt.Errorf("unable to generate a zero or negative length runeset")
+		return nil, errors.New("unable to generate a zero or negative length runeset")
 	}
 
 	// This can't always select indexes from [0-maxCharsetLen) because it could introduce bias to the character selection.
@@ -232,7 +233,7 @@ func (g *StringGenerator) validateConfig() (err error) {
 	// Ensure the sum of minimum lengths in the rules doesn't exceed the length specified
 	minLen := getMinLength(g.Rules)
 	if g.Length <= 0 {
-		merr = multierror.Append(merr, fmt.Errorf("length must be > 0"))
+		merr = multierror.Append(merr, errors.New("length must be > 0"))
 	} else if g.Length < minLen {
 		merr = multierror.Append(merr, fmt.Errorf("specified rules require at least %d characters but %d is specified", minLen, g.Length))
 	}
@@ -245,11 +246,11 @@ func (g *StringGenerator) validateConfig() (err error) {
 		g.charset = getChars(g.Rules)
 	}
 	if len(g.charset) == 0 {
-		merr = multierror.Append(merr, fmt.Errorf("no charset specified"))
+		merr = multierror.Append(merr, errors.New("no charset specified"))
 	} else {
 		for _, r := range g.charset {
 			if !unicode.IsPrint(r) {
-				merr = multierror.Append(merr, fmt.Errorf("non-printable character in charset"))
+				merr = multierror.Append(merr, errors.New("non-printable character in charset"))
 				break
 			}
 		}

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -554,7 +555,7 @@ func TestStringGenerator_JSON(t *testing.T) {
 type badReader struct{}
 
 func (badReader) Read([]byte) (int, error) {
-	return 0, fmt.Errorf("test error")
+	return 0, errors.New("test error")
 }
 
 func TestValidate(t *testing.T) {

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -195,7 +195,7 @@ func TestStringGenerator_Generate_errors(t *testing.T) {
 
 			actual, err := test.generator.Generate(ctx, test.rng)
 			if err == nil {
-				t.Fatalf("Expected error but none found")
+				t.Fatal("Expected error but none found")
 			}
 			if actual != "" {
 				t.Fatalf("Random string returned: %s", actual)
@@ -361,7 +361,7 @@ func TestRandomRunes_errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual, err := randomRunes(test.rng, test.charset, test.length)
 			if err == nil {
-				t.Fatalf("Expected error but none found")
+				t.Fatal("Expected error but none found")
 			}
 			if actual != nil {
 				t.Fatalf("Expected no value, but found [%s]", string(actual))
@@ -627,7 +627,7 @@ func TestValidate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := test.generator.validateConfig()
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/helper/storagepacker/storagepacker.go
+++ b/helper/storagepacker/storagepacker.go
@@ -6,6 +6,7 @@ package storagepacker
 import (
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -45,7 +46,7 @@ func (s *StoragePacker) View() logical.Storage {
 // GetBucket returns a bucket for a given key
 func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, error) {
 	if key == "" {
-		return nil, fmt.Errorf("missing bucket key")
+		return nil, errors.New("missing bucket key")
 	}
 
 	lock := locksutil.LockForKey(s.storageLocks, key)
@@ -82,15 +83,15 @@ func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, err
 // if an item with a matching key is already present.
 func (s *Bucket) upsert(item *Item) error {
 	if s == nil {
-		return fmt.Errorf("nil storage bucket")
+		return errors.New("nil storage bucket")
 	}
 
 	if item == nil {
-		return fmt.Errorf("nil item")
+		return errors.New("nil item")
 	}
 
 	if item.ID == "" {
-		return fmt.Errorf("missing item ID")
+		return errors.New("missing item ID")
 	}
 
 	// Look for an item with matching key and don't modify the collection while
@@ -233,11 +234,11 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_bucket"}, time.Now())
 	if bucket == nil {
-		return fmt.Errorf("nil bucket entry")
+		return errors.New("nil bucket entry")
 	}
 
 	if bucket.Key == "" {
-		return fmt.Errorf("missing key")
+		return errors.New("missing key")
 	}
 
 	if !strings.HasPrefix(bucket.Key, s.viewPrefix) {
@@ -274,7 +275,7 @@ func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
 	defer metrics.MeasureSince([]string{"storage_packer", "get_item"}, time.Now())
 
 	if itemID == "" {
-		return nil, fmt.Errorf("empty item ID")
+		return nil, errors.New("empty item ID")
 	}
 
 	bucketKey := s.BucketKey(itemID)
@@ -303,11 +304,11 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_item"}, time.Now())
 
 	if item == nil {
-		return fmt.Errorf("nil item")
+		return errors.New("nil item")
 	}
 
 	if item.ID == "" {
-		return fmt.Errorf("missing ID in item")
+		return errors.New("missing ID in item")
 	}
 
 	var err error
@@ -362,7 +363,7 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 // NewStoragePacker creates a new storage packer for a given view
 func NewStoragePacker(view logical.Storage, logger log.Logger, viewPrefix string) (*StoragePacker, error) {
 	if view == nil {
-		return nil, fmt.Errorf("nil view")
+		return nil, errors.New("nil view")
 	}
 
 	if viewPrefix == "" {

--- a/helper/storagepacker/storagepacker_test.go
+++ b/helper/storagepacker/storagepacker_test.go
@@ -91,7 +91,7 @@ func TestStoragePacker(t *testing.T) {
 		t.Fatal(err)
 	}
 	if fetchedItem == nil {
-		t.Fatalf("failed to read the stored item")
+		t.Fatal("failed to read the stored item")
 	}
 
 	if item1.ID != fetchedItem.ID {
@@ -111,7 +111,7 @@ func TestStoragePacker(t *testing.T) {
 	}
 
 	if fetchedItem != nil {
-		t.Fatalf("failed to delete item")
+		t.Fatal("failed to delete item")
 	}
 }
 
@@ -207,7 +207,7 @@ func TestStoragePacker_DeleteMultiple(t *testing.T) {
 			t.Fatal(err)
 		}
 		if fetchedItem == nil {
-			t.Fatalf("failed to read the stored item")
+			t.Fatal("failed to read the stored item")
 		}
 
 		if item.ID != fetchedItem.ID {
@@ -236,7 +236,7 @@ func TestStoragePacker_DeleteMultiple(t *testing.T) {
 			t.Fatal("expected item not found")
 		}
 		if i%2 == 1 && fetchedItem != nil {
-			t.Fatalf("failed to delete item")
+			t.Fatal("failed to delete item")
 		}
 	}
 }
@@ -267,7 +267,7 @@ func TestStoragePacker_DeleteMultiple_ALL(t *testing.T) {
 			t.Fatal(err)
 		}
 		if fetchedItem == nil {
-			t.Fatalf("failed to read the stored item")
+			t.Fatal("failed to read the stored item")
 		}
 
 		if item.ID != fetchedItem.ID {

--- a/helper/testhelpers/certhelpers/cert_helpers.go
+++ b/helper/testhelpers/certhelpers/cert_helpers.go
@@ -229,7 +229,7 @@ func getSubjKeyID(t *testing.T, privateKey crypto.Signer) []byte {
 	t.Helper()
 
 	if privateKey == nil {
-		t.Fatalf("passed-in private key is nil")
+		t.Fatal("passed-in private key is nil")
 	}
 
 	marshaledKey, err := x509.MarshalPKIXPublicKey(privateKey.Public())

--- a/helper/testhelpers/logical/testing.go
+++ b/helper/testhelpers/logical/testing.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -434,7 +435,7 @@ func TestCheckMulti(fs ...TestCheckFunc) TestCheckFunc {
 func TestCheckAuth(policies []string) TestCheckFunc {
 	return func(resp *logical.Response) error {
 		if resp == nil || resp.Auth == nil {
-			return fmt.Errorf("no auth in response")
+			return errors.New("no auth in response")
 		}
 		expected := make([]string, len(policies))
 		copy(expected, policies)
@@ -455,7 +456,7 @@ func TestCheckAuth(policies []string) TestCheckFunc {
 func TestCheckAuthEntityId(entity_id *string) TestCheckFunc {
 	return func(resp *logical.Response) error {
 		if resp == nil || resp.Auth == nil {
-			return fmt.Errorf("no auth in response")
+			return errors.New("no auth in response")
 		}
 
 		if *entity_id == "" {
@@ -474,11 +475,11 @@ func TestCheckAuthEntityId(entity_id *string) TestCheckFunc {
 func TestCheckAuthEntityAliasMetadataName(key string, value string) TestCheckFunc {
 	return func(resp *logical.Response) error {
 		if resp == nil || resp.Auth == nil {
-			return fmt.Errorf("no auth in response")
+			return errors.New("no auth in response")
 		}
 
 		if key == "" || value == "" {
-			return fmt.Errorf("alias metadata key and value required")
+			return errors.New("alias metadata key and value required")
 		}
 
 		name, ok := resp.Auth.Alias.Metadata[key]
@@ -498,7 +499,7 @@ func TestCheckAuthEntityAliasMetadataName(key string, value string) TestCheckFun
 func TestCheckAuthDisplayName(n string) TestCheckFunc {
 	return func(resp *logical.Response) error {
 		if resp.Auth == nil {
-			return fmt.Errorf("no auth in response")
+			return errors.New("no auth in response")
 		}
 		if n != "" && resp.Auth.DisplayName != "mnt-"+n {
 			return fmt.Errorf("invalid display name: %#v", resp.Auth.DisplayName)
@@ -512,7 +513,7 @@ func TestCheckAuthDisplayName(n string) TestCheckFunc {
 func TestCheckError() TestCheckFunc {
 	return func(resp *logical.Response) error {
 		if !resp.IsError() {
-			return fmt.Errorf("response should be error")
+			return errors.New("response should be error")
 		}
 
 		return nil

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -193,14 +193,14 @@ func AttemptUnsealCore(c *vault.TestCluster, core *vault.TestClusterCore) error 
 			}
 		}
 		if statusResp == nil {
-			return fmt.Errorf("nil status response during unseal")
+			return errors.New("nil status response during unseal")
 		}
 		if !statusResp.Sealed {
 			break
 		}
 	}
 	if core.Sealed() {
-		return fmt.Errorf("core is still sealed")
+		return errors.New("core is still sealed")
 	}
 	return nil
 }
@@ -601,7 +601,7 @@ func AwaitLeader(t testing.T, cluster *vault.TestCluster) (int, error) {
 		time.Sleep(time.Second)
 	}
 
-	return 0, fmt.Errorf("timeout waiting leader")
+	return 0, errors.New("timeout waiting leader")
 }
 
 func GenerateDebugLogs(t testing.T, client *api.Client) chan struct{} {
@@ -770,7 +770,7 @@ func SetNonRootToken(client *api.Client) error {
 	}
 
 	if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
-		return fmt.Errorf("missing token auth data")
+		return errors.New("missing token auth data")
 	}
 
 	client.SetToken(secret.Auth.ClientToken)

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -353,7 +353,7 @@ func WaitForActiveNode(t testing.T, cluster *vault.TestCluster) *vault.TestClust
 		time.Sleep(time.Second)
 	}
 
-	t.Fatalf("node did not become active")
+	t.Fatal("node did not become active")
 	return nil
 }
 
@@ -370,7 +370,7 @@ func WaitForStandbyNode(t testing.T, core *vault.TestClusterCore) {
 		time.Sleep(time.Second)
 	}
 
-	t.Fatalf("node did not become standby")
+	t.Fatal("node did not become standby")
 }
 
 func RekeyCluster(t testing.T, cluster *vault.TestCluster, recovery bool) [][]byte {
@@ -576,7 +576,7 @@ func WaitForRaftApply(t testing.T, core *vault.TestClusterCore, index uint64) {
 		time.Sleep(time.Second)
 	}
 
-	t.Fatalf("node did not apply index")
+	t.Fatal("node did not apply index")
 }
 
 // AwaitLeader waits for one of the cluster's nodes to become leader.
@@ -872,7 +872,7 @@ func SetupTOTPMethod(t testing.T, client *api.Client, config map[string]interfac
 
 	methodID := resp1.Data["method_id"].(string)
 	if methodID == "" {
-		t.Fatalf("method ID is empty")
+		t.Fatal("method ID is empty")
 	}
 
 	return methodID
@@ -884,7 +884,7 @@ func SetupMFALoginEnforcement(t testing.T, client *api.Client, config map[string
 	t.Helper()
 	enfName, ok := config["name"]
 	if !ok {
-		t.Fatalf("couldn't find name in login-enforcement config")
+		t.Fatal("couldn't find name in login-enforcement config")
 	}
 	_, err := client.Logical().WriteWithContext(context.Background(), fmt.Sprintf("identity/mfa/login-enforcement/%s", enfName), config)
 	if err != nil {
@@ -910,7 +910,7 @@ func SetupUserpassMountAccessor(t testing.T, client *api.Client) string {
 		t.Fatalf("failed to list auth methods: %v", err)
 	}
 	if auths == nil || auths["userpass/"] == nil {
-		t.Fatalf("failed to get userpass mount accessor")
+		t.Fatal("failed to get userpass mount accessor")
 	}
 
 	return auths["userpass/"].Accessor
@@ -945,7 +945,7 @@ func RegisterEntityInTOTPEngine(t testing.T, client *api.Client, entityID, metho
 		"mfa_method_ids":      []string{methodID},
 	})
 	if err != nil {
-		t.Fatalf("failed to create login enforcement")
+		t.Fatal("failed to create login enforcement")
 	}
 
 	return totpGenName

--- a/http/auth_token_test.go
+++ b/http/auth_token_test.go
@@ -48,7 +48,7 @@ func TestAuthTokenCreate(t *testing.T) {
 		t.Errorf("expected 1h, got %q", secret.Auth.LeaseDuration)
 	}
 	if secret.Auth.Renewable {
-		t.Errorf("expected non-renewable token")
+		t.Error("expected non-renewable token")
 	}
 
 	*renewCreateRequest.Renewable = true
@@ -60,7 +60,7 @@ func TestAuthTokenCreate(t *testing.T) {
 		t.Errorf("expected 1h, got %q", secret.Auth.LeaseDuration)
 	}
 	if !secret.Auth.Renewable {
-		t.Errorf("expected renewable token")
+		t.Error("expected renewable token")
 	}
 
 	explicitMaxCreateRequest := &api.TokenCreateRequest{

--- a/http/cors.go
+++ b/http/cors.go
@@ -4,7 +4,7 @@
 package http
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -44,7 +44,7 @@ func wrapCORSHandler(h http.Handler, core *vault.Core) http.Handler {
 
 		// Return a 403 if the origin is not allowed to make cross-origin requests.
 		if !corsConf.IsValidOrigin(origin) {
-			respondError(w, http.StatusForbidden, fmt.Errorf("origin not allowed"))
+			respondError(w, http.StatusForbidden, errors.New("origin not allowed"))
 			return
 		}
 

--- a/http/forwarding_test.go
+++ b/http/forwarding_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -173,7 +174,7 @@ func testHTTP_Forwarding_Stress_Common(t *testing.T, parallel bool, num uint32) 
 	client := &http.Client{
 		Transport: transport,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return fmt.Errorf("redirects not allowed in this test")
+			return errors.New("redirects not allowed in this test")
 		},
 	}
 
@@ -246,7 +247,7 @@ func testHTTP_Forwarding_Stress_Common(t *testing.T, parallel bool, num uint32) 
 
 		doResp := func(resp *http.Response) (*api.Secret, error) {
 			if resp == nil {
-				return nil, fmt.Errorf("nil response")
+				return nil, errors.New("nil response")
 			}
 			defer resp.Body.Close()
 
@@ -332,7 +333,7 @@ func testHTTP_Forwarding_Stress_Common(t *testing.T, parallel bool, num uint32) 
 
 				latest := secret.Data["ciphertext"].(string)
 				if latest == "" {
-					panic(fmt.Errorf("bad ciphertext"))
+					panic(errors.New("bad ciphertext"))
 				}
 				latestEncryptedText[chosenKey] = secret.Data["ciphertext"].(string)
 
@@ -521,7 +522,7 @@ func TestHTTP_Forwarding_ClientTLS(t *testing.T) {
 		httpClient := &http.Client{
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
-				return fmt.Errorf("redirects not allowed in this test")
+				return errors.New("redirects not allowed in this test")
 			},
 		}
 		client, err := api.NewClient(&api.Config{

--- a/http/handler.go
+++ b/http/handler.go
@@ -380,7 +380,7 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, props *vault.HandlerPr
 		// in-flight requests, and use that to update the req data with clientID
 		inFlightReqID, err := uuid.GenerateUUID()
 		if err != nil {
-			respondError(nw, http.StatusInternalServerError, fmt.Errorf("failed to generate an identifier for the in-flight request"))
+			respondError(nw, http.StatusInternalServerError, errors.New("failed to generate an identifier for the in-flight request"))
 		}
 		// adding an entry to the context to enable updating in-flight
 		// data with ClientID in the logical layer
@@ -437,7 +437,7 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 				h.ServeHTTP(w, r)
 				return
 			}
-			respondError(w, http.StatusBadRequest, fmt.Errorf("missing x-forwarded-for header and configured to reject when not present"))
+			respondError(w, http.StatusBadRequest, errors.New("missing x-forwarded-for header and configured to reject when not present"))
 			return
 		}
 
@@ -486,7 +486,7 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 				return
 			}
 
-			respondError(w, http.StatusBadRequest, fmt.Errorf("client address not authorized for x-forwarded-for and configured to reject connection"))
+			respondError(w, http.StatusBadRequest, errors.New("client address not authorized for x-forwarded-for and configured to reject connection"))
 			return
 		}
 
@@ -754,7 +754,7 @@ func handleRequestForwarding(core *vault.Core, handler http.Handler) http.Handle
 			return
 		}
 		if leaderAddr == "" {
-			respondError(w, http.StatusInternalServerError, fmt.Errorf("local node not active but active cluster node not found"))
+			respondError(w, http.StatusInternalServerError, errors.New("local node not active but active cluster node not found"))
 			return
 		}
 
@@ -981,7 +981,7 @@ func requestWrapInfo(r *http.Request, req *logical.Request) (*logical.Request, e
 		return req, err
 	}
 	if int64(dur) < 0 {
-		return req, fmt.Errorf("requested wrap ttl cannot be negative")
+		return req, errors.New("requested wrap ttl cannot be negative")
 	}
 
 	req.WrapInfo = &logical.RequestWrapInfo{
@@ -1001,7 +1001,7 @@ func requestWrapInfo(r *http.Request, req *logical.Request) (*logical.Request, e
 // them with MFA method name as the index.
 func parseMFAHeader(req *logical.Request) error {
 	if req == nil {
-		return fmt.Errorf("request is nil")
+		return errors.New("request is nil")
 	}
 
 	if req.Headers == nil {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -283,13 +283,13 @@ func TestHandler_CacheControlNoStore(t *testing.T) {
 	}
 
 	if resp == nil {
-		t.Fatalf("nil response")
+		t.Fatal("nil response")
 	}
 
 	actual := resp.Header.Get("Cache-Control")
 
 	if actual == "" {
-		t.Fatalf("missing 'Cache-Control' header entry in response writer")
+		t.Fatal("missing 'Cache-Control' header entry in response writer")
 	}
 
 	if actual != "no-store" {
@@ -316,7 +316,7 @@ func TestHandler_InFlightRequest(t *testing.T) {
 	}
 
 	if resp == nil {
-		t.Fatalf("nil response")
+		t.Fatal("nil response")
 	}
 
 	var actual map[string]interface{}
@@ -738,7 +738,7 @@ func TestHandler_requestAuth(t *testing.T) {
 			t.Fatal("token entry should not be nil")
 		}
 		if !reflect.DeepEqual(req.TokenEntry(), te) {
-			t.Fatalf("token entry should be the same as the core")
+			t.Fatal("token entry should be the same as the core")
 		}
 		if req.ClientTokenAccessor == "" {
 			t.Fatal("token accessor should not be empty")

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -6,6 +6,7 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,7 +92,7 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if disableRedirect {
-			return fmt.Errorf("checkRedirect disabled for test")
+			return errors.New("checkRedirect disabled for test")
 		}
 		if len(via) > defaultRedirectLimit {
 			return fmt.Errorf("%d consecutive requests(redirects)", len(via))

--- a/http/logical.go
+++ b/http/logical.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -141,7 +142,7 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 			if err != nil && err != bufio.ErrBufferFull && err != io.EOF {
 				status := http.StatusBadRequest
 				logical.AdjustErrorStatusCode(&status, err)
-				return nil, nil, status, fmt.Errorf("error reading data")
+				return nil, nil, status, errors.New("error reading data")
 			}
 
 			if isForm(head, contentType) {
@@ -149,7 +150,7 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 				if err != nil {
 					status := http.StatusBadRequest
 					logical.AdjustErrorStatusCode(&status, err)
-					return nil, nil, status, fmt.Errorf("error parsing form data")
+					return nil, nil, status, errors.New("error parsing form data")
 				}
 
 				data = formData
@@ -162,7 +163,7 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 				if err != nil {
 					status := http.StatusBadRequest
 					logical.AdjustErrorStatusCode(&status, err)
-					return nil, nil, status, fmt.Errorf("error parsing JSON")
+					return nil, nil, status, errors.New("error parsing JSON")
 				}
 			}
 		}
@@ -192,7 +193,7 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 		if err != nil {
 			status := http.StatusBadRequest
 			logical.AdjustErrorStatusCode(&status, err)
-			return nil, nil, status, fmt.Errorf("error parsing JSON")
+			return nil, nil, status, errors.New("error parsing JSON")
 		}
 
 	case "LIST":

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -771,7 +771,7 @@ func TestLogical_AuditPort(t *testing.T) {
 		resp, err := c.Logical().Write("kv/data/foo", writeData)
 		if err != nil {
 			if strings.Contains(err.Error(), "Upgrading from non-versioned to versioned data") {
-				t.Logf("Retrying fetch KV data due to upgrade error")
+				t.Log("Retrying fetch KV data due to upgrade error")
 				time.Sleep(100 * time.Millisecond)
 				numFailures += 1
 				return err

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -41,7 +40,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 		return
 	}
 	if barrierConfig == nil {
-		respondError(w, http.StatusBadRequest, fmt.Errorf("server is not yet initialized"))
+		respondError(w, http.StatusBadRequest, errors.New("server is not yet initialized"))
 		return
 	}
 

--- a/http/sys_generate_root_test.go
+++ b/http/sys_generate_root_test.go
@@ -80,7 +80,7 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["nonce"].(string) == "" {
-		t.Fatalf("nonce was empty")
+		t.Fatal("nonce was empty")
 	}
 	expected["nonce"] = actual["nonce"]
 	expected["otp"] = actual["otp"]
@@ -105,7 +105,7 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["nonce"].(string) == "" {
-		t.Fatalf("nonce was empty")
+		t.Fatal("nonce was empty")
 	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
@@ -141,7 +141,7 @@ func TestSysGenerateRootAttempt_Setup_PGP(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["nonce"].(string) == "" {
-		t.Fatalf("nonce was empty")
+		t.Fatal("nonce was empty")
 	}
 	expected["nonce"] = actual["nonce"]
 	if diff := deep.Equal(actual, expected); diff != nil {
@@ -171,7 +171,7 @@ func TestSysGenerateRootAttempt_Cancel(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["nonce"].(string) == "" {
-		t.Fatalf("nonce was empty")
+		t.Fatal("nonce was empty")
 	}
 	expected["nonce"] = actual["nonce"]
 	expected["otp"] = actual["otp"]
@@ -320,10 +320,10 @@ func TestSysGenerateRoot_Update_OTP(t *testing.T) {
 	}
 
 	if actual["encoded_token"] == nil || actual["encoded_token"] == "" {
-		t.Fatalf("no encoded token found in response")
+		t.Fatal("no encoded token found in response")
 	}
 	if actual["encoded_root_token"] == nil || actual["encoded_root-token"] == "" {
-		t.Fatalf("no encoded root token found in response")
+		t.Fatal("no encoded root token found in response")
 	}
 	expected["encoded_token"] = actual["encoded_token"]
 	expected["encoded_root_token"] = actual["encoded_root_token"]
@@ -424,10 +424,10 @@ func TestSysGenerateRoot_Update_PGP(t *testing.T) {
 	}
 
 	if actual["encoded_token"] == nil || actual["encoded_token"] == "" {
-		t.Fatalf("no encoded token found in response")
+		t.Fatal("no encoded token found in response")
 	}
 	if actual["encoded_root_token"] == nil || actual["encoded_root-token"] == "" {
-		t.Fatalf("no encoded root token found in response")
+		t.Fatal("no encoded root token found in response")
 	}
 	expected["encoded_token"] = actual["encoded_token"]
 	expected["encoded_root_token"] = actual["encoded_root_token"]

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -6,6 +6,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -151,7 +152,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 			return http.StatusInternalServerError, nil, err
 		}
 		if cluster == nil {
-			return http.StatusInternalServerError, nil, fmt.Errorf("failed to fetch cluster details")
+			return http.StatusInternalServerError, nil, errors.New("failed to fetch cluster details")
 		}
 		clusterName = cluster.Name
 		clusterID = cluster.ID

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -4,7 +4,7 @@
 package http
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -48,7 +48,7 @@ func handleMetricsUnauthenticated(core *vault.Core) http.Handler {
 			w.WriteHeader(status)
 			w.Write(v)
 		default:
-			respondError(w, http.StatusInternalServerError, fmt.Errorf("wrong response returned"))
+			respondError(w, http.StatusInternalServerError, errors.New("wrong response returned"))
 		}
 	})
 }

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/openbao/openbao/helper/pgpkeys"
@@ -28,7 +27,7 @@ func handleSysRekeyInit(core *vault.Core, recovery bool) http.Handler {
 
 		switch {
 		case recovery && !core.SealAccess().RecoveryKeySupported():
-			respondError(w, http.StatusBadRequest, fmt.Errorf("recovery rekeying not supported"))
+			respondError(w, http.StatusBadRequest, errors.New("recovery rekeying not supported"))
 		case r.Method == "GET":
 			handleSysRekeyInitGet(ctx, core, recovery, w, r)
 		case r.Method == "POST" || r.Method == "PUT":
@@ -48,7 +47,7 @@ func handleSysRekeyInitGet(ctx context.Context, core *vault.Core, recovery bool,
 		return
 	}
 	if barrierConfig == nil {
-		respondError(w, http.StatusBadRequest, fmt.Errorf("server is not yet initialized"))
+		respondError(w, http.StatusBadRequest, errors.New("server is not yet initialized"))
 		return
 	}
 
@@ -109,12 +108,12 @@ func handleSysRekeyInitPut(ctx context.Context, core *vault.Core, recovery bool,
 	}
 
 	if req.Backup && len(req.PGPKeys) == 0 {
-		respondError(w, http.StatusBadRequest, fmt.Errorf("cannot request a backup of the new keys without providing PGP keys for encryption"))
+		respondError(w, http.StatusBadRequest, errors.New("cannot request a backup of the new keys without providing PGP keys for encryption"))
 		return
 	}
 
 	if len(req.PGPKeys) > 0 && len(req.PGPKeys) != req.SecretShares {
-		respondError(w, http.StatusBadRequest, fmt.Errorf("incorrect number of PGP keys for rekey"))
+		respondError(w, http.StatusBadRequest, errors.New("incorrect number of PGP keys for rekey"))
 		return
 	}
 
@@ -229,7 +228,7 @@ func handleSysRekeyVerify(core *vault.Core, recovery bool) http.Handler {
 
 		switch {
 		case recovery && !core.SealAccess().RecoveryKeySupported():
-			respondError(w, http.StatusBadRequest, fmt.Errorf("recovery rekeying not supported"))
+			respondError(w, http.StatusBadRequest, errors.New("recovery rekeying not supported"))
 		case r.Method == "GET":
 			handleSysRekeyVerifyGet(ctx, core, recovery, w, r)
 		case r.Method == "POST" || r.Method == "PUT":
@@ -249,7 +248,7 @@ func handleSysRekeyVerifyGet(ctx context.Context, core *vault.Core, recovery boo
 		return
 	}
 	if barrierConfig == nil {
-		respondError(w, http.StatusBadRequest, fmt.Errorf("server is not yet initialized"))
+		respondError(w, http.StatusBadRequest, errors.New("server is not yet initialized"))
 		return
 	}
 

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -102,7 +102,7 @@ func TestSysRekey_Init_Setup(t *testing.T) {
 		}
 
 		if actual["nonce"].(string) == "" {
-			t.Fatalf("nonce was empty")
+			t.Fatal("nonce was empty")
 		}
 		expected["nonce"] = actual["nonce"]
 		if diff := deep.Equal(actual, expected); diff != nil {
@@ -127,10 +127,10 @@ func TestSysRekey_Init_Setup(t *testing.T) {
 			"verification_required": false,
 		}
 		if actual["nonce"].(string) == "" {
-			t.Fatalf("nonce was empty")
+			t.Fatal("nonce was empty")
 		}
 		if actual["nonce"].(string) == "" {
-			t.Fatalf("nonce was empty")
+			t.Fatal("nonce was empty")
 		}
 		expected["nonce"] = actual["nonce"]
 		if !reflect.DeepEqual(actual, expected) {

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -49,7 +49,7 @@ func TestSysSealStatus(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["version"] == nil {
-		t.Fatalf("expected version information")
+		t.Fatal("expected version information")
 	}
 	expected["version"] = actual["version"]
 	if actual["cluster_name"] == nil {
@@ -143,7 +143,7 @@ func TestSysUnseal(t *testing.T) {
 			expected["nonce"] = actual["nonce"]
 		}
 		if actual["version"] == nil {
-			t.Fatalf("expected version information")
+			t.Fatal("expected version information")
 		}
 		expected["version"] = actual["version"]
 		if actual["cluster_name"] == nil {
@@ -373,11 +373,11 @@ func TestSysUnseal_Reset(t *testing.T) {
 		testResponseStatus(t, resp, 200)
 		testResponseBody(t, resp, &actual)
 		if actual["version"] == nil {
-			t.Fatalf("expected version information")
+			t.Fatal("expected version information")
 		}
 		expected["version"] = actual["version"]
 		if actual["nonce"] == "" && expected["sealed"].(bool) {
-			t.Fatalf("expected a nonce")
+			t.Fatal("expected a nonce")
 		}
 		expected["nonce"] = actual["nonce"]
 		if actual["cluster_name"] == nil {
@@ -414,7 +414,7 @@ func TestSysUnseal_Reset(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if actual["version"] == nil {
-		t.Fatalf("expected version information")
+		t.Fatal("expected version information")
 	}
 	expected["version"] = actual["version"]
 	expected["nonce"] = actual["nonce"]

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -4,6 +4,7 @@
 package configutil
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -92,7 +93,7 @@ func ParseConfig(d string) (*SharedConfig, error) {
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	if o := list.Filter("hsm"); len(o.Items) > 0 {

--- a/internalshared/configutil/http_response_headers.go
+++ b/internalshared/configutil/http_response_headers.go
@@ -4,6 +4,7 @@
 package configutil
 
 import (
+	"errors"
 	"fmt"
 	"net/textproto"
 	"strconv"
@@ -38,14 +39,14 @@ func ParseCustomResponseHeaders(responseHeaders interface{}) (map[string]map[str
 
 	customResponseHeader, ok := responseHeaders.([]map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("response headers were not configured correctly. please make sure they're in a slice of maps")
+		return nil, errors.New("response headers were not configured correctly. please make sure they're in a slice of maps")
 	}
 
 	for _, crh := range customResponseHeader {
 		for statusCode, responseHeader := range crh {
 			headerValList, ok := responseHeader.([]map[string]interface{})
 			if !ok {
-				return nil, fmt.Errorf("response headers were not configured correctly. please make sure they're in a slice of maps")
+				return nil, errors.New("response headers were not configured correctly. please make sure they're in a slice of maps")
 			}
 
 			if !IsValidStatusCode(statusCode) {
@@ -53,7 +54,7 @@ func ParseCustomResponseHeaders(responseHeaders interface{}) (map[string]map[str
 			}
 
 			if len(headerValList) != 1 {
-				return nil, fmt.Errorf("invalid number of response headers exist")
+				return nil, errors.New("invalid number of response headers exist")
 			}
 			headerValMap := headerValList[0]
 			headerVal, err := parseHeaders(headerValMap)
@@ -112,7 +113,7 @@ func parseHeaders(in map[string]interface{}) (map[string]string, error) {
 func parseHeaderValues(header interface{}) (string, error) {
 	var sl []string
 	if _, ok := header.([]interface{}); !ok {
-		return "", fmt.Errorf("headers must be given in a list of strings")
+		return "", errors.New("headers must be given in a list of strings")
 	}
 	headerValList := header.([]interface{})
 	for _, vh := range headerValList {

--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -6,6 +6,7 @@ package configutil
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -145,7 +146,7 @@ func ParseKMSes(d string) ([]*KMS, error) {
 
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+		return nil, errors.New("error parsing: file doesn't contain a root object")
 	}
 
 	if o := list.Filter("seal"); len(o.Items) > 0 {

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -174,7 +174,7 @@ func (t *Telemetry) GoString() string {
 
 func parseTelemetry(result *SharedConfig, list *ast.ObjectList) error {
 	if len(list.Items) > 1 {
-		return fmt.Errorf("only one 'telemetry' block is permitted")
+		return errors.New("only one 'telemetry' block is permitted")
 	}
 
 	// Get our one item
@@ -418,7 +418,7 @@ func parsePrefixFilter(prefixFilters []string) ([]string, []string, error) {
 
 	for _, rule := range prefixFilters {
 		if rule == "" {
-			return nil, nil, fmt.Errorf("Cannot have empty filter rule in prefix_filter")
+			return nil, nil, errors.New("Cannot have empty filter rule in prefix_filter")
 		}
 		switch rule[0] {
 		case '+':

--- a/internalshared/listenerutil/listener.go
+++ b/internalshared/listenerutil/listener.go
@@ -6,6 +6,7 @@ package listenerutil
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -129,7 +130,7 @@ PASSPHRASECORRECT:
 	}
 
 	if tlsConf.MaxVersion < tlsConf.MinVersion {
-		return nil, nil, fmt.Errorf("'tls_max_version' must be greater than or equal to 'tls_min_version'")
+		return nil, nil, errors.New("'tls_max_version' must be greater than or equal to 'tls_min_version'")
 	}
 
 	if len(l.TLSCipherSuites) > 0 {
@@ -173,7 +174,7 @@ Please see https://tools.ietf.org/html/rfc7540#appendix-A for further informatio
 			}
 
 			if !caPool.AppendCertsFromPEM(data) {
-				return nil, nil, fmt.Errorf("failed to parse CA certificate in tls_client_ca_file")
+				return nil, nil, errors.New("failed to parse CA certificate in tls_client_ca_file")
 			}
 			tlsConf.ClientCAs = caPool
 		}
@@ -181,7 +182,7 @@ Please see https://tools.ietf.org/html/rfc7540#appendix-A for further informatio
 
 	if l.TLSDisableClientCerts {
 		if l.TLSRequireAndVerifyClientCert {
-			return nil, nil, fmt.Errorf("'tls_disable_client_certs' and 'tls_require_and_verify_client_cert' are mutually exclusive")
+			return nil, nil, errors.New("'tls_disable_client_certs' and 'tls_require_and_verify_client_cert' are mutually exclusive")
 		}
 		tlsConf.ClientAuth = tls.NoClientCert
 	}

--- a/internalshared/listenerutil/listener_test.go
+++ b/internalshared/listenerutil/listener_test.go
@@ -52,7 +52,7 @@ func TestUnixSocketListener(t *testing.T) {
 			t.Fatal(err)
 		}
 		if fi.Mode().Perm() != os.FileMode(mode) {
-			t.Fatalf("failed to set permissions on the socket file")
+			t.Fatal("failed to set permissions on the socket file")
 		}
 	})
 	t.Run("names", func(t *testing.T) {
@@ -83,7 +83,7 @@ func TestUnixSocketListener(t *testing.T) {
 			t.Fatal(err)
 		}
 		if fi.Mode().Perm() != os.FileMode(mode) {
-			t.Fatalf("failed to set permissions on the socket file")
+			t.Fatal("failed to set permissions on the socket file")
 		}
 	})
 }

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -6,6 +6,7 @@ package postgresql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 	// Get the PostgreSQL credentials to perform read/write operations.
 	connURL := connectionURL(conf)
 	if connURL == "" {
-		return nil, fmt.Errorf("missing connection_url")
+		return nil, errors.New("missing connection_url")
 	}
 
 	unquoted_table, ok := conf["table"]
@@ -176,7 +177,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 	}
 
 	if !upsertAvailable && conf["ha_enabled"] == "true" {
-		return nil, fmt.Errorf("ha_enabled=true in config but PG version doesn't support HA, must be at least 9.5")
+		return nil, errors.New("ha_enabled=true in config but PG version doesn't support HA, must be at least 9.5")
 	}
 
 	// Setup our put strategy based on the presence or absence of a native
@@ -588,7 +589,7 @@ func (l *PostgreSQLLock) writeItem() (bool, error) {
 		return false, err
 	}
 	if sqlResult == nil {
-		return false, fmt.Errorf("empty SQL response received")
+		return false, errors.New("empty SQL response received")
 	}
 
 	ar, err := sqlResult.RowsAffected()

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -86,12 +86,12 @@ func TestPostgreSQLBackend(t *testing.T) {
 
 	ha1, ok := b1.(physical.HABackend)
 	if !ok {
-		t.Fatalf("PostgreSQLDB does not implement HABackend")
+		t.Fatal("PostgreSQLDB does not implement HABackend")
 	}
 
 	ha2, ok := b2.(physical.HABackend)
 	if !ok {
-		t.Fatalf("PostgreSQLDB does not implement HABackend")
+		t.Fatal("PostgreSQLDB does not implement HABackend")
 	}
 
 	if ha1.HAEnabled() && ha2.HAEnabled() {
@@ -222,7 +222,7 @@ func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
 			t.Fatalf("err: %v", err)
 		}
 		if leaderCh == nil {
-			t.Fatalf("failed to get leader ch")
+			t.Fatal("failed to get leader ch")
 		}
 
 		if tries == 1 {
@@ -238,7 +238,7 @@ func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
 				// Our test environment is slow enough that we failed this, retry
 				return false
 			}
-			t.Fatalf("should be held")
+			t.Fatal("should be held")
 		}
 		if val != "bar" {
 			t.Fatalf("bad value: %v", val)
@@ -270,7 +270,7 @@ func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
 			t.Fatalf("err: %v", err)
 		}
 		if leaderCh2 == nil {
-			t.Fatalf("should get leader ch")
+			t.Fatal("should get leader ch")
 		}
 		defer lock2.Unlock()
 
@@ -284,7 +284,7 @@ func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
 				// Our test environment is slow enough that we failed this, retry
 				return false
 			}
-			t.Fatalf("should be held")
+			t.Fatal("should be held")
 		}
 		if val != "baz" {
 			t.Fatalf("bad value: %v", val)
@@ -293,7 +293,7 @@ func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {
 	// The first lock should have lost the leader channel
 	select {
 	case <-time.After(longRenewInterval * 2):
-		t.Fatalf("original lock did not have its leader channel closed.")
+		t.Fatal("original lock did not have its leader channel closed.")
 	case <-leaderCh:
 	}
 	return true
@@ -318,7 +318,7 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 	if leaderCh == nil {
-		t.Fatalf("failed to get leader ch")
+		t.Fatal("failed to get leader ch")
 	}
 
 	// Check the value
@@ -327,7 +327,7 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 	if !held {
-		t.Fatalf("should be held")
+		t.Fatal("should be held")
 	}
 	if val != "bar" {
 		t.Fatalf("bad value: %v", val)
@@ -371,7 +371,7 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 	if leaderCh2 == nil {
-		t.Fatalf("should get leader ch")
+		t.Fatal("should get leader ch")
 	}
 
 	// Check the value
@@ -380,7 +380,7 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 	if !held {
-		t.Fatalf("should be held")
+		t.Fatal("should be held")
 	}
 	if val != "baz" {
 		t.Fatalf("bad value: %v", val)
@@ -435,7 +435,7 @@ func TestPostgreSQLBackend_NoCreateTables(t *testing.T) {
 	entry := &physical.Entry{Key: "foo", Value: []byte("data")}
 	err = b.Put(context.Background(), entry)
 	if err == nil {
-		t.Fatalf("expected put to fail due to missing tables")
+		t.Fatal("expected put to fail due to missing tables")
 	}
 
 	pg := b.(*PostgreSQLBackend)

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -333,7 +333,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	if path == "" {
 		pathFromConfig, ok := conf["path"]
 		if !ok {
-			return nil, fmt.Errorf("'path' must be set")
+			return nil, errors.New("'path' must be set")
 		}
 		path = pathFromConfig
 	}
@@ -1698,7 +1698,7 @@ func (b *RaftBackend) applyLog(ctx context.Context, command *LogData) error {
 		if len(fsmar.EntrySlice) == 1 {
 			fsmEntry := fsmar.EntrySlice[0]
 			if !fsmEntry.IsTxError() {
-				return fmt.Errorf("unknown FSMEntry response type")
+				return errors.New("unknown FSMEntry response type")
 			}
 
 			return fsmEntry.AsTxError()

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -442,7 +442,7 @@ func (d *ReadableDuration) MarshalJSON() ([]byte, error) {
 
 func (d *ReadableDuration) UnmarshalJSON(raw []byte) (err error) {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal to nil pointer")
+		return errors.New("cannot unmarshal to nil pointer")
 	}
 
 	var dur time.Duration

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -385,7 +385,7 @@ func TestRaft_GetOfflineConfig(t *testing.T) {
 	}
 	for _, s := range conf.Servers {
 		if s.Voter != true {
-			t.Fatalf("one of the nodes is not a voter")
+			t.Fatal("one of the nodes is not a voter")
 		}
 	}
 }
@@ -469,7 +469,7 @@ func TestRaft_Recovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(peers) != 3 {
-		t.Fatalf("failed to recover the cluster")
+		t.Fatal("failed to recover the cluster")
 	}
 
 	time.Sleep(10 * time.Second)

--- a/physical/raft/snapshot.go
+++ b/physical/raft/snapshot.go
@@ -83,7 +83,7 @@ type BoltSnapshotSink struct {
 // on a base directory.
 func NewBoltSnapshotStore(base string, logger log.Logger, fsm *FSM) (*BoltSnapshotStore, error) {
 	if logger == nil {
-		return nil, fmt.Errorf("no logger provided")
+		return nil, errors.New("no logger provided")
 	}
 
 	// Ensure our path exists

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -906,7 +906,7 @@ func TestBoltSnapshotStore_BadPerm(t *testing.T) {
 
 	_, err = NewBoltSnapshotStore(dir2, logger, nil)
 	if err == nil {
-		t.Fatalf("should fail to use dir with bad perms")
+		t.Fatal("should fail to use dir with bad perms")
 	}
 }
 
@@ -943,7 +943,7 @@ func TestBoltSnapshotStore_CloseFailure(t *testing.T) {
 	// Cancel the snapshot! Should delete
 	err = sink.Close()
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	// Ensure the snapshot file does not exist

--- a/physical/raft/streamlayer.go
+++ b/physical/raft/streamlayer.go
@@ -356,7 +356,7 @@ func (l *raftLayer) Accept() (net.Conn, error) {
 	case conn := <-l.connCh:
 		return conn, nil
 	case <-l.closeCh:
-		return nil, fmt.Errorf("Raft RPC layer closed")
+		return nil, errors.New("Raft RPC layer closed")
 	}
 }
 

--- a/plugins/database/cassandra/cassandra.go
+++ b/plugins/database/cassandra/cassandra.go
@@ -5,6 +5,7 @@ package cassandra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -179,7 +180,7 @@ func rollbackUser(ctx context.Context, session *gocql.Session, username string, 
 
 func (c *Cassandra) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
 	if req.Password == nil && req.Expiration == nil {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("no changes requested")
+		return dbplugin.UpdateUserResponse{}, errors.New("no changes requested")
 	}
 
 	if req.Password != nil {

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -168,7 +168,7 @@ func TestCreateUser(t *testing.T) {
 			defer cancel()
 			newUserResp, err := db.NewUser(ctx, test.newUserReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -6,6 +6,7 @@ package cassandra
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -80,13 +81,13 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 
 	switch {
 	case len(c.Hosts) == 0:
-		return fmt.Errorf("hosts cannot be empty")
+		return errors.New("hosts cannot be empty")
 	case len(c.Username) == 0:
-		return fmt.Errorf("username cannot be empty")
+		return errors.New("username cannot be empty")
 	case len(c.Password) == 0:
-		return fmt.Errorf("password cannot be empty")
+		return errors.New("password cannot be empty")
 	case len(c.PemJSON) > 0 && len(c.PemBundle) > 0:
-		return fmt.Errorf("cannot specify both pem_json and pem_bundle")
+		return errors.New("cannot specify both pem_json and pem_bundle")
 	}
 
 	var tlsMinVersion uint16 = tls.VersionTLS12

--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -165,7 +165,7 @@ func TestSelfSignedCA(t *testing.T) {
 
 			_, err := db.Initialize(ctx, initReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/plugins/database/cassandra/tls.go
+++ b/plugins/database/cassandra/tls.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
@@ -22,7 +23,7 @@ func jsonBundleToTLSConfig(rawJSON string, tlsMinVersion uint16, serverName stri
 	}
 
 	if certBundle.IssuingCA != "" && len(certBundle.CAChain) > 0 {
-		return nil, fmt.Errorf("issuing_ca and ca_chain cannot both be specified")
+		return nil, errors.New("issuing_ca and ca_chain cannot both be specified")
 	}
 	if certBundle.IssuingCA != "" {
 		certBundle.CAChain = []string{certBundle.IssuingCA}
@@ -84,9 +85,9 @@ func pemBundleToTLSConfig(pemBundle string, tlsMinVersion uint16, serverName str
 
 func toClientTLSConfig(certificatePEM string, privateKeyPEM string, caChainPEMs []string, tlsMinVersion uint16, serverName string, insecureSkipVerify bool) (*tls.Config, error) {
 	if certificatePEM != "" && privateKeyPEM == "" {
-		return nil, fmt.Errorf("found certificate for client-side TLS authentication but no private key")
+		return nil, errors.New("found certificate for client-side TLS authentication but no private key")
 	} else if certificatePEM == "" && privateKeyPEM != "" {
-		return nil, fmt.Errorf("found private key for client-side TLS authentication but no certificate")
+		return nil, errors.New("found private key for client-side TLS authentication but no certificate")
 	}
 
 	var certificates []tls.Certificate
@@ -104,7 +105,7 @@ func toClientTLSConfig(certificatePEM string, privateKeyPEM string, caChainPEMs 
 		for _, caBlock := range caChainPEMs {
 			ok := rootCAs.AppendCertsFromPEM([]byte(caBlock))
 			if !ok {
-				return nil, fmt.Errorf("failed to add CA certificate to certificate pool: it may be malformed or empty")
+				return nil, errors.New("failed to add CA certificate to certificate pool: it may be malformed or empty")
 			}
 		}
 	}

--- a/plugins/database/influxdb/influxdb.go
+++ b/plugins/database/influxdb/influxdb.go
@@ -5,6 +5,7 @@ package influxdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -210,7 +211,7 @@ func (i *Influxdb) DeleteUser(ctx context.Context, req dbplugin.DeleteUserReques
 
 func (i *Influxdb) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
 	if req.Password == nil && req.Expiration == nil {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("no changes requested")
+		return dbplugin.UpdateUserResponse{}, errors.New("no changes requested")
 	}
 
 	i.Lock()

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -188,7 +188,7 @@ func TestInfluxdb_Initialize(t *testing.T) {
 
 			resp, err := db.Initialize(context.Background(), test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -199,9 +199,9 @@ func TestInfluxdb_Initialize(t *testing.T) {
 			}
 
 			if test.expectInitialized && !db.Initialized {
-				t.Fatalf("Database should be initialized but wasn't")
+				t.Fatal("Database should be initialized but wasn't")
 			} else if !test.expectInitialized && db.Initialized {
-				t.Fatalf("Database was initiailized when it shouldn't")
+				t.Fatal("Database was initiailized when it shouldn't")
 			}
 		})
 	}
@@ -251,7 +251,7 @@ func TestInfluxdb_CreateUser_DefaultUsernameTemplate(t *testing.T) {
 	resp := dbtesting.AssertNewUser(t, db, newUserReq)
 
 	if resp.Username == "" {
-		t.Fatalf("Missing username")
+		t.Fatal("Missing username")
 	}
 
 	assertCredsExist(t, config.URL().String(), resp.Username, password)
@@ -289,7 +289,7 @@ func TestInfluxdb_CreateUser_CustomUsernameTemplate(t *testing.T) {
 	resp := dbtesting.AssertNewUser(t, db, newUserReq)
 
 	if resp.Username == "" {
-		t.Fatalf("Missing username")
+		t.Fatal("Missing username")
 	}
 
 	assertCredsExist(t, config.URL().String(), resp.Username, password)
@@ -403,7 +403,7 @@ func TestInfluxdb_RevokeDeletedUser(t *testing.T) {
 	defer cancel()
 	_, err := db.DeleteUser(ctx, delReq)
 	if err == nil {
-		t.Fatalf("Expected err, got nil")
+		t.Fatal("Expected err, got nil")
 	}
 }
 

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -62,7 +63,7 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 	}
 
 	if len(c.ConnectionURL) == 0 {
-		return nil, fmt.Errorf("connection_url cannot be empty")
+		return nil, errors.New("connection_url cannot be empty")
 	}
 
 	// Don't escape special characters for MySQL password
@@ -192,7 +193,7 @@ func (c *mySQLConnectionProducer) getTLSAuth() (tlsConfig *tls.Config, err error
 	if len(c.TLSCAData) > 0 {
 		ok := rootCertPool.AppendCertsFromPEM(c.TLSCAData)
 		if !ok {
-			return nil, fmt.Errorf("failed to append CA to client options")
+			return nil, errors.New("failed to append CA to client options")
 		}
 	}
 

--- a/plugins/database/mysql/mysql.go
+++ b/plugins/database/mysql/mysql.go
@@ -46,7 +46,7 @@ type MySQL struct {
 func New(defaultUsernameTemplate string) func() (interface{}, error) {
 	return func() (interface{}, error) {
 		if defaultUsernameTemplate == "" {
-			return nil, fmt.Errorf("missing default username template")
+			return nil, errors.New("missing default username template")
 		}
 		db := newMySQL(defaultUsernameTemplate)
 		// Wrap the plugin with middleware to sanitize errors
@@ -193,7 +193,7 @@ func (m *MySQL) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) 
 
 func (m *MySQL) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
 	if req.Password == nil && req.Expiration == nil {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("no change requested")
+		return dbplugin.UpdateUserResponse{}, errors.New("no change requested")
 	}
 
 	if req.Password != nil {

--- a/plugins/database/mysql/mysql_test.go
+++ b/plugins/database/mysql/mysql_test.go
@@ -158,7 +158,7 @@ func testInitialize(t *testing.T, rootPassword string) {
 			defer dbtesting.AssertClose(t, db)
 			initResp, err := db.Initialize(context.Background(), test.initRequest)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -310,7 +310,7 @@ func TestMySQL_NewUser_nonLegacy(t *testing.T) {
 
 			userResp, err := db.NewUser(context.Background(), test.newUserReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -464,7 +464,7 @@ func TestMySQL_NewUser_legacy(t *testing.T) {
 
 			userResp, err := db.NewUser(context.Background(), test.newUserReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -549,7 +549,7 @@ func TestMySQL_RotateRootCredentials(t *testing.T) {
 
 			// verify old password doesn't work
 			if err := mysqlhelper.TestCredsExist(t, connURL, updateReq.Username, "secret"); err == nil {
-				t.Fatalf("Should not be able to connect with initial credentials")
+				t.Fatal("Should not be able to connect with initial credentials")
 			}
 
 			err = db.Close()
@@ -649,7 +649,7 @@ func TestMySQL_DeleteUser(t *testing.T) {
 			}
 
 			if err := mysqlhelper.TestCredsExist(t, connURL, userResp.Username, password); err == nil {
-				t.Fatalf("Credentials were not revoked!")
+				t.Fatal("Credentials were not revoked!")
 			}
 		})
 	}
@@ -739,7 +739,7 @@ func TestMySQL_UpdateUser(t *testing.T) {
 
 			// verify old password doesn't work
 			if err := mysqlhelper.TestCredsExist(t, connURL, dbUser, initPassword); err == nil {
-				t.Fatalf("Should not be able to connect with initial credentials")
+				t.Fatal("Should not be able to connect with initial credentials")
 			}
 		})
 	}

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -6,6 +6,7 @@ package postgresql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -143,10 +144,10 @@ func (p *PostgreSQL) getConnection(ctx context.Context) (*sql.DB, error) {
 
 func (p *PostgreSQL) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
 	if req.Username == "" {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("missing username")
+		return dbplugin.UpdateUserResponse{}, errors.New("missing username")
 	}
 	if req.Password == nil && req.Expiration == nil {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("no changes requested")
+		return dbplugin.UpdateUserResponse{}, errors.New("no changes requested")
 	}
 
 	merr := &multierror.Error{}
@@ -169,7 +170,7 @@ func (p *PostgreSQL) changeUserPassword(ctx context.Context, username string, ch
 
 	password := changePass.NewPassword
 	if password == "" {
-		return fmt.Errorf("missing password")
+		return errors.New("missing password")
 	}
 
 	p.Lock()

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -385,7 +385,7 @@ func TestPostgreSQL_NewUser(t *testing.T) {
 
 			resp, err := db.NewUser(ctx, test.req)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -468,7 +468,7 @@ func TestUpdateUser_Password(t *testing.T) {
 			defer cancel()
 			_, err := db.UpdateUser(ctx, updateReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -492,7 +492,7 @@ func TestUpdateUser_Password(t *testing.T) {
 		defer cancel()
 		_, err := db.UpdateUser(ctx, updateReq)
 		if err == nil {
-			t.Fatalf("err expected, got nil")
+			t.Fatal("err expected, got nil")
 		}
 
 		assertCredsDoNotExist(t, db.ConnectionURL, updateReq.Username, newPass)
@@ -565,7 +565,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 
 			actualExpiration := getExpiration(t, db, createResp.Username)
 			if actualExpiration.IsZero() {
-				t.Fatalf("Initial expiration is zero but should be set")
+				t.Fatal("Initial expiration is zero but should be set")
 			}
 			if !actualExpiration.Equal(initialExpiration) {
 				t.Fatalf("Actual expiration: %s Expected expiration: %s", actualExpiration, initialExpiration)
@@ -586,7 +586,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 			defer cancel()
 			_, err := db.UpdateUser(ctx, updateReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -732,7 +732,7 @@ func TestDeleteUser(t *testing.T) {
 
 			_, err := db.DeleteUser(ctx, deleteReq)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -773,7 +773,7 @@ func assertCredsDoNotExist(t testing.TB, connURL, username, password string) {
 	t.Helper()
 	err := testCredsExist(t, connURL, username, password)
 	if err == nil {
-		t.Fatalf("user should not exist but does")
+		t.Fatal("user should not exist but does")
 	}
 }
 
@@ -1113,7 +1113,7 @@ func TestNewUser_CustomUsername(t *testing.T) {
 func TestPostgreSQL_Repmgr(t *testing.T) {
 	_, exists := os.LookupEnv("POSTGRES_MULTIHOST_NET")
 	if !exists {
-		t.Skipf("POSTGRES_MULTIHOST_NET not set, skipping test")
+		t.Skip("POSTGRES_MULTIHOST_NET not set, skipping test")
 	}
 
 	// Run two postgres-repmgr containers in a replication cluster

--- a/sdk/database/dbplugin/v5/conversions_test.go
+++ b/sdk/database/dbplugin/v5/conversions_test.go
@@ -4,6 +4,7 @@
 package dbplugin
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -426,7 +427,7 @@ func TestAssertAllFieldsSet(t *testing.T) {
 
 func assertAllFieldsSet(name string, val interface{}) error {
 	if val == nil {
-		return fmt.Errorf("value is nil")
+		return errors.New("value is nil")
 	}
 
 	rVal := reflect.ValueOf(val)

--- a/sdk/database/dbplugin/v5/conversions_test.go
+++ b/sdk/database/dbplugin/v5/conversions_test.go
@@ -36,7 +36,7 @@ func TestConversionsHaveAllFields(t *testing.T) {
 		values := getAllGetterValues(protoReq)
 		if len(values) == 0 {
 			// Probably a test failure - the protos used in these tests should have Get functions on them
-			t.Fatalf("No values found from Get functions!")
+			t.Fatal("No values found from Get functions!")
 		}
 
 		for _, gtr := range values {
@@ -78,7 +78,7 @@ func TestConversionsHaveAllFields(t *testing.T) {
 		values := getAllGetterValues(protoReq)
 		if len(values) == 0 {
 			// Probably a test failure - the protos used in these tests should have Get functions on them
-			t.Fatalf("No values found from Get functions!")
+			t.Fatal("No values found from Get functions!")
 		}
 
 		for _, gtr := range values {
@@ -127,7 +127,7 @@ func TestConversionsHaveAllFields(t *testing.T) {
 		values := getAllGetterValues(protoReq)
 		if len(values) == 0 {
 			// Probably a test failure - the protos used in these tests should have Get functions on them
-			t.Fatalf("No values found from Get functions!")
+			t.Fatal("No values found from Get functions!")
 		}
 
 		for _, gtr := range values {
@@ -156,7 +156,7 @@ func TestConversionsHaveAllFields(t *testing.T) {
 		values := getAllGetterValues(protoReq)
 		if len(values) == 0 {
 			// Probably a test failure - the protos used in these tests should have Get functions on them
-			t.Fatalf("No values found from Get functions!")
+			t.Fatal("No values found from Get functions!")
 		}
 
 		for _, gtr := range values {
@@ -416,7 +416,7 @@ func TestAssertAllFieldsSet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := assertAllFieldsSet("", test.value)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/sdk/database/dbplugin/v5/grpc_client.go
+++ b/sdk/database/dbplugin/v5/grpc_client.go
@@ -98,18 +98,18 @@ func newUserReqToProto(req NewUserRequest) (*proto.NewUserRequest, error) {
 	switch req.CredentialType {
 	case CredentialTypePassword:
 		if req.Password == "" {
-			return nil, fmt.Errorf("missing password credential")
+			return nil, errors.New("missing password credential")
 		}
 	case CredentialTypeRSAPrivateKey:
 		if len(req.PublicKey) == 0 {
-			return nil, fmt.Errorf("missing public key credential")
+			return nil, errors.New("missing public key credential")
 		}
 	case CredentialTypeClientCertificate:
 		if req.Subject == "" {
-			return nil, fmt.Errorf("missing certificate subject")
+			return nil, errors.New("missing certificate subject")
 		}
 	default:
-		return nil, fmt.Errorf("unknown credential type")
+		return nil, errors.New("unknown credential type")
 	}
 
 	expiration, err := ptypes.TimestampProto(req.Expiration)
@@ -164,13 +164,13 @@ func (c gRPCClient) UpdateUser(ctx context.Context, req UpdateUserRequest) (Upda
 
 func updateUserReqToProto(req UpdateUserRequest) (*proto.UpdateUserRequest, error) {
 	if req.Username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	if (req.Password == nil || req.Password.NewPassword == "") &&
 		(req.PublicKey == nil || len(req.PublicKey.NewPublicKey) == 0) &&
 		(req.Expiration == nil || req.Expiration.NewExpiration.IsZero()) {
-		return nil, fmt.Errorf("missing changes")
+		return nil, errors.New("missing changes")
 	}
 
 	expiration, err := expirationToProto(req.Expiration)
@@ -251,7 +251,7 @@ func (c gRPCClient) DeleteUser(ctx context.Context, req DeleteUserRequest) (Dele
 
 func deleteUserReqToProto(req DeleteUserRequest) (*proto.DeleteUserRequest, error) {
 	if req.Username == "" {
-		return nil, fmt.Errorf("missing username")
+		return nil, errors.New("missing username")
 	}
 
 	rpcReq := &proto.DeleteUserRequest{

--- a/sdk/database/dbplugin/v5/grpc_client_test.go
+++ b/sdk/database/dbplugin/v5/grpc_client_test.go
@@ -498,7 +498,7 @@ type errorAssertion func(*testing.T, error)
 func assertErrNotNil(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {
-		t.Fatalf("err expected, got nil")
+		t.Fatal("err expected, got nil")
 	}
 }
 

--- a/sdk/database/dbplugin/v5/grpc_server.go
+++ b/sdk/database/dbplugin/v5/grpc_server.go
@@ -82,7 +82,7 @@ func (g *gRPCServer) getDatabaseInternal(ctx context.Context) (Database, error) 
 		return db, nil
 	}
 
-	return nil, fmt.Errorf("no database instance found")
+	return nil, errors.New("no database instance found")
 }
 
 // getDatabase holds a read lock and returns the database
@@ -230,7 +230,7 @@ func getUpdateUserRequest(req *proto.UpdateUserRequest) (UpdateUserRequest, erro
 	}
 
 	if !hasChange(dbReq) {
-		return UpdateUserRequest{}, fmt.Errorf("update user request has no changes")
+		return UpdateUserRequest{}, errors.New("update user request has no changes")
 	}
 
 	return dbReq, nil

--- a/sdk/database/dbplugin/v5/grpc_server_test.go
+++ b/sdk/database/dbplugin/v5/grpc_server_test.go
@@ -6,7 +6,6 @@ package dbplugin
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -687,11 +686,11 @@ func marshal(t *testing.T, m map[string]interface{}) *structpb.Struct {
 type badJSONValue struct{}
 
 func (badJSONValue) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("this cannot be marshalled to JSON")
+	return nil, errors.New("this cannot be marshalled to JSON")
 }
 
 func (badJSONValue) UnmarshalJSON([]byte) error {
-	return fmt.Errorf("this cannot be unmarshalled from JSON")
+	return errors.New("this cannot be unmarshalled from JSON")
 }
 
 var _ Database = fakeDatabase{}

--- a/sdk/database/dbplugin/v5/grpc_server_test.go
+++ b/sdk/database/dbplugin/v5/grpc_server_test.go
@@ -112,7 +112,7 @@ func TestGRPCServer_Initialize(t *testing.T) {
 			resp, err := g.Initialize(idCtx, test.req)
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -282,7 +282,7 @@ func TestGRPCServer_NewUser(t *testing.T) {
 			resp, err := g.NewUser(idCtx, test.req)
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -387,7 +387,7 @@ func TestGRPCServer_UpdateUser(t *testing.T) {
 			resp, err := g.UpdateUser(idCtx, test.req)
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -450,7 +450,7 @@ func TestGRPCServer_DeleteUser(t *testing.T) {
 			resp, err := g.DeleteUser(idCtx, test.req)
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -503,7 +503,7 @@ func TestGRPCServer_Type(t *testing.T) {
 			resp, err := g.Type(idCtx, &proto.Empty{})
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -547,7 +547,7 @@ func TestGRPCServer_Close(t *testing.T) {
 			grpcSetupFunc: testGrpcServer,
 			assertFunc: func(t *testing.T, g gRPCServer) {
 				if len(g.instances) != 0 {
-					t.Fatalf("err expected instances map to be empty")
+					t.Fatal("err expected instances map to be empty")
 				}
 			},
 		},
@@ -566,7 +566,7 @@ func TestGRPCServer_Close(t *testing.T) {
 			_, err := g.Close(idCtx, &proto.Empty{})
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -615,7 +615,7 @@ func TestGRPCServer_Version(t *testing.T) {
 			resp, err := g.Version(idCtx, &logical.Empty{})
 
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/sdk/database/dbplugin/v5/middleware_test.go
+++ b/sdk/database/dbplugin/v5/middleware_test.go
@@ -238,7 +238,7 @@ func TestDatabaseErrorSanitizerMiddleware(t *testing.T) {
 func secretFunc(t *testing.T, vals ...string) func() map[string]string {
 	t.Helper()
 	if len(vals)%2 != 0 {
-		t.Fatalf("Test configuration error: secretFunc must be called with an even number of values")
+		t.Fatal("Test configuration error: secretFunc must be called with an even number of values")
 	}
 
 	m := map[string]string{}

--- a/sdk/database/dbplugin/v5/plugin_client_test.go
+++ b/sdk/database/dbplugin/v5/plugin_client_test.go
@@ -79,7 +79,7 @@ func TestNewPluginClient(t *testing.T) {
 
 			resp, err := NewPluginClient(ctx, mockWrapper, test.config)
 			if test.expectedErr != nil && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if test.expectedErr == nil && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -83,7 +83,7 @@ func AssertNewUser(t *testing.T, db dbplugin.Database, req dbplugin.NewUserReque
 	}
 
 	if resp.Username == "" {
-		t.Fatalf("Missing username from NewUser response")
+		t.Fatal("Missing username from NewUser response")
 	}
 	return resp
 }

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -6,7 +6,7 @@ package connutil
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 	"net/url"
 	"strings"
 	"sync"
@@ -56,7 +56,7 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 	}
 
 	if len(c.ConnectionURL) == 0 {
-		return nil, fmt.Errorf("connection_url cannot be empty")
+		return nil, errors.New("connection_url cannot be empty")
 	}
 
 	// Do not allow the username or password template pattern to be used as
@@ -66,7 +66,7 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 		strings.Contains(c.Password, "{{username}}") ||
 		strings.Contains(c.Password, "{{password}}") {
 
-		return nil, fmt.Errorf("username and/or password cannot contain the template variables")
+		return nil, errors.New("username and/or password cannot contain the template variables")
 	}
 
 	// Don't escape special characters for MySQL password

--- a/sdk/database/helper/connutil/sql_test.go
+++ b/sdk/database/helper/connutil/sql_test.go
@@ -89,11 +89,11 @@ func TestSQLDisableEscaping(t *testing.T) {
 		} else {
 			if tc.DisableEscaping {
 				if !strings.Contains(sql.ConnectionURL, tc.Username) || !strings.Contains(sql.ConnectionURL, tc.Password) {
-					t.Errorf("Raw username and/or password missing from ConnectionURL")
+					t.Error("Raw username and/or password missing from ConnectionURL")
 				}
 			} else {
 				if strings.Contains(sql.ConnectionURL, tc.Username) || strings.Contains(sql.ConnectionURL, tc.Password) {
-					t.Errorf("Raw username and/or password was present in ConnectionURL")
+					t.Error("Raw username and/or password was present in ConnectionURL")
 				}
 			}
 		}

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -330,7 +331,7 @@ func HandlePatchOperation(input *FieldData, resource map[string]interface{}, pre
 	var err error
 
 	if resource == nil {
-		return nil, fmt.Errorf("resource does not exist")
+		return nil, errors.New("resource does not exist")
 	}
 
 	inputMap := map[string]interface{}{}
@@ -566,21 +567,21 @@ func (b *Backend) handleRevokeRenew(ctx context.Context, req *logical.Request) (
 	}
 
 	if req.Secret == nil {
-		return nil, fmt.Errorf("request has no secret")
+		return nil, errors.New("request has no secret")
 	}
 
 	rawSecretType, ok := req.Secret.InternalData["secret_type"]
 	if !ok {
-		return nil, fmt.Errorf("secret is unsupported by this backend")
+		return nil, errors.New("secret is unsupported by this backend")
 	}
 	secretType, ok := rawSecretType.(string)
 	if !ok {
-		return nil, fmt.Errorf("secret is unsupported by this backend")
+		return nil, errors.New("secret is unsupported by this backend")
 	}
 
 	secret := b.Secret(secretType)
 	if secret == nil {
-		return nil, fmt.Errorf("secret is unsupported by this backend")
+		return nil, errors.New("secret is unsupported by this backend")
 	}
 
 	switch req.Operation {

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -1009,7 +1009,7 @@ func TestFieldDataGet(t *testing.T) {
 			err := data.Validate()
 			switch {
 			case tc.ExpectError && err == nil:
-				t.Fatalf("expected error")
+				t.Fatal("expected error")
 			case tc.ExpectError && err != nil:
 				return
 			case !tc.ExpectError && err != nil:
@@ -1267,7 +1267,7 @@ func TestValidateStrict(t *testing.T) {
 			err := data.ValidateStrict()
 
 			if err == nil && tc.ExpectError == true {
-				t.Fatalf("expected an error, got nil")
+				t.Fatal("expected an error, got nil")
 			}
 			if err != nil && tc.ExpectError == false {
 				t.Fatalf("unexpected error: %v", err)

--- a/sdk/framework/lease.go
+++ b/sdk/framework/lease.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,13 +28,13 @@ func LeaseExtend(backendIncrement, backendMax time.Duration, systemView logical.
 			req.Secret.MaxTTL = backendMax
 			return &logical.Response{Secret: req.Secret}, nil
 		}
-		return nil, fmt.Errorf("no lease options for request")
+		return nil, errors.New("no lease options for request")
 	}
 }
 
 // CalculateTTL takes all the user-specified, backend, and system inputs and calculates
 // a TTL for a lease
-func CalculateTTL(sysView logical.SystemView, increment, backendTTL, period, backendMaxTTL, explicitMaxTTL time.Duration, startTime time.Time) (ttl time.Duration, warnings []string, errors error) {
+func CalculateTTL(sysView logical.SystemView, increment, backendTTL, period, backendMaxTTL, explicitMaxTTL time.Duration, startTime time.Time) (ttl time.Duration, warnings []string, err error) {
 	// Truncate all times to the second since that is the lowest precision for
 	// TTLs
 	now := time.Now().Truncate(time.Second)
@@ -56,7 +57,7 @@ func CalculateTTL(sysView logical.SystemView, increment, backendTTL, period, bac
 
 	// Should never happen, but guard anyways
 	if maxTTL <= 0 {
-		return 0, nil, fmt.Errorf("max TTL must be greater than zero")
+		return 0, nil, errors.New("max TTL must be greater than zero")
 	}
 
 	var maxValidTime time.Time
@@ -95,7 +96,7 @@ func CalculateTTL(sysView logical.SystemView, increment, backendTTL, period, bac
 		// If we are past the max TTL, we shouldn't be in this function...but
 		// fast path out if we are
 		if maxValidTTL <= 0 {
-			return 0, nil, fmt.Errorf("past the max TTL, cannot renew")
+			return 0, nil, errors.New("past the max TTL, cannot renew")
 		}
 
 		// If the proposed expiration is after the maximum TTL of the lease,

--- a/sdk/framework/path_map_test.go
+++ b/sdk/framework/path_map_test.go
@@ -179,7 +179,7 @@ func testSalting(t *testing.T, ctx context.Context, storage logical.Storage, sal
 		t.Fatalf("err: %v", err)
 	}
 	if out != nil {
-		t.Fatalf("non-salted key found")
+		t.Fatal("non-salted key found")
 	}
 
 	// Ensure the path is salted
@@ -189,7 +189,7 @@ func testSalting(t *testing.T, ctx context.Context, storage logical.Storage, sal
 		t.Fatalf("err: %v", err)
 	}
 	if out == nil {
-		t.Fatalf("missing salted key")
+		t.Fatal("missing salted key")
 	}
 
 	// Read via HTTP

--- a/sdk/helper/authmetadata/auth_metadata_acc_test.go
+++ b/sdk/helper/authmetadata/auth_metadata_acc_test.go
@@ -77,7 +77,7 @@ func (e *environment) TestInitialFieldsAreDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || resp.Auth == nil || resp.Auth.Alias == nil || resp.Auth.Alias.Metadata == nil {
-		t.Fatalf("expected alias metadata")
+		t.Fatal("expected alias metadata")
 	}
 	if len(resp.Auth.Alias.Metadata) != 1 {
 		t.Fatal("expected only 1 field")

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -390,34 +390,34 @@ func TestTLSConfig(t *testing.T) {
 			t.Fatalf("Error getting tls config: %s", err)
 		}
 		if tlsConfig == nil {
-			t.Fatalf("Got nil tls.Config")
+			t.Fatal("Got nil tls.Config")
 		}
 
 		if len(tlsConfig.Certificates) != 1 {
-			t.Fatalf("Unexpected length in config.Certificates")
+			t.Fatal("Unexpected length in config.Certificates")
 		}
 
 		// Length should be 2, since we passed in a CA
 		if len(tlsConfig.Certificates[0].Certificate) != 2 {
-			t.Fatalf("Did not find both certificates in config.Certificates.Certificate")
+			t.Fatal("Did not find both certificates in config.Certificates.Certificate")
 		}
 
 		if tlsConfig.Certificates[0].Leaf != pcbut.Certificate {
-			t.Fatalf("Leaf certificate does not match parsed bundle's certificate")
+			t.Fatal("Leaf certificate does not match parsed bundle's certificate")
 		}
 
 		if tlsConfig.Certificates[0].PrivateKey != pcbut.PrivateKey {
-			t.Fatalf("Config's private key does not match parsed bundle's private key")
+			t.Fatal("Config's private key does not match parsed bundle's private key")
 		}
 
 		switch usage {
 		case TLSServer | TLSClient:
 			if tlsConfig.ClientCAs == nil {
-				t.Fatalf("ClientCAs pool is nil, but expected a valid pool")
+				t.Fatal("ClientCAs pool is nil, but expected a valid pool")
 			}
 
 			if tlsConfig.RootCAs == nil {
-				t.Fatalf("RootCAs pool is nil, but expected a valid pool")
+				t.Fatal("RootCAs pool is nil, but expected a valid pool")
 			}
 
 			// Verify the leaf certificate against the RootCAs pool to ensure the
@@ -439,10 +439,10 @@ func TestTLSConfig(t *testing.T) {
 			}
 		case TLSServer:
 			if tlsConfig.ClientCAs == nil {
-				t.Fatalf("ClientCAs pool is nil, but expected a valid pool")
+				t.Fatal("ClientCAs pool is nil, but expected a valid pool")
 			}
 			if tlsConfig.RootCAs != nil {
-				t.Fatalf("Found root pools in config object when not expected")
+				t.Fatal("Found root pools in config object when not expected")
 			}
 			// Verify the leaf certificate against the ClientCAs pool to ensure the
 			// server can authenticate client certificates using the provided CA pool
@@ -454,10 +454,10 @@ func TestTLSConfig(t *testing.T) {
 			}
 		case TLSClient:
 			if tlsConfig.RootCAs == nil {
-				t.Fatalf("RootCAs pool is nil, but expected a valid pool")
+				t.Fatal("RootCAs pool is nil, but expected a valid pool")
 			}
 			if tlsConfig.ClientCAs != nil {
-				t.Fatalf("Found client pools in config object when not expected")
+				t.Fatal("Found client pools in config object when not expected")
 			}
 			// Verify the leaf certificate against the RootCAs pool to ensure the
 			// client can authenticate the server using the provided CA pool
@@ -469,7 +469,7 @@ func TestTLSConfig(t *testing.T) {
 			}
 		default:
 			if tlsConfig.RootCAs != nil || tlsConfig.ClientCAs != nil {
-				t.Fatalf("Found root pools in config object when not expected")
+				t.Fatal("Found root pools in config object when not expected")
 			}
 		}
 	}
@@ -1022,7 +1022,7 @@ func TestBasicConstraintExtension(t *testing.T) {
 		// Test invalid type errors out
 		_, _, err := ParseBasicConstraintExtension(pkix.Extension{})
 		if err == nil {
-			t.Fatalf("should have failed parsing non-basic constraint extension")
+			t.Fatal("should have failed parsing non-basic constraint extension")
 		}
 	})
 
@@ -1037,7 +1037,7 @@ func TestBasicConstraintExtension(t *testing.T) {
 		}
 		_, _, err = ParseBasicConstraintExtension(ext)
 		if err == nil {
-			t.Fatalf("should have failed parsing basic constraint with extra information")
+			t.Fatal("should have failed parsing basic constraint with extra information")
 		}
 	})
 }

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	mathrand "math/rand"
@@ -161,17 +162,17 @@ func TestCertBundleParsing(t *testing.T) {
 
 func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBundle) error {
 	if cbut == nil {
-		return fmt.Errorf("got nil bundle")
+		return errors.New("got nil bundle")
 	}
 	if pcbut == nil {
-		return fmt.Errorf("got nil parsed bundle")
+		return errors.New("got nil parsed bundle")
 	}
 
 	switch {
 	case pcbut.Certificate == nil:
-		return fmt.Errorf("parsed bundle has nil certificate")
+		return errors.New("parsed bundle has nil certificate")
 	case pcbut.PrivateKey == nil:
-		return fmt.Errorf("parsed bundle has nil private key")
+		return errors.New("parsed bundle has nil private key")
 	}
 
 	switch cbut.PrivateKey {
@@ -196,7 +197,7 @@ func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBund
 			return fmt.Errorf("parsed bundle has wrong pkcs8 private key type: %v, should be 'ed25519' (%v)", pcbut.PrivateKeyType, ECPrivateKey)
 		}
 	default:
-		return fmt.Errorf("parsed bundle has unknown private key type")
+		return errors.New("parsed bundle has unknown private key type")
 	}
 
 	subjKeyID, err := GetSubjKeyID(pcbut.PrivateKey)
@@ -209,9 +210,9 @@ func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBund
 
 	switch {
 	case len(pcbut.CAChain) > 0 && len(cbut.CAChain) == 0:
-		return fmt.Errorf("parsed bundle ca chain has certs when cert bundle does not")
+		return errors.New("parsed bundle ca chain has certs when cert bundle does not")
 	case len(pcbut.CAChain) == 0 && len(cbut.CAChain) > 0:
-		return fmt.Errorf("cert bundle ca chain has certs when parsed cert bundle does not")
+		return errors.New("cert bundle ca chain has certs when parsed cert bundle does not")
 	}
 
 	cb, err := pcbut.ToCertBundle()
@@ -221,32 +222,32 @@ func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBund
 
 	switch {
 	case len(cb.Certificate) == 0:
-		return fmt.Errorf("bundle has nil certificate")
+		return errors.New("bundle has nil certificate")
 	case len(cb.PrivateKey) == 0:
-		return fmt.Errorf("bundle has nil private key")
+		return errors.New("bundle has nil private key")
 	case len(cb.CAChain[0]) == 0:
-		return fmt.Errorf("bundle has nil issuing CA")
+		return errors.New("bundle has nil issuing CA")
 	}
 
 	switch pcbut.PrivateKeyType {
 	case RSAPrivateKey:
 		if cb.PrivateKey != privRSAKeyPem && cb.PrivateKey != privRSA8KeyPem {
-			return fmt.Errorf("bundle private key does not match")
+			return errors.New("bundle private key does not match")
 		}
 	case ECPrivateKey:
 		if cb.PrivateKey != privECKeyPem && cb.PrivateKey != privEC8KeyPem {
-			return fmt.Errorf("bundle private key does not match")
+			return errors.New("bundle private key does not match")
 		}
 	case Ed25519PrivateKey:
 		if cb.PrivateKey != privEd255198KeyPem {
-			return fmt.Errorf("bundle private key does not match")
+			return errors.New("bundle private key does not match")
 		}
 	default:
-		return fmt.Errorf("certBundle has unknown private key type")
+		return errors.New("certBundle has unknown private key type")
 	}
 
 	if cb.SerialNumber != GetHexFormatted(pcbut.Certificate.SerialNumber.Bytes(), ":") {
-		return fmt.Errorf("bundle serial number does not match")
+		return errors.New("bundle serial number does not match")
 	}
 
 	if !bytes.Equal(pcbut.Certificate.SerialNumber.Bytes(), ParseHexFormatted(cb.SerialNumber, ":")) {
@@ -255,9 +256,9 @@ func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBund
 
 	switch {
 	case len(pcbut.CAChain) > 0 && len(cb.CAChain) == 0:
-		return fmt.Errorf("parsed bundle ca chain has certs when cert bundle does not")
+		return errors.New("parsed bundle ca chain has certs when cert bundle does not")
 	case len(pcbut.CAChain) == 0 && len(cb.CAChain) > 0:
-		return fmt.Errorf("cert bundle ca chain has certs when parsed cert bundle does not")
+		return errors.New("cert bundle ca chain has certs when parsed cert bundle does not")
 	case !reflect.DeepEqual(cbut.CAChain, cb.CAChain):
 		return fmt.Errorf("cert bundle ca chain does not match: %#v\n\n%#v", cbut.CAChain, cb.CAChain)
 	}
@@ -297,34 +298,34 @@ func TestCSRBundleConversion(t *testing.T) {
 
 func compareCSRBundleToParsedCSRBundle(csrbut *CSRBundle, pcsrbut *ParsedCSRBundle) error {
 	if csrbut == nil {
-		return fmt.Errorf("got nil bundle")
+		return errors.New("got nil bundle")
 	}
 	if pcsrbut == nil {
-		return fmt.Errorf("got nil parsed bundle")
+		return errors.New("got nil parsed bundle")
 	}
 
 	switch {
 	case pcsrbut.CSR == nil:
-		return fmt.Errorf("parsed bundle has nil csr")
+		return errors.New("parsed bundle has nil csr")
 	case pcsrbut.PrivateKey == nil:
-		return fmt.Errorf("parsed bundle has nil private key")
+		return errors.New("parsed bundle has nil private key")
 	}
 
 	switch csrbut.PrivateKey {
 	case privRSAKeyPem:
 		if pcsrbut.PrivateKeyType != RSAPrivateKey {
-			return fmt.Errorf("parsed bundle has wrong private key type")
+			return errors.New("parsed bundle has wrong private key type")
 		}
 	case privECKeyPem:
 		if pcsrbut.PrivateKeyType != ECPrivateKey {
-			return fmt.Errorf("parsed bundle has wrong private key type")
+			return errors.New("parsed bundle has wrong private key type")
 		}
 	case privEd255198KeyPem:
 		if pcsrbut.PrivateKeyType != Ed25519PrivateKey {
-			return fmt.Errorf("parsed bundle has wrong private key type")
+			return errors.New("parsed bundle has wrong private key type")
 		}
 	default:
-		return fmt.Errorf("parsed bundle has unknown private key type")
+		return errors.New("parsed bundle has unknown private key type")
 	}
 
 	csrb, err := pcsrbut.ToCSRBundle()
@@ -334,35 +335,35 @@ func compareCSRBundleToParsedCSRBundle(csrbut *CSRBundle, pcsrbut *ParsedCSRBund
 
 	switch {
 	case len(csrb.CSR) == 0:
-		return fmt.Errorf("bundle has nil certificate")
+		return errors.New("bundle has nil certificate")
 	case len(csrb.PrivateKey) == 0:
-		return fmt.Errorf("bundle has nil private key")
+		return errors.New("bundle has nil private key")
 	}
 
 	switch csrb.PrivateKeyType {
 	case "rsa":
 		if pcsrbut.PrivateKeyType != RSAPrivateKey {
-			return fmt.Errorf("bundle has wrong private key type")
+			return errors.New("bundle has wrong private key type")
 		}
 		if csrb.PrivateKey != privRSAKeyPem {
 			return fmt.Errorf("bundle rsa private key does not match\nGot\n%#v\nExpected\n%#v", csrb.PrivateKey, privRSAKeyPem)
 		}
 	case "ec":
 		if pcsrbut.PrivateKeyType != ECPrivateKey {
-			return fmt.Errorf("bundle has wrong private key type")
+			return errors.New("bundle has wrong private key type")
 		}
 		if csrb.PrivateKey != privECKeyPem {
-			return fmt.Errorf("bundle ec private key does not match")
+			return errors.New("bundle ec private key does not match")
 		}
 	case "ed25519":
 		if pcsrbut.PrivateKeyType != Ed25519PrivateKey {
-			return fmt.Errorf("bundle has wrong private key type")
+			return errors.New("bundle has wrong private key type")
 		}
 		if csrb.PrivateKey != privEd255198KeyPem {
-			return fmt.Errorf("bundle ed25519 private key does not match")
+			return errors.New("bundle ed25519 private key does not match")
 		}
 	default:
-		return fmt.Errorf("bundle has unknown private key type")
+		return errors.New("bundle has unknown private key type")
 	}
 
 	return nil

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1463,7 +1463,7 @@ func CreateFreshestCRLExt(paths []string) (pkix.Extension, error) {
 // IsCA, MaxPathLen or error. If MaxPathLen was not set, a value of -1 will be returned.
 func ParseBasicConstraintExtension(ext pkix.Extension) (bool, int, error) {
 	if !ext.Id.Equal(ExtensionBasicConstraintsOID) {
-		return false, -1, fmt.Errorf("passed in extension was not a basic constraint extension")
+		return false, -1, errors.New("passed in extension was not a basic constraint extension")
 	}
 
 	// All elements are set to optional here, as it is possible that we receive a CSR with the extension

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -361,7 +361,7 @@ func (p *ParsedCertBundle) Verify() error {
 			return errwrap.Wrapf("could not compare public and private keys: {{err}}", err)
 		}
 		if !equal {
-			return fmt.Errorf("public key of certificate does not match private key")
+			return errors.New("public key of certificate does not match private key")
 		}
 	}
 
@@ -644,7 +644,7 @@ func (p *ParsedCertBundle) GetTLSConfig(usage TLSUsage) (*tls.Config, error) {
 		caPool := x509.NewCertPool()
 		ok := caPool.AppendCertsFromPEM([]byte(certBundle.CAChain[0]))
 		if !ok {
-			return nil, fmt.Errorf("could not append CA certificate")
+			return nil, errors.New("could not append CA certificate")
 		}
 
 		if usage&TLSServer > 0 {

--- a/sdk/helper/cidrutil/cidr.go
+++ b/sdk/helper/cidrutil/cidr.go
@@ -4,7 +4,7 @@
 package cidrutil
 
 import (
-	"fmt"
+	"errors"
 	"net"
 	"strings"
 
@@ -43,12 +43,12 @@ func RemoteAddrIsOk(remoteAddr string, boundCIDRs []*sockaddr.SockAddrMarshaler)
 // IPBelongsToCIDR checks if the given IP is encompassed by the given CIDR block
 func IPBelongsToCIDR(ipAddr string, cidr string) (bool, error) {
 	if ipAddr == "" {
-		return false, fmt.Errorf("missing IP address")
+		return false, errors.New("missing IP address")
 	}
 
 	ip := net.ParseIP(ipAddr)
 	if ip == nil {
-		return false, fmt.Errorf("invalid IP address")
+		return false, errors.New("invalid IP address")
 	}
 
 	_, ipnet, err := net.ParseCIDR(cidr)
@@ -67,15 +67,15 @@ func IPBelongsToCIDR(ipAddr string, cidr string) (bool, error) {
 // CIDR blocks
 func IPBelongsToCIDRBlocksSlice(ipAddr string, cidrs []string) (bool, error) {
 	if ipAddr == "" {
-		return false, fmt.Errorf("missing IP address")
+		return false, errors.New("missing IP address")
 	}
 
 	if len(cidrs) == 0 {
-		return false, fmt.Errorf("missing CIDR blocks to be checked against")
+		return false, errors.New("missing CIDR blocks to be checked against")
 	}
 
 	if ip := net.ParseIP(ipAddr); ip == nil {
-		return false, fmt.Errorf("invalid IP address")
+		return false, errors.New("invalid IP address")
 	}
 
 	for _, cidr := range cidrs {
@@ -97,10 +97,10 @@ func IPBelongsToCIDRBlocksSlice(ipAddr string, cidrs []string) (bool, error) {
 // of each is checked.
 func ValidateCIDRListString(cidrList string, separator string) (bool, error) {
 	if cidrList == "" {
-		return false, fmt.Errorf("missing CIDR list that needs validation")
+		return false, errors.New("missing CIDR list that needs validation")
 	}
 	if separator == "" {
-		return false, fmt.Errorf("missing separator")
+		return false, errors.New("missing separator")
 	}
 
 	return ValidateCIDRListSlice(strutil.ParseDedupLowercaseAndSortStrings(cidrList, separator))
@@ -109,7 +109,7 @@ func ValidateCIDRListString(cidrList string, separator string) (bool, error) {
 // ValidateCIDRListSlice checks if the given list of CIDR blocks are valid
 func ValidateCIDRListSlice(cidrBlocks []string) (bool, error) {
 	if len(cidrBlocks) == 0 {
-		return false, fmt.Errorf("missing CIDR blocks that needs validation")
+		return false, errors.New("missing CIDR blocks that needs validation")
 	}
 
 	for _, block := range cidrBlocks {
@@ -125,11 +125,11 @@ func ValidateCIDRListSlice(cidrBlocks []string) (bool, error) {
 // belonging to another CIDR block.
 func Subset(cidr1, cidr2 string) (bool, error) {
 	if cidr1 == "" {
-		return false, fmt.Errorf("missing CIDR to be checked against")
+		return false, errors.New("missing CIDR to be checked against")
 	}
 
 	if cidr2 == "" {
-		return false, fmt.Errorf("missing CIDR that needs to be checked")
+		return false, errors.New("missing CIDR that needs to be checked")
 	}
 
 	ip1, net1, err := net.ParseCIDR(cidr1)
@@ -147,7 +147,7 @@ func Subset(cidr1, cidr2 string) (bool, error) {
 
 	maskLen1, _ := net1.Mask.Size()
 	if !zeroAddr && maskLen1 == 0 {
-		return false, fmt.Errorf("CIDR to be checked against is not in its canonical form")
+		return false, errors.New("CIDR to be checked against is not in its canonical form")
 	}
 
 	ip2, net2, err := net.ParseCIDR(cidr2)
@@ -165,7 +165,7 @@ func Subset(cidr1, cidr2 string) (bool, error) {
 
 	maskLen2, _ := net2.Mask.Size()
 	if !zeroAddr && maskLen2 == 0 {
-		return false, fmt.Errorf("CIDR that needs to be checked is not in its canonical form")
+		return false, errors.New("CIDR that needs to be checked is not in its canonical form")
 	}
 
 	// If the mask length of the CIDR that needs to be checked is smaller
@@ -190,11 +190,11 @@ func Subset(cidr1, cidr2 string) (bool, error) {
 // parameter is the set of CIDR blocks that needs to be checked.
 func SubsetBlocks(cidrBlocks1, cidrBlocks2 []string) (bool, error) {
 	if len(cidrBlocks1) == 0 {
-		return false, fmt.Errorf("missing CIDR blocks to be checked against")
+		return false, errors.New("missing CIDR blocks to be checked against")
 	}
 
 	if len(cidrBlocks2) == 0 {
-		return false, fmt.Errorf("missing CIDR blocks that needs to be checked")
+		return false, errors.New("missing CIDR blocks that needs to be checked")
 	}
 
 	// Check if all the elements of cidrBlocks2 is a subset of at least one

--- a/sdk/helper/cidrutil/cidr_test.go
+++ b/sdk/helper/cidrutil/cidr_test.go
@@ -45,7 +45,7 @@ func TestCIDRUtil_IPBelongsToCIDR(t *testing.T) {
 	cidr = "192.168.26.30/24"
 	belongs, err = IPBelongsToCIDR(ip, cidr)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -66,7 +66,7 @@ func TestCIDRUtil_IPBelongsToCIDRBlocksSlice(t *testing.T) {
 
 	belongs, err = IPBelongsToCIDRBlocksSlice(ip, cidrList)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	ip = "30.40.50.60"

--- a/sdk/helper/compressutil/compress.go
+++ b/sdk/helper/compressutil/compress.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/lzw"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/golang/snappy"
@@ -78,7 +78,7 @@ func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
 	var err error
 
 	if config == nil {
-		return nil, fmt.Errorf("config is nil")
+		return nil, errors.New("config is nil")
 	}
 
 	// Write the canary into the buffer and create writer to compress the
@@ -112,7 +112,7 @@ func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
 		writer = lz4.NewWriter(&buf)
 
 	default:
-		return nil, fmt.Errorf("unsupported compression type")
+		return nil, errors.New("unsupported compression type")
 	}
 
 	if err != nil {
@@ -120,7 +120,7 @@ func Compress(data []byte, config *CompressionConfig) ([]byte, error) {
 	}
 
 	if writer == nil {
-		return nil, fmt.Errorf("failed to create a compression writer")
+		return nil, errors.New("failed to create a compression writer")
 	}
 
 	// Compress the input and place it in the same buffer containing the
@@ -158,7 +158,7 @@ func DecompressWithCanary(data []byte) ([]byte, string, bool, error) {
 	var reader io.ReadCloser
 	var compressionType string
 	if data == nil || len(data) == 0 {
-		return nil, "", false, fmt.Errorf("'data' being decompressed is empty")
+		return nil, "", false, errors.New("'data' being decompressed is empty")
 	}
 
 	canary := data[0]
@@ -169,21 +169,21 @@ func DecompressWithCanary(data []byte) ([]byte, string, bool, error) {
 	// byte and try to decompress the data that is after the canary.
 	case CompressionCanaryGzip:
 		if len(data) < 2 {
-			return nil, "", false, fmt.Errorf("invalid 'data' after the canary")
+			return nil, "", false, errors.New("invalid 'data' after the canary")
 		}
 		reader, err = gzip.NewReader(bytes.NewReader(cData))
 		compressionType = CompressionTypeGzip
 
 	case CompressionCanaryLZW:
 		if len(data) < 2 {
-			return nil, "", false, fmt.Errorf("invalid 'data' after the canary")
+			return nil, "", false, errors.New("invalid 'data' after the canary")
 		}
 		reader = lzw.NewReader(bytes.NewReader(cData), lzw.LSB, 8)
 		compressionType = CompressionTypeLZW
 
 	case CompressionCanarySnappy:
 		if len(data) < 2 {
-			return nil, "", false, fmt.Errorf("invalid 'data' after the canary")
+			return nil, "", false, errors.New("invalid 'data' after the canary")
 		}
 		reader = &CompressUtilReadCloser{
 			Reader: snappy.NewReader(bytes.NewReader(cData)),
@@ -192,7 +192,7 @@ func DecompressWithCanary(data []byte) ([]byte, string, bool, error) {
 
 	case CompressionCanaryLZ4:
 		if len(data) < 2 {
-			return nil, "", false, fmt.Errorf("invalid 'data' after the canary")
+			return nil, "", false, errors.New("invalid 'data' after the canary")
 		}
 		reader = &CompressUtilReadCloser{
 			Reader: lz4.NewReader(bytes.NewReader(cData)),
@@ -209,7 +209,7 @@ func DecompressWithCanary(data []byte) ([]byte, string, bool, error) {
 		return nil, "", false, errwrap.Wrapf("failed to create a compression reader: {{err}}", err)
 	}
 	if reader == nil {
-		return nil, "", false, fmt.Errorf("failed to create a compression reader")
+		return nil, "", false, errors.New("failed to create a compression reader")
 	}
 
 	// Close the io.ReadCloser

--- a/sdk/helper/cryptoutil/cryptoutil_test.go
+++ b/sdk/helper/cryptoutil/cryptoutil_test.go
@@ -9,6 +9,6 @@ func TestBlake2b256Hash(t *testing.T) {
 	hashVal := Blake2b256Hash("sampletext")
 
 	if string(hashVal) == "" || string(hashVal) == "sampletext" {
-		t.Fatalf("failed to hash the text")
+		t.Fatal("failed to hash the text")
 	}
 }

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -95,7 +96,7 @@ func NewServiceRunner(opts RunOptions) (*Runner, error) {
 	}
 	if opts.ContainerName == "" {
 		if strings.Contains(opts.ImageRepo, "/") {
-			return nil, fmt.Errorf("ContainerName is required for non-library images")
+			return nil, errors.New("ContainerName is required for non-library images")
 		}
 		// If there's no slash in the repo it's almost certainly going to be
 		// a good container name.
@@ -315,7 +316,7 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 			return err
 		}
 		if c == nil {
-			return fmt.Errorf("service adapter returned nil error and config")
+			return errors.New("service adapter returned nil error and config")
 		}
 		config = c
 		return nil

--- a/sdk/helper/jsonutil/json.go
+++ b/sdk/helper/jsonutil/json.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/hashicorp/errwrap"
@@ -17,7 +17,7 @@ import (
 // Encodes/Marshals the given object into JSON
 func EncodeJSON(in interface{}) ([]byte, error) {
 	if in == nil {
-		return nil, fmt.Errorf("input for encoding is nil")
+		return nil, errors.New("input for encoding is nil")
 	}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -33,7 +33,7 @@ func EncodeJSON(in interface{}) ([]byte, error) {
 // in decompression method to identify compressed input.
 func EncodeJSONAndCompress(in interface{}, config *compressutil.CompressionConfig) ([]byte, error) {
 	if in == nil {
-		return nil, fmt.Errorf("input for encoding is nil")
+		return nil, errors.New("input for encoding is nil")
 	}
 
 	// First JSON encode the given input
@@ -59,10 +59,10 @@ func EncodeJSONAndCompress(in interface{}, config *compressutil.CompressionConfi
 // decoded.
 func DecodeJSON(data []byte, out interface{}) error {
 	if data == nil || len(data) == 0 {
-		return fmt.Errorf("'data' being decoded is nil")
+		return errors.New("'data' being decoded is nil")
 	}
 	if out == nil {
-		return fmt.Errorf("output parameter 'out' is nil")
+		return errors.New("output parameter 'out' is nil")
 	}
 
 	// Decompress the data if it was compressed in the first place
@@ -71,7 +71,7 @@ func DecodeJSON(data []byte, out interface{}) error {
 		return errwrap.Wrapf("failed to decompress JSON: {{err}}", err)
 	}
 	if !uncompressed && (decompressedBytes == nil || len(decompressedBytes) == 0) {
-		return fmt.Errorf("decompressed data being decoded is invalid")
+		return errors.New("decompressed data being decoded is invalid")
 	}
 
 	// If the input supplied failed to contain the compression canary, it
@@ -87,10 +87,10 @@ func DecodeJSON(data []byte, out interface{}) error {
 // Decodes/Unmarshals the given io.Reader pointing to a JSON, into a desired object
 func DecodeJSONFromReader(r io.Reader, out interface{}) error {
 	if r == nil {
-		return fmt.Errorf("'io.Reader' being decoded is nil")
+		return errors.New("'io.Reader' being decoded is nil")
 	}
 	if out == nil {
-		return fmt.Errorf("output parameter 'out' is nil")
+		return errors.New("output parameter 'out' is nil")
 	}
 
 	dec := json.NewDecoder(r)

--- a/sdk/helper/jsonutil/json_test.go
+++ b/sdk/helper/jsonutil/json_test.go
@@ -31,7 +31,7 @@ func TestJSONUtil_CompressDecompressJSON(t *testing.T) {
 
 	// Check if canary is present in the compressed data
 	if compressedBytes[0] != compressutil.CompressionCanaryGzip {
-		t.Fatalf("canary missing in compressed data")
+		t.Fatal("canary missing in compressed data")
 	}
 
 	// Decompress and decode the compressed information and verify the functional
@@ -49,14 +49,14 @@ func TestJSONUtil_CompressDecompressJSON(t *testing.T) {
 
 	// Test invalid data
 	if err = DecodeJSON([]byte{}, &actual); err == nil {
-		t.Fatalf("expected a failure")
+		t.Fatal("expected a failure")
 	}
 
 	// Test invalid data after the canary byte
 	var buf bytes.Buffer
 	buf.Write([]byte{compressutil.CompressionCanaryGzip})
 	if err = DecodeJSON(buf.Bytes(), &actual); err == nil {
-		t.Fatalf("expected a failure")
+		t.Fatal("expected a failure")
 	}
 
 	// Compress an object
@@ -73,7 +73,7 @@ func TestJSONUtil_CompressDecompressJSON(t *testing.T) {
 
 	// Check if canary is present in the compressed data
 	if compressedBytes[0] != compressutil.CompressionCanaryGzip {
-		t.Fatalf("canary missing in compressed data")
+		t.Fatal("canary missing in compressed data")
 	}
 
 	// Decompress and decode the compressed information and verify the functional

--- a/sdk/helper/kdf/kdf.go
+++ b/sdk/helper/kdf/kdf.go
@@ -11,6 +11,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 )
@@ -27,12 +28,12 @@ type PRF func([]byte, []byte) ([]byte, error)
 func CounterMode(prf PRF, prfLen uint32, key []byte, context []byte, bits uint32) ([]byte, error) {
 	// Ensure the PRF is byte aligned
 	if prfLen%8 != 0 {
-		return nil, fmt.Errorf("PRF must be byte aligned")
+		return nil, errors.New("PRF must be byte aligned")
 	}
 
 	// Ensure the bits required are byte aligned
 	if bits%8 != 0 {
-		return nil, fmt.Errorf("bits required must be byte aligned")
+		return nil, errors.New("bits required must be byte aligned")
 	}
 
 	// Determine the number of rounds required

--- a/sdk/helper/kdf/kdf_test.go
+++ b/sdk/helper/kdf/kdf_test.go
@@ -39,11 +39,11 @@ func TestCounterMode(t *testing.T) {
 		}
 
 		if bytes.Contains(out, key) {
-			t.Fatalf("output contains key")
+			t.Fatal("output contains key")
 		}
 
 		if l == 256 && !bytes.Equal(out, expect256) {
-			t.Fatalf("mis-match")
+			t.Fatal("mis-match")
 		}
 	}
 }
@@ -57,7 +57,7 @@ func TestHMACSHA256PRF(t *testing.T) {
 	}
 
 	if uint32(len(out)*8) != HMACSHA256PRFLen {
-		t.Fatalf("Bad len")
+		t.Fatal("Bad len")
 	}
 
 	// Expect was generated in python with:
@@ -73,6 +73,6 @@ func TestHMACSHA256PRF(t *testing.T) {
 		90, 246, 133, 191, 124,
 	}
 	if !bytes.Equal(expect, out) {
-		t.Fatalf("mis-matched output")
+		t.Fatal("mis-matched output")
 	}
 }

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -361,7 +361,7 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 		switch req.KeyType {
 		case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305:
 			if req.Convergent && !req.Derived {
-				return nil, false, fmt.Errorf("convergent encryption requires derivation to be enabled")
+				return nil, false, errors.New("convergent encryption requires derivation to be enabled")
 			}
 
 		case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521:
@@ -532,12 +532,12 @@ func (lm *LockManager) DeletePolicy(ctx context.Context, storage logical.Storage
 			return err
 		}
 		if p == nil {
-			return fmt.Errorf("could not delete key; not found")
+			return errors.New("could not delete key; not found")
 		}
 	}
 
 	if !p.DeletionAllowed {
-		return fmt.Errorf("deletion is not allowed for this key")
+		return errors.New("deletion is not allowed for this key")
 	}
 
 	atomic.StoreUint32(&p.deleted, 1)

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -266,12 +266,12 @@ func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage
 			return "", err
 		}
 		if p == nil {
-			return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
+			return "", fmt.Errorf("key %q not found", name)
 		}
 	}
 
 	if atomic.LoadUint32(&p.deleted) == 1 {
-		return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
+		return "", fmt.Errorf("key %q not found", name)
 	}
 
 	backup, err := p.Backup(ctx, storage)

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -64,7 +65,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 				break
 			}
 			if conn == nil {
-				err = fmt.Errorf("empty connection after dialing")
+				err = errors.New("empty connection after dialing")
 				break
 			}
 			if cfg.StartTLS {
@@ -183,7 +184,7 @@ func (c *Client) GetUserBindDN(cfg *ConfigEntry, conn Connection, username strin
 			return bindDN, fmt.Errorf("LDAP search for binddn failed %w", err)
 		}
 		if len(result.Entries) != 1 {
-			return bindDN, fmt.Errorf("LDAP search for binddn 0 or not unique")
+			return bindDN, errors.New("LDAP search for binddn 0 or not unique")
 		}
 
 		bindDN = result.Entries[0].DN
@@ -270,11 +271,11 @@ func (c *Client) GetUserAliasAttributeValue(cfg *ConfigEntry, conn Connection, u
 			return aliasAttributeValue, fmt.Errorf("LDAP search for entity alias attribute failed: %w", err)
 		}
 		if len(result.Entries) != 1 {
-			return aliasAttributeValue, fmt.Errorf("LDAP search for entity alias attribute 0 or not unique")
+			return aliasAttributeValue, errors.New("LDAP search for entity alias attribute 0 or not unique")
 		}
 
 		if len(result.Entries[0].Attributes) != 1 {
-			return aliasAttributeValue, fmt.Errorf("LDAP attribute missing for entity alias mapping")
+			return aliasAttributeValue, errors.New("LDAP attribute missing for entity alias mapping")
 		}
 
 		if len(result.Entries[0].Attributes[0].Values) != 1 {
@@ -715,7 +716,7 @@ func getTLSConfig(cfg *ConfigEntry, host string) (*tls.Config, error) {
 	if cfg.TLSMinVersion != "" {
 		tlsMinVersion, ok := tlsutil.TLSLookup[cfg.TLSMinVersion]
 		if !ok {
-			return nil, fmt.Errorf("invalid 'tls_min_version' in config")
+			return nil, errors.New("invalid 'tls_min_version' in config")
 		}
 		tlsConfig.MinVersion = tlsMinVersion
 	}
@@ -723,7 +724,7 @@ func getTLSConfig(cfg *ConfigEntry, host string) (*tls.Config, error) {
 	if cfg.TLSMaxVersion != "" {
 		tlsMaxVersion, ok := tlsutil.TLSLookup[cfg.TLSMaxVersion]
 		if !ok {
-			return nil, fmt.Errorf("invalid 'tls_max_version' in config")
+			return nil, errors.New("invalid 'tls_max_version' in config")
 		}
 		tlsConfig.MaxVersion = tlsMaxVersion
 	}
@@ -735,7 +736,7 @@ func getTLSConfig(cfg *ConfigEntry, host string) (*tls.Config, error) {
 		caPool := x509.NewCertPool()
 		ok := caPool.AppendCertsFromPEM([]byte(cfg.Certificate))
 		if !ok {
-			return nil, fmt.Errorf("could not append CA certificate")
+			return nil, errors.New("could not append CA certificate")
 		}
 		tlsConfig.RootCAs = caPool
 	}
@@ -746,7 +747,7 @@ func getTLSConfig(cfg *ConfigEntry, host string) (*tls.Config, error) {
 		}
 		tlsConfig.Certificates = append(tlsConfig.Certificates, certificate)
 	} else if cfg.ClientTLSCert != "" || cfg.ClientTLSKey != "" {
-		return nil, fmt.Errorf("both client_tls_cert and client_tls_key must be set")
+		return nil, errors.New("both client_tls_cert and client_tls_key must be set")
 	}
 	return tlsConfig, nil
 }

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -37,7 +37,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 	for _, uut := range urls {
 		u, err := url.Parse(uut)
 		if err != nil {
-			retErr = multierror.Append(retErr, fmt.Errorf(fmt.Sprintf("error parsing url %q: {{err}}", uut), err))
+			retErr = multierror.Append(retErr, fmt.Errorf("error parsing url %q: %w", uut, err))
 			continue
 		}
 		host, port, err := net.SplitHostPort(u.Host)
@@ -104,7 +104,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			retErr = nil
 			break
 		}
-		retErr = multierror.Append(retErr, fmt.Errorf(fmt.Sprintf("error connecting to host %q: {{err}}", uut), err))
+		retErr = multierror.Append(retErr, fmt.Errorf("error connecting to host %q: %w", uut, err))
 	}
 	if retErr != nil {
 		return nil, retErr
@@ -453,21 +453,21 @@ func sidBytesToString(b []byte) (string, error) {
 	var identifierAuthorityParts [3]uint16
 
 	if err := binary.Read(reader, binary.LittleEndian, &revision); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading Revision: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading Revision: %w", b, err)
 	}
 
 	if err := binary.Read(reader, binary.LittleEndian, &subAuthorityCount); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading SubAuthorityCount: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading SubAuthorityCount: %w", b, err)
 	}
 
 	if err := binary.Read(reader, binary.BigEndian, &identifierAuthorityParts); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading IdentifierAuthority: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading IdentifierAuthority: %w", b, err)
 	}
 	identifierAuthority := (uint64(identifierAuthorityParts[0]) << 32) + (uint64(identifierAuthorityParts[1]) << 16) + uint64(identifierAuthorityParts[2])
 
 	subAuthority := make([]uint32, subAuthorityCount)
 	if err := binary.Read(reader, binary.LittleEndian, &subAuthority); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading SubAuthority: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading SubAuthority: %w", b, err)
 	}
 
 	result := fmt.Sprintf("S-%d-%d", revision, identifierAuthority)

--- a/sdk/helper/ldaputil/config.go
+++ b/sdk/helper/ldaputil/config.go
@@ -358,7 +358,7 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 			return nil, errwrap.Wrapf("failed to parse client X509 key pair: {{err}}", err)
 		}
 	} else if cfg.ClientTLSCert != "" || cfg.ClientTLSKey != "" {
-		return nil, fmt.Errorf("both client_tls_cert and client_tls_key must be set")
+		return nil, errors.New("both client_tls_cert and client_tls_key must be set")
 	}
 
 	if _, ok := d.Raw["insecure_tls"]; ok || !hadExisting {
@@ -377,11 +377,11 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 		cfg.TLSMaxVersion = d.Get("tls_max_version").(string)
 		_, ok = tlsutil.TLSLookup[cfg.TLSMaxVersion]
 		if !ok {
-			return nil, fmt.Errorf("invalid 'tls_max_version'")
+			return nil, errors.New("invalid 'tls_max_version'")
 		}
 	}
 	if cfg.TLSMaxVersion < cfg.TLSMinVersion {
-		return nil, fmt.Errorf("'tls_max_version' must be greater than or equal to 'tls_min_version'")
+		return nil, errors.New("'tls_max_version' must be greater than or equal to 'tls_min_version'")
 	}
 
 	if _, ok := d.Raw["starttls"]; ok || !hadExisting {

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -470,7 +470,7 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 
 	ocspStatuses := make([]*ocspStatus, len(ocspHosts))
 	ocspResponses := make([]*ocsp.Response, len(ocspHosts))
-	errors := make([]error, len(ocspHosts))
+	allErrors := make([]error, len(ocspHosts))
 
 	for i, ocspHost := range ocspHosts {
 		u, err := url.Parse(ocspHost)
@@ -499,7 +499,7 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 				ctx, ocspClient, retryablehttp.NewRequest, u, headers, ocspReq, issuer)
 			ocspResponses[i] = ocspRes
 			if err != nil {
-				errors[i] = err
+				allErrors[i] = err
 				return err
 			}
 			if ocspS.code != ocspSuccess {
@@ -509,7 +509,7 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 
 			ret, err := validateOCSP(ocspRes)
 			if err != nil {
-				errors[i] = err
+				allErrors[i] = err
 				return err
 			}
 			if isValidOCSPStatus(ret.code) {
@@ -517,7 +517,7 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 			} else if ret.err != nil {
 				// This check needs to occur after the isValidOCSPStatus as the unknown
 				// status also sets an err value within ret.
-				errors[i] = ret.err
+				allErrors[i] = ret.err
 				return ret.err
 			}
 			return nil
@@ -540,9 +540,9 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 	ocspRes := ocspResponses[0]
 	var firstError error
 	for i := range ocspHosts {
-		if errors[i] != nil {
+		if allErrors[i] != nil {
 			if firstError == nil {
-				firstError = errors[i]
+				firstError = allErrors[i]
 			}
 		} else if ocspStatuses[i] != nil {
 			switch ocspStatuses[i].code {
@@ -572,7 +572,7 @@ func (c *Client) GetRevocationStatus(ctx context.Context, subject, issuer *x509.
 	}
 	// An extra safety in case ret and firstError are both nil
 	if ret == nil {
-		return nil, fmt.Errorf("failed to extract a known response code or error from the OCSP server")
+		return nil, errors.New("failed to extract a known response code or error from the OCSP server")
 	}
 
 	// otherwise ret should contain a response for the overall request

--- a/sdk/helper/ocsp/ocsp_test.go
+++ b/sdk/helper/ocsp/ocsp_test.go
@@ -203,7 +203,7 @@ func TestUnitCheckOCSPResponseCache(t *testing.T) {
 	c.ocspResponseCache.Add(dummyKey, &ocspCachedResponse{time: float64(currentTime - 1000)})
 	ost, err = c.checkOCSPResponseCache(&dummyKey, subject, nil)
 	if err == nil && isValidOCSPStatus(ost.code) {
-		t.Fatalf("should have failed.")
+		t.Fatal("should have failed.")
 	}
 }
 
@@ -293,7 +293,7 @@ func TestUnitValidateOCSP(t *testing.T) {
 	ocspRes := &ocsp.Response{}
 	ost, err := validateOCSP(ocspRes)
 	if err == nil && isValidOCSPStatus(ost.code) {
-		t.Fatalf("should have failed.")
+		t.Fatal("should have failed.")
 	}
 
 	currentTime := time.Now()

--- a/sdk/helper/pathmanager/pathmanager_test.go
+++ b/sdk/helper/pathmanager/pathmanager_test.go
@@ -33,7 +33,7 @@ func TestPathManager(t *testing.T) {
 		t.Fatalf("bad: path length expect 3, got %d", len(m.Paths()))
 	}
 	if !reflect.DeepEqual(paths, m.Paths()) {
-		t.Fatalf("mismatch in paths")
+		t.Fatal("mismatch in paths")
 	}
 	for _, path := range paths {
 		if !m.HasPath(path) {
@@ -76,7 +76,7 @@ func TestPathManager_RemovePrefix(t *testing.T) {
 		t.Fatalf("bad: path length expect 3, got %d", len(m.Paths()))
 	}
 	if !reflect.DeepEqual(paths, m.Paths()) {
-		t.Fatalf("mismatch in paths")
+		t.Fatal("mismatch in paths")
 	}
 	for _, path := range paths {
 		if !m.HasPath(path) {

--- a/sdk/helper/pluginutil/multiplexing.go
+++ b/sdk/helper/pluginutil/multiplexing.go
@@ -33,7 +33,7 @@ func (pm PluginMultiplexingServerImpl) MultiplexingSupport(_ context.Context, _ 
 
 func MultiplexingSupported(ctx context.Context, cc grpc.ClientConnInterface, name string) (bool, error) {
 	if cc == nil {
-		return false, fmt.Errorf("client connection is nil")
+		return false, errors.New("client connection is nil")
 	}
 
 	out := strings.Split(api.ReadBaoVariable(PluginMultiplexingOptOut), ",")
@@ -64,7 +64,7 @@ func MultiplexingSupported(ctx context.Context, cc grpc.ClientConnInterface, nam
 func GetMultiplexIDFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", fmt.Errorf("missing plugin multiplexing metadata")
+		return "", errors.New("missing plugin multiplexing metadata")
 	}
 
 	multiplexIDs := md[MultiplexingCtxKey]
@@ -76,7 +76,7 @@ func GetMultiplexIDFromContext(ctx context.Context) (string, error) {
 
 	multiplexID := multiplexIDs[0]
 	if multiplexID == "" {
-		return "", fmt.Errorf("empty multiplex ID in metadata")
+		return "", errors.New("empty multiplex ID in metadata")
 	}
 
 	return multiplexID, nil

--- a/sdk/helper/pluginutil/multiplexing_test.go
+++ b/sdk/helper/pluginutil/multiplexing_test.go
@@ -120,7 +120,7 @@ func TestGetMultiplexIDFromContext(t *testing.T) {
 			resp, err := GetMultiplexIDFromContext(test.ctx)
 
 			if test.expectedErr != nil && test.expectedErr.Error() != "" && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			} else if !reflect.DeepEqual(err, test.expectedErr) {
 				t.Fatalf("Actual error: %#v\nExpected error: %#v", err, test.expectedErr)
 			}

--- a/sdk/helper/pluginutil/multiplexing_test.go
+++ b/sdk/helper/pluginutil/multiplexing_test.go
@@ -5,7 +5,7 @@ package pluginutil
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -96,17 +96,17 @@ func TestGetMultiplexIDFromContext(t *testing.T) {
 		"missing plugin multiplexing metadata": {
 			ctx:          context.Background(),
 			expectedResp: "",
-			expectedErr:  fmt.Errorf("missing plugin multiplexing metadata"),
+			expectedErr:  errors.New("missing plugin multiplexing metadata"),
 		},
 		"unexpected number of IDs in metadata": {
 			ctx:          idCtx(t, "12345", "67891"),
 			expectedResp: "",
-			expectedErr:  fmt.Errorf("unexpected number of IDs in metadata: (2)"),
+			expectedErr:  errors.New("unexpected number of IDs in metadata: (2)"),
 		},
 		"empty multiplex ID in metadata": {
 			ctx:          idCtx(t, ""),
 			expectedResp: "",
-			expectedErr:  fmt.Errorf("empty multiplex ID in metadata"),
+			expectedErr:  errors.New("empty multiplex ID in metadata"),
 		},
 		"happy path, id is returned from metadata": {
 			ctx:          idCtx(t, "12345"),

--- a/sdk/helper/pluginutil/run_config_test.go
+++ b/sdk/helper/pluginutil/run_config_test.go
@@ -322,12 +322,12 @@ func TestMakeConfig(t *testing.T) {
 			// The value must be nilled out before performing a DeepEqual check
 			hsh := config.SecureConfig.Hash
 			if hsh == nil {
-				t.Fatalf("Missing SecureConfig.Hash")
+				t.Fatal("Missing SecureConfig.Hash")
 			}
 			config.SecureConfig.Hash = nil
 
 			if test.expectTLSConfig && config.TLSConfig == nil {
-				t.Fatalf("TLS config expected, got nil")
+				t.Fatal("TLS config expected, got nil")
 			}
 			if !test.expectTLSConfig && config.TLSConfig != nil {
 				t.Fatalf("no TLS config expected, got: %#v", config.TLSConfig)

--- a/sdk/helper/roottoken/encode.go
+++ b/sdk/helper/roottoken/encode.go
@@ -5,6 +5,7 @@ package roottoken
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/helper/xor"
@@ -14,9 +15,9 @@ import (
 // The OTP must have the same length as the token.
 func EncodeToken(token, otp string) (string, error) {
 	if len(token) == 0 {
-		return "", fmt.Errorf("no token provided")
+		return "", errors.New("no token provided")
 	} else if len(otp) == 0 {
-		return "", fmt.Errorf("no otp provided")
+		return "", errors.New("no otp provided")
 	}
 
 	// This function performs decoding checks so rather than decode the OTP,

--- a/sdk/helper/salt/salt.go
+++ b/sdk/helper/salt/salt.go
@@ -9,7 +9,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"hash"
 
 	"github.com/hashicorp/errwrap"
@@ -111,7 +111,7 @@ func NewSalt(ctx context.Context, view logical.Storage, config *Config) (*Salt, 
 
 	if config.HMAC != nil {
 		if len(config.HMACType) == 0 {
-			return nil, fmt.Errorf("HMACType must be defined")
+			return nil, errors.New("HMACType must be defined")
 		}
 	}
 

--- a/sdk/helper/salt/salt_test.go
+++ b/sdk/helper/salt/salt_test.go
@@ -23,7 +23,7 @@ func TestSalt(t *testing.T) {
 	}
 
 	if !salt.DidGenerate() {
-		t.Fatalf("expected generation")
+		t.Fatal("expected generation")
 	}
 
 	// Verify the salt exists
@@ -32,7 +32,7 @@ func TestSalt(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out == nil {
-		t.Fatalf("missing salt")
+		t.Fatal("missing salt")
 	}
 
 	// Create a new salt, should restore
@@ -42,7 +42,7 @@ func TestSalt(t *testing.T) {
 	}
 
 	if salt2.DidGenerate() {
-		t.Fatalf("unexpected generation")
+		t.Fatal("unexpected generation")
 	}
 
 	// Check for a match
@@ -56,7 +56,7 @@ func TestSalt(t *testing.T) {
 	sid2 := salt2.SaltID(id)
 
 	if sid1 != sid2 {
-		t.Fatalf("mismatch")
+		t.Fatal("mismatch")
 	}
 }
 
@@ -75,7 +75,7 @@ func TestSaltID(t *testing.T) {
 	}
 
 	if sid1 != sid2 {
-		t.Fatalf("mismatch")
+		t.Fatal("mismatch")
 	}
 
 	sid1 = SaltID(salt, id, SHA256Hash)
@@ -86,6 +86,6 @@ func TestSaltID(t *testing.T) {
 	}
 
 	if sid1 != sid2 {
-		t.Fatalf("mismatch")
+		t.Fatal("mismatch")
 	}
 }

--- a/sdk/helper/shamir/shamir.go
+++ b/sdk/helper/shamir/shamir.go
@@ -6,6 +6,7 @@ package shamir
 import (
 	"crypto/rand"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"math/big"
 )
@@ -191,19 +192,19 @@ func add(a, b uint8) uint8 {
 func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	// Sanity check the input
 	if parts < threshold {
-		return nil, fmt.Errorf("parts cannot be less than threshold")
+		return nil, errors.New("parts cannot be less than threshold")
 	}
 	if parts > 255 {
-		return nil, fmt.Errorf("parts cannot exceed 255")
+		return nil, errors.New("parts cannot exceed 255")
 	}
 	if threshold < 2 {
-		return nil, fmt.Errorf("threshold must be at least 2")
+		return nil, errors.New("threshold must be at least 2")
 	}
 	if threshold > 255 {
-		return nil, fmt.Errorf("threshold cannot exceed 255")
+		return nil, errors.New("threshold cannot exceed 255")
 	}
 	if len(secret) == 0 {
-		return nil, fmt.Errorf("cannot split an empty secret")
+		return nil, errors.New("cannot split an empty secret")
 	}
 
 	// Generate random list of x coordinates
@@ -250,17 +251,17 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 func Combine(parts [][]byte) ([]byte, error) {
 	// Verify enough parts provided
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("less than two parts cannot be used to reconstruct the secret")
+		return nil, errors.New("less than two parts cannot be used to reconstruct the secret")
 	}
 
 	// Verify the parts are all the same length
 	firstPartLen := len(parts[0])
 	if firstPartLen < 2 {
-		return nil, fmt.Errorf("parts must be at least two bytes")
+		return nil, errors.New("parts must be at least two bytes")
 	}
 	for i := 1; i < len(parts); i++ {
 		if len(parts[i]) != firstPartLen {
-			return nil, fmt.Errorf("all parts must be the same length")
+			return nil, errors.New("all parts must be the same length")
 		}
 	}
 
@@ -277,7 +278,7 @@ func Combine(parts [][]byte) ([]byte, error) {
 	for i, part := range parts {
 		samp := part[firstPartLen-1]
 		if exists := checkMap[samp]; exists {
-			return nil, fmt.Errorf("duplicate part detected")
+			return nil, errors.New("duplicate part detected")
 		}
 		checkMap[samp] = true
 		x_samples[i] = samp

--- a/sdk/helper/shamir/shamir_test.go
+++ b/sdk/helper/shamir/shamir_test.go
@@ -12,23 +12,23 @@ func TestSplit_invalid(t *testing.T) {
 	secret := []byte("test")
 
 	if _, err := Split(secret, 0, 0); err == nil {
-		t.Fatalf("expect error")
+		t.Fatal("expect error")
 	}
 
 	if _, err := Split(secret, 2, 3); err == nil {
-		t.Fatalf("expect error")
+		t.Fatal("expect error")
 	}
 
 	if _, err := Split(secret, 1000, 3); err == nil {
-		t.Fatalf("expect error")
+		t.Fatal("expect error")
 	}
 
 	if _, err := Split(secret, 10, 1); err == nil {
-		t.Fatalf("expect error")
+		t.Fatal("expect error")
 	}
 
 	if _, err := Split(nil, 3, 2); err == nil {
-		t.Fatalf("expect error")
+		t.Fatal("expect error")
 	}
 }
 
@@ -54,7 +54,7 @@ func TestSplit(t *testing.T) {
 func TestCombine_invalid(t *testing.T) {
 	// Not enough parts
 	if _, err := Combine(nil); err == nil {
-		t.Fatalf("should err")
+		t.Fatal("should err")
 	}
 
 	// Mis-match in length
@@ -63,7 +63,7 @@ func TestCombine_invalid(t *testing.T) {
 		[]byte("ba"),
 	}
 	if _, err := Combine(parts); err == nil {
-		t.Fatalf("should err")
+		t.Fatal("should err")
 	}
 
 	// Too short
@@ -72,7 +72,7 @@ func TestCombine_invalid(t *testing.T) {
 		[]byte("b"),
 	}
 	if _, err := Combine(parts); err == nil {
-		t.Fatalf("should err")
+		t.Fatal("should err")
 	}
 
 	parts = [][]byte{
@@ -80,7 +80,7 @@ func TestCombine_invalid(t *testing.T) {
 		[]byte("foo"),
 	}
 	if _, err := Combine(parts); err == nil {
-		t.Fatalf("should err")
+		t.Fatal("should err")
 	}
 }
 
@@ -178,7 +178,7 @@ func TestPolynomial_Eval(t *testing.T) {
 		defer func() {
 			r := recover()
 			if r == nil {
-				t.Fatalf("expected panic trying to call p.evaluate(0)")
+				t.Fatal("expected panic trying to call p.evaluate(0)")
 			}
 		}()
 

--- a/sdk/helper/stepwise/environments/docker/environment.go
+++ b/sdk/helper/stepwise/environments/docker/environment.go
@@ -179,7 +179,7 @@ func (dc *DockerCluster) Initialize(ctx context.Context) error {
 		return err
 	}
 	if resp == nil {
-		return fmt.Errorf("nil response to init request")
+		return errors.New("nil response to init request")
 	}
 
 	for _, k := range resp.Keys {
@@ -501,7 +501,7 @@ func (n *dockerClusterNode) NewAPIClient() (*api.Client, error) {
 		Transport: transport,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			// This can of course be overridden per-test by using its own client
-			return fmt.Errorf("redirects not allowed in these tests")
+			return errors.New("redirects not allowed in these tests")
 		},
 	}
 	config := api.DefaultConfig()
@@ -618,7 +618,7 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 	ports := n.container.NetworkSettings.NetworkSettingsBase.Ports[nat.Port("8200/tcp")]
 	if len(ports) == 0 {
 		n.Cleanup()
-		return fmt.Errorf("could not find port binding for 8200/tcp")
+		return errors.New("could not find port binding for 8200/tcp")
 	}
 	n.HostPort = ports[0].HostPort
 
@@ -652,7 +652,7 @@ func ensureHealthMatches(ctx context.Context, client *api.Client, ready func(res
 		switch {
 		case err != nil:
 		case health == nil:
-			err = fmt.Errorf("nil response to health check")
+			err = errors.New("nil response to health check")
 		default:
 			err = ready(health)
 			if err == nil {
@@ -672,7 +672,7 @@ func ensureLeaderMatches(ctx context.Context, client *api.Client, ready func(res
 		switch {
 		case err != nil:
 		case leader == nil:
-			err = fmt.Errorf("nil response to leader check")
+			err = errors.New("nil response to leader check")
 		default:
 			err = ready(leader)
 			if err == nil {

--- a/sdk/helper/stepwise/helpers.go
+++ b/sdk/helper/stepwise/helpers.go
@@ -126,7 +126,7 @@ func (cg *CertificateGetter) GetCertificate(clientHello *tls.ClientHelloInfo) (*
 	defer cg.RUnlock()
 
 	if cg.cert == nil {
-		return nil, fmt.Errorf("nil certificate")
+		return nil, errors.New("nil certificate")
 	}
 
 	return cg.cert, nil

--- a/sdk/helper/template/funcs_test.go
+++ b/sdk/helper/template/funcs_test.go
@@ -96,7 +96,7 @@ func TestTruncate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual, err := truncate(test.maxLen, test.input)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -176,7 +176,7 @@ func TestTruncateSHA256(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual, err := truncateSHA256(test.maxLen, test.input)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/sdk/helper/template/template.go
+++ b/sdk/helper/template/template.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -26,10 +27,10 @@ func Template(rawTemplate string) Opt {
 func Function(name string, f interface{}) Opt {
 	return func(up *StringTemplate) error {
 		if name == "" {
-			return fmt.Errorf("missing function name")
+			return errors.New("missing function name")
 		}
 		if f == nil {
-			return fmt.Errorf("missing function")
+			return errors.New("missing function")
 		}
 		up.funcMap[name] = f
 		return nil
@@ -149,7 +150,7 @@ func NewTemplate(opts ...Opt) (up StringTemplate, err error) {
 	}
 
 	if up.rawTemplate == "" {
-		return StringTemplate{}, fmt.Errorf("missing template")
+		return StringTemplate{}, errors.New("missing template")
 	}
 
 	tmpl, err := template.New("template").
@@ -167,7 +168,7 @@ func NewTemplate(opts ...Opt) (up StringTemplate, err error) {
 // Generate based on the provided template
 func (up StringTemplate) Generate(data interface{}) (string, error) {
 	if up.tmpl == nil || up.rawTemplate == "" {
-		return "", fmt.Errorf("failed to generate: template not initialized")
+		return "", errors.New("failed to generate: template not initialized")
 	}
 	str := &strings.Builder{}
 	err := up.tmpl.Execute(str, data)

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -208,7 +209,7 @@ func TestBadConstructorArguments(t *testing.T) {
 		st, err := NewTemplate(
 			Template("{{foo}}"),
 			Function("foo", func() (string, error) {
-				return "", fmt.Errorf("an error!")
+				return "", errors.New("an error!")
 			}),
 		)
 		require.NoError(t, err)

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -97,7 +97,7 @@ Some string 6841cf80`,
 
 			actual, err := st.Generate(test.data)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)

--- a/sdk/helper/testcluster/docker/cert.go
+++ b/sdk/helper/testcluster/docker/cert.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"os"
 	"sync"
 
@@ -81,7 +80,7 @@ func (cg *CertificateGetter) GetCertificate(clientHello *tls.ClientHelloInfo) (*
 	defer cg.RUnlock()
 
 	if cg.cert == nil {
-		return nil, fmt.Errorf("nil certificate")
+		return nil, errors.New("nil certificate")
 	}
 
 	return cg.cert, nil

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -179,7 +180,7 @@ func (dc *DockerCluster) setupNode0(ctx context.Context) error {
 		return err
 	}
 	if resp == nil {
-		return fmt.Errorf("nil response to init request")
+		return errors.New("nil response to init request")
 	}
 
 	for _, k := range resp.Keys {
@@ -515,7 +516,7 @@ func (n *DockerClusterNode) apiConfig() (*api.Config, error) {
 		Transport: transport,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			// This can of course be overridden per-test by using its own client
-			return fmt.Errorf("redirects not allowed in these tests")
+			return errors.New("redirects not allowed in these tests")
 		},
 	}
 	config := api.DefaultConfig()
@@ -930,7 +931,7 @@ func ensureLeaderMatches(ctx context.Context, client *api.Client, ready func(res
 		switch {
 		case err != nil:
 		case leader == nil:
-			err = fmt.Errorf("nil response to leader check")
+			err = errors.New("nil response to leader check")
 		default:
 			err = ready(leader)
 			if err == nil {

--- a/sdk/helper/testcluster/exec.go
+++ b/sdk/helper/testcluster/exec.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -143,7 +144,7 @@ func (dc *ExecDevCluster) setupExecDevCluster(ctx context.Context, opts *ExecDev
 	case opts.NumCores == 1:
 		args = append(args, "-dev-tls")
 	default:
-		return fmt.Errorf("NumCores=1 and NumCores=3 are the only supported options right now")
+		return errors.New("NumCores=1 and NumCores=3 are the only supported options right now")
 	}
 	if opts.BaseListenAddress != "" {
 		args = append(args, "-dev-listen-address", opts.BaseListenAddress)

--- a/sdk/helper/testcluster/util.go
+++ b/sdk/helper/testcluster/util.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -144,7 +145,7 @@ func NodeHealthy(ctx context.Context, cluster VaultCluster, nodeIdx int) error {
 		switch {
 		case err != nil:
 		case health == nil:
-			err = fmt.Errorf("nil response to health check")
+			err = errors.New("nil response to health check")
 		case health.Sealed:
 			err = fmt.Errorf("sealed: %#v", health)
 		default:
@@ -181,7 +182,7 @@ func LeaderNode(ctx context.Context, cluster VaultCluster) (int, error) {
 		leaderActiveTimes[i] = resp.ActiveTime
 	}
 	if len(leaderActiveTimes) == 0 {
-		return -1, fmt.Errorf("no leader found")
+		return -1, errors.New("no leader found")
 	}
 	// At least one node thinks it is active. If multiple, pick the one with the
 	// most recent ActiveTime. Note if there is only one then this just returns
@@ -256,7 +257,7 @@ func GenerateRoot(cluster VaultCluster, kind GenerateRootKind) (string, error) {
 		}
 	}
 	if !status.Complete {
-		return "", fmt.Errorf("generate root operation did not end successfully")
+		return "", errors.New("generate root operation did not end successfully")
 	}
 
 	tokenBytes, err := base64.RawStdEncoding.DecodeString(status.EncodedToken)

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -173,7 +173,7 @@ func ResponseValidatingCallback(t *testing.T) func(logical.Backend, *logical.Req
 		t.Helper()
 
 		if b == nil {
-			t.Fatalf("non-nil backend required")
+			t.Fatal("non-nil backend required")
 		}
 
 		backend, ok := b.(PathRouter)

--- a/sdk/helper/testhelpers/schema/response_validation_test.go
+++ b/sdk/helper/testhelpers/schema/response_validation_test.go
@@ -349,7 +349,7 @@ func TestValidateResponse(t *testing.T) {
 				tc.strict,
 			)
 			if err == nil && tc.errorExpected == true {
-				t.Fatalf("expected an error, got nil")
+				t.Fatal("expected an error, got nil")
 			}
 			if err != nil && tc.errorExpected == false {
 				t.Fatalf("unexpected error: %v", err)

--- a/sdk/helper/xor/xor.go
+++ b/sdk/helper/xor/xor.go
@@ -5,6 +5,7 @@ package xor
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 )
 
@@ -34,7 +35,7 @@ func XORBase64(a, b string) ([]byte, error) {
 		return nil, fmt.Errorf("error decoding first base64 value: %w", err)
 	}
 	if aBytes == nil || len(aBytes) == 0 {
-		return nil, fmt.Errorf("decoded first base64 value is nil or empty")
+		return nil, errors.New("decoded first base64 value is nil or empty")
 	}
 
 	bBytes, err := base64.StdEncoding.DecodeString(b)
@@ -42,7 +43,7 @@ func XORBase64(a, b string) ([]byte, error) {
 		return nil, fmt.Errorf("error decoding second base64 value: %w", err)
 	}
 	if bBytes == nil || len(bBytes) == 0 {
-		return nil, fmt.Errorf("decoded second base64 value is nil or empty")
+		return nil, errors.New("decoded second base64 value is nil or empty")
 	}
 
 	return XORBytes(aBytes, bBytes)

--- a/sdk/logical/secret.go
+++ b/sdk/logical/secret.go
@@ -3,7 +3,10 @@
 
 package logical
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Secret represents the secret part of a response.
 type Secret struct {
@@ -22,7 +25,7 @@ type Secret struct {
 
 func (s *Secret) Validate() error {
 	if s.TTL < 0 {
-		return fmt.Errorf("ttl duration must not be less than zero")
+		return errors.New("ttl duration must not be less than zero")
 	}
 
 	return nil

--- a/sdk/logical/system_view.go
+++ b/sdk/logical/system_view.go
@@ -6,7 +6,6 @@ package logical
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"time"
 
@@ -228,16 +227,16 @@ func (d StaticSystemView) VaultVersion(_ context.Context) (string, error) {
 func (d StaticSystemView) GeneratePasswordFromPolicy(ctx context.Context, policyName string) (password string, err error) {
 	select {
 	case <-ctx.Done():
-		return "", fmt.Errorf("context timed out")
+		return "", errors.New("context timed out")
 	default:
 	}
 
 	if d.PasswordPolicies == nil {
-		return "", fmt.Errorf("password policy not found")
+		return "", errors.New("password policy not found")
 	}
 	policy, exists := d.PasswordPolicies[policyName]
 	if !exists {
-		return "", fmt.Errorf("password policy not found")
+		return "", errors.New("password policy not found")
 	}
 	return policy()
 }

--- a/sdk/logical/token_test.go
+++ b/sdk/logical/token_test.go
@@ -53,7 +53,7 @@ func TestCreateClientID(t *testing.T) {
 	entry := TokenEntry{NamespaceID: "namespaceFoo", Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE := entry.CreateClientID()
 	if !isTWE {
-		t.Fatalf("TWE token should return true value in isTWE bool")
+		t.Fatal("TWE token should return true value in isTWE bool")
 	}
 	expectedIDPlaintext := "banana" + string(SortedPoliciesTWEDelimiter) + "bar" +
 		string(SortedPoliciesTWEDelimiter) + "baz" +
@@ -68,17 +68,17 @@ func TestCreateClientID(t *testing.T) {
 	entry = TokenEntry{EntityID: "entityFoo", NamespaceID: "namespaceFoo", Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE = entry.CreateClientID()
 	if isTWE {
-		t.Fatalf("token with entity should return false value in isTWE bool")
+		t.Fatal("token with entity should return false value in isTWE bool")
 	}
 	if id != "entityFoo" {
-		t.Fatalf("client ID should be entity ID")
+		t.Fatal("client ID should be entity ID")
 	}
 
 	// Test without namespace
 	entry = TokenEntry{Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE = entry.CreateClientID()
 	if !isTWE {
-		t.Fatalf("TWE token should return true value in isTWE bool")
+		t.Fatal("TWE token should return true value in isTWE bool")
 	}
 	expectedIDPlaintext = "banana" + string(SortedPoliciesTWEDelimiter) + "bar" +
 		string(SortedPoliciesTWEDelimiter) + "baz" +
@@ -94,7 +94,7 @@ func TestCreateClientID(t *testing.T) {
 	entry = TokenEntry{NamespaceID: "namespaceFoo"}
 	id, isTWE = entry.CreateClientID()
 	if !isTWE {
-		t.Fatalf("TWE token should return true value in isTWE bool")
+		t.Fatal("TWE token should return true value in isTWE bool")
 	}
 	expectedIDPlaintext = "namespaceFoo"
 

--- a/sdk/physical/file/file.go
+++ b/sdk/physical/file/file.go
@@ -50,7 +50,7 @@ type fileEntry struct {
 func NewFileBackend(conf map[string]string, logger log.Logger) (physical.Backend, error) {
 	path, ok := conf["path"]
 	if !ok {
-		return nil, fmt.Errorf("'path' must be set")
+		return nil, errors.New("'path' must be set")
 	}
 
 	return &FileBackend{

--- a/sdk/physical/inmem/cache_test.go
+++ b/sdk/physical/inmem/cache_test.go
@@ -87,7 +87,7 @@ func TestCache_Purge(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out == nil {
-		t.Fatalf("should have key")
+		t.Fatal("should have key")
 	}
 
 	// Clear the cache
@@ -99,7 +99,7 @@ func TestCache_Purge(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out != nil {
-		t.Fatalf("should not have key")
+		t.Fatal("should not have key")
 	}
 }
 
@@ -128,7 +128,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		err = inm.Delete(context.Background(), ent.Key)
@@ -142,7 +142,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out != nil {
-			t.Fatalf("should not have key")
+			t.Fatal("should not have key")
 		}
 
 		// Put through the cache and try again
@@ -157,14 +157,14 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 		out, err = cache.Get(context.Background(), "foo")
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		err = inm.Delete(context.Background(), ent.Key)
@@ -178,7 +178,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out != nil {
-			t.Fatalf("should not have key")
+			t.Fatal("should not have key")
 		}
 	}
 
@@ -198,7 +198,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		err = inm.Delete(context.Background(), ent.Key)
@@ -212,7 +212,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		// Put through the cache and try again
@@ -227,14 +227,14 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 		out, err = cache.Get(context.Background(), "foo")
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		err = inm.Delete(context.Background(), ent.Key)
@@ -248,7 +248,7 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		// Put through the cache
@@ -263,14 +263,14 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 		out, err = cache.Get(context.Background(), "foo")
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("should have key")
+			t.Fatal("should have key")
 		}
 
 		// Delete via cache
@@ -285,14 +285,14 @@ func TestCache_Disable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out != nil {
-			t.Fatalf("should not have key")
+			t.Fatal("should not have key")
 		}
 		out, err = cache.Get(context.Background(), "foo")
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if out != nil {
-			t.Fatalf("should not have key")
+			t.Fatal("should not have key")
 		}
 	}
 

--- a/sdk/physical/inmem/inmem_ha.go
+++ b/sdk/physical/inmem/inmem_ha.go
@@ -4,7 +4,7 @@
 package inmem
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 
 	log "github.com/hashicorp/go-hclog"
@@ -73,7 +73,7 @@ func (i *InmemLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	i.l.Lock()
 	defer i.l.Unlock()
 	if i.held {
-		return nil, fmt.Errorf("lock already held")
+		return nil, errors.New("lock already held")
 	}
 
 	// Attempt an async acquisition

--- a/sdk/physical/inmem/physical_view_test.go
+++ b/sdk/physical/inmem/physical_view_test.go
@@ -30,17 +30,17 @@ func TestPhysicalView_BadKeysKeys(t *testing.T) {
 
 	_, err = view.List(context.Background(), "../")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	_, err = view.Get(context.Background(), "../")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	err = view.Delete(context.Background(), "../foo")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	le := &physical.Entry{
@@ -49,7 +49,7 @@ func TestPhysicalView_BadKeysKeys(t *testing.T) {
 	}
 	err = view.Put(context.Background(), le)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 
@@ -96,7 +96,7 @@ func TestPhysicalView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("missing nested foo/test")
+		t.Fatal("missing nested foo/test")
 	}
 
 	// Delete nested
@@ -110,7 +110,7 @@ func TestPhysicalView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry != nil {
-		t.Fatalf("nested foo/test should be gone")
+		t.Fatal("nested foo/test should be gone")
 	}
 
 	// Check the non-nested key
@@ -119,6 +119,6 @@ func TestPhysicalView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("root test missing")
+		t.Fatal("root test missing")
 	}
 }

--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -406,7 +406,7 @@ func ExerciseHABackend(t testing.TB, b HABackend, b2 HABackend) {
 		t.Fatalf("lock attempt 1: %v", err)
 	}
 	if leaderCh == nil {
-		t.Fatalf("missing leaderCh")
+		t.Fatal("missing leaderCh")
 	}
 
 	// Check the value
@@ -415,7 +415,7 @@ func ExerciseHABackend(t testing.TB, b HABackend, b2 HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 	if !held {
-		t.Errorf("should be held")
+		t.Error("should be held")
 	}
 	if val != "bar" {
 		t.Errorf("expected value bar: %v", err)
@@ -464,7 +464,7 @@ func ExerciseHABackend(t testing.TB, b HABackend, b2 HABackend) {
 		t.Fatalf("lock 2 lock: %v", err)
 	}
 	if leaderCh2 == nil {
-		t.Errorf("should get leaderCh")
+		t.Error("should get leaderCh")
 	}
 
 	// Check if it's fencing that we can register the lock
@@ -478,7 +478,7 @@ func ExerciseHABackend(t testing.TB, b HABackend, b2 HABackend) {
 		t.Fatalf("value: %v", err)
 	}
 	if !held {
-		t.Errorf("should still be held")
+		t.Error("should still be held")
 	}
 	if val != "baz" {
 		t.Errorf("expected: baz, got: %v", val)
@@ -695,7 +695,7 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 			for {
 				switch {
 				case done.Load() == true:
-					t.Logf("shutting down reader")
+					t.Log("shutting down reader")
 					return
 				default:
 					ctx := context.Background()
@@ -787,7 +787,7 @@ func testTransactionalExclusiveWriters(t testing.TB, b TransactionalBackend) {
 			for {
 				switch {
 				case done.Load() == true:
-					t.Logf("shutting down lister")
+					t.Log("shutting down lister")
 					return
 				default:
 					ctx := context.Background()
@@ -943,7 +943,7 @@ func testTransactionalMixedWriters(t testing.TB, b TransactionalBackend) {
 			for {
 				switch {
 				case done.Load() == true:
-					t.Logf("shutting down reader")
+					t.Log("shutting down reader")
 					return
 				default:
 					ctx := context.Background()

--- a/sdk/plugin/grpc_backend_server.go
+++ b/sdk/plugin/grpc_backend_server.go
@@ -6,7 +6,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	log "github.com/hashicorp/go-hclog"
@@ -62,7 +61,7 @@ func (b *backendGRPCPluginServer) getBackendAndBrokeredClientInternal(ctx contex
 		return singleImpl.backend, singleImpl.brokeredClient, nil
 	}
 
-	return nil, nil, fmt.Errorf("no backend instance found")
+	return nil, nil, errors.New("no backend instance found")
 }
 
 // getBackendAndBrokeredClient holds a read lock and returns the backend and

--- a/sdk/plugin/grpc_system.go
+++ b/sdk/plugin/grpc_system.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -107,19 +106,19 @@ func (s *gRPCSystemViewClient) ResponseWrapData(ctx context.Context, data map[st
 }
 
 func (s *gRPCSystemViewClient) NewPluginClient(ctx context.Context, config pluginutil.PluginClientConfig) (pluginutil.PluginClient, error) {
-	return nil, fmt.Errorf("cannot call NewPluginClient from a plugin backend")
+	return nil, errors.New("cannot call NewPluginClient from a plugin backend")
 }
 
 func (s *gRPCSystemViewClient) LookupPlugin(_ context.Context, _ string, _ consts.PluginType) (*pluginutil.PluginRunner, error) {
-	return nil, fmt.Errorf("cannot call LookupPlugin from a plugin backend")
+	return nil, errors.New("cannot call LookupPlugin from a plugin backend")
 }
 
 func (s *gRPCSystemViewClient) LookupPluginVersion(_ context.Context, _ string, _ consts.PluginType, _ string) (*pluginutil.PluginRunner, error) {
-	return nil, fmt.Errorf("cannot call LookupPluginVersion from a plugin backend")
+	return nil, errors.New("cannot call LookupPluginVersion from a plugin backend")
 }
 
 func (s *gRPCSystemViewClient) ListVersionedPlugins(_ context.Context, _ consts.PluginType) ([]pluginutil.VersionedPlugin, error) {
-	return nil, fmt.Errorf("cannot call ListVersionedPlugins from a plugin backend")
+	return nil, errors.New("cannot call ListVersionedPlugins from a plugin backend")
 }
 
 func (s *gRPCSystemViewClient) MlockEnabled() bool {

--- a/sdk/plugin/storage_test.go
+++ b/sdk/plugin/storage_test.go
@@ -63,11 +63,11 @@ func TestStorage_GRPCTransaction(t *testing.T) {
 	}
 
 	if _, ok := storage.(logical.Transactional); !ok {
-		t.Fatalf("expected base storage to be transactional but wasn't")
+		t.Fatal("expected base storage to be transactional but wasn't")
 	}
 
 	if _, ok := testStorage.(logical.Transactional); !ok {
-		t.Fatalf("expected client to be transactional but wasn't")
+		t.Fatal("expected client to be transactional but wasn't")
 	}
 
 	logical.TestStorage(t, testStorage)

--- a/serviceregistration/kubernetes/retry_handler_test.go
+++ b/serviceregistration/kubernetes/retry_handler_test.go
@@ -55,7 +55,7 @@ func TestRetryHandlerSimple(t *testing.T) {
 	// Initial number of patches upon Run from setting the initial state
 	initStatePatches := testState.NumPatches()
 	if initStatePatches == 0 {
-		t.Fatalf("expected number of states patches after initial patches to be non-zero")
+		t.Fatal("expected number of states patches after initial patches to be non-zero")
 	}
 
 	// Send a new patch

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -92,17 +93,17 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 		switch policy.Type {
 		case PolicyTypeACL:
 		default:
-			return nil, fmt.Errorf("unable to parse policy (wrong type)")
+			return nil, errors.New("unable to parse policy (wrong type)")
 		}
 
 		// Check if this is root
 		if policy.Name == "root" {
 			if ns.ID != namespace.RootNamespaceID {
-				return nil, fmt.Errorf("root policy is only allowed in root namespace")
+				return nil, errors.New("root policy is only allowed in root namespace")
 			}
 
 			if len(policies) != 1 {
-				return nil, fmt.Errorf("other policies present along with root")
+				return nil, errors.New("other policies present along with root")
 			}
 			a.root = true
 		}

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -175,10 +175,10 @@ func testACLRoot(t *testing.T, ns *namespace.Namespace) {
 
 	authResults := acl.AllowOperation(ctx, request, false)
 	if !authResults.RootPrivs {
-		t.Fatalf("expected root")
+		t.Fatal("expected root")
 	}
 	if !authResults.Allowed {
-		t.Fatalf("expected permissions")
+		t.Fatal("expected permissions")
 	}
 }
 
@@ -210,7 +210,7 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 
 	authResults := acl.AllowOperation(ctx, request, false)
 	if authResults.RootPrivs {
-		t.Fatalf("unexpected root")
+		t.Fatal("unexpected root")
 	}
 
 	type tcase struct {
@@ -319,7 +319,7 @@ func testLayeredACL(t *testing.T, acl *ACL, ns *namespace.Namespace) {
 
 	authResults := acl.AllowOperation(ctx, request, false)
 	if authResults.RootPrivs {
-		t.Fatalf("unexpected root")
+		t.Fatal("unexpected root")
 	}
 
 	type tcase struct {
@@ -382,7 +382,7 @@ func testLayeredACL(t *testing.T, acl *ACL, ns *namespace.Namespace) {
 func TestACL_ParseMalformedPolicy(t *testing.T) {
 	_, err := ParseACLPolicy(namespace.RootNamespace, `name{}`)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -68,7 +68,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 
 	// Ensure there is a name
 	if entry.Path == "/" {
-		return fmt.Errorf("backend path must be specified")
+		return errors.New("backend path must be specified")
 	}
 
 	// Update the audit table
@@ -83,7 +83,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 		case strings.HasPrefix(ent.Path, entry.Path):
 			fallthrough
 		case strings.HasPrefix(entry.Path, ent.Path):
-			return fmt.Errorf("path already in use")
+			return errors.New("path already in use")
 		}
 	}
 
@@ -171,7 +171,7 @@ func (c *Core) disableAudit(ctx context.Context, path string, updateStorage bool
 
 	// Ensure there is a name
 	if path == "/" {
-		return false, fmt.Errorf("backend path must be specified")
+		return false, errors.New("backend path must be specified")
 	}
 
 	// Remove the entry from the mount table
@@ -186,7 +186,7 @@ func (c *Core) disableAudit(ctx context.Context, path string, updateStorage bool
 
 	// Ensure there was a match
 	if entry == nil {
-		return false, fmt.Errorf("no matching backend")
+		return false, errors.New("no matching backend")
 	}
 
 	c.removeAuditReloadFunc(entry)
@@ -309,7 +309,7 @@ func (c *Core) loadAudits(ctx context.Context) error {
 func (c *Core) persistAudit(ctx context.Context, table *MountTable, localOnly bool) error {
 	if table.Type != auditTableType {
 		c.logger.Error("given table to persist has wrong type", "actual_type", table.Type, "expected_type", auditTableType)
-		return fmt.Errorf("invalid table type given, not persisting")
+		return errors.New("invalid table type given, not persisting")
 	}
 
 	nonLocalAudit := &MountTable{
@@ -323,7 +323,7 @@ func (c *Core) persistAudit(ctx context.Context, table *MountTable, localOnly bo
 	for _, entry := range table.Entries {
 		if entry.Table != table.Type {
 			c.logger.Error("given entry to persist in audit table has wrong table value", "path", entry.Path, "entry_table_type", entry.Table, "actual_type", table.Type)
-			return fmt.Errorf("invalid audit entry found, not persisting")
+			return errors.New("invalid audit entry found, not persisting")
 		}
 
 		if entry.Local {

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -110,7 +111,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 	defer func() {
 		if r := recover(); r != nil {
 			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r, "stacktrace", string(debug.Stack()))
-			retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log"))
+			retErr = multierror.Append(retErr, errors.New("panic generating audit log"))
 		}
 
 		ret = retErr.ErrorOrNil()
@@ -154,7 +155,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 		}
 	}
 	if !anyLogged && len(a.backends) > 0 {
-		retErr = multierror.Append(retErr, fmt.Errorf("no audit backend succeeded in logging the request"))
+		retErr = multierror.Append(retErr, errors.New("no audit backend succeeded in logging the request"))
 	}
 
 	return retErr.ErrorOrNil()
@@ -181,7 +182,7 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 	defer func() {
 		if r := recover(); r != nil {
 			a.logger.Error("panic during logging", "request_path", in.Request.Path, "error", r, "stacktrace", string(debug.Stack()))
-			retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log"))
+			retErr = multierror.Append(retErr, errors.New("panic generating audit log"))
 		}
 
 		ret = retErr.ErrorOrNil()
@@ -219,7 +220,7 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 		}
 	}
 	if !anyLogged && len(a.backends) > 0 {
-		retErr = multierror.Append(retErr, fmt.Errorf("no audit backend succeeded in logging the response"))
+		retErr = multierror.Append(retErr, errors.New("no audit backend succeeded in logging the response"))
 	}
 
 	return retErr.ErrorOrNil()

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -32,7 +32,7 @@ func TestAudit_ReadOnlyViewDuringMount(t *testing.T) {
 			Value: []byte("baz"),
 		})
 		if err == nil || !strings.Contains(err.Error(), logical.ErrSetupReadOnly.Error()) {
-			t.Fatalf("expected a read-only error")
+			t.Fatal("expected a read-only error")
 		}
 		factory := corehelpers.NoopAuditFactory(nil)
 		return factory(ctx, config)
@@ -64,7 +64,7 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 
 	if !c.auditBroker.IsRegistered("foo/") {
-		t.Fatalf("missing audit backend")
+		t.Fatal("missing audit backend")
 	}
 
 	conf := &CoreConfig{
@@ -83,7 +83,7 @@ func TestCore_EnableAudit(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -94,7 +94,7 @@ func TestCore_EnableAudit(t *testing.T) {
 
 	// Check for registration
 	if !c2.auditBroker.IsRegistered("foo/") {
-		t.Fatalf("missing audit backend")
+		t.Fatal("missing audit backend")
 	}
 }
 
@@ -259,7 +259,7 @@ func TestCore_DisableAudit(t *testing.T) {
 
 	// Check for registration
 	if c.auditBroker.IsRegistered("foo") {
-		t.Fatalf("audit backend present")
+		t.Fatal("audit backend present")
 	}
 
 	conf := &CoreConfig{
@@ -276,7 +276,7 @@ func TestCore_DisableAudit(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -292,7 +292,7 @@ func TestCore_DefaultAuditTable(t *testing.T) {
 
 	// Verify we have an audit broker
 	if c.auditBroker == nil {
-		t.Fatalf("missing audit broker")
+		t.Fatal("missing audit broker")
 	}
 
 	// Start a second core with same physical
@@ -310,7 +310,7 @@ func TestCore_DefaultAuditTable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -103,7 +102,7 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
 	c.auditBackends["fail"] = func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
-		return nil, fmt.Errorf("failing enabling")
+		return nil, errors.New("failing enabling")
 	}
 
 	c.audit = &MountTable{
@@ -152,7 +151,7 @@ func TestCore_EnableAudit_Local(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
 	c.auditBackends["fail"] = func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
-		return nil, fmt.Errorf("failing enabling")
+		return nil, errors.New("failing enabling")
 	}
 
 	c.audit = &MountTable{
@@ -406,7 +405,7 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 	}
 
 	// Should still work with one failing backend
-	a1.ReqErr = fmt.Errorf("failed")
+	a1.ReqErr = errors.New("failed")
 	logInput = &logical.LogInput{
 		Auth:    auth,
 		Request: req,
@@ -416,7 +415,7 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 	}
 
 	// Should FAIL work with both failing backends
-	a2.ReqErr = fmt.Errorf("failed")
+	a2.ReqErr = errors.New("failed")
 	if err := b.LogRequest(ctx, logInput, headersConf); !errwrap.Contains(err, "no audit backend succeeded in logging the request") {
 		t.Fatalf("err: %v", err)
 	}
@@ -454,7 +453,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 			"password": "password",
 		},
 	}
-	respErr := fmt.Errorf("permission denied")
+	respErr := errors.New("permission denied")
 
 	// Copy so we can verify nothing changed
 	authCopyRaw, err := copystructure.Copy(auth)
@@ -507,7 +506,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 	}
 
 	// Should still work with one failing backend
-	a1.RespErr = fmt.Errorf("failed")
+	a1.RespErr = errors.New("failed")
 	logInput = &logical.LogInput{
 		Auth:     auth,
 		Request:  req,
@@ -520,7 +519,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 	}
 
 	// Should FAIL work with both failing backends
-	a2.RespErr = fmt.Errorf("failed")
+	a2.RespErr = errors.New("failed")
 	err = b.LogResponse(ctx, logInput, headersConf)
 	if !strings.Contains(err.Error(), "no audit backend succeeded in logging the response") {
 		t.Fatalf("err: %v", err)
@@ -554,7 +553,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 			"Content-Type":   {"baz"},
 		},
 	}
-	respErr := fmt.Errorf("permission denied")
+	respErr := errors.New("permission denied")
 
 	// Copy so we can verify nothing changed
 	reqCopyRaw, err := copystructure.Copy(req)
@@ -592,7 +591,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 	}
 
 	// Should still work with one failing backend
-	a1.ReqErr = fmt.Errorf("failed")
+	a1.ReqErr = errors.New("failed")
 	logInput = &logical.LogInput{
 		Auth:     auth,
 		Request:  req,
@@ -604,7 +603,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 	}
 
 	// Should FAIL work with both failing backends
-	a2.ReqErr = fmt.Errorf("failed")
+	a2.ReqErr = errors.New("failed")
 	err = b.LogRequest(ctx, logInput, headersConf)
 	if !errwrap.Contains(err, "no audit backend succeeded in logging the request") {
 		t.Fatalf("err: %v", err)

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -38,7 +39,7 @@ type AuditedHeadersConfig struct {
 // add adds or overwrites a header in the config and updates the barrier view
 func (a *AuditedHeadersConfig) add(ctx context.Context, header string, hmac bool) error {
 	if header == "" {
-		return fmt.Errorf("header value cannot be empty")
+		return errors.New("header value cannot be empty")
 	}
 
 	// Grab a write lock
@@ -65,7 +66,7 @@ func (a *AuditedHeadersConfig) add(ctx context.Context, header string, hmac bool
 // remove deletes a header out of the header config and updates the barrier view
 func (a *AuditedHeadersConfig) remove(ctx context.Context, header string) error {
 	if header == "" {
-		return fmt.Errorf("header value cannot be empty")
+		return errors.New("header value cannot be empty")
 	}
 
 	// Grab a write lock

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -76,7 +76,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 
 	// Ensure there is a name
 	if entry.Path == "/" {
-		return fmt.Errorf("backend path must be specified")
+		return errors.New("backend path must be specified")
 	}
 
 	c.mountsLock.Lock()
@@ -117,7 +117,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 
 	// Ensure the token backend is a singleton
 	if entry.Type == mountTypeToken {
-		return fmt.Errorf("token credential backend cannot be instantiated")
+		return errors.New("token credential backend cannot be instantiated")
 	}
 
 	// Check for conflicts according to the router
@@ -225,7 +225,7 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 
 	// Ensure the token backend is not affected
 	if path == "token/" {
-		return fmt.Errorf("token credential backend cannot be disabled")
+		return errors.New("token credential backend cannot be disabled")
 	}
 
 	// Disable credential internally
@@ -247,7 +247,7 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 	// Verify exact match of the route
 	match := c.router.MatchingMount(ctx, path)
 	if match == "" || ns.Path+path != match {
-		return fmt.Errorf("no matching mount")
+		return errors.New("no matching mount")
 	}
 
 	// Store the view for this backend
@@ -787,7 +787,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 
 	if table.Type != credentialTableType {
 		c.logger.Error("given table to persist has wrong type", "actual_type", table.Type, "expected_type", credentialTableType)
-		return fmt.Errorf("invalid table type given, not persisting")
+		return errors.New("invalid table type given, not persisting")
 	}
 
 	nonLocalAuth := &MountTable{
@@ -801,7 +801,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 	for _, entry := range table.Entries {
 		if entry.Table != table.Type {
 			c.logger.Error("given entry to persist in auth table has wrong table value", "path", entry.Path, "entry_table_type", entry.Table, "actual_type", table.Type)
-			return fmt.Errorf("invalid auth entry found, not persisting")
+			return errors.New("invalid auth entry found, not persisting")
 		}
 
 		if entry.Local {

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -29,7 +29,7 @@ func TestAuth_ReadOnlyViewDuringMount(t *testing.T) {
 			Value: []byte("baz"),
 		})
 		if err == nil || !strings.Contains(err.Error(), logical.ErrSetupReadOnly.Error()) {
-			t.Fatalf("expected a read-only error")
+			t.Fatal("expected a read-only error")
 		}
 		return &NoopBackend{
 			BackendType: logical.TypeCredential,
@@ -77,40 +77,40 @@ func TestAuthMountMetrics(t *testing.T) {
 	loadMetric, ok = mountMetrics.Load(mountKeyName)
 	numEntriesMetric = loadMetric.(metricsutil.GaugeMetric)
 	if !ok || numEntriesMetric.Value != 2 {
-		t.Fatalf("mount metrics for num entries do not match true values")
+		t.Fatal("mount metrics for num entries do not match true values")
 	}
 	if len(numEntriesMetric.Key) != 3 ||
 		numEntriesMetric.Key[0] != "core" ||
 		numEntriesMetric.Key[1] != "mount_table" ||
 		numEntriesMetric.Key[2] != "num_entries" {
-		t.Fatalf("mount metrics for num entries have wrong key")
+		t.Fatal("mount metrics for num entries have wrong key")
 	}
 	if len(numEntriesMetric.Labels) != 2 ||
 		numEntriesMetric.Labels[0].Name != "type" ||
 		numEntriesMetric.Labels[0].Value != "auth" ||
 		numEntriesMetric.Labels[1].Name != "local" ||
 		numEntriesMetric.Labels[1].Value != "false" {
-		t.Fatalf("mount metrics for num entries have wrong labels")
+		t.Fatal("mount metrics for num entries have wrong labels")
 	}
 	mountSizeKeyName := "core.mount_table.size.type|auth||local|false||"
 	loadMetric, ok = mountMetrics.Load(mountSizeKeyName)
 	sizeMetric := loadMetric.(metricsutil.GaugeMetric)
 
 	if !ok {
-		t.Fatalf("mount metrics for size do not match exist")
+		t.Fatal("mount metrics for size do not match exist")
 	}
 	if len(sizeMetric.Key) != 3 ||
 		sizeMetric.Key[0] != "core" ||
 		sizeMetric.Key[1] != "mount_table" ||
 		sizeMetric.Key[2] != "size" {
-		t.Fatalf("mount metrics for size have wrong key")
+		t.Fatal("mount metrics for size have wrong key")
 	}
 	if len(sizeMetric.Labels) != 2 ||
 		sizeMetric.Labels[0].Name != "type" ||
 		sizeMetric.Labels[0].Value != "auth" ||
 		sizeMetric.Labels[1].Name != "local" ||
 		sizeMetric.Labels[1].Value != "false" {
-		t.Fatalf("mount metrics for size have wrong labels")
+		t.Fatal("mount metrics for size have wrong labels")
 	}
 }
 
@@ -137,7 +137,7 @@ func TestCore_DefaultAuthTable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -223,7 +223,7 @@ func TestCore_EnableCredential(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -291,7 +291,7 @@ func TestCore_EnableCredential_aws_ec2(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -432,10 +432,10 @@ func TestCore_EnableCredential_twice_409(t *testing.T) {
 	switch err2.(type) {
 	case logical.HTTPCodedError:
 		if err2.(logical.HTTPCodedError).Code() != 409 {
-			t.Fatalf("invalid code given")
+			t.Fatal("invalid code given")
 		}
 	default:
-		t.Fatalf("expected a different error type")
+		t.Fatal("expected a different error type")
 	}
 }
 
@@ -482,7 +482,7 @@ func TestCore_DisableCredential(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "auth/foo/bar")
 	if match != "" {
-		t.Fatalf("backend present")
+		t.Fatal("backend present")
 	}
 
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
@@ -503,7 +503,7 @@ func TestCore_DisableCredential(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -745,7 +745,7 @@ func TestCore_RemountCredential(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -961,7 +961,7 @@ func (b *AESGCMBarrier) aeadFromKey(key []byte) (cipher.AEAD, error) {
 	// Create the GCM mode AEAD
 	gcm, err := cipher.NewGCM(aesCipher)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize GCM mode")
+		return nil, errors.New("failed to initialize GCM mode")
 	}
 	return gcm, nil
 }
@@ -1025,7 +1025,7 @@ func termLabel(term uint32) []metrics.Label {
 // decrypt is used to decrypt a value using the keyring
 func (b *AESGCMBarrier) decrypt(path string, gcm cipher.AEAD, cipher []byte) ([]byte, error) {
 	if len(cipher) < 5+gcm.NonceSize() {
-		return nil, fmt.Errorf("invalid cipher length")
+		return nil, errors.New("invalid cipher length")
 	}
 	// Capture the parts
 	nonce := cipher[5 : 5+gcm.NonceSize()]
@@ -1043,7 +1043,7 @@ func (b *AESGCMBarrier) decrypt(path string, gcm cipher.AEAD, cipher []byte) ([]
 		}
 		return gcm.Open(out, nonce, raw, aad)
 	default:
-		return nil, fmt.Errorf("version bytes mis-match")
+		return nil, errors.New("version bytes mis-match")
 	}
 }
 
@@ -1080,13 +1080,13 @@ func (b *AESGCMBarrier) Decrypt(_ context.Context, key string, ciphertext []byte
 
 	if len(ciphertext) == 0 {
 		b.l.RUnlock()
-		return nil, fmt.Errorf("empty ciphertext")
+		return nil, errors.New("empty ciphertext")
 	}
 
 	// Verify the term
 	if len(ciphertext) < 4 {
 		b.l.RUnlock()
-		return nil, fmt.Errorf("invalid ciphertext term")
+		return nil, errors.New("invalid ciphertext term")
 	}
 	term := binary.BigEndian.Uint32(ciphertext[:4])
 

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -88,7 +88,7 @@ func TestAESGCMBarrier_MissingRotateConfig(t *testing.T) {
 
 	// At this point, the rotation config should match the default
 	if !defaultRotationConfig.Equals(b.keyring.rotationConfig) {
-		t.Fatalf("expected empty rotation config to recover as default config")
+		t.Fatal("expected empty rotation config to recover as default config")
 	}
 }
 
@@ -166,7 +166,7 @@ func TestAESGCMBarrier_Confidential(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if pe == nil {
-		t.Fatalf("missing physical entry")
+		t.Fatal("missing physical entry")
 	}
 
 	if pe.Key != "test" {
@@ -212,7 +212,7 @@ func TestAESGCMBarrier_Integrity(t *testing.T) {
 	// Read from the barrier
 	_, err = b.Get(context.Background(), "test")
 	if err == nil {
-		t.Fatalf("should fail!")
+		t.Fatal("should fail!")
 	}
 }
 
@@ -258,7 +258,7 @@ func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
 	// Read from the barrier
 	_, err = b.Get(context.Background(), "moved")
 	if err != nil {
-		t.Fatalf("should succeed with version 1!")
+		t.Fatal("should succeed with version 1!")
 	}
 }
 
@@ -303,7 +303,7 @@ func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
 	// Read from the barrier
 	_, err = b.Get(context.Background(), "moved")
 	if err == nil {
-		t.Fatalf("should fail with version 2!")
+		t.Fatal("should fail with version 2!")
 	}
 }
 
@@ -360,7 +360,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 	// Check successful decryption
 	_, err = b.Get(context.Background(), "test")
 	if err != nil {
-		t.Fatalf("Upgrade unsuccessful")
+		t.Fatal("Upgrade unsuccessful")
 	}
 }
 
@@ -380,7 +380,7 @@ func TestEncrypt_Unique(t *testing.T) {
 	b.Unseal(context.Background(), key)
 
 	if b.keyring == nil {
-		t.Fatalf("barrier is sealed")
+		t.Fatal("barrier is sealed")
 	}
 
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
@@ -397,7 +397,7 @@ func TestEncrypt_Unique(t *testing.T) {
 	}
 
 	if bytes.Equal(first, second) {
-		t.Fatalf("improper random seeding detected")
+		t.Fatal("improper random seeding detected")
 	}
 }
 
@@ -419,19 +419,19 @@ func TestInitialize_KeyLength(t *testing.T) {
 	err = b.Initialize(context.Background(), long, nil, rand.Reader)
 
 	if err == nil {
-		t.Fatalf("key length protection failed")
+		t.Fatal("key length protection failed")
 	}
 
 	err = b.Initialize(context.Background(), middle, nil, rand.Reader)
 
 	if err == nil {
-		t.Fatalf("key length protection failed")
+		t.Fatal("key length protection failed")
 	}
 
 	err = b.Initialize(context.Background(), short, nil, rand.Reader)
 
 	if err == nil {
-		t.Fatalf("key length protection failed")
+		t.Fatal("key length protection failed")
 	}
 }
 

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -149,7 +149,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("err: %v", err)
 	}
 	if init {
-		t.Fatalf("should not be initialized")
+		t.Fatal("should not be initialized")
 	}
 
 	// Should start sealed
@@ -158,7 +158,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("err: %v", err)
 	}
 	if !sealed {
-		t.Fatalf("should be sealed")
+		t.Fatal("should be sealed")
 	}
 
 	// Sealing should be a no-op
@@ -193,7 +193,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("minimum key size too small: %d", min)
 	}
 	if max < min {
-		t.Fatalf("maximum key size smaller than min")
+		t.Fatal("maximum key size smaller than min")
 	}
 
 	// Unseal should not work
@@ -217,7 +217,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("err: %v", err)
 	}
 	if !init {
-		t.Fatalf("should be initialized")
+		t.Fatal("should be initialized")
 	}
 
 	// Should still be sealed
@@ -226,7 +226,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("err: %v", err)
 	}
 	if !sealed {
-		t.Fatalf("should sealed")
+		t.Fatal("should sealed")
 	}
 
 	// Unseal should work
@@ -245,7 +245,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 		t.Fatalf("err: %v", err)
 	}
 	if sealed {
-		t.Fatalf("should be unsealed")
+		t.Fatal("should be unsealed")
 	}
 
 	// Verify the root key
@@ -416,7 +416,7 @@ func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
 	// Unseal with old key should fail
 	err = b.Unseal(context.Background(), key)
 	if err == nil {
-		t.Fatalf("unseal should fail")
+		t.Fatal("unseal should fail")
 	}
 
 	// Unseal with new keys should work
@@ -472,7 +472,7 @@ func testBarrier_Upgrade(t *testing.T, b1, b2 SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 	if !did || updated != newTerm {
-		t.Fatalf("failed to upgrade")
+		t.Fatal("failed to upgrade")
 	}
 
 	// Should have no upgrades pending
@@ -481,7 +481,7 @@ func testBarrier_Upgrade(t *testing.T, b1, b2 SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 	if did {
-		t.Fatalf("should not have upgrade")
+		t.Fatal("should not have upgrade")
 	}
 
 	// Rotate the encryption key
@@ -508,7 +508,7 @@ func testBarrier_Upgrade(t *testing.T, b1, b2 SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 	if did {
-		t.Fatalf("should not have upgrade")
+		t.Fatal("should not have upgrade")
 	}
 }
 

--- a/vault/barrier_view_test.go
+++ b/vault/barrier_view_test.go
@@ -24,17 +24,17 @@ func TestBarrierView_BadKeysKeys(t *testing.T) {
 
 	_, err := view.List(context.Background(), "../")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	_, err = view.Get(context.Background(), "../")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	err = view.Delete(context.Background(), "../foo")
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	le := &logical.StorageEntry{
@@ -43,7 +43,7 @@ func TestBarrierView_BadKeysKeys(t *testing.T) {
 	}
 	err = view.Put(context.Background(), le)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 
@@ -86,7 +86,7 @@ func TestBarrierView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("missing nested foo/test")
+		t.Fatal("missing nested foo/test")
 	}
 
 	// Delete nested
@@ -100,7 +100,7 @@ func TestBarrierView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry != nil {
-		t.Fatalf("nested foo/test should be gone")
+		t.Fatal("nested foo/test should be gone")
 	}
 
 	// Check the non-nested key
@@ -109,7 +109,7 @@ func TestBarrierView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if entry == nil {
-		t.Fatalf("root test missing")
+		t.Fatal("root test missing")
 	}
 }
 
@@ -148,7 +148,7 @@ func TestBarrierView_SubView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if bout == nil {
-		t.Fatalf("missing nested foo/bar/test")
+		t.Fatal("missing nested foo/bar/test")
 	}
 
 	// Check for visibility in root
@@ -157,7 +157,7 @@ func TestBarrierView_SubView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out == nil {
-		t.Fatalf("missing nested bar/test")
+		t.Fatal("missing nested bar/test")
 	}
 
 	// Delete nested
@@ -171,7 +171,7 @@ func TestBarrierView_SubView(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if bout != nil {
-		t.Fatalf("nested foo/bar/test should be gone")
+		t.Fatal("nested foo/bar/test should be gone")
 	}
 }
 
@@ -312,6 +312,6 @@ func TestBarrierView_Readonly(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if e == nil {
-		t.Fatalf("key test missing")
+		t.Fatal("key test missing")
 	}
 }

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -106,19 +106,19 @@ func (c *Core) loadLocalClusterTLS(adv activeAdvertisement) (retErr error) {
 
 	case adv.ClusterKeyParams == nil:
 		c.logger.Error("no key params found loading local cluster TLS information")
-		return fmt.Errorf("no local cluster key params found")
+		return errors.New("no local cluster key params found")
 
 	case adv.ClusterKeyParams.X == nil, adv.ClusterKeyParams.Y == nil, adv.ClusterKeyParams.D == nil:
 		c.logger.Error("failed to parse local cluster key due to missing params")
-		return fmt.Errorf("failed to parse local cluster key")
+		return errors.New("failed to parse local cluster key")
 
 	case adv.ClusterKeyParams.Type != corePrivateKeyTypeP521:
 		c.logger.Error("unknown local cluster key type", "key_type", adv.ClusterKeyParams.Type)
-		return fmt.Errorf("failed to find valid local cluster key type")
+		return errors.New("failed to find valid local cluster key type")
 
 	case adv.ClusterCert == nil || len(adv.ClusterCert) == 0:
 		c.logger.Error("no local cluster cert found")
-		return fmt.Errorf("no local cluster cert found")
+		return errors.New("no local cluster cert found")
 
 	}
 
@@ -313,7 +313,7 @@ func (c *Core) startClusterListener(ctx context.Context) error {
 
 	if c.clusterListenerAddrs == nil || len(c.clusterListenerAddrs) == 0 {
 		c.logger.Warn("clustering not disabled but no addresses to listen on")
-		return fmt.Errorf("cluster addresses not found")
+		return errors.New("cluster addresses not found")
 	}
 
 	c.logger.Debug("starting cluster listeners")

--- a/vault/core.go
+++ b/vault/core.go
@@ -807,7 +807,7 @@ func (c *CoreConfig) GetServiceRegistration() sr.ServiceRegistration {
 func CreateCore(conf *CoreConfig) (*Core, error) {
 	if conf.HAPhysical != nil && conf.HAPhysical.HAEnabled() {
 		if conf.RedirectAddr == "" {
-			return nil, fmt.Errorf("missing API address, please set in configuration or via environment")
+			return nil, errors.New("missing API address, please set in configuration or via environment")
 		}
 	}
 
@@ -818,7 +818,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		conf.MaxLeaseTTL = maxLeaseTTL
 	}
 	if conf.DefaultLeaseTTL > conf.MaxLeaseTTL {
-		return nil, fmt.Errorf("cannot have DefaultLeaseTTL larger than MaxLeaseTTL")
+		return nil, errors.New("cannot have DefaultLeaseTTL larger than MaxLeaseTTL")
 	}
 
 	// Validate the advertise addr if its given to us
@@ -829,7 +829,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		}
 
 		if u.Scheme == "" {
-			return nil, fmt.Errorf("redirect address must include scheme (ex. 'http')")
+			return nil, errors.New("redirect address must include scheme (ex. 'http')")
 		}
 	}
 
@@ -1427,10 +1427,10 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 	ctx := context.Background()
 
 	if migrate && c.migrationInfo == nil {
-		return fmt.Errorf("can't perform a seal migration, no migration seal found")
+		return errors.New("can't perform a seal migration, no migration seal found")
 	}
 	if migrate && c.isRaftUnseal() {
-		return fmt.Errorf("can't perform a seal migration while joining a raft cluster")
+		return errors.New("can't perform a seal migration while joining a raft cluster")
 	}
 	if !migrate && c.migrationInfo != nil {
 		done, err := c.sealMigrated(ctx)
@@ -1438,7 +1438,7 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 			return fmt.Errorf("error checking to see if seal is migrated: %w", err)
 		}
 		if !done {
-			return fmt.Errorf("migrate option not provided and seal migration is pending")
+			return errors.New("migrate option not provided and seal migration is pending")
 		}
 	}
 
@@ -1623,7 +1623,7 @@ func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
 		return nil, err
 	}
 	if config == nil {
-		return nil, fmt.Errorf("failed to obtain seal/recovery configuration")
+		return nil, errors.New("failed to obtain seal/recovery configuration")
 	}
 
 	// Check if we don't have enough keys to unlock, proceed through the rest of
@@ -2139,7 +2139,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock, keepHALock, performCleanup
 
 		if err := c.preSeal(); err != nil {
 			c.logger.Error("pre-seal teardown failed", "error", err)
-			return fmt.Errorf("internal error")
+			return errors.New("internal error")
 		}
 	} else {
 		// If we are keeping the lock we already have the state write lock
@@ -2810,7 +2810,7 @@ func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []
 		}
 		return storedKeys[0], nil
 	}
-	return nil, fmt.Errorf("invalid seal")
+	return nil, errors.New("invalid seal")
 }
 
 // IsInSealMigrationMode returns true if we're configured to perform a seal migration,
@@ -2948,11 +2948,11 @@ func (c *Core) ExistCustomResponseHeader(header string) bool {
 func (c *Core) ReloadCustomResponseHeaders() error {
 	conf := c.rawConfig.Load()
 	if conf == nil {
-		return fmt.Errorf("failed to load core raw config")
+		return errors.New("failed to load core raw config")
 	}
 	lns := conf.(*server.Config).Listeners
 	if lns == nil {
-		return fmt.Errorf("no listener configured")
+		return errors.New("no listener configured")
 	}
 
 	uiHeaders, err := c.UIHeaders()
@@ -3700,7 +3700,7 @@ func (c *Core) aliasNameFromLoginRequest(ctx context.Context, req *logical.Reque
 // ListMounts will provide a slice containing a deep copy each mount entry
 func (c *Core) ListMounts() ([]*MountEntry, error) {
 	if c.Sealed() {
-		return nil, fmt.Errorf("vault is sealed")
+		return nil, errors.New("vault is sealed")
 	}
 
 	c.mountsLock.RLock()
@@ -3723,7 +3723,7 @@ func (c *Core) ListMounts() ([]*MountEntry, error) {
 // ListAuths will provide a slice containing a deep copy each auth entry
 func (c *Core) ListAuths() ([]*MountEntry, error) {
 	if c.Sealed() {
-		return nil, fmt.Errorf("vault is sealed")
+		return nil, errors.New("vault is sealed")
 	}
 
 	c.authLock.RLock()
@@ -3787,12 +3787,12 @@ func (c *Core) ListenerAddresses() ([]string, error) {
 
 	conf := c.rawConfig.Load()
 	if conf == nil {
-		return nil, fmt.Errorf("failed to load core raw config")
+		return nil, errors.New("failed to load core raw config")
 	}
 
 	listeners := conf.(*server.Config).Listeners
 	if listeners == nil {
-		return nil, fmt.Errorf("no listener configured")
+		return nil, errors.New("no listener configured")
 	}
 
 	for _, listener := range listeners {

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -199,10 +199,10 @@ func TestCoreMetrics_KvSecretGauge_BadPath(t *testing.T) {
 	}
 	if found {
 		if count != 1.0 {
-			t.Errorf("bad secret count for kv1/")
+			t.Error("bad secret count for kv1/")
 		}
 	} else {
-		t.Errorf("no secret count for kv1/")
+		t.Error("no secret count for kv1/")
 	}
 }
 

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -362,7 +362,7 @@ func TestSealConfig_Invalid(t *testing.T) {
 	}
 	err := s.Validate()
 	if err == nil {
-		t.Fatalf("expected err")
+		t.Fatal("expected err")
 	}
 }
 
@@ -371,7 +371,7 @@ func TestSealConfig_Invalid(t *testing.T) {
 func TestCore_HasVaultVersion(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	if c.versionHistory == nil {
-		t.Fatalf("Version timestamps for core were not initialized for a new core")
+		t.Fatal("Version timestamps for core were not initialized for a new core")
 	}
 	versionEntry, ok := c.versionHistory[version.Version]
 	if !ok {
@@ -407,7 +407,7 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 	}
 
 	if !c.Sealed() {
-		t.Fatalf("should be sealed")
+		t.Fatal("should be sealed")
 	}
 
 	if prog, _ := c.SecretProgress(true); prog != 0 {
@@ -427,14 +427,14 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 		}
 		if i >= 2 {
 			if !unseal {
-				t.Fatalf("should be unsealed")
+				t.Fatal("should be unsealed")
 			}
 			if prog, _ := c.SecretProgress(true); prog != 0 {
 				t.Fatalf("bad progress: %d", prog)
 			}
 		} else {
 			if unseal {
-				t.Fatalf("should not be unsealed")
+				t.Fatal("should not be unsealed")
 			}
 			if prog, _ := c.SecretProgress(true); prog != i+1 {
 				t.Fatalf("bad progress: %d", prog)
@@ -443,7 +443,7 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 	}
 
 	if c.Sealed() {
-		t.Fatalf("should not be sealed")
+		t.Fatal("should not be sealed")
 	}
 
 	err = c.Seal(res.RootToken)
@@ -458,7 +458,7 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 	}
 
 	if !c.Sealed() {
-		t.Fatalf("should be sealed")
+		t.Fatal("should be sealed")
 	}
 }
 
@@ -586,7 +586,7 @@ func TestCore_Unseal_Single(t *testing.T) {
 	}
 
 	if !c.Sealed() {
-		t.Fatalf("should be sealed")
+		t.Fatal("should be sealed")
 	}
 
 	if prog, _ := c.SecretProgress(true); prog != 0 {
@@ -599,14 +599,14 @@ func TestCore_Unseal_Single(t *testing.T) {
 	}
 
 	if !unseal {
-		t.Fatalf("should be unsealed")
+		t.Fatal("should be unsealed")
 	}
 	if prog, _ := c.SecretProgress(true); prog != 0 {
 		t.Fatalf("bad progress: %d", prog)
 	}
 
 	if c.Sealed() {
-		t.Fatalf("should not be sealed")
+		t.Fatal("should not be sealed")
 	}
 }
 
@@ -642,7 +642,7 @@ func TestCore_Route_Sealed(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !unseal {
-		t.Fatalf("should be unsealed")
+		t.Fatal("should be unsealed")
 	}
 
 	// Should not error after unseal
@@ -665,7 +665,7 @@ func TestCore_SealUnseal(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 }
@@ -710,7 +710,7 @@ func TestCore_RunLockedUserUpdatesForStaleEntry(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 
@@ -764,7 +764,7 @@ func TestCore_RunLockedUserUpdatesForValidEntry(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 
@@ -774,7 +774,7 @@ func TestCore_RunLockedUserUpdatesForValidEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 	if existingEntry == nil {
-		t.Fatalf("err: entry must exist for locked user in storage")
+		t.Fatal("err: entry must exist for locked user in storage")
 	}
 
 	// userFailedLoginInfo map should have the correct information for locked user
@@ -785,13 +785,13 @@ func TestCore_RunLockedUserUpdatesForValidEntry(t *testing.T) {
 
 	failedLoginInfoFromMap := core.LocalGetUserFailedLoginInfo(context.Background(), loginUserInfoKey)
 	if failedLoginInfoFromMap == nil {
-		t.Fatalf("err: entry must exist for locked user in userFailedLoginInfo map")
+		t.Fatal("err: entry must exist for locked user in userFailedLoginInfo map")
 	}
 	if failedLoginInfoFromMap.lastFailedLoginTime != lastFailedLoginTime {
-		t.Fatalf("err: incorrect failed login time information for locked user updated in userFailedLoginInfo map")
+		t.Fatal("err: incorrect failed login time information for locked user updated in userFailedLoginInfo map")
 	}
 	if int(failedLoginInfoFromMap.count) != configutil.UserLockoutThresholdDefault {
-		t.Fatalf("err: incorrect failed login count information for locked user updated in userFailedLoginInfo map")
+		t.Fatal("err: incorrect failed login count information for locked user updated in userFailedLoginInfo map")
 	}
 }
 
@@ -822,10 +822,10 @@ func TestCore_ShutdownDone(t *testing.T) {
 	select {
 	case <-doneCh:
 		if !c.Sealed() {
-			t.Fatalf("shutdown done called prematurely!")
+			t.Fatal("shutdown done called prematurely!")
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatalf("shutdown notification not received")
+		t.Fatal("shutdown notification not received")
 	}
 }
 
@@ -911,7 +911,7 @@ func TestCore_Seal_SingleUse(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 	if err := c.Seal("foo"); err == nil {
@@ -1818,7 +1818,7 @@ func TestCore_Standby_Seal(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -1852,7 +1852,7 @@ func TestCore_Standby_Seal(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Check the leader is not local
@@ -1861,7 +1861,7 @@ func TestCore_Standby_Seal(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -1929,7 +1929,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -1964,7 +1964,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Check the leader is not local
@@ -1973,7 +1973,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2005,7 +2005,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Check the leader is core2
@@ -2014,7 +2014,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal2 {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal2)
@@ -2026,7 +2026,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal2 {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal2)
@@ -2048,7 +2048,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Check the leader is core1
@@ -2057,7 +2057,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2069,7 +2069,7 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2147,7 +2147,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2181,7 +2181,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Check the leader is not local
@@ -2190,7 +2190,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2208,7 +2208,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Wait for core2 to become active
@@ -2220,7 +2220,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal2 {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal2)
@@ -2314,7 +2314,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2348,7 +2348,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Request should fail in standby mode
@@ -2363,7 +2363,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		t.Fatalf("err: %v", err)
 	}
 	if isLeader {
-		t.Fatalf("should not be leader")
+		t.Fatal("should not be leader")
 	}
 	if advertise != redirectOriginal {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal)
@@ -2381,7 +2381,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		t.Fatalf("err: %v", err)
 	}
 	if !standby {
-		t.Fatalf("should be standby")
+		t.Fatal("should be standby")
 	}
 
 	// Wait for core2 to become active
@@ -2409,7 +2409,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 		t.Fatalf("err: %v", err)
 	}
 	if !isLeader {
-		t.Fatalf("should be leader")
+		t.Fatal("should be leader")
 	}
 	if advertise != redirectOriginal2 {
 		t.Fatalf("Bad advertise: %v, orig is %v", advertise, redirectOriginal2)
@@ -2418,17 +2418,17 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 	if inm.(*inmem.InmemHABackend) == inmha.(*inmem.InmemHABackend) {
 		lockSize := inm.(*inmem.InmemHABackend).LockMapSize()
 		if lockSize == 0 {
-			t.Fatalf("locks not used with only one HA backend")
+			t.Fatal("locks not used with only one HA backend")
 		}
 	} else {
 		lockSize := inmha.(*inmem.InmemHABackend).LockMapSize()
 		if lockSize == 0 {
-			t.Fatalf("locks not used with expected HA backend")
+			t.Fatal("locks not used with expected HA backend")
 		}
 
 		lockSize = inm.(*inmem.InmemHABackend).LockMapSize()
 		if lockSize != 0 {
-			t.Fatalf("locks used with unexpected HA backend")
+			t.Fatal("locks used with unexpected HA backend")
 		}
 	}
 }
@@ -2727,7 +2727,7 @@ path "secret/*" {
 	}
 	lresp, err := c.HandleRequest(namespace.RootContext(nil), lreq)
 	if err == nil || lresp == nil || !lresp.IsError() {
-		t.Fatalf("expected error trying to auth and receive root policy")
+		t.Fatal("expected error trying to auth and receive root policy")
 	}
 
 	// Fix and try again
@@ -2979,7 +2979,7 @@ func TestCore_HandleRequest_Headers(t *testing.T) {
 			t.Fatalf("expected: %v, got: %v", expected, val)
 		}
 	} else {
-		t.Fatalf("expected 'Should-Passthrough' to be present in the headers map")
+		t.Fatal("expected 'Should-Passthrough' to be present in the headers map")
 	}
 
 	if val, ok := headers["Should-Passthrough-Case-Insensitive"]; ok {

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -29,7 +29,7 @@ func coreInit(c *Core, conf *CoreConfig) error {
 
 func (c *Core) barrierViewForNamespace(namespaceId string) (BarrierView, error) {
 	if namespaceId != namespace.RootNamespaceID {
-		return nil, fmt.Errorf("failed to find barrier view for non-root namespace")
+		return nil, errors.New("failed to find barrier view for non-root namespace")
 	}
 
 	return c.systemBarrierView, nil

--- a/vault/custom_response_headers_test.go
+++ b/vault/custom_response_headers_test.go
@@ -83,20 +83,20 @@ func TestConfigCustomHeaders(t *testing.T) {
 
 	listenerCustomHeaders := NewListenerCustomHeader(rawListenerConfig, logger, uiHeaders)
 	if listenerCustomHeaders == nil || len(listenerCustomHeaders) != 1 {
-		t.Fatalf("failed to get custom header configuration")
+		t.Fatal("failed to get custom header configuration")
 	}
 
 	lch := listenerCustomHeaders[0]
 
 	if lch.ExistCustomResponseHeader("X-Vault-Ignored-307") {
-		t.Fatalf("header name with X-Vault prefix is not valid")
+		t.Fatal("header name with X-Vault prefix is not valid")
 	}
 	if lch.ExistCustomResponseHeader("X-Vault-Ignored-3xx") {
-		t.Fatalf("header name with X-Vault prefix is not valid")
+		t.Fatal("header name with X-Vault prefix is not valid")
 	}
 
 	if !lch.ExistCustomResponseHeader("X-Custom-Header") {
-		t.Fatalf("header name with X-Vault prefix is not valid")
+		t.Fatal("header name with X-Vault prefix is not valid")
 	}
 }
 
@@ -124,16 +124,16 @@ func TestCustomResponseHeadersConfigInteractUiConfig(t *testing.T) {
 	}
 	uiHeaders, err := b.(*SystemBackend).Core.uiConfig.Headers(context.Background())
 	if err != nil {
-		t.Fatalf("failed to get headers from ui config")
+		t.Fatal("failed to get headers from ui config")
 	}
 	customListenerHeader := NewListenerCustomHeader(rawListenerConfig, logger, uiHeaders)
 	if customListenerHeader == nil {
-		t.Fatalf("custom header config should be configured")
+		t.Fatal("custom header config should be configured")
 	}
 	b.(*SystemBackend).Core.customListenerHeader.Store(customListenerHeader)
 	clh := b.(*SystemBackend).Core.customListenerHeader
 	if clh == nil {
-		t.Fatalf("custom header config should be configured in core")
+		t.Fatal("custom header config should be configured in core")
 	}
 
 	w := httptest.NewRecorder()
@@ -156,7 +156,7 @@ func TestCustomResponseHeadersConfigInteractUiConfig(t *testing.T) {
 	)
 
 	if !strings.Contains(resp.Data["error"].(string), fmt.Sprintf("This header already exists in the server configuration and cannot be set in the UI.")) {
-		t.Fatalf("failed to get the expected error")
+		t.Fatal("failed to get the expected error")
 	}
 
 	// setting a header that already exist in custom headers
@@ -180,7 +180,7 @@ func TestCustomResponseHeadersConfigInteractUiConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if h.Get("Someheader-400") == "400" {
-		t.Fatalf("should not be able to set a header that is in custom response headers")
+		t.Fatal("should not be able to set a header that is in custom response headers")
 	}
 
 	// setting an ui specific header
@@ -204,6 +204,6 @@ func TestCustomResponseHeadersConfigInteractUiConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if h.Get("X-CustomUiHeader") != "Ui header value" {
-		t.Fatalf("failed to set a header that is not in custom response headers")
+		t.Fatal("failed to set a header that is not in custom response headers")
 	}
 }

--- a/vault/diagnose/mock_storage_backend.go
+++ b/vault/diagnose/mock_storage_backend.go
@@ -5,6 +5,7 @@ package diagnose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -79,12 +80,12 @@ func (m mockStorageBackend) Delete(ctx context.Context, key string) error {
 
 // List is not used in a mock.
 func (m mockStorageBackend) List(ctx context.Context, prefix string) ([]string, error) {
-	return nil, fmt.Errorf("method not implemented")
+	return nil, errors.New("method not implemented")
 }
 
 // ListPage is not used in a mock.
 func (m mockStorageBackend) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
-	return nil, fmt.Errorf("method not implemented")
+	return nil, errors.New("method not implemented")
 }
 
 func callTypeToOp(ctype string) string {
@@ -117,7 +118,7 @@ func (m mockStorageBackend) GetConfigurationOffline() (*raft.RaftConfigurationRe
 		threeServerList[2].Voter = false
 		return &raft.RaftConfigurationResponse{Servers: threeServerList}, nil
 	case 3:
-		return &raft.RaftConfigurationResponse{Servers: threeServerList}, fmt.Errorf("error: something bad")
+		return &raft.RaftConfigurationResponse{Servers: threeServerList}, errors.New("error: something bad")
 	}
 	return nil, nil
 }

--- a/vault/diagnose/raft_checks.go
+++ b/vault/diagnose/raft_checks.go
@@ -35,7 +35,7 @@ func RaftFileChecks(ctx context.Context, path string) {
 	}
 
 	if !IsDir(info) {
-		SpotError(ctx, ownershipTestName, fmt.Errorf("Error: Raft storage path variable does not point to a folder."))
+		SpotError(ctx, ownershipTestName, errors.New("Error: Raft storage path variable does not point to a folder."))
 	}
 
 	if !HasDB(path) {

--- a/vault/diagnose/storage_checks.go
+++ b/vault/diagnose/storage_checks.go
@@ -5,6 +5,7 @@ package diagnose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -45,7 +46,7 @@ func EndToEndLatencyCheckRead(ctx context.Context, uuid string, b physical.Backe
 		return time.Duration(0), err
 	}
 	if val == nil {
-		return time.Duration(0), fmt.Errorf("No value found when reading generated data.")
+		return time.Duration(0), errors.New("No value found when reading generated data.")
 	}
 	if val.Key != uuid && string(val.Value) != secretVal {
 		return time.Duration(0), fmt.Errorf(wrongRWValsPrefix+"expecting %s as key and diagnose for value, but got %s, %s.", uuid, val.Key, val.Value)

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -150,14 +151,14 @@ func ParseTLSInformation(certFilePath string) ([]*x509.Certificate, []*x509.Cert
 	for len(rst) != 0 {
 		block, rest := pem.Decode(rst)
 		if block == nil {
-			return leafCerts, interCerts, rootCerts, fmt.Errorf("Could not decode certificate in certificate file.")
+			return leafCerts, interCerts, rootCerts, errors.New("Could not decode certificate in certificate file.")
 		}
 		certBlocks = append(certBlocks, block)
 		rst = rest
 	}
 
 	if len(certBlocks) == 0 {
-		return leafCerts, interCerts, rootCerts, fmt.Errorf("No certificates found in certificate file.")
+		return leafCerts, interCerts, rootCerts, errors.New("No certificates found in certificate file.")
 	}
 
 	for _, certBlock := range certBlocks {
@@ -186,7 +187,7 @@ func ParseTLSInformation(certFilePath string) ([]*x509.Certificate, []*x509.Cert
 func TLSErrorChecks(leafCerts, interCerts, rootCerts []*x509.Certificate) error {
 	// Make sure there's the proper number of leafCerts. If there are multiple, it's a bad pem file.
 	if len(leafCerts) == 0 {
-		return fmt.Errorf("No leaf certificates detected.")
+		return errors.New("No leaf certificates detected.")
 	}
 
 	// First, create root pools and interPools from the root and inter certs lists
@@ -316,7 +317,7 @@ func TLSCAFileCheck(CAFilePath string) ([]string, error) {
 	}
 
 	if len(rootCerts) == 0 {
-		return nil, fmt.Errorf("No root certificate found in CA certificate file.")
+		return nil, errors.New("No root certificate found in CA certificate file.")
 	}
 	if len(rootCerts) > 1 {
 		warningsSlc = append(warningsSlc, fmt.Sprintf("Found multiple root certificates in CA Certificate file instead of just one."))

--- a/vault/diagnose/tls_verification_test.go
+++ b/vault/diagnose/tls_verification_test.go
@@ -32,7 +32,7 @@ func TestTLSValidCert(t *testing.T) {
 		t.Fatalf(errs[0].Error())
 	}
 	if warnings != nil {
-		t.Fatalf("warnings returned from good listener")
+		t.Fatal("warnings returned from good listener")
 	}
 }
 
@@ -51,7 +51,7 @@ func TestTLSFakeCert(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if len(errs) != 1 {
 		t.Fatalf("more than one error returned: %+v", errs)
@@ -79,7 +79,7 @@ func TestTLSTrailingData(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "x509: trailing data") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -102,13 +102,13 @@ func TestTLSExpiredCert(t *testing.T) {
 	}
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "certificate has expired or is not yet valid") {
 		t.Fatalf("Bad error message: %s", errs[0])
 	}
 	if warnings == nil || len(warnings) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should warn")
+		t.Fatal("TLS Config check on fake certificate should warn")
 	}
 	if !strings.Contains(warnings[0], "expired or near expiry") {
 		t.Fatalf("Bad warning: %s", warnings[0])
@@ -131,7 +131,7 @@ func TestTLSMismatchedCryptographicInfo(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "tls: private key type does not match public key type") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -151,7 +151,7 @@ func TestTLSMismatchedCryptographicInfo(t *testing.T) {
 	}
 	_, errs = ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "tls: private key type does not match public key type") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -174,7 +174,7 @@ func TestTLSMultiKeys(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "PEM block does not parse to a certificate") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -196,7 +196,7 @@ func TestTLSCertAsKey(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "found a certificate rather than a key in the PEM for the private key") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -220,7 +220,7 @@ func TestTLSInvalidRoot(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on fake certificate should fail")
+		t.Fatal("TLS Config check on fake certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), "certificate signed by unknown authority") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -245,7 +245,7 @@ func TestTLSNoRoot(t *testing.T) {
 	_, errs := ListenerChecks(context.Background(), listeners)
 
 	if errs != nil {
-		t.Fatalf("server certificate without root certificate is insecure, but still valid")
+		t.Fatal("server certificate without root certificate is insecure, but still valid")
 	}
 }
 
@@ -266,7 +266,7 @@ func TestTLSInvalidMinVersion(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on invalid 'tls_min_version' should fail")
+		t.Fatal("TLS Config check on invalid 'tls_min_version' should fail")
 	}
 	if !strings.Contains(errs[0].Error(), fmt.Errorf(minVersionError, "0").Error()) {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -290,7 +290,7 @@ func TestTLSInvalidMaxVersion(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on invalid 'tls_max_version' should fail")
+		t.Fatal("TLS Config check on invalid 'tls_max_version' should fail")
 	}
 	if !strings.Contains(errs[0].Error(), fmt.Errorf(maxVersionError, "0").Error()) {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -315,7 +315,7 @@ func TestDisabledClientCertsAndDisabledTLSClientCAVerfiy(t *testing.T) {
 	}
 	status, _ := TLSMutualExclusionCertCheck(listeners[0])
 	if status != 0 {
-		t.Fatalf("TLS config failed when both TLSRequireAndVerifyClientCert and TLSDisableClientCerts are false")
+		t.Fatal("TLS config failed when both TLSRequireAndVerifyClientCert and TLSDisableClientCerts are false")
 	}
 }
 
@@ -380,7 +380,7 @@ func TestTLSClientCAVerfiyMutualExclusion(t *testing.T) {
 	}
 	status, err := TLSMutualExclusionCertCheck(listeners[0])
 	if status == 0 {
-		t.Fatalf("TLS config check should have failed when both 'tls_disable_client_certs' and 'tls_require_and_verify_client_cert' are true")
+		t.Fatal("TLS config check should have failed when both 'tls_disable_client_certs' and 'tls_require_and_verify_client_cert' are true")
 	}
 	if !strings.Contains(err, "The tls_disable_client_certs and tls_require_and_verify_client_cert fields in the "+
 		"listener stanza of the OpenBao server configuration are mutually exclusive fields") {
@@ -405,10 +405,10 @@ func TestTLSClientCAFileCheck(t *testing.T) {
 	}
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs != nil {
-		t.Fatalf("TLS config check failed while a good ClientCAFile was used")
+		t.Fatal("TLS config check failed while a good ClientCAFile was used")
 	}
 	if warnings != nil {
-		t.Fatalf("TLS config check return warning while a good ClientCAFile was used")
+		t.Fatal("TLS config check return warning while a good ClientCAFile was used")
 	}
 }
 
@@ -429,10 +429,10 @@ func TestTLSLeafCertInClientCAFile(t *testing.T) {
 	}
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatalf("TLS Config check on bad ClientCAFile certificate should fail once")
+		t.Fatal("TLS Config check on bad ClientCAFile certificate should fail once")
 	}
 	if warnings == nil || len(warnings) != 1 {
-		t.Fatalf("TLS Config check on bad ClientCAFile certificate should warn once")
+		t.Fatal("TLS Config check on bad ClientCAFile certificate should warn once")
 	}
 	if !strings.Contains(warnings[0], "Found at least one leaf certificate in the CA certificate file.") {
 		t.Fatalf("Bad error message: %s", warnings[0])
@@ -459,7 +459,7 @@ func TestTLSNoRootInClientCAFile(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil {
-		t.Fatalf("TLS Config check on bad ClientCAFile certificate should fail")
+		t.Fatal("TLS Config check on bad ClientCAFile certificate should fail")
 	}
 	if !strings.Contains(errs[0].Error(), " No root certificate found") {
 		t.Fatalf("Bad error message: %s", errs[0])
@@ -483,7 +483,7 @@ func TestTLSIntermediateCertInClientCAFile(t *testing.T) {
 	}
 	warnings, _ := ListenerChecks(context.Background(), listeners)
 	if warnings == nil || len(warnings) != 1 {
-		t.Fatalf("TLS Config check on bad ClientCAFile certificate should fail")
+		t.Fatal("TLS Config check on bad ClientCAFile certificate should fail")
 	}
 	if !strings.Contains(warnings[0], "Found at least one intermediate certificate in the CA certificate file.") {
 		t.Fatalf("Bad error message: %s", warnings[0])
@@ -507,10 +507,10 @@ func TestTLSMultipleRootInClietCACert(t *testing.T) {
 	}
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs != nil {
-		t.Fatalf("TLS Config check on valid certificate should not fail")
+		t.Fatal("TLS Config check on valid certificate should not fail")
 	}
 	if warnings == nil {
-		t.Fatalf("TLS Config check on valid but bad certificate should warn")
+		t.Fatal("TLS Config check on valid but bad certificate should warn")
 	}
 	if !strings.Contains(warnings[0], "Found multiple root certificates in CA Certificate file instead of just one.") {
 		t.Fatalf("Bad warning: %s", warnings[0])
@@ -534,7 +534,7 @@ func TestTLSSelfSignedCert(t *testing.T) {
 	}
 	_, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil {
-		t.Fatalf("Self-signed certificate is insecure")
+		t.Fatal("Self-signed certificate is insecure")
 	}
 	if !strings.Contains(errs[0].Error(), "No root certificate found") {
 		t.Fatalf("Bad error message: %s", errs[0])

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -130,7 +131,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 func (e extendedSystemViewImpl) APILockShouldBlockRequest() (bool, error) {
 	mountEntry := e.mountEntry
 	if mountEntry == nil {
-		return false, fmt.Errorf("no mount entry")
+		return false, errors.New("no mount entry")
 	}
 
 	return false, nil
@@ -218,10 +219,10 @@ func (d dynamicSystemView) ResponseWrapData(ctx context.Context, data map[string
 
 func (d dynamicSystemView) NewPluginClient(ctx context.Context, config pluginutil.PluginClientConfig) (pluginutil.PluginClient, error) {
 	if d.core == nil {
-		return nil, fmt.Errorf("system view core is nil")
+		return nil, errors.New("system view core is nil")
 	}
 	if d.core.pluginCatalog == nil {
-		return nil, fmt.Errorf("system view core plugin catalog is nil")
+		return nil, errors.New("system view core plugin catalog is nil")
 	}
 
 	c, err := d.core.pluginCatalog.NewPluginClient(ctx, config)
@@ -242,10 +243,10 @@ func (d dynamicSystemView) LookupPlugin(ctx context.Context, name string, plugin
 // returns a PluginRunner or an error if no plugin was found.
 func (d dynamicSystemView) LookupPluginVersion(ctx context.Context, name string, pluginType consts.PluginType, version string) (*pluginutil.PluginRunner, error) {
 	if d.core == nil {
-		return nil, fmt.Errorf("system view core is nil")
+		return nil, errors.New("system view core is nil")
 	}
 	if d.core.pluginCatalog == nil {
-		return nil, fmt.Errorf("system view core plugin catalog is nil")
+		return nil, errors.New("system view core plugin catalog is nil")
 	}
 	r, err := d.core.pluginCatalog.Get(ctx, name, pluginType, version)
 	if err != nil {
@@ -266,10 +267,10 @@ func (d dynamicSystemView) LookupPluginVersion(ctx context.Context, name string,
 // typein the catalog, including any versioning information stored for them.
 func (d dynamicSystemView) ListVersionedPlugins(ctx context.Context, pluginType consts.PluginType) ([]pluginutil.VersionedPlugin, error) {
 	if d.core == nil {
-		return nil, fmt.Errorf("system view core is nil")
+		return nil, errors.New("system view core is nil")
 	}
 	if d.core.pluginCatalog == nil {
-		return nil, fmt.Errorf("system view core plugin catalog is nil")
+		return nil, errors.New("system view core plugin catalog is nil")
 	}
 	return d.core.pluginCatalog.ListVersionedPlugins(ctx, pluginType)
 }
@@ -287,10 +288,10 @@ func (d dynamicSystemView) EntityInfo(entityID string) (*logical.Entity, error) 
 	}
 
 	if d.core == nil {
-		return nil, fmt.Errorf("system view core is nil")
+		return nil, errors.New("system view core is nil")
 	}
 	if d.core.identityStore == nil {
-		return nil, fmt.Errorf("system view identity store is nil")
+		return nil, errors.New("system view identity store is nil")
 	}
 
 	// Retrieve the entity from MemDB
@@ -346,10 +347,10 @@ func (d dynamicSystemView) GroupsForEntity(entityID string) ([]*logical.Group, e
 	}
 
 	if d.core == nil {
-		return nil, fmt.Errorf("system view core is nil")
+		return nil, errors.New("system view core is nil")
 	}
 	if d.core.identityStore == nil {
-		return nil, fmt.Errorf("system view identity store is nil")
+		return nil, errors.New("system view identity store is nil")
 	}
 
 	groups, inheritedGroups, err := d.core.identityStore.groupsByEntityID(entityID)
@@ -387,7 +388,7 @@ func (d dynamicSystemView) VaultVersion(_ context.Context) (string, error) {
 
 func (d dynamicSystemView) GeneratePasswordFromPolicy(ctx context.Context, policyName string) (password string, err error) {
 	if policyName == "" {
-		return "", fmt.Errorf("missing password policy name")
+		return "", errors.New("missing password policy name")
 	}
 
 	// Ensure there's a timeout on the context of some sort
@@ -405,7 +406,7 @@ func (d dynamicSystemView) GeneratePasswordFromPolicy(ctx context.Context, polic
 	}
 
 	if policyCfg == nil {
-		return "", fmt.Errorf("no password policy found")
+		return "", errors.New("no password policy found")
 	}
 
 	passPolicy, err := random.ParsePolicy(policyCfg.HCLPolicy)

--- a/vault/dynamic_system_view_test.go
+++ b/vault/dynamic_system_view_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -256,7 +257,7 @@ func TestDynamicSystemView_GeneratePasswordFromPolicy_failed(t *testing.T) {
 		"error retrieving policy": {
 			policyName: "testpolicy",
 			getEntry:   nil,
-			getErr:     fmt.Errorf("a test error"),
+			getErr:     errors.New("a test error"),
 		},
 		"saved policy is malformed": {
 			policyName: "testpolicy",
@@ -309,17 +310,17 @@ func (b fakeBarrier) Get(context.Context, string) (*logical.StorageEntry, error)
 }
 
 func (b fakeBarrier) List(context.Context, string) ([]string, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (b fakeBarrier) ListPage(context.Context, string, string, int) ([]string, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (b fakeBarrier) Put(context.Context, *logical.StorageEntry) error {
-	return fmt.Errorf("not implemented")
+	return errors.New("not implemented")
 }
 
 func (b fakeBarrier) Delete(context.Context, string) error {
-	return fmt.Errorf("not implemented")
+	return errors.New("not implemented")
 }

--- a/vault/dynamic_system_view_test.go
+++ b/vault/dynamic_system_view_test.go
@@ -285,7 +285,7 @@ func TestDynamicSystemView_GeneratePasswordFromPolicy_failed(t *testing.T) {
 			defer cancel()
 			actualPassword, err := dsv.GeneratePasswordFromPolicy(ctx, test.policyName)
 			if err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if actualPassword != "" {
 				t.Fatalf("no password expected, got %s", actualPassword)

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -170,13 +170,13 @@ type revocationJob struct {
 
 func newRevocationJob(nsCtx context.Context, leaseID string, ns *namespace.Namespace, m *ExpirationManager) (*revocationJob, error) {
 	if leaseID == "" {
-		return nil, fmt.Errorf("cannot have empty lease id")
+		return nil, errors.New("cannot have empty lease id")
 	}
 	if m == nil {
-		return nil, fmt.Errorf("cannot have nil expiration manager")
+		return nil, errors.New("cannot have nil expiration manager")
 	}
 	if nsCtx == nil {
-		return nil, fmt.Errorf("cannot have nil namespace context.Context")
+		return nil, errors.New("cannot have nil namespace context.Context")
 	}
 
 	return &revocationJob{
@@ -1216,7 +1216,7 @@ func (m *ExpirationManager) Renew(ctx context.Context, leaseID string, increment
 	sysViewCtx := namespace.ContextWithNamespace(ctx, le.namespace)
 	sysView := m.router.MatchingSystemView(sysViewCtx, le.Path)
 	if sysView == nil {
-		return nil, fmt.Errorf("unable to retrieve system view from router")
+		return nil, errors.New("unable to retrieve system view from router")
 	}
 
 	// Attempt to renew the entry
@@ -1365,7 +1365,7 @@ func (m *ExpirationManager) RenewToken(ctx context.Context, req *logical.Request
 	sysViewCtx := namespace.ContextWithNamespace(ctx, le.namespace)
 	sysView := m.router.MatchingSystemView(sysViewCtx, le.Path)
 	if sysView == nil {
-		return nil, fmt.Errorf("unable to retrieve system view from router")
+		return nil, errors.New("unable to retrieve system view from router")
 	}
 
 	ttl, warnings, err := framework.CalculateTTL(sysView, increment, resp.Auth.TTL, resp.Auth.Period, resp.Auth.MaxTTL, resp.Auth.ExplicitMaxTTL, le.IssueTime)
@@ -1416,7 +1416,7 @@ func (m *ExpirationManager) Register(ctx context.Context, req *logical.Request, 
 
 	te := req.TokenEntry()
 	if te == nil {
-		return "", fmt.Errorf("cannot register a lease with an empty client token")
+		return "", errors.New("cannot register a lease with an empty client token")
 	}
 
 	// Ignore if there is no leased secret
@@ -1553,7 +1553,7 @@ func (m *ExpirationManager) RegisterAuth(ctx context.Context, te *logical.TokenE
 	// Triggers failure of RegisterAuth. This should only be set and triggered
 	// by tests to simulate partial failure during a token creation request.
 	if m.testRegisterAuthFailure.Load() {
-		return fmt.Errorf("failing explicitly on RegisterAuth")
+		return errors.New("failing explicitly on RegisterAuth")
 	}
 
 	authExpirationTime := auth.ExpirationTime()
@@ -2134,7 +2134,7 @@ func (m *ExpirationManager) indexByToken(ctx context.Context, le *leaseEntry) (*
 	tokenView := m.tokenIndexView(tokenNS)
 	entry, err := tokenView.Get(ctx, key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to look up secondary index entry")
+		return nil, errors.New("failed to look up secondary index entry")
 	}
 	return entry, nil
 }
@@ -2706,27 +2706,27 @@ func (le *leaseEntry) renewable() (bool, error) {
 	switch {
 	// If there is no entry, cannot review to renew
 	case le == nil:
-		return false, fmt.Errorf("lease not found")
+		return false, errors.New("lease not found")
 
 	case le.isIrrevocable():
-		return false, fmt.Errorf("lease is expired and has failed previous revocation attempts")
+		return false, errors.New("lease is expired and has failed previous revocation attempts")
 
 	case le.ExpireTime.IsZero():
-		return false, fmt.Errorf("lease is not renewable")
+		return false, errors.New("lease is not renewable")
 
 	case le.ClientTokenType == logical.TokenTypeBatch:
 		return false, nil
 
 	// Determine if the lease is expired
 	case le.ExpireTime.Before(time.Now()):
-		return false, fmt.Errorf("lease expired")
+		return false, errors.New("lease expired")
 
 	// Determine if the lease is renewable
 	case le.Secret != nil && !le.Secret.Renewable:
-		return false, fmt.Errorf("lease is not renewable")
+		return false, errors.New("lease is not renewable")
 
 	case le.Auth != nil && !le.Auth.Renewable:
-		return false, fmt.Errorf("lease is not renewable")
+		return false, errors.New("lease is not renewable")
 	}
 
 	return true, nil

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -2786,7 +2786,7 @@ func badRenewFactory(ctx context.Context, conf *logical.BackendConfig) (logical.
 			{
 				Type: "badRenewBackend",
 				Revoke: func(context.Context, *logical.Request, *framework.FieldData) (*logical.Response, error) {
-					return nil, fmt.Errorf("always errors")
+					return nil, errors.New("always errors")
 				},
 			},
 		},
@@ -3030,7 +3030,7 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 		t.Fatalf("lease not included in pending map")
 	}
 
-	irrevocableErr := fmt.Errorf("test irrevocable error")
+	irrevocableErr := errors.New("test irrevocable error")
 
 	exp.pendingLock.Lock()
 	exp.markLeaseIrrevocable(ctx, loadedLE, irrevocableErr)
@@ -3112,7 +3112,7 @@ func TestExpiration_FetchLeaseTimesIrrevocable(t *testing.T) {
 		t.Fatalf("error loading lease: %v", err)
 	}
 	exp.pendingLock.Lock()
-	exp.markLeaseIrrevocable(ctx, le, fmt.Errorf("test irrevocable error"))
+	exp.markLeaseIrrevocable(ctx, le, errors.New("test irrevocable error"))
 	exp.pendingLock.Unlock()
 
 	irrevocableLeaseTimes, err := exp.FetchLeaseTimes(ctx, leaseID)
@@ -3151,7 +3151,7 @@ func TestExpiration_StopClearsIrrevocableCache(t *testing.T) {
 	}
 
 	exp.pendingLock.Lock()
-	exp.markLeaseIrrevocable(ctx, le, fmt.Errorf("test irrevocable error"))
+	exp.markLeaseIrrevocable(ctx, le, errors.New("test irrevocable error"))
 	exp.pendingLock.Unlock()
 
 	err = c.stopExpiration()
@@ -3202,7 +3202,7 @@ func TestExpiration_errorIsUnrecoverable(t *testing.T) {
 			isUnrecoverable: false,
 		},
 		{
-			err:             fmt.Errorf("some other error"),
+			err:             errors.New("some other error"),
 			isUnrecoverable: false,
 		},
 	}
@@ -3256,7 +3256,7 @@ func TestExpiration_unrecoverableErrorMakesIrrevocable(t *testing.T) {
 			shouldBeIrrevocable: false,
 		},
 		{
-			err:                 fmt.Errorf("some random recoverable error"),
+			err:                 errors.New("some random recoverable error"),
 			job:                 makeJob(),
 			shouldBeIrrevocable: false,
 		},

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -215,7 +215,7 @@ func TestExpiration_Metrics(t *testing.T) {
 
 	for _, labelVal := range flattenedResults {
 		if len(labelVal.Labels) != 1 {
-			t.Errorf("Namespace label is returned when explicitly not requested.")
+			t.Error("Namespace label is returned when explicitly not requested.")
 		}
 		retTimeLabel := labelVal.Labels[0]
 		if labelVal.Value == 100 {
@@ -230,7 +230,7 @@ func TestExpiration_Metrics(t *testing.T) {
 		}
 	}
 	if !foundLabelOne || !foundLabelTwo {
-		t.Errorf("One of the labels is missing")
+		t.Error("One of the labels is missing")
 	}
 }
 
@@ -1192,7 +1192,7 @@ func TestExpiration_RegisterAuth_NoLease(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out == nil {
-		t.Fatalf("missing token")
+		t.Fatal("missing token")
 	}
 }
 
@@ -2102,7 +2102,7 @@ func TestExpiration_Renew_FinalSecond(t *testing.T) {
 	}
 
 	if _, ok := exp.nonexpiring.Load(id); ok {
-		t.Fatalf("expirable lease became nonexpiring")
+		t.Fatal("expirable lease became nonexpiring")
 	}
 }
 
@@ -2164,7 +2164,7 @@ func TestExpiration_Renew_FinalSecond_Lease(t *testing.T) {
 	}
 
 	if _, ok := exp.nonexpiring.Load(id); ok {
-		t.Fatalf("expirable lease became nonexpiring")
+		t.Fatal("expirable lease became nonexpiring")
 	}
 }
 
@@ -2264,7 +2264,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if indexEntry == nil {
-		t.Fatalf("err: should have found a secondary index entry")
+		t.Fatal("err: should have found a secondary index entry")
 	}
 
 	err = exp.revokeEntry(namespace.RootContext(nil), le)
@@ -2286,7 +2286,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 	}
 
 	if indexEntry != nil {
-		t.Fatalf("should not have found a secondary index entry after revocation")
+		t.Fatal("should not have found a secondary index entry after revocation")
 	}
 
 	out, err := exp.tokenStore.Lookup(namespace.RootContext(nil), le.ClientToken)
@@ -2372,10 +2372,10 @@ func TestExpiration_revokeEntry_rejected_fairsharing(t *testing.T) {
 		RequestHandler: func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
 			if req.Operation == logical.RevokeOperation {
 				if atomic.CompareAndSwapUint32(rejected, 0, 1) {
-					t.Logf("denying revocation")
+					t.Log("denying revocation")
 					return nil, errors.New("nope")
 				}
-				t.Logf("allowing revocation")
+				t.Log("allowing revocation")
 			}
 			return nil, nil
 		},
@@ -2916,7 +2916,7 @@ func waitForRestore(t *testing.T, exp *ExpirationManager) {
 	for exp.inRestoreMode() {
 		select {
 		case <-timeout:
-			t.Fatalf("Timeout waiting for expiration manager to recover.")
+			t.Fatal("Timeout waiting for expiration manager to recover.")
 		case <-ticker:
 			continue
 		}
@@ -3021,13 +3021,13 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 	}
 
 	if loadedLE.isIrrevocable() {
-		t.Fatalf("lease is irrevocable and shouldn't be")
+		t.Fatal("lease is irrevocable and shouldn't be")
 	}
 	if _, ok := exp.irrevocable.Load(leaseID); ok {
-		t.Fatalf("lease included in irrevocable map")
+		t.Fatal("lease included in irrevocable map")
 	}
 	if _, ok := exp.pending.Load(leaseID); !ok {
-		t.Fatalf("lease not included in pending map")
+		t.Fatal("lease not included in pending map")
 	}
 
 	irrevocableErr := errors.New("test irrevocable error")
@@ -3037,13 +3037,13 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 	exp.pendingLock.Unlock()
 
 	if !loadedLE.isIrrevocable() {
-		t.Fatalf("irrevocable lease is not irrevocable and should be")
+		t.Fatal("irrevocable lease is not irrevocable and should be")
 	}
 	if loadedLE.RevokeErr != irrevocableErr.Error() {
 		t.Errorf("irrevocable lease has wrong error message. expected %s, got %s", irrevocableErr.Error(), loadedLE.RevokeErr)
 	}
 	if _, ok := exp.irrevocable.Load(leaseID); !ok {
-		t.Fatalf("irrevocable lease not included in irrevocable map")
+		t.Fatal("irrevocable lease not included in irrevocable map")
 	}
 
 	exp.pendingLock.RLock()
@@ -3054,10 +3054,10 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 		t.Fatalf("expected 1 irrevocable lease, found %d", irrevocableLeaseCount)
 	}
 	if _, ok := exp.pending.Load(leaseID); ok {
-		t.Fatalf("irrevocable lease included in pending map")
+		t.Fatal("irrevocable lease included in pending map")
 	}
 	if _, ok := exp.nonexpiring.Load(leaseID); ok {
-		t.Fatalf("irrevocable lease included in nonexpiring map")
+		t.Fatal("irrevocable lease included in nonexpiring map")
 	}
 
 	// stop and restore to verify that irrevocable leases are properly loaded from storage
@@ -3078,19 +3078,19 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 	exp.updatePending(loadedLE)
 
 	if !loadedLE.isIrrevocable() {
-		t.Fatalf("irrevocable lease is not irrevocable and should be")
+		t.Fatal("irrevocable lease is not irrevocable and should be")
 	}
 	if loadedLE.RevokeErr != irrevocableErr.Error() {
 		t.Errorf("irrevocable lease has wrong error message. expected %s, got %s", irrevocableErr.Error(), loadedLE.RevokeErr)
 	}
 	if _, ok := exp.irrevocable.Load(leaseID); !ok {
-		t.Fatalf("irrevocable lease not included in irrevocable map")
+		t.Fatal("irrevocable lease not included in irrevocable map")
 	}
 	if _, ok := exp.pending.Load(leaseID); ok {
-		t.Fatalf("irrevocable lease included in pending map")
+		t.Fatal("irrevocable lease included in pending map")
 	}
 	if _, ok := exp.nonexpiring.Load(leaseID); ok {
-		t.Fatalf("irrevocable lease included in nonexpiring map")
+		t.Fatal("irrevocable lease included in nonexpiring map")
 	}
 }
 
@@ -3479,7 +3479,7 @@ func TestExpiration_listIrrevocableLeases_includeAll(t *testing.T) {
 		t.Errorf("expected no warning, got %q", warn)
 	}
 	if dataRaw == nil {
-		t.Fatalf("got nil data when using limit=none")
+		t.Fatal("got nil data when using limit=none")
 	}
 
 	leaseListLength = len(dataRaw["leases"].([]*leaseResponse))
@@ -3489,10 +3489,10 @@ func TestExpiration_listIrrevocableLeases_includeAll(t *testing.T) {
 
 	numLeasesRaw, ok := dataRaw["lease_count"]
 	if !ok {
-		t.Fatalf("lease count data not present")
+		t.Fatal("lease count data not present")
 	}
 	if numLeasesRaw == nil {
-		t.Fatalf("nil lease count")
+		t.Fatal("nil lease count")
 	}
 
 	numLeases := numLeasesRaw.(int)

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -402,7 +402,7 @@ func TestCore_EnableExternalPlugin_ShadowBuiltin(t *testing.T) {
 		}
 		status := resp.Data["deprecation_status"]
 		if checkExists && status == nil {
-			return fmt.Errorf("expected deprecation status but found none")
+			return errors.New("expected deprecation status but found none")
 		} else if !checkExists && status != nil {
 			return fmt.Errorf("expected nil deprecation status but found %q", status)
 		}

--- a/vault/external_plugin_test.go
+++ b/vault/external_plugin_test.go
@@ -226,7 +226,7 @@ func TestCore_EnableExternalPlugin_Deregister_SealUnseal(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 
@@ -286,7 +286,7 @@ func TestCore_Unseal_isMajorVersionFirstMount_PendingRemoval_Plugin(t *testing.T
 
 	// Make sure this isn't the first mount for the current major version.
 	if c.isMajorVersionFirstMount(context.Background()) {
-		t.Fatalf("expected major version to register as mounted")
+		t.Fatal("expected major version to register as mounted")
 	}
 
 	if err := c.Seal(root); err != nil {
@@ -298,7 +298,7 @@ func TestCore_Unseal_isMajorVersionFirstMount_PendingRemoval_Plugin(t *testing.T
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("err: should be unsealed")
+			t.Fatal("err: should be unsealed")
 		}
 	}
 
@@ -317,7 +317,7 @@ func TestCore_Unseal_isMajorVersionFirstMount_PendingRemoval_Plugin(t *testing.T
 	// Make sure this appears to be the first mount for the current major
 	// version.
 	if !c.isMajorVersionFirstMount(context.Background()) {
-		t.Fatalf("expected major version first mount")
+		t.Fatal("expected major version first mount")
 	}
 
 	// Seal again and check for unseal failure.
@@ -332,7 +332,7 @@ func TestCore_Unseal_isMajorVersionFirstMount_PendingRemoval_Plugin(t *testing.T
 			}
 
 			if unseal {
-				t.Fatalf("err: should not be unsealed")
+				t.Fatal("err: should not be unsealed")
 			}
 		}
 	}
@@ -362,7 +362,7 @@ func TestCore_EnableExternalPlugin_PendingRemoval(t *testing.T) {
 	// Create a new auth method with builtin pending-removal-test-plugin
 	resp, err := mountPluginWithResponse(t, c.systemBackend, pluginName, consts.PluginTypeCredential, "", "")
 	if err == nil {
-		t.Fatalf("expected error when mounting deprecated backend")
+		t.Fatal("expected error when mounting deprecated backend")
 	}
 	if resp == nil || resp.Data == nil || !strings.Contains(resp.Data["error"].(string), pendingRemovalString) {
 		t.Fatalf("expected error response to contain %q but got %+v", pendingRemovalString, resp)

--- a/vault/external_tests/api/kv_helpers_test.go
+++ b/vault/external_tests/api/kv_helpers_test.go
@@ -95,7 +95,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 
 		if secret.Data["foo"] != "bar" {
-			t.Fatalf("kv v1 secret did not contain expected value")
+			t.Fatal("kv v1 secret did not contain expected value")
 		}
 
 		if err := client.KVv1(v1MountPath).Delete(context.Background(), secretPath); err != nil {
@@ -111,7 +111,7 @@ func TestKVHelpers(t *testing.T) {
 	t.Run("kv v1: get secret that does not exist", func(t *testing.T) {
 		_, err = client.KVv1(v1MountPath).Get(context.Background(), "does/not/exist")
 		if err == nil {
-			t.Fatalf("KVv1.Get is expected to return an error for a missing secret")
+			t.Fatal("KVv1.Get is expected to return an error for a missing secret")
 		}
 		if !errors.Is(err, api.ErrSecretNotFound) {
 			t.Fatalf("KVv1.Get is expected to return an api.ErrSecretNotFound wrapped error for a missing secret; got %v", err)
@@ -140,7 +140,7 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(secret.CustomMetadata, fullMetadata.CustomMetadata) {
-			t.Fatalf("custom metadata on the secret does not match the custom metadata in the full metadata")
+			t.Fatal("custom metadata on the secret does not match the custom metadata in the full metadata")
 		}
 	})
 
@@ -181,7 +181,7 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatal(err)
 		}
 		if s2.Data["foo"] != "baz" {
-			t.Fatalf("second version of secret did not have expected contents")
+			t.Fatal("second version of secret did not have expected contents")
 		}
 		if s2.VersionMetadata.Version != 2 {
 			t.Fatalf("wrong version of kv v2 secret was read, expected 2 but got %d", s2.VersionMetadata.Version)
@@ -220,11 +220,11 @@ func TestKVHelpers(t *testing.T) {
 		}
 
 		if s1AfterDelete.VersionMetadata.DeletionTime.IsZero() {
-			t.Fatalf("the deletion_time in the first version of the secret was not updated")
+			t.Fatal("the deletion_time in the first version of the secret was not updated")
 		}
 
 		if s1AfterDelete.Data != nil {
-			t.Fatalf("data still exists on the first version of the secret despite this version being deleted")
+			t.Fatal("data still exists on the first version of the secret despite this version being deleted")
 		}
 
 		// undelete it
@@ -239,7 +239,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 
 		if s1AfterUndelete.Data == nil {
-			t.Fatalf("data is empty for the first version of the secret despite this version being undeleted")
+			t.Fatal("data is empty for the first version of the secret despite this version being undeleted")
 		}
 	})
 
@@ -258,7 +258,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 
 		if !destroyedSecret.VersionMetadata.Destroyed {
-			t.Fatalf("expected secret to be destroyed but it wasn't")
+			t.Fatal("expected secret to be destroyed but it wasn't")
 		}
 	})
 
@@ -273,7 +273,7 @@ func TestKVHelpers(t *testing.T) {
 		}, api.WithCheckAndSet(99))
 		// should fail
 		if err == nil {
-			t.Fatalf("expected error from trying to update different version from check-and-set value using WithCheckAndSet")
+			t.Fatal("expected error from trying to update different version from check-and-set value using WithCheckAndSet")
 		}
 
 		// WithOption (generic)
@@ -282,7 +282,7 @@ func TestKVHelpers(t *testing.T) {
 		}, api.WithOption("cas", 99))
 		// should fail
 		if err == nil {
-			t.Fatalf("expected error from trying to update different version from check-and-set value using generic WithOption")
+			t.Fatal("expected error from trying to update different version from check-and-set value using generic WithOption")
 		}
 	})
 
@@ -329,19 +329,19 @@ func TestKVHelpers(t *testing.T) {
 		}
 		_, ok := secretAfterPatches.Data["dog"]
 		if !ok {
-			t.Fatalf("secret did not contain data patched with implicit Patch method")
+			t.Fatal("secret did not contain data patched with implicit Patch method")
 		}
 		_, ok = secretAfterPatches.Data["rat"]
 		if !ok {
-			t.Fatalf("secret did not contain data patched with explicit Patch method")
+			t.Fatal("secret did not contain data patched with explicit Patch method")
 		}
 		_, ok = secretAfterPatches.Data["bird"]
 		if !ok {
-			t.Fatalf("secret did not contain data patched with RW method")
+			t.Fatal("secret did not contain data patched with RW method")
 		}
 		value, ok := secretAfterPatches.Data["foo"]
 		if !ok || value != "bar" {
-			t.Fatalf("secret did not keep original data after patch")
+			t.Fatal("secret did not keep original data after patch")
 		}
 
 		// patch an existing field
@@ -357,7 +357,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 		v, ok := patchedFieldKV.Data["dog"]
 		if !ok || v != "pug" {
-			t.Fatalf("secret's data was not replaced by patch")
+			t.Fatal("secret's data was not replaced by patch")
 		}
 
 		// delete a key in a secret via patch
@@ -435,7 +435,7 @@ func TestKVHelpers(t *testing.T) {
 		}
 
 		if versions[0].Version != 1 || versions[len(versions)-1].Version != expectedLength {
-			t.Fatalf("versions list is not ordered as expected")
+			t.Fatal("versions list is not ordered as expected")
 		}
 
 		// roll back to version 1
@@ -456,7 +456,7 @@ func TestKVHelpers(t *testing.T) {
 		// roll back but fail
 		_, err = client.KVv2(v2MountPath).Rollback(context.Background(), secretPath, 1)
 		if err == nil {
-			t.Fatalf("expected error from trying to rollback to destroyed version")
+			t.Fatal("expected error from trying to rollback to destroyed version")
 		}
 	})
 
@@ -480,10 +480,10 @@ func TestKVHelpers(t *testing.T) {
 
 		versions, err := client.KVv2(v2MountPath).GetVersionsAsList(context.Background(), secretPath)
 		if err == nil {
-			t.Fatalf("expected to be unable to get list of versions since all metadata was destroyed")
+			t.Fatal("expected to be unable to get list of versions since all metadata was destroyed")
 		}
 		if len(versions) > 0 {
-			t.Fatalf("expected no versions of secret after deleting all metadata")
+			t.Fatal("expected no versions of secret after deleting all metadata")
 		}
 	})
 
@@ -511,7 +511,7 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatalf("secret metadata was not populated as expected: %v", err)
 		}
 		if len(md.Versions) > 0 {
-			t.Fatalf("no secret versions should have been created since only metadata was populated")
+			t.Fatal("no secret versions should have been created since only metadata was populated")
 		}
 	})
 
@@ -541,7 +541,7 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatal(err)
 		}
 		if md.CASRequired == md2.CASRequired || md.MaxVersions == md2.MaxVersions || md.DeleteVersionAfter == md2.DeleteVersionAfter || reflect.DeepEqual(md.CustomMetadata, md2.CustomMetadata) {
-			t.Fatalf("metadata fields should have been updated by PutMetadata")
+			t.Fatal("metadata fields should have been updated by PutMetadata")
 		}
 
 		// now let's try a patch
@@ -560,13 +560,13 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatal(err)
 		}
 		if md2.CASRequired != md3.CASRequired || md2.DeleteVersionAfter != md3.DeleteVersionAfter {
-			t.Fatalf("expected fields to remain unchanged but they were updated")
+			t.Fatal("expected fields to remain unchanged but they were updated")
 		}
 		if md3.MaxVersions == 0 {
-			t.Fatalf("field was reset to its zero value when it should not have been")
+			t.Fatal("field was reset to its zero value when it should not have been")
 		}
 		if md2.MaxVersions == md3.MaxVersions {
-			t.Fatalf("expected field to be updated but it remained unchanged")
+			t.Fatal("expected field to be updated but it remained unchanged")
 		}
 
 		// let's check the custom metadata was updated correctly
@@ -613,7 +613,7 @@ func TestKVHelpers(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(md4.CustomMetadata) > 0 {
-			t.Fatalf("expected empty map to cause deletion of all custom metadata")
+			t.Fatal("expected empty map to cause deletion of all custom metadata")
 		}
 
 		if md4.MaxVersions != 0 || md4.CASRequired != false {

--- a/vault/external_tests/api/renewer_integration_test.go
+++ b/vault/external_tests/api/renewer_integration_test.go
@@ -151,7 +151,7 @@ func TestRenewer_Renew(t *testing.T) {
 					renewed = true
 				case <-timeout:
 					if !renewed {
-						t.Errorf("no renewal")
+						t.Error("no renewal")
 					}
 					done = true
 				}

--- a/vault/external_tests/api/sudo_paths_test.go
+++ b/vault/external_tests/api/sudo_paths_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -102,12 +103,12 @@ func getSudoPathsFromSpec(client *api.Client) (map[string]struct{}, error) {
 
 	paths, ok := oasInfo["paths"]
 	if !ok {
-		return nil, fmt.Errorf("OpenAPI response did not include paths")
+		return nil, errors.New("OpenAPI response did not include paths")
 	}
 
 	pathsMap, ok := paths.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("OpenAPI response did not return valid paths")
+		return nil, errors.New("OpenAPI response did not return valid paths")
 	}
 
 	sudoPaths := make(map[string]struct{})

--- a/vault/external_tests/approle/wrapped_secretid_test.go
+++ b/vault/external_tests/approle/wrapped_secretid_test.go
@@ -114,6 +114,6 @@ func TestApproleSecretId_NotWrapped(t *testing.T) {
 	require.NoError(t, err)
 
 	if resp.WrapInfo != nil && resp.WrapInfo.WrappedAccessor != "" {
-		t.Fatalf("WrappedAccessor unexpectedly set")
+		t.Fatal("WrappedAccessor unexpectedly set")
 	}
 }

--- a/vault/external_tests/identity/aliases_test.go
+++ b/vault/external_tests/identity/aliases_test.go
@@ -66,7 +66,7 @@ func TestIdentityStore_ListAlias(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	entityID := resp.Data["id"].(string)
@@ -241,7 +241,7 @@ func TestIdentityStore_RenameAlias_CannotMergeEntity(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, entityResp)
 	}
 	if entityResp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	aliasResp, err := client.Logical().Write("identity/entity-alias", map[string]interface{}{

--- a/vault/external_tests/identity/group_aliases_test.go
+++ b/vault/external_tests/identity/group_aliases_test.go
@@ -62,6 +62,6 @@ func TestIdentityStore_GroupAliasLocalMount(t *testing.T) {
 		"canonical_id":   groupID,
 	})
 	if err == nil {
-		t.Fatalf("expected error since mount is local")
+		t.Fatal("expected error since mount is local")
 	}
 }

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -363,7 +363,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 	if group.MemberEntityIDs != nil {
-		t.Fatalf("failed to remove entity ID from the group")
+		t.Fatal("failed to remove entity ID from the group")
 	}
 
 	group, err = identityStore.MemDBGroupByID(adminStaffGroupID, true)
@@ -384,7 +384,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 	if group.MemberEntityIDs != nil {
-		t.Fatalf("failed to remove entity ID from the group")
+		t.Fatal("failed to remove entity ID from the group")
 	}
 
 	group, err = identityStore.MemDBGroupByID(devopsGroupID, true)
@@ -405,7 +405,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 	if group.MemberEntityIDs != nil {
-		t.Fatalf("failed to remove entity ID from the group")
+		t.Fatal("failed to remove entity ID from the group")
 	}
 
 	_, err = client.Auth().Token().Renew(token, 0)
@@ -439,7 +439,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 	if group.MemberEntityIDs != nil {
-		t.Fatalf("failed to remove entity ID from the group")
+		t.Fatal("failed to remove entity ID from the group")
 	}
 }
 
@@ -632,7 +632,7 @@ func assertMember(t *testing.T, client *api.Client, entityID, groupName, groupID
 
 	groupEntityMembers, ok := groupMap["member_entity_ids"].([]interface{})
 	if !ok && expectFound {
-		t.Fatalf("expected member_entity_ids not to be nil")
+		t.Fatal("expected member_entity_ids not to be nil")
 	}
 
 	// if type assertion fails and expectFound is false, groupEntityMembers

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -50,7 +50,7 @@ func TestInteg_PolicyMFADUO(t *testing.T) {
 
 	err = mfaGeneratePolicyDUOTest(client)
 	if err != nil {
-		t.Fatalf("DUO verification failed")
+		t.Fatal("DUO verification failed")
 	}
 }
 

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -5,6 +5,7 @@ package identity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -65,7 +66,7 @@ path "secret/foo" {
 
 	auths, err := client.Sys().ListAuth()
 	if err != nil {
-		return fmt.Errorf("failed to list auth mount")
+		return errors.New("failed to list auth mount")
 	}
 	mountAccessor := auths["userpass/"].Accessor
 
@@ -139,7 +140,7 @@ path "secret/foo" {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 403 {
-		return fmt.Errorf("failed to read the secret")
+		return errors.New("failed to read the secret")
 	}
 	if err != nil {
 		return fmt.Errorf("failed to read the secret: %v", err)
@@ -185,7 +186,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 
 	auths, err := client.Sys().ListAuth()
 	if err != nil {
-		return fmt.Errorf("failed to list auth mount")
+		return errors.New("failed to list auth mount")
 	}
 	mountAccessor := auths["userpass/"].Accessor
 
@@ -199,7 +200,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 		"name": "test",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create an entity")
+		return errors.New("failed to create an entity")
 	}
 	entityID := secret.Data["id"].(string)
 
@@ -209,7 +210,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 		"mount_accessor": mountAccessor,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create an entity alias")
+		return errors.New("failed to create an entity alias")
 	}
 
 	var methodID string
@@ -230,7 +231,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 
 		methodID = resp.Data["method_id"].(string)
 		if methodID == "" {
-			return fmt.Errorf("method ID is empty")
+			return errors.New("method ID is empty")
 		}
 
 		// creating MFAEnforcementConfig
@@ -253,24 +254,24 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 	}
 
 	if secret.Auth == nil || secret.Auth.MFARequirement == nil {
-		return fmt.Errorf("two phase login returned nil MFARequirement")
+		return errors.New("two phase login returned nil MFARequirement")
 	}
 	if secret.Auth.MFARequirement.MFARequestID == "" {
-		return fmt.Errorf("MFARequirement contains empty MFARequestID")
+		return errors.New("MFARequirement contains empty MFARequestID")
 	}
 	if secret.Auth.MFARequirement.MFAConstraints == nil || len(secret.Auth.MFARequirement.MFAConstraints) == 0 {
-		return fmt.Errorf("MFAConstraints is nil or empty")
+		return errors.New("MFAConstraints is nil or empty")
 	}
 	mfaConstraints, ok := secret.Auth.MFARequirement.MFAConstraints["randomName"]
 	if !ok {
-		return fmt.Errorf("failed to find the mfaConstrains")
+		return errors.New("failed to find the mfaConstrains")
 	}
 	if mfaConstraints.Any == nil || len(mfaConstraints.Any) == 0 {
-		return fmt.Errorf("")
+		return errors.New("")
 	}
 	for _, mfaAny := range mfaConstraints.Any {
 		if mfaAny.ID != methodID || mfaAny.Type != "duo" {
-			return fmt.Errorf("invalid mfa constraints")
+			return errors.New("invalid mfa constraints")
 		}
 	}
 
@@ -285,7 +286,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 	}
 
 	if secret.Auth.ClientToken == "" {
-		return fmt.Errorf("MFA was not enforced")
+		return errors.New("MFA was not enforced")
 	}
 
 	return nil

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -136,7 +136,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 		entityIDCheck := secret.Data["entity_id"].(string)
 		if entityIDCheck != entityID1 {
-			t.Fatalf("different entityID assigned")
+			t.Fatal("different entityID assigned")
 		}
 	}
 
@@ -184,28 +184,28 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	}
 
 	if len(secret.Warnings) == 0 || !strings.Contains(strings.Join(secret.Warnings, ""), "A login request was issued that is subject to MFA validation") {
-		t.Fatalf("first phase of login did not have a warning")
+		t.Fatal("first phase of login did not have a warning")
 	}
 
 	if secret.Auth == nil || secret.Auth.MFARequirement == nil {
-		t.Fatalf("two phase login returned nil MFARequirement")
+		t.Fatal("two phase login returned nil MFARequirement")
 	}
 	if secret.Auth.MFARequirement.MFARequestID == "" {
-		t.Fatalf("MFARequirement contains empty MFARequestID")
+		t.Fatal("MFARequirement contains empty MFARequestID")
 	}
 	if secret.Auth.MFARequirement.MFAConstraints == nil || len(secret.Auth.MFARequirement.MFAConstraints) == 0 {
-		t.Fatalf("MFAConstraints is nil or empty")
+		t.Fatal("MFAConstraints is nil or empty")
 	}
 	mfaConstraints, ok := secret.Auth.MFARequirement.MFAConstraints[methodID[0:4]]
 	if !ok {
-		t.Fatalf("failed to find the mfaConstrains")
+		t.Fatal("failed to find the mfaConstrains")
 	}
 	if mfaConstraints.Any == nil || len(mfaConstraints.Any) == 0 {
-		t.Fatalf("expected to see the methodID is enforced in MFAConstaint.Any")
+		t.Fatal("expected to see the methodID is enforced in MFAConstaint.Any")
 	}
 	for _, mfaAny := range mfaConstraints.Any {
 		if mfaAny.ID != methodID || mfaAny.Type != "totp" || !mfaAny.UsesPasscode {
-			t.Fatalf("Invalid mfa constraints")
+			t.Fatal("Invalid mfa constraints")
 		}
 	}
 
@@ -224,7 +224,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 			return fmt.Errorf("MFA failed: %v", err)
 		}
 		if secret.Auth == nil || secret.Auth.ClientToken == "" {
-			t.Fatalf("successful mfa validation did not return a client token")
+			t.Fatal("successful mfa validation did not return a client token")
 		}
 
 		return nil
@@ -248,7 +248,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 
 	// checking audit log
 	if noop.Req == nil {
-		t.Fatalf("no request was logged in audit log")
+		t.Fatal("no request was logged in audit log")
 	}
 	var found bool
 	for _, req := range noop.Req {
@@ -258,7 +258,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("mfa/validate was not logged in audit log")
+		t.Fatal("mfa/validate was not logged in audit log")
 	}
 
 	// check for login request expiration
@@ -270,7 +270,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	}
 
 	if secret.Auth == nil || secret.Auth.MFARequirement == nil {
-		t.Fatalf("two phase login returned nil MFARequirement")
+		t.Fatal("two phase login returned nil MFARequirement")
 	}
 
 	_, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
@@ -280,7 +280,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatalf("MFA succeeded with an already used passcode")
+		t.Fatal("MFA succeeded with an already used passcode")
 	}
 	if !strings.Contains(err.Error(), "code already used") {
 		t.Fatalf("got: %+v, expected: code already used", err.Error())
@@ -305,7 +305,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 			},
 		})
 		if maxErr == nil {
-			t.Fatalf("MFA succeeded with an invalid passcode")
+			t.Fatal("MFA succeeded with an invalid passcode")
 		}
 	}
 	if !strings.Contains(maxErr.Error(), "maximum TOTP validation attempts") {

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -292,6 +292,6 @@ func TestKV_Patch_RootToken(t *testing.T) {
 	}
 
 	if _, ok := secret.Data["data"].(map[string]interface{})["foo"]; ok {
-		t.Fatalf("expected data not to include foo")
+		t.Fatal("expected data not to include foo")
 	}
 }

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -163,18 +163,18 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 		if gauge.Name == "core.active" {
 			coreLeaderMetric = true
 			if gauge.Value != 1 {
-				t.Errorf("metric incorrectly reports active status")
+				t.Error("metric incorrectly reports active status")
 			}
 		}
 		if gauge.Name == "core.unsealed" {
 			coreUnsealMetric = true
 			if gauge.Value != 1 {
-				t.Errorf("metric incorrectly reports unseal status of leader")
+				t.Error("metric incorrectly reports unseal status of leader")
 			}
 		}
 	}
 	if !coreLeaderMetric || !coreUnsealMetric {
-		t.Errorf("unseal metric or leader metric are missing")
+		t.Error("unseal metric or leader metric are missing")
 	}
 
 	err = client.Sys().StepDown()
@@ -203,18 +203,18 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 			if gauge.Name == "core.active" {
 				coreLeaderMetric = true
 				if gauge.Value != 1 {
-					t.Errorf("metric incorrectly reports active status")
+					t.Error("metric incorrectly reports active status")
 				}
 			}
 			if gauge.Name == "core.unsealed" {
 				coreUnsealMetric = true
 				if gauge.Value != 1 {
-					t.Errorf("metric incorrectly reports unseal status of leader")
+					t.Error("metric incorrectly reports unseal status of leader")
 				}
 			}
 		}
 		if !coreLeaderMetric || !coreUnsealMetric {
-			t.Errorf("unseal metric or leader metric are missing")
+			t.Error("unseal metric or leader metric are missing")
 		}
 	}
 	if respo != nil {

--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -435,7 +435,7 @@ func TestLoginMFA_ListAllMFAConfigsGlobally(t *testing.T) {
 	}
 
 	if len(resp.Data["keys"].([]interface{})) != len(methodIDs) {
-		t.Fatalf("global list request did not return all MFA method IDs")
+		t.Fatal("global list request did not return all MFA method IDs")
 	}
 	if len(resp.Data["key_info"].(map[string]interface{})) != len(methodIDs) {
 		t.Fatal("global list request did not return all MFA method configurations")

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -283,7 +283,7 @@ func testExternalPlugin_ContinueOnError(t *testing.T, mismatch bool, pluginType 
 		t.Fatalf("err: %v", err)
 	}
 	if resp == nil {
-		t.Fatalf("bad: response should not be nil")
+		t.Fatal("bad: response should not be nil")
 	}
 }
 
@@ -387,7 +387,7 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 				// Lookup - expect FAILURE
 				resp, err = client.Auth().Token().Lookup(revokeToken)
 				if err == nil {
-					t.Fatalf("expected error, got nil")
+					t.Fatal("expected error, got nil")
 				}
 
 				// Reset root token
@@ -708,7 +708,7 @@ func TestExternalPlugin_Database(t *testing.T) {
 					t.Fatal(err)
 				}
 				if resp == nil {
-					t.Fatalf("lease lookup response is nil")
+					t.Fatal("lease lookup response is nil")
 				}
 
 				// Revoke
@@ -722,7 +722,7 @@ func TestExternalPlugin_Database(t *testing.T) {
 				// Lookup - expect FAILURE
 				resp, err = client.Sys().Lookup(revokeLease)
 				if err == nil {
-					t.Fatalf("expected error, got nil")
+					t.Fatal("expected error, got nil")
 				}
 			})
 		}

--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -76,7 +76,7 @@ func TestSystemBackend_Plugin_secret(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 			if resp == nil {
-				t.Fatalf("bad: response should not be nil")
+				t.Fatal("bad: response should not be nil")
 			}
 
 			// Seal the cluster
@@ -134,7 +134,7 @@ func TestSystemBackend_Plugin_auth(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 			if resp == nil {
-				t.Fatalf("bad: response should not be nil")
+				t.Fatal("bad: response should not be nil")
 			}
 
 			// Seal the cluster
@@ -192,7 +192,7 @@ func TestSystemBackend_Plugin_MissingBinary(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 			if resp == nil {
-				t.Fatalf("bad: response should not be nil")
+				t.Fatal("bad: response should not be nil")
 			}
 
 			// Seal the cluster
@@ -215,7 +215,7 @@ func TestSystemBackend_Plugin_MissingBinary(t *testing.T) {
 			req.ClientToken = core.Client.Token()
 			_, err = core.HandleRequest(namespace.RootContext(testCtx), req)
 			if err == nil {
-				t.Fatalf("expected error")
+				t.Fatal("expected error")
 			}
 		})
 	}
@@ -403,7 +403,7 @@ func TestSystemBackend_Plugin_autoReload(t *testing.T) {
 			req.ClientToken = core.Client.Token()
 			_, err = core.HandleRequest(namespace.RootContext(testCtx), req)
 			if err == nil {
-				t.Fatalf("expected error from error/rpc request")
+				t.Fatal("expected error from error/rpc request")
 			}
 
 			// Check internal value to make sure it's reset
@@ -414,7 +414,7 @@ func TestSystemBackend_Plugin_autoReload(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 			if resp == nil {
-				t.Fatalf("bad: response should not be nil")
+				t.Fatal("bad: response should not be nil")
 			}
 			if resp.Data["value"].(string) == "baz" {
 				t.Fatal("did not expect backend internal value to be 'baz'")
@@ -571,7 +571,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 					t.Fatalf("err: %v", err)
 				}
 				if resp == nil {
-					t.Fatalf("bad: response should not be nil")
+					t.Fatal("bad: response should not be nil")
 				}
 				if resp.Data["value"].(string) == "baz" {
 					t.Fatal("did not expect backend internal value to be 'baz'")

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -617,7 +617,7 @@ func joinAndStabilize(t *testing.T, core *vault.TestClusterCore, client *api.Cli
 		time.Sleep(1 * time.Second)
 	}
 	if !healthy {
-		t.Fatalf("cluster failed to stabilize")
+		t.Fatal("cluster failed to stabilize")
 	}
 }
 

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -293,7 +293,7 @@ func TestRaft_Join(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !resp.Joined {
-			t.Fatalf("failed to join raft cluster")
+			t.Fatal("failed to join raft cluster")
 		}
 	}
 
@@ -408,7 +408,7 @@ func TestRaft_NodeIDHeader(t *testing.T) {
 					t.Fatalf("err: %s", err)
 				}
 				if resp == nil {
-					t.Fatalf("nil response")
+					t.Fatal("nil response")
 				}
 
 				rniHeader := resp.Header.Get("X-Vault-Raft-Node-ID")
@@ -1088,7 +1088,7 @@ func TestRaft_Join_InitStatus(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !resp.Joined {
-			t.Fatalf("failed to join raft cluster")
+			t.Fatal("failed to join raft cluster")
 		}
 	}
 

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -81,7 +81,7 @@ func testRaftHANewCluster(t *testing.T, bundler teststorage.PhysicalBackendBundl
 			t.Fatal(err)
 		}
 		if !resp.Joined {
-			t.Fatalf("failed to join raft cluster")
+			t.Fatal("failed to join raft cluster")
 		}
 	}
 
@@ -221,7 +221,7 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !resp.Joined {
-				t.Fatalf("failed to join raft cluster")
+				t.Fatal("failed to join raft cluster")
 			}
 		}
 

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -6,6 +6,7 @@ package sealmigration
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -471,7 +472,7 @@ func attemptUnsealMigrate(client *api.Client, keys [][]byte, transitServerAvaila
 			} else {
 				// The transit server is stopped.
 				if err == nil {
-					return fmt.Errorf("expected error due to transit server being stopped.")
+					return errors.New("expected error due to transit server being stopped.")
 				}
 			}
 			break

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -402,7 +402,7 @@ func migratePost14(t *testing.T, storage teststorage.ReusableStorage, cluster *v
 		time.Sleep(1 * time.Second)
 	}
 	if leaderIdx == 0 {
-		t.Fatalf("Core 0 cannot be the leader right now")
+		t.Fatal("Core 0 cannot be the leader right now")
 	}
 	leader := cluster.Cores[leaderIdx]
 
@@ -500,7 +500,7 @@ func awaitMigration(t *testing.T, client *api.Client) {
 		time.Sleep(time.Second)
 	}
 
-	t.Fatalf("migration did not complete.")
+	t.Fatal("migration did not complete.")
 }
 
 func unseal(t *testing.T, client *api.Client, keys [][]byte) {

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -102,7 +102,7 @@ func TestTokenStore_TokenInvalidEntityID(t *testing.T) {
 
 	secret, err = client.Logical().Write("auth/token/lookup-self", nil)
 	if err == nil {
-		t.Fatalf("expected error due to token being invalid when its entity is invalid")
+		t.Fatal("expected error due to token being invalid when its entity is invalid")
 	}
 }
 
@@ -192,7 +192,7 @@ func TestTokenStore_IdentityPolicies(t *testing.T) {
 	}
 	_, ok := secret.Data["identity_policies"]
 	if ok {
-		t.Fatalf("identity_policies should not have been set")
+		t.Fatal("identity_policies should not have been set")
 	}
 
 	// Extract the entity ID of the token and set some policies on the entity

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -52,7 +52,7 @@ func (g generateStandardRootToken) generate(ctx context.Context, c *Core) (strin
 	}
 	if te == nil {
 		c.logger.Error("got nil token entry back from root generation")
-		return "", nil, fmt.Errorf("got nil token entry back from root generation")
+		return "", nil, errors.New("got nil token entry back from root generation")
 	}
 
 	cleanupFunc := func() {
@@ -131,7 +131,7 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 	case len(otp) > 0:
 		if (len(otp) != TokenLength+TokenPrefixLength && !c.DisableSSCTokens()) ||
 			(len(otp) != TokenLength+OldTokenPrefixLength && c.DisableSSCTokens()) {
-			return fmt.Errorf("OTP string is wrong length")
+			return errors.New("OTP string is wrong length")
 		}
 
 	case len(pgpKey) > 0:
@@ -140,12 +140,12 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 			return fmt.Errorf("error parsing PGP key: %w", err)
 		}
 		if len(fingerprints) != 1 || fingerprints[0] == "" {
-			return fmt.Errorf("could not acquire PGP key entity")
+			return errors.New("could not acquire PGP key entity")
 		}
 		fingerprint = fingerprints[0]
 
 	default:
-		return fmt.Errorf("otp or pgp_key parameter must be provided")
+		return errors.New("otp or pgp_key parameter must be provided")
 	}
 
 	c.stateLock.RLock()
@@ -169,7 +169,7 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 
 	// Prevent multiple concurrent root generations
 	if c.generateRootConfig != nil {
-		return fmt.Errorf("root generation already in progress")
+		return errors.New("root generation already in progress")
 	}
 
 	// Copy the configuration
@@ -256,7 +256,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 
 	// Ensure a generateRoot is in progress
 	if c.generateRootConfig == nil {
-		return nil, fmt.Errorf("no root generation in progress")
+		return nil, errors.New("no root generation in progress")
 	}
 
 	if nonce != c.generateRootConfig.Nonce {
@@ -264,13 +264,13 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 	}
 
 	if strategy != c.generateRootConfig.Strategy {
-		return nil, fmt.Errorf("incorrect strategy supplied; a generate root operation of another type is already in progress")
+		return nil, errors.New("incorrect strategy supplied; a generate root operation of another type is already in progress")
 	}
 
 	// Check if we already have this piece
 	for _, existing := range c.generateRootProgress {
 		if bytes.Equal(existing, key) {
-			return nil, fmt.Errorf("given key has already been provided during this generation operation")
+			return nil, errors.New("given key has already been provided during this generation operation")
 		}
 	}
 
@@ -324,7 +324,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		_, tokenBytesArr, err = pgpkeys.EncryptShares([][]byte{[]byte(token)}, []string{c.generateRootConfig.PGPKey})
 		encodedToken = base64.StdEncoding.EncodeToString(tokenBytesArr[0])
 	default:
-		err = fmt.Errorf("unreachable condition")
+		err = errors.New("unreachable condition")
 	}
 
 	if err != nil {

--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -21,7 +21,7 @@ func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
 func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, keys [][]byte) {
 	// Verify update not allowed
 	if _, err := c.GenerateRootUpdate(namespace.RootContext(nil), keys[0], "", GenerateStandardRootTokenStrategy); err == nil {
-		t.Fatalf("no root generation in progress")
+		t.Fatal("no root generation in progress")
 	}
 
 	// Should be no progress
@@ -105,7 +105,7 @@ func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core) {
 	// Second should fail
 	err = c.GenerateRootInit("", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy)
 	if err == nil {
-		t.Fatalf("should fail")
+		t.Fatal("should fail")
 	}
 }
 
@@ -133,13 +133,13 @@ func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, keys [
 		t.Fatalf("err: %v", err)
 	}
 	if rgconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 
 	// Provide the nonce (invalid)
 	_, err = c.GenerateRootUpdate(namespace.RootContext(nil), keys[0], "abcd", GenerateStandardRootTokenStrategy)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	// Provide the root (invalid)
@@ -147,7 +147,7 @@ func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, keys [
 		_, err = c.GenerateRootUpdate(namespace.RootContext(nil), key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
 	}
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 }
 
@@ -174,7 +174,7 @@ func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byt
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no root generation config received")
+		t.Fatal("bad: no root generation config received")
 	}
 
 	// Provide the keys
@@ -189,7 +189,7 @@ func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byt
 		}
 	}
 	if result == nil {
-		t.Fatalf("Bad, result is nil")
+		t.Fatal("Bad, result is nil")
 	}
 
 	encodedToken := result.EncodedToken
@@ -230,7 +230,7 @@ func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byt
 		t.Fatalf("err: %v", err)
 	}
 	if te == nil {
-		t.Fatalf("token was nil")
+		t.Fatal("token was nil")
 	}
 	if te.ID != token || te.Parent != "" ||
 		len(te.Policies) != 1 || te.Policies[0] != "root" {
@@ -256,7 +256,7 @@ func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byt
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no root generation config received")
+		t.Fatal("bad: no root generation config received")
 	}
 
 	// Provide the keys
@@ -271,7 +271,7 @@ func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byt
 		}
 	}
 	if result == nil {
-		t.Fatalf("Bad, result is nil")
+		t.Fatal("Bad, result is nil")
 	}
 
 	encodedToken := result.EncodedToken
@@ -310,7 +310,7 @@ func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byt
 		t.Fatalf("err: %v", err)
 	}
 	if te == nil {
-		t.Fatalf("token was nil")
+		t.Fatal("token was nil")
 	}
 	if te.ID != token || te.Parent != "" ||
 		len(te.Policies) != 1 || te.Policies[0] != "root" {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -974,7 +974,7 @@ func (c *Core) reloadShamirKey(ctx context.Context) error {
 		}
 		shamirKey = entry.Value
 	case seal.StoredKeysNotSupported:
-		return fmt.Errorf("legacy shamir seals are not supported by OpenBao")
+		return errors.New("legacy shamir seals are not supported by OpenBao")
 	}
 	shamirWrapper, err := c.seal.GetShamirWrapper()
 	if err != nil {

--- a/vault/identity_lookup_test.go
+++ b/vault/identity_lookup_test.go
@@ -115,7 +115,7 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Supply alias name and skip accessor
@@ -128,7 +128,7 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Supply alias accessor and skip name
@@ -141,7 +141,7 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Don't supply any criteria
@@ -152,7 +152,7 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Delete the alias in the entity
@@ -172,7 +172,7 @@ func TestIdentityStore_Lookup_Entity(t *testing.T) {
 		t.Fatalf("bad: err: %#v\nresp: %v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -207,7 +207,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\n err: %#v\n", resp, err)
 	}
 	if resp.Data["id"].(string) != groupID {
-		t.Fatalf("failed to lookup group")
+		t.Fatal("failed to lookup group")
 	}
 
 	lookupReq.Data = map[string]interface{}{
@@ -219,7 +219,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\n err: %#v\n", resp, err)
 	}
 	if resp.Data["id"].(string) != groupID {
-		t.Fatalf("failed to lookup group")
+		t.Fatal("failed to lookup group")
 	}
 
 	// Query using an invalid alias_id
@@ -231,7 +231,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\n err: %#v\n", resp, err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	groupReq.Data = map[string]interface{}{
@@ -267,7 +267,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\n err: %#v\n", resp, err)
 	}
 	if resp.Data["id"].(string) != groupID {
-		t.Fatalf("failed to lookup group")
+		t.Fatal("failed to lookup group")
 	}
 
 	lookupReq.Data = map[string]interface{}{
@@ -280,7 +280,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\n err: %#v\n", resp, err)
 	}
 	if resp.Data["id"].(string) != groupID {
-		t.Fatalf("failed to lookup group")
+		t.Fatal("failed to lookup group")
 	}
 
 	// Supply 2 query criteria
@@ -294,7 +294,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Supply alias name and skip accessor
@@ -307,7 +307,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Supply alias accessor and skip name
@@ -320,7 +320,7 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Don't supply any criteria
@@ -331,6 +331,6 @@ func TestIdentityStore_Lookup_Group(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -983,7 +984,7 @@ func (i *IdentityStore) parseLocalAliases(entityID string) (*identity.LocalAlias
 
 func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *storagepacker.Item) (*identity.Entity, error) {
 	if item == nil {
-		return nil, fmt.Errorf("nil item")
+		return nil, errors.New("nil item")
 	}
 
 	persistNeeded := false
@@ -1068,7 +1069,7 @@ func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *sto
 
 func (i *IdentityStore) parseCachedEntity(item *storagepacker.Item) (*identity.Entity, error) {
 	if item == nil {
-		return nil, fmt.Errorf("nil item")
+		return nil, errors.New("nil item")
 	}
 
 	var entity identity.Entity
@@ -1086,7 +1087,7 @@ func (i *IdentityStore) parseCachedEntity(item *storagepacker.Item) (*identity.E
 
 func (i *IdentityStore) parseGroupFromBucketItem(item *storagepacker.Item) (*identity.Group, error) {
 	if item == nil {
-		return nil, fmt.Errorf("nil item")
+		return nil, errors.New("nil item")
 	}
 
 	var group identity.Group
@@ -1106,11 +1107,11 @@ func (i *IdentityStore) parseGroupFromBucketItem(item *storagepacker.Item) (*ide
 // accessor and the alias name.
 func (i *IdentityStore) entityByAliasFactors(mountAccessor, aliasName string, clone bool) (*identity.Entity, error) {
 	if mountAccessor == "" {
-		return nil, fmt.Errorf("missing mount accessor")
+		return nil, errors.New("missing mount accessor")
 	}
 
 	if aliasName == "" {
-		return nil, fmt.Errorf("missing alias name")
+		return nil, errors.New("missing alias name")
 	}
 
 	txn := i.db.Txn(false)
@@ -1122,15 +1123,15 @@ func (i *IdentityStore) entityByAliasFactors(mountAccessor, aliasName string, cl
 // mount accessor and the alias name.
 func (i *IdentityStore) entityByAliasFactorsInTxn(txn *memdb.Txn, mountAccessor, aliasName string, clone bool) (*identity.Entity, error) {
 	if txn == nil {
-		return nil, fmt.Errorf("nil txn")
+		return nil, errors.New("nil txn")
 	}
 
 	if mountAccessor == "" {
-		return nil, fmt.Errorf("missing mount accessor")
+		return nil, errors.New("missing mount accessor")
 	}
 
 	if aliasName == "" {
-		return nil, fmt.Errorf("missing alias name")
+		return nil, errors.New("missing alias name")
 	}
 
 	alias, err := i.MemDBAliasByFactorsInTxn(txn, mountAccessor, aliasName, false, false)
@@ -1187,11 +1188,11 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 	var entityCreated bool
 
 	if alias == nil {
-		return nil, false, fmt.Errorf("alias is nil")
+		return nil, false, errors.New("alias is nil")
 	}
 
 	if alias.Name == "" {
-		return nil, false, fmt.Errorf("empty alias name")
+		return nil, false, errors.New("empty alias name")
 	}
 
 	mountValidationResp := i.router.ValidateMountByAccessor(alias.MountAccessor)

--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -602,7 +603,7 @@ func (i *IdentityStore) pathAliasIDDelete() framework.OperationFunc {
 
 		// If there is no entity tied to a valid alias, something is wrong
 		if entity == nil {
-			return nil, fmt.Errorf("alias not associated to an entity")
+			return nil, errors.New("alias not associated to an entity")
 		}
 
 		aliases := []*identity.Alias{

--- a/vault/identity_store_aliases_test.go
+++ b/vault/identity_store_aliases_test.go
@@ -81,7 +81,7 @@ func TestIdentityStore_DuplicateAliases(t *testing.T) {
 
 	// Ensure that no merging activity has taken place
 	if len(aliases[0].(map[string]interface{})["merged_from_canonical_ids"].([]string)) != 0 {
-		t.Fatalf("expected no merging to take place")
+		t.Fatal("expected no merging to take place")
 	}
 }
 
@@ -200,7 +200,7 @@ func TestIdentityStore_AliasSameAliasNames(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatalf("expected no response since this modification should be idempotent")
+		t.Fatal("expected no response since this modification should be idempotent")
 	}
 }
 
@@ -303,7 +303,7 @@ func TestIdentityStore_MemDBAliasIndexes(t *testing.T) {
 	}
 
 	if aliasFetched != nil {
-		t.Fatalf("expected a nil alias")
+		t.Fatal("expected a nil alias")
 	}
 }
 
@@ -338,22 +338,22 @@ func TestIdentityStore_AliasRegister(t *testing.T) {
 
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("alias id not present in alias register response")
+		t.Fatal("alias id not present in alias register response")
 	}
 
 	id := idRaw.(string)
 	if id == "" {
-		t.Fatalf("invalid alias id in alias register response")
+		t.Fatal("invalid alias id in alias register response")
 	}
 
 	entityIDRaw, ok := resp.Data["canonical_id"]
 	if !ok {
-		t.Fatalf("entity id not present in alias register response")
+		t.Fatal("entity id not present in alias register response")
 	}
 
 	entityID := entityIDRaw.(string)
 	if entityID == "" {
-		t.Fatalf("invalid entity id in alias register response")
+		t.Fatal("invalid entity id in alias register response")
 	}
 }
 
@@ -647,7 +647,7 @@ func TestIdentityStore_AliasMove_DuplicateAccessor(t *testing.T) {
 	}
 
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error as alias on the github accessor exists for testentity1")
+		t.Fatal("expected an error as alias on the github accessor exists for testentity1")
 	}
 }
 
@@ -719,7 +719,7 @@ func TestIdentityStore_AliasUpdate_DuplicateAccessor(t *testing.T) {
 	}
 
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error as an alias on the github accessor already exists for testentity")
+		t.Fatal("expected an error as an alias on the github accessor already exists for testentity")
 	}
 }
 
@@ -771,7 +771,7 @@ func TestIdentityStore_AliasCreate_DuplicateAccessor(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error as alias already exists for this accessor and entity")
+		t.Fatal("expected an error as alias already exists for this accessor and entity")
 	}
 }
 
@@ -798,7 +798,7 @@ func TestIdentityStore_AliasUpdate_ByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error due to invalid alias id")
+		t.Fatal("expected an error due to invalid alias id")
 	}
 
 	customMetadata := make(map[string]string)
@@ -822,11 +822,11 @@ func TestIdentityStore_AliasUpdate_ByID(t *testing.T) {
 
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("alias id not present in response")
+		t.Fatal("alias id not present in response")
 	}
 	id := idRaw.(string)
 	if id == "" {
-		t.Fatalf("invalid alias id")
+		t.Fatal("invalid alias id")
 	}
 
 	updateReq.Path = "entity-alias/id/" + id
@@ -858,7 +858,7 @@ func TestIdentityStore_AliasUpdate_ByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error due to missing alias name")
+		t.Fatal("expected error due to missing alias name")
 	}
 
 	registerReq.Data["name"] = "testaliasname"
@@ -869,7 +869,7 @@ func TestIdentityStore_AliasUpdate_ByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error due to missing mount accessor")
+		t.Fatal("expected error due to missing mount accessor")
 	}
 }
 
@@ -902,11 +902,11 @@ func TestIdentityStore_AliasReadDelete(t *testing.T) {
 
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("alias id not present in response")
+		t.Fatal("alias id not present in response")
 	}
 	id := idRaw.(string)
 	if id == "" {
-		t.Fatalf("invalid alias id")
+		t.Fatal("invalid alias id")
 	}
 
 	// Read it back using alias id

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -916,7 +916,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 					// If it doesn't, check if it clashes with the toEntities
 					if toAlias.MountAccessor == fromAlias.MountAccessor {
 						if aliasClashError == nil {
-							aliasClashError = multierror.Append(aliasClashError, fmt.Errorf("toEntity and at least one fromEntity have aliases with the same mount accessor, repeat the merge request specifying exactly one fromEntity, clashes: "))
+							aliasClashError = multierror.Append(aliasClashError, errors.New("toEntity and at least one fromEntity have aliases with the same mount accessor, repeat the merge request specifying exactly one fromEntity, clashes: "))
 						}
 						aliasClashError = multierror.Append(aliasClashError,
 							fmt.Errorf("mountAccessor: %s, toEntity ID: %s, fromEntity ID: %s, conflicting toEntity alias ID: %s, conflicting fromEntity alias ID: %s",

--- a/vault/identity_store_entities_test.go
+++ b/vault/identity_store_entities_test.go
@@ -171,7 +171,7 @@ func TestIdentityStore_EntityByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	// Test the read by name endpoint
@@ -231,7 +231,7 @@ func TestIdentityStore_EntityByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// Create 2 entities
@@ -243,7 +243,7 @@ func TestIdentityStore_EntityByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 	resp, err = i.HandleRequest(ctx, &logical.Request{
 		Path:      "entity/name/testentityname2",
@@ -253,7 +253,7 @@ func TestIdentityStore_EntityByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	// List the entities by name
@@ -488,7 +488,7 @@ func TestIdentityStore_CloneImmutability(t *testing.T) {
 	entity.Aliases[0].ID = "invalidid"
 
 	if clonedEntity.Aliases[0].ID == "invalidid" {
-		t.Fatalf("cloned entity is mutated")
+		t.Fatal("cloned entity is mutated")
 	}
 
 	clonedAlias, err := alias.Clone()
@@ -499,7 +499,7 @@ func TestIdentityStore_CloneImmutability(t *testing.T) {
 	alias.MergedFromCanonicalIDs[0] = "invalidid"
 
 	if clonedAlias.MergedFromCanonicalIDs[0] == "invalidid" {
-		t.Fatalf("cloned alias is mutated")
+		t.Fatal("cloned alias is mutated")
 	}
 }
 
@@ -708,7 +708,7 @@ func TestIdentityStore_LoadingEntities(t *testing.T) {
 	// Identity store will be mounted by now, just fetch it from router
 	identitystore := c.router.MatchingBackend(namespace.RootContext(nil), "identity/")
 	if identitystore == nil {
-		t.Fatalf("failed to fetch identity store from router")
+		t.Fatal("failed to fetch identity store from router")
 	}
 
 	is := identitystore.(*IdentityStore)
@@ -747,7 +747,7 @@ func TestIdentityStore_LoadingEntities(t *testing.T) {
 	}
 
 	if resp.Data["id"] != entityID {
-		t.Fatalf("failed to read the created entity")
+		t.Fatal("failed to read the created entity")
 	}
 
 	// Perform a seal/unseal cycle
@@ -777,7 +777,7 @@ func TestIdentityStore_LoadingEntities(t *testing.T) {
 	}
 
 	if resp.Data["id"] != entityID {
-		t.Fatalf("failed to read the created entity after a seal/unseal cycle")
+		t.Fatal("failed to read the created entity after a seal/unseal cycle")
 	}
 }
 
@@ -919,11 +919,11 @@ func TestIdentityStore_EntityCRUD(t *testing.T) {
 
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("entity id not present in response")
+		t.Fatal("entity id not present in response")
 	}
 	id := idRaw.(string)
 	if id == "" {
-		t.Fatalf("invalid entity id")
+		t.Fatal("invalid entity id")
 	}
 
 	readReq := &logical.Request{
@@ -939,7 +939,7 @@ func TestIdentityStore_EntityCRUD(t *testing.T) {
 	if resp.Data["id"] != id ||
 		resp.Data["name"] != registerData["name"] ||
 		!reflect.DeepEqual(resp.Data["policies"], strutil.RemoveDuplicates(registerData["policies"].([]string), false)) {
-		t.Fatalf("bad: entity response")
+		t.Fatal("bad: entity response")
 	}
 
 	updateData := map[string]interface{}{
@@ -1138,7 +1138,7 @@ func TestIdentityStore_MergeEntitiesByID(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("entity should have been deleted")
+		t.Fatal("entity should have been deleted")
 	}
 
 	entityReq.Path = "entity/id/" + entityID1
@@ -1289,7 +1289,7 @@ func TestIdentityStore_MergeEntitiesByID_DuplicateFromEntityIDs(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("entity should have been deleted")
+		t.Fatal("entity should have been deleted")
 	}
 
 	entityReq.Path = "entity/id/" + entityID1

--- a/vault/identity_store_group_aliases.go
+++ b/vault/identity_store_group_aliases.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -274,7 +275,7 @@ func (i *IdentityStore) handleGroupAliasUpdateCommon(ctx context.Context, req *l
 			return nil, err
 		}
 		if previousGroup == nil {
-			return nil, fmt.Errorf("group alias is not associated with a group")
+			return nil, errors.New("group alias is not associated with a group")
 		}
 		if previousGroup.NamespaceID != groupAlias.NamespaceID {
 			return logical.ErrorResponse("previous group found for alias not in the same namespace as alias"), logical.ErrPermissionDenied
@@ -363,7 +364,7 @@ func (i *IdentityStore) pathGroupAliasIDDelete() framework.OperationFunc {
 
 		// If there is no group tied to a valid alias, something is wrong
 		if group == nil {
-			return nil, fmt.Errorf("alias not associated to a group")
+			return nil, errors.New("alias not associated to a group")
 		}
 
 		// Delete group alias in memdb

--- a/vault/identity_store_group_aliases_test.go
+++ b/vault/identity_store_group_aliases_test.go
@@ -166,7 +166,7 @@ func TestIdentityStore_EnsureNoDanglingGroupAlias(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 	if resp == nil || resp.Data["id"].(string) != userpassGroupAliasID {
-		t.Fatalf("failed to read userpass group alias")
+		t.Fatal("failed to read userpass group alias")
 	}
 
 	// Attach a different alias to the same group, overriding the previous one
@@ -193,7 +193,7 @@ func TestIdentityStore_EnsureNoDanglingGroupAlias(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 	if resp == nil || resp.Data["id"].(string) != ldapGroupAliasID {
-		t.Fatalf("failed to read ldap group alias")
+		t.Fatal("failed to read ldap group alias")
 	}
 
 	// Ensure previous alias is gone
@@ -205,7 +205,7 @@ func TestIdentityStore_EnsureNoDanglingGroupAlias(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v\n", resp, err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -258,7 +258,7 @@ func TestIdentityStore_GroupAliasDeletionOnGroupDeletion(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -338,7 +338,7 @@ func TestIdentityStore_GroupAliases_CRUD(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("failed to delete group alias")
+		t.Fatal("failed to delete group alias")
 	}
 }
 
@@ -435,7 +435,7 @@ func TestIdentityStore_GroupAliases_AliasOnInternalGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 

--- a/vault/identity_store_groups_test.go
+++ b/vault/identity_store_groups_test.go
@@ -184,7 +184,7 @@ func TestIdentityStore_GroupEntityMembershipUpgrade(t *testing.T) {
 			t.Fatal(err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("failed to unseal")
+			t.Fatal("failed to unseal")
 		}
 	}
 
@@ -352,7 +352,7 @@ func TestIdentityStore_GroupByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	// Test the read by name endpoint
@@ -412,7 +412,7 @@ func TestIdentityStore_GroupByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// Create 2 entities
@@ -424,7 +424,7 @@ func TestIdentityStore_GroupByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 	resp, err = i.HandleRequest(ctx, &logical.Request{
 		Path:      "group/name/testgroupname2",
@@ -434,7 +434,7 @@ func TestIdentityStore_GroupByName(t *testing.T) {
 		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	// List the entities by name
@@ -475,7 +475,7 @@ func TestIdentityStore_Groups_TypeMembershipAdditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	groupReq.Data = map[string]interface{}{
@@ -488,7 +488,7 @@ func TestIdentityStore_Groups_TypeMembershipAdditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -528,7 +528,7 @@ func TestIdentityStore_Groups_TypeImmutability(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	// Try to mark internal group as external
@@ -541,7 +541,7 @@ func TestIdentityStore_Groups_TypeImmutability(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !resp.IsError() {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -605,7 +605,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if fetchedGroup == nil || fetchedGroup.Name != "testgroupname" {
-		t.Fatalf("failed to fetch an indexed group")
+		t.Fatal("failed to fetch an indexed group")
 	}
 
 	// Fetch group given the ID
@@ -614,7 +614,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if fetchedGroup == nil || fetchedGroup.Name != "testgroupname" {
-		t.Fatalf("failed to fetch an indexed group")
+		t.Fatal("failed to fetch an indexed group")
 	}
 
 	var fetchedGroups []*identity.Group
@@ -624,7 +624,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(fetchedGroups) != 1 || fetchedGroups[0].Name != "testgroupname" {
-		t.Fatalf("failed to fetch an indexed group")
+		t.Fatal("failed to fetch an indexed group")
 	}
 
 	fetchedGroups, err = i.MemDBGroupsByParentGroupID("testparentgroupid2", false)
@@ -632,7 +632,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(fetchedGroups) != 2 {
-		t.Fatalf("failed to fetch a indexed groups")
+		t.Fatal("failed to fetch a indexed groups")
 	}
 
 	// Fetch groups based on member entity ID
@@ -641,7 +641,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(fetchedGroups) != 1 || fetchedGroups[0].Name != "testgroupname" {
-		t.Fatalf("failed to fetch an indexed group")
+		t.Fatal("failed to fetch an indexed group")
 	}
 
 	fetchedGroups, err = i.MemDBGroupsByMemberEntityID("testentityid2", false, false)
@@ -650,7 +650,7 @@ func TestIdentityStore_MemDBGroupIndexes(t *testing.T) {
 	}
 
 	if len(fetchedGroups) != 2 {
-		t.Fatalf("failed to fetch groups by entity ID")
+		t.Fatal("failed to fetch groups by entity ID")
 	}
 }
 
@@ -998,7 +998,7 @@ func TestIdentityStore_GroupsCRUD_ByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -1258,7 +1258,7 @@ func TestIdentityStore_GroupHierarchyCases(t *testing.T) {
 	kubeGroupData["member_group_ids"] = []string{engGroupID}
 	resp, err = is.HandleRequest(ctx, groupUpdateReq)
 	if err != nil || resp == nil || !resp.IsError() {
-		t.Fatalf("expected an error response")
+		t.Fatal("expected an error response")
 	}
 
 	// Create an entity ID

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1141,7 +1141,7 @@ func (k *namedKey) generateAndSetNextKey(ctx context.Context, logger hclog.Logge
 
 func (k *namedKey) signPayload(payload []byte) (string, error) {
 	if k.SigningKey == nil {
-		return "", fmt.Errorf("signing key is nil; rotate the key and try again")
+		return "", errors.New("signing key is nil; rotate the key and try again")
 	}
 	signingKey := jose.SigningKey{Key: k.SigningKey, Algorithm: jose.SignatureAlgorithm(k.Algorithm)}
 	signer, err := jose.NewSigner(signingKey, &jose.SignerOptions{})

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -2301,7 +2301,7 @@ func TestOIDC_pathOIDCClientExistenceCheck(t *testing.T) {
 	client := &client{}
 	entry, _ := logical.StorageEntryJSON(clientPath+clientName, client)
 	if err := storage.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Expect true with a populated storage
@@ -2646,7 +2646,7 @@ func TestOIDC_pathOIDCScopeExistenceCheck(t *testing.T) {
 	scope := &scope{}
 	entry, _ := logical.StorageEntryJSON(scopePath+scopeName, scope)
 	if err := storage.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Expect true with a populated storage
@@ -3012,7 +3012,7 @@ func TestOIDC_pathOIDCAssignmentExistenceCheck(t *testing.T) {
 	assignment := &assignment{}
 	entry, _ := logical.StorageEntryJSON(assignmentPath+assignmentName, assignment)
 	if err := storage.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Expect true with a populated storage

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -945,7 +945,7 @@ func TestOIDC_SignIDToken(t *testing.T) {
 		}
 	}
 	if errorCount == keyCount {
-		t.Fatalf("unable to validate signed token with any of the .well-known keys")
+		t.Fatal("unable to validate signed token with any of the .well-known keys")
 	}
 }
 
@@ -984,12 +984,12 @@ func TestOIDC_SignIDToken_NilSigningKey(t *testing.T) {
 	}
 	s := c.router.MatchingStorageByAPIPath(ctx, "identity/oidc")
 	if err := namedKey.generateAndSetNextKey(ctx, hclog.NewNullLogger(), s); err != nil {
-		t.Fatalf("failed to set next signing key")
+		t.Fatal("failed to set next signing key")
 	}
 	// Store namedKey
 	entry, _ := logical.StorageEntryJSON(namedKeyConfigPath+namedKey.name, namedKey)
 	if err := s.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Create a test role "test-role" -- expect no warning
@@ -1112,12 +1112,12 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 
 			if testSet.setSigningKey {
 				if err := testSet.namedKey.generateAndSetKey(ctx, hclog.NewNullLogger(), storage); err != nil {
-					t.Fatalf("failed to set signing key")
+					t.Fatal("failed to set signing key")
 				}
 			}
 			if testSet.setNextSigningKey {
 				if err := testSet.namedKey.generateAndSetNextKey(ctx, hclog.NewNullLogger(), storage); err != nil {
-					t.Fatalf("failed to set next signing key")
+					t.Fatal("failed to set next signing key")
 				}
 			}
 			testSet.namedKey.NextRotation = time.Now().Add(testSet.namedKey.RotationPeriod)
@@ -1125,7 +1125,7 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 			// Store namedKey
 			entry, _ := logical.StorageEntryJSON(namedKeyConfigPath+testSet.namedKey.name, testSet.namedKey)
 			if err := storage.Put(ctx, entry); err != nil {
-				t.Fatalf("writing to in mem storage failed")
+				t.Fatal("writing to in mem storage failed")
 			}
 
 			currentCycle := 1
@@ -1184,7 +1184,7 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 			}
 
 			if err := storage.Delete(ctx, namedKeyConfigPath+testSet.namedKey.name); err != nil {
-				t.Fatalf("deleting from in mem storage failed")
+				t.Fatal("deleting from in mem storage failed")
 			}
 		})
 	}
@@ -1287,7 +1287,7 @@ func TestOIDC_pathOIDCKeyExistenceCheck(t *testing.T) {
 	namedKey := &namedKey{}
 	entry, _ := logical.StorageEntryJSON(namedKeyConfigPath+keyName, namedKey)
 	if err := storage.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Expect true with a populated storage
@@ -1347,7 +1347,7 @@ func TestOIDC_pathOIDCRoleExistenceCheck(t *testing.T) {
 	role := &role{}
 	entry, _ := logical.StorageEntryJSON(roleConfigPath+roleName, role)
 	if err := storage.Put(ctx, entry); err != nil {
-		t.Fatalf("writing to in mem storage failed")
+		t.Fatal("writing to in mem storage failed")
 	}
 
 	// Expect true with a populated storage

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -191,7 +191,7 @@ func TestIdentityStore_EntityIDPassthrough(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 
 	// Create a token with the above created entity set on it
@@ -245,7 +245,7 @@ func TestIdentityStore_EntityIDPassthrough(t *testing.T) {
 
 	// Expected entity ID to be in the response
 	if resp.Data["entity_id"] != entity.ID {
-		t.Fatalf("expected entity ID to be passed through to the backend")
+		t.Fatal("expected entity ID to be passed through to the backend")
 	}
 }
 
@@ -267,7 +267,7 @@ func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 
 	if len(entity.Aliases) != 1 {
@@ -283,7 +283,7 @@ func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 
 	if len(entity.Aliases) != 1 {
@@ -318,7 +318,7 @@ func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 
 	if len(entity.Aliases) != 2 {
@@ -344,7 +344,7 @@ func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 
 	if len(entity.Aliases) != 2 {
@@ -386,11 +386,11 @@ func TestIdentityStore_EntityByAliasFactors(t *testing.T) {
 	}
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("entity id not present in response")
+		t.Fatal("entity id not present in response")
 	}
 	entityID := idRaw.(string)
 	if entityID == "" {
-		t.Fatalf("invalid entity id")
+		t.Fatal("invalid entity id")
 	}
 
 	aliasData := map[string]interface{}{
@@ -409,7 +409,7 @@ func TestIdentityStore_EntityByAliasFactors(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("expected a non-nil response")
+		t.Fatal("expected a non-nil response")
 	}
 
 	entity, err := is.entityByAliasFactors(ghAccessor, "alias_name", false)
@@ -417,7 +417,7 @@ func TestIdentityStore_EntityByAliasFactors(t *testing.T) {
 		t.Fatal(err)
 	}
 	if entity == nil {
-		t.Fatalf("expected a non-nil entity")
+		t.Fatal("expected a non-nil entity")
 	}
 	if entity.ID != entityID {
 		t.Fatalf("bad: entity ID; expected: %q actual: %q", entityID, entity.ID)
@@ -451,11 +451,11 @@ func TestIdentityStore_WrapInfoInheritance(t *testing.T) {
 
 	idRaw, ok := resp.Data["id"]
 	if !ok {
-		t.Fatalf("entity id not present in response")
+		t.Fatal("entity id not present in response")
 	}
 	entityID := idRaw.(string)
 	if entityID == "" {
-		t.Fatalf("invalid entity id")
+		t.Fatal("invalid entity id")
 	}
 
 	// Create a token which has EntityID set and has update permissions to
@@ -486,7 +486,7 @@ func TestIdentityStore_WrapInfoInheritance(t *testing.T) {
 	}
 
 	if resp.WrapInfo == nil {
-		t.Fatalf("expected a non-nil WrapInfo")
+		t.Fatal("expected a non-nil WrapInfo")
 	}
 
 	if resp.WrapInfo.WrappedEntityID != entityID {
@@ -532,7 +532,7 @@ func TestIdentityStore_TokenEntityInheritance(t *testing.T) {
 	}
 
 	if resp.Auth.EntityID != "" {
-		t.Fatalf("expected entity ID to be not set")
+		t.Fatal("expected entity ID to be not set")
 	}
 }
 
@@ -892,7 +892,7 @@ func TestIdentityStore_DeleteCaseSensitivityKey(t *testing.T) {
 	}
 
 	if storageEntry == nil {
-		t.Fatalf("bad: expected a non-nil entry for casesensitivity key")
+		t.Fatal("bad: expected a non-nil entry for casesensitivity key")
 	}
 
 	// Seal and unseal to trigger identityStore initialize
@@ -918,6 +918,6 @@ func TestIdentityStore_DeleteCaseSensitivityKey(t *testing.T) {
 	}
 
 	if storageEntry != nil {
-		t.Fatalf("bad: expected no entry for casesensitivity key")
+		t.Fatal("bad: expected no entry for casesensitivity key")
 	}
 }

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -518,7 +518,7 @@ func (i *IdentityStore) upsertEntityInTxn(ctx context.Context, txn *memdb.Txn, e
 
 func (i *IdentityStore) processLocalAlias(ctx context.Context, lAlias *logical.Alias, entity *identity.Entity, updateDb bool) (*identity.Alias, error) {
 	if !lAlias.Local {
-		return nil, fmt.Errorf("alias is not local")
+		return nil, errors.New("alias is not local")
 	}
 
 	mountValidationResp := i.router.ValidateMountByAccessor(lAlias.MountAccessor)
@@ -685,11 +685,11 @@ func (i *IdentityStore) upsertEntity(ctx context.Context, entity *identity.Entit
 
 func (i *IdentityStore) MemDBUpsertAliasInTxn(txn *memdb.Txn, alias *identity.Alias, groupAlias bool) error {
 	if txn == nil {
-		return fmt.Errorf("nil txn")
+		return errors.New("nil txn")
 	}
 
 	if alias == nil {
-		return fmt.Errorf("alias is nil")
+		return errors.New("alias is nil")
 	}
 
 	if alias.NamespaceID == "" {
@@ -722,11 +722,11 @@ func (i *IdentityStore) MemDBUpsertAliasInTxn(txn *memdb.Txn, alias *identity.Al
 
 func (i *IdentityStore) MemDBAliasByIDInTxn(txn *memdb.Txn, aliasID string, clone bool, groupAlias bool) (*identity.Alias, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	tableName := entityAliasesTable
@@ -745,7 +745,7 @@ func (i *IdentityStore) MemDBAliasByIDInTxn(txn *memdb.Txn, aliasID string, clon
 
 	alias, ok := aliasRaw.(*identity.Alias)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched alias")
+		return nil, errors.New("failed to declare the type of fetched alias")
 	}
 
 	if clone {
@@ -757,7 +757,7 @@ func (i *IdentityStore) MemDBAliasByIDInTxn(txn *memdb.Txn, aliasID string, clon
 
 func (i *IdentityStore) MemDBAliasByID(aliasID string, clone bool, groupAlias bool) (*identity.Alias, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	txn := i.db.Txn(false)
@@ -767,11 +767,11 @@ func (i *IdentityStore) MemDBAliasByID(aliasID string, clone bool, groupAlias bo
 
 func (i *IdentityStore) MemDBAliasByFactors(mountAccessor, aliasName string, clone bool, groupAlias bool) (*identity.Alias, error) {
 	if aliasName == "" {
-		return nil, fmt.Errorf("missing alias name")
+		return nil, errors.New("missing alias name")
 	}
 
 	if mountAccessor == "" {
-		return nil, fmt.Errorf("missing mount accessor")
+		return nil, errors.New("missing mount accessor")
 	}
 
 	txn := i.db.Txn(false)
@@ -781,15 +781,15 @@ func (i *IdentityStore) MemDBAliasByFactors(mountAccessor, aliasName string, clo
 
 func (i *IdentityStore) MemDBAliasByFactorsInTxn(txn *memdb.Txn, mountAccessor, aliasName string, clone bool, groupAlias bool) (*identity.Alias, error) {
 	if txn == nil {
-		return nil, fmt.Errorf("nil txn")
+		return nil, errors.New("nil txn")
 	}
 
 	if aliasName == "" {
-		return nil, fmt.Errorf("missing alias name")
+		return nil, errors.New("missing alias name")
 	}
 
 	if mountAccessor == "" {
-		return nil, fmt.Errorf("missing mount accessor")
+		return nil, errors.New("missing mount accessor")
 	}
 
 	tableName := entityAliasesTable
@@ -808,7 +808,7 @@ func (i *IdentityStore) MemDBAliasByFactorsInTxn(txn *memdb.Txn, mountAccessor, 
 
 	alias, ok := aliasRaw.(*identity.Alias)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched alias")
+		return nil, errors.New("failed to declare the type of fetched alias")
 	}
 
 	if clone {
@@ -824,7 +824,7 @@ func (i *IdentityStore) MemDBDeleteAliasByIDInTxn(txn *memdb.Txn, aliasID string
 	}
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	alias, err := i.MemDBAliasByIDInTxn(txn, aliasID, false, groupAlias)
@@ -869,11 +869,11 @@ func (i *IdentityStore) MemDBAliases(ws memdb.WatchSet, groupAlias bool) (memdb.
 
 func (i *IdentityStore) MemDBUpsertEntityInTxn(txn *memdb.Txn, entity *identity.Entity) error {
 	if txn == nil {
-		return fmt.Errorf("nil txn")
+		return errors.New("nil txn")
 	}
 
 	if entity == nil {
-		return fmt.Errorf("entity is nil")
+		return errors.New("entity is nil")
 	}
 
 	if entity.NamespaceID == "" {
@@ -901,11 +901,11 @@ func (i *IdentityStore) MemDBUpsertEntityInTxn(txn *memdb.Txn, entity *identity.
 
 func (i *IdentityStore) MemDBEntityByIDInTxn(txn *memdb.Txn, entityID string, clone bool) (*identity.Entity, error) {
 	if entityID == "" {
-		return nil, fmt.Errorf("missing entity id")
+		return nil, errors.New("missing entity id")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	entityRaw, err := txn.First(entitiesTable, "id", entityID)
@@ -919,7 +919,7 @@ func (i *IdentityStore) MemDBEntityByIDInTxn(txn *memdb.Txn, entityID string, cl
 
 	entity, ok := entityRaw.(*identity.Entity)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched entity")
+		return nil, errors.New("failed to declare the type of fetched entity")
 	}
 
 	if clone {
@@ -931,7 +931,7 @@ func (i *IdentityStore) MemDBEntityByIDInTxn(txn *memdb.Txn, entityID string, cl
 
 func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.Entity, error) {
 	if entityID == "" {
-		return nil, fmt.Errorf("missing entity id")
+		return nil, errors.New("missing entity id")
 	}
 
 	txn := i.db.Txn(false)
@@ -941,7 +941,7 @@ func (i *IdentityStore) MemDBEntityByID(entityID string, clone bool) (*identity.
 
 func (i *IdentityStore) MemDBEntityByName(ctx context.Context, entityName string, clone bool) (*identity.Entity, error) {
 	if entityName == "" {
-		return nil, fmt.Errorf("missing entity name")
+		return nil, errors.New("missing entity name")
 	}
 
 	txn := i.db.Txn(false)
@@ -951,7 +951,7 @@ func (i *IdentityStore) MemDBEntityByName(ctx context.Context, entityName string
 
 func (i *IdentityStore) MemDBEntityByNameInTxn(ctx context.Context, txn *memdb.Txn, entityName string, clone bool) (*identity.Entity, error) {
 	if entityName == "" {
-		return nil, fmt.Errorf("missing entity name")
+		return nil, errors.New("missing entity name")
 	}
 
 	ns, err := namespace.FromContext(ctx)
@@ -970,7 +970,7 @@ func (i *IdentityStore) MemDBEntityByNameInTxn(ctx context.Context, txn *memdb.T
 
 	entity, ok := entityRaw.(*identity.Entity)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched entity")
+		return nil, errors.New("failed to declare the type of fetched entity")
 	}
 
 	if clone {
@@ -982,11 +982,11 @@ func (i *IdentityStore) MemDBEntityByNameInTxn(ctx context.Context, txn *memdb.T
 
 func (i *IdentityStore) MemDBLocalAliasesByBucketKeyInTxn(txn *memdb.Txn, bucketKey string) ([]*identity.Alias, error) {
 	if txn == nil {
-		return nil, fmt.Errorf("nil txn")
+		return nil, errors.New("nil txn")
 	}
 
 	if bucketKey == "" {
-		return nil, fmt.Errorf("empty bucket key")
+		return nil, errors.New("empty bucket key")
 	}
 
 	iter, err := txn.Get(entityAliasesTable, "local_bucket_key", bucketKey)
@@ -1007,11 +1007,11 @@ func (i *IdentityStore) MemDBLocalAliasesByBucketKeyInTxn(txn *memdb.Txn, bucket
 
 func (i *IdentityStore) MemDBEntitiesByBucketKeyInTxn(txn *memdb.Txn, bucketKey string) ([]*identity.Entity, error) {
 	if txn == nil {
-		return nil, fmt.Errorf("nil txn")
+		return nil, errors.New("nil txn")
 	}
 
 	if bucketKey == "" {
-		return nil, fmt.Errorf("empty bucket key")
+		return nil, errors.New("empty bucket key")
 	}
 
 	entitiesIter, err := txn.Get(entitiesTable, "bucket_key", bucketKey)
@@ -1033,7 +1033,7 @@ func (i *IdentityStore) MemDBEntitiesByBucketKeyInTxn(txn *memdb.Txn, bucketKey 
 
 func (i *IdentityStore) MemDBEntityByMergedEntityID(mergedEntityID string, clone bool) (*identity.Entity, error) {
 	if mergedEntityID == "" {
-		return nil, fmt.Errorf("missing merged entity id")
+		return nil, errors.New("missing merged entity id")
 	}
 
 	txn := i.db.Txn(false)
@@ -1049,7 +1049,7 @@ func (i *IdentityStore) MemDBEntityByMergedEntityID(mergedEntityID string, clone
 
 	entity, ok := entityRaw.(*identity.Entity)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched entity")
+		return nil, errors.New("failed to declare the type of fetched entity")
 	}
 
 	if clone {
@@ -1061,11 +1061,11 @@ func (i *IdentityStore) MemDBEntityByMergedEntityID(mergedEntityID string, clone
 
 func (i *IdentityStore) MemDBEntityByAliasIDInTxn(txn *memdb.Txn, aliasID string, clone bool) (*identity.Entity, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	alias, err := i.MemDBAliasByIDInTxn(txn, aliasID, false, false)
@@ -1082,7 +1082,7 @@ func (i *IdentityStore) MemDBEntityByAliasIDInTxn(txn *memdb.Txn, aliasID string
 
 func (i *IdentityStore) MemDBEntityByAliasID(aliasID string, clone bool) (*identity.Entity, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	txn := i.db.Txn(false)
@@ -1114,7 +1114,7 @@ func (i *IdentityStore) MemDBDeleteEntityByIDInTxn(txn *memdb.Txn, entityID stri
 	}
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	entity, err := i.MemDBEntityByIDInTxn(txn, entityID, false)
@@ -1138,12 +1138,12 @@ func (i *IdentityStore) sanitizeAlias(ctx context.Context, alias *identity.Alias
 	var err error
 
 	if alias == nil {
-		return fmt.Errorf("alias is nil")
+		return errors.New("alias is nil")
 	}
 
 	// Alias must always be tied to a canonical object
 	if alias.CanonicalID == "" {
-		return fmt.Errorf("missing canonical ID")
+		return errors.New("missing canonical ID")
 	}
 
 	// Alias must have a name
@@ -1161,7 +1161,7 @@ func (i *IdentityStore) sanitizeAlias(ctx context.Context, alias *identity.Alias
 	if alias.ID == "" {
 		alias.ID, err = uuid.GenerateUUID()
 		if err != nil {
-			return fmt.Errorf("failed to generate alias ID")
+			return errors.New("failed to generate alias ID")
 		}
 
 		alias.LocalBucketKey = i.localAliasPacker.BucketKey(alias.CanonicalID)
@@ -1198,14 +1198,14 @@ func (i *IdentityStore) sanitizeEntity(ctx context.Context, entity *identity.Ent
 	var err error
 
 	if entity == nil {
-		return fmt.Errorf("entity is nil")
+		return errors.New("entity is nil")
 	}
 
 	// Create an ID if there isn't one already
 	if entity.ID == "" {
 		entity.ID, err = uuid.GenerateUUID()
 		if err != nil {
-			return fmt.Errorf("failed to generate entity id")
+			return errors.New("failed to generate entity id")
 		}
 
 		// Set the storage bucket key in entity
@@ -1227,7 +1227,7 @@ func (i *IdentityStore) sanitizeEntity(ctx context.Context, entity *identity.Ent
 	if entity.Name == "" {
 		entity.Name, err = i.generateName(ctx, "entity")
 		if err != nil {
-			return fmt.Errorf("failed to generate entity name")
+			return errors.New("failed to generate entity name")
 		}
 	}
 
@@ -1258,14 +1258,14 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 	var err error
 
 	if group == nil {
-		return fmt.Errorf("group is nil")
+		return errors.New("group is nil")
 	}
 
 	// Create an ID if there isn't one already
 	if group.ID == "" {
 		group.ID, err = uuid.GenerateUUID()
 		if err != nil {
-			return fmt.Errorf("failed to generate group id")
+			return errors.New("failed to generate group id")
 		}
 
 		// Set the hash value of the storage bucket key in group
@@ -1291,7 +1291,7 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 	if group.Name == "" {
 		group.Name, err = i.generateName(ctx, "group")
 		if err != nil {
-			return fmt.Errorf("failed to generate group name")
+			return errors.New("failed to generate group name")
 		}
 	}
 
@@ -1470,11 +1470,11 @@ ALIAS:
 
 func (i *IdentityStore) deleteAliasesInEntityInTxn(txn *memdb.Txn, entity *identity.Entity, aliases []*identity.Alias) error {
 	if entity == nil {
-		return fmt.Errorf("entity is nil")
+		return errors.New("entity is nil")
 	}
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	var remainList []*identity.Alias
@@ -1526,10 +1526,10 @@ func validateMetadata(meta map[string]string) error {
 // validateMetaPair checks that the given key/value pair is in a valid format
 func validateMetaPair(key, value string) error {
 	if key == "" {
-		return fmt.Errorf("key cannot be blank")
+		return errors.New("key cannot be blank")
 	}
 	if !metaKeyFormatRegEx(key) {
-		return fmt.Errorf("key contains invalid characters")
+		return errors.New("key contains invalid characters")
 	}
 	if len(key) > metaKeyMaxLength {
 		return fmt.Errorf("key is too long (limit: %d characters)", metaKeyMaxLength)
@@ -1545,11 +1545,11 @@ func validateMetaPair(key, value string) error {
 
 func (i *IdentityStore) MemDBGroupByNameInTxn(ctx context.Context, txn *memdb.Txn, groupName string, clone bool) (*identity.Group, error) {
 	if groupName == "" {
-		return nil, fmt.Errorf("missing group name")
+		return nil, errors.New("missing group name")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	ns, err := namespace.FromContext(ctx)
@@ -1568,7 +1568,7 @@ func (i *IdentityStore) MemDBGroupByNameInTxn(ctx context.Context, txn *memdb.Tx
 
 	group, ok := groupRaw.(*identity.Group)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched group")
+		return nil, errors.New("failed to declare the type of fetched group")
 	}
 
 	if clone {
@@ -1580,7 +1580,7 @@ func (i *IdentityStore) MemDBGroupByNameInTxn(ctx context.Context, txn *memdb.Tx
 
 func (i *IdentityStore) MemDBGroupByName(ctx context.Context, groupName string, clone bool) (*identity.Group, error) {
 	if groupName == "" {
-		return nil, fmt.Errorf("missing group name")
+		return nil, errors.New("missing group name")
 	}
 
 	txn := i.db.Txn(false)
@@ -1610,11 +1610,11 @@ func (i *IdentityStore) UpsertGroupInTxn(ctx context.Context, txn *memdb.Txn, gr
 	var err error
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	if group == nil {
-		return fmt.Errorf("group is nil")
+		return errors.New("group is nil")
 	}
 
 	// Increment the modify index of the group
@@ -1673,11 +1673,11 @@ func (i *IdentityStore) UpsertGroupInTxn(ctx context.Context, txn *memdb.Txn, gr
 
 func (i *IdentityStore) MemDBUpsertGroupInTxn(txn *memdb.Txn, group *identity.Group) error {
 	if txn == nil {
-		return fmt.Errorf("nil txn")
+		return errors.New("nil txn")
 	}
 
 	if group == nil {
-		return fmt.Errorf("group is nil")
+		return errors.New("group is nil")
 	}
 
 	if group.NamespaceID == "" {
@@ -1709,7 +1709,7 @@ func (i *IdentityStore) MemDBDeleteGroupByIDInTxn(txn *memdb.Txn, groupID string
 	}
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	group, err := i.MemDBGroupByIDInTxn(txn, groupID, false)
@@ -1731,11 +1731,11 @@ func (i *IdentityStore) MemDBDeleteGroupByIDInTxn(txn *memdb.Txn, groupID string
 
 func (i *IdentityStore) MemDBGroupByIDInTxn(txn *memdb.Txn, groupID string, clone bool) (*identity.Group, error) {
 	if groupID == "" {
-		return nil, fmt.Errorf("missing group ID")
+		return nil, errors.New("missing group ID")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	groupRaw, err := txn.First(groupsTable, "id", groupID)
@@ -1749,7 +1749,7 @@ func (i *IdentityStore) MemDBGroupByIDInTxn(txn *memdb.Txn, groupID string, clon
 
 	group, ok := groupRaw.(*identity.Group)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched group")
+		return nil, errors.New("failed to declare the type of fetched group")
 	}
 
 	if clone {
@@ -1761,7 +1761,7 @@ func (i *IdentityStore) MemDBGroupByIDInTxn(txn *memdb.Txn, groupID string, clon
 
 func (i *IdentityStore) MemDBGroupByID(groupID string, clone bool) (*identity.Group, error) {
 	if groupID == "" {
-		return nil, fmt.Errorf("missing group ID")
+		return nil, errors.New("missing group ID")
 	}
 
 	txn := i.db.Txn(false)
@@ -1771,7 +1771,7 @@ func (i *IdentityStore) MemDBGroupByID(groupID string, clone bool) (*identity.Gr
 
 func (i *IdentityStore) MemDBGroupsByParentGroupIDInTxn(txn *memdb.Txn, memberGroupID string, clone bool) ([]*identity.Group, error) {
 	if memberGroupID == "" {
-		return nil, fmt.Errorf("missing member group ID")
+		return nil, errors.New("missing member group ID")
 	}
 
 	groupsIter, err := txn.Get(groupsTable, "parent_group_ids", memberGroupID)
@@ -1796,7 +1796,7 @@ func (i *IdentityStore) MemDBGroupsByParentGroupIDInTxn(txn *memdb.Txn, memberGr
 
 func (i *IdentityStore) MemDBGroupsByParentGroupID(memberGroupID string, clone bool) ([]*identity.Group, error) {
 	if memberGroupID == "" {
-		return nil, fmt.Errorf("missing member group ID")
+		return nil, errors.New("missing member group ID")
 	}
 
 	txn := i.db.Txn(false)
@@ -1813,7 +1813,7 @@ func (i *IdentityStore) MemDBGroupsByMemberEntityID(entityID string, clone bool,
 
 func (i *IdentityStore) MemDBGroupsByMemberEntityIDInTxn(txn *memdb.Txn, entityID string, clone bool, externalOnly bool) ([]*identity.Group, error) {
 	if entityID == "" {
-		return nil, fmt.Errorf("missing entity ID")
+		return nil, errors.New("missing entity ID")
 	}
 
 	groupsIter, err := txn.Get(groupsTable, "member_entity_ids", entityID)
@@ -1841,7 +1841,7 @@ func (i *IdentityStore) MemDBGroupsByMemberEntityIDInTxn(txn *memdb.Txn, entityI
 
 func (i *IdentityStore) groupPoliciesByEntityID(entityID string) (map[string][]string, error) {
 	if entityID == "" {
-		return nil, fmt.Errorf("empty entity ID")
+		return nil, errors.New("empty entity ID")
 	}
 
 	groups, err := i.MemDBGroupsByMemberEntityID(entityID, false, false)
@@ -1863,7 +1863,7 @@ func (i *IdentityStore) groupPoliciesByEntityID(entityID string) (map[string][]s
 
 func (i *IdentityStore) groupsByEntityID(entityID string) ([]*identity.Group, []*identity.Group, error) {
 	if entityID == "" {
-		return nil, nil, fmt.Errorf("empty entity ID")
+		return nil, nil, errors.New("empty entity ID")
 	}
 
 	groups, err := i.MemDBGroupsByMemberEntityID(entityID, true, false)
@@ -1897,7 +1897,7 @@ func (i *IdentityStore) groupsByEntityID(entityID string) ([]*identity.Group, []
 	// For sanity
 	// There should not be any group that gets deleted
 	if len(diff.Deleted) != 0 {
-		return nil, nil, fmt.Errorf("failed to diff group memberships")
+		return nil, nil, errors.New("failed to diff group memberships")
 	}
 
 	return diff.Unmodified, diff.New, nil
@@ -1905,7 +1905,7 @@ func (i *IdentityStore) groupsByEntityID(entityID string) ([]*identity.Group, []
 
 func (i *IdentityStore) collectGroupsReverseDFS(group *identity.Group, visited map[string]bool, groups []*identity.Group) ([]*identity.Group, error) {
 	if group == nil {
-		return nil, fmt.Errorf("nil group")
+		return nil, errors.New("nil group")
 	}
 
 	// If traversal for a groupID is performed before, skip it
@@ -1936,7 +1936,7 @@ func (i *IdentityStore) collectGroupsReverseDFS(group *identity.Group, visited m
 
 func (i *IdentityStore) collectPoliciesReverseDFS(group *identity.Group, visited map[string]bool, policies map[string][]string) error {
 	if group == nil {
-		return fmt.Errorf("nil group")
+		return errors.New("nil group")
 	}
 
 	// If traversal for a groupID is performed before, skip it
@@ -2055,11 +2055,11 @@ OUTER:
 
 func (i *IdentityStore) MemDBGroupsByBucketKeyInTxn(txn *memdb.Txn, bucketKey string) ([]*identity.Group, error) {
 	if txn == nil {
-		return nil, fmt.Errorf("nil txn")
+		return nil, errors.New("nil txn")
 	}
 
 	if bucketKey == "" {
-		return nil, fmt.Errorf("empty bucket key")
+		return nil, errors.New("empty bucket key")
 	}
 
 	groupsIter, err := txn.Get(groupsTable, "bucket_key", bucketKey)
@@ -2077,11 +2077,11 @@ func (i *IdentityStore) MemDBGroupsByBucketKeyInTxn(txn *memdb.Txn, bucketKey st
 
 func (i *IdentityStore) MemDBGroupByAliasIDInTxn(txn *memdb.Txn, aliasID string, clone bool) (*identity.Group, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	alias, err := i.MemDBAliasByIDInTxn(txn, aliasID, false, true)
@@ -2098,7 +2098,7 @@ func (i *IdentityStore) MemDBGroupByAliasIDInTxn(txn *memdb.Txn, aliasID string,
 
 func (i *IdentityStore) MemDBGroupByAliasID(aliasID string, clone bool) (*identity.Group, error) {
 	if aliasID == "" {
-		return nil, fmt.Errorf("missing alias ID")
+		return nil, errors.New("missing alias ID")
 	}
 
 	txn := i.db.Txn(false)
@@ -2110,7 +2110,7 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Co
 	defer metrics.MeasureSince([]string{"identity", "refresh_external_groups"}, time.Now())
 
 	if entityID == "" {
-		return nil, fmt.Errorf("empty entity ID")
+		return nil, errors.New("empty entity ID")
 	}
 
 	refreshFunc := func(dryRun bool) (bool, []*logical.Alias, error) {

--- a/vault/init.go
+++ b/vault/init.go
@@ -110,7 +110,7 @@ func (c *Core) InitializedLocally(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	if sealConf == nil {
-		return false, fmt.Errorf("core: barrier reports initialized but no seal configuration found")
+		return false, errors.New("core: barrier reports initialized but no seal configuration found")
 	}
 
 	return true, nil
@@ -170,7 +170,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	// operators.
 	if c.SealAccess().StoredKeysSupported() == seal.StoredKeysSupportedGeneric {
 		if len(barrierConfig.PGPKeys) > 0 {
-			return nil, fmt.Errorf("PGP keys not supported when storing shares")
+			return nil, errors.New("PGP keys not supported when storing shares")
 		}
 		barrierConfig.SecretShares = 1
 		barrierConfig.SecretThreshold = 1
@@ -182,22 +182,22 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	barrierConfig.StoredShares = 1
 
 	if len(barrierConfig.PGPKeys) > 0 && len(barrierConfig.PGPKeys) != barrierConfig.SecretShares {
-		return nil, fmt.Errorf("incorrect number of PGP keys")
+		return nil, errors.New("incorrect number of PGP keys")
 	}
 
 	if c.SealAccess().RecoveryKeySupported() {
 		if len(recoveryConfig.PGPKeys) > 0 && len(recoveryConfig.PGPKeys) != recoveryConfig.SecretShares {
-			return nil, fmt.Errorf("incorrect number of PGP keys for recovery")
+			return nil, errors.New("incorrect number of PGP keys for recovery")
 		}
 	}
 
 	if c.seal.RecoveryKeySupported() {
 		if recoveryConfig == nil {
-			return nil, fmt.Errorf("recovery configuration must be supplied")
+			return nil, errors.New("recovery configuration must be supplied")
 		}
 
 		if recoveryConfig.SecretShares < 1 {
-			return nil, fmt.Errorf("recovery configuration must specify a positive number of shares")
+			return nil, errors.New("recovery configuration must specify a positive number of shares")
 		}
 
 		// Check if the seal configuration is valid

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -61,7 +61,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	if init {
-		t.Fatalf("should not be init")
+		t.Fatal("should not be init")
 	}
 
 	// Check the seal configuration
@@ -117,7 +117,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	if !init {
-		t.Fatalf("should be init")
+		t.Fatal("should be init")
 	}
 
 	// Check the seal configuration
@@ -158,7 +158,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	if !init {
-		t.Fatalf("should be init")
+		t.Fatal("should be init")
 	}
 
 	// Check the seal configuration

--- a/vault/inspectable_test.go
+++ b/vault/inspectable_test.go
@@ -41,7 +41,7 @@ func TestInspectRouter(t *testing.T) {
 			// Verify that data exists
 			data, ok := resp.Data[tag].([]map[string]interface{})
 			if !ok {
-				t.Fatalf("Router data is malformed")
+				t.Fatal("Router data is malformed")
 			}
 			for _, entry := range data {
 				for _, field := range subTreeFields[subTreeType] {

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -144,7 +145,7 @@ func (k *Keyring) AddKey(key *Key) (*Keyring, error) {
 func (k *Keyring) RemoveKey(term uint32) (*Keyring, error) {
 	// Ensure this is not the active key
 	if term == k.activeTerm {
-		return nil, fmt.Errorf("cannot remove active key")
+		return nil, errors.New("cannot remove active key")
 	}
 
 	// Check if this term does not exist

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -163,7 +163,7 @@ func TestKeyring_Serialize(t *testing.T) {
 	}
 
 	if k2.ActiveTerm() != k.ActiveTerm() {
-		t.Fatalf("Term mismatch")
+		t.Fatal("Term mismatch")
 	}
 
 	var i uint32

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,7 @@ func CubbyholeBackendFactory(ctx context.Context, conf *logical.BackendConfig) (
 	b.Backend.Paths = append(b.Backend.Paths, b.paths()...)
 
 	if conf == nil {
-		return nil, fmt.Errorf("configuration passed into backend is nil")
+		return nil, errors.New("configuration passed into backend is nil")
 	}
 	b.Backend.Setup(ctx, conf)
 
@@ -109,7 +110,7 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 
 func (b *CubbyholeBackend) revoke(ctx context.Context, view BarrierView, saltedToken string) error {
 	if saltedToken == "" {
-		return fmt.Errorf("client token empty during revocation")
+		return errors.New("client token empty during revocation")
 	}
 
 	if err := logical.ClearView(ctx, view.SubView(saltedToken+"/")); err != nil {
@@ -130,13 +131,13 @@ func (b *CubbyholeBackend) handleExistenceCheck(ctx context.Context, req *logica
 
 func (b *CubbyholeBackend) handleRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if req.ClientToken == "" {
-		return nil, fmt.Errorf("client token empty")
+		return nil, errors.New("client token empty")
 	}
 
 	path := data.Get("path").(string)
 
 	if path == "" {
-		return nil, fmt.Errorf("missing path")
+		return nil, errors.New("missing path")
 	}
 
 	// Read the path
@@ -166,17 +167,17 @@ func (b *CubbyholeBackend) handleRead(ctx context.Context, req *logical.Request,
 
 func (b *CubbyholeBackend) handleWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if req.ClientToken == "" {
-		return nil, fmt.Errorf("client token empty")
+		return nil, errors.New("client token empty")
 	}
 	// Check that some fields are given
 	if len(req.Data) == 0 {
-		return nil, fmt.Errorf("missing data fields")
+		return nil, errors.New("missing data fields")
 	}
 
 	path := data.Get("path").(string)
 
 	if path == "" {
-		return nil, fmt.Errorf("missing path")
+		return nil, errors.New("missing path")
 	}
 
 	// JSON encode the data
@@ -202,7 +203,7 @@ func (b *CubbyholeBackend) handleWrite(ctx context.Context, req *logical.Request
 
 func (b *CubbyholeBackend) handleDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if req.ClientToken == "" {
-		return nil, fmt.Errorf("client token empty")
+		return nil, errors.New("client token empty")
 	}
 
 	path := data.Get("path").(string)
@@ -217,7 +218,7 @@ func (b *CubbyholeBackend) handleDelete(ctx context.Context, req *logical.Reques
 
 func (b *CubbyholeBackend) handleList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if req.ClientToken == "" {
-		return nil, fmt.Errorf("client token empty")
+		return nil, errors.New("client token empty")
 	}
 
 	// Right now we only handle directories, so ensure it ends with / We also

--- a/vault/logical_cubbyhole_test.go
+++ b/vault/logical_cubbyhole_test.go
@@ -243,7 +243,7 @@ func TestCubbyholeIsolation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp != nil {
-		t.Fatalf("err: was able to read from other user's cubbyhole")
+		t.Fatal("err: was able to read from other user's cubbyhole")
 	}
 
 	req = logical.TestRequest(t, logical.ReadOperation, "bar")
@@ -254,7 +254,7 @@ func TestCubbyholeIsolation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp != nil {
-		t.Fatalf("err: was able to read from other user's cubbyhole")
+		t.Fatal("err: was able to read from other user's cubbyhole")
 	}
 }
 

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -95,7 +96,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 	}
 
 	if conf == nil {
-		return nil, fmt.Errorf("configuration passed into backend is nil")
+		return nil, errors.New("configuration passed into backend is nil")
 	}
 	b.Backend.Setup(ctx, conf)
 

--- a/vault/logical_passthrough_test.go
+++ b/vault/logical_passthrough_test.go
@@ -45,7 +45,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if out == nil {
-			t.Fatalf("failed to write to view")
+			t.Fatal("failed to write to view")
 		}
 	}
 	b := testPassthroughBackend()

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -301,7 +301,7 @@ func processLimit(d *framework.FieldData) (bool, int, error) {
 		}
 
 		if limit < 1 {
-			return false, 0, fmt.Errorf("limit must be 'none' or a positive integer")
+			return false, 0, errors.New("limit must be 'none' or a positive integer")
 		}
 
 		maxResults = limit
@@ -738,7 +738,7 @@ func (b *SystemBackend) handleCapabilities(ctx context.Context, req *logical.Req
 		}
 	}
 	if token == "" {
-		return nil, fmt.Errorf("no token found")
+		return nil, errors.New("no token found")
 	}
 
 	ret := &logical.Response{
@@ -1209,7 +1209,7 @@ func handleErrorNoReadOnlyForward(
 	err error,
 ) (*logical.Response, error) {
 	if strings.Contains(err.Error(), logical.ErrReadOnly.Error()) {
-		return nil, fmt.Errorf("operation could not be completed as storage is read-only")
+		return nil, errors.New("operation could not be completed as storage is read-only")
 	}
 	switch err.(type) {
 	case logical.HTTPCodedError:
@@ -3468,11 +3468,11 @@ func (b *SystemBackend) responseWrappingUnwrap(ctx context.Context, te *logical.
 
 	responseRaw := cubbyResp.Data["response"]
 	if responseRaw == nil {
-		return "", fmt.Errorf("no response found inside the cubbyhole")
+		return "", errors.New("no response found inside the cubbyhole")
 	}
 	response, ok := responseRaw.(string)
 	if !ok {
-		return "", fmt.Errorf("could not decode response inside the cubbyhole")
+		return "", errors.New("could not decode response inside the cubbyhole")
 	}
 
 	return response, nil
@@ -3558,7 +3558,7 @@ func (b *SystemBackend) handleMonitor(ctx context.Context, req *logical.Request,
 	defer mon.Stop()
 
 	if logCh == nil {
-		return nil, fmt.Errorf("error trying to start a monitor that's already been started")
+		return nil, errors.New("error trying to start a monitor that's already been started")
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -3795,7 +3795,7 @@ func (b *SystemBackend) handleWrappingRewrap(ctx context.Context, req *logical.R
 	// Set the creation TTL on the request
 	creationTTLRaw := cubbyResp.Data["creation_ttl"]
 	if creationTTLRaw == nil {
-		return nil, fmt.Errorf("creation_ttl value in wrapping information was nil")
+		return nil, errors.New("creation_ttl value in wrapping information was nil")
 	}
 	creationTTL, err := cubbyResp.Data["creation_ttl"].(json.Number).Int64()
 	if err != nil {
@@ -3805,7 +3805,7 @@ func (b *SystemBackend) handleWrappingRewrap(ctx context.Context, req *logical.R
 	// Get creation_path to return as the response later
 	creationPathRaw := cubbyResp.Data["creation_path"]
 	if creationPathRaw == nil {
-		return nil, fmt.Errorf("creation_path value in wrapping information was nil")
+		return nil, errors.New("creation_path value in wrapping information was nil")
 	}
 	creationPath := creationPathRaw.(string)
 
@@ -3832,7 +3832,7 @@ func (b *SystemBackend) handleWrappingRewrap(ctx context.Context, req *logical.R
 
 	response := cubbyResp.Data["response"]
 	if response == nil {
-		return nil, fmt.Errorf("no response found inside the cubbyhole")
+		return nil, errors.New("no response found inside the cubbyhole")
 	}
 
 	// Return response in "response"; wrapping code will detect the rewrap and
@@ -4552,7 +4552,7 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 			return nil, err
 		}
 		if cluster == nil {
-			return nil, fmt.Errorf("failed to fetch cluster details")
+			return nil, errors.New("failed to fetch cluster details")
 		}
 		clusterName = cluster.Name
 		clusterID = cluster.ID
@@ -4943,7 +4943,7 @@ func checkListingVisibility(visibility ListingVisibilityType) error {
 	case ListingVisibilityHidden:
 	case ListingVisibilityUnauth:
 	default:
-		return fmt.Errorf("invalid listing visibility type")
+		return errors.New("invalid listing visibility type")
 	}
 
 	return nil

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -17,7 +18,7 @@ var pathInternalUINamespacesRead = func(b *SystemBackend) framework.OperationFun
 	return func(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 		// Short-circuit here if there's no client token provided
 		if req.ClientToken == "" {
-			return nil, fmt.Errorf("client token empty")
+			return nil, errors.New("client token empty")
 		}
 
 		// Load the ACL policies so we can check for access and filter namespaces
@@ -75,7 +76,7 @@ func (b *SystemBackend) tuneMountTTLs(ctx context.Context, path string, me *Moun
 	if err != nil {
 		me.Config.MaxLeaseTTL = origMax
 		me.Config.DefaultLeaseTTL = origDefault
-		return fmt.Errorf("failed to update mount table, rolling back TTL changes")
+		return errors.New("failed to update mount table, rolling back TTL changes")
 	}
 	if b.Core.logger.IsInfo() {
 		b.Core.logger.Info("mount tuning of leases successful", "path", path)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -449,7 +449,7 @@ func TestSystemBackend_mount_force_no_cache(t *testing.T) {
 
 	mountEntry := core.router.MatchingMountEntry(namespace.RootContext(nil), "prod/secret/")
 	if mountEntry == nil {
-		t.Fatalf("missing mount entry")
+		t.Fatal("missing mount entry")
 	}
 	if !mountEntry.Config.ForceNoCache {
 		t.Fatalf("bad config %#v", mountEntry)
@@ -1480,7 +1480,7 @@ func TestSystemBackend_renew(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp2.IsError() {
-		t.Fatalf("got an error")
+		t.Fatal("got an error")
 	}
 	if resp2.Data == nil {
 		t.Fatal("nil data")
@@ -1497,7 +1497,7 @@ func TestSystemBackend_renew(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp2.IsError() {
-		t.Fatalf("got an error")
+		t.Fatal("got an error")
 	}
 	if resp2.Data == nil {
 		t.Fatal("nil data")
@@ -1514,7 +1514,7 @@ func TestSystemBackend_renew(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp2.IsError() {
-		t.Fatalf("got an error")
+		t.Fatal("got an error")
 	}
 	if resp2.Data == nil {
 		t.Fatal("nil data")
@@ -2554,7 +2554,7 @@ func TestSystemBackend_decodeToken(t *testing.T) {
 		req.Data = data
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
-			t.Fatalf("no error despite missing payload")
+			t.Fatal("no error despite missing payload")
 		}
 		schema.ValidateResponse(
 			t,
@@ -2595,7 +2595,7 @@ func TestSystemBackend_auditHash(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp == nil || resp.Data == nil {
-		t.Fatalf("response or its data was nil")
+		t.Fatal("response or its data was nil")
 	}
 
 	schema.ValidateResponse(
@@ -2814,7 +2814,7 @@ func TestSystemBackend_rawRead_Compressed(t *testing.T) {
 		req = logical.TestRequest(t, logical.ReadOperation, "raw/test_raw")
 		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
-			t.Fatalf("expected error if trying to read uncompressed entry with prefix byte")
+			t.Fatal("expected error if trying to read uncompressed entry with prefix byte")
 		}
 		if !resp.IsError() {
 			t.Fatalf("bad: %v", resp)
@@ -2890,19 +2890,19 @@ func TestSystemBackend_rawWrite_ExistanceCheck(t *testing.T) {
 	req := logical.TestRequest(t, logical.CreateOperation, "raw/core/audit")
 	_, exist, err := b.HandleExistenceCheck(namespace.RootContext(nil), req)
 	if err != nil {
-		t.Fatalf("err: #{err}")
+		t.Fatal("err: #{err}")
 	}
 	if !exist {
-		t.Fatalf("raw existence check failed for actual key")
+		t.Fatal("raw existence check failed for actual key")
 	}
 
 	req = logical.TestRequest(t, logical.CreateOperation, "raw/non_existent")
 	_, exist, err = b.HandleExistenceCheck(namespace.RootContext(nil), req)
 	if err != nil {
-		t.Fatalf("err: #{err}")
+		t.Fatal("err: #{err}")
 	}
 	if exist {
-		t.Fatalf("raw existence check failed for non-existent key")
+		t.Fatal("raw existence check failed for non-existent key")
 	}
 }
 
@@ -2944,7 +2944,7 @@ func TestSystemBackend_rawReadWrite_base64(t *testing.T) {
 		}
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
-			t.Fatalf("no error")
+			t.Fatal("no error")
 		}
 
 		if err != logical.ErrInvalidRequest {
@@ -2966,7 +2966,7 @@ func TestSystemBackend_rawReadWrite_base64(t *testing.T) {
 		}
 		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
-			t.Fatalf("no error")
+			t.Fatal("no error")
 		}
 
 		if err != logical.ErrInvalidRequest {
@@ -3262,7 +3262,7 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if out != nil {
-		t.Fatalf("policy should be gone")
+		t.Fatal("policy should be gone")
 	}
 }
 
@@ -4243,7 +4243,7 @@ func TestSystemBackend_OpenAPI(t *testing.T) {
 		}
 
 		if doc.Paths["/rotate"] == nil {
-			t.Fatalf("expected to find path '/rotate'")
+			t.Fatal("expected to find path '/rotate'")
 		}
 	}
 }
@@ -4478,7 +4478,7 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 
 			actualResp, err := b.handlePoliciesPasswordSet(ctx, req, test.inputData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -4579,7 +4579,7 @@ func TestHandlePoliciesPasswordGet(t *testing.T) {
 
 			actualResp, err := b.handlePoliciesPasswordGet(ctx, req, test.inputData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -4679,7 +4679,7 @@ func TestHandlePoliciesPasswordDelete(t *testing.T) {
 
 			actualResp, err := b.handlePoliciesPasswordDelete(ctx, req, test.inputData)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -4845,7 +4845,7 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 
 			actualResp, err := b.handlePoliciesPasswordList(ctx, req, nil)
 			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+				t.Fatal("err expected, got nil")
 			}
 			if !test.expectErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
@@ -4938,7 +4938,7 @@ func TestHandlePoliciesPasswordGenerate(t *testing.T) {
 
 				actualResp, err := b.handlePoliciesPasswordGenerate(ctx, req, test.inputData)
 				if test.expectErr && err == nil {
-					t.Fatalf("err expected, got nil")
+					t.Fatal("err expected, got nil")
 				}
 				if !test.expectErr && err != nil {
 					t.Fatalf("no error expected, got: %s", err)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -5110,10 +5111,10 @@ type walkFunc func(*logical.StorageEntry) error
 // - vault/helper/testhelpers/teststorage
 func WalkLogicalStorage(ctx context.Context, store logical.Storage, walker walkFunc) (err error) {
 	if store == nil {
-		return fmt.Errorf("no storage provided")
+		return errors.New("no storage provided")
 	}
 	if walker == nil {
-		return fmt.Errorf("no walk function provided")
+		return errors.New("no walk function provided")
 	}
 
 	keys, err := store.List(ctx, "")

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1918,7 +1918,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 	case "deny":
 		return fmt.Errorf(preauth.Response.Status_Msg)
 	case "enroll":
-		return fmt.Errorf(fmt.Sprintf("%q - %q", preauth.Response.Status_Msg, preauth.Response.Enroll_Portal_Url))
+		return fmt.Errorf("%q - %q", preauth.Response.Status_Msg, preauth.Response.Enroll_Portal_Url)
 	case "auth":
 		break
 	default:

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -548,7 +548,7 @@ func (i *IdentityStore) handleLoginMFAAdminDestroyUpdate(ctx context.Context, re
 	}
 
 	if mConfig.Type != mfaMethodTypeTOTP {
-		return nil, fmt.Errorf("method ID does not match TOTP type")
+		return nil, errors.New("method ID does not match TOTP type")
 	}
 
 	ns, err := namespace.FromContext(ctx)
@@ -786,11 +786,11 @@ func (b *LoginMFABackend) handleMFALoginValidate(ctx context.Context, req *logic
 	// finding the MFAEnforcement config that matches our ns. ns could be root as well
 	matchedMfaEnforcementList, err := b.Core.buildMFAEnforcementConfigList(ctx, entity, cachedResponseAuth.RequestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find MFAEnforcement configuration")
+		return nil, errors.New("failed to find MFAEnforcement configuration")
 	}
 
 	if len(matchedMfaEnforcementList) == 0 {
-		return nil, fmt.Errorf("found nil or empty MFAEnforcement configuration")
+		return nil, errors.New("found nil or empty MFAEnforcement configuration")
 	}
 
 	for _, eConfig := range matchedMfaEnforcementList {
@@ -1090,7 +1090,7 @@ func (b *MFABackend) handleMFAGenerateTOTP(ctx context.Context, mConfig *mfa.Con
 	var totpConfig *mfa.TOTPConfig
 
 	if b.Core.identityStore == nil {
-		return nil, fmt.Errorf("identity store not set up, cannot service totp mfa requests")
+		return nil, errors.New("identity store not set up, cannot service totp mfa requests")
 	}
 
 	switch mConfig.Config.(type) {
@@ -1189,17 +1189,17 @@ func (b *MFABackend) handleMFAGenerateTOTP(ctx context.Context, mConfig *mfa.Con
 func parseDuoConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	secretKey := d.Get("secret_key").(string)
 	if secretKey == "" {
-		return fmt.Errorf("secret_key is empty")
+		return errors.New("secret_key is empty")
 	}
 
 	integrationKey := d.Get("integration_key").(string)
 	if integrationKey == "" {
-		return fmt.Errorf("integration_key is empty")
+		return errors.New("integration_key is empty")
 	}
 
 	apiHostname := d.Get("api_hostname").(string)
 	if apiHostname == "" {
-		return fmt.Errorf("api_hostname is empty")
+		return errors.New("api_hostname is empty")
 	}
 
 	config := &mfa.DuoConfig{
@@ -1220,7 +1220,7 @@ func parseDuoConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 func parsePingIDConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	fileString := d.Get("settings_file_base64").(string)
 	if fileString == "" {
-		return fmt.Errorf("settings_file_base64 is empty")
+		return errors.New("settings_file_base64 is empty")
 	}
 
 	fileBytes, err := base64.StdEncoding.DecodeString(fileString)
@@ -1485,11 +1485,11 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 
 func parseTOTPConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	if mConfig == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	if d == nil {
-		return fmt.Errorf("field data is nil")
+		return errors.New("field data is nil")
 	}
 
 	algorithm := d.Get("algorithm").(string)
@@ -1502,7 +1502,7 @@ func parseTOTPConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	case "SHA512":
 		keyAlgorithm = otplib.AlgorithmSHA512
 	default:
-		return fmt.Errorf("unrecognized algorithm")
+		return errors.New("unrecognized algorithm")
 	}
 
 	digits := d.Get("digits").(int)
@@ -1513,12 +1513,12 @@ func parseTOTPConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	case 8:
 		keyDigits = otplib.DigitsEight
 	default:
-		return fmt.Errorf("digits can only be 6 or 8")
+		return errors.New("digits can only be 6 or 8")
 	}
 
 	period := d.Get("period").(int)
 	if period <= 0 {
-		return fmt.Errorf("period must be greater than zero")
+		return errors.New("period must be greater than zero")
 	}
 
 	skew := d.Get("skew").(int)
@@ -1526,22 +1526,22 @@ func parseTOTPConfig(mConfig *mfa.Config, d *framework.FieldData) error {
 	case 0:
 	case 1:
 	default:
-		return fmt.Errorf("skew must be 0 or 1")
+		return errors.New("skew must be 0 or 1")
 	}
 
 	keySize := d.Get("key_size").(int)
 	if keySize <= 0 {
-		return fmt.Errorf("key_size must be greater than zero")
+		return errors.New("key_size must be greater than zero")
 	}
 
 	issuer := d.Get("issuer").(string)
 	if issuer == "" {
-		return fmt.Errorf("issuer must be set")
+		return errors.New("issuer must be set")
 	}
 
 	maxValidationAttempt := d.Get("max_validation_attempts").(int)
 	if maxValidationAttempt < 0 {
-		return fmt.Errorf("max_validation_attempts must be greater than zero")
+		return errors.New("max_validation_attempts must be greater than zero")
 	}
 	if maxValidationAttempt == 0 {
 		maxValidationAttempt = defaultMaxTOTPValidateAttempts
@@ -1652,17 +1652,17 @@ func (c *Core) validateLoginMFA(ctx context.Context, eConfig *mfa.MFAEnforcement
 
 func (c *Core) validateLoginMFAInternal(ctx context.Context, methodID string, entity *identity.Entity, reqConnectionRemoteAddress string, mfaCreds []string) (retErr error) {
 	if entity == nil {
-		return fmt.Errorf("entity is nil")
+		return errors.New("entity is nil")
 	}
 
 	// Get the configuration for the MFA method set in system backend
 	mConfig, err := c.loginMFABackend.MemDBMFAConfigByID(methodID)
 	if err != nil {
-		return fmt.Errorf("failed to read MFA configuration")
+		return errors.New("failed to read MFA configuration")
 	}
 
 	if mConfig == nil {
-		return fmt.Errorf("MFA method configuration not present")
+		return errors.New("MFA method configuration not present")
 	}
 
 	var finalUsername string
@@ -1748,7 +1748,7 @@ ECONFIG_LOOP:
 		// i.e. is it the req's ns or an ancestor of req's ns?
 		eConfigNS, err := c.NamespaceByID(ctx, eConfig.NamespaceID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find the MFAEnforcementConfig namespace")
+			return nil, errors.New("failed to find the MFAEnforcementConfig namespace")
 		}
 
 		if eConfig == nil || eConfigNS == nil || (eConfigNS.ID != ns.ID && !ns.HasParent(eConfigNS)) {
@@ -1759,7 +1759,7 @@ ECONFIG_LOOP:
 		// having mount type/accessor
 		if entity != nil {
 			if entity.NamespaceID != ns.ID {
-				return nil, fmt.Errorf("entity namespace ID is different than the current ns ID")
+				return nil, errors.New("entity namespace ID is different than the current ns ID")
 			}
 
 			// Check if entityID is in the MFAEnforcement config
@@ -1771,7 +1771,7 @@ ECONFIG_LOOP:
 			// Retrieve entity groups
 			directGroups, inheritedGroups, err := c.identityStore.groupsByEntityID(entity.ID)
 			if err != nil {
-				return nil, fmt.Errorf("error on retrieving groups by entityID in MFA")
+				return nil, errors.New("error on retrieving groups by entityID in MFA")
 			}
 			for _, g := range directGroups {
 				if strutil.StrListContains(eConfig.IdentityGroupIds, g.ID) {
@@ -1835,12 +1835,12 @@ func parseMfaFactors(creds []string) (*MFAFactor, error) {
 			continue
 		case strings.HasPrefix(cred, "passcode="):
 			if mfaFactor.passcode != "" {
-				return nil, fmt.Errorf("found multiple passcodes for the same MFA method")
+				return nil, errors.New("found multiple passcodes for the same MFA method")
 			}
 
 			splits := strings.SplitN(cred, "=", 2)
 			if splits[1] == "" {
-				return nil, fmt.Errorf("invalid passcode")
+				return nil, errors.New("invalid passcode")
 			}
 
 			mfaFactor.passcode = splits[1]
@@ -1850,7 +1850,7 @@ func parseMfaFactors(creds []string) (*MFAFactor, error) {
 			// a non-empty cred that does not match the above
 			// means it is a passcode
 			if mfaFactor.passcode != "" {
-				return nil, fmt.Errorf("found multiple passcodes for the same MFA method")
+				return nil, errors.New("found multiple passcodes for the same MFA method")
 			}
 			mfaFactor.passcode = cred
 		}
@@ -1906,7 +1906,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		return errwrap.Wrapf("failed to perform Duo preauth: {{err}}", err)
 	}
 	if preauth == nil {
-		return fmt.Errorf("failed to perform Duo preauth")
+		return errors.New("failed to perform Duo preauth")
 	}
 	if preauth.StatResult.Stat != "OK" {
 		return fmt.Errorf("failed to perform Duo preauth: %q - %q", *preauth.StatResult.Message, *preauth.StatResult.Message_Detail)
@@ -1949,7 +1949,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		return fmt.Errorf("failed to authenticate with Duo: %q - %q", *result.StatResult.Message, *result.StatResult.Message_Detail)
 	}
 	if result.Response.Txid == "" {
-		return fmt.Errorf("failed to get transaction ID for Duo authentication")
+		return errors.New("failed to get transaction ID for Duo authentication")
 	}
 
 	for {
@@ -1977,7 +1977,7 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return fmt.Errorf("duo push verification operation canceled")
+			return errors.New("duo push verification operation canceled")
 		case <-timer.C:
 		}
 	}
@@ -2021,9 +2021,9 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 	}
 	switch {
 	case len(users) == 0:
-		return fmt.Errorf("no users found for e-mail address")
+		return errors.New("no users found for e-mail address")
 	case len(users) > 1:
-		return fmt.Errorf("more than one user found for e-mail address")
+		return errors.New("more than one user found for e-mail address")
 	}
 
 	user := users[0]
@@ -2034,7 +2034,7 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 	}
 
 	if len(factors) == 0 {
-		return fmt.Errorf("no MFA factors found for user")
+		return errors.New("no MFA factors found for user")
 	}
 
 	var factorFound bool
@@ -2050,7 +2050,7 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 	}
 
 	if !factorFound {
-		return fmt.Errorf("no push-type MFA factor found for user")
+		return errors.New("no push-type MFA factor found for user")
 	}
 
 	result, _, err := client.UserFactor.VerifyFactor(ctx, user.Id, userFactor.Id, okta.VerifyFactorRequest{}, userFactor, nil)
@@ -2097,18 +2097,18 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 		case "SUCCESS":
 			return nil
 		case "REJECTED":
-			return fmt.Errorf("push verification explicitly rejected")
+			return errors.New("push verification explicitly rejected")
 		case "TIMEOUT":
-			return fmt.Errorf("push verification timed out")
+			return errors.New("push verification timed out")
 		default:
-			return fmt.Errorf("unknown status code")
+			return errors.New("unknown status code")
 		}
 		timer := time.NewTimer(time.Second)
 
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return fmt.Errorf("push verification operation canceled")
+			return errors.New("push verification operation canceled")
 		case <-timer.C:
 		}
 	}
@@ -2182,10 +2182,10 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 			return nil, err
 		}
 		if resp == nil {
-			return nil, fmt.Errorf("nil response from pingid")
+			return nil, errors.New("nil response from pingid")
 		}
 		if resp.Body == nil {
-			return nil, fmt.Errorf("nil body in pingid response")
+			return nil, errors.New("nil body in pingid response")
 		}
 		bodyBytes := bytes.NewBuffer(nil)
 		_, err = bodyBytes.ReadFrom(resp.Body)
@@ -2211,7 +2211,7 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 			return nil, fmt.Errorf("%q header not found", "token")
 		}
 		if headerTokenStr, ok := token.Header["token"].(string); !ok || headerTokenStr != pingConfig.Token {
-			return nil, fmt.Errorf("invalid token in ping response")
+			return nil, errors.New("invalid token in ping response")
 		}
 
 		// validate org alias
@@ -2221,12 +2221,12 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 		oa := token.Header["orgAlias"]
 		if oa == nil {
 			if oa = token.Header["org_alias"]; oa == nil {
-				return nil, fmt.Errorf("neither orgAlias nor org_alias headers were found")
+				return nil, errors.New("neither orgAlias nor org_alias headers were found")
 			}
 		}
 
 		if headerOrgAliasStr, ok := oa.(string); !ok || headerOrgAliasStr != pingConfig.OrgAlias {
-			return nil, fmt.Errorf("invalid org_alias in ping response")
+			return nil, errors.New("invalid org_alias in ping response")
 		}
 		return token, nil
 	}
@@ -2280,10 +2280,10 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 		var foundPush bool
 		switch {
 		case body.ErrorID != 30007:
-			return fmt.Errorf("only pingid push authentication is currently supported")
+			return errors.New("only pingid push authentication is currently supported")
 
 		case len(body.UserDevices) == 0:
-			return fmt.Errorf("no user mfa devices returned from pingid")
+			return errors.New("no user mfa devices returned from pingid")
 
 		default:
 			for _, dev := range body.UserDevices {
@@ -2294,7 +2294,7 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 			}
 
 			if !foundPush {
-				return fmt.Errorf("no push enabled device id found from pingid")
+				return errors.New("no push enabled device id found from pingid")
 			}
 		}
 	*/
@@ -2327,13 +2327,13 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 
 func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMethodSecret *mfa.Secret, configID, entityID string, usedCodes *cache.Cache, maximumValidationAttempts uint32) error {
 	if mfaFactors == nil || mfaFactors.passcode == "" {
-		return fmt.Errorf("MFA credentials not supplied")
+		return errors.New("MFA credentials not supplied")
 	}
 	passcode := mfaFactors.passcode
 
 	totpSecret := entityMethodSecret.GetTOTPSecret()
 	if totpSecret == nil {
-		return fmt.Errorf("entity does not contain the TOTP secret")
+		return errors.New("entity does not contain the TOTP secret")
 	}
 
 	usedName := fmt.Sprintf("%s_%s", configID, passcode)
@@ -2356,14 +2356,14 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 	} else {
 		num, ok := numAttempts.(uint32)
 		if !ok {
-			return fmt.Errorf("invalid counter type returned in TOTP usedCode cache")
+			return errors.New("invalid counter type returned in TOTP usedCode cache")
 		}
 		if num == maximumValidationAttempts {
 			return fmt.Errorf("maximum TOTP validation attempts %d exceeded the allowed attempts %d. Please try again in %v seconds", num+1, maximumValidationAttempts, passcodeTTL)
 		}
 		err := usedCodes.Increment(rateLimitID, 1)
 		if err != nil {
-			return fmt.Errorf("failed to increment the TOTP code counter")
+			return errors.New("failed to increment the TOTP code counter")
 		}
 	}
 
@@ -2373,7 +2373,7 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 	}
 
 	if key == "" {
-		return fmt.Errorf("empty key for entity's TOTP secret")
+		return errors.New("empty key for entity's TOTP secret")
 	}
 
 	validateOpts := totplib.ValidateOpts{
@@ -2389,7 +2389,7 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 	}
 
 	if !valid {
-		return fmt.Errorf("failed to validate TOTP passcode")
+		return errors.New("failed to validate TOTP passcode")
 	}
 
 	// Take the key skew, add two for behind and in front, and multiply that by
@@ -2505,11 +2505,11 @@ func (b *MFABackend) MemDBUpsertMFAConfig(ctx context.Context, mConfig *mfa.Conf
 
 func (b *MFABackend) MemDBUpsertMFAConfigInTxn(txn *memdb.Txn, mConfig *mfa.Config) error {
 	if txn == nil {
-		return fmt.Errorf("nil txn")
+		return errors.New("nil txn")
 	}
 
 	if mConfig == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	mConfigRaw, err := txn.First(b.methodTable, "id", mConfig.ID)
@@ -2533,7 +2533,7 @@ func (b *MFABackend) MemDBUpsertMFAConfigInTxn(txn *memdb.Txn, mConfig *mfa.Conf
 
 func (b *LoginMFABackend) MemDBUpsertMFALoginEnforcementConfig(ctx context.Context, eConfig *mfa.MFAEnforcementConfig) error {
 	if eConfig == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	txn := b.db.Txn(true)
@@ -2561,11 +2561,11 @@ func (b *LoginMFABackend) MemDBUpsertMFALoginEnforcementConfig(ctx context.Conte
 
 func (b *LoginMFABackend) MemDBMFAConfigByIDInTxn(txn *memdb.Txn, mConfigID string) (*mfa.Config, error) {
 	if mConfigID == "" {
-		return nil, fmt.Errorf("missing config id")
+		return nil, errors.New("missing config id")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	mConfigRaw, err := txn.First(b.methodTable, "id", mConfigID)
@@ -2579,7 +2579,7 @@ func (b *LoginMFABackend) MemDBMFAConfigByIDInTxn(txn *memdb.Txn, mConfigID stri
 
 	mConfig, ok := mConfigRaw.(*mfa.Config)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched MFA config")
+		return nil, errors.New("failed to declare the type of fetched MFA config")
 	}
 
 	return mConfig.Clone()
@@ -2587,7 +2587,7 @@ func (b *LoginMFABackend) MemDBMFAConfigByIDInTxn(txn *memdb.Txn, mConfigID stri
 
 func (b *LoginMFABackend) MemDBMFAConfigByID(mConfigID string) (*mfa.Config, error) {
 	if mConfigID == "" {
-		return nil, fmt.Errorf("missing config id")
+		return nil, errors.New("missing config id")
 	}
 
 	txn := b.db.Txn(false)
@@ -2597,11 +2597,11 @@ func (b *LoginMFABackend) MemDBMFAConfigByID(mConfigID string) (*mfa.Config, err
 
 func (b *LoginMFABackend) MemDBMFAConfigByNameInTxn(ctx context.Context, txn *memdb.Txn, mConfigName string) (*mfa.Config, error) {
 	if mConfigName == "" {
-		return nil, fmt.Errorf("missing config name")
+		return nil, errors.New("missing config name")
 	}
 
 	if txn == nil {
-		return nil, fmt.Errorf("txn is nil")
+		return nil, errors.New("txn is nil")
 	}
 
 	ns, err := namespace.FromContext(ctx)
@@ -2620,7 +2620,7 @@ func (b *LoginMFABackend) MemDBMFAConfigByNameInTxn(ctx context.Context, txn *me
 
 	mConfig, ok := mConfigRaw.(*mfa.Config)
 	if !ok {
-		return nil, fmt.Errorf("failed to declare the type of fetched MFA config")
+		return nil, errors.New("failed to declare the type of fetched MFA config")
 	}
 
 	return mConfig.Clone()
@@ -2628,7 +2628,7 @@ func (b *LoginMFABackend) MemDBMFAConfigByNameInTxn(ctx context.Context, txn *me
 
 func (b *LoginMFABackend) MemDBMFAConfigByName(ctx context.Context, name string) (*mfa.Config, error) {
 	if name == "" {
-		return nil, fmt.Errorf("missing config name")
+		return nil, errors.New("missing config name")
 	}
 
 	txn := b.db.Txn(false)
@@ -2638,7 +2638,7 @@ func (b *LoginMFABackend) MemDBMFAConfigByName(ctx context.Context, name string)
 
 func (b *LoginMFABackend) MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (*mfa.MFAEnforcementConfig, error) {
 	if name == "" {
-		return nil, fmt.Errorf("missing config name")
+		return nil, errors.New("missing config name")
 	}
 
 	txn := b.db.Txn(false)
@@ -2655,7 +2655,7 @@ func (b *LoginMFABackend) MemDBMFALoginEnforcementConfigByNameAndNamespace(name,
 
 	eConfig, ok := eConfigRaw.(*mfa.MFAEnforcementConfig)
 	if !ok {
-		return nil, fmt.Errorf("invalid type for MFA login enforcement config in memdb")
+		return nil, errors.New("invalid type for MFA login enforcement config in memdb")
 	}
 
 	return eConfig.Clone()
@@ -2678,7 +2678,7 @@ func (b *LoginMFABackend) deleteMFALoginEnforcementConfigByNameAndNamespace(ctx 
 	var err error
 
 	if name == "" {
-		return fmt.Errorf("missing config name")
+		return errors.New("missing config name")
 	}
 
 	b.mfaLock.Lock()
@@ -2747,7 +2747,7 @@ func (b *LoginMFABackend) deleteMFAConfigByMethodID(ctx context.Context, configI
 	var err error
 
 	if configID == "" {
-		return fmt.Errorf("missing config id")
+		return errors.New("missing config id")
 	}
 
 	b.mfaLock.Lock()
@@ -2786,7 +2786,7 @@ func (b *LoginMFABackend) deleteMFAConfigByMethodID(ctx context.Context, configI
 	}
 
 	if mConfig.Type != methodType {
-		return fmt.Errorf("method type does not match the MFA config type")
+		return errors.New("method type does not match the MFA config type")
 	}
 
 	mfaNs, err := b.Core.NamespaceByID(ctx, mConfig.NamespaceID)
@@ -2803,7 +2803,7 @@ func (b *LoginMFABackend) deleteMFAConfigByMethodID(ctx context.Context, configI
 	// namespace should be the same. Note an ancestor of mfaNs is not allowed
 	// to delete methodID
 	if ns.ID != mfaNs.ID {
-		return fmt.Errorf("request namespace does not match method namespace")
+		return errors.New("request namespace does not match method namespace")
 	}
 
 	if mConfig.Type == "totp" && mConfig.ID != "" {
@@ -2848,7 +2848,7 @@ func (b *LoginMFABackend) MemDBDeleteMFAConfigByIDInTxn(txn *memdb.Txn, configID
 	}
 
 	if txn == nil {
-		return fmt.Errorf("txn is nil")
+		return errors.New("txn is nil")
 	}
 
 	mConfig, err := b.MemDBMFAConfigByIDInTxn(txn, configID)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -557,7 +557,7 @@ func (c *Core) fetchAndDecodeMountTableEntry(ctx context.Context, barrier logica
 		return nil, err
 	}
 	if sEntry == nil {
-		return nil, fmt.Errorf("unexpected empty storage entry for mount")
+		return nil, errors.New("unexpected empty storage entry for mount")
 	}
 
 	entry := new(MountEntry)
@@ -830,7 +830,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 	// Verify exact match of the route
 	match := c.router.MatchingMount(ctx, path)
 	if match == "" || ns.Path+path != match {
-		return fmt.Errorf("no matching mount")
+		return errors.New("no matching mount")
 	}
 
 	// Get the view for this backend
@@ -1496,7 +1496,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 
 	if table.Type != mountTableType {
 		c.logger.Error("given table to persist has wrong type", "actual_type", table.Type, "expected_type", mountTableType)
-		return fmt.Errorf("invalid table type given, not persisting")
+		return errors.New("invalid table type given, not persisting")
 	}
 
 	nonLocalMounts := &MountTable{
@@ -1510,7 +1510,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 	for _, entry := range table.Entries {
 		if entry.Table != table.Type {
 			c.logger.Error("given entry to persist in mount table has wrong table value", "path", entry.Path, "entry_table_type", entry.Table, "actual_type", table.Type)
-			return fmt.Errorf("invalid mount entry found, not persisting")
+			return errors.New("invalid mount entry found, not persisting")
 		}
 
 		if entry.Local {

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -32,7 +32,7 @@ func TestMount_ReadOnlyViewDuringMount(t *testing.T) {
 			Value: []byte("baz"),
 		})
 		if err == nil || !strings.Contains(err.Error(), logical.ErrSetupReadOnly.Error()) {
-			t.Fatalf("expected a read-only error")
+			t.Fatal("expected a read-only error")
 		}
 		return &NoopBackend{}, nil
 	}
@@ -77,40 +77,40 @@ func TestLogicalMountMetrics(t *testing.T) {
 	loadMetric, ok = mountMetrics.Load(mountKeyName)
 	numEntriesMetric = loadMetric.(metricsutil.GaugeMetric)
 	if !ok || numEntriesMetric.Value != 4 {
-		t.Fatalf("mount metrics for num entries do not match true values")
+		t.Fatal("mount metrics for num entries do not match true values")
 	}
 	if len(numEntriesMetric.Key) != 3 ||
 		numEntriesMetric.Key[0] != "core" ||
 		numEntriesMetric.Key[1] != "mount_table" ||
 		numEntriesMetric.Key[2] != "num_entries" {
-		t.Fatalf("mount metrics for num entries have wrong key")
+		t.Fatal("mount metrics for num entries have wrong key")
 	}
 	if len(numEntriesMetric.Labels) != 2 ||
 		numEntriesMetric.Labels[0].Name != "type" ||
 		numEntriesMetric.Labels[0].Value != "logical" ||
 		numEntriesMetric.Labels[1].Name != "local" ||
 		numEntriesMetric.Labels[1].Value != "false" {
-		t.Fatalf("mount metrics for num entries have wrong labels")
+		t.Fatal("mount metrics for num entries have wrong labels")
 	}
 	mountSizeKeyName := "core.mount_table.size.type|logical||local|false||"
 	loadMetric, ok = mountMetrics.Load(mountSizeKeyName)
 	sizeMetric := loadMetric.(metricsutil.GaugeMetric)
 
 	if !ok {
-		t.Fatalf("mount metrics for size do not match exist")
+		t.Fatal("mount metrics for size do not match exist")
 	}
 	if len(sizeMetric.Key) != 3 ||
 		sizeMetric.Key[0] != "core" ||
 		sizeMetric.Key[1] != "mount_table" ||
 		sizeMetric.Key[2] != "size" {
-		t.Fatalf("mount metrics for size have wrong key")
+		t.Fatal("mount metrics for size have wrong key")
 	}
 	if len(sizeMetric.Labels) != 2 ||
 		sizeMetric.Labels[0].Name != "type" ||
 		sizeMetric.Labels[0].Value != "logical" ||
 		sizeMetric.Labels[1].Name != "local" ||
 		sizeMetric.Labels[1].Value != "false" {
-		t.Fatalf("mount metrics for size have wrong labels")
+		t.Fatal("mount metrics for size have wrong labels")
 	}
 }
 
@@ -137,7 +137,7 @@ func TestCore_DefaultMountTable(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -160,7 +160,7 @@ func TestCore_Mount(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "foo/bar")
 	if match != "foo/" {
-		t.Fatalf("missing mount")
+		t.Fatal("missing mount")
 	}
 
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
@@ -181,7 +181,7 @@ func TestCore_Mount(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -205,7 +205,7 @@ func TestCore_Mount_secrets_builtin_RunningVersion(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "foo/bar")
 	if match != "foo/" {
-		t.Fatalf("missing mount")
+		t.Fatal("missing mount")
 	}
 
 	raw, _ := c.router.root.Get(match)
@@ -231,7 +231,7 @@ func TestCore_Mount_kv_generic(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "foo/bar")
 	if match != "foo/" {
-		t.Fatalf("missing mount")
+		t.Fatal("missing mount")
 	}
 
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
@@ -252,7 +252,7 @@ func TestCore_Mount_kv_generic(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -465,7 +465,7 @@ func TestCore_Unmount(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "secret/foo")
 	if match != "" {
-		t.Fatalf("backend present")
+		t.Fatal("backend present")
 	}
 
 	inmemSink := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
@@ -486,7 +486,7 @@ func TestCore_Unmount(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -619,7 +619,7 @@ func TestCore_Remount(t *testing.T) {
 
 	match := c.router.MatchingMount(namespace.RootContext(nil), "foo/bar")
 	if match != "foo/" {
-		t.Fatalf("failed remount")
+		t.Fatal("failed remount")
 	}
 
 	c.sealInternal()
@@ -629,13 +629,13 @@ func TestCore_Remount(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if i+1 == len(keys) && !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
 	match = c.router.MatchingMount(namespace.RootContext(nil), "foo/bar")
 	if match != "foo/" {
-		t.Fatalf("failed remount")
+		t.Fatal("failed remount")
 	}
 }
 
@@ -826,7 +826,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	}
 
 	if reflect.DeepEqual(raw, goodJson) {
-		t.Fatalf("bad: values here should be different")
+		t.Fatal("bad: values here should be different")
 	}
 
 	// Remove any transactional storage entries: we want to replace the mount

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -228,7 +228,7 @@ func (p *pluginClient) Reload() error {
 func (c *PluginCatalog) reloadExternalPlugin(key externalPluginsKey, id, path string) error {
 	extPlugin, ok := c.externalPlugins[key]
 	if !ok {
-		return fmt.Errorf("plugin client not found")
+		return errors.New("plugin client not found")
 	}
 	if !extPlugin.multiplexingSupport {
 		err := c.cleanupExternalPlugin(key, id, path)
@@ -264,7 +264,7 @@ func (p *pluginClient) Close() error {
 func (c *PluginCatalog) cleanupExternalPlugin(key externalPluginsKey, id, path string) error {
 	extPlugin, ok := c.externalPlugins[key]
 	if !ok {
-		return fmt.Errorf("plugin client not found")
+		return errors.New("plugin client not found")
 	}
 
 	pc, ok := extPlugin.connections[id]
@@ -322,10 +322,10 @@ func (c *PluginCatalog) NewPluginClient(ctx context.Context, config pluginutil.P
 	defer c.lock.Unlock()
 
 	if config.Name == "" {
-		return nil, fmt.Errorf("no name provided for plugin")
+		return nil, errors.New("no name provided for plugin")
 	}
 	if config.PluginType == consts.PluginTypeUnknown {
-		return nil, fmt.Errorf("no plugin type provided")
+		return nil, errors.New("no plugin type provided")
 	}
 
 	pluginRunner, err := c.get(ctx, config.Name, config.PluginType, config.Version)
@@ -333,7 +333,7 @@ func (c *PluginCatalog) NewPluginClient(ctx context.Context, config pluginutil.P
 		return nil, fmt.Errorf("failed to lookup plugin: %w", err)
 	}
 	if pluginRunner == nil {
-		return nil, fmt.Errorf("no plugin found")
+		return nil, errors.New("no plugin found")
 	}
 	pc, err := c.newPluginClient(ctx, pluginRunner, config)
 	return pc, err
@@ -343,7 +343,7 @@ func (c *PluginCatalog) NewPluginClient(ctx context.Context, config pluginutil.P
 // process. Callers should have the write lock held.
 func (c *PluginCatalog) newPluginClient(ctx context.Context, pluginRunner *pluginutil.PluginRunner, config pluginutil.PluginClientConfig) (*pluginClient, error) {
 	if pluginRunner == nil {
-		return nil, fmt.Errorf("no plugin found")
+		return nil, errors.New("no plugin found")
 	}
 
 	key, err := makeExternalPluginsKey(pluginRunner)
@@ -400,7 +400,7 @@ func (c *PluginCatalog) newPluginClient(ctx context.Context, pluginRunner *plugi
 		}
 
 		if pc.client == nil {
-			return nil, fmt.Errorf("plugin client is nil")
+			return nil, errors.New("plugin client is nil")
 		}
 	}
 

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -244,7 +244,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	// Top-level item should be the object list
 	list, ok := root.Node.(*ast.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("failed to parse policy: does not contain a root object")
+		return nil, errors.New("failed to parse policy: does not contain a root object")
 	}
 
 	// Check for invalid top-level keys

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -285,10 +286,10 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy) error {
 	defer metrics.MeasureSince([]string{"policy", "set_policy"}, time.Now())
 	if p == nil {
-		return fmt.Errorf("nil policy passed in for storage")
+		return errors.New("nil policy passed in for storage")
 	}
 	if p.Name == "" {
-		return fmt.Errorf("policy name missing")
+		return errors.New("policy name missing")
 	}
 	// Policies are normalized to lower-case
 	p.Name = ps.sanitizeName(p.Name)
@@ -335,7 +336,7 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy) error {
 			ps.tokenPoliciesLRU.Add(index, p)
 		}
 	default:
-		return fmt.Errorf("unknown policy type, cannot set")
+		return errors.New("unknown policy type, cannot set")
 	}
 
 	return nil
@@ -581,7 +582,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 				return fmt.Errorf("cannot delete %q policy", name)
 			}
 			if name == "default" {
-				return fmt.Errorf("cannot delete default policy")
+				return errors.New("cannot delete default policy")
 			}
 		}
 

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -354,7 +354,7 @@ bad  = "foo"
 nope = "yes"
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `invalid key "bad" on line 2`) {
@@ -375,7 +375,7 @@ path "/" {
 }
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `invalid key "capabilites" on line 3`) {
@@ -390,7 +390,7 @@ path "/" {
 }
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `path "/": invalid policy "banana"`) {
@@ -407,7 +407,7 @@ path "/" {
 }
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `max_wrapping_ttl cannot be less than min_wrapping_ttl`) {
@@ -422,7 +422,7 @@ path "/" {
 }
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `path "/": invalid capability "banana"`) {
@@ -437,7 +437,7 @@ path "foo/+*" {
 }
 `))
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	if !strings.Contains(err.Error(), `path "foo/+*": invalid use of wildcards ('+*' is forbidden)`) {

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -461,7 +461,7 @@ func (m *Manager) QuotaByFactors(ctx context.Context, qType, nsPath, mountPath, 
 	}
 	if len(quotas) > 1 {
 		m.logger.Debug("conflicting quotas in QuotaByFactors", "matching_quotas", quotas)
-		return nil, fmt.Errorf("conflicting quota definitions detected")
+		return nil, errors.New("conflicting quota definitions detected")
 	}
 	if len(quotas) == 0 {
 		return nil, nil
@@ -513,7 +513,7 @@ func (m *Manager) queryQuota(txn *memdb.Txn, req *Request) (Quota, error) {
 		}
 		if len(quotas) > 1 {
 			m.logger.Debug("conflicting quotas in queryQuota", "matching_quotas", quotas, "args", args)
-			return nil, fmt.Errorf("conflicting quota definitions detected")
+			return nil, errors.New("conflicting quota definitions detected")
 		}
 		if len(quotas) == 0 {
 			return nil, nil

--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -6,6 +6,7 @@ package quotas
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -285,7 +286,7 @@ func (rlq *RateLimitQuota) allow(ctx context.Context, req *Request) (Response, e
 	}
 
 	if req.ClientAddress == "" {
-		return resp, fmt.Errorf("missing request client address in quota request")
+		return resp, errors.New("missing request client address in quota request")
 	}
 
 	var retryAfter string

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -566,7 +566,7 @@ func (c *Core) raftReadTLSKeyring(ctx context.Context) (*raft.TLSKeyring, error)
 // error.
 func (c *Core) raftCreateTLSKeyring(ctx context.Context) (*raft.TLSKeyring, error) {
 	if raftBackend := c.getRaftBackend(); raftBackend == nil {
-		return nil, fmt.Errorf("raft backend not in use")
+		return nil, errors.New("raft backend not in use")
 	}
 
 	// Check if the keyring is already present
@@ -576,7 +576,7 @@ func (c *Core) raftCreateTLSKeyring(ctx context.Context) (*raft.TLSKeyring, erro
 	}
 
 	if raftTLSEntry != nil {
-		return nil, fmt.Errorf("TLS keyring already present")
+		return nil, errors.New("TLS keyring already present")
 	}
 
 	raftTLS, err := raft.GenerateTLSKey(c.secureRandomReader)
@@ -1030,7 +1030,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				}
 			} else {
 				// Return an error so we can retry_join
-				err = fmt.Errorf("failed to get raft challenge")
+				err = errors.New("failed to get raft challenge")
 			}
 		}
 		return err

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -114,7 +114,7 @@ func testCore_Rekey_Init_Common(t *testing.T, c *Core, recovery bool) {
 	}
 	err := c.RekeyInit(badConf, recovery)
 	if err == nil {
-		t.Fatalf("should fail")
+		t.Fatal("should fail")
 	}
 
 	// Start a rekey
@@ -137,7 +137,7 @@ func testCore_Rekey_Init_Common(t *testing.T, c *Core, recovery bool) {
 	// Second should fail
 	err = c.RekeyInit(newConf, recovery)
 	if err == nil {
-		t.Fatalf("should fail")
+		t.Fatal("should fail")
 	}
 }
 
@@ -176,7 +176,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatalf("err: %v", hErr)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 
 	// Provide the root/recovery keys
@@ -247,7 +247,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 			}
 		}
 		if c.Sealed() {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -269,7 +269,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 
 	// Provide the parts root
@@ -306,7 +306,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 			t.Fatalf("err: %v", err)
 		}
 		if !unseal {
-			t.Fatalf("should be unsealed")
+			t.Fatal("should be unsealed")
 		}
 	}
 
@@ -355,13 +355,13 @@ func testCore_Rekey_Invalid_Common(t *testing.T, c *Core, keys [][]byte, recover
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 
 	// Provide the nonce (invalid)
 	_, err = c.RekeyUpdate(context.Background(), keys[0], "abcd", recovery)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	// Provide the key (invalid)
@@ -451,7 +451,7 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 	var rekeyResult *RekeyResult
 	for _, key := range keys {
@@ -461,7 +461,7 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		}
 	}
 	if rekeyResult == nil {
-		t.Fatalf("rekey failed")
+		t.Fatal("rekey failed")
 	}
 
 	// Seal the first core, should step down
@@ -484,7 +484,7 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if rkconf == nil {
-		t.Fatalf("bad: no rekey config received")
+		t.Fatal("bad: no rekey config received")
 	}
 	var rekeyResult2 *RekeyResult
 	for _, key := range rekeyResult.SecretShares {
@@ -494,14 +494,14 @@ func TestCore_Rekey_Standby(t *testing.T) {
 		}
 	}
 	if rekeyResult2 == nil {
-		t.Fatalf("rekey failed")
+		t.Fatal("rekey failed")
 	}
 
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if rekeyResult2 == nil {
-		t.Fatalf("rekey failed")
+		t.Fatal("rekey failed")
 	}
 }
 

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"math"
 	"net/http"
 	"net/url"
@@ -117,7 +116,7 @@ func (c *requestForwardingClusterClient) CACert(ctx context.Context) *x509.Certi
 func (rf *requestForwardingHandler) ServerLookup(ctx context.Context, clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	currCert := rf.core.localClusterCert.Load().([]byte)
 	if len(currCert) == 0 {
-		return nil, fmt.Errorf("got forwarding connection but no local cert")
+		return nil, errors.New("got forwarding connection but no local cert")
 	}
 
 	localCert := make([]byte, len(currCert))
@@ -135,7 +134,7 @@ func (rf *requestForwardingHandler) CALookup(ctx context.Context) ([]*x509.Certi
 	parsedCert := rf.core.localClusterParsedCert.Load().(*x509.Certificate)
 
 	if parsedCert == nil {
-		return nil, fmt.Errorf("forwarding connection client but no local cert")
+		return nil, errors.New("forwarding connection client but no local cert")
 	}
 
 	return []*x509.Certificate{parsedCert}, nil
@@ -341,17 +340,17 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 	freq, err := forwarding.GenerateForwardedRequest(req)
 	if err != nil {
 		c.logger.Error("error creating forwarding RPC request", "error", err)
-		return 0, nil, nil, fmt.Errorf("error creating forwarding RPC request")
+		return 0, nil, nil, errors.New("error creating forwarding RPC request")
 	}
 	if freq == nil {
 		c.logger.Error("got nil forwarding RPC request")
-		return 0, nil, nil, fmt.Errorf("got nil forwarding RPC request")
+		return 0, nil, nil, errors.New("got nil forwarding RPC request")
 	}
 	resp, err := c.rpcForwardingClient.ForwardRequest(req.Context(), freq)
 	if err != nil {
 		metrics.IncrCounter([]string{"ha", "rpc", "client", "forward", "errors"}, 1)
 		c.logger.Error("error during forwarded RPC request", "error", err)
-		return 0, nil, nil, fmt.Errorf("error during forwarding RPC request")
+		return 0, nil, nil, errors.New("error during forwarding RPC request")
 	}
 
 	var header http.Header

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1392,7 +1392,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			auth.Alias.Local = mEntry.Local
 
 			if auth.Alias.Name == "" {
-				return nil, nil, fmt.Errorf("missing name in alias")
+				return nil, nil, errors.New("missing name in alias")
 			}
 
 			var err error
@@ -1403,7 +1403,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 				return nil, nil, err
 			}
 			if entity == nil {
-				return nil, nil, fmt.Errorf("failed to create an entity for the authenticated alias")
+				return nil, nil, errors.New("failed to create an entity for the authenticated alias")
 			}
 
 			if entity.Disabled {
@@ -1585,7 +1585,7 @@ func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, re
 	// Determine mount type
 	mountEntry := c.router.MatchingMountEntry(ctx, reqPath)
 	if mountEntry == nil {
-		return false, nil, fmt.Errorf("failed to find a matching mount")
+		return false, nil, errors.New("failed to find a matching mount")
 	}
 
 	sysView := c.router.MatchingSystemView(ctx, reqPath)
@@ -1905,7 +1905,7 @@ func (c *Core) buildMfaEnforcementResponse(eConfig *mfa.MFAEnforcementConfig) (*
 		if mConfig.Type == mfaMethodTypeDuo {
 			duoConf, ok := mConfig.Config.(*mfa.Config_DuoConfig)
 			if !ok {
-				return nil, fmt.Errorf("invalid MFA configuration type")
+				return nil, errors.New("invalid MFA configuration type")
 			}
 			duoUsePasscode = duoConf.DuoConfig.UsePasscode
 		}
@@ -2177,7 +2177,7 @@ func (c *Core) DecodeSSCTokenInternal(token string) (*tokens.Token, error) {
 	// Skip batch and old style service tokens. These can have the prefix "b.",
 	// "s." (for old tokens) or "hvb."
 	if !strings.HasPrefix(token, consts.ServiceTokenPrefix) {
-		return nil, fmt.Errorf("not service token")
+		return nil, errors.New("not service token")
 	}
 
 	// Consider the suffix of the token only when unmarshalling
@@ -2185,7 +2185,7 @@ func (c *Core) DecodeSSCTokenInternal(token string) (*tokens.Token, error) {
 
 	tokenBytes, err := base64.RawURLEncoding.DecodeString(suffixToken)
 	if err != nil {
-		return nil, fmt.Errorf("can't decode token")
+		return nil, errors.New("can't decode token")
 	}
 
 	err = proto.Unmarshal(tokenBytes, signedToken)

--- a/vault/router.go
+++ b/vault/router.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -649,7 +650,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		te := req.TokenEntry()
 
 		if te == nil {
-			return nil, false, false, fmt.Errorf("nil token entry")
+			return nil, false, false, errors.New("nil token entry")
 		}
 
 		if te.Type != logical.TokenTypeService {
@@ -669,7 +670,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 
 		default:
 			if te.CubbyholeID == "" {
-				return nil, false, false, fmt.Errorf("empty cubbyhole id")
+				return nil, false, false, errors.New("empty cubbyhole id")
 			}
 			req.ClientToken = te.CubbyholeID
 		}

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -75,7 +75,7 @@ func TestRouter_Mount(t *testing.T) {
 
 	_, mount, prefix, ok := r.MatchingAPIPrefixByStoragePath(namespace.RootContext(nil), "logical/foo")
 	if !ok {
-		t.Fatalf("missing storage prefix")
+		t.Fatal("missing storage prefix")
 	}
 	if mount != "prod/aws/" || prefix != "logical/" {
 		t.Fatalf("Bad: %v - %v", mount, prefix)
@@ -112,7 +112,7 @@ func TestRouter_Mount(t *testing.T) {
 	}
 
 	if r.MountConflict(namespace.RootContext(nil), "prod/aws/") == "" {
-		t.Fatalf("bad: prod/aws/")
+		t.Fatal("bad: prod/aws/")
 	}
 
 	// No error is shown here because MountConflict is checked before Mount
@@ -121,7 +121,7 @@ func TestRouter_Mount(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if r.MountConflict(namespace.RootContext(nil), "prod/test") == "" {
-		t.Fatalf("bad: prod/test/")
+		t.Fatal("bad: prod/test/")
 	}
 }
 
@@ -182,7 +182,7 @@ func TestRouter_MountCredential(t *testing.T) {
 
 	_, mount, prefix, ok := r.MatchingAPIPrefixByStoragePath(namespace.RootContext(nil), "auth/foo")
 	if !ok {
-		t.Fatalf("missing storage prefix")
+		t.Fatal("missing storage prefix")
 	}
 	if mount != "auth/aws" || prefix != credentialBarrierPrefix {
 		t.Fatalf("Bad: %v - %v", mount, prefix)
@@ -234,7 +234,7 @@ func TestRouter_Unmount(t *testing.T) {
 	}
 
 	if _, _, _, ok := r.MatchingAPIPrefixByStoragePath(namespace.RootContext(nil), "logical/foo"); ok {
-		t.Fatalf("should not have matching storage prefix")
+		t.Fatal("should not have matching storage prefix")
 	}
 }
 

--- a/vault/router_testing.go
+++ b/vault/router_testing.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -47,7 +46,7 @@ func (n *NoopBackend) HandleRequest(ctx context.Context, req *logical.Request) (
 	}
 
 	if n.RollbackErrs && req.Operation == "rollback" {
-		return nil, fmt.Errorf("no-op backend rollback has erred out")
+		return nil, errors.New("no-op backend rollback has erred out")
 	}
 
 	var err error
@@ -63,7 +62,7 @@ func (n *NoopBackend) HandleRequest(ctx context.Context, req *logical.Request) (
 	n.Paths = append(n.Paths, req.Path)
 	n.Requests = append(n.Requests, &requestCopy)
 	if req.Storage == nil {
-		return nil, fmt.Errorf("missing view")
+		return nil, errors.New("missing view")
 	}
 
 	if req.Path == "panic" {

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -103,7 +103,7 @@ func (d *defaultSeal) SealWrapable() bool {
 
 func (d *defaultSeal) checkCore() error {
 	if d.core == nil {
-		return fmt.Errorf("seal does not have a core set")
+		return errors.New("seal does not have a core set")
 	}
 	return nil
 }
@@ -252,26 +252,26 @@ func (d *defaultSeal) RecoveryType() string {
 }
 
 func (d *defaultSeal) RecoveryConfig(ctx context.Context) (*SealConfig, error) {
-	return nil, fmt.Errorf("recovery not supported")
+	return nil, errors.New("recovery not supported")
 }
 
 func (d *defaultSeal) RecoveryKey(ctx context.Context) ([]byte, error) {
-	return nil, fmt.Errorf("recovery not supported")
+	return nil, errors.New("recovery not supported")
 }
 
 func (d *defaultSeal) SetRecoveryConfig(ctx context.Context, config *SealConfig) error {
-	return fmt.Errorf("recovery not supported")
+	return errors.New("recovery not supported")
 }
 
 func (d *defaultSeal) SetCachedRecoveryConfig(config *SealConfig) {
 }
 
 func (d *defaultSeal) VerifyRecoveryKey(ctx context.Context, key []byte) error {
-	return fmt.Errorf("recovery not supported")
+	return errors.New("recovery not supported")
 }
 
 func (d *defaultSeal) SetRecoveryKey(ctx context.Context, key []byte) error {
-	return fmt.Errorf("recovery not supported")
+	return errors.New("recovery not supported")
 }
 
 func (d *defaultSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
@@ -338,28 +338,28 @@ type SealConfig struct {
 // Validate is used to sanity check the seal configuration
 func (s *SealConfig) Validate() error {
 	if s.SecretShares < 1 {
-		return fmt.Errorf("shares must be at least one")
+		return errors.New("shares must be at least one")
 	}
 	if s.SecretThreshold < 1 {
-		return fmt.Errorf("threshold must be at least one")
+		return errors.New("threshold must be at least one")
 	}
 	if s.SecretShares > 1 && s.SecretThreshold == 1 {
-		return fmt.Errorf("threshold must be greater than one for multiple shares")
+		return errors.New("threshold must be greater than one for multiple shares")
 	}
 	if s.SecretShares > 255 {
-		return fmt.Errorf("shares must be less than 256")
+		return errors.New("shares must be less than 256")
 	}
 	if s.SecretThreshold > 255 {
-		return fmt.Errorf("threshold must be less than 256")
+		return errors.New("threshold must be less than 256")
 	}
 	if s.SecretThreshold > s.SecretShares {
-		return fmt.Errorf("threshold cannot be larger than shares")
+		return errors.New("threshold cannot be larger than shares")
 	}
 	if s.StoredShares > 1 {
-		return fmt.Errorf("stored keys cannot be larger than 1")
+		return errors.New("stored keys cannot be larger than 1")
 	}
 	if len(s.PGPKeys) > 0 && len(s.PGPKeys) != s.SecretShares {
-		return fmt.Errorf("count mismatch between number of provided PGP keys and number of shares")
+		return errors.New("count mismatch between number of provided PGP keys and number of shares")
 	}
 	if len(s.PGPKeys) > 0 {
 		for _, keystring := range s.PGPKeys {
@@ -430,10 +430,10 @@ func (e *ErrDecrypt) Is(target error) bool {
 
 func writeStoredKeys(ctx context.Context, storage physical.Backend, encryptor seal.Access, keys [][]byte) error {
 	if keys == nil {
-		return fmt.Errorf("keys were nil")
+		return errors.New("keys were nil")
 	}
 	if len(keys) == 0 {
-		return fmt.Errorf("no keys provided")
+		return errors.New("no keys provided")
 	}
 
 	buf, err := json.Marshal(keys)

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	mathrand "math/rand"
 	"sync"
@@ -79,7 +80,7 @@ func (d *autoSeal) GetAccess() seal.Access {
 
 func (d *autoSeal) checkCore() error {
 	if d.core == nil {
-		return fmt.Errorf("seal does not have a core set")
+		return errors.New("seal does not have a core set")
 	}
 	return nil
 }
@@ -105,7 +106,7 @@ func (d *autoSeal) BarrierType() wrapping.WrapperType {
 }
 
 func (d *autoSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
-	return nil, fmt.Errorf("autoSeal does not use a ShamirWrapper")
+	return nil, errors.New("autoSeal does not use a ShamirWrapper")
 }
 
 func (d *autoSeal) StoredKeysSupported() seal.StoredKeysSupport {
@@ -134,7 +135,7 @@ func (d *autoSeal) upgradeStoredKeys(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch stored keys: %w", err)
 	}
 	if pe == nil {
-		return fmt.Errorf("no stored keys found")
+		return errors.New("no stored keys found")
 	}
 
 	blobInfo := &wrapping.BlobInfo{}
@@ -392,7 +393,7 @@ func (d *autoSeal) SetCachedRecoveryConfig(config *SealConfig) {
 
 func (d *autoSeal) VerifyRecoveryKey(ctx context.Context, key []byte) error {
 	if key == nil {
-		return fmt.Errorf("recovery key to verify is nil")
+		return errors.New("recovery key to verify is nil")
 	}
 
 	pt, err := d.getRecoveryKeyInternal(ctx)
@@ -401,7 +402,7 @@ func (d *autoSeal) VerifyRecoveryKey(ctx context.Context, key []byte) error {
 	}
 
 	if subtle.ConstantTimeCompare(key, pt) != 1 {
-		return fmt.Errorf("recovery key does not match submitted values")
+		return errors.New("recovery key does not match submitted values")
 	}
 
 	return nil
@@ -413,7 +414,7 @@ func (d *autoSeal) SetRecoveryKey(ctx context.Context, key []byte) error {
 	}
 
 	if key == nil {
-		return fmt.Errorf("recovery key to store is nil")
+		return errors.New("recovery key to store is nil")
 	}
 
 	// Encrypt and marshal the keys
@@ -452,7 +453,7 @@ func (d *autoSeal) getRecoveryKeyInternal(ctx context.Context) ([]byte, error) {
 	}
 	if pe == nil {
 		d.logger.Warn("no recovery key found")
-		return nil, fmt.Errorf("no recovery key found")
+		return nil, errors.New("no recovery key found")
 	}
 
 	blobInfo := &wrapping.BlobInfo{}
@@ -474,7 +475,7 @@ func (d *autoSeal) upgradeRecoveryKey(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch recovery key: %w", err)
 	}
 	if pe == nil {
-		return fmt.Errorf("no recovery key found")
+		return errors.New("no recovery key found")
 	}
 
 	blobInfo := &wrapping.BlobInfo{}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -850,7 +850,7 @@ WAITACTIVE:
 		time.Sleep(time.Second)
 	}
 	if activeCore == -1 {
-		t.Fatalf("no core became active")
+		t.Fatal("no core became active")
 	}
 
 	switch {
@@ -1629,7 +1629,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 	if opts != nil && opts.InmemClusterLayers {
 		if opts.ClusterLayers != nil {
-			t.Fatalf("cannot specify ClusterLayers when InmemClusterLayers is true")
+			t.Fatal("cannot specify ClusterLayers when InmemClusterLayers is true")
 		}
 		inmemCluster, err := cluster.NewInmemLayerCluster("inmem-cluster", numCores, testCluster.Logger.Named("inmem-cluster"))
 		if err != nil {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -645,10 +645,10 @@ var (
 // invoked before the test core is created.
 func AddTestCredentialBackend(name string, factory logical.Factory) error {
 	if name == "" {
-		return fmt.Errorf("missing backend name")
+		return errors.New("missing backend name")
 	}
 	if factory == nil {
-		return fmt.Errorf("missing backend factory function")
+		return errors.New("missing backend factory function")
 	}
 	testCredentialBackends[name] = factory
 	return nil
@@ -662,10 +662,10 @@ func ClearTestCredentialBackends() {
 // invoked before the test core is created.
 func AddTestLogicalBackend(name string, factory logical.Factory) error {
 	if name == "" {
-		return fmt.Errorf("missing backend name")
+		return errors.New("missing backend name")
 	}
 	if factory == nil {
-		return fmt.Errorf("missing backend factory function")
+		return errors.New("missing backend factory function")
 	}
 	testLogicalBackends[name] = factory
 	return nil
@@ -725,7 +725,7 @@ func (n *rawHTTP) Type() logical.BackendType {
 
 func GenerateRandBytes(length int) ([]byte, error) {
 	if length < 0 {
-		return nil, fmt.Errorf("length must be >= 0")
+		return nil, errors.New("length must be >= 0")
 	}
 
 	buf := make([]byte, length)
@@ -902,7 +902,7 @@ func (c *TestCluster) UnsealCoresWithError(useStoredKeys bool) error {
 
 	// Verify unsealed
 	if c.Cores[0].Sealed() {
-		return fmt.Errorf("should not be sealed")
+		return errors.New("should not be sealed")
 	}
 
 	if err := TestWaitActiveWithError(c.Cores[0].Core); err != nil {
@@ -1082,7 +1082,7 @@ func (c *TestCluster) ensureCoresSealed() error {
 		timeout := time.Now().Add(60 * time.Second)
 		for {
 			if time.Now().After(timeout) {
-				return fmt.Errorf("timeout waiting for core to seal")
+				return errors.New("timeout waiting for core to seal")
 			}
 			if core.Sealed() {
 				break
@@ -2174,7 +2174,7 @@ func (testCluster *TestCluster) getAPIClient(
 		Transport: transport,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			// This can of course be overridden per-test by using its own client
-			return fmt.Errorf("redirects not allowed in these tests")
+			return errors.New("redirects not allowed in these tests")
 		},
 	}
 	config := api.DefaultConfig()

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -4129,7 +4129,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4286,7 +4286,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4678,7 +4678,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4739,7 +4739,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4791,7 +4791,7 @@ func testTokenStore_NumUses_ErrorCheckHelper(t *testing.T, resp *logical.Respons
 		t.Fatal("response was nil")
 	}
 	if resp.Auth == nil {
-		t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+		t.Fatalf("response auth was nil, resp is %#v", *resp)
 	}
 	if resp.Auth.ClientToken == "" {
 		t.Fatalf("bad: %#v", resp)
@@ -4938,7 +4938,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -5012,7 +5012,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -50,7 +50,7 @@ func TestTokenStore_CreateOrphanResponse(t *testing.T) {
 		t.Fatalf("bad: err: %v, resp: %#v", err, resp)
 	}
 	if !resp.Auth.Orphan {
-		t.Fatalf("failed to set orphan as true in the response")
+		t.Fatal("failed to set orphan as true in the response")
 	}
 }
 
@@ -242,7 +242,7 @@ func TestTokenStore_Salting(t *testing.T) {
 		t.Fatal(err)
 	}
 	if strings.HasPrefix(saltedID, "h") {
-		t.Fatalf("expected sha1 hash; got sha2-256 hmac")
+		t.Fatal("expected sha1 hash; got sha2-256 hmac")
 	}
 
 	saltedID, err = ts.SaltID(namespace.RootContext(nil), "hvs.foo")
@@ -250,7 +250,7 @@ func TestTokenStore_Salting(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.HasPrefix(saltedID, "h") {
-		t.Fatalf("expected sha2-256 hmac; got sha1 hash")
+		t.Fatal("expected sha2-256 hmac; got sha1 hash")
 	}
 
 	nsCtx := namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "testid", Path: "ns1"})
@@ -259,7 +259,7 @@ func TestTokenStore_Salting(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.HasPrefix(saltedID, "h") {
-		t.Fatalf("expected sha2-256 hmac; got sha1 hash")
+		t.Fatal("expected sha2-256 hmac; got sha1 hash")
 	}
 
 	saltedID, err = ts.SaltID(nsCtx, "hvs.foo")
@@ -267,7 +267,7 @@ func TestTokenStore_Salting(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.HasPrefix(saltedID, "h") {
-		t.Fatalf("expected sha2-256 hmac; got sha1 hash")
+		t.Fatal("expected sha2-256 hmac; got sha1 hash")
 	}
 }
 
@@ -572,7 +572,7 @@ func testMakeTokenViaRequestContext(t testing.TB, ctx context.Context, ts *Token
 		t.Fatal(err)
 	}
 	if resp == nil {
-		t.Fatalf("got nil token from create call")
+		t.Fatal("got nil token from create call")
 	}
 	// Let the caller handle the error
 	if resp.IsError() {
@@ -752,16 +752,16 @@ func TestTokenStore_HandleRequest_LookupAccessor(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if resp.Data == nil {
-		t.Fatalf("response should contain data")
+		t.Fatal("response should contain data")
 	}
 
 	if resp.Data["accessor"].(string) == "" {
-		t.Fatalf("accessor should not be empty")
+		t.Fatal("accessor should not be empty")
 	}
 
 	// Verify that the lookup-accessor operation does not return the token ID
 	if resp.Data["id"].(string) != "" {
-		t.Fatalf("token ID should not be returned")
+		t.Fatal("token ID should not be returned")
 	}
 }
 
@@ -789,14 +789,14 @@ func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if resp.Data == nil {
-		t.Fatalf("response should contain data")
+		t.Fatal("response should contain data")
 	}
 	if resp.Data["keys"] == nil {
-		t.Fatalf("keys should not be empty")
+		t.Fatal("keys should not be empty")
 	}
 	keys := resp.Data["keys"].([]string)
 	if len(keys) != len(testKeys) {
-		t.Fatalf("wrong number of accessors found")
+		t.Fatal("wrong number of accessors found")
 	}
 	if len(resp.Warnings) != 0 {
 		t.Fatalf("got warnings:\n%#v", resp.Warnings)
@@ -809,7 +809,7 @@ func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 			t.Fatal(err)
 		}
 		if aEntry.TokenID == "" || aEntry.AccessorID == "" {
-			t.Fatalf("error, accessor entry looked up is empty, but no error thrown")
+			t.Fatal("error, accessor entry looked up is empty, but no error thrown")
 		}
 		saltID, err := ts.SaltID(namespace.RootContext(nil), accessor)
 		if err != nil {
@@ -827,14 +827,14 @@ func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if resp.Data == nil {
-		t.Fatalf("response should contain data")
+		t.Fatal("response should contain data")
 	}
 	if resp.Data["keys"] == nil {
-		t.Fatalf("keys should not be empty")
+		t.Fatal("keys should not be empty")
 	}
 	keys2 := resp.Data["keys"].([]string)
 	if len(keys) != len(testKeys) {
-		t.Fatalf("wrong number of accessors found")
+		t.Fatal("wrong number of accessors found")
 	}
 	if len(resp.Warnings) != 0 {
 		t.Fatalf("got warnings:\n%#v", resp.Warnings)
@@ -846,7 +846,7 @@ func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 			t.Fatal(err)
 		}
 		if aEntry.TokenID == "" || aEntry.AccessorID == "" {
-			t.Fatalf("error, accessor entry looked up is empty, but no error thrown")
+			t.Fatal("error, accessor entry looked up is empty, but no error thrown")
 		}
 	}
 }
@@ -1016,7 +1016,7 @@ func TestTokenStore_RootToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if te.ID == "" {
-		t.Fatalf("missing ID")
+		t.Fatal("missing ID")
 	}
 
 	out, err := ts.Lookup(namespace.RootContext(nil), te.ID)
@@ -1059,7 +1059,7 @@ func TestTokenStore_CreateLookup(t *testing.T) {
 	}
 	testMakeTokenDirectly(t, ts, ent)
 	if ent.ID == "" {
-		t.Fatalf("missing ID")
+		t.Fatal("missing ID")
 	}
 
 	out, err := ts.Lookup(namespace.RootContext(nil), ent.ID)
@@ -1136,7 +1136,7 @@ func TestTokenStore_CreateLookup_ExpirationInRestoreMode(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if ent.ID == "" {
-		t.Fatalf("missing ID")
+		t.Fatal("missing ID")
 	}
 
 	// Replace the lease with a lease with an expire time in the past
@@ -1209,7 +1209,7 @@ func TestTokenStore_UseToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if te == nil {
-		t.Fatalf("token entry after use was nil")
+		t.Fatal("token entry after use was nil")
 	}
 
 	// Lookup the root token again
@@ -1238,7 +1238,7 @@ func TestTokenStore_UseToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if te == nil {
-		t.Fatalf("token entry for use #1 was nil")
+		t.Fatal("token entry for use #1 was nil")
 	}
 
 	// Lookup the token
@@ -1258,10 +1258,10 @@ func TestTokenStore_UseToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if te == nil {
-		t.Fatalf("token entry for use #2 was nil")
+		t.Fatal("token entry for use #2 was nil")
 	}
 	if te.NumUses != tokenRevocationPending {
-		t.Fatalf("token entry after use #2 did not have revoke flag")
+		t.Fatal("token entry after use #2 did not have revoke flag")
 	}
 	ts.revokeOrphan(namespace.RootContext(nil), te.ID)
 
@@ -1972,7 +1972,7 @@ func TestTokenStore_HandleRequest_CreateToken_NonRoot_RootChild(t *testing.T) {
 		t.Fatalf("err: %v; resp: %#v", err, resp)
 	}
 	if resp == nil || resp.Data == nil {
-		t.Fatalf("expected a response")
+		t.Fatal("expected a response")
 	}
 	if resp.Data["error"].(string) != "root tokens may not be created without parent token being root" {
 		t.Fatalf("bad: %#v", resp)
@@ -2004,7 +2004,7 @@ func TestTokenStore_HandleRequest_CreateToken_Root_RootChild_NoExpiry_Expiry(t *
 	}
 	resp, err := ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 	expectedErr := "expiring root tokens cannot create non-expiring root tokens"
 	if resp.Data["error"].(string) != expectedErr {
@@ -2024,7 +2024,7 @@ func TestTokenStore_HandleRequest_CreateToken_Root_RootChild(t *testing.T) {
 		t.Fatalf("err: %v; resp: %#v", err, resp)
 	}
 	if resp == nil || resp.Auth == nil {
-		t.Fatalf("failed to create a root token using another root token")
+		t.Fatal("failed to create a root token using another root token")
 	}
 	if !reflect.DeepEqual(resp.Auth.Policies, []string{"root"}) {
 		t.Fatalf("bad: policies: expected: root; actual: %s", resp.Auth.Policies)
@@ -2456,7 +2456,7 @@ func testTokenStoreHandleRequestLookup(t *testing.T, batch, periodic bool) {
 	}
 
 	if resp.Data["creation_time"].(int64) == 0 {
-		t.Fatalf("creation time was zero")
+		t.Fatal("creation time was zero")
 	}
 	delete(resp.Data, "creation_time")
 
@@ -2513,7 +2513,7 @@ func testTokenStoreHandleRequestLookup(t *testing.T, batch, periodic bool) {
 	}
 
 	if resp.Data["creation_time"].(int64) == 0 {
-		t.Fatalf("creation time was zero")
+		t.Fatal("creation time was zero")
 	}
 	delete(resp.Data, "creation_time")
 	if resp.Data["issue_time"].(time.Time).IsZero() {
@@ -2561,7 +2561,7 @@ func testTokenStoreHandleRequestLookup(t *testing.T, batch, periodic bool) {
 
 	if !batch {
 		if resp.Data["last_renewal_time"].(int64) == 0 {
-			t.Fatalf("last_renewal_time was zero")
+			t.Fatal("last_renewal_time was zero")
 		}
 	} else if _, ok := resp.Data["last_renewal_time"]; ok {
 		t.Fatal("expected zero last renewal time")
@@ -2601,15 +2601,15 @@ func TestTokenStore_HandleRequest_LookupSelf(t *testing.T) {
 	}
 
 	if resp.Data["creation_time"].(int64) == 0 {
-		t.Fatalf("creation time was zero")
+		t.Fatal("creation time was zero")
 	}
 	delete(resp.Data, "creation_time")
 	if resp.Data["issue_time"].(time.Time).IsZero() {
-		t.Fatalf("creation time was zero")
+		t.Fatal("creation time was zero")
 	}
 	delete(resp.Data, "issue_time")
 	if resp.Data["expire_time"].(time.Time).IsZero() {
-		t.Fatalf("expire time was zero")
+		t.Fatal("expire time was zero")
 	}
 	delete(resp.Data, "expire_time")
 
@@ -3169,7 +3169,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("should not see a role")
+		t.Fatal("should not see a role")
 	}
 
 	// First test creation
@@ -3190,7 +3190,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Operation = logical.ReadOperation
@@ -3202,7 +3202,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	}
 
 	if resp == nil {
-		t.Fatalf("got a nil response")
+		t.Fatal("got a nil response")
 	}
 
 	expected := map[string]interface{}{
@@ -3256,7 +3256,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Operation = logical.ReadOperation
@@ -3267,7 +3267,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("got a nil response")
+		t.Fatal("got a nil response")
 	}
 
 	expected = map[string]interface{}{
@@ -3320,7 +3320,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("got a nil response")
+		t.Fatal("got a nil response")
 	}
 
 	expected = map[string]interface{}{
@@ -3374,7 +3374,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("got a nil response")
+		t.Fatal("got a nil response")
 	}
 
 	expected = map[string]interface{}{
@@ -3407,15 +3407,15 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("got a nil response")
+		t.Fatal("got a nil response")
 	}
 	keysInt, ok := resp.Data["keys"]
 	if !ok {
-		t.Fatalf("did not find keys in response")
+		t.Fatal("did not find keys in response")
 	}
 	keys, ok := keysInt.([]string)
 	if !ok {
-		t.Fatalf("could not convert keys interface to key list")
+		t.Fatal("could not convert keys interface to key list")
 	}
 	if len(keys) != 1 {
 		t.Fatalf("unexpected number of keys: %d", len(keys))
@@ -3431,7 +3431,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Operation = logical.ReadOperation
@@ -3440,7 +3440,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 }
 
@@ -3638,7 +3638,7 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Data = map[string]interface{}{}
@@ -3647,7 +3647,7 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 	req.Data["policies"] = []string{"foo"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"test2"}
@@ -3668,20 +3668,20 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Path = "create/testnoglob"
 	req.Data["policies"] = []string{"test"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"testfoo"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"test*"}
@@ -3701,7 +3701,7 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req = logical.TestRequest(t, logical.UpdateOperation, "create")
@@ -3726,7 +3726,7 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 	req.Data["policies"] = []string{"foo"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"test2"}
@@ -3893,7 +3893,7 @@ func TestTokenStore_RoleAllowedPoliciesGlob(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Data = map[string]interface{}{}
@@ -3902,7 +3902,7 @@ func TestTokenStore_RoleAllowedPoliciesGlob(t *testing.T) {
 	req.Data["policies"] = []string{"foo"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"test2"}
@@ -3923,14 +3923,14 @@ func TestTokenStore_RoleAllowedPoliciesGlob(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Path = "create/test"
 	req.Data["policies"] = []string{"footest"}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatal("expected error")
 	}
 
 	req.Data["policies"] = []string{"testfoo", "test2", "test"}
@@ -3955,7 +3955,7 @@ func TestTokenStore_RoleOrphan(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Path = "create/test"
@@ -3973,11 +3973,11 @@ func TestTokenStore_RoleOrphan(t *testing.T) {
 	}
 
 	if out.Parent != "" {
-		t.Fatalf("expected orphan token, but found a parent")
+		t.Fatal("expected orphan token, but found a parent")
 	}
 
 	if !strings.HasPrefix(out.Path, "auth/token/create/test") {
-		t.Fatalf("expected role in path but did not find it")
+		t.Fatal("expected role in path but did not find it")
 	}
 }
 
@@ -3996,7 +3996,7 @@ func TestTokenStore_RolePathSuffix(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	req.Path = "create/test"
@@ -4015,7 +4015,7 @@ func TestTokenStore_RolePathSuffix(t *testing.T) {
 	}
 
 	if out.Path != "auth/token/create/test/happenin" {
-		t.Fatalf("expected role in path but did not find it")
+		t.Fatal("expected role in path but did not find it")
 	}
 }
 
@@ -4039,7 +4039,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// This first set of logic is to verify that a normal non-root token will
@@ -4068,7 +4068,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 		}
 		ttl := resp.Data["ttl"].(int64)
 		if ttl > 10 {
-			t.Fatalf("TTL too large")
+			t.Fatal("TTL too large")
 		}
 
 		// Let the TTL go down a bit to 8 seconds
@@ -4112,7 +4112,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 		}
 		ttl = resp.Data["ttl"].(int64)
 		if ttl > 8 {
-			t.Fatalf("TTL too large")
+			t.Fatal("TTL too large")
 		}
 	}
 
@@ -4195,17 +4195,17 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp == nil {
-		t.Fatalf("expected a warning")
+		t.Fatal("expected a warning")
 	}
 
 	req.Operation = logical.UpdateOperation
 	req.Path = "auth/token/create/test"
 	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 	if len(resp.Warnings) == 0 {
-		t.Fatalf("expected a warning")
+		t.Fatal("expected a warning")
 	}
 
 	// Reset to a good explicit max
@@ -4220,7 +4220,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// This first set of logic is to verify that a normal non-root token will
@@ -4248,7 +4248,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		}
 		ttl := resp.Data["ttl"].(int64)
 		if ttl > 5 {
-			t.Fatalf("TTL too large")
+			t.Fatal("TTL too large")
 		}
 
 		// Let the TTL go down a bit to 3 seconds
@@ -4269,7 +4269,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		}
 		ttl = resp.Data["ttl"].(int64)
 		if ttl < 4 {
-			t.Fatalf("TTL too small after renewal")
+			t.Fatal("TTL too small after renewal")
 		}
 	}
 
@@ -4302,7 +4302,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		}
 		ttl := resp.Data["ttl"].(int64)
 		if ttl > 10 {
-			t.Fatalf("TTL too big")
+			t.Fatal("TTL too big")
 		}
 		// explicit max ttl is stored in the role so not returned here
 		maxTTL := resp.Data["explicit_max_ttl"].(int64)
@@ -4355,7 +4355,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		}
 		ttl = resp.Data["ttl"].(int64)
 		if ttl > 6 {
-			t.Fatalf("TTL too big")
+			t.Fatal("TTL too big")
 		}
 
 		// It should expire
@@ -4368,7 +4368,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 		}
 		resp, err = core.HandleRequest(namespace.RootContext(nil), req)
 		if err == nil {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 
 		time.Sleep(2 * time.Second)
@@ -4380,7 +4380,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 			t.Fatalf("expected error, response is %#v", *resp)
 		}
 		if err == nil {
-			t.Fatalf("expected error")
+			t.Fatal("expected error")
 		}
 	}
 }
@@ -4493,7 +4493,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
 		if resp != nil {
-			t.Fatalf("expected a nil response")
+			t.Fatal("expected a nil response")
 		}
 
 		req = logical.TestRequest(t, logical.ReadOperation, "roles/test")
@@ -4548,7 +4548,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
 		if resp != nil {
-			t.Fatalf("expected a nil response")
+			t.Fatal("expected a nil response")
 		}
 
 		req = logical.TestRequest(t, logical.ReadOperation, "roles/test")
@@ -4602,7 +4602,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
 		if resp == nil {
-			t.Fatalf("expected a non-nil response")
+			t.Fatal("expected a non-nil response")
 		}
 		if len(resp.Warnings) != 3 {
 			t.Fatalf("expected 3 warnings, got %#v", resp.Warnings)
@@ -4663,7 +4663,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// First make one directly and verify on renew it uses the period.
@@ -4832,7 +4832,7 @@ func TestTokenStore_NumUses(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// Create a test role with unlimited token_num_uses
@@ -4843,7 +4843,7 @@ func TestTokenStore_NumUses(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// Generate some tokens from the test roles
@@ -4919,7 +4919,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 	if resp != nil {
-		t.Fatalf("expected a nil response")
+		t.Fatal("expected a nil response")
 	}
 
 	// First make one directly and verify on renew it uses the period.
@@ -4999,7 +4999,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatalf("err: %v\nresp: %#v", err, resp)
 		}
 		if resp != nil {
-			t.Fatalf("expected a nil response")
+			t.Fatal("expected a nil response")
 		}
 
 		req.ClientToken = root
@@ -5299,7 +5299,7 @@ func TestTokenStore_AllowedDisallowedPolicies(t *testing.T) {
 	}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), tokenReq)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 
 	roleReq.Operation = logical.UpdateOperation
@@ -5317,7 +5317,7 @@ func TestTokenStore_AllowedDisallowedPolicies(t *testing.T) {
 	}
 	resp, err = ts.HandleRequest(namespace.RootContext(nil), tokenReq)
 	if err == nil {
-		t.Fatalf("expected an error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -5418,7 +5418,7 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 
 	err = ts.revokeInternal(namespace.RootContext(nil), saltTut, false)
 	if err == nil {
-		t.Fatalf("expected err")
+		t.Fatal("expected err")
 	}
 
 	// Since revocation failed we should still be able to get a token
@@ -5751,11 +5751,11 @@ func TestTokenStore_HandleTidy_parentCleanup(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 		if resp.Data == nil {
-			t.Fatalf("response should contain data")
+			t.Fatal("response should contain data")
 		}
 		// These tokens should now be orphaned
 		if resp.Data["orphan"] != true {
-			t.Fatalf("token should be orphan")
+			t.Fatal("token should be orphan")
 		}
 	}
 }
@@ -6050,7 +6050,7 @@ func TestTokenStore_TokenID(t *testing.T) {
 		// Ensure that using a custom token ID results in a warning
 		expectedWarning := "Supplying a custom ID for the token uses the weaker SHA1 hashing instead of the more secure SHA2-256 HMAC for token obfuscation. SHA1 hashed tokens on the wire leads to less secure lookups."
 		if resp.Warnings[0] != expectedWarning {
-			t.Fatalf("expected warning not present")
+			t.Fatal("expected warning not present")
 		}
 	})
 
@@ -6068,10 +6068,10 @@ func TestTokenStore_TokenID(t *testing.T) {
 			},
 		})
 		if err == nil {
-			t.Fatalf("expected an error")
+			t.Fatal("expected an error")
 		}
 		if resp.Error().Error() != "custom token ID cannot have the 'hvs.' prefix" {
-			t.Fatalf("expected input error not present in error response")
+			t.Fatal("expected input error not present in error response")
 		}
 	})
 
@@ -6088,10 +6088,10 @@ func TestTokenStore_TokenID(t *testing.T) {
 			},
 		})
 		if err == nil {
-			t.Fatalf("expected an error")
+			t.Fatal("expected an error")
 		}
 		if resp.Error().Error() != "custom token ID cannot have a '.' in the value" {
-			t.Fatalf("expected input error not present in error response")
+			t.Fatal("expected input error not present in error response")
 		}
 	})
 }

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -5412,7 +5413,7 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 	origDestroyCubbyhole := ts.cubbyholeDestroyer
 
 	ts.cubbyholeDestroyer = func(context.Context, *TokenStore, *logical.TokenEntry) error {
-		return fmt.Errorf("keep it frosty")
+		return errors.New("keep it frosty")
 	}
 
 	err = ts.revokeInternal(namespace.RootContext(nil), saltTut, false)
@@ -5432,7 +5433,7 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 	// Check the race condition situation by making the process sleep
 	ts.cubbyholeDestroyer = func(context.Context, *TokenStore, *logical.TokenEntry) error {
 		time.Sleep(1 * time.Second)
-		return fmt.Errorf("keep it frosty")
+		return errors.New("keep it frosty")
 	}
 	cubbyFuncLock.Unlock()
 

--- a/vault/version_store.go
+++ b/vault/version_store.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -73,7 +74,7 @@ func (c *Core) storeVersionEntry(ctx context.Context, vaultVersion *VaultVersion
 // upgrade timestamp from storage. The earliest version this can be is 1.9.0.
 func (c *Core) FindOldestVersionTimestamp() (string, time.Time, error) {
 	if c.versionHistory == nil {
-		return "", time.Time{}, fmt.Errorf("version history is not initialized")
+		return "", time.Time{}, errors.New("version history is not initialized")
 	}
 
 	oldestUpgradeTime := time.Now().UTC()
@@ -90,7 +91,7 @@ func (c *Core) FindOldestVersionTimestamp() (string, time.Time, error) {
 
 func (c *Core) FindNewestVersionTimestamp() (string, time.Time, error) {
 	if c.versionHistory == nil {
-		return "", time.Time{}, fmt.Errorf("version history is not initialized")
+		return "", time.Time{}, errors.New("version history is not initialized")
 	}
 
 	var newestUpgradeTime time.Time

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -340,7 +340,7 @@ DONELISTHANDLING:
 // a JWT token.
 func (c *Core) validateWrappingToken(ctx context.Context, req *logical.Request) (valid bool, err error) {
 	if req == nil {
-		return false, fmt.Errorf("invalid request")
+		return false, errors.New("invalid request")
 	}
 
 	if c.Sealed() {
@@ -386,9 +386,9 @@ func (c *Core) validateWrappingToken(ctx context.Context, req *logical.Request) 
 	if req.Data != nil && req.Data["token"] != nil {
 		thirdParty = true
 		if tokenStr, ok := req.Data["token"].(string); !ok {
-			return false, fmt.Errorf("could not decode token in request body")
+			return false, errors.New("could not decode token in request body")
 		} else if tokenStr == "" {
-			return false, fmt.Errorf("empty token in request body")
+			return false, errors.New("empty token in request body")
 		} else {
 			token = tokenStr
 		}
@@ -434,7 +434,7 @@ func (c *Core) validateWrappingToken(ctx context.Context, req *logical.Request) 
 	}
 
 	if token == "" {
-		return false, fmt.Errorf("token is empty")
+		return false, errors.New("token is empty")
 	}
 
 	te, err := c.tokenStore.Lookup(ctx, token)


### PR DESCRIPTION
This fixes various format string errors (using a formatter where none is required mostly), which prevent testing with the upcoming Go 1.24 toolchain. This was tested with 1.24rc1. 

This will be required to address #496 in the future.