### PR TITLE
Add explicit hsm build tag

### DIFF
--- a/internalshared/configutil/no_pkcs11.go
+++ b/internalshared/configutil/no_pkcs11.go
@@ -1,4 +1,4 @@
-//go:build !cgo || !linux
+//go:build !hsm || !linux
 
 package configutil
 

--- a/internalshared/configutil/pkcs11.go
+++ b/internalshared/configutil/pkcs11.go
@@ -1,4 +1,4 @@
-//go:build cgo && linux
+//go:build hsm && linux
 
 package configutil
 


### PR DESCRIPTION
Using an implicit CGO tag means that the PKCS#11 build must succeed on musl (which it likely won't); move it to an explicit tag and let the build fail with a rather cryptic error if CGO is not specified but the hsm build tag is:

```
   ==> Building bao...
   # github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:55:22: undefined: pkcs11.Ctx
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:278:53: undefined: pkcs11.SessionHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:278:79: undefined: pkcs11.ObjectHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:309:54: undefined: pkcs11.SessionHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:309:80: undefined: pkcs11.ObjectHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:364:53: undefined: pkcs11.SessionHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:364:79: undefined: pkcs11.ObjectHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:381:54: undefined: pkcs11.SessionHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:381:80: undefined: pkcs11.ObjectHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:442:45: undefined: pkcs11.SessionHandle
   ../../../go/pkg/mod/github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2@v2.0.0-20250114185509-3fa7a3d31521/pkcs11_client.go:442:45: too many errors
```