### PR TITLE
Fix ACME TLS documentation

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -233,6 +233,9 @@ in the root of the TCP listener configuration.
   certificates. If this not writable, `/var/lib/openbao/certmagic` and then
   a temporary directory in `$TEMPDIR` will be used as fallback.
 
+  If issuing certificates for a shared cluster hostname, this must be shared
+  across all nodes.
+
 - `tls_acme_ca_root` `(string: "")` - Path to an optional Root CA to use to
   validate connections to the ACME directory. Defaults to all system
   certificates when empty.

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -223,8 +223,10 @@ in the root of the TCP listener configuration.
 - `tls_acme_ca_directory` `(string: "https://acme-v02.api.letsencrypt.org/directory")` - Path
   to the ACME directory; defaults to Let's Encrypt's production CA.
 
-- `tls_acme_ca_directory` `(string: "")` - Path
-  to the ACME directory; defaults to Let's Encrypt's staging CA.
+- `tls_acme_test_ca_directory` `(string: "")` - Path
+  to the test ACME directory; defaults to Let's Encrypt's staging CA if
+  `tls_acme_ca_directory` is the Let's Encrypt production CA (otherwise defaults
+  to empty/disabled).
 
 - `tls_acme_cache_path` `(string: "~/.local/share/certmagic")` - Specifies the
   location of the ACME certificate and account information cache to reuse


### PR DESCRIPTION
The documentation had a confusing duplication of `tls_acme_ca_directory`. From looking at the defaults & the code of `certmagic`, it looks like one of them should be `tls_acme_test_ca_directory` instead.

Resolves #1121

Also add a note about the `tls_acme_cache_path` - if I undestand correctly, this is the `Storage` passed to the `certmagic` instance, and needs to be shared across cluster members if issuing certificates for a cluster behind a load-balancer or otherwise using a shared hostname. I was confused about how this might work when reading about the feature. Happy to remove this change though, since it's not directly related to the issue.