### PR TITLE
PKI test failure

### DIFF
--- a/changelog/1139.txt
+++ b/changelog/1139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: addresses a timing issue revealed in pki Backend_RevokePlusTidy test
+```


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->
`logical/pki/backend_test.go` is sporadically failing in the `race` tests. This change allows a few retries of the assertions in question, as there appears to be a timing issue.
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1097 
