### PR TITLE
docs: add rfc#432 to docs rfc index

### DIFF
--- a/website/content/docs/rfcs/index.mdx
+++ b/website/content/docs/rfcs/index.mdx
@@ -33,3 +33,7 @@ Steering Committee.
  - [Safely limit pagination via ACL policies](/docs/rfcs/acl-paginated-lists),
    adding a new ACL policy parameter, `pagination_limit`, to restrict the size
    of list and scan operation requests.
+ - [Split the mount table using transactional storage](/docs/rfcs/split-mount-tables),
+   removes mount table limits, allowing potentially hundreds of thousands of
+   mounts on a single scaled-up server. This landed in
+   [622](https://github.com/openbao/openbao/pull/622).


### PR DESCRIPTION
This PR adds the [RFC#432](https://github.com/openbao/openbao/issues/432) to the RFC-Index of the [documentation on the OpenBao Website](https://openbao.org/docs/rfcs/).