### PR TITLE
Fix vault/diagnose test failure

### DIFF
--- a/vault/diagnose/tls_verification_test.go
+++ b/vault/diagnose/tls_verification_test.go
@@ -436,7 +436,7 @@ func TestTLSLeafCertInClientCAFile(t *testing.T) {
 		// root CA is expiring soon (May '25); it has serial number 33554617
 		// and is affecting tests.
 		var skipBaltimore bool
-		if len(warnings) > 1 {
+		if len(warnings) == 2 {
 			for _, warning := range warnings {
 				if strings.Contains(warning, "33554617") {
 					skipBaltimore = true


### PR DESCRIPTION
The Baltimore CyberTrust CA is expiring soon; it is a global root CA installed in most system trust stores but otherwise appears on our diagnose tests. Exclude this particular certificate's serial number from our test suite for now.

See also: https://tls-observatory.services.mozilla.com/static/certsplainer.html?id=16

---

As reported by @driif, thank you!