### PR TITLE
Forbid illegal namespace characters

### DIFF
--- a/http/sys_namespaces_test.go
+++ b/http/sys_namespaces_test.go
@@ -1,0 +1,144 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/openbao/openbao/helper/benchhelpers"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/vault"
+)
+
+func FuzzNamespaceName(f *testing.F) {
+	t := benchhelpers.TBtoT(f)
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(f, core)
+	defer ln.Close()
+	TestServerAuth(f, addr, token)
+
+	f.Add(".")
+	f.Add("..")
+	f.Add("/")
+	f.Add("foo/bar")
+	f.Add("sys")
+	f.Add("cubbyhole")
+	f.Add("root")
+	f.Add("audit")
+	f.Add("auth")
+	f.Add("identity")
+	f.Add("valid")
+	f.Add("%")
+	f.Add("💪")
+	f.Add("大")
+	f.Add("foo bar")
+	f.Add(string([]byte{0x20, 0x00}))
+	f.Add(string([]byte{0xE2, 0x80, 0x80}))
+
+	namesCache := make(map[string]bool)
+	namesList := make([]string, 0)
+
+	f.Fuzz(func(t *testing.T, name string) {
+		expect := http.StatusOK
+		switch {
+		// exact values
+		case name == "..":
+			expect = http.StatusNotFound
+		case name == ".":
+			expect = http.StatusMethodNotAllowed
+		case name == "":
+			expect = http.StatusBadRequest
+		case name == "sys":
+			expect = http.StatusInternalServerError
+		case name == "cubbyhole":
+			expect = http.StatusInternalServerError
+		case name == "root":
+			expect = http.StatusInternalServerError
+		case name == "audit":
+			expect = http.StatusInternalServerError
+		case name == "auth":
+			expect = http.StatusInternalServerError
+		case name == "identity":
+			expect = http.StatusInternalServerError
+
+		// 400
+		case strings.ContainsFunc(name, not(unicode.IsPrint)):
+			expect = http.StatusBadRequest
+		case strings.HasSuffix(name, "/"):
+			expect = http.StatusBadRequest
+
+		// 500
+		case strings.Contains(name, " "):
+			expect = http.StatusInternalServerError
+		case strings.Contains(name, "/"):
+			expect = http.StatusInternalServerError
+		case strings.Contains(name, "+*"):
+			expect = http.StatusInternalServerError
+
+		// 400 again
+		case !utf8.ValidString(name):
+			expect = http.StatusBadRequest
+		}
+
+		escapedName := url.PathEscape(name)
+		canonicalName := namespace.Canonicalize(path.Clean(name))
+		if namesCache[canonicalName] {
+			return
+		}
+		namesCache[canonicalName] = true
+		namesList = append(namesList, name)
+
+		resp := testHttpPut(t, token, addr+"/v1/sys/namespaces/"+escapedName, nil)
+		t.Logf("creating namespace '%s' (%x)", name, name)
+		if resp.StatusCode < 300 {
+			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces?list=true")
+			t.Log("listing namespaces")
+			testResponseStatus(t, resp, http.StatusOK)
+
+			resp = testHttpGet(t, token, addr+"/v1/"+escapedName+"/sys/namespaces?list=true")
+			t.Logf("listing child namespaces of '%s' (%x)", name, name)
+			testResponseStatus(t, resp, http.StatusNotFound)
+
+			resp = testHttpDelete(t, token, addr+"/v1/sys/namespaces/"+escapedName)
+			t.Logf("deleting namespace '%s' (%x)", name, name)
+			testResponseStatus(t, resp, http.StatusNoContent)
+			return
+		}
+
+		if resp.StatusCode >= 500 {
+			b, _ := io.ReadAll(resp.Body)
+			var out struct {
+				Errors []string `json:"errors"`
+			}
+			json.Unmarshal(b, &out)
+
+			for _, e := range out.Errors {
+				if strings.Contains(e, "existing mount") {
+					t.Logf("existing mount: '%s' (%x)", name, name)
+					for _, n := range namesList {
+						if strings.Contains(n, name) || strings.Contains(name, n) {
+							t.Logf("possible mount: %s", n)
+						}
+					}
+					if canonicalName != name {
+						t.Logf("found differing name: '%s', cleaned: '%s'", name, canonicalName)
+					}
+				}
+			}
+		}
+
+		testResponseStatus(t, resp, expect)
+	})
+}
+
+func not[T any](f func(T) bool) func(T) bool {
+	return func(t T) bool {
+		return !f(t)
+	}
+}

--- a/http/sys_namespaces_test.go
+++ b/http/sys_namespaces_test.go
@@ -55,33 +55,31 @@ func FuzzNamespaceName(f *testing.F) {
 		case name == "":
 			expect = http.StatusBadRequest
 		case name == "sys":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case name == "cubbyhole":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case name == "root":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case name == "audit":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case name == "auth":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case name == "identity":
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 
 		// 400
 		case strings.ContainsFunc(name, not(unicode.IsPrint)):
 			expect = http.StatusBadRequest
 		case strings.HasSuffix(name, "/"):
 			expect = http.StatusBadRequest
-
-		// 500
 		case strings.Contains(name, " "):
-			expect = http.StatusInternalServerError
+			expect = http.StatusBadRequest
 		case strings.Contains(name, "/"):
-			expect = http.StatusInternalServerError
-		case strings.Contains(name, "+*"):
-			expect = http.StatusInternalServerError
-
-		// 400 again
+			expect = http.StatusBadRequest
+		case strings.Contains(name, "+"):
+			expect = http.StatusBadRequest
+		case strings.Contains(name, "*"):
+			expect = http.StatusBadRequest
 		case !utf8.ValidString(name):
 			expect = http.StatusBadRequest
 		}

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -231,7 +231,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		path := namespace.Canonicalize(data.Get("path").(string))
 
 		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
-			return nil, errors.New("path must not contain /")
+			return logical.ErrorResponse("path must not contain /"), logical.ErrInvalidRequest
 		}
 
 		imetadata, ok := data.GetOk("custom_metadata")
@@ -240,7 +240,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			metadata = make(map[string]string)
 			for k, v := range imetadata.(map[string]interface{}) {
 				if metadata[k], ok = v.(string); !ok {
-					return nil, fmt.Errorf("custom_metadata values must be strings")
+					return logical.ErrorResponse("custom_metadata values must be strings"), logical.ErrInvalidRequest
 				}
 			}
 		}
@@ -250,7 +250,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			return ns, nil
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to modify namespace: %w", err)
+			return handleError(err)
 		}
 
 		resp := &logical.Response{Data: map[string]interface{}{

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"sync"
 	"sync/atomic"
@@ -267,7 +268,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *Names
 	// Copy the entry before validating and potentially mutating it.
 	entry := nsEntry.Clone()
 	if err := entry.Validate(); err != nil {
-		return fmt.Errorf("failed validating namespace: %w", err)
+		return logical.CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Validate that we have a parent namespace.
@@ -529,7 +530,7 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 
 	path = namespace.Canonicalize(parent.Path + path)
 	if path == "" {
-		return nil, errors.New("refusing to modify root namespace")
+		return nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
 	}
 
 	ns.lock.Lock()


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

This adds a fuzz test for the namespaces API to check for characters that cause problems. It also adds checks to the `(*Namespace).Validate` function for the characters found so far. All illegal characters now return a `400` error code, except for:

- `.`, and `..` return `405` and `404` respectively. They are interpreted by the HTTP stack, so these never reach the actual namespace validation. Not much that we can do here, I'm afraid.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1183 

cc: @cipherboy @driif @klaus-sap @satoqz @voigt @wslabosz-reply @genelet
