### PR TITLE
Implement Cascading Delete for Namespaces and Associated Resources

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -92,6 +92,7 @@ var (
 		ID:             RootNamespaceID,
 		UUID:           RootNamespaceUUID,
 		Path:           "",
+		Tainted:        false,
 		CustomMetadata: make(map[string]string),
 	}
 )

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -34,10 +34,13 @@ var reservedNames = []string{
 type contextValues struct{}
 
 type Namespace struct {
-	ID             string            `json:"id" mapstructure:"id"`
-	UUID           string            `json:"uuid" mapstructure:"uuid"`
-	Path           string            `json:"path" mapstructure:"path"`
-	Tainted        bool              `json:"tainted" mapstructure:"tainted"`
+	ID      string `json:"id" mapstructure:"id"`
+	UUID    string `json:"uuid" mapstructure:"uuid"`
+	Path    string `json:"path" mapstructure:"path"`
+	Tainted bool   `json:"tainted" mapstructure:"tainted"`
+	// IsDeleting tracks whether there's an ongoing deletion process of the specified namespace
+	// If tainted is true, but IsDeleting not, then namespace deletion operation has to be retried.
+	IsDeleting     bool              `json:"-"`
 	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
 }
 
@@ -94,6 +97,7 @@ var (
 		UUID:           RootNamespaceUUID,
 		Path:           "",
 		Tainted:        false,
+		IsDeleting:     false,
 		CustomMetadata: make(map[string]string),
 	}
 )
@@ -138,6 +142,7 @@ func (n *Namespace) Clone() *Namespace {
 		UUID:           n.UUID,
 		Path:           n.Path,
 		Tainted:        n.Tainted,
+		IsDeleting:     n.IsDeleting,
 		CustomMetadata: meta,
 	}
 }

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -36,7 +36,7 @@ type Namespace struct {
 	ID             string            `json:"id" mapstructure:"id"`
 	UUID           string            `json:"uuid" mapstructure:"uuid"`
 	Path           string            `json:"path" mapstructure:"path"`
-	Tainted        bool              `json:"tainted,omitempty" mapstructure:"tainted"`
+	Tainted        bool              `json:"tainted" mapstructure:"tainted"`
 	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
 }
 

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -36,6 +36,7 @@ type Namespace struct {
 	ID             string            `json:"id" mapstructure:"id"`
 	UUID           string            `json:"uuid" mapstructure:"uuid"`
 	Path           string            `json:"path" mapstructure:"path"`
+	Tainted        bool              `json:"tainted,omitempty" mapstructure:"tainted"`
 	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
 }
 

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 	"slices"
 	"strings"
@@ -130,14 +131,13 @@ func (n *Namespace) TrimmedPath(path string) string {
 
 func (n *Namespace) Clone() *Namespace {
 	meta := make(map[string]string, len(n.CustomMetadata))
-	for k, v := range n.CustomMetadata {
-		meta[k] = v
-	}
+	maps.Copy(meta, n.CustomMetadata)
 
 	return &Namespace{
 		ID:             n.ID,
 		UUID:           n.UUID,
 		Path:           n.Path,
+		Tainted:        n.Tainted,
 		CustomMetadata: meta,
 	}
 }

--- a/http/sys_namespaces_test.go
+++ b/http/sys_namespaces_test.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -111,15 +110,6 @@ func FuzzNamespaceName(f *testing.F) {
 			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces/"+escapedName)
 			t.Logf("retrieving namespace details")
 			testResponseStatus(t, resp, http.StatusOK)
-
-			// TODO(wslabosz): As deletion is asynchronous we have to wait before it completes
-			// this should be adjusted with more comprehensive test, hypotheticall with polling
-			// whenever we have "deletion status" endpoint, but for now sleeping for 1ms
-			time.Sleep(1 * time.Millisecond)
-
-			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces/"+escapedName)
-			t.Logf("retrieving namespace details after deletion")
-			testResponseStatus(t, resp, http.StatusNotFound)
 
 			return
 		}

--- a/http/sys_namespaces_test.go
+++ b/http/sys_namespaces_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -93,19 +94,33 @@ func FuzzNamespaceName(f *testing.F) {
 		namesList = append(namesList, name)
 
 		resp := testHttpPut(t, token, addr+"/v1/sys/namespaces/"+escapedName, nil)
-		t.Logf("creating namespace '%s' (%x)", name, name)
+		t.Logf("creating namespace %q (%x)", name, name)
 		if resp.StatusCode < 300 {
 			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces?list=true")
 			t.Log("listing namespaces")
 			testResponseStatus(t, resp, http.StatusOK)
 
 			resp = testHttpGet(t, token, addr+"/v1/"+escapedName+"/sys/namespaces?list=true")
-			t.Logf("listing child namespaces of '%s' (%x)", name, name)
+			t.Logf("listing child namespaces of %q (%x)", name, name)
 			testResponseStatus(t, resp, http.StatusNotFound)
 
 			resp = testHttpDelete(t, token, addr+"/v1/sys/namespaces/"+escapedName)
-			t.Logf("deleting namespace '%s' (%x)", name, name)
-			testResponseStatus(t, resp, http.StatusNoContent)
+			t.Logf("deleting namespace %q (%x)", name, name)
+			testResponseStatus(t, resp, http.StatusOK)
+
+			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces/"+escapedName)
+			t.Logf("retrieving namespace details")
+			testResponseStatus(t, resp, http.StatusOK)
+
+			// TODO(wslabosz): As deletion is asynchronous we have to wait before it completes
+			// this should be adjusted with more comprehensive test, hypotheticall with polling
+			// whenever we have "deletion status" endpoint, but for now sleeping for 1ms
+			time.Sleep(1 * time.Millisecond)
+
+			resp = testHttpGet(t, token, addr+"/v1/sys/namespaces/"+escapedName)
+			t.Logf("retrieving namespace details after deletion")
+			testResponseStatus(t, resp, http.StatusNotFound)
+
 			return
 		}
 
@@ -118,14 +133,14 @@ func FuzzNamespaceName(f *testing.F) {
 
 			for _, e := range out.Errors {
 				if strings.Contains(e, "existing mount") {
-					t.Logf("existing mount: '%s' (%x)", name, name)
+					t.Logf("existing mount: %q (%x)", name, name)
 					for _, n := range namesList {
 						if strings.Contains(n, name) || strings.Contains(name, n) {
 							t.Logf("possible mount: %s", n)
 						}
 					}
 					if canonicalName != name {
-						t.Logf("found differing name: '%s', cleaned: '%s'", name, canonicalName)
+						t.Logf("found differing name: %q, cleaned: %q", name, canonicalName)
 					}
 				}
 			}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -223,13 +223,8 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 		path += "/"
 	}
 
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Ensure the token backend is not affected
-	if path == "token/" && ns.Path == namespace.RootNamespace.Path {
+	if path == "token/" {
 		return errors.New("token credential backend cannot be disabled")
 	}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -84,7 +84,6 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 		return errors.New("backend path must be specified")
 	}
 
-	// not sure why we lock the mounts here
 	c.mountsLock.Lock()
 	c.authLock.Lock()
 	locked := true

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -446,14 +446,14 @@ func (c *Core) stopExpiration() error {
 	return nil
 }
 
-func (m *ExpirationManager) leaseView(ctx context.Context, ns *namespace.Namespace) BarrierView {
+func (m *ExpirationManager) leaseView(ns *namespace.Namespace) BarrierView {
 	if ns.ID == namespace.RootNamespaceID {
 		return m.core.systemBarrierView.SubView(expirationSubPath + leaseViewPrefix)
 	}
 	return m.core.namespaceMountEntryView(ns, systemBarrierPrefix+expirationSubPath+leaseViewPrefix)
 }
 
-func (m *ExpirationManager) tokenIndexView(ctx context.Context, ns *namespace.Namespace) BarrierView {
+func (m *ExpirationManager) tokenIndexView(ns *namespace.Namespace) BarrierView {
 	if ns.ID == namespace.RootNamespaceID {
 		return m.core.systemBarrierView.SubView(expirationSubPath + tokenViewPrefix)
 	}
@@ -469,7 +469,7 @@ func (m *ExpirationManager) collectLeases() (map[*namespace.Namespace][]string, 
 	}
 
 	for _, namespace := range namespaces {
-		view := m.leaseView(m.quitContext, namespace)
+		view := m.leaseView(namespace)
 		keys, err := logical.CollectKeys(m.quitContext, view)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to scan for leases: %w", err)
@@ -665,7 +665,7 @@ func (m *ExpirationManager) Tidy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	leaseView := m.leaseView(ctx, ns)
+	leaseView := m.leaseView(ns)
 	if err := logical.ScanView(m.quitContext, leaseView, tidyFunc); err != nil {
 		return err
 	}
@@ -1179,7 +1179,7 @@ func (m *ExpirationManager) revokePrefixCommon(ctx context.Context, prefix strin
 	if err != nil {
 		return err
 	}
-	view := m.leaseView(ctx, ns).SubView(prefix)
+	view := m.leaseView(ns).SubView(prefix)
 	existing, err := logical.CollectKeys(ctx, view)
 	if err != nil {
 		return fmt.Errorf("failed to scan for leases: %w", err)
@@ -2027,7 +2027,7 @@ func (m *ExpirationManager) loadEntryInternal(ctx context.Context, leaseID strin
 		return nil, err
 	}
 
-	out, err := m.leaseView(ctx, ns).Get(ctx, leaseID)
+	out, err := m.leaseView(ns).Get(ctx, leaseID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read lease entry %s: %w", leaseID, err)
 	}
@@ -2077,7 +2077,7 @@ func (m *ExpirationManager) persistEntry(ctx context.Context, le *leaseEntry) er
 		ent.SealWrap = true
 	}
 
-	if err := m.leaseView(ctx, le.namespace).Put(ctx, &ent); err != nil {
+	if err := m.leaseView(le.namespace).Put(ctx, &ent); err != nil {
 		return fmt.Errorf("failed to persist lease entry: %w", err)
 	}
 	return nil
@@ -2085,7 +2085,7 @@ func (m *ExpirationManager) persistEntry(ctx context.Context, le *leaseEntry) er
 
 // deleteEntry is used to delete a lease entry
 func (m *ExpirationManager) deleteEntry(ctx context.Context, le *leaseEntry) error {
-	if err := m.leaseView(ctx, le.namespace).Delete(ctx, le.LeaseID); err != nil {
+	if err := m.leaseView(le.namespace).Delete(ctx, le.LeaseID); err != nil {
 		return fmt.Errorf("failed to delete lease entry: %w", err)
 	}
 	return nil
@@ -2122,7 +2122,7 @@ func (m *ExpirationManager) createIndexByToken(ctx context.Context, le *leaseEnt
 		Value: []byte(le.LeaseID),
 	}
 
-	if err := m.tokenIndexView(ctx, tokenNS).Put(ctx, &ent); err != nil {
+	if err := m.tokenIndexView(tokenNS).Put(ctx, &ent); err != nil {
 		return fmt.Errorf("failed to persist lease index entry: %w", err)
 	}
 	return nil
@@ -2155,7 +2155,7 @@ func (m *ExpirationManager) indexByToken(ctx context.Context, le *leaseEntry) (*
 	}
 
 	key := saltedID + "/" + leaseSaltedID
-	entry, err := m.tokenIndexView(ctx, tokenNS).Get(ctx, key)
+	entry, err := m.tokenIndexView(tokenNS).Get(ctx, key)
 	if err != nil {
 		return nil, errors.New("failed to look up secondary index entry")
 	}
@@ -2189,7 +2189,7 @@ func (m *ExpirationManager) removeIndexByToken(ctx context.Context, le *leaseEnt
 	}
 
 	key := saltedID + "/" + leaseSaltedID
-	if err := m.tokenIndexView(ctx, tokenNS).Delete(ctx, key); err != nil {
+	if err := m.tokenIndexView(tokenNS).Delete(ctx, key); err != nil {
 		return fmt.Errorf("failed to delete lease index entry: %w", err)
 	}
 	return nil
@@ -2286,7 +2286,7 @@ func (m *ExpirationManager) lookupLeasesByToken(ctx context.Context, te *logical
 		return nil, err
 	}
 
-	tokenView := m.tokenIndexView(ctx, tokenNS)
+	tokenView := m.tokenIndexView(tokenNS)
 
 	// Scan via the index for sub-leases
 	prefix := saltedID + "/"
@@ -2311,7 +2311,7 @@ func (m *ExpirationManager) lookupLeasesByToken(ctx context.Context, te *logical
 	// Downgrade logic for old-style (V0) leases entries created by a namespace
 	// token that lived in the root namespace.
 	if tokenNS.ID != namespace.RootNamespaceID {
-		tokenView := m.tokenIndexView(ctx, namespace.RootNamespace)
+		tokenView := m.tokenIndexView(namespace.RootNamespace)
 
 		// Scan via the index for sub-leases on the root namespace
 		prefix := saltedID + "/"

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -75,7 +75,7 @@ func TestExpiration_Metrics(t *testing.T) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	idView := exp.tokenIndexView(ctx, namespace.RootNamespace)
+	idView := exp.tokenIndexView(namespace.RootNamespace)
 
 	// Scan the storage with the count func set
 	if err := logical.ScanView(ctx, idView, countFunc); err != nil {
@@ -459,7 +459,7 @@ func TestExpiration_Tidy(t *testing.T) {
 
 	ctx := namespace.RootContext(context.Background())
 
-	view := exp.leaseView(ctx, namespace.RootNamespace)
+	view := exp.leaseView(namespace.RootNamespace)
 
 	// Scan the storage with the count func set
 	if err := logical.ScanView(ctx, view, countFunc); err != nil {
@@ -1077,7 +1077,7 @@ func TestExpiration_Register_BatchToken(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	var idEnts []string
 	for time.Now().Before(deadline) {
-		tokenView := exp.tokenIndexView(ctx, namespace.RootNamespace)
+		tokenView := exp.tokenIndexView(namespace.RootNamespace)
 		idEnts, err = tokenView.List(context.Background(), "")
 		if err != nil {
 			t.Fatal(err)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2203,7 +2203,7 @@ func (b *SystemBackend) handleLeaseLookupList(ctx context.Context, req *logical.
 	if err != nil {
 		return nil, err
 	}
-	keys, err := b.Core.expiration.leaseView(ctx, ns).List(ctx, prefix)
+	keys, err := b.Core.expiration.leaseView(ns).List(ctx, prefix)
 	if err != nil {
 		b.Backend.Logger().Error("error listing leases", "prefix", prefix, "error", err)
 		return handleErrorNoReadOnlyForward(err)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2669,7 +2669,7 @@ func (b *SystemBackend) handlePoliciesList(policyType PolicyType) framework.Oper
 		if err != nil {
 			return nil, err
 		}
-		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, policyType, prefix)
+		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, policyType, prefix, true)
 		if err != nil {
 			return nil, err
 		}
@@ -3089,7 +3089,7 @@ func (b *SystemBackend) handleDisableAudit(ctx context.Context, req *logical.Req
 
 	b.Core.auditLock.RLock()
 	table := b.Core.audit.shallowClone()
-	entry, err := table.find(ctx, path)
+	entry, err := table.findByPath(ctx, path)
 	b.Core.auditLock.RUnlock()
 
 	if err != nil {

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -138,14 +138,14 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 
 // createNamespaceDataResponse is the standard response object
 // for any operations concerning a namespace
-func createNamespaceDataResponse(ns *namespace.Namespace) *logical.Response {
-	return &logical.Response{Data: map[string]interface{}{
+func createNamespaceDataResponse(ns *namespace.Namespace) map[string]any {
+	return map[string]any{
 		"uuid":            ns.UUID,
 		"path":            ns.Path,
 		"id":              ns.ID,
 		"tainted":         ns.Tainted,
 		"custom_metadata": ns.CustomMetadata,
-	}}
+	}
 }
 
 // handleNamespacesList handles "/sys/namespaces" endpoint to list the enabled namespaces.
@@ -214,7 +214,7 @@ func (b *SystemBackend) handleNamespacesRead() framework.OperationFunc {
 			return nil, nil
 		}
 
-		return createNamespaceDataResponse(ns), nil
+		return &logical.Response{Data: createNamespaceDataResponse(ns)}, nil
 	}
 }
 
@@ -246,7 +246,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			return handleError(err)
 		}
 
-		return createNamespaceDataResponse(entry), nil
+		return &logical.Response{Data: createNamespaceDataResponse(entry)}, nil
 	}
 }
 
@@ -302,7 +302,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to modify namespace: %w", err)
 		}
 
-		return createNamespaceDataResponse(ns), nil
+		return &logical.Response{Data: createNamespaceDataResponse(ns)}, nil
 	}
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -136,6 +136,18 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 	}
 }
 
+// createNamespaceDataResponse is the standard response object
+// for any operations concerning a namespace
+func createNamespaceDataResponse(ns *namespace.Namespace) *logical.Response {
+	return &logical.Response{Data: map[string]interface{}{
+		"uuid":            ns.UUID,
+		"path":            ns.Path,
+		"id":              ns.ID,
+		"tainted":         ns.Tainted,
+		"custom_metadata": ns.CustomMetadata,
+	}}
+}
+
 // handleNamespacesList handles "/sys/namespaces" endpoint to list the enabled namespaces.
 func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -153,12 +165,7 @@ func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 		for _, entry := range entries {
 			p := parent.TrimmedPath(entry.Path)
 			keys = append(keys, p)
-			keyInfo[p] = map[string]any{
-				"uuid":            entry.UUID,
-				"id":              entry.ID,
-				"path":            entry.Path,
-				"custom_metadata": entry.CustomMetadata,
-			}
+			keyInfo[p] = createNamespaceDataResponse(entry)
 		}
 
 		return logical.ListResponseWithInfo(keys, keyInfo), nil
@@ -182,12 +189,7 @@ func (b *SystemBackend) handleNamespacesScan() framework.OperationFunc {
 		for _, entry := range entries {
 			p := parent.TrimmedPath(entry.Path)
 			keys = append(keys, p)
-			keyInfo[p] = map[string]any{
-				"uuid":            entry.UUID,
-				"id":              entry.ID,
-				"path":            entry.Path,
-				"custom_metadata": entry.CustomMetadata,
-			}
+			keyInfo[p] = createNamespaceDataResponse(entry)
 		}
 
 		return logical.ListResponseWithInfo(keys, keyInfo), nil
@@ -212,16 +214,7 @@ func (b *SystemBackend) handleNamespacesRead() framework.OperationFunc {
 			return nil, nil
 		}
 
-		resp := &logical.Response{
-			Data: map[string]interface{}{
-				"uuid":            ns.UUID,
-				"id":              ns.ID,
-				"path":            ns.Path,
-				"custom_metadata": ns.CustomMetadata,
-			},
-		}
-
-		return resp, nil
+		return createNamespaceDataResponse(ns), nil
 	}
 }
 
@@ -253,13 +246,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			return handleError(err)
 		}
 
-		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            entry.UUID,
-			"path":            entry.Path,
-			"id":              entry.ID,
-			"custom_metadata": entry.CustomMetadata,
-		}}
-		return resp, nil
+		return createNamespaceDataResponse(entry), nil
 	}
 }
 
@@ -315,13 +302,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to modify namespace: %w", err)
 		}
 
-		resp := &logical.Response{Data: map[string]interface{}{
-			"uuid":            ns.UUID,
-			"path":            ns.Path,
-			"id":              ns.ID,
-			"custom_metadata": ns.CustomMetadata,
-		}}
-		return resp, nil
+		return createNamespaceDataResponse(ns), nil
 	}
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -325,7 +325,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 	}
 }
 
-// handleNamespacesDelete handles the "/sys/namespace/<path>" endpoints to delete a namespace.
+// handleNamespacesDelete handles the "/sys/namespace/<path>" endpoint to delete a namespace.
 func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -300,7 +300,7 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "in-progress", res.Data["status"])
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/foo")
 		res, err = b.HandleRequest(rootCtx, req)
@@ -320,7 +320,7 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "in-progress", res.Data["status"])
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/baz")
 		res, err = b.HandleRequest(nestedCtx, req)

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/openbao/openbao/helper/namespace"
@@ -295,11 +296,14 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 		testCreateNamespace(t, rootCtx, b, "foo", nil)
 
 		req := logical.TestRequest(t, logical.DeleteOperation, "namespaces/foo")
-		_, err := b.HandleRequest(rootCtx, req)
+		res, err := b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
+		require.Equal(t, "in-progress", res.Data["status"])
+
+		time.Sleep(10 * time.Millisecond)
 
 		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/foo")
-		res, err := b.HandleRequest(rootCtx, req)
+		res, err = b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
 		require.Empty(t, res, "expected empty response")
 	})
@@ -312,11 +316,14 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 
 		// ctx ns = foobar, path = baz
 		req := logical.TestRequest(t, logical.DeleteOperation, "namespaces/baz")
-		_, err := b.HandleRequest(nestedCtx, req)
+		res, err := b.HandleRequest(nestedCtx, req)
 		require.NoError(t, err)
+		require.Equal(t, "in-progress", res.Data["status"])
+
+		time.Sleep(10 * time.Millisecond)
 
 		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/baz")
-		res, err := b.HandleRequest(nestedCtx, req)
+		res, err = b.HandleRequest(nestedCtx, req)
 		require.NoError(t, err)
 		require.Empty(t, res, "expected empty response")
 

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -309,6 +309,7 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 				continue
 			}
 			require.Empty(t, res.Data, "data should be empty when deleting already deleted namespace")
+			break
 		}
 	})
 
@@ -345,6 +346,7 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 			}
 
 			require.Empty(t, res, "expected empty response")
+			break
 		}
 
 		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/foobar")

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5993,9 +5993,9 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 		const nonExistentBuiltinVersion = "v1.0.0+builtin"
 		var mountEntry *MountEntry
 		if tc.mountTable == "mounts" {
-			mountEntry, err = core.mounts.find(ctx, tc.pluginName+"/")
+			mountEntry, err = core.mounts.findByPath(ctx, tc.pluginName+"/")
 		} else {
-			mountEntry, err = core.auth.find(ctx, tc.pluginName+"/")
+			mountEntry, err = core.auth.findByPath(ctx, tc.pluginName+"/")
 		}
 		if err != nil {
 			t.Fatal(err)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -642,7 +642,6 @@ func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 
 func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
 	c.mountsLock.Lock()
-	// not sure why we lock the auth here
 	c.authLock.Lock()
 	locked := true
 	unlock := func() {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -265,49 +266,59 @@ func (t *MountTable) setTaint(nsID, path string, tainted bool, mountState string
 // remove is used to remove a given path entry; returns the entry that was
 // removed
 func (t *MountTable) remove(ctx context.Context, path string) (*MountEntry, error) {
-	n := len(t.Entries)
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := 0; i < n; i++ {
-		if entry := t.Entries[i]; entry.Path == path && entry.Namespace().ID == ns.ID {
-			t.Entries[i], t.Entries[n-1] = t.Entries[n-1], nil
-			t.Entries = t.Entries[:n-1]
-			return entry, nil
+	var mountEntryToDelete *MountEntry
+	t.Entries = slices.DeleteFunc(t.Entries, func(me *MountEntry) bool {
+		if me.Path == path && me.Namespace().ID == ns.ID {
+			mountEntryToDelete = me
+			return true
 		}
-	}
-	return nil, nil
+		return false
+	})
+
+	return mountEntryToDelete, nil
 }
 
-func (t *MountTable) find(ctx context.Context, path string) (*MountEntry, error) {
-	n := len(t.Entries)
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := 0; i < n; i++ {
-		if entry := t.Entries[i]; entry.Path == path && entry.Namespace().ID == ns.ID {
-			return entry, nil
-		}
-	}
-	return nil, nil
+func (t *MountTable) findByPath(ctx context.Context, path string) (*MountEntry, error) {
+	return t.find(ctx, func(me *MountEntry) bool { return me.Path == path })
 }
 
 func (t *MountTable) findByBackendUUID(ctx context.Context, backendUUID string) (*MountEntry, error) {
-	n := len(t.Entries)
+	return t.find(ctx, func(me *MountEntry) bool { return me.BackendAwareUUID == backendUUID })
+}
+
+func (t *MountTable) findAllNamespaceMounts(ctx context.Context) ([]*MountEntry, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := 0; i < n; i++ {
-		if entry := t.Entries[i]; entry.BackendAwareUUID == backendUUID && entry.Namespace().ID == ns.ID {
+	var mounts []*MountEntry
+	for _, entry := range t.Entries {
+		if entry.Namespace().ID == ns.ID {
+			mounts = append(mounts, entry)
+		}
+	}
+
+	return mounts, nil
+}
+
+func (t *MountTable) find(ctx context.Context, predicate func(*MountEntry) bool) (*MountEntry, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range t.Entries {
+		if predicate(entry) && entry.Namespace().ID == ns.ID {
 			return entry, nil
 		}
 	}
+
 	return nil, nil
 }
 
@@ -631,6 +642,7 @@ func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 
 func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
 	c.mountsLock.Lock()
+	// not sure why we lock the auth here
 	c.authLock.Lock()
 	locked := true
 	unlock := func() {
@@ -817,9 +829,14 @@ func (c *Core) unmount(ctx context.Context, path string) error {
 		path += "/"
 	}
 
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Prevent protected paths from being unmounted
 	for _, p := range protectedMounts {
-		if strings.HasPrefix(path, p) {
+		if strings.HasPrefix(path, p) && ns.Path == namespace.RootNamespace.Path {
 			return fmt.Errorf("cannot unmount %q", path)
 		}
 	}
@@ -846,6 +863,9 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 
 	// Get the view for this backend
 	view := c.router.MatchingStorageByAPIPath(ctx, path)
+	if view == nil {
+		return fmt.Errorf("no matching storage %q", path)
+	}
 
 	// Get the backend/mount entry for this path, used to remove ignored
 	// replication prefixes
@@ -853,7 +873,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 
 	// Mark the entry as tainted
 	if err := c.taintMountEntry(ctx, ns.ID, path, updateStorage, true); err != nil {
-		c.logger.Error("failed to taint mount entry for path being unmounted", "error", err, "path", path)
+		c.logger.Error("failed to taint mount entry for path being unmounted", "error", err, "namespace", ns.Path, "path", path)
 		return err
 	}
 
@@ -863,27 +883,27 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 		return err
 	}
 
-	rCtx := namespace.ContextWithNamespace(c.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(c.activeContext, ns)
 	if backend != nil && c.rollback != nil {
 		// Invoke the rollback manager a final time. This is not fatal as
 		// various periodic funcs (e.g., PKI) can legitimately error; the
 		// periodic rollback manager logs these errors rather than failing
 		// replication like returning this error would do.
-		if err := c.rollback.Rollback(rCtx, path); err != nil {
+		if err := c.rollback.Rollback(revokeCtx, path); err != nil {
 			c.logger.Error("ignoring rollback error during unmount", "error", err, "path", path)
 			err = nil
 		}
 	}
 	if backend != nil && c.expiration != nil && updateStorage {
 		// Revoke all the dynamic keys
-		if err := c.expiration.RevokePrefix(rCtx, path, true); err != nil {
+		if err := c.expiration.RevokePrefix(revokeCtx, path, true); err != nil {
 			return err
 		}
 	}
 
 	if backend != nil {
 		// Call cleanup function if it exists
-		backend.Cleanup(ctx)
+		backend.Cleanup(revokeCtx)
 	}
 
 	switch {
@@ -891,32 +911,32 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 		// Don't attempt to clear data, replication will handle this
 	default:
 		// Have writable storage, remove the whole thing
-		if err := logical.ClearViewWithLogging(ctx, view, c.logger.Named("secrets.deletion").With("namespace", ns.ID, "path", path)); err != nil {
-			c.logger.Error("failed to clear view for path being unmounted", "error", err, "path", path)
+		if err := logical.ClearViewWithLogging(revokeCtx, view, c.logger.Named("secrets.deletion").With("namespace", ns.Path, "path", path)); err != nil {
+			c.logger.Error("failed to clear view for path being unmounted", "error", err, "namespace", ns.Path, "path", path)
 			return err
 		}
 	}
 
 	// Remove the mount table entry
-	if err := c.removeMountEntry(ctx, path, updateStorage); err != nil {
-		c.logger.Error("failed to remove mount entry for path being unmounted", "error", err, "path", path)
+	if err := c.removeMountEntry(revokeCtx, path, updateStorage); err != nil {
+		c.logger.Error("failed to remove mount entry for path being unmounted", "error", err, "namespace", ns.Path, "path", path)
 		return err
 	}
 
 	// Unmount the backend entirely
-	if err := c.router.Unmount(ctx, path); err != nil {
+	if err := c.router.Unmount(revokeCtx, path); err != nil {
 		return err
 	}
 
 	if c.quotaManager != nil {
-		if err := c.quotaManager.HandleBackendDisabling(ctx, ns.Path, path); err != nil {
-			c.logger.Error("failed to update quotas after disabling mount", "path", path, "error", err)
+		if err := c.quotaManager.HandleBackendDisabling(revokeCtx, ns.Path, path); err != nil {
+			c.logger.Error("failed to update quotas after disabling mount", "error", err, "namespace", ns.Path, "path", path)
 			return err
 		}
 	}
 
 	if c.logger.IsInfo() {
-		c.logger.Info("successfully unmounted", "path", path, "namespace", ns.Path)
+		c.logger.Info("successfully unmounted", "namespace", ns.Path, "path", path)
 	}
 
 	return nil

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -828,14 +828,9 @@ func (c *Core) unmount(ctx context.Context, path string) error {
 		path += "/"
 	}
 
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Prevent protected paths from being unmounted
 	for _, p := range protectedMounts {
-		if strings.HasPrefix(path, p) && ns.Path == namespace.RootNamespace.Path {
+		if strings.HasPrefix(path, p) {
 			return fmt.Errorf("cannot unmount %q", path)
 		}
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -433,7 +433,7 @@ func TestCore_FindOps(t *testing.T) {
 	if err != nil || entry != nil {
 		t.Fatalf("expected no errors nor matches got, error: %#v entry: %#v", err, entry)
 	}
-	entry, err = c.mounts.find(namespace.RootContext(nil), "unknown")
+	entry, err = c.mounts.findByPath(namespace.RootContext(nil), "unknown")
 	if err != nil || entry != nil {
 		t.Fatalf("expected no errors nor matches got, error: %#v entry: %#v", err, entry)
 	}
@@ -448,7 +448,7 @@ func TestCore_FindOps(t *testing.T) {
 	}
 
 	// Find another entry by its path
-	entry, err = c.mounts.find(namespace.RootContext(nil), path2)
+	entry, err = c.mounts.findByPath(namespace.RootContext(nil), path2)
 	if err != nil || entry == nil {
 		t.Fatalf("failed finding entry by path error: %#v entry: %#v", err, entry)
 	}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -569,7 +569,11 @@ func (ns *NamespaceStore) taintNamespace(ctx context.Context, namespaceToTaint *
 
 	ns.namespacesByUUID[namespaceToTaint.UUID].Tainted = true
 	ns.namespacesByAccessor[namespaceToTaint.ID].Tainted = true
+
+	// We've got to grab write lock because we modify the namespace tree structure
+	ns.lock.Lock()
 	ns.namespacesByPath.Get(namespaceToTaint.Path).Tainted = true
+	ns.lock.Unlock()
 
 	return nil
 }

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -650,7 +650,7 @@ func clearNamespaceResources(ctx context.Context, ns *NamespaceStore, namespaceT
 	}
 
 	for _, me := range authMountEntries {
-		err := ns.core.disableCredential(ctx, me.Path)
+		err := ns.core.disableCredentialInternal(ctx, me.Path, true)
 		if err != nil {
 			ns.logger.Error(fmt.Sprintf("failed to unmount %q", me.Path), "namespace", namespaceToDelete.Path, "error", err.Error())
 			return
@@ -665,7 +665,7 @@ func clearNamespaceResources(ctx context.Context, ns *NamespaceStore, namespaceT
 	}
 
 	for _, me := range mountEntries {
-		err := ns.core.unmount(ctx, me.Path)
+		err := ns.core.unmountInternal(ctx, me.Path, true)
 		if err != nil {
 			ns.logger.Error(fmt.Sprintf("failed to unmount %q", me.Path), "namespace", namespaceToDelete.Path, "error", err.Error())
 			return

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -496,6 +496,10 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 
 	entry := ns.namespacesByPath.Get(path)
 	if entry != nil {
+		if entry.Tainted {
+			ns.lock.Unlock()
+			return nil, errors.New("namespace with that name exists and is currently tainted")
+		}
 		entry = entry.Clone()
 	} else {
 		entry = &namespace.Namespace{

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -170,7 +170,7 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	require.Equal(t, s.namespacesByPath.size, 1)
 
 	// try to delete root
-	_, err = s.DeleteNamespace(ctx, "")
+	_, err = s.DeleteNamespace(ctx, namespace.RootNamespaceUUID)
 	require.Error(t, err)
 
 	// try to delete namespace with child namespaces

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -89,9 +89,11 @@ func TestNamespaceStore(t *testing.T) {
 	require.Equal(t, ns[0].UUID, itemUUID)
 
 	// Delete that item.
-	_, err = s.DeleteNamespace(ctx, itemUUID)
+	status, err := s.DeleteNamespace(ctx, itemUUID)
 	require.NoError(t, err)
+	require.Equal(t, "in-progress", status)
 
+	// wait until deletion
 	time.Sleep(10 * time.Millisecond)
 
 	// Store should be empty.

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -157,7 +157,7 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	_, err = s.DeleteNamespace(ctx, createdNS.UUID)
 	require.NoError(t, err)
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	// verify namespace deletion
 	nsList, err := s.ListAllNamespaces(ctx, false)

--- a/vault/namespaces_store_tree.go
+++ b/vault/namespaces_store_tree.go
@@ -31,6 +31,7 @@ func newNamespaceTree(root *namespace.Namespace) *namespaceTree {
 	}
 	return &namespaceTree{
 		root: node,
+		size: 1,
 	}
 }
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -652,7 +652,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 
 	// If the path is tainted, we reject any operation except for
 	// Rollback and Revoke
-	if re.tainted {
+	if re.tainted || ns.Tainted {
 		switch req.Operation {
 		case logical.RevokeOperation, logical.RollbackOperation:
 		default:

--- a/vault/router.go
+++ b/vault/router.go
@@ -650,13 +650,13 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		return logical.ErrorResponse(fmt.Sprintf("no handler for route %q. route entry found, but backend is nil.", req.Path)), false, false, logical.ErrUnsupportedPath
 	}
 
-	// If the path is tainted, we reject any operation except for
-	// Rollback and Revoke
+	// If the path or namespace is tainted, we reject any operation
+	// except for Rollback and Revoke
 	if re.tainted || ns.Tainted {
 		switch req.Operation {
 		case logical.RevokeOperation, logical.RollbackOperation:
 		default:
-			return logical.ErrorResponse(fmt.Sprintf("no handler for route %q. route entry is tainted.", req.Path)), false, false, logical.ErrUnsupportedPath
+			return logical.ErrorResponse(fmt.Sprintf("no handler for route %q on namespace %q. route entry or namespace is tainted.", req.Path, ns.Path)), false, false, logical.ErrUnsupportedPath
 		}
 	}
 


### PR DESCRIPTION
Resolves #1025

implements the `delete namespace` operation with following assumptions:
- requests to core have a deadline of 90 seconds, and the deletion operation might take an unknown period of time, depending on the amount of resources to free up, we opt for asynchronous operation
- delete namespace now taints the namespace, blocking all future requests to the tainted namespace
- namespace taint is persisted, all other non-leader nodes will also reject the request
- delete namespace returns a response of `"status": "in-progress"`
- TODO:  for further enhancements, add the status endpoint for checking the deletion progress 
- TODO: in case of the interruption of the deletion operation, the operator should retry the delete operation resulting in a one more attempt at the deletion

```
bao namespace create ns1

bao namespace delete ns1
Key       Value
---       -----
status    in-progress

----

// subsequent calls also lead to
Key       Value
---       -----
status    in-progress
// until the namespace deletion succeeds

----

// during that time all requests using path of a namespace being in process of deletion result in
bao token create -ns=ns1
Error creating token: Error making API request.

Namespace: ns1/
URL: POST http://127.0.0.1:8200/v1/auth/token/create
Code: 404. Errors:

* no handler for route "auth/token/create" on namespace "ns1/". route entry or namespace is tainted.

----

bao write ns1/cubbyhole/test foo=bar
Error writing data to ns1/cubbyhole/test: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/ns1/cubbyhole/test
Code: 404. Errors:

* no handler for route "cubbyhole/test" on namespace "ns1/". route entry or namespace is tainted.
```

```
bao namespace create ns1

bao namespace create -ns=ns1 ns2

bao namespace delete ns1
Error deleting namespace: Error making API request.

URL: DELETE http://127.0.0.1:8200/v1/sys/namespaces/ns1
Code: 400. Errors:

* cannot delete namespace ("ns1/") containing child namespaces
----
curl -X DELETE -H "X-Vault-Token: $(bao print token)" -H "X-Vault-Request: true" http://127.0.0.1:8200/v1/sys/namespaces/ns1
{"errors":["cannot delete namespace (\"ns1/\") containing child namespaces"]}
```
___
cc: @cipherboy @klaus-sap @satoqz @phyrog @voigt @driif