### PR TITLE
Backport: Add API and CLI commands to promote/demote nodes in the Raft cluster (#996)

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -404,6 +404,16 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"operator raft promote": func() (cli.Command, error) {
+			return &OperatorRaftPromoteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"operator raft demote": func() (cli.Command, error) {
+			return &OperatorRaftDemoteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"operator raft snapshot": func() (cli.Command, error) {
 			return &OperatorRaftSnapshotCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/operator_raft_demote.go
+++ b/command/operator_raft_demote.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*OperatorRaftDemoteCommand)(nil)
+	_ cli.CommandAutocomplete = (*OperatorRaftDemoteCommand)(nil)
+)
+
+type OperatorRaftDemoteCommand struct {
+	*BaseCommand
+}
+
+func (c *OperatorRaftDemoteCommand) Synopsis() string {
+	return "Demotes a voter to a permanent non-voter"
+}
+
+func (c *OperatorRaftDemoteCommand) Help() string {
+	helpText := `
+Usage: bao operator raft demote <server_id>
+
+  Demotes voter to a permanent non-voter.
+
+	  $ bao operator raft demote node1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftDemoteCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+}
+
+func (c *OperatorRaftDemoteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorRaftDemoteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorRaftDemoteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	serverID := ""
+
+	args = f.Args()
+	switch len(args) {
+	case 1:
+		serverID = strings.TrimSpace(args[0])
+	default:
+		c.UI.Error(fmt.Sprintf("Incorrect arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	if len(serverID) == 0 {
+		c.UI.Error("Server id is required")
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	_, err = client.Logical().Write("sys/storage/raft/demote", map[string]interface{}{
+		"server_id": serverID,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Server demoted successfully!")
+
+	return 0
+}

--- a/command/operator_raft_promote.go
+++ b/command/operator_raft_promote.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*OperatorRaftPromoteCommand)(nil)
+	_ cli.CommandAutocomplete = (*OperatorRaftPromoteCommand)(nil)
+)
+
+type OperatorRaftPromoteCommand struct {
+	*BaseCommand
+}
+
+func (c *OperatorRaftPromoteCommand) Synopsis() string {
+	return "Promotes a permanent non-voter to a voter"
+}
+
+func (c *OperatorRaftPromoteCommand) Help() string {
+	helpText := `
+Usage: bao operator raft promote <server_id>
+
+  Promotes a permanent non-voter to a voter.
+
+	  $ bao operator raft promote node1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftPromoteCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+}
+
+func (c *OperatorRaftPromoteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorRaftPromoteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorRaftPromoteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	serverID := ""
+
+	args = f.Args()
+	switch len(args) {
+	case 1:
+		serverID = strings.TrimSpace(args[0])
+	default:
+		c.UI.Error(fmt.Sprintf("Incorrect arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	if len(serverID) == 0 {
+		c.UI.Error("Server id is required")
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	_, err = client.Logical().Write("sys/storage/raft/promote", map[string]interface{}{
+		"server_id": serverID,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error promoting server: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Server promoted successfully!")
+
+	return 0
+}

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -164,6 +164,60 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/storage/raft/remove-peer
 ```
 
+## Promote a node in the raft cluster
+
+This endpoint promotes a permanent [non-voter](/docs/commands/operator/raft#parameters) to voter in the raft cluster. An optional `dr_operation_token`
+may be provided if the node is in a DR secondary cluster.
+
+| Method | Path                        |
+|:-------|:----------------------------|
+| `POST` | `/sys/storage/raft/promote` |
+
+### Sample payload
+
+```json
+{
+  "server_id": "raft1",
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/storage/raft/promote
+```
+
+## Demote a node in the raft cluster
+
+This endpoint demotes a voter to a permanent [non-voter](/docs/commands/operator/raft#parameters) in the raft cluster. An optional `dr_operation_token`
+may be provided if the node is in a DR secondary cluster.
+
+| Method | Path                       |
+|:-------|:---------------------------|
+| `POST` | `/sys/storage/raft/demote` |
+
+### Sample payload
+
+```json
+{
+  "server_id": "raft1",
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/storage/raft/demote
+```
+
 ## Take a snapshot of the raft cluster
 
 This endpoint returns a snapshot of the current state of the raft cluster. The

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -159,6 +159,34 @@ Usage: bao operator raft remove-peer <server_id>
   Once a node is removed, its Raft data needs to be deleted before it may be joined back into an existing cluster. This requires shutting down the OpenBao process, deleting the data, then restarting the OpenBao process on the removed node.
 :::
 
+## promote
+
+This command is used to promote a permanent [non-voter](#parameters) to a voter in the Raft cluster.
+
+```text
+Usage: bao operator raft promote <server_id>
+
+  Promotes a permanent non-voter to a voter.
+
+	  $ bao operator raft promote node1
+```
+
+## demote
+
+This command is used to demote a voter to a permanent [non-voter](#parameters) in the Raft cluster.
+
+```text
+Usage: bao operator raft demote <server_id>
+
+  Demotes voter to a permanent non-voter.
+
+	  $ bao operator raft demote node1
+```
+
+
+:::note
+  Demoting the current leader to a non-voter will not trigger a leader election. The node will become a non-voter after the leadership has changed.
+:::
 ## snapshot
 
 This command groups subcommands for operators interacting with the snapshot


### PR DESCRIPTION
* add commands to promote and demote raft peers

Building on top of the new non-voter feature, this allows controlling
the voting status of individual nodes using the CLI.

Signed-off-by: Jan Martens <jan@martens.eu.org>

* document new commands and api endpoints

Signed-off-by: Jan Martens <jan@martens.eu.org>

* remove DR Token options

This is not supported by OpenBao and probably never will be.

Signed-off-by: Jan Martens <jan@martens.eu.org>

* add fallback if autopilot is disabled

Use the raw Raft backend functions to promote or demote a node.

Signed-off-by: Jan Martens <jan@martens.eu.org>

---------

Signed-off-by: Jan Martens <jan@martens.eu.org>

-------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->