### PR TITLE
ci: increase timeout for Go tests with race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         {
           "VAULT_CI_GO_TEST_RACE": 1
         }
-      extra-flags: "-race"
+      extra-flags: "-race -timout=30m"
       go-arch: amd64
       go-tags: ${{ needs.setup.outputs.go-tags }}
       runs-on: ubuntu-latest


### PR DESCRIPTION
The Go tests with the race detector were occasionally timing out. Increasing the timeout to 30 minutes ensures that the tests have sufficient time to complete, especially under heavy load or slower environments.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
