### PR TITLE
Add policy and path expiration

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/armon/go-radix"
 	"github.com/hashicorp/go-multierror"
@@ -116,6 +117,11 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 			var raw interface{}
 			var ok bool
 			var tree *radix.Tree
+
+			if !pc.Expiration.IsZero() && time.Now().After(pc.Expiration) {
+				// Skip adding expired paths.
+				continue
+			}
 
 			switch {
 			case pc.HasSegmentWildcards:

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2721,6 +2721,10 @@ func (b *SystemBackend) handlePoliciesRead(policyType PolicyType) framework.Oper
 			},
 		}
 
+		if !policy.Expiration.IsZero() {
+			resp.Data["expiration"] = policy.Expiration
+		}
+
 		return resp, nil
 	}
 }
@@ -2763,6 +2767,20 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 
 		if polBytes, err := base64.StdEncoding.DecodeString(policy.Raw); err == nil {
 			policy.Raw = string(polBytes)
+		}
+
+		expirationRaw, expirationOk := data.GetOk("expiration")
+		ttlRaw, ttlOk := data.GetOk("ttl")
+		if expirationOk && ttlOk {
+			return logical.ErrorResponse("cannot supply both 'expiration' and 'ttl' for policies"), nil
+		} else if expirationOk {
+			policy.Expiration = expirationRaw.(time.Time)
+		} else if ttlOk {
+			policy.Expiration = time.Now().Add(time.Duration(ttlRaw.(int)) * time.Second)
+		}
+
+		if !policy.Expiration.IsZero() && !time.Now().Before(policy.Expiration) {
+			return logical.ErrorResponse("refusing to update policy as expiration time has already elapsed"), nil
 		}
 
 		switch policyType {

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3717,6 +3717,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
 				},
+				"expiration": {
+					Type:        framework.TypeTime,
+					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
+				},
+				"ttl": {
+					Type:        framework.TypeDurationSecond,
+					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -3732,10 +3740,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 								},
 								"rules": {
 									Type:     framework.TypeString,
-									Required: true,
+									Required: false,
 								},
 								"policy": {
 									Type:     framework.TypeString,
+									Required: false,
+								},
+								"expiration": {
+									Type:     framework.TypeTime,
 									Required: false,
 								},
 							},
@@ -3835,6 +3847,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
 				},
+				"expiration": {
+					Type:        framework.TypeTime,
+					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
+				},
+				"ttl": {
+					Type:        framework.TypeDurationSecond,
+					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -3854,6 +3874,10 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 								},
 								"policy": {
 									Type:     framework.TypeString,
+									Required: false,
+								},
+								"expiration": {
+									Type:     framework.TypeTime,
 									Required: false,
 								},
 							},

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6039,3 +6039,63 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 		}
 	}
 }
+
+func TestPolicyStore_Store(t *testing.T) {
+	t.Parallel()
+
+	core, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+
+	t.Run("ttl", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.UpdateOperation, "policies/acl/ttl-test-policy")
+		req.Data["policy"] = `path "*" { capabilities = ["read"] }`
+		req.Data["ttl"] = "10s"
+
+		resp, err := core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "policies/acl/ttl-test-policy")
+		resp, err = core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "expiration")
+
+		exp := resp.Data["expiration"].(time.Time)
+
+		time.Sleep(time.Until(exp) + 10*time.Millisecond)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "policies/acl/ttl-test-policy")
+		resp, err = core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("expiration", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.UpdateOperation, "policies/acl/expiration-test-policy")
+		req.Data["policy"] = `path "*" { capabilities = ["read"] }`
+
+		expectedExpiration := time.Now().Add(10 * time.Second).UTC()
+		req.Data["expiration"] = expectedExpiration.Format(time.RFC3339)
+
+		resp, err := core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "policies/acl/expiration-test-policy")
+		resp, err = core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "expiration")
+
+		exp := resp.Data["expiration"].(time.Time)
+		require.Equal(t, expectedExpiration.Format(time.RFC3339), exp.Format(time.RFC3339))
+
+		time.Sleep(time.Until(exp) + 10*time.Millisecond)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "policies/acl/expiration-test-policy")
+		resp, err = core.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+	})
+}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -84,12 +84,13 @@ var cap2Int = map[string]uint32{
 
 // Policy is used to represent the policy specified by an ACL configuration.
 type Policy struct {
-	Name      string       `hcl:"name"`
-	Paths     []*PathRules `hcl:"-"`
-	Raw       string
-	Type      PolicyType
-	Templated bool
-	namespace *namespace.Namespace
+	Name       string       `hcl:"name"`
+	Paths      []*PathRules `hcl:"-"`
+	Raw        string
+	Type       PolicyType
+	Templated  bool
+	Expiration time.Time
+	namespace  *namespace.Namespace
 }
 
 // ShallowClone returns a shallow clone of the policy. This should not be used

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -115,6 +115,9 @@ type PathRules struct {
 	HasSegmentWildcards bool
 	Capabilities        []string
 
+	ExpirationRaw string    `hcl:"expiration"`
+	Expiration    time.Time `hcl:"-"`
+
 	// These keys are used at the top level to make the HCL nicer; we store in
 	// the ACLPermissions object though
 	MinWrappingTTLHCL     interface{}              `hcl:"min_wrapping_ttl"`
@@ -325,6 +328,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			"max_wrapping_ttl",
 			"mfa_methods",
 			"pagination_limit",
+			"expiration",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -339,6 +343,23 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 
 		if err := hcl.DecodeObject(&pc, item.Val); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
+		}
+
+		if len(pc.ExpirationRaw) > 0 {
+			expiration, err := time.Parse(time.RFC3339, pc.ExpirationRaw)
+			if err != nil {
+				return fmt.Errorf("path %q: invalid expiration time (must be in format '%v'): %w", pc.Path, time.RFC3339, err)
+			}
+
+			pc.Expiration = expiration
+
+			// If this path is expired, ignore it. We assume that the policy
+			// author has set an overall expiration time of the last-valid
+			// path for automatic cleanup.
+			if time.Now().After(expiration) {
+				// Skip the path because it has expired.
+				continue
+			}
 		}
 
 		// Strip a leading '/' as paths in Vault start after the / in the API path

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -169,10 +169,11 @@ type PolicyStore struct {
 
 // PolicyEntry is used to store a policy by name
 type PolicyEntry struct {
-	Version   int
-	Raw       string
-	Templated bool
-	Type      PolicyType
+	Version    int
+	Raw        string
+	Templated  bool
+	Type       PolicyType
+	Expiration time.Time
 }
 
 // NewPolicyStore creates a new PolicyStore that is backed
@@ -312,10 +313,11 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy) error {
 
 	// Create the entry
 	entry, err := logical.StorageEntryJSON(p.Name, &PolicyEntry{
-		Version:   2,
-		Raw:       p.Raw,
-		Type:      p.Type,
-		Templated: p.Templated,
+		Version:    2,
+		Raw:        p.Raw,
+		Type:       p.Type,
+		Templated:  p.Templated,
+		Expiration: p.Expiration,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create entry: %w", err)
@@ -403,8 +405,23 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	if cache != nil {
-		// Check for cached policy
+		// Check for cached policy.
 		if raw, ok := cache.Get(index); ok {
+			// Check for expiration of cached policy.
+			if !raw.Expiration.IsZero() && time.Now().After(raw.Expiration) {
+				// Only remove the entry from cache; we have not locked the
+				// store so a change might have modified it but hasn't yet
+				// invalidated the cache entry. This forces us to read it
+				// fresh next time or remove it from storage if no update
+				// occurred.
+				if err := view.Delete(ctx, raw.Name); err != nil {
+					return nil, fmt.Errorf("failed to remove expired policy: %w", err)
+				}
+
+				cache.Remove(index)
+				return nil, nil
+			}
+
 			return raw, nil
 		}
 	}
@@ -429,6 +446,17 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	// See if anything has added it since we got the lock
 	if cache != nil {
 		if raw, ok := cache.Get(index); ok {
+			// Check for expiration of cached policy.
+			if !raw.Expiration.IsZero() && time.Now().After(raw.Expiration) {
+				// This is an odd edge case. We have the entry in cache and we
+				// know nobody else has yet modified it in storage, otherwise
+				// we wouldn't have held the modifyLock. Remove it both from
+				// cache and from storage.
+				cache.Remove(index)
+
+				return nil, nil
+			}
+
 			return raw, nil
 		}
 	}
@@ -454,12 +482,22 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 		return nil, fmt.Errorf("failed to parse policy: %w", err)
 	}
 
+	// Handle expiration, removing the entry if it is expired.
+	if !policy.Expiration.IsZero() && time.Now().After(policy.Expiration) {
+		if err := view.Delete(ctx, name); err != nil {
+			return nil, fmt.Errorf("failed to remove expired policy: %w", err)
+		}
+
+		return nil, nil
+	}
+
 	// Set these up here so that they're available for loading into
 	// Sentinel
 	policy.Name = name
 	policy.Raw = policyEntry.Raw
 	policy.Type = policyEntry.Type
 	policy.Templated = policyEntry.Templated
+	policy.Expiration = policyEntry.Expiration
 	policy.namespace = ns
 	switch policyEntry.Type {
 	case PolicyTypeACL:

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -387,4 +388,33 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Validate that expiration works as expected.
+func TestPolicyStore_Expiration(t *testing.T) {
+	t.Parallel()
+	_, ps := mockPolicyWithCore(t, false)
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	p, err := ParseACLPolicy(namespace.RootNamespace, `path "*" { capabilities = ["read"] }`)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	p.Name = "testing"
+	p.Expiration = time.Now().Add(15 * time.Second)
+
+	err = ps.SetPolicy(ctx, p)
+	require.NoError(t, err)
+
+	p1, err := ps.GetPolicy(ctx, p.Name, p.Type)
+	require.NoError(t, err)
+	require.NotNil(t, p1)
+	require.Equal(t, p, p1)
+
+	time.Sleep(time.Until(p.Expiration) + 10*time.Millisecond)
+
+	p2, err := ps.GetPolicy(ctx, p.Name, p.Type)
+	require.NoError(t, err)
+	require.Nil(t, p2)
 }

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -118,6 +118,10 @@ path "paginated-kv/metadata" {
 path "unpaginated-kv/metadata" {
 	capabilities = ["list"]
 }
+path "some-expired-path" {
+	capabilities = ["list"]
+	expiration = "2006-01-02T15:04:05Z"
+}
 `)
 
 func TestPolicy_Parse(t *testing.T) {

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -81,6 +81,14 @@ updated, it takes effect immediately to all associated users.
 - `policy` `(string: <required>)` - Specifies the policy document. This can be
   base64-encoded to avoid string escaping.
 
+- `expiration` `(time: <optional>)` - Specifies an expiration time after which
+  the policy will no longer be valid and will be removed on next load. Cannot
+  be set in conjunction with `ttl`.
+
+- `ttl` `(duration: <optional>)` - Specifies a time for which the policy will
+  be valid and will be removed on next load. Cannot be set in conjunction with
+  `expiration`.
+
 ### Sample payload
 
 ```json

--- a/website/content/api-docs/system/policy.mdx
+++ b/website/content/api-docs/system/policy.mdx
@@ -78,6 +78,14 @@ updated, it takes effect immediately to all associated users.
 
 - `policy` `(string: <required>)` - Specifies the policy document.
 
+- `expiration` `(time: <optional>)` - Specifies an expiration time after which
+  the policy will no longer be valid and will be removed on next load. Cannot
+  be set in conjunction with `ttl`.
+
+- `ttl` `(duration: <optional>)` - Specifies a time for which the policy will
+  be valid and will be removed on next load. Cannot be set in conjunction with
+  `expiration`.
+
 ### Sample payload
 
 ```json


### PR DESCRIPTION
```
commit 14ba04ea035ad4c3addb670a3213659bfceeb036 (HEAD -> add-policy-expiration)
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Thu Mar 20 22:28:40 2025 -0500

    Add expiration to specific paths
    
    Expiration on the policy level allows writing policies which
    self-destruct. However, when using external authentication systems
    tied to group-like policies (e.g., from templated claims on JWTs or LDAP
    groups), having the ability to expire access to specific paths within a
    policy is useful so that new policies do not need to be added and
    instead paths within an existing policy can be added and expired.
    
    This adds absolute expiration to the path; this is necessary because
    creation time is not tracked on the policy so TTL-based expiration
    cannot be added.
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

commit 0a92f9ade9f8d12b6774233bf8cf678e0c0c0e0f
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Thu Mar 20 21:06:20 2025 -0500

    Allow expiration of ACL policies
    
    This change allows policy authors to set expiration times for policies;
    after which, the system will remove them (on next fetch; though they'll
    still be present in list results) and will not allow them to be used.
    
    Note that there is no PATCH operation on policies at the moment; this
    means that expiration must continually set on each write operation. In
    the future, supporting PATCH to either modify expiration or would be
    ideal.
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>
```