### PR TITLE
Add hex to templating for ACL policies

### DIFF
--- a/sdk/helper/template/funcs.go
+++ b/sdk/helper/template/funcs.go
@@ -6,6 +6,7 @@ package template
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -66,6 +67,15 @@ func encodeBase64(str string) string {
 
 func decodeBase64(str string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(str)
+	return string(data), err
+}
+
+func encodeHex(str string) string {
+	return hex.EncodeToString([]byte(str))
+}
+
+func decodeHex(str string) (string, error) {
+	data, err := hex.DecodeString(str)
 	return string(data), err
 }
 

--- a/sdk/helper/template/funcs_test.go
+++ b/sdk/helper/template/funcs_test.go
@@ -326,6 +326,38 @@ func TestBase64(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestHex(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"cipherboy": {
+			input:    "cipherboy",
+			expected: "636970686572626f79",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := encodeHex(test.input)
+			require.Equal(t, test.expected, actual)
+
+			actual, err := decodeHex(test.expected)
+			require.NoError(t, err)
+			require.Equal(t, test.input, actual)
+		})
+	}
+
+	_, err := decodeHex("invalid: *")
+	require.Error(t, err)
+}
+
 func TestReplace(t *testing.T) {
 	type testCase struct {
 		input    string

--- a/sdk/helper/template/template.go
+++ b/sdk/helper/template/template.go
@@ -89,6 +89,14 @@ func Option(opts ...string) Opt {
 //   - decode_base64 decodes the previous value.
 //     Example: {{ .DisplayName | decode_base64 }}
 //
+// - hex
+//   - hex encodes the previous value.
+//     Example: {{ .DisplayName | hex }}
+//
+// - decode_hex
+//   - hex decodes the previous value.
+//     Example: {{ .DisplayName | decode_hex }}
+//
 // - unix_time
 //   - Provides the current unix time in seconds.
 //     Example: {{ unix_time }}
@@ -121,16 +129,17 @@ type StringTemplate struct {
 func NewTemplate(opts ...Opt) (up StringTemplate, err error) {
 	up = StringTemplate{
 		funcMap: map[string]interface{}{
-			"random":          base62.Random,
-			"truncate":        truncate,
-			"truncate_sha256": truncateSHA256,
-			"uppercase":       uppercase,
-			"lowercase":       lowercase,
-			"replace":         replace,
-			"sha256":          hashSHA256,
-			"base64":          encodeBase64,
-			"decode_base64":   decodeBase64,
-
+			"random":           base62.Random,
+			"truncate":         truncate,
+			"truncate_sha256":  truncateSHA256,
+			"uppercase":        uppercase,
+			"lowercase":        lowercase,
+			"replace":          replace,
+			"sha256":           hashSHA256,
+			"base64":           encodeBase64,
+			"decode_base64":    decodeBase64,
+			"hex":              encodeHex,
+			"decode_hex":       decodeHex,
 			"unix_time":        unixTime,
 			"unix_time_millis": unixTimeMillis,
 			"timestamp":        timestamp,

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -52,6 +52,8 @@ func TestGenerate(t *testing.T) {
 {{.String | sha256}}
 {{.String | base64}}
 {{.String | base64 | decode_base64}}
+{{.String | hex}}
+{{.String | hex | decode_hex}}
 {{.String | truncate_sha256 20}}`,
 			data: struct {
 				String string
@@ -65,11 +67,22 @@ Some.string.with.Multiple.Capitals.LETTERS
 da9872dd96609c72897defa11fe81017a62c3f44339d9d3b43fe37540ede3601
 U29tZSBzdHJpbmcgd2l0aCBNdWx0aXBsZSBDYXBpdGFscyBMRVRURVJT
 Some string with Multiple Capitals LETTERS
+536f6d6520737472696e672077697468204d756c7469706c65204361706974616c73204c455454455253
+Some string with Multiple Capitals LETTERS
 Some string 6841cf80`,
 			expectErr: false,
 		},
 		"template with invalid base64": {
 			template: `{{.String | decode_base64}}`,
+			data: struct {
+				String string
+			}{
+				String: "invalid: *",
+			},
+			expectErr: true,
+		},
+		"template with invalid hex": {
+			template: `{{.String | decode_hex}}`,
 			data: struct {
 				String string
 			}{


### PR DESCRIPTION
Per PolicyStore.sanitizeName, ACL policies must have lower case names, not reflected in documentation. This makes the original choice of base64 (in #618) not work well: base64 is case sensitive and thus does not survive lowercase conversion.

Using hex allows us to retain the original purpose but without making the policy store case-sensitive (as that would likely be a breaking change).