### PR TITLE
Nit: fix indentation for basic_constraints_valid_for_non_ca

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1305,7 +1305,7 @@ based on this parameter.
   User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the
   signed certificate. No validation on names is performed using this endpoint.
 
-  - `basic_constraints_valid_for_non_ca` `(bool: false)` - Mark Basic Constraints
+- `basic_constraints_valid_for_non_ca` `(bool: false)` - Mark Basic Constraints
   valid when issuing non-CA certificates. When the endpoint is used with a role, this parameter overwrites the `basic_constraints_valid_for_non_ca` value set in the role.
 
 #### Sample payload


### PR DESCRIPTION
Nit: `basic_constraints_valid_for_non_ca` is indented under `user_ids` which makes it look like it's a sub-property or related field.

![image](https://github.com/user-attachments/assets/177fa1f5-7d9e-49f9-8271-f448c6b8b993)
