### PR TITLE
Clarify that region is required

### DIFF
--- a/website/content/docs/configuration/seal/gcpckms.mdx
+++ b/website/content/docs/configuration/seal/gcpckms.mdx
@@ -47,7 +47,7 @@ These parameters apply to the `seal` stanza in the OpenBao configuration file:
 - `project` `(string: <required>)`: The GCP project ID to use. May also be
   specified by the `GOOGLE_PROJECT` environment variable.
 
-- `region` `(string: "us-east-1")`: The GCP region/location where the key ring
+- `region` `(string: <required>)`: The GCP region/location where the key ring
   lives. May also be specified by the `GOOGLE_REGION` environment variable.
 
 - `key_ring` `(string: <required>)`: The GCP CKMS key ring to use. May also be


### PR DESCRIPTION
We recently stumbled across this internally when attempting to start OpenBao with GCP CloudKMS without explicitly setting region.

Thanks to Gonzalo Servat for identifying this.

