### PR TITLE
doc(telemetry.mdx): add metrics_prefix

### DIFF
--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -35,6 +35,7 @@ The following options are available on all telemetry configurations.
 - `enable_hostname_label` `(bool: false)` - Specifies if all metric values should
   contain the `host` label with the local hostname. It is recommended to enable
   `disable_hostname` if this option is used.
+- `metrics_prefix` (string: "vault") - Specifies the prefix used for metric vaules. By default, metrics are prefixed with "vault".
 - `lease_metrics_epsilon` `(string: "1h")` - Specifies the size of the bucket used to measure future
   lease expiration. For example, for the default value of 1 hour, the `vault.expire.leases.by_expiration`
   metric will aggregate the total number of expiring leases for 1 hour buckets, starting from the current time.


### PR DESCRIPTION
Add `metrics_prefix` configuration details in `telemetry` stanza documentation

Relatets to #1145
