### PR TITLE
Ensure pki health-check errs on non-pki mounts

### DIFF
--- a/changelog/935.txt
+++ b/changelog/935.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix bao pki health-check detection on non-pki mounts.
+```

--- a/command/pki_health_check.go
+++ b/command/pki_health_check.go
@@ -206,6 +206,14 @@ func (c *PKIHealthCheckCommand) Run(args []string) int {
 		pkiPath = args[0]
 	}
 
+	// Validate the mount type before executing tests
+	err = healthcheck.ValidateMountType(client, pkiPath, "pki")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return pkiRetUsage
+	}
+
+	// Build health check executor
 	mount := sanitizePath(pkiPath)
 	executor := healthcheck.NewExecutor(client, mount)
 	executor.AddCheck(healthcheck.NewCAValidityPeriodCheck())


### PR DESCRIPTION
When `bao pki health-check` runs on a non-PKI mount, we see results like:

    ca_validity_period
    ------------------
    status             endpoint                        message
    ------             --------                        -------
    invalid_version    /auth/userpass/users/issuers    This health check requires Vault 1.11+ but an earlier version of Vault Server was contacted, preventing this health check from running.

which isn't correct: we are running on a non-PKI mount, not on an invalid version of Vault or OpenBao.

As reported by @pgnd on Matrix.