### PR TITLE
Correctly handle request routing

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -509,13 +509,11 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 		}
 	}(ctx, httpCtx)
 
-	ns, err := namespace.FromContext(httpCtx)
+	ctx, _, req.Path, err = c.namespaceStore.ResolveNamespaceFromRequest(ctx, httpCtx, req.Path)
 	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not parse namespace from http context: %w", err)
+		return nil, err
 	}
 
-	ctx = namespace.ContextWithNamespace(ctx, ns)
 	inFlightReqID, ok := httpCtx.Value(logical.CtxKeyInFlightRequestID{}).(string)
 	if ok {
 		ctx = context.WithValue(ctx, logical.CtxKeyInFlightRequestID{}, inFlightReqID)
@@ -678,15 +676,6 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 			return nil, ErrCannotForwardLocalOnly
 		}
 	}
-
-	//ns, err = namespace.FromContext(ctx)
-	//if err != nil {
-	//	return nil, errwrap.Wrapf("could not parse namespace from http context: {{err}}", err)
-	//}
-
-	//if ns.Path != "" {
-	//	return nil, logical.CodedError(403, "namespaces feature not enabled")
-	//}
 
 	var auth *logical.Auth
 	if c.isLoginRequest(ctx, req) {


### PR DESCRIPTION
During [live-coding with Andrii](https://youtu.be/Gm15qRTtiUY), we worked through correctly handling request routing with namespaces from paths or headers. Right now there is no support for child namespaces, but we've solved the issue with using the root namespace and the data race from the concurrent modification issue in http/util.go.

This doesn't yet allow secret engine mounting within a namespace; we still need to enable the `sys/`, `cubbyhole/`, and `identity/` mounts within the namespace's mount table and load them at runtime.

---

cc: @genelet @driif @klaus-sap @phyrog @voigt @satoqz