### PR TITLE
Nit: Fix link to create/update role in api/pki docs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3254,7 +3254,7 @@ like rotating the CRLs or performing tidy operations.
 Refer to the [earlier section](#list-roles) for more information about
 listing roles.
 
-### Create/Update role
+### Create/Update role {#create-update-role}
 
 This endpoint creates or updates the role definition. Note that the
 `allowed_domains`, `allow_subdomains`, `allow_glob_domains`, and


### PR DESCRIPTION
The link to **create/update role** is broken in the PKI Table of Contents. 

To fix this, we can either update the href to `#createupdate-role`, as observed in the raw HTML, or explicitly specify a heading ID, as I have done, following the [docusaurus docs](https://docusaurus.io/docs/markdown-features/toc#heading-ids). 