### PR TITLE
move namespace uuid into namespace struct

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -29,6 +29,7 @@ type contextValues struct{}
 
 type Namespace struct {
 	ID             string            `json:"id" mapstructure:"id"`
+	UUID           string            `json:"uuid" mapstructure:"uuid"`
 	Path           string            `json:"path" mapstructure:"path"`
 	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
 }
@@ -64,7 +65,8 @@ func (n *Namespace) Validate() error {
 }
 
 const (
-	RootNamespaceID = "root"
+	RootNamespaceID   = "root"
+	RootNamespaceUUID = "00000000-0000-0000-0000-000000000000"
 )
 
 var (
@@ -72,6 +74,7 @@ var (
 	ErrNoNamespace   error         = errors.New("no namespace")
 	RootNamespace    *Namespace    = &Namespace{
 		ID:             RootNamespaceID,
+		UUID:           RootNamespaceUUID,
 		Path:           "",
 		CustomMetadata: make(map[string]string),
 	}

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -111,6 +111,20 @@ func (n *Namespace) TrimmedPath(path string) string {
 	return strings.TrimPrefix(path, n.Path)
 }
 
+func (n *Namespace) Clone() *Namespace {
+	meta := make(map[string]string, len(n.CustomMetadata))
+	for k, v := range n.CustomMetadata {
+		meta[k] = v
+	}
+
+	return &Namespace{
+		ID:             n.ID,
+		UUID:           n.UUID,
+		Path:           n.Path,
+		CustomMetadata: meta,
+	}
+}
+
 // ContextWithNamespace adds the given namespace to the given context
 func ContextWithNamespace(ctx context.Context, ns *Namespace) context.Context {
 	return context.WithValue(ctx, contextNamespace, ns)

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -103,7 +103,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 		entry.Accessor = accessor
 	}
 
-	view, err := c.mountEntryView(ctx, entry)
+	view, err := c.mountEntryView(entry)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (c *Core) setupAudits(ctx context.Context) error {
 
 	for _, entry := range c.audit.Entries {
 		// Create a barrier view using the UUID
-		view, err := c.mountEntryView(ctx, entry)
+		view, err := c.mountEntryView(entry)
 		if err != nil {
 			return err
 		}

--- a/vault/counters.go
+++ b/vault/counters.go
@@ -35,12 +35,7 @@ func (c *Core) countActiveTokens(ctx context.Context) (*ActiveTokens, error) {
 	// Count the tokens under each namespace
 	total := 0
 	for i := range ns {
-		view, err := c.tokenStore.idView(ctx, ns[i])
-		if err != nil {
-			return nil, err
-		}
-
-		ids, err := view.List(ctx, "")
+		ids, err := c.tokenStore.idView(ctx, ns[i]).List(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -75,10 +75,7 @@ func TestExpiration_Metrics(t *testing.T) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	idView, err := exp.tokenIndexView(ctx, namespace.RootNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	idView := exp.tokenIndexView(ctx, namespace.RootNamespace)
 
 	// Scan the storage with the count func set
 	if err := logical.ScanView(ctx, idView, countFunc); err != nil {
@@ -147,7 +144,7 @@ func TestExpiration_Metrics(t *testing.T) {
 	}
 
 	count = 0
-	if err = logical.ScanView(context.Background(), idView, countFunc); err != nil {
+	if err := logical.ScanView(context.Background(), idView, countFunc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -462,13 +459,10 @@ func TestExpiration_Tidy(t *testing.T) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	view, err := exp.leaseView(ctx, namespace.RootNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	view := exp.leaseView(ctx, namespace.RootNamespace)
 
 	// Scan the storage with the count func set
-	if err = logical.ScanView(ctx, view, countFunc); err != nil {
+	if err := logical.ScanView(ctx, view, countFunc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -485,12 +479,12 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	// Persist the invalid lease entry
-	if err = exp.persistEntry(ctx, le); err != nil {
+	if err := exp.persistEntry(ctx, le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
 	count = 0
-	if err = logical.ScanView(context.Background(), view, countFunc); err != nil {
+	if err := logical.ScanView(context.Background(), view, countFunc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -500,7 +494,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	// Run the tidy operation
-	err = exp.Tidy(ctx)
+	err := exp.Tidy(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1083,10 +1077,7 @@ func TestExpiration_Register_BatchToken(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	var idEnts []string
 	for time.Now().Before(deadline) {
-		tokenView, err := exp.tokenIndexView(ctx, namespace.RootNamespace)
-		if err != nil {
-			t.Fatal(err)
-		}
+		tokenView := exp.tokenIndexView(ctx, namespace.RootNamespace)
 		idEnts, err = tokenView.List(context.Background(), "")
 		if err != nil {
 			t.Fatal(err)

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1206,8 +1206,7 @@ func TestIdentityStore_NamespaceIsolation(t *testing.T) {
 	t.Run("namespace_hierarchy_isolation", func(t *testing.T) {
 		// Create a child namespace under ns1
 		childNs := &namespace.Namespace{ID: "childns", Path: "testns1/childns/"}
-		childNsEntry := &NamespaceEntry{Namespace: childNs}
-		require.NoError(t, c.namespaceStore.SetNamespace(rootCtx, childNsEntry))
+		require.NoError(t, c.namespaceStore.SetNamespace(rootCtx, childNs))
 
 		childCtx := namespace.ContextWithNamespace(context.Background(), childNs)
 
@@ -1572,11 +1571,8 @@ func setupNamespaces(t *testing.T, c *Core, ctx context.Context) (*namespace.Nam
 	ns1 := &namespace.Namespace{ID: "testns1", Path: "testns1/"}
 	ns2 := &namespace.Namespace{ID: "testns2", Path: "testns2/"}
 
-	ns1Entry := &NamespaceEntry{Namespace: ns1}
-	ns2Entry := &NamespaceEntry{Namespace: ns2}
-
-	require.NoError(t, c.namespaceStore.SetNamespace(ctx, ns1Entry))
-	require.NoError(t, c.namespaceStore.SetNamespace(ctx, ns2Entry))
+	require.NoError(t, c.namespaceStore.SetNamespace(ctx, ns1))
+	require.NoError(t, c.namespaceStore.SetNamespace(ctx, ns2))
 
 	return ns1, ns2
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2203,12 +2203,7 @@ func (b *SystemBackend) handleLeaseLookupList(ctx context.Context, req *logical.
 	if err != nil {
 		return nil, err
 	}
-	view, err := b.Core.expiration.leaseView(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
-	keys, err := view.List(ctx, prefix)
+	keys, err := b.Core.expiration.leaseView(ctx, ns).List(ctx, prefix)
 	if err != nil {
 		b.Backend.Logger().Error("error listing leases", "prefix", prefix, "error", err)
 		return handleErrorNoReadOnlyForward(err)

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -154,7 +154,7 @@ func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 			p := parent.TrimmedPath(entry.Namespace.Path)
 			keys = append(keys, p)
 			keyInfo[p] = map[string]any{
-				"uuid":            entry.UUID,
+				"uuid":            entry.Namespace.UUID,
 				"id":              entry.Namespace.ID,
 				"path":            entry.Namespace.Path,
 				"custom_metadata": entry.Namespace.CustomMetadata,
@@ -183,7 +183,7 @@ func (b *SystemBackend) handleNamespacesScan() framework.OperationFunc {
 			p := parent.TrimmedPath(entry.Namespace.Path)
 			keys = append(keys, p)
 			keyInfo[p] = map[string]any{
-				"uuid":            entry.UUID,
+				"uuid":            entry.Namespace.UUID,
 				"id":              entry.Namespace.ID,
 				"path":            entry.Namespace.Path,
 				"custom_metadata": entry.Namespace.CustomMetadata,
@@ -214,7 +214,7 @@ func (b *SystemBackend) handleNamespacesRead() framework.OperationFunc {
 
 		resp := &logical.Response{
 			Data: map[string]interface{}{
-				"uuid":            ns.UUID,
+				"uuid":            ns.Namespace.UUID,
 				"id":              ns.Namespace.ID,
 				"path":            ns.Namespace.Path,
 				"custom_metadata": ns.Namespace.CustomMetadata,
@@ -254,7 +254,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		}
 
 		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            entry.UUID,
+			"uuid":            entry.Namespace.UUID,
 			"path":            entry.Namespace.Path,
 			"id":              entry.Namespace.ID,
 			"custom_metadata": entry.Namespace.CustomMetadata,
@@ -289,7 +289,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 		}
 
 		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *NamespaceEntry) (*NamespaceEntry, error) {
-			if ns.UUID == "" {
+			if ns.Namespace.UUID == "" {
 				return nil, fmt.Errorf("requested namespace does not exist")
 			}
 
@@ -316,7 +316,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 		}
 
 		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            ns.UUID,
+			"uuid":            ns.Namespace.UUID,
 			"path":            ns.Namespace.Path,
 			"id":              ns.Namespace.ID,
 			"custom_metadata": ns.Namespace.CustomMetadata,
@@ -345,7 +345,7 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 			return resp, nil
 		}
 
-		if err := b.Core.namespaceStore.DeleteNamespace(ctx, ns.UUID); err != nil {
+		if err := b.Core.namespaceStore.DeleteNamespace(ctx, ns.Namespace.UUID); err != nil {
 			return handleError(err)
 		}
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -143,7 +143,7 @@ func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		entries, err := b.Core.namespaceStore.ListNamespaceEntries(ctx, false, false)
+		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -151,13 +151,13 @@ func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 		var keys []string
 		keyInfo := make(map[string]interface{})
 		for _, entry := range entries {
-			p := parent.TrimmedPath(entry.Namespace.Path)
+			p := parent.TrimmedPath(entry.Path)
 			keys = append(keys, p)
 			keyInfo[p] = map[string]any{
-				"uuid":            entry.Namespace.UUID,
-				"id":              entry.Namespace.ID,
-				"path":            entry.Namespace.Path,
-				"custom_metadata": entry.Namespace.CustomMetadata,
+				"uuid":            entry.UUID,
+				"id":              entry.ID,
+				"path":            entry.Path,
+				"custom_metadata": entry.CustomMetadata,
 			}
 		}
 
@@ -172,7 +172,7 @@ func (b *SystemBackend) handleNamespacesScan() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		entries, err := b.Core.namespaceStore.ListNamespaceEntries(ctx, false, true)
+		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, false, true)
 		if err != nil {
 			return nil, err
 		}
@@ -180,13 +180,13 @@ func (b *SystemBackend) handleNamespacesScan() framework.OperationFunc {
 		var keys []string
 		keyInfo := make(map[string]interface{})
 		for _, entry := range entries {
-			p := parent.TrimmedPath(entry.Namespace.Path)
+			p := parent.TrimmedPath(entry.Path)
 			keys = append(keys, p)
 			keyInfo[p] = map[string]any{
-				"uuid":            entry.Namespace.UUID,
-				"id":              entry.Namespace.ID,
-				"path":            entry.Namespace.Path,
-				"custom_metadata": entry.Namespace.CustomMetadata,
+				"uuid":            entry.UUID,
+				"id":              entry.ID,
+				"path":            entry.Path,
+				"custom_metadata": entry.CustomMetadata,
 			}
 		}
 
@@ -214,10 +214,10 @@ func (b *SystemBackend) handleNamespacesRead() framework.OperationFunc {
 
 		resp := &logical.Response{
 			Data: map[string]interface{}{
-				"uuid":            ns.Namespace.UUID,
-				"id":              ns.Namespace.ID,
-				"path":            ns.Namespace.Path,
-				"custom_metadata": ns.Namespace.CustomMetadata,
+				"uuid":            ns.UUID,
+				"id":              ns.ID,
+				"path":            ns.Path,
+				"custom_metadata": ns.CustomMetadata,
 			},
 		}
 
@@ -245,8 +245,8 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
-		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *NamespaceEntry) (*NamespaceEntry, error) {
-			ns.Namespace.CustomMetadata = metadata
+		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+			ns.CustomMetadata = metadata
 			return ns, nil
 		})
 		if err != nil {
@@ -254,10 +254,10 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		}
 
 		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            entry.Namespace.UUID,
-			"path":            entry.Namespace.Path,
-			"id":              entry.Namespace.ID,
-			"custom_metadata": entry.Namespace.CustomMetadata,
+			"uuid":            entry.UUID,
+			"path":            entry.Path,
+			"id":              entry.ID,
+			"custom_metadata": entry.CustomMetadata,
 		}}
 		return resp, nil
 	}
@@ -288,13 +288,13 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
-		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *NamespaceEntry) (*NamespaceEntry, error) {
-			if ns.Namespace.UUID == "" {
+		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+			if ns.UUID == "" {
 				return nil, fmt.Errorf("requested namespace does not exist")
 			}
 
 			current := make(map[string]interface{})
-			for k, v := range ns.Namespace.CustomMetadata {
+			for k, v := range ns.CustomMetadata {
 				current[k] = v
 			}
 
@@ -308,7 +308,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 				return nil, err
 			}
 
-			ns.Namespace.CustomMetadata = patched
+			ns.CustomMetadata = patched
 			return ns, nil
 		})
 		if err != nil {
@@ -316,10 +316,10 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 		}
 
 		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            ns.Namespace.UUID,
-			"path":            ns.Namespace.Path,
-			"id":              ns.Namespace.ID,
-			"custom_metadata": ns.Namespace.CustomMetadata,
+			"uuid":            ns.UUID,
+			"path":            ns.Path,
+			"id":              ns.ID,
+			"custom_metadata": ns.CustomMetadata,
 		}}
 		return resp, nil
 	}
@@ -345,7 +345,7 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 			return resp, nil
 		}
 
-		if err := b.Core.namespaceStore.DeleteNamespace(ctx, ns.Namespace.UUID); err != nil {
+		if err := b.Core.namespaceStore.DeleteNamespace(ctx, ns.UUID); err != nil {
 			return handleError(err)
 		}
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1129,8 +1129,8 @@ func TestCore_MountEntryView(t *testing.T) {
 	s := c.namespaceStore
 
 	testMountEntryUUID := "mount-entry-uuid"
-	testNamespace1 := &NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/"}}
-	testNamespace2 := &NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/ns2/"}}
+	testNamespace1 := &namespace.Namespace{Path: "ns1/"}
+	testNamespace2 := &namespace.Namespace{Path: "ns1/ns2/"}
 
 	err := s.SetNamespace(ctx, testNamespace1)
 	require.NoError(t, err)
@@ -1205,11 +1205,11 @@ func TestCore_MountEntryView(t *testing.T) {
 				UUID:        testMountEntryUUID,
 				Table:       mountTableType,
 				Type:        mountTypeNSCubbyhole,
-				NamespaceID: testNamespace1.Namespace.ID,
-				namespace:   testNamespace1.Namespace,
+				NamespaceID: testNamespace1.ID,
+				namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table type, and 'cubbyholeNS' type with namespace not present in store",
@@ -1219,7 +1219,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Type:  mountTypeNSCubbyhole,
 				// does not exist in store
 				NamespaceID: "ns-2",
-				namespace:   testNamespace1.Namespace,
+				namespace:   testNamespace1,
 			},
 
 			wantError: true,
@@ -1230,11 +1230,11 @@ func TestCore_MountEntryView(t *testing.T) {
 				UUID:        testMountEntryUUID,
 				Table:       mountTableType,
 				Type:        mountTypeKV,
-				NamespaceID: testNamespace1.Namespace.ID,
-				namespace:   testNamespace1.Namespace,
+				NamespaceID: testNamespace1.ID,
+				namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table, and 'kv' type with nested namespace present",
@@ -1242,11 +1242,11 @@ func TestCore_MountEntryView(t *testing.T) {
 				UUID:        testMountEntryUUID,
 				Table:       mountTableType,
 				Type:        mountTypeKV,
-				NamespaceID: testNamespace2.Namespace.ID,
-				namespace:   testNamespace2.Namespace,
+				NamespaceID: testNamespace2.ID,
+				namespace:   testNamespace2,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table, and 'kv' type without namespace present",
@@ -1264,11 +1264,11 @@ func TestCore_MountEntryView(t *testing.T) {
 				UUID:        testMountEntryUUID,
 				Table:       credentialTableType,
 				Type:        "userpass",
-				NamespaceID: testNamespace1.Namespace.ID,
-				namespace:   testNamespace1.Namespace,
+				NamespaceID: testNamespace1.ID,
+				namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type with nested namespace present",
@@ -1276,11 +1276,11 @@ func TestCore_MountEntryView(t *testing.T) {
 				UUID:        testMountEntryUUID,
 				Table:       credentialTableType,
 				Type:        "userpass",
-				NamespaceID: testNamespace2.Namespace.ID,
-				namespace:   testNamespace2.Namespace,
+				NamespaceID: testNamespace2.ID,
+				namespace:   testNamespace2,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.Namespace.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type without namespace present",
@@ -1359,14 +1359,14 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nsBar)
 
-	barCtx := namespace.ContextWithNamespace(context.Background(), nsBar.Namespace)
+	barCtx := namespace.ContextWithNamespace(context.Background(), nsBar)
 
 	// Doing the above inside bar should behave the same.
 	me = &MountEntry{
 		Table:       mountTableType,
 		Path:        "foo/",
 		Type:        "noop",
-		NamespaceID: nsBar.Namespace.ID,
+		NamespaceID: nsBar.ID,
 	}
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
@@ -1383,7 +1383,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Table:       mountTableType,
 		Path:        "fud/bar/baz/foo/",
 		Type:        "noop",
-		NamespaceID: nsBar.Namespace.ID,
+		NamespaceID: nsBar.ID,
 	}
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
@@ -1420,7 +1420,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Table:       mountTableType,
 		Path:        "fud/bar/baz/qux/",
 		Type:        "noop",
-		NamespaceID: nsBar.Namespace.ID,
+		NamespaceID: nsBar.ID,
 	}
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1209,7 +1209,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				namespace:   testNamespace1.Namespace,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table type, and 'cubbyholeNS' type with namespace not present in store",
@@ -1234,7 +1234,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				namespace:   testNamespace1.Namespace,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table, and 'kv' type with nested namespace present",
@@ -1246,7 +1246,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				namespace:   testNamespace2.Namespace,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.Namespace.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table, and 'kv' type without namespace present",
@@ -1268,7 +1268,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				namespace:   testNamespace1.Namespace,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.Namespace.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type with nested namespace present",
@@ -1280,7 +1280,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				namespace:   testNamespace2.Namespace,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.Namespace.UUID + "/" + credentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type without namespace present",
@@ -1298,7 +1298,7 @@ func TestCore_MountEntryView(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotView, err := c.mountEntryView(ctx, tt.mountEntry)
+			gotView, err := c.mountEntryView(tt.mountEntry)
 
 			require.Equalf(t, tt.wantError, (err != nil), "(*Core).mountEntryView() got unexpected error: %v", err)
 			if err == nil {

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -17,11 +17,7 @@ func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Names
 		return nil, err
 	}
 
-	if ns == nil {
-		return nil, nil
-	}
-
-	return ns.Namespace, nil
+	return ns, nil
 }
 
 func (c *Core) ListNamespaces(ctx context.Context) ([]*namespace.Namespace, error) {

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -5,8 +5,10 @@ package vault
 
 import (
 	"context"
+	"path"
 
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
 func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Namespace, error) {
@@ -24,4 +26,12 @@ func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Names
 
 func (c *Core) ListNamespaces(ctx context.Context) ([]*namespace.Namespace, error) {
 	return c.namespaceStore.ListAllNamespaces(ctx, true)
+}
+
+func NamespaceView(barrier logical.Storage, ns *namespace.Namespace) BarrierView {
+	if ns.ID == namespace.RootNamespaceID {
+		return NewBarrierView(barrier, "")
+	}
+
+	return NewBarrierView(barrier, path.Join(namespaceBarrierPrefix, ns.UUID)+"/")
 }

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -32,12 +32,12 @@ func TestNamespaceStore(t *testing.T) {
 
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
-	require.NotEmpty(t, item.UUID)
+	require.NotEmpty(t, item.Namespace.UUID)
 	require.NotEmpty(t, item.Namespace.ID)
 	require.Equal(t, item.Namespace.Path, namespace.Canonicalize("ns1"))
 	require.Equal(t, item.Namespace.Path, "ns1/")
 
-	itemUUID := item.UUID
+	itemUUID := item.Namespace.UUID
 	itemAccessor := item.Namespace.ID
 	itemPath := item.Namespace.Path
 
@@ -45,24 +45,24 @@ func TestNamespaceStore(t *testing.T) {
 	ns, err = s.ListAllNamespaceEntries(ctx, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
-	require.Equal(t, ns[0].UUID, item.UUID)
+	require.Equal(t, ns[0].Namespace.UUID, item.Namespace.UUID)
 
 	// Modifying our copy shouldn't affect anything.
 	item.Namespace.CustomMetadata = map[string]string{"openbao": "true"}
 	item.Namespace.Path = "modified"
 	item.Namespace.ID = "modified"
-	item.UUID = "modified"
+	item.Namespace.UUID = "modified"
 
 	fetched, err := s.GetNamespace(ctx, itemUUID)
 	require.NoError(t, err)
 	require.NotNil(t, fetched)
-	require.Equal(t, fetched.UUID, itemUUID)
+	require.Equal(t, fetched.Namespace.UUID, itemUUID)
 	require.Equal(t, fetched.Namespace.ID, itemAccessor)
 	require.Equal(t, fetched.Namespace.Path, itemPath)
 	require.Empty(t, fetched.Namespace.CustomMetadata)
 
 	// Fetching the modified ID should fail.
-	fetched, err = s.GetNamespace(ctx, item.UUID)
+	fetched, err = s.GetNamespace(ctx, item.Namespace.UUID)
 	require.NoError(t, err)
 	require.Nil(t, fetched)
 
@@ -87,7 +87,7 @@ func TestNamespaceStore(t *testing.T) {
 	ns, err = s.ListAllNamespaceEntries(ctx, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
-	require.Equal(t, ns[0].UUID, itemUUID)
+	require.Equal(t, ns[0].Namespace.UUID, itemUUID)
 
 	// Delete that item.
 	err = s.DeleteNamespace(ctx, itemUUID)
@@ -129,8 +129,8 @@ func TestNamespaceStore(t *testing.T) {
 
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
-	require.NotEmpty(t, item.UUID)
-	require.NotEqual(t, item.UUID, itemUUID)
+	require.NotEmpty(t, item.Namespace.UUID)
+	require.NotEqual(t, item.Namespace.UUID, itemUUID)
 	require.NotEmpty(t, item.Namespace.ID)
 	require.NotEqual(t, item.Namespace.ID, itemAccessor)
 	require.Equal(t, item.Namespace.Path, namespace.Canonicalize("ns1"))
@@ -173,7 +173,7 @@ func TestNamespaceHierarchy(t *testing.T) {
 	for idx, ns := range namespaces {
 		err := s.SetNamespace(ns.Context, ns.NamespaceEntry)
 		require.NoError(t, err)
-		require.NotEmpty(t, ns.UUID)
+		require.NotEmpty(t, ns.Namespace.UUID)
 		require.NotEmpty(t, ns.Namespace.ID)
 		require.Equal(t, ns.Namespace.Path, namespace.Canonicalize(namespaces[idx].Namespace.Path))
 	}
@@ -228,10 +228,10 @@ func TestNamespaceTree(t *testing.T) {
 	tree := newNamespaceTree(rootNs)
 
 	namespaces1 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns1/", ID: "00001"}, UUID: "00001"},
-		{Namespace: &namespace.Namespace{Path: "ns1/ns2/", ID: "00002"}, UUID: "00002"},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns4/", ID: "00004"}, UUID: "00004"},
-		{Namespace: &namespace.Namespace{Path: "ns3/", ID: "00003"}, UUID: "00003"},
+		{Namespace: &namespace.Namespace{Path: "ns1/", ID: "00001", UUID: "00001"}},
+		{Namespace: &namespace.Namespace{Path: "ns1/ns2/", ID: "00002", UUID: "00002"}},
+		{Namespace: &namespace.Namespace{Path: "ns3/ns4/", ID: "00004", UUID: "00004"}},
+		{Namespace: &namespace.Namespace{Path: "ns3/", ID: "00003", UUID: "00003"}},
 	}
 
 	for _, entry := range namespaces1 {
@@ -241,8 +241,8 @@ func TestNamespaceTree(t *testing.T) {
 	require.NoError(t, err)
 
 	namespaces2 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns3/ns6/ns7/", ID: "00007"}, UUID: "00007"},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns8/ns9/", ID: "00009"}, UUID: "00009"},
+		{Namespace: &namespace.Namespace{Path: "ns3/ns6/ns7/", ID: "00007", UUID: "00007"}},
+		{Namespace: &namespace.Namespace{Path: "ns3/ns8/ns9/", ID: "00009", UUID: "00009"}},
 	}
 
 	for _, entry := range namespaces2 {
@@ -252,9 +252,9 @@ func TestNamespaceTree(t *testing.T) {
 	require.Error(t, err)
 
 	namespaces3 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns3/ns6/", ID: "00006"}, UUID: "00006"},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns8/", ID: "00008"}, UUID: "00008"},
-		{Namespace: &namespace.Namespace{Path: "ns9/ns10/", ID: "00010"}, UUID: "00010"},
+		{Namespace: &namespace.Namespace{Path: "ns3/ns6/", ID: "00006", UUID: "00006"}},
+		{Namespace: &namespace.Namespace{Path: "ns3/ns8/", ID: "00008", UUID: "00008"}},
+		{Namespace: &namespace.Namespace{Path: "ns9/ns10/", ID: "00010", UUID: "00010"}},
 	}
 
 	err = tree.Insert(namespaces3[0])
@@ -333,7 +333,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("GetNamespace", func(b *testing.B) {
 		for b.Loop() {
-			uuid := randomNamespace(s).UUID
+			uuid := randomNamespace(s).Namespace.UUID
 			s.GetNamespace(ctx, uuid)
 		}
 	})
@@ -392,14 +392,14 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("DeleteNamespace", func(b *testing.B) {
 		for b.Loop() {
-			uuid := randomNamespace(s).UUID
+			uuid := randomNamespace(s).Namespace.UUID
 			s.DeleteNamespace(ctx, uuid)
 		}
 	})
 }
 
 func testModifyNamespace(_ context.Context, ns *NamespaceEntry) (*NamespaceEntry, error) {
-	uuid := ns.UUID
+	uuid := ns.Namespace.UUID
 	accessor := ns.Namespace.ID
 	ns.Namespace.CustomMetadata["uuid"] = uuid
 	ns.Namespace.CustomMetadata["accessor"] = accessor

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -19,50 +19,48 @@ func TestNamespaceStore(t *testing.T) {
 	ctx := namespace.RootContext(context.TODO())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaceEntries(ctx, false)
+	ns, err := s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
 	// Creating an item should save it, set IDs, and canonicalize path.
-	item := &NamespaceEntry{
-		Namespace: &namespace.Namespace{
-			Path: "ns1",
-		},
+	item := &namespace.Namespace{
+		Path: "ns1",
 	}
 
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
-	require.NotEmpty(t, item.Namespace.UUID)
-	require.NotEmpty(t, item.Namespace.ID)
-	require.Equal(t, item.Namespace.Path, namespace.Canonicalize("ns1"))
-	require.Equal(t, item.Namespace.Path, "ns1/")
+	require.NotEmpty(t, item.UUID)
+	require.NotEmpty(t, item.ID)
+	require.Equal(t, item.Path, namespace.Canonicalize("ns1"))
+	require.Equal(t, item.Path, "ns1/")
 
-	itemUUID := item.Namespace.UUID
-	itemAccessor := item.Namespace.ID
-	itemPath := item.Namespace.Path
+	itemUUID := item.UUID
+	itemAccessor := item.ID
+	itemPath := item.Path
 
 	// We should now have one item.
-	ns, err = s.ListAllNamespaceEntries(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
-	require.Equal(t, ns[0].Namespace.UUID, item.Namespace.UUID)
+	require.Equal(t, ns[0].UUID, item.UUID)
 
 	// Modifying our copy shouldn't affect anything.
-	item.Namespace.CustomMetadata = map[string]string{"openbao": "true"}
-	item.Namespace.Path = "modified"
-	item.Namespace.ID = "modified"
-	item.Namespace.UUID = "modified"
+	item.CustomMetadata = map[string]string{"openbao": "true"}
+	item.Path = "modified"
+	item.ID = "modified"
+	item.UUID = "modified"
 
 	fetched, err := s.GetNamespace(ctx, itemUUID)
 	require.NoError(t, err)
 	require.NotNil(t, fetched)
-	require.Equal(t, fetched.Namespace.UUID, itemUUID)
-	require.Equal(t, fetched.Namespace.ID, itemAccessor)
-	require.Equal(t, fetched.Namespace.Path, itemPath)
-	require.Empty(t, fetched.Namespace.CustomMetadata)
+	require.Equal(t, fetched.UUID, itemUUID)
+	require.Equal(t, fetched.ID, itemAccessor)
+	require.Equal(t, fetched.Path, itemPath)
+	require.Empty(t, fetched.CustomMetadata)
 
 	// Fetching the modified ID should fail.
-	fetched, err = s.GetNamespace(ctx, item.Namespace.UUID)
+	fetched, err = s.GetNamespace(ctx, item.UUID)
 	require.NoError(t, err)
 	require.Nil(t, fetched)
 
@@ -84,17 +82,17 @@ func TestNamespaceStore(t *testing.T) {
 	s = c.namespaceStore
 
 	// We should still have one item.
-	ns, err = s.ListAllNamespaceEntries(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
-	require.Equal(t, ns[0].Namespace.UUID, itemUUID)
+	require.Equal(t, ns[0].UUID, itemUUID)
 
 	// Delete that item.
 	err = s.DeleteNamespace(ctx, itemUUID)
 	require.NoError(t, err)
 
 	// Store should be empty.
-	ns, err = s.ListAllNamespaceEntries(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -115,27 +113,25 @@ func TestNamespaceStore(t *testing.T) {
 	// however, the s.SetNamespace function is still using the previous namespace.
 	s = c.namespaceStore
 
-	ns, err = s.ListAllNamespaceEntries(ctx, false)
+	ns, err = s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
 	// Creating a new version of item should yield a new id even though the
 	// path is the same.
-	item = &NamespaceEntry{
-		Namespace: &namespace.Namespace{
-			Path: "ns1/",
-		},
+	item = &namespace.Namespace{
+		Path: "ns1/",
 	}
 
 	err = s.SetNamespace(ctx, item)
 	require.NoError(t, err)
-	require.NotEmpty(t, item.Namespace.UUID)
-	require.NotEqual(t, item.Namespace.UUID, itemUUID)
-	require.NotEmpty(t, item.Namespace.ID)
-	require.NotEqual(t, item.Namespace.ID, itemAccessor)
-	require.Equal(t, item.Namespace.Path, namespace.Canonicalize("ns1"))
-	require.Equal(t, item.Namespace.Path, "ns1/")
-	require.Equal(t, item.Namespace.Path, itemPath)
+	require.NotEmpty(t, item.UUID)
+	require.NotEqual(t, item.UUID, itemUUID)
+	require.NotEmpty(t, item.ID)
+	require.NotEqual(t, item.ID, itemAccessor)
+	require.Equal(t, item.Path, namespace.Canonicalize("ns1"))
+	require.Equal(t, item.Path, "ns1/")
+	require.Equal(t, item.Path, itemPath)
 }
 
 func TestNamespaceHierarchy(t *testing.T) {
@@ -147,31 +143,31 @@ func TestNamespaceHierarchy(t *testing.T) {
 	ctx := namespace.RootContext(context.TODO())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaceEntries(ctx, false)
+	ns, err := s.ListAllNamespaces(ctx, false)
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
 	// Creating an item should save it, set IDs, and canonicalize path.
 	namespaces := []struct {
 		context.Context
-		*NamespaceEntry
+		*namespace.Namespace
 	}{
 		{
 			namespace.ContextWithNamespace(ctx, namespace.RootNamespace),
-			&NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1"}},
+			&namespace.Namespace{Path: "ns1"},
 		},
 		{
 			namespace.ContextWithNamespace(ctx, namespace.RootNamespace),
-			&NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns2"}},
+			&namespace.Namespace{Path: "ns2"},
 		},
 		{
 			namespace.ContextWithNamespace(ctx, namespace.RootNamespace),
-			&NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/ns3"}},
+			&namespace.Namespace{Path: "ns1/ns3"},
 		},
 	}
 
 	for idx, ns := range namespaces {
-		err := s.SetNamespace(ns.Context, ns.NamespaceEntry)
+		err := s.SetNamespace(ns.Context, ns.Namespace)
 		require.NoError(t, err)
 		require.NotEmpty(t, ns.Namespace.UUID)
 		require.NotEmpty(t, ns.Namespace.ID)
@@ -224,14 +220,14 @@ func TestNamespaceHierarchy(t *testing.T) {
 }
 
 func TestNamespaceTree(t *testing.T) {
-	rootNs := &NamespaceEntry{Namespace: namespace.RootNamespace}
+	rootNs := namespace.RootNamespace
 	tree := newNamespaceTree(rootNs)
 
-	namespaces1 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns1/", ID: "00001", UUID: "00001"}},
-		{Namespace: &namespace.Namespace{Path: "ns1/ns2/", ID: "00002", UUID: "00002"}},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns4/", ID: "00004", UUID: "00004"}},
-		{Namespace: &namespace.Namespace{Path: "ns3/", ID: "00003", UUID: "00003"}},
+	namespaces1 := []*namespace.Namespace{
+		{Path: "ns1/", ID: "00001", UUID: "00001"},
+		{Path: "ns1/ns2/", ID: "00002", UUID: "00002"},
+		{Path: "ns3/ns4/", ID: "00004", UUID: "00004"},
+		{Path: "ns3/", ID: "00003", UUID: "00003"},
 	}
 
 	for _, entry := range namespaces1 {
@@ -240,9 +236,9 @@ func TestNamespaceTree(t *testing.T) {
 	err := tree.validate()
 	require.NoError(t, err)
 
-	namespaces2 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns3/ns6/ns7/", ID: "00007", UUID: "00007"}},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns8/ns9/", ID: "00009", UUID: "00009"}},
+	namespaces2 := []*namespace.Namespace{
+		{Path: "ns3/ns6/ns7/", ID: "00007", UUID: "00007"},
+		{Path: "ns3/ns8/ns9/", ID: "00009", UUID: "00009"},
 	}
 
 	for _, entry := range namespaces2 {
@@ -251,10 +247,10 @@ func TestNamespaceTree(t *testing.T) {
 	err = tree.validate()
 	require.Error(t, err)
 
-	namespaces3 := []*NamespaceEntry{
-		{Namespace: &namespace.Namespace{Path: "ns3/ns6/", ID: "00006", UUID: "00006"}},
-		{Namespace: &namespace.Namespace{Path: "ns3/ns8/", ID: "00008", UUID: "00008"}},
-		{Namespace: &namespace.Namespace{Path: "ns9/ns10/", ID: "00010", UUID: "00010"}},
+	namespaces3 := []*namespace.Namespace{
+		{Path: "ns3/ns6/", ID: "00006", UUID: "00006"},
+		{Path: "ns3/ns8/", ID: "00008", UUID: "00008"},
+		{Path: "ns9/ns10/", ID: "00010", UUID: "00010"},
 	}
 
 	err = tree.Insert(namespaces3[0])
@@ -301,7 +297,7 @@ func TestNamespaceTree(t *testing.T) {
 	require.Equal(t, "foobar", pathSuffix)
 }
 
-func randomNamespace(ns *NamespaceStore) *NamespaceEntry {
+func randomNamespace(ns *NamespaceStore) *namespace.Namespace {
 	// make use of random map iteration order
 	for _, item := range ns.namespacesByUUID {
 		return item
@@ -319,11 +315,9 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	for i := range n {
 		parent := randomNamespace(s)
-		ctx := namespace.ContextWithNamespace(ctx, parent.Namespace)
-		item := &NamespaceEntry{
-			Namespace: &namespace.Namespace{
-				Path: parent.Namespace.Path + "ns" + strconv.Itoa(i) + "/",
-			},
+		ctx := namespace.ContextWithNamespace(ctx, parent)
+		item := &namespace.Namespace{
+			Path: parent.Path + "ns" + strconv.Itoa(i) + "/",
 		}
 		err := s.SetNamespace(ctx, item)
 		require.NoError(b, err)
@@ -333,28 +327,28 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("GetNamespace", func(b *testing.B) {
 		for b.Loop() {
-			uuid := randomNamespace(s).Namespace.UUID
+			uuid := randomNamespace(s).UUID
 			s.GetNamespace(ctx, uuid)
 		}
 	})
 
 	b.Run("GetNamespaceByAccessor", func(b *testing.B) {
 		for b.Loop() {
-			accessor := randomNamespace(s).Namespace.ID
+			accessor := randomNamespace(s).ID
 			s.GetNamespaceByAccessor(ctx, accessor)
 		}
 	})
 
 	b.Run("GetNamespaceByPath", func(b *testing.B) {
 		for b.Loop() {
-			path := randomNamespace(s).Namespace.Path
+			path := randomNamespace(s).Path
 			s.GetNamespaceByPath(ctx, path)
 		}
 	})
 
 	b.Run("ModifyNamespaceByPath", func(b *testing.B) {
 		for b.Loop() {
-			path := randomNamespace(s).Namespace.Path
+			path := randomNamespace(s).Path
 			s.ModifyNamespaceByPath(ctx, path, testModifyNamespace)
 		}
 	})
@@ -367,7 +361,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("ListNamespaces non-recursive", func(b *testing.B) {
 		for b.Loop() {
-			parent := randomNamespace(s).Namespace
+			parent := randomNamespace(s)
 			ctx = namespace.ContextWithNamespace(ctx, parent)
 			s.ListNamespaces(ctx, false, false)
 		}
@@ -375,7 +369,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("ListNamespaces recursive", func(b *testing.B) {
 		for b.Loop() {
-			parent := randomNamespace(s).Namespace
+			parent := randomNamespace(s)
 			ctx = namespace.ContextWithNamespace(ctx, parent)
 			s.ListNamespaces(ctx, false, true)
 		}
@@ -384,7 +378,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 	b.Run("ResolveNamespaceFromRequest", func(b *testing.B) {
 		rootCtx := namespace.RootContext(context.TODO())
 		for b.Loop() {
-			ns := randomNamespace(s).Namespace
+			ns := randomNamespace(s)
 			ctx := namespace.ContextWithNamespace(rootCtx, ns)
 			s.ResolveNamespaceFromRequest(rootCtx, ctx, "/sys/namespaces")
 		}
@@ -392,17 +386,17 @@ func BenchmarkNamespaceStore(b *testing.B) {
 
 	b.Run("DeleteNamespace", func(b *testing.B) {
 		for b.Loop() {
-			uuid := randomNamespace(s).Namespace.UUID
+			uuid := randomNamespace(s).UUID
 			s.DeleteNamespace(ctx, uuid)
 		}
 	})
 }
 
-func testModifyNamespace(_ context.Context, ns *NamespaceEntry) (*NamespaceEntry, error) {
-	uuid := ns.Namespace.UUID
-	accessor := ns.Namespace.ID
-	ns.Namespace.CustomMetadata["uuid"] = uuid
-	ns.Namespace.CustomMetadata["accessor"] = accessor
+func testModifyNamespace(_ context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+	uuid := ns.UUID
+	accessor := ns.ID
+	ns.CustomMetadata["uuid"] = uuid
+	ns.CustomMetadata["accessor"] = accessor
 
 	return ns, nil
 }
@@ -413,13 +407,11 @@ func BenchmarkNamespaceSet(b *testing.B) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	item := &NamespaceEntry{
-		Namespace: &namespace.Namespace{},
-	}
+	item := &namespace.Namespace{}
 
 	var i int
 	for b.Loop() {
-		item.Namespace.Path = "ns" + strconv.Itoa(i)
+		item.Path = "ns" + strconv.Itoa(i)
 		s.SetNamespace(ctx, item)
 		i += 1
 	}
@@ -431,13 +423,11 @@ func BenchmarkNamespaceSetLocked(b *testing.B) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	item := &NamespaceEntry{
-		Namespace: &namespace.Namespace{},
-	}
+	item := &namespace.Namespace{}
 
 	var i int
 	for b.Loop() {
-		item.Namespace.Path = "ns" + strconv.Itoa(i)
+		item.Path = "ns" + strconv.Itoa(i)
 		s.lock.Lock()
 		s.setNamespaceLocked(ctx, item)
 		i += 1
@@ -450,10 +440,10 @@ func TestNamespaces_ResolveNamespaceFromRequest(t *testing.T) {
 	nsStore := core.namespaceStore
 
 	// Setup only necessary namespaces
-	ns1Entry := &NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/"}}
-	ns2Entry := &NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/ns2/"}}
+	ns1Entry := &namespace.Namespace{Path: "ns1/"}
+	ns2Entry := &namespace.Namespace{Path: "ns1/ns2/"}
 
-	ns3Entry := &NamespaceEntry{Namespace: &namespace.Namespace{Path: "ns1/ns2/namespaces/ns3/"}}
+	ns3Entry := &namespace.Namespace{Path: "ns1/ns2/namespaces/ns3/"}
 
 	// Create namespaces
 	rootCtx := namespace.RootContext(nil)
@@ -461,11 +451,11 @@ func TestNamespaces_ResolveNamespaceFromRequest(t *testing.T) {
 	require.NoError(t, nsStore.SetNamespace(rootCtx, ns1Entry))
 
 	// Set child into ns1
-	ns1Ctx := namespace.ContextWithNamespace(rootCtx, ns1Entry.Namespace)
+	ns1Ctx := namespace.ContextWithNamespace(rootCtx, ns1Entry)
 	require.NoError(t, nsStore.SetNamespace(ns1Ctx, ns2Entry))
 
 	// Set child into ns1/ns2
-	ns2Ctx := namespace.ContextWithNamespace(ns1Ctx, ns2Entry.Namespace)
+	ns2Ctx := namespace.ContextWithNamespace(ns1Ctx, ns2Entry)
 	require.NoError(t, nsStore.SetNamespace(ns2Ctx, ns3Entry))
 
 	// Define test cases
@@ -478,25 +468,25 @@ func TestNamespaces_ResolveNamespaceFromRequest(t *testing.T) {
 		{
 			name:            "NS in path",
 			reqPath:         "ns1/secret/foo",
-			expectedFinalNS: ns1Entry.Namespace,
+			expectedFinalNS: ns1Entry,
 			expectedRelPath: "secret/foo",
 		},
 		{
 			name:            "Nested NS in path",
 			reqPath:         "ns1/ns2/secret/foo",
-			expectedFinalNS: ns2Entry.Namespace,
+			expectedFinalNS: ns2Entry,
 			expectedRelPath: "secret/foo",
 		},
 		{
 			name:            "Route to existing namespace ns2 with sys in path",
 			reqPath:         "ns1/sys/namespaces/ns2",
-			expectedFinalNS: ns1Entry.Namespace,
+			expectedFinalNS: ns1Entry,
 			expectedRelPath: "sys/namespaces/ns2",
 		},
 		{
 			name:            "Route to existing namespace ns3 with ns1/ns2/sys in path",
 			reqPath:         "ns1/ns2/sys/namespaces/ns3",
-			expectedFinalNS: ns2Entry.Namespace,
+			expectedFinalNS: ns2Entry,
 			expectedRelPath: "sys/namespaces/ns3",
 		},
 	}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -368,13 +368,13 @@ func (ps *PolicyStore) getACLView(ns *namespace.Namespace) (BarrierView, error) 
 	}
 
 	// First, get the namespace's entry from the namespace store
-	nsEntry, err := ps.core.namespaceStore.GetNamespaceByAccessor(context.Background(), ns.ID)
-	if err != nil || nsEntry == nil {
+	ns, err := ps.core.NamespaceByID(context.Background(), ns.ID)
+	if err != nil || ns == nil {
 		ps.logger.Error("failed to find namespace entry", "namespace_id", ns.ID)
 		return nil, fmt.Errorf("failed to find namespace entry for %q", ns.ID)
 	}
 
-	nsView := nsEntry.View(ps.core.barrier)
+	nsView := NamespaceView(ps.core.barrier, ns)
 	return nsView.SubView(path.Join("sys", policyACLSubPath) + "/"), nil
 }
 

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -408,10 +408,9 @@ func TestPolicyStore_LoadACLPolicyNamespaces(t *testing.T) {
 	require.False(t, resp.IsError())
 
 	// Lookup the namespace
-	nsEntry, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
+	ns, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
 	require.NoError(t, err)
-	require.NotNil(t, nsEntry, "namespace not found: %s", nsPath)
-	ns := nsEntry.Namespace
+	require.NotNil(t, ns, "namespace not found: %s", nsPath)
 
 	// Create namespace context
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
@@ -470,10 +469,9 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 	require.False(t, resp.IsError())
 
 	// Lookup the namespace
-	nsEntry, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
+	ns, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
 	require.NoError(t, err)
-	require.NotNil(t, nsEntry, "namespace not found: %s", nsPath)
-	ns := nsEntry.Namespace
+	require.NotNil(t, ns, "namespace not found: %s", nsPath)
 
 	// Create policy in namespace
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
@@ -555,10 +553,9 @@ func TestPolicyStore_NamespaceAPI(t *testing.T) {
 	require.False(t, rootResp.IsError())
 
 	// Get namespace and create context
-	nsEntry, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
+	ns, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
 	require.NoError(t, err)
-	require.NotNil(t, nsEntry, "namespace not found: %s", nsPath)
-	ns := nsEntry.Namespace
+	require.NotNil(t, ns, "namespace not found: %s", nsPath)
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
 
 	// Create and verify namespace policy
@@ -643,7 +640,7 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 	// Get parent namespace context
 	parentNS, err := core.namespaceStore.GetNamespaceByPath(rootCtx, "parent")
 	require.NoError(t, err)
-	parentCtx := namespace.ContextWithNamespace(rootCtx, parentNS.Namespace)
+	parentCtx := namespace.ContextWithNamespace(rootCtx, parentNS)
 
 	// Create child namespace
 	childResp, err := core.HandleRequest(parentCtx, &logical.Request{
@@ -658,7 +655,7 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 	childNS, err := core.namespaceStore.GetNamespaceByPath(parentCtx, "child")
 	require.NoError(t, err)
 	// Create child context from root context to avoid inheriting parent context
-	childCtx := namespace.ContextWithNamespace(parentCtx, childNS.Namespace)
+	childCtx := namespace.ContextWithNamespace(parentCtx, childNS)
 
 	// Add distinct policies to each namespace
 	policyTemplates := []struct {
@@ -668,8 +665,8 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 		content string
 	}{
 		{namespace.RootNamespace, rootCtx, "root-policy", `path "sys/*" { capabilities = ["read"] }`},
-		{parentNS.Namespace, parentCtx, "parent-policy", `path "secret/*" { capabilities = ["list"] }`},
-		{childNS.Namespace, childCtx, "child-policy", `path "auth/*" { capabilities = ["create"] }`},
+		{parentNS, parentCtx, "parent-policy", `path "secret/*" { capabilities = ["list"] }`},
+		{childNS, childCtx, "child-policy", `path "auth/*" { capabilities = ["create"] }`},
 	}
 
 	for _, tmpl := range policyTemplates {
@@ -768,10 +765,9 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	require.False(t, resp.IsError(), "response error: %#v", resp)
 
 	// Get the parent namespace
-	parentEntry, err := core.namespaceStore.GetNamespaceByPath(ctx, parentPath)
+	parentNS, err := core.namespaceStore.GetNamespaceByPath(ctx, parentPath)
 	require.NoError(t, err)
-	require.NotNil(t, parentEntry, "parent namespace not found")
-	parentNS := parentEntry.Namespace
+	require.NotNil(t, parentNS, "parent namespace not found")
 	parentCtx := namespace.ContextWithNamespace(ctx, parentNS)
 
 	// Create a child namespace
@@ -785,10 +781,9 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	require.False(t, resp.IsError(), "response error: %#v", resp)
 
 	// Get the child namespace
-	childEntry, err := core.namespaceStore.GetNamespaceByPath(parentCtx, childPath)
+	childNS, err := core.namespaceStore.GetNamespaceByPath(parentCtx, childPath)
 	require.NoError(t, err)
-	require.NotNil(t, childEntry, "child namespace not found")
-	childNS := childEntry.Namespace
+	require.NotNil(t, childNS, "child namespace not found")
 	childCtx := namespace.ContextWithNamespace(parentCtx, childNS)
 
 	// Create policies in each namespace

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -362,7 +362,7 @@ func TestCoreCreateNamespaces(core *Core, namespaces ...*namespace.Namespace) er
 	// Use root context to ensure parent namespace is available
 	ctx := namespace.RootContext(context.Background())
 	for _, ns := range namespaces {
-		err := core.namespaceStore.SetNamespace(ctx, &NamespaceEntry{Namespace: ns})
+		err := core.namespaceStore.SetNamespace(ctx, ns)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1166.

- Moves UUID field from `NamespaceEntry` into `Namespace`
- Removes unnecessary fetches from NamespaceStore
- Use `(*Core).ListNamespaces` and `(*Core).NamespaceByID` where now possible
- Removes `NamespaceEntry` completely

cc: @cipherboy, @driif, @voigt, @wslabosz-reply