### PR TITLE
Validate policies can contain comments, be JSON

### DIFF
--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -91,6 +91,18 @@ path "secret/foo" {
 }
 ```
 
+Equivalently in JSON, this would be:
+
+```json
+{
+  "paths": {
+    "secret/foo": {
+      "capabilities": ["read"]
+    }
+  }
+}
+```
+
 When this policy is assigned to a token, the token can read from `"secret/foo"`.
 However, the token cannot update or delete `"secret/foo"`, since the
 capabilities do not allow it. Because policies are **deny by default**, the
@@ -366,6 +378,18 @@ path "secret/data/{{identity.entity.aliases.auth_kubernetes_xxxx.metadata.servic
 In addition to the standard set of capabilities, OpenBao offers finer-grained
 control over permissions at a given path. The capabilities associated with a
 path take precedence over permissions on parameters.
+
+Each path can contain an optional, ignored field, `comment` which can be used
+to describe the contents.
+
+For instance:
+
+```hcl
+path "pki/*" {
+  capabilities = ["deny"]
+  comment = "explicitly deny access to PKI path based on discussion in TRACKER-12345."
+}
+```
 
 ### Parameter constraints
 


### PR DESCRIPTION
Uncommenting the JSON test fails presently:

    --- FAIL: TestPolicy_Parse (0.00s)
        --- FAIL: TestPolicy_Parse/JSON (0.00s)
            policy_test.go:247: value: &vault.PathRules{Path:"test/types", Policy:"", Permissions:(*vault.ACLPermissions)(0xc000467570), IsPrefix:false, HasSegmentWildcards:false, Capabilities:[]string{"create", "sudo"}, MinWrappingTTLHCL:interface {}(nil), MaxWrappingTTLHCL:interface {}(nil), AllowedParametersHCL:map[string][]interface {}{"int":[]interface {}{1, 2}, "map":[]interface {}{map[string]interface {}{"good":"one"}}}, DeniedParametersHCL:map[string][]interface {}{"bool":[]interface {}{}, "string":[]interface {}{"test"}}, RequiredParametersHCL:[]string(nil), MFAMethodsHCL:[]string(nil), PaginationLimitHCL:0}
            policy_test.go:494: [slice[8].Permissions.DeniedParameters.map[bool].slice[0]: <no value> != false slice[8].DeniedParametersHCL.map[bool].slice[0]: <no value> != false]
    FAIL
    FAIL	github.com/openbao/openbao/vault	0.021s
    FAIL

See also: https://github.com/hashicorp/hcl/issues/740
See also: https://github.com/hashicorp/hcl/pull/741
