### PR TITLE
Feat/fix test coverage script

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,10 +7,12 @@
 # Works around the fact that `go test -coverprofile` currently does not work
 # with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
 #
-# Usage: script/coverage [--html|--coveralls]
+# Usage: script/coverage [--html|--coveralls|--json] [--pr|<package>]
 #
 #     --html      Additionally create HTML report and open it in browser
 #     --coveralls Push coverage statistics to coveralls.io
+#     --json      Output coverage data in JSON format
+#     --pr        Only include packages changed in the current PR
 #
 
 set -e
@@ -25,7 +27,8 @@ generate_cover_data() {
 
     for pkg in "$@"; do
         f="$workdir/$(echo $pkg | tr / -).cover"
-        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+        # gotestsum --format=short-verbose -- -covermode="$mode" -coverprofile="$f" "$pkg"
+        go test -v -covermode="$mode" -coverprofile="$f" "$pkg"
     done
 
     echo "mode: $mode" >"$profile"
@@ -41,15 +44,32 @@ push_to_coveralls() {
     goveralls -coverprofile="$profile"
 }
 
-generate_cover_data $(go list ./... | grep -v /vendor/)
+# Get packages to test
+if [ "$2" = "--pr" ]; then
+    pkgs=$(git diff --name-only origin/main...HEAD | grep '\.go$' | xargs -n1 dirname | sort -u | uniq | xargs -I{} go list ./{} 2>/dev/null)
+elif [ -n "$2" ]; then
+    pkgs=$(go list ./... | grep -v /vendor/ | grep "$2")
+else
+    pkgs=$(go list ./... | grep -v /vendor/)
+fi
+
+generate_cover_data $pkgs
+
 show_cover_report func
+
 case "$1" in
-"")
-    ;;
---html)
-    show_cover_report html ;;
---coveralls)
-    push_to_coveralls ;;
-*)
-    echo >&2 "error: invalid option: $1"; exit 1 ;;
+    "")
+        ;;
+    --html)
+        show_cover_report html
+        ;;
+    --json)
+        cat "$profile" | jq -R -s -c 'split("\n") | map(select(length > 0))'
+        ;;
+    --coveralls)
+        push_to_coveralls
+        ;;
+    *)
+        echo >&2 "error: invalid option: $2"; exit 1
+        ;;
 esac

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// coreAuthConfigPath is used to store the auth configuration.
+	// coreAuthConfigPath is used to store the auth configuration.11
 	// Auth configuration is protected within the Vault itself, which means it
 	// can only be viewed or modified after an unseal.
 	coreAuthConfigPath = "core/auth"


### PR DESCRIPTION
# Summary
This PR updates scripts/coverage.sh with new features to improve test coverage handling and output formatting.

# Changes

- Added a --pr flag to run coverage only on files changed in the current branch.
- Added a --json flag to output coverage results as a JSON string.
- Added a test filter option to run only specific tests matching a provided string.

# Motivation

These improvements make it easier to:

- Focus coverage checks on relevant changes.
- Integrate coverage data into other tools via JSON output.
- Quickly run targeted tests during development.