### PR TITLE
Bump alpine from 3.20 to 3.21 (#831)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 #### DOCKERHUB DOCKERFILE ####
-FROM alpine:3.20 as default
+FROM alpine:3.21 as default
 
 ARG BIN_NAME
 # NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com


### PR DESCRIPTION
Bumps alpine from 3.20 to 3.21.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...

Backport of: https://github.com/openbao/openbao/pull/831 