### PR TITLE
Add wildcard so Dependabot traverses child directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
Attempt to fix Dependabot not opening PRs for workflow files in `.github/actions/*` by adding a wildcard to the directory path.

References:
* [Dependabot directory options](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--)
* [Defining multiple locations for manifest files](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files)