### PR TITLE
Set BAO_CONFIG_DIR to a default but let it be overridable.

### DIFF
--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 # BAO_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
 # BAO_LOCAL_CONFIG below.
-BAO_CONFIG_DIR=/openbao/config
+BAO_CONFIG_DIR=${BAO_CONFIG_DIR:-/openbao/config}
 
 # You can also set the BAO_LOCAL_CONFIG environment variable to pass some
 # OpenBao configuration JSON without having to bind any volumes.


### PR DESCRIPTION
Allow the config directory env var to be overridable so that it will work inside of bankvaults deployments.