### PR TITLE
Attempt to add reusable components to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This might address why `actions/cache` is out of date in `.github/actions/set-up-go/action.yml` despite dependabot saying there is nothing to do: https://github.com/openbao/openbao/pull/163#issuecomment-2599722950 