### PR TITLE
Support retrying PostgreSQL connection

### DIFF
--- a/changelog/1280.txt
+++ b/changelog/1280.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/postgresql: support retrying database connection on startup to gracefully handle service ordering issues
+```

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/cenkalti/backoff/v4"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-uuid"
@@ -155,8 +156,23 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		}
 	}
 
+	// Set maximum retries for DB connection liveness check on startup.
+	maxRetriesStr, ok := conf["max_connect_retries"]
+	var maxRetriesInt int
+	if ok {
+		maxRetriesInt, err = strconv.Atoi(maxRetriesStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing max_connect_retries parameter: %w", err)
+		}
+		if logger.IsDebug() {
+			logger.Debug("max_connect_retries set", "max_connect_retries", maxRetriesInt)
+		}
+	} else {
+		maxRetriesInt = 1
+	}
+
 	// Create PostgreSQL handle for the database.
-	db, err := sql.Open("pgx", connURL)
+	db, err := doRetryConnect(logger, connURL, uint64(maxRetriesInt))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to postgres: %w", err)
 	}
@@ -299,6 +315,38 @@ func connectionURL(conf map[string]string) string {
 	}
 
 	return connURL
+}
+
+func doRetryConnect(logger log.Logger, connURL string, retries uint64) (*sql.DB, error) {
+	db, err := sql.Open("pgx", connURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to postgres: %w", err)
+	}
+
+	var b backoff.BackOff = backoff.NewExponentialBackOff(
+		backoff.WithMaxInterval(5*time.Second),
+		backoff.WithInitialInterval(15*time.Millisecond),
+	)
+	if retries > 0 {
+		b = backoff.WithMaxRetries(b, retries)
+	}
+
+	b.Reset()
+
+	if err := backoff.Retry(func() error {
+		err := db.Ping()
+		if err != nil {
+			logger.Debug("database not ready", "err", err)
+			return err
+		}
+
+		return nil
+	}, b); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("unable to verify connection: %w", err)
+	}
+
+	return db, nil
 }
 
 // splitKey is a helper to split a full path key into individual

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -320,7 +320,7 @@ func connectionURL(conf map[string]string) string {
 func doRetryConnect(logger log.Logger, connURL string, retries uint64) (*sql.DB, error) {
 	db, err := sql.Open("pgx", connURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to postgres: %w", err)
+		return nil, err
 	}
 
 	var b backoff.BackOff = backoff.NewExponentialBackOff(

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -79,6 +79,12 @@ to disable SSL.
   PostgreSQL 9.5 or later. Set to `true` if the database user does not have
   the required permissions; otherwise, OpenBao will fail to start.
 
+- `max_connect_retries` `(int: 1)` - Maximum number of retries to perform
+  when waiting for the database to be active. This uses exponential backoff,
+  starting with 15ms and increasing to 5s between retries. To ensure the
+  connection is active, OpenBao calls [`db.Ping()`](https://pkg.go.dev/database/sql#DB.Ping).
+  Can be set to zero to ensure unlimited retries.
+
 ## `postgresql` examples
 
 ### Custom SSL verification


### PR DESCRIPTION
When starting OpenBao, we formerly assumed that the database instance was already up and running. In certain scenarios, such as executing in the context of Kubernetes, with a PGBouncer instance, or in Podman Compose, we might have a looser coupling of service availability. Support graceful retry logic in the initial connection handler to accommodate startup ordering issues.
