### PR TITLE
Do not encode empty subproblems in ACME (#1236)

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -110,7 +110,7 @@ type ErrorResponse struct {
 	StatusCode  int              `json:"-"`
 	Type        string           `json:"type"`
 	Detail      string           `json:"detail"`
-	Subproblems []*ErrorResponse `json:"subproblems"`
+	Subproblems []*ErrorResponse `json:"subproblems,omitempty"`
 }
 
 func (e *ErrorResponse) MarshalForStorage() map[string]interface{} {

--- a/changelog/1236.txt
+++ b/changelog/1236.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Remove null value for subproblems encoding, fixing compatibility with certain ACME clients like certbot.
+```


### PR DESCRIPTION
* Do not encode empty subproblems in ACME

While JSON arrays may be empty, RFC 8259 does not necessarily ensure that the literal value `null` is type-equivalent to an array. This means that sending `{"subproblems":null}` is not valid under RFC 8555. This breaks compatibility with some type-sensitive ACME clients.

See also: https://github.com/certbot/certbot/pull/10001



* Add changelog entry



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
