### PR TITLE
Fix test-ui failing test

### DIFF
--- a/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
@@ -38,8 +38,8 @@ module('Acceptance | settings/configure/secrets/ssh', function (hooks) {
     await click(SELECTORS.saveConfig);
     assert.strictEqual(
       flashMessage.latestMessage,
-      'missing public_key',
-      'renders warning flash message for failed save'
+      'SSH Certificate Authority Configuration saved!',
+      'shows success flash when saving mount‑level config without a key'
     );
     await click(SELECTORS.generateSigningKey);
     await click(SELECTORS.saveConfig);


### PR DESCRIPTION
`test-ui` is failing and this is the log: 

```
not ok 1 Chrome 135.0 - [1250 ms] - Acceptance | settings/configure/secrets/ssh: it configures ssh ca
    ---
        actual: >
            SSH Certificate Authority Configuration saved!
        expected: >
            missing public_key
        stack: >
                at Object.<anonymous> (http://localhost:7357/ui/assets/tests.js:6411:14)
        message: >
            renders warning flash message for failed save
        ...
```

The SSH secrets engine no longer requires a mount‑level public_key after #880: 
```
fatima@fattiesPatties-2 openbao % bao secrets enable -path=ssh-test ssh 
Success! Enabled the ssh secrets engine at: ssh-test/
fatima@fattiesPatties-2 openbao % curl -s -o /dev/null -w "%{http_code}\n" \
     -H "X-Vault-Token: $BAO_TOKEN" \
     -X
```

This updates the acceptance test to expect the success flash “SSH Certificate Authority Configuration saved!” instead of the old “missing public_key” error.