### PR TITLE
Namespaces Regression: Restricted APIs in `sys/raw`

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -370,13 +370,12 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, props *vault.HandlerPr
 
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/v1/"):
-			newR, status := adjustRequest(r)
+			status := validateNamespace(r)
 			if status != 0 {
-				respondError(nw, status, fmt.Errorf("unavailable operation (%s %s) from namespace [%s]", r.Method, r.URL.Path, ns.Path))
+				respondError(nw, status, fmt.Errorf("unavailable operation (%s %s)", r.Method, r.URL.Path))
 				cancelFunc()
 				return
 			}
-			r = newR
 
 		case strings.HasPrefix(r.URL.Path, "/ui"), r.URL.Path == "/robots.txt", r.URL.Path == "/":
 		case strings.HasPrefix(r.URL.Path, "/.well-known/acme-challenge/"):

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -1067,6 +1067,7 @@ func TestHandler_RestrictedEndpointCalls(t *testing.T) {
 			client.Timeout = 60 * time.Second
 
 			res, err := client.Do(req)
+			require.NoError(t, err)
 			require.Equal(t, tt.expectedStatusCode, res.StatusCode)
 		})
 	}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-cleanhttp"
@@ -948,4 +949,125 @@ func TestHandler_MaxRequestSize_Memory(t *testing.T) {
 	client.Do(req)
 	runtime.ReadMemStats(&end)
 	require.Less(t, end.TotalAlloc-start.TotalAlloc, uint64(1024*1024))
+}
+
+func TestHandler_RestrictedEndpointCalls(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	// add namespaces for tests
+	err := vault.TestCoreCreateNamespaces(core,
+		&namespace.Namespace{Path: "test"},
+		&namespace.Namespace{Path: "test/test2"},
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		method          string
+		path            string
+		namespaceHeader string
+
+		expectedStatusCode int
+	}{
+		{
+			name:               "happy path - root namespace quota call",
+			method:             "GET",
+			path:               "/v1/sys/quotas/rate-limit?list=true",
+			expectedStatusCode: 404,
+		},
+		{
+			name:               "happy path - root namespace quota call through sys-raw",
+			method:             "GET",
+			path:               "/v1/sys/raw/sys/quotas/rate-limit?list=true",
+			expectedStatusCode: 404,
+		},
+		{
+			name:               "bad path - namespace in path request",
+			method:             "GET",
+			path:               "/v1/test/sys/quotas/rate-limit?list=true",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "bad path - namespace in header request",
+			method:             "GET",
+			path:               "/v1/sys/quotas/rate-limit?list=true",
+			namespaceHeader:    "test",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "bad path - namespace in both header and path request",
+			method:             "GET",
+			path:               "/v1/test2/sys/quotas/rate-limit?list=true",
+			namespaceHeader:    "test",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "bad path - namespace at the beginning path request through sys-raw",
+			method:             "GET",
+			path:               "/v1/test/sys/raw/sys/quotas/rate-limit?list=true",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "bad path - namespace in header passed for request through sys-raw",
+			method:             "GET",
+			path:               "/v1/sys/raw/sys/quotas/rate-limit?list=true",
+			namespaceHeader:    "test",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "bad path - namespace in both header and path passed for request through sys-raw",
+			method:             "GET",
+			path:               "/v1/test2/sys/raw/sys/quotas/rate-limit?list=true",
+			namespaceHeader:    "test",
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "happy path - root can create policy with restricted name",
+			method:             "PUT",
+			path:               "/v1/sys/policies/acl/sys/raw",
+			expectedStatusCode: 204,
+		},
+		{
+			name:               "happy path - namespace (path) can create policy with restricted name",
+			method:             "PUT",
+			path:               "/v1/test/sys/policies/acl/sys/raw",
+			expectedStatusCode: 204,
+		},
+		{
+			name:               "happy path - namespace (header) can create policy with restricted name",
+			method:             "PUT",
+			path:               "/v1/sys/policies/acl/sys/raw",
+			namespaceHeader:    "test",
+			expectedStatusCode: 204,
+		},
+		{
+			name:               "happy path - namespace (path & header) can create policy with restricted name",
+			method:             "PUT",
+			path:               "/v1/test2/sys/policies/acl/sys/raw",
+			namespaceHeader:    "test",
+			expectedStatusCode: 204,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ln, addr := TestServer(t, core)
+			defer ln.Close()
+
+			var body io.Reader
+			if tt.method == "PUT" {
+				bodyString := `{"policy":"path \"auth/token/lookup\" {\n capabilities = [\"read\", \"update\"]\n}\n\npath \"*/auth/token/lookup\" {\n capabilities = [\"read\", \"update\"]\n}"}`
+				body = bytes.NewBufferString(bodyString)
+			}
+			req, err := http.NewRequest(tt.method, addr+tt.path, body)
+			require.NoError(t, err)
+
+			req.Header.Set(consts.AuthHeaderName, token)
+			req.Header.Set(consts.NamespaceHeaderName, tt.namespaceHeader)
+			client := cleanhttp.DefaultClient()
+			client.Timeout = 60 * time.Second
+
+			res, err := client.Do(req)
+			require.Equal(t, tt.expectedStatusCode, res.StatusCode)
+		})
+	}
 }

--- a/http/util.go
+++ b/http/util.go
@@ -89,7 +89,7 @@ var (
 			namespacePath, _, ok := strings.Cut(fullURL, api)
 
 			// exclude any occurences of possible restricted APIs paths when path dictates that the suffix is a policy name
-			if ok && strings.HasSuffix(namespacePath, "sys/policies/acl/") {
+			if ok && (strings.HasSuffix(namespacePath, "sys/policies/acl/") || strings.HasSuffix(namespacePath, "sys/policy/")) {
 				return 0
 			}
 

--- a/http/util.go
+++ b/http/util.go
@@ -80,7 +80,8 @@ var (
 		}
 
 		for _, api := range restrictedAPIs {
-			if strings.HasSuffix(p, api) {
+			// exclude any occurences of possible restriced APIs paths when prefix indicates it's a policy name
+			if strings.HasSuffix(p, api) && !strings.HasPrefix(p, "/sys/policies") {
 				return r, http.StatusBadRequest
 			}
 		}

--- a/http/util.go
+++ b/http/util.go
@@ -99,7 +99,7 @@ var (
 		}
 
 		for _, api := range containsAPIs {
-			if strings.Contains(fullURL, api) {
+			if strings.Contains(fullURL, api) && !strings.HasPrefix(fullURL, api) {
 				return http.StatusBadRequest
 			}
 		}


### PR DESCRIPTION
Resolves #1070  

 - [x] Fixes the restriction on operations (e.g. list, read) on `sys/raw/sys` resources while using root namespace, retaining the restriction on the same operations requested with namespace specification
 - [x] Simplifies logic for preventing serving requests to restricted APIs for namespaces

_Questions from the issue:_
> Should sys/quotas/rate-limit be restricted in the first place?

Depends on the implementation of quotas we want to do within OpenBao (not this PR)
> We have sys/quotas/lease-count in the restricted APIs - I don't think those exist in OpenBao?

Definitely a leftover from [upstream](https://developer.hashicorp.com/vault/api-docs/system/lease-count-quotas) implementation 
> Has this broken any other APIs besides sys/raw?

To be honest it hasn't broken the listing of the `sys/raw/sys` resources, as `bao list sys/quotas/rate-limit` is the equivalent of `bao list sys/raw/sys/quotas/rate-limit` and that worked as always. But to answer the question, yes this broke the usage of `bao list sys/raw/sys...` for restricted APIs

**Before**:
```
bao list sys/raw/sys/quotas/rate-limit
Error listing sys/raw/sys/quotas/rate-limit: Error making API request.

URL: GET http://127.0.0.1:8200/v1/sys/raw/sys/quotas/rate-limit?list=true
Code: 400. Errors:
```

```
bao list -ns=test sys/raw/sys/quotas/rate-limit
Error listing sys/raw/sys/quotas/rate-limit: Error making API request.

URL: GET http://127.0.0.1:8200/v1/sys/raw/sys/quotas/rate-limit?list=true
Code: 400. Errors:
```

And for the policies names (thanks @cipherboy)
```
bao policy write -ns=test sys/raw ./test.hcl 
Error uploading policy: Error making API request.

Namespace: test/
URL: PUT http://127.0.0.1:8200/v1/sys/policies/acl/sys/raw
Code: 400. Errors:
```

**After**:

```
bao list sys/raw/sys/quotas/rate-limit
No value found at sys/raw/sys/quotas/rate-limit

bao write sys/quotas/rate-limit/test rate=5.2
Success! Data written to: sys/quotas/rate-limit/test
bao list sys/raw/sys/quotas/rate-limit
Keys
----
test
```

```
bao list test/sys/raw/sys/quotas/rate-limit
Error listing test/sys/raw/sys/quotas/rate-limit: Error making API request.

URL: GET http://127.0.0.1:8200/v1/test/sys/raw/sys/quotas/rate-limit?list=true
Code: 400. Errors:

* unavailable operation (GET /v1/test/sys/raw/sys/quotas/rate-limit)
...

bao list sys/raw/test/sys/quotas/rate-limit
Error listing sys/raw/test/sys/quotas/rate-limit: Error making API request.

URL: GET http://127.0.0.1:8200/v1/sys/raw/test/sys/quotas/rate-limit?list=true
Code: 400. Errors:

* unavailable operation (GET /v1/sys/raw/test/sys/quotas/rate-limit)
...

bao list /sys/quotas/rate-limit       
No value found at sys/quotas/rate-limit
...

bao list sys/raw/sys/quotas/rate-limit 
No value found at sys/raw/sys/quotas/rate-limit
```

```
bao list -ns=test sys/raw/sys/quotas/rate-limit
Error listing sys/raw/sys/quotas/rate-limit: Error making API request.

Namespace: test/
URL: GET http://127.0.0.1:8200/v1/sys/raw/sys/quotas/rate-limit?list=true
Code: 400. Errors:

* unavailable operation (GET /v1/sys/raw/sys/quotas/rate-limit)
```

```
bao policy write -ns=test sys/raw test.hcl
Success! Uploaded policy: sys/raw
```
--- 

With this PR I also try to address following TODO comment:
```		
// TODO(ascheel): Consider if we can combine header with actual request path here without triggering redirect logic.
```
___
cc: @cipherboy @klaus-sap @satoqz @phyrog @voigt @driif