### PR TITLE
Feat: Implement external ACL evaluation

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -132,6 +132,10 @@ type ServerCommand struct {
 	flagTestVerifyOnly     bool
 	flagTestServerConfig   bool
 	flagExitOnCoreShutdown bool
+
+	// TODO
+	flagEnableExternalAcl  bool
+	flagExternalAclAddress string
 }
 
 func (c *ServerCommand) Synopsis() string {
@@ -196,6 +200,19 @@ func (c *ServerCommand) Flags() *FlagSets {
 		Target: &c.flagRecovery,
 		Usage: "Enable recovery mode. In this mode, OpenBao is used to perform recovery actions." +
 			"Using a recovery operation token, \"sys/raw\" API can be used to manipulate the storage.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "enable-external-acl",
+		Target:  &c.flagEnableExternalAcl,
+		Default: false,
+		Usage:   "Enable ACL evaluation by an external service.",
+	})
+
+	f.StringVar(&StringVar{
+		Name:   "external-acl-address",
+		Target: &c.flagExternalAclAddress,
+		Usage:  "Address of a server for external ACL evaluation",
 	})
 
 	f = set.NewFlagSet("Dev Options")
@@ -1214,6 +1231,11 @@ func (c *ServerCommand) Run(args []string) int {
 			c.UI.Warn("")
 		}
 	}
+
+	// TODO
+	// Store config for external ACL
+	coreConfig.EnableExternalAcl = c.flagEnableExternalAcl
+	coreConfig.ExternalAclAddress = c.flagExternalAclAddress
 
 	// Initialize the core
 	core, newCoreError := vault.NewCore(&coreConfig)

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.2
 	github.com/stretchr/testify v1.10.0
 	github.com/tink-crypto/tink-go v0.0.0-20230613075026-d6de17e3f164
+	github.com/tmccombs/hcl2json v0.6.7
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
@@ -208,9 +209,8 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 // indirect
-	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -353,7 +353,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	github.com/zclconf/go-cty v1.13.0 // indirect
+	github.com/zclconf/go-cty v1.16.2 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
-github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
-github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -124,8 +122,6 @@ github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7V
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 h1:8mgvCpqsv3mQAcqZ/baAaMGUBj5J6MKMhxLd+K8L27Q=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301/go.mod h1:Api2AkmMgGaSUAhmk76oaFObkoeCPc/bKAqcyplPODs=
-github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
-github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -1033,8 +1029,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0=
-github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty v1.16.2 h1:LAJSwc3v81IRBZyUVQDUdZ7hs3SYs9jv0eZJDWHD/70=
 github.com/zclconf/go-cty v1.16.2/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KM
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -1002,6 +1004,8 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tmccombs/hcl2json v0.6.7 h1:RYKTs4kd/gzRsEiv7J3M2WQ7TYRYZVc+0H0pZdERkxA=
+github.com/tmccombs/hcl2json v0.6.7/go.mod h1:lJgBOOGDpbhjvdG2dLaWsqB4KBzul2HytfDTS3H465o=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
@@ -1031,6 +1035,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0=
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty v1.16.2 h1:LAJSwc3v81IRBZyUVQDUdZ7hs3SYs9jv0eZJDWHD/70=
+github.com/zclconf/go-cty v1.16.2/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -44,7 +44,6 @@ type ACL struct {
 	externalAclAddress string
 }
 
-// TODO
 type ACLOptions struct {
 	ExternalAclAddress string
 }
@@ -80,7 +79,6 @@ const limitParameterName = "limit"
 
 // NewACL is used to construct a policy based ACL from a set of policies.
 func NewACL(ctx context.Context, policies []*Policy, options ACLOptions) (*ACL, error) {
-
 	// Initialize
 	a := &ACL{
 		exactRules:           radix.New(),
@@ -297,7 +295,6 @@ func NewACL(ctx context.Context, policies []*Policy, options ACLOptions) (*ACL, 
 }
 
 func (a *ACL) Capabilities(ctx context.Context, path string) (pathCapabilities []string) {
-
 	req := &logical.Request{
 		Path: path,
 		// doesn't matter, but use List to trigger fallback behavior so we can
@@ -347,7 +344,6 @@ func (a *ACL) Capabilities(ctx context.Context, path string) (pathCapabilities [
 
 // AllowOperation is used to check if the given operation is permitted.
 func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheckOnly bool) (ret *ACLResults) {
-
 	// Request ACL evaluation to an external service when required by the user
 	if !strings.EqualFold(a.externalAclAddress, "") {
 		return a.AllowOperationExternal(ctx, req, capCheckOnly)
@@ -669,7 +665,6 @@ type wcPathDescr struct {
 func (a *ACL) CheckAllowedFromNonExactPaths(path string, bareMount bool) *ACLPermissions {
 	wcPathDescrs := make([]wcPathDescr, 0, len(a.segmentWildcardPaths)+1)
 
-	// TODO
 	// When using external ACL evaluation service, all permission checks must be fully delegated and explicit.
 	// This function only processes locally-evaluated ACLs.
 	if !strings.EqualFold(a.externalAclAddress, "") {

--- a/vault/acl_external.go
+++ b/vault/acl_external.go
@@ -1,0 +1,211 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"slices"
+	"time"
+
+	//
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+
+	//
+	"github.com/tmccombs/hcl2json/convert"
+)
+
+// ExternalEvaluationRequestPolicy represents a policy inside the request sent to an external service for ACL evaluation
+type ExternalEvaluationRequestPolicy struct {
+	Name string `json:"name"`
+	Raw  string `json:"raw"`
+}
+
+// ExternalEvaluationRequest represents the request sent to an external service for ACL evaluation
+type ExternalEvaluationRequest struct {
+	Path      string                            `json:"path"`
+	Operation string                            `json:"operation"`
+	Policies  []ExternalEvaluationRequestPolicy `json:"policies"`
+
+	// Useful payload
+	Parameters map[string]any `json:"parameters"`
+	TTL        time.Duration  `json:"TTL"`
+
+	// Make it easy for fast responses
+	IsRoot          bool `json:"isRoot"`
+	IsAuthenticated bool `json:"isAuthenticated"`
+}
+
+// ExternalEvaluationResponse represents the response given by an external service evaluating ACL
+type ExternalEvaluationResponse struct {
+	Capabilities     []string `json:"capabilities"`
+	GrantingPolicies []string `json:"grantingPolicies"`
+}
+
+// AllowOperationExternal is used to check if the given operation is permitted by asking an external authorization service.
+func (a *ACL) AllowOperationExternal(ctx context.Context, req *logical.Request, capCheckOnly bool) (ret *ACLResults) {
+	ret = new(ACLResults)
+
+	// Fast-path root
+	if a.root {
+		ret.Allowed = true
+		ret.RootPrivs = true
+		ret.IsRoot = true
+		ret.GrantingPolicies = []logical.PolicyInfo{{
+			Name:          "root",
+			NamespaceId:   "root",
+			NamespacePath: "",
+			Type:          "acl",
+		}}
+		return
+	}
+	op := req.Operation
+
+	// Help is always allowed
+	if op == logical.HelpOperation {
+		ret.Allowed = true
+		return
+	}
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return
+	}
+	path := ns.Path + req.Path
+
+	// The request path should take care of this already but this is useful for
+	// tests and as defense in depth
+	for {
+		if len(path) > 0 && path[0] == '/' {
+			path = path[1:]
+		} else {
+			break
+		}
+	}
+
+	//
+	var reqTTL time.Duration
+	wrapInfo := req.WrapInfo
+	if wrapInfo != nil {
+		reqTTL = wrapInfo.TTL
+	}
+
+	// Marshal policies into JSON for ease with the external service
+	var rawAclPoliciesJson []ExternalEvaluationRequestPolicy
+	for _, policy := range a.rawAclPolicies {
+
+		jsonBytes, err := convert.Bytes([]byte(policy.Raw), "policy.hcl", convert.Options{})
+		if err != nil {
+			continue
+		}
+
+		tmpPolicy := ExternalEvaluationRequestPolicy{
+			Name: policy.Name,
+			Raw:  string(jsonBytes),
+		}
+		rawAclPoliciesJson = append(rawAclPoliciesJson, tmpPolicy)
+	}
+
+	reqContent := ExternalEvaluationRequest{
+		Path:      path,
+		Operation: string(op),
+		Policies:  rawAclPoliciesJson,
+
+		Parameters: req.Data,
+		TTL:        reqTTL,
+
+		IsRoot:          a.root,
+		IsAuthenticated: req.Unauthenticated,
+	}
+
+	extReqContentBytes, err := json.Marshal(reqContent)
+	if err != nil {
+		return
+	}
+
+	extReq, err := http.NewRequest(http.MethodPost, a.externalAclAddress, bytes.NewReader(extReqContentBytes))
+	if err != nil {
+		return
+	}
+
+	extRes, err := http.DefaultClient.Do(extReq)
+	if err != nil {
+		return
+	}
+
+	extResBodyBytes, err := io.ReadAll(extRes.Body)
+	if err != nil {
+		return
+	}
+
+	resContent := ExternalEvaluationResponse{}
+	err = json.Unmarshal(extResBodyBytes, &resContent)
+	if err != nil {
+		return
+	}
+
+	// Don't allow non-explicit capabilities
+	if len(resContent.Capabilities) == 0 {
+		return
+	}
+
+	// Throw info about policies causing the capabilities
+	for _, grantingPolicy := range resContent.GrantingPolicies {
+		tmpPolicy := logical.PolicyInfo{
+			Name:          grantingPolicy,
+			NamespaceId:   "root",
+			NamespacePath: "",
+			Type:          "acl",
+		}
+		ret.GrantingPolicies = append(ret.GrantingPolicies, tmpPolicy)
+	}
+
+	// Early deny when required
+	if slices.Contains(resContent.Capabilities, DenyCapability) {
+		ret.CapabilitiesBitmap |= DenyCapabilityInt
+		return
+	}
+
+	// Add the rest of capabilities
+	if slices.Contains(resContent.Capabilities, SudoCapability) {
+		ret.RootPrivs = true
+		ret.CapabilitiesBitmap |= SudoCapabilityInt
+	}
+
+	//
+	ret.Allowed = slices.Contains(resContent.Capabilities, string(op))
+
+	for _, capability := range resContent.Capabilities {
+
+		switch logical.Operation(capability) {
+		case logical.ReadOperation:
+			ret.CapabilitiesBitmap |= ReadCapabilityInt
+		case logical.ListOperation:
+			ret.CapabilitiesBitmap |= ListCapabilityInt
+		case logical.UpdateOperation:
+			ret.CapabilitiesBitmap |= UpdateCapabilityInt
+		case logical.DeleteOperation:
+			ret.CapabilitiesBitmap |= DeleteCapabilityInt
+		case logical.CreateOperation:
+			ret.CapabilitiesBitmap |= CreateCapabilityInt
+		case logical.PatchOperation:
+			ret.CapabilitiesBitmap |= PatchCapabilityInt
+		case logical.ScanOperation:
+			ret.CapabilitiesBitmap |= ScanCapabilityInt
+
+		// These three re-use UpdateCapabilityInt since that's the most appropriate
+		// capability/operation mapping
+		case logical.RevokeOperation, logical.RenewOperation, logical.RollbackOperation:
+			ret.CapabilitiesBitmap |= UpdateCapabilityInt
+		default:
+			return
+		}
+	}
+
+	return
+}

--- a/vault/acl_external.go
+++ b/vault/acl_external.go
@@ -181,7 +181,6 @@ func (a *ACL) AllowOperationExternal(ctx context.Context, req *logical.Request, 
 	ret.Allowed = slices.Contains(resContent.Capabilities, string(op))
 
 	for _, capability := range resContent.Capabilities {
-
 		switch logical.Operation(capability) {
 		case logical.ReadOperation:
 			ret.CapabilitiesBitmap |= ReadCapabilityInt

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -25,7 +25,7 @@ func TestACL_NewACL(t *testing.T) {
 func testNewACL(t *testing.T, ns *namespace.Namespace) {
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
 	policy := []*Policy{{Name: "root"}}
-	_, err := NewACL(ctx, policy)
+	_, err := NewACL(ctx, policy, ACLOptions{})
 	switch ns.ID {
 	case namespace.RootNamespaceID:
 		if err != nil {
@@ -67,7 +67,7 @@ path "secret/split/definition" {
 	}
 
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestACL_Capabilities(t *testing.T) {
 		t.Parallel()
 		policy := []*Policy{{Name: "root"}}
 		ctx := namespace.RootContext(context.Background())
-		acl, err := NewACL(ctx, policy)
+		acl, err := NewACL(ctx, policy, ACLOptions{})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -128,7 +128,7 @@ func testACLCapabilities(t *testing.T, ns *namespace.Namespace) {
 		t.Fatalf("err: %v", err)
 	}
 
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -163,7 +163,7 @@ func testACLRoot(t *testing.T, ns *namespace.Namespace) {
 	// Create the root policy ACL. Always create on root namespace regardless of
 	// which namespace to ACL check on.
 	policy := []*Policy{{Name: "root"}}
-	acl, err := NewACL(namespace.RootContext(context.Background()), policy)
+	acl, err := NewACL(namespace.RootContext(context.Background()), policy, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -196,7 +196,7 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 	}
 
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestACL_Layered(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		acl, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy1, policy2})
+		acl, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy1, policy2}, ACLOptions{})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -399,7 +399,7 @@ func testACLPolicyMerge(t *testing.T, ns *namespace.Namespace) {
 		t.Fatalf("err: %v", err)
 	}
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -468,7 +468,7 @@ func testACLAllowOperation(t *testing.T, ns *namespace.Namespace) {
 		t.Fatalf("err: %v", err)
 	}
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -553,7 +553,7 @@ func testACLValuePermissions(t *testing.T, ns *namespace.Namespace) {
 	}
 
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -710,7 +710,7 @@ path "foo/bar/+/ba*" { capabilities = ["update"] }
 			t.Fatalf("err: %v", err)
 		}
 
-		acl, err := NewACL(ctx, []*Policy{policy})
+		acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -807,7 +807,7 @@ func TestACL_SegmentWildcardPriority_BareMount(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		acl, err := NewACL(ctx, []*Policy{policy})
+		acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -839,7 +839,7 @@ func TestACL_CreationRace(t *testing.T) {
 				if time.Now().After(stopTime) {
 					return
 				}
-				_, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy})
+				_, err := NewACL(namespace.RootContext(context.Background()), []*Policy{policy}, ACLOptions{})
 				if err != nil {
 					errs <- fmt.Errorf("goroutine %d: %w", i, err)
 				}
@@ -911,7 +911,7 @@ func TestACLGrantingPolicies(t *testing.T) {
 			Operation: tc.op,
 		}
 
-		acl, err := NewACL(ctx, tc.policies)
+		acl, err := NewACL(ctx, tc.policies, ACLOptions{})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -635,6 +635,9 @@ type Core struct {
 
 	// Config value for "detect_deadlocks".
 	detectDeadlocks []string
+
+	//
+	externalAclAddress string
 }
 
 // c.stateLock needs to be held in read mode before calling this function.
@@ -781,6 +784,10 @@ type CoreConfig struct {
 	AdministrativeNamespacePath string
 
 	NumRollbackWorkers int
+
+	//
+	EnableExternalAcl  bool
+	ExternalAclAddress string
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -1151,6 +1158,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	if c.versionHistory == nil {
 		c.logger.Info("Initializing version history cache for core")
 		c.versionHistory = make(map[string]VaultVersion)
+	}
+
+	//
+	if conf.EnableExternalAcl {
+		c.externalAclAddress = conf.ExternalAclAddress
 	}
 
 	return c, nil

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3960,6 +3960,9 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 		acl.prefixRules.WalkPrefix(path, walkFn)
 	}
 
+	// TODO
+	// Useful to know whether an entity has access to a mount or not.
+	// Does it guessing if the user has permissions in any specific path inside
 	if !aclCapabilitiesGiven {
 		if perms := acl.CheckAllowedFromNonExactPaths(path, true); perms != nil {
 			return true

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -203,6 +203,7 @@ func NewPolicyStore(ctx context.Context, core *Core, baseView BarrierView, syste
 
 	// Special-case root; doesn't exist on disk but does need to be found
 	ps.policyTypeMap.Store(ps.cacheKey(namespace.RootNamespace, "root"), PolicyTypeACL)
+
 	return ps, nil
 }
 
@@ -656,8 +657,9 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 		}
 	}
 
-	// Construct the ACL
-	acl, err := NewACL(ctx, allPolicies)
+	acl, err := NewACL(ctx, allPolicies, ACLOptions{
+		ExternalAclAddress: ps.core.externalAclAddress,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct ACL: %w", err)
 	}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -287,7 +287,7 @@ func TestDefaultPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := NewACL(ctx, []*Policy{policy}, ACLOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
See the contributing guide:
https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md
-->

Finally i have implemented this 🙂 

**Changes are focused on adding ACL evaluation by an external server.** Passing enough not-sensitive data to the external server, such as the fields expressed later, an external server can implement a different way to evaluate the policies or priorities. This allow different companies to have different logic more suitable for them

Fields in the request: 

```golang
type ExternalEvaluationRequest struct {
	Path      string                            `json:"path"`
	Operation string                            `json:"operation"`
	Policies  []ExternalEvaluationRequestPolicy `json:"policies"`

	// Useful payload
	Parameters map[string]any `json:"parameters"`
	TTL        time.Duration  `json:"TTL"`

	// Make it easy for fast responses
	IsRoot          bool `json:"isRoot"`
	IsAuthenticated bool `json:"isAuthenticated"`
}
```

Expected fields in the response:

```golang
type ExternalEvaluationResponse struct {
	Capabilities     []string `json:"capabilities"`
	GrantingPolicies []string `json:"grantingPolicies"`
}
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

[Resolves #514 ](https://github.com/openbao/openbao/issues/514)

It's useful as a first simple approach to this problem.

Still pending but promised: If this PR get merged, i will add the documentation to the docs website
