### PR TITLE
Add UI to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,16 @@ jobs:
       - name: go-check
         run: go version
 
+      - name: Node setup
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: "./ui/package.json"
+
+      - name: Yarn setup
+        id: install-yarn
+        run: |
+          npm install -g yarn
+
       # Supports syft/sbom generation
       - uses: anchore/sbom-action/download-syft@v0
 
@@ -120,6 +130,20 @@ jobs:
         env:
           GPG_TTY: /dev/ttys000 # Set the GPG_TTY to avoid issues with pinentry
 
+      # Before executing binary builds, build the UI.
+      - name: Install UI dependencies
+        id: ui-dependencies
+        working-directory: ./ui
+        run: |
+          yarn install --frozen-lockfile
+          npm rebuild node-sass
+
+      - name: Build UI
+        id: ui-build
+        run: |
+          make static-dist
+
+      # Execute Go binary builds
       - name: "Template GoRelaser configuration"
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.goreleaser-template.yaml
+++ b/.goreleaser-template.yaml
@@ -27,6 +27,8 @@ before:
 
 builds:
   - id: builds-linux
+    tags:
+      - ui
     ldflags:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }}
     env:
@@ -54,6 +56,8 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     skip: false
   - id: builds-other
+    tags:
+      - ui
     ldflags:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }}
     env:
@@ -770,7 +774,8 @@ checksum:
 #LINUXONLY#      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi:{{ .Version }}-s390x
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_
@@ -781,7 +786,8 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - 'LICENSE'
       - 'README.md'

--- a/changelog/940.txt
+++ b/changelog/940.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**UI**: Reintroduction of the WebUI.
+```


### PR DESCRIPTION
Resolves: #739 

---

I think I will setup a new repository, `openbao-nightly`, which mirrors `openbao` and launches nightly release builds... I'll provision fresh keys, fresh access tokens, and fresh repositories (with `-nightly` suffix) which contain updated nightly releases.

Thoughts? 