### PR TITLE
Replace Vault with OpenBao in init error msg

### DIFF
--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -15,15 +15,15 @@ import (
 var (
 	// ErrBarrierSealed is returned if an operation is performed on
 	// a sealed barrier. No operation is expected to succeed before unsealing
-	ErrBarrierSealed = errors.New("Vault is sealed")
+	ErrBarrierSealed = errors.New("OpenBao is sealed")
 
 	// ErrBarrierAlreadyInit is returned if the barrier is already
 	// initialized. This prevents a re-initialization.
-	ErrBarrierAlreadyInit = errors.New("Vault is already initialized")
+	ErrBarrierAlreadyInit = errors.New("OpenBao is already initialized")
 
 	// ErrBarrierNotInit is returned if a non-initialized barrier
 	// is attempted to be unsealed.
-	ErrBarrierNotInit = errors.New("Vault is not initialized")
+	ErrBarrierNotInit = errors.New("OpenBao is not initialized")
 
 	// ErrBarrierInvalidKey is returned if the Unseal key is invalid
 	ErrBarrierInvalidKey = errors.New("Unseal failed, invalid key")

--- a/vault/core.go
+++ b/vault/core.go
@@ -116,11 +116,11 @@ const (
 var (
 	// ErrAlreadyInit is returned if the core is already
 	// initialized. This prevents a re-initialization.
-	ErrAlreadyInit = errors.New("Vault is already initialized")
+	ErrAlreadyInit = errors.New("OpenBao is already initialized")
 
 	// ErrNotInit is returned if a non-initialized barrier
 	// is attempted to be unsealed.
-	ErrNotInit = errors.New("Vault is not initialized")
+	ErrNotInit = errors.New("OpenBao is not initialized")
 
 	// ErrInternalError is returned when we don't want to leak
 	// any information about an internal error
@@ -128,11 +128,11 @@ var (
 
 	// ErrHANotEnabled is returned if the operation only makes sense
 	// in an HA setting
-	ErrHANotEnabled = errors.New("Vault is not configured for highly-available mode")
+	ErrHANotEnabled = errors.New("OpenBao is not configured for highly-available mode")
 
 	// ErrIntrospectionNotEnabled is returned if "introspection_endpoint" is not
 	// enabled in the configuration file
-	ErrIntrospectionNotEnabled = errors.New("The Vault configuration must set \"introspection_endpoint\" to true to enable this endpoint")
+	ErrIntrospectionNotEnabled = errors.New("The OpenBao configuration must set \"introspection_endpoint\" to true to enable this endpoint")
 
 	// manualStepDownSleepPeriod is how long to sleep after a user-initiated
 	// step down of the active node, to prevent instantly regrabbing the lock.

--- a/vault/init.go
+++ b/vault/init.go
@@ -64,7 +64,7 @@ func (c *Core) InitializeRecovery(ctx context.Context) error {
 	return nil
 }
 
-// Initialized checks if the Vault is already initialized.  This means one of
+// Initialized checks if the OpenBao is already initialized.  This means one of
 // two things: either the barrier has been created (with keyring and root key)
 // and the seal config written to storage, or Raft is forming a cluster and a
 // join/bootstrap is in progress.
@@ -87,7 +87,7 @@ func (c *Core) Initialized(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-// InitializedLocally checks if the Vault is already initialized from the
+// InitializedLocally checks if the OpenBao is already initialized from the
 // local node's perspective.  This is the same thing as Initialized, unless
 // using Raft, in which case Initialized may return true (because a peer
 // we're joining to has been initialized) while InitializedLocally returns


### PR DESCRIPTION
I just noticed while doing some tests that the error msg when initializing fails still contains `Vault`