### PR TITLE
Delete namespace-level quota on namespace deletion

### DIFF
--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -711,6 +711,12 @@ func clearNamespaceResources(ctx context.Context, ns *NamespaceStore, namespaceT
 		}
 	}
 
+	err = ns.core.quotaManager.HandleNamespaceDeletion(ctx, namespaceToDelete.Path)
+	if err != nil {
+		ns.logger.Error("failed to update quotas after deleting namespace", "namespace", namespaceToDelete.Path, "error", err.Error())
+		return
+	}
+
 	// Now grab write lock so that we can write to storage.
 	ns.lock.Lock()
 	defer ns.lock.Unlock()

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
+	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/require"
 )
 
@@ -158,4 +159,68 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	required, err = qm.QueryResolveRoleQuotas(rlqReq)
 	require.NoError(t, err)
 	require.False(t, required)
+}
+
+func TestQuotas_HandleNamespaceDeletion(t *testing.T) {
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink(), true)
+	require.NoError(t, err)
+
+	err = qm.Setup(context.Background(), new(logical.InmemStorage))
+	require.NoError(t, err)
+
+	rlqs := []*RateLimitQuota{
+		NewRateLimitQuota("namespace-only", "foo/", "", "", "", 10, time.Minute, time.Second, false),
+		NewRateLimitQuota("namespace-mount", "foo/", "sys/", "", "", 10, time.Minute, time.Second, false),
+	}
+
+	for _, rlq := range rlqs {
+		err := qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false)
+		require.NoError(t, err)
+	}
+
+	err = qm.HandleNamespaceDeletion(context.Background(), "foo/")
+	require.NoError(t, err)
+
+	q, err := qm.QuotaByName(TypeRateLimit.String(), "namespace-only")
+	require.NoError(t, err)
+	require.Nil(t, q)
+
+	// Should still be there, handled by HandleBackendDisabling.
+	q, err = qm.QuotaByName(TypeRateLimit.String(), "namespace-mount")
+	require.NoError(t, err)
+	require.NotNil(t, q)
+}
+
+func TestQuotas_HandleBackendDisabling(t *testing.T) {
+	qm, err := NewManager(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink(), true)
+	require.NoError(t, err)
+
+	err = qm.Setup(context.Background(), new(logical.InmemStorage))
+	require.NoError(t, err)
+
+	rlqs := []*RateLimitQuota{
+		NewRateLimitQuota("namespace-only", "foo/", "", "", "", 10, time.Minute, time.Second, false),
+		NewRateLimitQuota("namespace-mount", "foo/", "sys/", "", "", 10, time.Minute, time.Second, false),
+		NewRateLimitQuota("namespace-mount-path", "foo/", "sys/", "policies/", "", 10, time.Minute, time.Second, false),
+		NewRateLimitQuota("namespace-mount-role", "foo/", "sys/", "", "bob", 10, time.Minute, time.Second, false),
+	}
+
+	for _, rlq := range rlqs {
+		err := qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false)
+		require.NoError(t, err)
+	}
+
+	err = qm.HandleBackendDisabling(context.Background(), "foo/", "sys/")
+	require.NoError(t, err)
+
+	for _, name := range []string{"namespace-mount", "namespace-mount-path", "namespace-mount-role"} {
+		q, err := qm.QuotaByName(TypeRateLimit.String(), name)
+		require.NoError(t, err)
+		require.Nil(t, q)
+	}
+
+	// Should not be deleted by HandleBackendDisabling, but by HandleNamespaceDeletion.
+	q, err := qm.QuotaByName(TypeRateLimit.String(), "namespace-only")
+	require.NoError(t, err)
+	require.NotNil(t, q)
 }


### PR DESCRIPTION
Followup to #1161 and #1206 because it turns out "it depends" would have been the correct answer to https://github.com/openbao/openbao/pull/1161#discussion_r2068161550 😄

Quotas attached to a mount are automatically deleted on unmount, which ususally clears all namespace-specific quotas on namespace deletion.

There's one edge case where quota is not attached to the mount and thus not removed on namespace deletion yet:

`path=foo/bar` where `foo/bar` is a namespace, no mount path, no API path

---

cc @cipherboy @voigt @wslabosz-reply