### PR TITLE
fix(identity): ensure identity store is set only for root namespace

### DIFF
--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2157,7 +2157,11 @@ func (c *Core) setCoreBackend(entry *MountEntry, backend logical.Backend, view B
 		ch.saltUUID = entry.UUID
 		c.cubbyholeBackend = ch
 	case mountTypeIdentity:
-		c.identityStore = backend.(*IdentityStore)
+		// Identity mount is a singleton mount, so we need to set the identity store only for root namespace.
+		// All token validation and ACL checks are done against the root identity store.
+		if entry.NamespaceID == namespace.RootNamespaceID {
+			c.identityStore = backend.(*IdentityStore)
+		}
 	}
 }
 


### PR DESCRIPTION
After creating a namespace, the Core's global c.identityStore has been replaced with a new, namespace-specific store. This store had an empty cache, which removes the previously cached LDAP-login entity.

Resolves #1261 

---

cc: @cipherboy [@satoqz](https://github.com/satoqz) [@phyrog](https://github.com/phyrog) @voigt @wslabosz-reply
