### PR TITLE
Fix deadlock on legacy root key path migration

### DIFF
--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -451,7 +451,7 @@ func (b *AESGCMBarrier) ReloadRootKey(ctx context.Context) error {
 	}
 
 	if out == nil {
-		out, err = b.Get(ctx, legacyRootKeyPath)
+		out, err = b.lockSwitchedGet(ctx, b.backend, legacyRootKeyPath, false)
 		if err != nil {
 			return fmt.Errorf("failed to read legacy root key path: %w", err)
 		}


### PR DESCRIPTION
As reported by @LuyeT, migration of the root key entry causes a
deadlock. This is because, while holding the write lock, we attempt to
call `barrier.Get(...)`, which acquires its own read lock. Use the
lockless variant instead to avoid this.
    
Resolves: #1111

---

Many thanks to @DanGhita for identifying the cause of the bug.

This can be tested with the attached test case, or by upgrading from v2.2.0 to v2.3.0 (with e.g., Raft) prior to this change. 