### PR TITLE
Do not set LimitNOFILE

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/openbao.service
+++ b/.release/linux/package/usr/lib/systemd/system/openbao.service
@@ -26,7 +26,6 @@ KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
-LimitNOFILE=65536
 MemorySwapMax=0
 
 [Install]

--- a/changelog/1179.txt
+++ b/changelog/1179.txt
@@ -1,0 +1,3 @@
+```release-note:change
+packaging/systemd: Do not set LimitNOFILE, allowing Go to automatically manage this value on behalf of the server. See also https://github.com/golang/go/issues/46279.
+```


### PR DESCRIPTION
This is not needed anymore since https://github.com/golang/go/issues/46279 was resolved.   golang automatically raises the soft limit on startup.

Quoting https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Process%20Properties

> **Don't use.** Be careful when raising the soft limit above 1024, since select(2) cannot function with file descriptors above 1023 on Linux. Nowadays, the hard limit defaults to 524288, a very high value compared to historical defaults. Typically applications should increase their soft limit to the hard limit on their own, if they are OK with working with file descriptors above 1023, i.e. do not use select(2). Note that file descriptors are nowadays accounted like any other form of memory, thus there should not be any need to lower the hard limit. Use MemoryMax= to control overall service memory use, including file descriptor memory.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
