### PR TITLE
Add cert details to cert list in UI

### DIFF
--- a/ui/app/adapters/pki/certificate/base.js
+++ b/ui/app/adapters/pki/certificate/base.js
@@ -11,7 +11,7 @@ export default class PkiCertificateBaseAdapter extends ApplicationAdapter {
 
   getURL(backend, id) {
     const uri = `${this.buildURL()}/${encodePath(backend)}`;
-    return id ? `${uri}/cert/${id}` : `${uri}/certs`;
+    return id ? `${uri}/cert/${id}` : `${uri}/certs/detailed`;
   }
 
   fetchByQuery(query) {

--- a/ui/app/serializers/pki/certificate/base.js
+++ b/ui/app/serializers/pki/certificate/base.js
@@ -27,4 +27,22 @@ export default class PkiCertificateBaseSerializer extends ApplicationSerializer 
     }
     return super.normalizeResponse(...arguments);
   }
+
+  // rehydrate each cert model so all model attributes are accessible from the LIST response
+  normalizeItems(payload) {
+    if (payload.data) {
+      if (payload.data?.keys && Array.isArray(payload.data.keys)) {
+        return payload.data.keys.map((key) => {
+          return {
+            serial_number: key,
+            ...payload.data.key_info[key],
+          };
+        });
+      }
+      Object.assign(payload, payload.data);
+      delete payload.data;
+    }
+
+    return payload;
+  }
 }

--- a/ui/lib/pki/addon/templates/certificates/index.hbs
+++ b/ui/lib/pki/addon/templates/certificates/index.hbs
@@ -19,7 +19,7 @@
 
 {{#if this.model.hasConfig}}
   {{#if this.model.certificates.length}}
-    {{#each this.model.certificates as |pkiCertificate|}}
+    {{#each this.model.certificates as |pkiCertificate idx|}}
       <LinkedBlock
         class="list-item-row"
         @params={{array "certificates.certificate.details" pkiCertificate.id}}
@@ -33,6 +33,14 @@
                 {{pkiCertificate.id}}
               </span>
               <div class="is-flex-row has-left-margin-l has-top-margin-xs">
+                {{#if pkiCertificate.commonName}}
+                  <span class="tag is-transparent has-left-margin-none" data-test-common-name={{idx}}>
+                    <InfoTooltip>
+                      Common name
+                    </InfoTooltip>
+                    {{pkiCertificate.commonName}}
+                  </span>
+                {{/if}}
               </div>
             </div>
           </div>


### PR DESCRIPTION
The cert list in the UI currently only shows the serial number. It now also shows the common name if it exists.

![image](https://github.com/user-attachments/assets/b505027e-2e38-4c6e-9248-5c74954a9f4e)

Pairs with #680
Resolves [Vault 27249](https://github.com/hashicorp/vault/issues/27249) 