### PR TITLE
Fix unix-listener in `bao operator diagnose`

### DIFF
--- a/changelog/958.txt
+++ b/changelog/958.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core-listener: Fix operator diagnose with unix-socker listener
+```

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -38,6 +38,11 @@ func ListenerChecks(ctx context.Context, listeners []*configutil.Listener) ([]st
 	for _, l := range listeners {
 		listenerID := l.Address
 
+		if strings.ToLower(l.Type) == "unix" {
+			Warn(ctx, fmt.Sprintf("Listener at address %s: Unix socket being used in a listener config stanza.", listenerID))
+			continue
+		}
+
 		if l.TLSDisable {
 			Warn(ctx, fmt.Sprintf("Listener at address %s: TLS is disabled in a listener config stanza.", listenerID))
 			continue


### PR DESCRIPTION
Resolves #957

`bao operator diagnose` skips listener TLS checks for unix-socket based listeners 