### PR TITLE
Implement namespace name restrictions #1023

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -47,7 +47,11 @@ func (n *Namespace) Validate() error {
 		return errors.New("cannot reuse root namespace identifier")
 	}
 
-	for segment := range strings.SplitSeq(n.Path, "/") {
+	// canonicalize adds a trailing slash, we don't need to consider it here
+	for segment := range strings.SplitSeq(n.Path[:len(n.Path)-1], "/") {
+		if segment == "" {
+			return fmt.Errorf("namespace name cannot be empty")
+		}
 		if strings.Contains(segment, " ") {
 			return fmt.Errorf("%q contains space characters and cannot be used as a namespace name", segment)
 		}

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -47,17 +47,13 @@ func (n *Namespace) Validate() error {
 		return errors.New("cannot reuse root namespace identifier")
 	}
 
-	// path depending on the nesting level of the namespace will have multiple segments
-	// so we need to retrieve last segment which ends at "/"
-	indexOfNsName := strings.Count(n.Path, "/") - 1
-	namespaceName := strings.Split(n.Path, "/")[indexOfNsName]
-
-	if strings.Contains(namespaceName, " ") {
-		return fmt.Errorf("%q contains space characters and cannot be used as a namespace name", namespaceName)
-	}
-
-	if slices.Contains(reservedNames, namespaceName) {
-		return fmt.Errorf("%q is a reserved path and cannot be used as a namespace name", namespaceName)
+	for segment := range strings.SplitSeq(n.Path, "/") {
+		if strings.Contains(segment, " ") {
+			return fmt.Errorf("%q contains space characters and cannot be used as a namespace name", segment)
+		}
+		if slices.Contains(reservedNames, segment) {
+			return fmt.Errorf("%q is a reserved path and cannot be used as a namespace name", segment)
+		}
 	}
 
 	return nil

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -388,3 +388,61 @@ func TestParentPath(t *testing.T) {
 		require.Equal(t, test.ok, ok)
 	}
 }
+
+func TestValidate(t *testing.T) {
+	tcases := []struct {
+		namespace *Namespace
+		wantError bool
+	}{
+		{
+			RootNamespace,
+			true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   RootNamespaceID,
+				Path: "test",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "root",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "cubbyhole",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "sys",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "comsys",
+			},
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "path with space",
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		gotErr := tc.namespace.Validate()
+		require.Equal(t, tc.wantError, (gotErr != nil))
+	}
+}

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -454,6 +454,31 @@ func TestValidate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "test/cubbyhole",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "test/cubbyhole_1",
+			},
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "test/1_cubbyhole",
+			},
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "test/1_cubbyhole_1",
+			},
+		},
 	}
 
 	for _, tc := range tcases {

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -442,6 +442,14 @@ func TestValidate(t *testing.T) {
 		{
 			namespace: &Namespace{
 				ID: "nsid",
+				// empty second segment, as after canonicalize its "/e/"
+				Path: "//e",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID: "nsid",
 				// valid as team_1 comes from header/context specification
 				Path: "team_1/team_2",
 			},

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -439,6 +439,21 @@ func TestValidate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			namespace: &Namespace{
+				ID: "nsid",
+				// valid as team_1 comes from header/context specification
+				Path: "team_1/team_2",
+			},
+		},
+		{
+			namespace: &Namespace{
+				ID: "nsid",
+				// invalid as last segment is incorrect
+				Path: "team_1/team_2/team 3",
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tc := range tcases {

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -479,6 +479,20 @@ func TestValidate(t *testing.T) {
 				Path: "test/1_cubbyhole_1",
 			},
 		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "test/cubbyhole/test2",
+			},
+			wantError: true,
+		},
+		{
+			namespace: &Namespace{
+				ID:   "nsid",
+				Path: "sys/test",
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tc := range tcases {


### PR DESCRIPTION
Resolves #1023 with some changes introduced already with #1051

From the issue:
> Expected Behavior:
> The error message should:
> Clearly indicate that certain characters are not allowed
- done for empty spaces
> Specify which characters are prohibited
- as above, only empty spaces are forbidden, as "/" are handled at the request level
> Provide guidance on valid namespace naming conventions
- I don't think it's necessary that we give any hints as for the name convention, as there are almost none restrictions, the only two (with appropriate error messages) are: reserved name and empty space

**This PR**:
- Fixes the bug that enabled namespace creation with the reserved name (`sys`, `cubbyhole`)
**Q: "should we also restrict naming the namespace as `namespace`"?**
```
bao namespace create cubbyhole
Error creating namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/cubbyhole
Code: 500. Errors:

* 1 error occurred:
        * failed to modify namespace: failed validating namespace: "cubbyhole" is a reserved path and cannot be used as a namespace name
```

- Adds a requirement that the namespace name doesn't contain the empty spaces, decision dictated by [reference](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#namespace-naming-restrictions)
```
bao namespace create "bad namespace" 
Error creating namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/bad%20namespace
Code: 500. Errors:

* 1 error occurred:
        * failed to modify namespace: failed validating namespace: "bad namespace" contains space characters and cannot be used as a namespace name
```

The use of the `/` at the end is allowed as it gets stripped at the request level:
```
bao namespace create test/
Key                Value
---                -----
custom_metadata    map[]
id                 VBW1vr
path               test/
uuid               d82873ec-b880-b935-707c-63aade3f5f9e
``` 
and it doesn't matter how many `/` are at the end.

but trying to specify the namespace name in a format that would indicate it's a child namespace of some other (so usage of `/` but with some other characters after), results in:
```
bao namespace create test/child
Error creating namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/test/child
Code: 500. Errors:

* 1 error occurred:
        * path must not contain /
```
as introduced in #1051
___
cc: @cipherboy @klaus-sap @satoqz @phyrog @voigt @driif
