### PR TITLE
Fix vault/diagnose test failure (#1221)

### DIFF
--- a/vault/diagnose/tls_verification_test.go
+++ b/vault/diagnose/tls_verification_test.go
@@ -429,10 +429,25 @@ func TestTLSLeafCertInClientCAFile(t *testing.T) {
 	}
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs == nil || len(errs) != 1 {
-		t.Fatal("TLS Config check on bad ClientCAFile certificate should fail once")
+		t.Fatalf("TLS Config check on bad ClientCAFile certificate should fail once: %v", errs)
 	}
 	if warnings == nil || len(warnings) != 1 {
-		t.Fatal("TLS Config check on bad ClientCAFile certificate should warn once")
+		// CN=Baltimore CyberTrust Root,OU=CyberTrust,O=Baltimore,C=IE global
+		// root CA is expiring soon (May '25); it has serial number 33554617
+		// and is affecting tests.
+		var skipBaltimore bool
+		if len(warnings) == 2 {
+			for _, warning := range warnings {
+				if strings.Contains(warning, "33554617") {
+					skipBaltimore = true
+					break
+				}
+			}
+		}
+
+		if !skipBaltimore {
+			t.Fatalf("TLS Config check on bad ClientCAFile certificate should warn once: %v", warnings)
+		}
 	}
 	if !strings.Contains(warnings[0], "Found at least one leaf certificate in the CA certificate file.") {
 		t.Fatalf("Bad error message: %s", warnings[0])


### PR DESCRIPTION
* Fix vault/diagnose test failure

The Baltimore CyberTrust CA is expiring soon; it is a global root CA installed in most system trust stores but otherwise appears on our diagnose tests. Exclude this particular certificate's serial number from our test suite for now.



* Update vault/diagnose/tls_verification_test.go




---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
