### PR TITLE
Fix noisy warn in Raft key rotation

### DIFF
--- a/changelog/937.txt
+++ b/changelog/937.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: Fix noisy warn on follower-less keyring rotation.
+```

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -256,6 +256,13 @@ func (s *FollowerStates) MinIndex() uint64 {
 	return min
 }
 
+func (s *FollowerStates) HaveFollower() bool {
+	s.l.RLock()
+	defer s.l.RUnlock()
+
+	return len(s.followers) > 0
+}
+
 // SetFollowerStates sets the followerStates field in the backend to track peers
 // in the raft cluster.
 func (b *RaftBackend) SetFollowerStates(states *FollowerStates) {


### PR DESCRIPTION
When we attempt Raft keyring rotation on a standby-less node, the minimum follower index is zero, which differs from our actual present index. This means the new keyring is never accepted, unless we later join a standby node. Instead, always apply the new keyring if we have no followers.

We keep the rotation to prevent the 30-year certificates from expiring before a follower is added (or, more likely, in the event of bad system clock at initial rotation).

Thanks to @pgnd for reporting on Matrix.

Resolves: #936

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->