### PR TITLE
Implement namespace aware Cubbyhole #1067

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -102,8 +102,12 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 		}
 		entry.Accessor = accessor
 	}
-	viewPath := entry.ViewPath()
-	view := NewBarrierView(c.barrier, viewPath)
+
+	view, err := c.mountEntryView(ctx, entry)
+	if err != nil {
+		return err
+	}
+
 	origViewReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
@@ -388,8 +392,11 @@ func (c *Core) setupAudits(ctx context.Context) error {
 
 	for _, entry := range c.audit.Entries {
 		// Create a barrier view using the UUID
-		viewPath := entry.ViewPath()
-		view := NewBarrierView(c.barrier, viewPath)
+		view, err := c.mountEntryView(ctx, entry)
+		if err != nil {
+			return err
+		}
+
 		origViewReadOnlyErr := view.GetReadOnlyErr()
 
 		// Mark the view as read-only until the mounting is complete and

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -147,8 +147,10 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	// Sync values to the cache
 	entry.SyncCache()
 
-	viewPath := entry.ViewPath()
-	view := NewBarrierView(c.barrier, viewPath)
+	view, err := c.mountEntryView(ctx, entry)
+	if err != nil {
+		return err
+	}
 
 	origViewReadOnlyErr := view.GetReadOnlyErr()
 
@@ -1034,10 +1036,11 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 	for _, entry := range c.auth.sortEntriesByPathDepth().Entries {
 		var backend logical.Backend
 
-		// Create a barrier view using the UUID
-		viewPath := entry.ViewPath()
-
-		view := NewBarrierView(c.barrier, viewPath)
+		var view BarrierView
+		view, err = c.mountEntryView(ctx, entry)
+		if err != nil {
+			return err
+		}
 
 		origViewReadOnlyErr := view.GetReadOnlyErr()
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1032,12 +1032,8 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
-	var err error
 	for _, entry := range c.auth.sortEntriesByPathDepth().Entries {
-		var backend logical.Backend
-
-		var view BarrierView
-		view, err = c.mountEntryView(ctx, entry)
+		view, err := c.mountEntryView(ctx, entry)
 		if err != nil {
 			return err
 		}
@@ -1055,6 +1051,7 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 		// Initialize the backend
 		sysView := c.mountEntrySysView(entry)
 
+		var backend logical.Backend
 		backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
 		if err != nil {
 			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)

--- a/vault/core.go
+++ b/vault/core.go
@@ -1241,7 +1241,7 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 
 	// Cubbyhole
 	logicalBackends[mountTypeCubbyhole] = CubbyholeBackendFactory
-	logicalBackends[mountTypeNSCubbyhole] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	logicalBackends[mountTypeNSCubbyhole] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		if c.cubbyholeBackend != nil {
 			return c.cubbyholeBackend, nil
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1241,7 +1241,12 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 
 	// Cubbyhole
 	logicalBackends[mountTypeCubbyhole] = CubbyholeBackendFactory
-	logicalBackends[mountTypeNSCubbyhole] = logicalBackends[mountTypeCubbyhole]
+	logicalBackends[mountTypeNSCubbyhole] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		if c.cubbyholeBackend != nil {
+			return c.cubbyholeBackend, nil
+		}
+		return nil, errors.New("cubbyhole backend does not exist")
+	}
 
 	// System
 	logicalBackends[mountTypeSystem] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1751,11 +1751,9 @@ func (c *Core) setupMounts(ctx context.Context) error {
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
-	var err error
 	for _, entry := range c.mounts.sortEntriesByPathDepth().Entries {
 		// Initialize the backend, special casing for system
-		var view BarrierView
-		view, err = c.mountEntryView(ctx, entry)
+		view, err := c.mountEntryView(ctx, entry)
 		if err != nil {
 			return err
 		}
@@ -1770,8 +1768,8 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			defer view.SetReadOnlyErr(origReadOnlyErr)
 		}
 
-		var backend logical.Backend
 		// Create the new backend
+		var backend logical.Backend
 		sysView := c.mountEntrySysView(entry)
 		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 		if err != nil {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2226,5 +2226,5 @@ func (c *Core) mountEntryView(ctx context.Context, me *MountEntry) (BarrierView,
 		return NewBarrierView(c.barrier, auditBarrierPrefix+me.UUID+"/"), nil
 	}
 
-	panic("invalid mount entry")
+	return nil, errors.New("invalid mount entry")
 }

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1205,7 +1205,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				NamespaceID: "ns-1",
 			},
 
-			wantViewPrefix: "namespace/" + testNamespaceEntryUUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespaceEntryUUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table type, and 'cubbyholeNS' type with namespace not present in store",

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1140,16 +1140,14 @@ func TestCore_MountEntryView(t *testing.T) {
 
 		wantViewPrefix string
 		wantError      bool
-		wantPanic      bool
 	}{
 		{
-			// in real application it should never come to this
-			name: "entry without both type and mount table type leads to panic",
+			name: "entry without type nor table type leading to error",
 			mountEntry: &MountEntry{
 				UUID: testMountEntryUUID,
 			},
 
-			wantPanic: true,
+			wantError: true,
 		},
 		{
 			name: "entry of 'system' mount type",
@@ -1227,16 +1225,12 @@ func TestCore_MountEntryView(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			defer func() {
-				if r := recover(); (r == nil) && tt.wantPanic {
-					t.Errorf("expected execution to panic")
-				}
-			}()
-
 			gotView, err := c.mountEntryView(ctx, tt.mountEntry)
 
 			require.Equalf(t, tt.wantError, (err != nil), "(*Core).mountEntryView() got unexpected error: %v", err)
-			require.Equalf(t, tt.wantViewPrefix, gotView.Prefix(), "(*Core).mountEntryView() gotViewPrefix: %v, want: %v", gotView.Prefix(), tt.wantViewPrefix)
+			if err == nil {
+				require.Equalf(t, tt.wantViewPrefix, gotView.Prefix(), "(*Core).mountEntryView() gotViewPrefix: %v, want: %v", gotView.Prefix(), tt.wantViewPrefix)
+			}
 		})
 	}
 }

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -3,31 +3,6 @@
 
 package vault
 
-import (
-	"path"
-)
-
-// ViewPath returns storage prefix for the view
-func (e *MountEntry) ViewPath() string {
-	switch e.Type {
-	case mountTypeSystem:
-		return systemBarrierPrefix
-	case "token":
-		return path.Join(systemBarrierPrefix, tokenSubPath) + "/"
-	}
-
-	switch e.Table {
-	case mountTableType:
-		return backendBarrierPrefix + e.UUID + "/"
-	case credentialTableType:
-		return credentialBarrierPrefix + e.UUID + "/"
-	case auditTableType:
-		return auditBarrierPrefix + e.UUID + "/"
-	}
-
-	panic("invalid mount entry")
-}
-
 // mountEntrySysView creates a logical.SystemView from global and
 // mount-specific entries; because this should be called when setting
 // up a mountEntry, it doesn't check to ensure that me is not nil

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -30,8 +30,14 @@ import (
 // See: https://developer.hashicorp.com/vault/api-docs/system/namespaces
 const namespaceIdLength = 6
 
-// Namespace storage location.
-const namespaceStoreRoot = "core/namespaces/"
+const (
+	// Namespace storage location.
+	namespaceStoreRoot = "core/namespaces/"
+
+	// namespaceBarrierPrefix is the prefix to the UUID of a namespaces
+	// used in the barrier view for the namespace-owned backends.
+	namespaceBarrierPrefix = "namespaces/"
+)
 
 // NamespaceStore is used to provide durable storage of namespace. It is
 // a singleton store across the Core and contains all child namespaces.
@@ -92,7 +98,7 @@ func (ne *NamespaceEntry) View(barrier logical.Storage) BarrierView {
 		return NewBarrierView(barrier, "")
 	}
 
-	return NewBarrierView(barrier, path.Join("namespaces", ne.UUID)+"/")
+	return NewBarrierView(barrier, path.Join(namespaceBarrierPrefix, ne.UUID)+"/")
 }
 
 // NewNamespaceStore creates a new NamespaceStore that is backed

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -169,6 +169,10 @@ func TestNamespaceStore(t *testing.T) {
 		},
 	}
 
+	// Override the store.
+	s = c.namespaceStore
+	// After sealing and unsealing, the namespace stored in the core is replaced with a new one.
+	// however, the s.SetNamespace function is still using the previous namespace.
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
 	require.NotEmpty(t, item.UUID)

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -169,10 +169,6 @@ func TestNamespaceStore(t *testing.T) {
 		},
 	}
 
-	// Override the store.
-	s = c.namespaceStore
-	// After sealing and unsealing, the namespace stored in the core is replaced with a new one.
-	// however, the s.SetNamespace function is still using the previous namespace.
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
 	require.NotEmpty(t, item.UUID)


### PR DESCRIPTION
Resolves #1067

 - Implements Cubbyhole (storage-wise) awareness of namespace by refactoring 
 `(*mountEntry).View()` into `(*Core).mountEntryView()`
 - Adjusts the logical backend creation of `CubbyholeNS` to reuse the existing root owned Cubbyhole backend

___
cc: @cipherboy @klaus-sap @satoqz @phyrog @voigt @driif