### PR TITLE
Allow tuning HMAC status on protected mounts

### DIFF
--- a/changelog/921.txt
+++ b/changelog/921.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/mounts: Allow tuning HMAC request and response parameters on sys/, cubbyhole/, and identity/, enabling auditing of core policy changes.
+```

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -365,6 +367,21 @@ func (n *NoopAudit) Invalidate(ctx context.Context) {
 	n.saltMutex.Lock()
 	defer n.saltMutex.Unlock()
 	n.salt = nil
+}
+
+func (n *NoopAudit) GetDecodedRecord(index int) (map[string]interface{}, error) {
+	if index > len(n.records) {
+		return nil, fmt.Errorf("index %v exceeds current record length: %v", index, len(n.records))
+	}
+
+	record := n.records[index]
+	var ret map[string]interface{}
+
+	if err := json.Unmarshal(record, &ret); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal record %d: %v\n\terr: %w", index, string(record), err)
+	}
+
+	return ret, nil
 }
 
 type TestLogger struct {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	semver "github.com/hashicorp/go-version"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbao/openbao/audit"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	"github.com/openbao/openbao/helper/builtinplugins"
 	"github.com/openbao/openbao/helper/identity"
@@ -37,6 +38,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/testhelpers/schema"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSystemBackend_RootPaths(t *testing.T) {
@@ -2252,6 +2254,99 @@ func TestSystemBackend_tuneAuth(t *testing.T) {
 	if resp.Data["plugin_version"] != "v1.0.0" {
 		t.Fatalf("got: %#v, expected: %v", resp.Data["version"], "v1.0.0")
 	}
+}
+
+func TestSystemBackend_tuneSys(t *testing.T) {
+	// Create a noop audit backend
+	var noop *corehelpers.NoopAudit
+	c, b, root := testCoreSystemBackend(t)
+	c.auditBackends["noop"] = func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
+		var err error
+		noop, err = corehelpers.NewNoopAudit(config.Config)
+		if err != nil {
+			return nil, err
+		}
+		return noop, nil
+	}
+
+	// Validate Tune behavior.
+	req := logical.TestRequest(t, logical.UpdateOperation, "mounts/sys/tune")
+	req.Data["audit_non_hmac_request_keys"] = "policy"
+	req.Data["audit_non_hmac_response_keys"] = "policy"
+	_, err := b.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed to perform request")
+
+	req.Data["description"] = "new sys/ description"
+	_, err = b.HandleRequest(namespace.RootContext(nil), req)
+	require.Error(t, err, "expected to fail to modify description of sys/")
+
+	req = logical.TestRequest(t, logical.UpdateOperation, "mounts/sys/tune")
+	req.Data["description"] = "new sys/ description"
+	_, err = b.HandleRequest(namespace.RootContext(nil), req)
+	require.Error(t, err, "expected to fail to modify description of sys/")
+
+	// Enable the audit backend
+	req = logical.TestRequest(t, logical.UpdateOperation, "sys/audit/noop")
+	req.Data["type"] = "noop"
+	req.ClientToken = root
+	_, err = c.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed to enable audit backend")
+
+	// Now test policies are un-HMAC'd
+	req = &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "sys/policies/acl/default",
+		ClientToken: root,
+	}
+
+	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed to read default ACL policy")
+
+	require.Equal(t, 1, len(noop.RespNonHMACKeys))
+	require.Equal(t, noop.RespNonHMACKeys[0], []string{"policy"})
+	require.Equal(t, 2, len(noop.Resp))
+	require.Equal(t, noop.Resp[1], resp)
+	record, err := noop.GetDecodedRecord(3)
+	require.NoError(t, err)
+	require.Contains(t, record, "type")
+	recordType := record["type"].(string)
+	require.Equal(t, recordType, "response")
+	require.Contains(t, record, "response")
+	recordResp := record["response"].(map[string]interface{})
+	require.Contains(t, recordResp, "data")
+	recordData := recordResp["data"].(map[string]interface{})
+	require.Contains(t, recordData, "policy")
+	recordPolicy := recordData["policy"].(string)
+	require.NotContains(t, recordPolicy, "hmac-sha256:")
+
+	// Writing a new policy should also be un-HMAC'd.
+	req.Operation = logical.UpdateOperation
+	req.Data = map[string]interface{}{
+		"policy": `path "auth/token/lookup-self" {
+    capabilities = ["read"]
+}
+`,
+	}
+	resp, err = c.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed to read default ACL policy")
+
+	require.Equal(t, 1, len(noop.RespNonHMACKeys))
+	require.Equal(t, noop.RespNonHMACKeys[0], []string{"policy"})
+	require.Equal(t, 3, len(noop.Resp))
+	require.Equal(t, noop.Resp[2], resp)
+	record, err = noop.GetDecodedRecord(4)
+	require.NoError(t, err)
+	require.Contains(t, record, "type")
+	recordType = record["type"].(string)
+	require.Equal(t, recordType, "request")
+	require.Contains(t, record, "request")
+	recordReq := record["request"].(map[string]interface{})
+	require.Contains(t, recordReq, "data")
+	recordData = recordReq["data"].(map[string]interface{})
+	require.Contains(t, recordData, "policy")
+	recordPolicy = recordData["policy"].(string)
+	require.NotContains(t, recordPolicy, "hmac-sha256:")
+	require.Equal(t, recordPolicy, req.Data["policy"])
 }
 
 func TestSystemBackend_policyList(t *testing.T) {


### PR DESCRIPTION
When protected mounts were disallowed from tuning in b9a5a137c002211328cc90d9d7e92170d0d86908, only TTL status was present in the tune interface at the time. Tuning HMAC status of request/response in the audit log was not present but makes sense for all mounts, even protected mounts.

Thanks to @jficz for pair coding this!

Resolves: #474

---

Live coding video: https://youtu.be/lr7_YmEIOro
