### PR TITLE
Add API and CLI commands to promote/demote nodes in the Raft cluster

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -404,6 +404,16 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"operator raft promote": func() (cli.Command, error) {
+			return &OperatorRaftPromoteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"operator raft demote": func() (cli.Command, error) {
+			return &OperatorRaftDemoteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"operator raft snapshot": func() (cli.Command, error) {
 			return &OperatorRaftSnapshotCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/operator_raft_demote.go
+++ b/command/operator_raft_demote.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*OperatorRaftDemoteCommand)(nil)
+	_ cli.CommandAutocomplete = (*OperatorRaftDemoteCommand)(nil)
+)
+
+type OperatorRaftDemoteCommand struct {
+	*BaseCommand
+	flagDRToken string
+}
+
+func (c *OperatorRaftDemoteCommand) Synopsis() string {
+	return "Demotes a voter to a permanent non-voter"
+}
+
+func (c *OperatorRaftDemoteCommand) Help() string {
+	helpText := `
+Usage: bao operator raft demote <server_id>
+
+  Demotes voter to a permanent non-voter.
+
+	  $ bao operator raft demote node1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftDemoteCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:       "dr-token",
+		Target:     &c.flagDRToken,
+		Default:    "",
+		EnvVar:     "",
+		Completion: complete.PredictAnything,
+		Usage:      "DR operation token used to authorize this request (if a DR secondary node).",
+	})
+
+	return set
+}
+
+func (c *OperatorRaftDemoteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorRaftDemoteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorRaftDemoteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	serverID := ""
+
+	args = f.Args()
+	switch len(args) {
+	case 1:
+		serverID = strings.TrimSpace(args[0])
+	default:
+		c.UI.Error(fmt.Sprintf("Incorrect arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	if len(serverID) == 0 {
+		c.UI.Error("Server id is required")
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	_, err = client.Logical().Write("sys/storage/raft/demote", map[string]interface{}{
+		"server_id":          serverID,
+		"dr_operation_token": c.flagDRToken,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Server demoted successfully!")
+
+	return 0
+}

--- a/command/operator_raft_demote.go
+++ b/command/operator_raft_demote.go
@@ -18,7 +18,6 @@ var (
 
 type OperatorRaftDemoteCommand struct {
 	*BaseCommand
-	flagDRToken string
 }
 
 func (c *OperatorRaftDemoteCommand) Synopsis() string {
@@ -39,20 +38,7 @@ Usage: bao operator raft demote <server_id>
 }
 
 func (c *OperatorRaftDemoteCommand) Flags() *FlagSets {
-	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
-
-	f := set.NewFlagSet("Command Options")
-
-	f.StringVar(&StringVar{
-		Name:       "dr-token",
-		Target:     &c.flagDRToken,
-		Default:    "",
-		EnvVar:     "",
-		Completion: complete.PredictAnything,
-		Usage:      "DR operation token used to authorize this request (if a DR secondary node).",
-	})
-
-	return set
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
 }
 
 func (c *OperatorRaftDemoteCommand) AutocompleteArgs() complete.Predictor {
@@ -94,8 +80,7 @@ func (c *OperatorRaftDemoteCommand) Run(args []string) int {
 	}
 
 	_, err = client.Logical().Write("sys/storage/raft/demote", map[string]interface{}{
-		"server_id":          serverID,
-		"dr_operation_token": c.flagDRToken,
+		"server_id": serverID,
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))

--- a/command/operator_raft_promote.go
+++ b/command/operator_raft_promote.go
@@ -18,7 +18,6 @@ var (
 
 type OperatorRaftPromoteCommand struct {
 	*BaseCommand
-	flagDRToken string
 }
 
 func (c *OperatorRaftPromoteCommand) Synopsis() string {
@@ -39,20 +38,7 @@ Usage: bao operator raft promote <server_id>
 }
 
 func (c *OperatorRaftPromoteCommand) Flags() *FlagSets {
-	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
-
-	f := set.NewFlagSet("Command Options")
-
-	f.StringVar(&StringVar{
-		Name:       "dr-token",
-		Target:     &c.flagDRToken,
-		Default:    "",
-		EnvVar:     "",
-		Completion: complete.PredictAnything,
-		Usage:      "DR operation token used to authorize this request (if a DR secondary node).",
-	})
-
-	return set
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
 }
 
 func (c *OperatorRaftPromoteCommand) AutocompleteArgs() complete.Predictor {
@@ -94,8 +80,7 @@ func (c *OperatorRaftPromoteCommand) Run(args []string) int {
 	}
 
 	_, err = client.Logical().Write("sys/storage/raft/promote", map[string]interface{}{
-		"server_id":          serverID,
-		"dr_operation_token": c.flagDRToken,
+		"server_id": serverID,
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))

--- a/command/operator_raft_promote.go
+++ b/command/operator_raft_promote.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*OperatorRaftPromoteCommand)(nil)
+	_ cli.CommandAutocomplete = (*OperatorRaftPromoteCommand)(nil)
+)
+
+type OperatorRaftPromoteCommand struct {
+	*BaseCommand
+	flagDRToken string
+}
+
+func (c *OperatorRaftPromoteCommand) Synopsis() string {
+	return "Promotes a permanent non-voter to a voter"
+}
+
+func (c *OperatorRaftPromoteCommand) Help() string {
+	helpText := `
+Usage: bao operator raft promote <server_id>
+
+  Promotes a permanent non-voter to a voter.
+
+	  $ bao operator raft promote node1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftPromoteCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:       "dr-token",
+		Target:     &c.flagDRToken,
+		Default:    "",
+		EnvVar:     "",
+		Completion: complete.PredictAnything,
+		Usage:      "DR operation token used to authorize this request (if a DR secondary node).",
+	})
+
+	return set
+}
+
+func (c *OperatorRaftPromoteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorRaftPromoteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorRaftPromoteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	serverID := ""
+
+	args = f.Args()
+	switch len(args) {
+	case 1:
+		serverID = strings.TrimSpace(args[0])
+	default:
+		c.UI.Error(fmt.Sprintf("Incorrect arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	if len(serverID) == 0 {
+		c.UI.Error("Server id is required")
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	_, err = client.Logical().Write("sys/storage/raft/promote", map[string]interface{}{
+		"server_id":          serverID,
+		"dr_operation_token": c.flagDRToken,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Server promoted successfully!")
+
+	return 0
+}

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -178,7 +178,6 @@ may be provided if the node is in a DR secondary cluster.
 ```json
 {
   "server_id": "raft1",
-  "dr_operation_token": ""
 }
 ```
 
@@ -206,7 +205,6 @@ may be provided if the node is in a DR secondary cluster.
 ```json
 {
   "server_id": "raft1",
-  "dr_operation_token": ""
 }
 ```
 

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -164,6 +164,62 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/storage/raft/remove-peer
 ```
 
+## Promote a node in the raft cluster
+
+This endpoint promotes a permanent [non-voter](/docs/commands/operator/raft#parameters) to voter in the raft cluster. An optional `dr_operation_token`
+may be provided if the node is in a DR secondary cluster.
+
+| Method | Path                        |
+|:-------|:----------------------------|
+| `POST` | `/sys/storage/raft/promote` |
+
+### Sample payload
+
+```json
+{
+  "server_id": "raft1",
+  "dr_operation_token": ""
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/storage/raft/promote
+```
+
+## Demote a node in the raft cluster
+
+This endpoint demotes a voter to a permanent [non-voter](/docs/commands/operator/raft#parameters) in the raft cluster. An optional `dr_operation_token`
+may be provided if the node is in a DR secondary cluster.
+
+| Method | Path                       |
+|:-------|:---------------------------|
+| `POST` | `/sys/storage/raft/demote` |
+
+### Sample payload
+
+```json
+{
+  "server_id": "raft1",
+  "dr_operation_token": ""
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/storage/raft/demote
+```
+
 ## Take a snapshot of the raft cluster
 
 This endpoint returns a snapshot of the current state of the raft cluster. The

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -159,6 +159,34 @@ Usage: bao operator raft remove-peer <server_id>
   Once a node is removed, its Raft data needs to be deleted before it may be joined back into an existing cluster. This requires shutting down the OpenBao process, deleting the data, then restarting the OpenBao process on the removed node.
 :::
 
+## promote
+
+This command is used to promote a permanent [non-voter](#parameters) to a voter in the Raft cluster.
+
+```text
+Usage: bao operator raft promote <server_id>
+
+  Promotes a permanent non-voter to a voter.
+
+	  $ bao operator raft promote node1
+```
+
+## demote
+
+This command is used to demote a voter to a permanent [non-voter](#parameters) in the Raft cluster.
+
+```text
+Usage: bao operator raft demote <server_id>
+
+  Demotes voter to a permanent non-voter.
+
+	  $ bao operator raft demote node1
+```
+
+
+:::note
+  Demoting the current leader to a non-voter will not trigger a leader election. The node will become a non-voter after the leadership has changed.
+:::
 ## snapshot
 
 This command groups subcommands for operators interacting with the snapshot


### PR DESCRIPTION
This is a follow up of #741 to allow managing the voter state of a node in the
cluster at runtime.  We provide new CLI commands `bao operator raft promote` and
`demote` to promote a non-voter to a voter and vice versa.  Matching API
endpoints at `sys/storage/raft/promte` and `demote` are also added for
convenience.

I am no sure yet if I should also expose this directly in the UI's Raft Storage
overview.