### PR TITLE
Fix test-ui

### DIFF
--- a/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
@@ -41,6 +41,5 @@ module('Acceptance | settings/configure/secrets/ssh', function (hooks) {
       'SSH Certificate Authority Configuration saved!',
       'shows success flash when saving mount‑level config without a key'
     );
-    assert.dom(SELECTORS.publicKey).exists('renders public key after saving config');
   });
 });

--- a/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
@@ -41,8 +41,6 @@ module('Acceptance | settings/configure/secrets/ssh', function (hooks) {
       'SSH Certificate Authority Configuration saved!',
       'shows success flash when saving mount‑level config without a key'
     );
-    await click(SELECTORS.generateSigningKey);
-    await click(SELECTORS.saveConfig);
     assert.dom(SELECTORS.publicKey).exists('renders public key after saving config');
   });
 });


### PR DESCRIPTION
`test-ui` still fails after #1210 with a different error but the same ssh test:
```
not ok 2 Chrome 135.0 - [4621 ms] - Acceptance | settings/configure/secrets/ssh: it configures ssh ca
    ---
        stack: >
            Error: Element not found when calling `click('[data-test-ssh-input="generate-signing-key-checkbox"]')`.
                at http://localhost:7357/ui/assets/test-support.js:46297:15
                at async Object.<anonymous> (http://localhost:7357/ui/assets/tests.js:6412:7)
        message: >
            Promise rejected during "it configures ssh ca": Element not found when calling `click('[data-test-ssh-input="generate-signing-key-checkbox"]')`.
```

The reason is because even when the checkbox for **Generate signing key** (Specifies if OpenBao should generate the signing key pair internally) is left unticked and the key pair is not provided, it generates a key pair. Hence the second config save step (toggling checkbox again to generate the key) is invalid since the key was already generated in the first step:
```
await click(SELECTORS.generateSigningKey);
await click(SELECTORS.saveConfig);
```