### PR TITLE
Fix preSeal ordering w.r.t NamespaceStore

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2485,14 +2485,14 @@ func (c *Core) preSeal() error {
 	if err := c.teardownPolicyStore(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down policy store: %w", err))
 	}
-	if err := c.teardownNamespaceStore(); err != nil {
-		result = multierror.Append(result, fmt.Errorf("error tearing down namespaces store: %w", err))
-	}
 	if err := c.stopRollback(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error stopping rollback: %w", err))
 	}
 	if err := c.unloadMounts(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
+	}
+	if err := c.teardownNamespaceStore(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("error tearing down namespaces store: %w", err))
 	}
 
 	if c.autoRotateCancel != nil {

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -742,6 +742,9 @@ func (ns *NamespaceStore) copyNamespaceFromCtx(intoCtx context.Context, fromCtx 
 // because logic elsewhere in vault/ combines the namespace with the
 // path again.
 func (ns *NamespaceStore) ResolveNamespaceFromRequest(baseCtx context.Context, httpCtx context.Context, reqPath string) (context.Context, *namespace.Namespace, string, error) {
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
+
 	// We stack the namespace context ahead of any namespace in path.
 	newCtx, parentNs, err := ns.copyNamespaceFromCtx(baseCtx, httpCtx)
 	if err != nil {

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -93,8 +93,17 @@ func TestNamespaceStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "in-progress", status)
 
-	// wait until deletion
-	time.Sleep(10 * time.Millisecond)
+	// Wait until deletion has finished.
+	maxRetries := 50
+	for range maxRetries {
+		ns, err = s.ListAllNamespaces(ctx, false)
+		require.NoError(t, err)
+		if len(ns) > 0 {
+			time.Sleep(1 * time.Millisecond)
+			continue
+		}
+		break
+	}
 
 	// Store should be empty.
 	ns, err = s.ListAllNamespaces(ctx, false)


### PR DESCRIPTION
Within preSeal, we faced a race condition:

 - NamespaceStore was first destroyed
 - Then RollbackManager was stopped.

In particular, this ordering means that any rollback functions which
relied on namespaces, such as the token or identity subsystems, would
occasionally panic.

This was only reported in CI, but the code path is reachable in
production systems and thus may have manifested in heavy load scenarios.

Tear down the namespace store as the very last thing, so that rollback
manager and any dangling mount options can access namespaces if
necessary.

---

cc: @wslabosz-reply @klaus-sap @satoqz @phyrog @voigt @driif 
