### PR TITLE
Minor cleanup of the rekey webpage

### DIFF
--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -67,9 +67,9 @@ Rekey an Auto Unseal OpenBao and encrypt the resulting recovery keys with PGP:
 $ bao operator rekey \
     -target=recovery \
     -init \
+    -key-shares=1 \
+    -key-threshold=1 \
     -pgp-keys=keybase:grahamopenbao
-    -key-shares=1
-    -key-threshold=1
 ```
 
 Store encrypted PGP keys in OpenBao's core:

--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -58,7 +58,7 @@ $ bao operator rekey \
     -init \
     -key-shares=3 \
     -key-threshold=2 \
-    -pgp-keys="keybase:hashicorp,keybase:jefferai,keybase:sethvargo"
+    -pgp-keys="keybase:openbao,keybase:jefferai,keybase:sethvargo"
 ```
 
 Rekey an Auto Unseal OpenBao and encrypt the resulting recovery keys with PGP:
@@ -67,7 +67,7 @@ Rekey an Auto Unseal OpenBao and encrypt the resulting recovery keys with PGP:
 $ bao operator rekey \
     -target=recovery \
     -init \
-    -pgp-keys=keybase:grahamhashicorp
+    -pgp-keys=keybase:grahamopenbao
     -key-shares=1
     -key-threshold=1
 ```


### PR DESCRIPTION
The https://openbao.org/docs/commands/operator/rekey/ page has two minor issues:
* still references hashicorp as keybase key names
* one example has broken end-of-line handling in shell excerpt