### PR TITLE
Create required mounts when setting up namespace

### DIFF
--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
@@ -598,7 +599,8 @@ func TestCore_DisableCredential_Cleanup(t *testing.T) {
 
 func TestDefaultAuthTable(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	table := c.defaultAuthTable()
+	table, err := c.defaultAuthTable(context.Background())
+	require.NoError(t, err)
 	verifyDefaultAuthTable(t, table)
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1219,6 +1219,7 @@ func (c *Core) configureCredentialsBackends(backends map[string]logical.Factory,
 
 		return NewTokenStore(ctx, tsLogger, c, config)
 	}
+	credentialBackends[mountTypeNSToken] = credentialBackends[mountTypeToken]
 
 	c.credentialBackends = credentialBackends
 }
@@ -1240,6 +1241,7 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 
 	// Cubbyhole
 	logicalBackends[mountTypeCubbyhole] = CubbyholeBackendFactory
+	logicalBackends[mountTypeNSCubbyhole] = logicalBackends[mountTypeCubbyhole]
 
 	// System
 	logicalBackends[mountTypeSystem] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
@@ -1251,6 +1253,7 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 		}
 		return b, nil
 	}
+	logicalBackends[mountTypeNSSystem] = logicalBackends[mountTypeSystem]
 
 	// Identity
 	logicalBackends[mountTypeIdentity] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -734,7 +734,7 @@ func TestCore_Remount_Protected(t *testing.T) {
 
 func TestDefaultMountTable(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	table := c.defaultMountTable()
+	table := c.defaultMountTable(context.Background())
 	verifyDefaultTable(t, table, 3)
 }
 


### PR DESCRIPTION
When setting up namespaces, we're required to create additional mounts
for sys/, identity/, cubbyhole/, and token/ within the namespace. Of
these, cubbyhole is never persisted but is instead a dynamic mount,
whereas the remainder exist in the underlying storage.

We don't yet handle the separation of these mounts' data by namespace;
this will be handled in later updates to this branch. Many singleton
stores like TokenStore and PolicyStore will need broader updates to
align with the RFC's data storage model.

This was created during live-coding with @satoqz.

`Signed-off-by: Alexander Scheel <ascheel@gitlab.com>`

----

Resolves: #1029

cc: @genelet @driif @klaus-sap @phyrog @voigt @satoqz