### PR TITLE
Add guide for listing detailed endpoints

### DIFF
--- a/website/content/docs/plugins/plugin-authors-guide.mdx
+++ b/website/content/docs/plugins/plugin-authors-guide.mdx
@@ -11,6 +11,7 @@ plugins for OpenBao.
 ## Table of contents
 
 - [List pagination](#list-pagination)
+- [Listing Detailed Endpoints](#listing-detailed-endpoints)
 
 ## List pagination
 
@@ -40,3 +41,21 @@ and batch-level callbacks for flexibility:
 
 The callbacks are executed sequentially, with `itemCallback` processing each entry individually,
 followed by `batchCallback` handling the entire batch.
+
+## Listing Detailed Endpoints
+
+Detailed listing of items is implemented using one of the following two methods:
+- Supplying the `-detailed` CLI flag.
+- Querying a `/detailed` API endpoint.
+
+While both approaches are valid, it is recommended to implement a dedicated `/detailed` endpoint, as 
+done in the `pki/certs/detailed` implementation ([PR #680](https://github.com/openbao/openbao/pull/680)).
+
+This has the following benefits:
+* Avoids adding performance overhead on the default list endpoint. For example, in `pki/issuers`, 
+the list API always returns both the list of `keys` and a `key_info` map containing metadata for each 
+issuer. The `-detailed` flag simply controls whether this metadata is displayed in the CLI output.
+* Restricts access to detailed listing by default unless an administrator has set up wildcards. For
+instance, when using `- detailed`, an admin who doesn't want users listing detailed information 
+(because it is too resource intensive) would need to explicitly update their ACL policies to include 
+`denied_parameters=detailed`.


### PR DESCRIPTION
Lists benefits of implementing `/detailed` endpoint vs using `- detailed` flag.