### PR TITLE
fix(docs/pkcs11): remove documentation regarding key generation

### DIFF
--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -35,8 +35,7 @@ migration of data between nodes may be required.
 
 The following software packages are required for OpenBao:
 
-- PKCS#11 compatible HSM integration library. Depending on any given HSM, some
-  functions (such as key generation) may have to be performed manually.
+- PKCS#11 compatible HSM integration library.
 - The cgo-enabled OpenBao binary for your architecture, complete with relevant
   dynamic libraries such as `glibc`.
 
@@ -98,9 +97,7 @@ differently as determined by the HSM in use.
   `BAO_HSM_PIN` environment variable. _If set via the environment variable,
   it will need to be re-set if OpenBao is restarted._
 
-- `key_label` `(string: <required>)`: The label of the key to use. If the key
-  does not exist and generation is enabled, this is the label that will be given
-  to the generated key. May also be specified by the `BAO_HSM_KEY_LABEL`
+- `key_label` `(string: <required>)`: The label of the key to use. May also be specified by the `BAO_HSM_KEY_LABEL`
   environment variable.
 
 - `default_key_label` `(string: "")`: This is the default key label for decryption


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

OpenBao requires the key to be generated externally inside the HSM. This PR removes phrases suggesting OpenBao can generate the key by itself.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
