### PR TITLE
Namespace-aware password policy storage & lookup

### DIFF
--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2210,7 +2210,10 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 	}
 
 	switch me.Type {
-	case mountTypeSystem:
+	case mountTypeSystem, mountTypeNSSystem:
+		if me.Namespace() != nil && me.NamespaceID != namespace.RootNamespaceID {
+			return c.namespaceMountEntryView(me.Namespace(), systemBarrierPrefix), nil
+		}
 		return NewBarrierView(c.barrier, systemBarrierPrefix), nil
 	case mountTypeToken:
 		return NewBarrierView(c.barrier, systemBarrierPrefix+tokenSubPath), nil

--- a/vault/password_policy_util.go
+++ b/vault/password_policy_util.go
@@ -7,15 +7,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/openbao/openbao/helper/namespace"
 )
 
 const (
-	passwordPolicySubPath = "password_policy/"
+	passwordPolicySubPath = "sys/password_policy/"
 )
 
 // retrievePasswordPolicy retrieves a password policy from the logical storage
 func (d dynamicSystemView) retrievePasswordPolicy(ctx context.Context, policyName string) (*passwordPolicyConfig, error) {
-	storage := d.core.systemBarrierView.SubView(passwordPolicySubPath)
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	storage := d.core.namespaceMountEntryView(ns, passwordPolicySubPath)
 	entry, err := storage.Get(ctx, policyName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Resolves #1263

In addition to checking the written storage paths, we did some testing with the database secrets engine + Postgres, ensuring that it can only find the password policies for the namespace the engine is enabled in.