### PR TITLE
Match ssh test to updated behaviour

### DIFF
--- a/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/configure-ssh-secret-test.js
@@ -38,8 +38,11 @@ module('Acceptance | settings/configure/secrets/ssh', function (hooks) {
     await click(SELECTORS.saveConfig);
     assert.strictEqual(
       flashMessage.latestMessage,
-      'SSH Certificate Authority Configuration saved!',
-      'shows success flash when saving mount‑level config without a key'
+      'missing public_key',
+      'renders warning flash message for failed save'
     );
+    await click(SELECTORS.generateSigningKey);
+    await click(SELECTORS.saveConfig);
+    assert.dom(SELECTORS.publicKey).exists('renders public key after saving config');
   });
 });


### PR DESCRIPTION
In #1210 and #1211, I updated the SSH configuration UI test to mirror the behavior of the SSH engine. However, that behavior was later identified as unintended and patched in #1235. This PR updates the test to reflect the intended behavior of the engine, ensuring consistency and helping clean up the pipeline! :D