### PR TITLE
Detailed metadata in policy endpoint

### DIFF
--- a/changelog/1224.txt
+++ b/changelog/1224.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/policies: Add endpoint to allow detailed listing of policies
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3011,7 +3011,7 @@ func (*SystemBackend) handlePoliciesPasswordGenerate(ctx context.Context, req *l
 func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		// Get policies list
-		policies, err := b.Core.policyStore.ListPolicies(ctx, PolicyTypeACL)
+		policies, err := b.Core.policyStore.ListPolicies(ctx, PolicyTypeACL, true)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3007,6 +3007,45 @@ func (*SystemBackend) handlePoliciesPasswordGenerate(ctx context.Context, req *l
 	return resp, nil
 }
 
+// handlePoliciesDetailedAclList handles the listing of ACL policies with detailed information
+func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		// Get policies list
+		policies, err := b.Core.policyStore.ListPolicies(ctx, PolicyTypeACL)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add root policy if in root namespace
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if ns.ID == namespace.RootNamespaceID {
+			policies = append(policies, "root")
+		}
+
+		// Get detailed information for each policy
+		policyInfos := make(map[string]interface{})
+		for _, policyName := range policies {
+			policy, err := b.Core.policyStore.GetPolicy(ctx, policyName, PolicyTypeACL)
+			if err != nil {
+				continue
+			}
+			if policy == nil {
+				continue
+			}
+
+			policyInfos[policyName] = map[string]interface{}{
+				"name":   policy.Name,
+				"policy": policy.Raw,
+			}
+		}
+
+		return logical.ListResponseWithInfo(policies, policyInfos), nil
+	}
+}
+
 // handleAuditTable handles the "audit" endpoint to provide the audit table
 func (b *SystemBackend) handleAuditTable(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	b.Core.auditLock.RLock()

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -4030,6 +4030,25 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 			HelpDescription: "Read the rules of an existing password policy, create or update " +
 				"the rules of a password policy, or delete a password policy.",
 		},
+
+		{
+			Pattern: "policies/detailed/acl/?$",
+			Fields: map[string]*framework.FieldSchema{
+				"list": {
+					Type:        framework.TypeBool,
+					Description: "List ACL policies",
+					Query:       true,
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handlePoliciesDetailedAclList(),
+					Summary:  "List ACL policies with detailed information.",
+				},
+			},
+			HelpSynopsis:    strings.TrimSpace(sysHelp["policies"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["policies"][1]),
+		},
 	}
 }
 


### PR DESCRIPTION
This PR allows Openbao to list detailed information about capabilities in policies endpoint, avoiding N+1 while trying to retrieve the policies and their capabilities.

Issue link: https://github.com/openbao/openbao/issues/1156
