### PR TITLE
Add namespace-aware rate-limit quota

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -118,10 +118,16 @@ func (n *Namespace) HasParent(possibleParent *Namespace) bool {
 // ParentPath returns the path of the parent namespace. n.Path must be a
 // canonicalized path.
 func (n *Namespace) ParentPath() (string, bool) {
-	if n.Path == "" {
+	return ParentOf(n.Path)
+}
+
+// ParentOf returns the path of the parent namespace. path must be a
+// canonicalized path.
+func ParentOf(path string) (string, bool) {
+	if path == "" {
 		return "", false
 	}
-	segments := strings.SplitAfter(n.Path, "/")
+	segments := strings.SplitAfter(path, "/")
 	if len(segments) <= 2 {
 		return "", true
 	}

--- a/http/util.go
+++ b/http/util.go
@@ -143,12 +143,6 @@ func wrapMaxRequestSizeHandler(handler http.Handler, props *vault.HandlerPropert
 
 func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ns, err := namespace.FromContext(r.Context())
-		if err != nil {
-			respondError(w, http.StatusInternalServerError, err)
-			return
-		}
-
 		// We don't want to do buildLogicalRequestNoAuth here because, if the
 		// request gets allowed by the quota, the same function will get called
 		// again, which is not desired.
@@ -157,6 +151,7 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 			respondError(w, status, err)
 			return
 		}
+		ns, _ := core.NamespaceByPath(r.Context(), path)
 		mountPath := strings.TrimPrefix(core.MatchingMount(r.Context(), path), ns.Path)
 
 		quotaReq := &quotas.Request{

--- a/http/util.go
+++ b/http/util.go
@@ -98,6 +98,11 @@ var (
 			}
 		}
 
+		namespacedQuotaRequest := (strings.Contains(fullURL, "sys/quotas") && ns.Path != "")
+		if namespacedQuotaRequest {
+			return http.StatusBadRequest
+		}
+
 		for _, api := range containsAPIs {
 			if strings.Contains(fullURL, api) && !strings.HasPrefix(fullURL, api) {
 				return http.StatusBadRequest

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -301,13 +301,7 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 		}
 
 		mountPath := sanitizePath(d.Get("path").(string))
-		ns, err := namespace.FromContext(ctx)
-		if err != nil {
-			return logical.ErrorResponse("failed to find namespace in context: %v", err), nil
-		}
-		if ns.ID != namespace.RootNamespaceID {
-			mountPath = strings.TrimPrefix(mountPath, ns.Path)
-		}
+		ns, mountPath := b.Core.NamespaceByPath(ctx, mountPath)
 
 		var pathSuffix string
 		if mountPath != "" {

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -303,7 +303,7 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 		mountPath := sanitizePath(d.Get("path").(string))
 		ns, err := namespace.FromContext(ctx)
 		if err != nil {
-			return logical.ErrorResponse("invalid namespace"), nil
+			return logical.ErrorResponse("failed to find namespace in context: %v", err), nil
 		}
 		if ns.ID != namespace.RootNamespaceID {
 			mountPath = strings.TrimPrefix(mountPath, ns.Path)

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -149,6 +149,11 @@ The 'rate' must be positive.`,
 					Description: `If set, when a client reaches a rate limit threshold, the client will be prohibited
 from any further requests until after the 'block_interval' has elapsed.`,
 				},
+				"inheritable": {
+					Type: framework.TypeBool,
+					Description: `If set to true, child namespaces will use this quota, unless another more specific
+quota exists. Can only be set on namespace quotas. A quota on the root namespace will by default be inheritable.`,
+				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
@@ -197,6 +202,10 @@ from any further requests until after the 'block_interval' has elapsed.`,
 								},
 								"block_interval": {
 									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"inheritable": {
+									Type:     framework.TypeBool,
 									Required: true,
 								},
 							},
@@ -351,9 +360,17 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 			return nil, err
 		}
 
+		inheritable := false
+		inheritableI, ok := d.GetOk("inheritable")
+		if ok {
+			inheritable = inheritableI.(bool)
+		} else if ns.Path == "" && mountPath == "" {
+			inheritable = true
+		}
+
 		switch {
 		case quota == nil:
-			quota = quotas.NewRateLimitQuota(name, ns.Path, mountPath, pathSuffix, role, rate, interval, blockInterval)
+			quota = quotas.NewRateLimitQuota(name, ns.Path, mountPath, pathSuffix, role, rate, interval, blockInterval, inheritable)
 		default:
 			// Re-inserting the already indexed object in memdb might cause problems.
 			// So, clone the object. See https://github.com/hashicorp/go-memdb/issues/76.
@@ -365,6 +382,7 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 			rlq.Rate = rate
 			rlq.Interval = interval
 			rlq.BlockInterval = blockInterval
+			rlq.Inheritable = inheritable
 			quota = rlq
 		}
 
@@ -413,6 +431,7 @@ func (b *SystemBackend) handleRateLimitQuotasRead() framework.OperationFunc {
 			"rate":           rlq.Rate,
 			"interval":       int(rlq.Interval.Seconds()),
 			"block_interval": int(rlq.BlockInterval.Seconds()),
+			"inheritable":    rlq.Inheritable,
 		}
 
 		return &logical.Response{

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -301,7 +301,10 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 		}
 
 		mountPath := sanitizePath(d.Get("path").(string))
-		ns := namespace.RootNamespace
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return logical.ErrorResponse("invalid namespace"), nil
+		}
 		if ns.ID != namespace.RootNamespaceID {
 			mountPath = strings.TrimPrefix(mountPath, ns.Path)
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2206,6 +2206,8 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 	}
 
 	switch me.Type {
+	case mountTypeNSSystem:
+		return c.namespaceMountEntryView(ctx, me.NamespaceID, systemBarrierPrefix)
 	case mountTypeSystem:
 		return NewBarrierView(c.barrier, systemBarrierPrefix), nil
 	case mountTypeToken:

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2206,9 +2206,10 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 	}
 
 	switch me.Type {
-	case mountTypeNSSystem:
-		return c.namespaceMountEntryView(ctx, me.NamespaceID, systemBarrierPrefix)
-	case mountTypeSystem:
+	case mountTypeSystem, mountTypeNSSystem:
+		if me.Namespace() != nil && me.NamespaceID != namespace.RootNamespaceID {
+			return c.namespaceMountEntryView(me.Namespace(), systemBarrierPrefix), nil
+		}
 		return NewBarrierView(c.barrier, systemBarrierPrefix), nil
 	case mountTypeToken:
 		return NewBarrierView(c.barrier, systemBarrierPrefix+tokenSubPath), nil

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1153,6 +1153,28 @@ func TestCore_MountEntryView(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name: "entry of 'ns_system' mount type",
+			mountEntry: &MountEntry{
+				UUID:        testMountEntryUUID,
+				Type:        mountTypeNSSystem,
+				NamespaceID: testNamespace1.Namespace.ID,
+				namespace:   testNamespace1.Namespace,
+			},
+
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + systemBarrierPrefix,
+		},
+		{
+			name: "entry of 'ns_system' mount type for nested namespace",
+			mountEntry: &MountEntry{
+				UUID:        testMountEntryUUID,
+				Type:        mountTypeNSSystem,
+				NamespaceID: testNamespace2.Namespace.ID,
+				namespace:   testNamespace2.Namespace,
+			},
+
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + systemBarrierPrefix,
+		},
+		{
 			name: "entry of 'system' mount type",
 			mountEntry: &MountEntry{
 				UUID: testMountEntryUUID,

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1153,28 +1153,6 @@ func TestCore_MountEntryView(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "entry of 'ns_system' mount type",
-			mountEntry: &MountEntry{
-				UUID:        testMountEntryUUID,
-				Type:        mountTypeNSSystem,
-				NamespaceID: testNamespace1.Namespace.ID,
-				namespace:   testNamespace1.Namespace,
-			},
-
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + systemBarrierPrefix,
-		},
-		{
-			name: "entry of 'ns_system' mount type for nested namespace",
-			mountEntry: &MountEntry{
-				UUID:        testMountEntryUUID,
-				Type:        mountTypeNSSystem,
-				NamespaceID: testNamespace2.Namespace.ID,
-				namespace:   testNamespace2.Namespace,
-			},
-
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + systemBarrierPrefix,
-		},
-		{
 			name: "entry of 'system' mount type",
 			mountEntry: &MountEntry{
 				UUID: testMountEntryUUID,

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -31,3 +31,7 @@ func NamespaceView(barrier logical.Storage, ns *namespace.Namespace) BarrierView
 
 	return NewBarrierView(barrier, path.Join(namespaceBarrierPrefix, ns.UUID)+"/")
 }
+
+func (c *Core) NamespaceByPath(ctx context.Context, path string) (*namespace.Namespace, string) {
+	return c.namespaceStore.GetNamespaceByLongestPrefix(ctx, path)
+}

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -32,6 +32,8 @@ func NamespaceView(barrier logical.Storage, ns *namespace.Namespace) BarrierView
 	return NewBarrierView(barrier, path.Join(namespaceBarrierPrefix, ns.UUID)+"/")
 }
 
+// NamespaceByPath returns the namespace and the path prefix for the given path.
+// Note, that it is on the caller to ensure that the namespace is resolved, as NamespaceByPath otherwise resolves to root.
 func (c *Core) NamespaceByPath(ctx context.Context, path string) (*namespace.Namespace, string) {
 	return c.namespaceStore.GetNamespaceByLongestPrefix(ctx, path)
 }

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -594,7 +594,6 @@ func (m *Manager) queryQuota(txn *memdb.Txn, req *Request) (Quota, error) {
 		}
 		if quota != nil && quota.IsInheritable() {
 			return quota, nil
-		} else if quota != nil {
 		}
 
 		if path == "root" {

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -200,6 +200,9 @@ type Quota interface {
 	// QuotaName is the name of the quota rule
 	QuotaName() string
 
+	// IsInheritable returns whether the quota is inheritable
+	IsInheritable() bool
+
 	// initialize sets up the fields in the quota type to begin operating
 	initialize(log.Logger, *metricsutil.ClusterMetricSink) error
 
@@ -576,18 +579,27 @@ func (m *Manager) queryQuota(txn *memdb.Txn, req *Request) (Quota, error) {
 	// If the request belongs to "root" namespace, then we have already looked at
 	// global quotas when fetching namespace specific quota rule. When the request
 	// belongs to a non-root namespace, and when there are no namespace specific
-	// quota rules present, we fallback on the global quotas.
+	// quota rules present, we fallback on the inheritable quotas.
 	if req.NamespacePath == "root" {
 		return nil, nil
 	}
 
-	// Fetch global quota
-	quota, err = quotaFetchFunc(indexNamespace, "root", false, false, false)
-	if err != nil {
-		return nil, err
-	}
-	if quota != nil {
-		return quota, nil
+	for path, isParent := namespace.ParentOf(req.NamespacePath); isParent; path, isParent = namespace.ParentOf(path) {
+		if path == "" {
+			path = "root"
+		}
+		quota, err = quotaFetchFunc(indexNamespace, path, false, false, false)
+		if err != nil {
+			return nil, err
+		}
+		if quota != nil && quota.IsInheritable() {
+			return quota, nil
+		} else if quota != nil {
+		}
+
+		if path == "root" {
+			break
+		}
 	}
 
 	return nil, nil

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -30,7 +30,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 		rlq       *RateLimitQuota
 		expectErr bool
 	}{
-		{"valid rate", NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", 16.7, time.Second, 0), false},
+		{"valid rate", NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", 16.7, time.Second, 0, false), false},
 	}
 
 	for _, tc := range testCases {
@@ -47,7 +47,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 }
 
 func TestRateLimitQuota_Close(t *testing.T) {
-	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", 16.7, time.Second, time.Minute)
+	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", 16.7, time.Second, time.Minute, false)
 	require.NoError(t, rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()))
 	require.NoError(t, rlq.close(context.Background()))
 
@@ -221,7 +221,7 @@ func TestRateLimitQuota_Update(t *testing.T) {
 	qm, err := NewManager(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
-	quota := NewRateLimitQuota("quota1", "", "", "", "", 10, time.Second, 0)
+	quota := NewRateLimitQuota("quota1", "", "", "", "", 10, time.Second, 0, false)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -19,7 +19,7 @@ func TestQuotas_MountPathOverwrite(t *testing.T) {
 	qm, err := NewManager(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)
 
-	quota := NewRateLimitQuota("tq", "", "kv1/", "", "", 10, time.Second, 0)
+	quota := NewRateLimitQuota("tq", "", "kv1/", "", "", 10, time.Second, 0, false)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, false))
 	quota = quota.Clone().(*RateLimitQuota)
 	quota.MountPath = "kv2/"
@@ -48,7 +48,7 @@ func TestQuotas_Precedence(t *testing.T) {
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath, pathSuffix, role string) Quota {
 		t.Helper()
-		quota := NewRateLimitQuota(name, nsPath, mountPath, pathSuffix, role, 10, time.Second, 0)
+		quota := NewRateLimitQuota(name, nsPath, mountPath, pathSuffix, role, 10, time.Second, 0, false)
 		require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 		return quota
 	}
@@ -137,7 +137,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	require.False(t, required)
 
 	// Create a non-role-based RLQ on mount1/ and make sure it doesn't require role resolution
-	rlq := NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, 10, 1*time.Minute, 10*time.Second)
+	rlq := NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, 10, 1*time.Minute, 10*time.Second, false)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false))
 
 	required, err = qm.QueryResolveRoleQuotas(rlqReq)
@@ -146,7 +146,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 
 	// Create a role-based RLQ on mount1/ and make sure it requires role resolution
 	rlqReq.Role = "test"
-	rlq = NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, 10, 1*time.Minute, 10*time.Second)
+	rlq = NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, 10, 1*time.Minute, 10*time.Second, false)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false))
 
 	required, err = qm.QueryResolveRoleQuotas(rlqReq)


### PR DESCRIPTION
This PR addresses #1084 and replicates namespace-aware quota behavior.

#### 1. Enables quota configuration per namespace
  ```bash
$ bao namespace create ns1
Key                Value
---                -----
custom_metadata    map[]
id                 g7B5Hn
path               ns1/
uuid               4f4afac3-adbf-baad-6576-6444a9e19a64
$ bao write sys/quotas/rate-limit/foo-limit path="ns1" rate=100 interval=2s
Success! Data written to: sys/quotas/rate-limit/foo-limit
$ bao read sys/quotas/rate-limit/foo-limit
Key               Value
---               -----
block_interval    0
inheritable       false
interval          2
name              foo-limit
path              ns1/
rate              100
role              n/a
type              rate-limit
  ```

The quota api endpoints under `/sys/quotas` remain restricted and can't be called in namespaces. Consequently, writing a quota with namespace header will fail.

```bash
$ bao write -ns ns1 sys/quotas/rate-limit/foo-limit rate=100 interval=2s
Error writing data to sys/quotas/rate-limit/foo-limit: Error making API request.

Namespace: ns1/
URL: PUT http://127.0.0.1:8200/v1/sys/quotas/rate-limit/foo-limit
Code: 400. Errors:

* unavailable operation (PUT /v1/sys/quotas/rate-limit/foo-limit)
```

#### 2. Writes quota configuration to `/sys/quotas`

Global, as well as namespace specific quotas will be stored in the same, global, location.

```bash
$ bao write sys/quotas/rate-limit/global-limit rate=3000 interval=1m
Success! Data written to: sys/quotas/rate-limit/global-limit
$ bao list sys/quotas/rate-limit/
Keys
----
foo-limit
global-limit
```

#### 3. Namespace-aware quota evaluation

#### 4. Adds `inheritable` flag to quotas
  ```bash
# Update `foo-limit` to inherit quota configuration to child namespaces
$ bao write sys/quotas/rate-limit/foo-limit path="ns1" rate=2 interval=2s inheritable=true
Success! Data written to: sys/quotas/rate-limit/foo-limit
$ bao namespace create -ns ns1 ns1.1
Key                Value
---                -----
custom_metadata    map[]
id                 3i7Ufc
path               ns1/ns1.1/
uuid               382c8d0d-f713-413c-c724-36e1f0712045
# Quota of `ns1` now also applies to `ns1/ns1.1`

$ while true; sleep 0.1; bao namespace list -ns=ns1/ns1.1; end
No namespaces found
No namespaces found
No namespaces found
No namespaces found
Error listing namespaces: Error making API request.

Namespace: ns1/ns1.1/
URL: GET http://127.0.0.1:8200/v1/sys/namespaces?list=true
Code: 429. Errors:

* request path "sys/namespaces/": rate limit quota exceeded
  ```