### PR TITLE
(secrets/pki): add not_before_bound and not_after_bound

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -228,6 +228,8 @@ func TestPKI_DeviceCert(t *testing.T) {
 		"allow_subdomains":   true,
 		"not_after":          "9999-12-31T23:59:59Z",
 		"not_before":         "1900-01-01T00:00:00Z",
+		"not_after_bound":    "9999-12-31T23:59:59Z",
+		"not_before_bound":   "permit",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1435,11 +1435,10 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 	}
 
 	// Get certificate's Not Before
-	notBefore, err := getCertificateNotBefore(data)
+	notBefore, warnings, err := getCertificateNotBefore(data)
 	if err != nil {
 		return nil, warnings, err
 	}
-
 	// Get the TTL and verify it against the max allowed
 	notAfter, ttlWarnings, err := getCertificateNotAfter(b, data, caSign)
 	if err != nil {
@@ -1577,27 +1576,32 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 }
 
 // compute a certificate's Not Before based on the role and input api data sent. Returns notBefore Time and an error.
-func getCertificateNotBefore(data *inputBundle) (time.Time, error) {
+func getCertificateNotBefore(data *inputBundle) (time.Time, []string, error) {
 	var notBefore time.Time
+	var warnings []string
 	var err error
 
+	notBeforeBound := data.role.NotBeforeBound
 	notBeforeAlt := data.role.NotBefore
 
 	if notBeforeAlt == "" {
 		notBeforeAltRaw, ok := data.apiData.GetOk("not_before")
-		if ok {
+		if ok && notBeforeBound == certutil.PermitNotBeforeBound.String() {
 			notBeforeAlt = notBeforeAltRaw.(string)
+		}
+		if ok && notBeforeBound == certutil.ForbidNotBeforeBound.String() {
+			return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf("not_before_bound is set to %s. not_before cannot be provided.", notBeforeBound)}
 		}
 	}
 
 	if notBeforeAlt != "" {
 		notBefore, err = time.Parse(time.RFC3339, notBeforeAlt)
 		if err != nil {
-			return notBefore, errutil.UserError{Err: err.Error()}
+			return notBefore, warnings, errutil.UserError{Err: err.Error()}
 		}
 	}
 
-	return notBefore, err
+	return notBefore, warnings, err
 }
 
 // getCertificateNotAfter compute a certificate's NotAfter date based on the mount ttl, role, signing bundle and input
@@ -1609,13 +1613,44 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 	var err error
 
 	ttl := time.Duration(data.apiData.Get("ttl").(int)) * time.Second
+
 	notAfterAlt := data.role.NotAfter
-	if notAfterAlt == "" {
-		notAfterAltRaw, ok := data.apiData.GetOk("not_after")
-		if ok {
-			notAfterAlt = notAfterAltRaw.(string)
+	notAfterBound := data.role.NotAfterBound
+	var timestamp time.Time
+	forbidBound := false
+	ttlLimitedBound := false
+	timestampBound := false
+
+	switch notAfterBound {
+	case "":
+	// Nothing to do - for pki/root/generate/internal we have no not_after_bound
+	case certutil.ForbidNotAfterBound.String():
+		forbidBound = true
+	case certutil.TTLNotAfterBound.String():
+		ttlLimitedBound = true
+	default:
+		timestamp, err = time.Parse(time.RFC3339, notAfterBound)
+		if err != nil {
+			return notAfter, warnings, errutil.UserError{Err: err.Error()}
 		}
+		timestampBound = true
 	}
+
+	if !forbidBound {
+		if notAfterAlt == "" {
+			notAfterAltRaw, ok := data.apiData.GetOk("not_after")
+			if ok {
+				notAfterAlt = notAfterAltRaw.(string)
+				notAfter, err = time.Parse(time.RFC3339, notAfterAlt)
+				if err != nil {
+					return notAfter, warnings, errutil.UserError{Err: err.Error()}
+				}
+			}
+		}
+	} else {
+		return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf("not_after_bound is set to %s. not_after cannot be provided.", notAfterBound)}
+	}
+
 	if ttl > 0 && notAfterAlt != "" {
 		return time.Time{}, warnings, errutil.UserError{Err: "Either ttl or not_after should be provided. Both should not be provided in the same request."}
 	}
@@ -1637,6 +1672,10 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 	if ttl > maxTTL {
 		warnings = append(warnings, fmt.Sprintf("TTL %q is longer than permitted maxTTL %q, so maxTTL is being used", ttl, maxTTL))
 		ttl = maxTTL
+	}
+
+	if ttlLimitedBound && notAfter.After(time.Now().Add(ttl)) {
+		return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf("not_after_bound is set to %s. Cannot statisfy request as that would result in notAfter of %s that is beyond the TTL of %s", notAfterBound, notAfter.UTC().Format(time.RFC3339Nano), ttl)}
 	}
 
 	if notAfterAlt != "" {
@@ -1664,6 +1703,11 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 				"cannot satisfy request, as TTL would result in notAfter of %s that is beyond the expiration of the CA certificate at %s", notAfter.UTC().Format(time.RFC3339Nano), caSign.Certificate.NotAfter.UTC().Format(time.RFC3339Nano))}
 		}
 	}
+
+	if timestampBound && notAfter.After(timestamp) {
+		return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf("not_after_bound is set to %s. Cannot statisfy request as that would result in notAfter of %s that is beyond the maximum timestamp of %s", notAfterBound, notAfter.UTC().Format(time.RFC3339Nano), timestamp.UTC().Format(time.RFC3339Nano))}
+	}
+
 	return notAfter, warnings, nil
 }
 

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -246,7 +246,7 @@ func TestPki_getCertificateNotBefore(t *testing.T) {
 
 	expectedNotBefore := "2024-12-31 23:59:59 +0000 UTC"
 
-	notBefore, err := getCertificateNotBefore(&data)
+	notBefore, _, err := getCertificateNotBefore(&data)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -704,6 +704,45 @@ func (n NotAfterBehavior) String() string {
 	return "unknown"
 }
 
+type notBeforeBound int
+
+const (
+	ForbidNotBeforeBound notBeforeBound = iota
+	PermitNotBeforeBound
+)
+
+var notBeforeBoundNames = map[notBeforeBound]string{
+	ForbidNotBeforeBound: "forbid",
+	PermitNotBeforeBound: "permit",
+}
+
+func (n notBeforeBound) String() string {
+	if name, ok := notBeforeBoundNames[n]; ok && len(name) > 0 {
+		return name
+	}
+	return "unknown"
+}
+
+type NotAfterBound int
+
+const (
+	ForbidNotAfterBound NotAfterBound = iota
+	TTLNotAfterBound
+)
+
+var notAfterBoundNames = map[NotAfterBound]string{
+	ForbidNotAfterBound: "forbid",
+	TTLNotAfterBound:    "ttl-limited",
+}
+
+func (n NotAfterBound) String() string {
+	if name, ok := notAfterBoundNames[n]; ok && len(name) > 0 {
+		return name
+	}
+
+	return "unknown"
+}
+
 type CAInfoBundle struct {
 	ParsedCertBundle
 	URLs                 *URLEntries

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3595,11 +3595,23 @@ based on this parameter.
 - `not_before_duration` `(duration: "30s")` - Specifies the duration by which to
   backdate the NotBefore property. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.
+  
+- `not_before_bound` `(string: "permit")` - Specifies if `not_before` can be 
+  provided When requesting a certificate. Valid options are `permit` or `forbid`. 
+  Defaults to `permit`.
 
 - `not_before` `(string)` - Set the Not Before field of the certificate with
   specified date value. The value format should be given in UTC format
   `YYYY-MM-ddTHH:MM:SSZ`. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.
+  
+- `not_after_bound` `(string: "ttl-limited")` - Specifcies if and how `not_after` 
+  can be provided when requesting a certificate. Defaults to `ttl-limited`. Valid 
+  options are :
+  
+    - `ttl-limited` to allow providing `not_after` within the bound of the role TTL
+    - `forbid` to disallow providing `not_after`
+    - or an explicit maximum timestamp in  UTC format `YYYY-MM-ddTHH:MM:SSZ`
 
 - `not_after` `(string)` - Set the Not After field of the certificate with
   specified date value. The value format should be given in UTC format


### PR DESCRIPTION
This is related to #489 which was on my table for quite some time now. 

Feedback is welcome :dancers: 


This adds two parameters to pki roles.

`not_after_bound` can take the following values :
* `forbid` to prevent users from supplying `not_after`
* `tll-limited` to allow supplying `not_after` but within the bounds of the TTL
* an explicit timestamp in UTC format `YYYY-MM-ddTHH:MM:SSZ` up to which `not_after` can be set

`not_before_bound` can take the following values :
* `forbid` to prevent users from supplying `not_after`
* `permit` allow users from supplying `not_after

