### PR TITLE
ci: increase total-runners and adjust go-test-parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       # binary-dependent tests. We isolate them there so that the
       # other tests aren't slowed down waiting for a binary build.
       binary-tests: true
-      total-runners: 12
+      total-runners: 16
       go-arch: amd64
       go-tags: "${{ needs.setup.outputs.go-tags }},deadlock"
       runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
       needs.verify-changes.outputs.is_ui_change == 'false'
     uses: ./.github/workflows/test-go.yml
     with:
-      total-runners: 12
+      total-runners: 16
       env-vars: |
         {
           "VAULT_CI_GO_TEST_RACE": 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       # binary-dependent tests. We isolate them there so that the
       # other tests aren't slowed down waiting for a binary build.
       binary-tests: true
-      total-runners: 16
+      total-runners: 20
       go-arch: amd64
       go-tags: "${{ needs.setup.outputs.go-tags }},deadlock"
       runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
       needs.verify-changes.outputs.is_ui_change == 'false'
     uses: ./.github/workflows/test-go.yml
     with:
-      total-runners: 16
+      total-runners: 20
       env-vars: |
         {
           "VAULT_CI_GO_TEST_RACE": 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       # binary-dependent tests. We isolate them there so that the
       # other tests aren't slowed down waiting for a binary build.
       binary-tests: true
-      total-runners: 20
+      total-runners: 12
       go-arch: amd64
       go-tags: "${{ needs.setup.outputs.go-tags }},deadlock"
       runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
       needs.verify-changes.outputs.is_ui_change == 'false'
     uses: ./.github/workflows/test-go.yml
     with:
-      total-runners: 20
+      total-runners: 12
       env-vars: |
         {
           "VAULT_CI_GO_TEST_RACE": 1

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -41,7 +41,7 @@ on:
       go-test-parallelism:
         description: The parallelism parameter for Go tests
         required: false
-        default: 16
+        default: 12
         type: number
       timeout-minutes:
         description: The maximum number of minutes that this workflow should run

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -41,7 +41,7 @@ on:
       go-test-parallelism:
         description: The parallelism parameter for Go tests
         required: false
-        default: 20
+        default: 16
         type: number
       timeout-minutes:
         description: The maximum number of minutes that this workflow should run

--- a/changelog/1225.txt
+++ b/changelog/1225.txt
@@ -1,0 +1,2 @@
+```release-note:change
+Adjusted CI configuration, improved test stability.

--- a/changelog/1225.txt
+++ b/changelog/1225.txt
@@ -1,2 +1,0 @@
-```release-note:change
-Adjusted CI configuration, improved test stability.


### PR DESCRIPTION
Increase the total-runners from 16 to 20 in ci.yml and adjust the go-test-parallelism default from 20 to 16 in test-go.yml to optimize test execution and resource allocation.

Resolves occasional CI test failures under high load.
