### PR TITLE
Add h1 for mfa-validate api-doc

### DIFF
--- a/website/content/api-docs/system/mfa-validate.mdx
+++ b/website/content/api-docs/system/mfa-validate.mdx
@@ -1,8 +1,13 @@
 ---
 description: >-
-  The '/sys/mfa/validate' endpoint focuses on validating login MFA requests.
+  The `/sys/mfa/validate` endpoint focuses on validating login MFA requests.
   If validation succeeds, it returns an auth response which includes a client token.
 ---
+
+# `/sys/mfa/validate`
+
+The `/sys/mfa/validate` endpoint focuses on validating login MFA requests.
+If validation succeeds, it returns an auth response which includes a client token.
 
 ## Validate login MFA request
 


### PR DESCRIPTION
This fix presentation issue for this item on the api documentation website.

Currently, the api-doc show inconsistency for `mfa-validate` endpoint:

![image](https://github.com/user-attachments/assets/676d2b29-b927-40df-bc92-86149566d461)

This fix use the same presentation as the other endpoints:

![image](https://github.com/user-attachments/assets/b6c20b34-7c78-4720-a520-21a244d9c227)

