### PR TITLE
feat(identity/entity-alias): return metadata when listing entity-aliases

### DIFF
--- a/changelog/1013.txt
+++ b/changelog/1013.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: return alias metadata when listing entity aliases
+```

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -2306,6 +2306,7 @@ func (i *IdentityStore) handleAliasListCommon(ctx context.Context, groupAlias bo
 			"canonical_id":    alias.CanonicalID,
 			"mount_accessor":  alias.MountAccessor,
 			"custom_metadata": alias.CustomMetadata,
+			"metadata":        alias.Metadata,
 			"local":           alias.Local,
 		}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

When listing the `identity/entity-alias/id` endpoint it can be helpful to also get the `metadata`, not only `custom_metadata`, which can be set by auth methods (OIDC provider for example).
This helps especially when you need to search for a specific user using the metadata on an entity-alias, as the alias-id should be a unique identifier (sub), that might not be an email address etc.

```
$ bao list -detailed identity/entity-alias/id

Keys                                    canonical_id                            custom_metadata         local    metadata                 mount_accessor            mount_path        mount_type    name
----                                    ------------                            ---------------         -----    --------                 --------------            ----------        ----------    ----
e22d422d-ccba-48e1-959c-d940cac823f7    51e6d76b-5ef6-48cb-98c4-67a78edfac75    <nil>                   false    map[username:pree]       auth_oidc_a44c8eff        auth/oidc/        oidc          210ff03b-02a8-48a8-a869-91a50cefb327
```
