### PR TITLE
feat: add `bao namespace scan`

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -307,6 +307,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace scan": func() (cli.Command, error) {
+			return &NamespaceScanCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"namespace lookup": func() (cli.Command, error) {
 			return &NamespaceLookupCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace.go
+++ b/command/namespace.go
@@ -31,6 +31,10 @@ Usage: bao namespace <subcommand> [options] [args]
 
       $ bao namespace list
 
+  List enabled child namespaces recursively:
+
+      $ bao namespace scan
+
   Look up an existing namespace:
 
       $ bao namespace lookup

--- a/command/namespace_scan.go
+++ b/command/namespace_scan.go
@@ -26,7 +26,7 @@ func (c *NamespaceScanCommand) Synopsis() string {
 
 func (c *NamespaceScanCommand) Help() string {
 	helpText := `
-Usage: bao namespace san [options]
+Usage: bao namespace scan [options]
 
   Lists the enabled child namespaces recursively.
 

--- a/command/namespace_scan.go
+++ b/command/namespace_scan.go
@@ -34,6 +34,10 @@ Usage: bao namespace san [options]
 
       $ bao namespace scan
 
+  List enabled child namespaces relative to parent:
+
+      $ bao namespace scan -namespace=my-parent
+
 ` + c.Flags().Help()
 
 	return strings.TrimSpace(helpText)

--- a/command/namespace_scan.go
+++ b/command/namespace_scan.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/command/namespace_scan.go
+++ b/command/namespace_scan.go
@@ -1,0 +1,123 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceScanCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceScanCommand)(nil)
+)
+
+type NamespaceScanCommand struct {
+	*BaseCommand
+}
+
+func (c *NamespaceScanCommand) Synopsis() string {
+	return "List all (child) namespaces recursively"
+}
+
+func (c *NamespaceScanCommand) Help() string {
+	helpText := `
+Usage: bao namespace san [options]
+
+  Lists the enabled child namespaces recursively.
+
+  List all enabled child namespaces recursively:
+
+      $ bao namespace scan
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceScanCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "detailed",
+		Target:  &c.flagDetailed,
+		Default: false,
+		Usage:   "Print detailed information such as namespace ID.",
+	})
+
+	return set
+}
+
+func (c *NamespaceScanCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *NamespaceScanCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceScanCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) > 0 {
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 0, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	secret, err := client.Logical().Scan("sys/namespaces")
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error scanning namespaces: %s", err))
+		return 2
+	}
+
+	_, ok := extractListData(secret)
+	if Format(c.UI) != "table" {
+		if secret == nil || secret.Data == nil || !ok {
+			OutputData(c.UI, map[string]interface{}{})
+			return 2
+		}
+	}
+
+	if secret == nil {
+		c.UI.Error("No namespaces found")
+		return 2
+	}
+
+	// There could be e.g. warnings
+	if secret.Data == nil {
+		return OutputSecret(c.UI, secret)
+	}
+
+	if secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
+		return OutputSecret(c.UI, secret)
+	}
+
+	if !ok {
+		c.UI.Error("No entries found")
+		return 2
+	}
+
+	if c.flagDetailed && Format(c.UI) != "table" {
+		return OutputData(c.UI, secret.Data["key_info"])
+	}
+
+	return OutputList(c.UI, secret)
+}

--- a/command/namespace_scan_test.go
+++ b/command/namespace_scan_test.go
@@ -31,7 +31,7 @@ func TestNamespaceScanCommand_Run(t *testing.T) {
 		code int
 	}{
 		{
-			"fine",
+			"no_entries",
 			[]string{},
 			"No entries found",
 			2,
@@ -68,5 +68,10 @@ func TestNamespaceScanCommand_Run(t *testing.T) {
 		})
 	}
 
-	t.Run("", func(t *testing.T) {})
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceScanCommand(t)
+		assertNoTabs(t, cmd)
+	})
 }

--- a/command/namespace_scan_test.go
+++ b/command/namespace_scan_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceScanCommand(tb testing.TB) (*cli.MockUi, *NamespaceScanCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceScanCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceScanCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"fine",
+			[]string{},
+			"No entries found",
+			2,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceScanCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("", func(t *testing.T) {})
+}


### PR DESCRIPTION
This PR adds `bao namespace scan` subcommand.

This command recursively lists all (child) namespaces and is namespace aware.

This resolves #1063

```
$ bao namespace scan
Keys
----
reply/
reply/comsysto/
reply/ki/
reply/ki/christoph/
reply/liquid/

$ bao namespace scan -ns=reply
Keys
----
comsysto/
ki/
ki/christoph/
liquid/
```