### PR TITLE
Allow empty PostgreSQL connection URLs

### DIFF
--- a/changelog/1297.txt
+++ b/changelog/1297.txt
@@ -1,0 +1,3 @@
+```release-note:change
+storage/postgresql: Support empty connection URLs to use standard component-wise variables
+```

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -101,9 +101,6 @@ type PostgreSQLLock struct {
 func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.Backend, error) {
 	// Get the PostgreSQL credentials to perform read/write operations.
 	connURL := connectionURL(conf)
-	if connURL == "" {
-		return nil, errors.New("missing connection_url")
-	}
 
 	unquoted_table, ok := conf["table"]
 	if !ok {

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -41,11 +41,15 @@ to disable SSL.
 
 ## `postgresql` parameters
 
-- `connection_url` `(string: <required>)` – Specifies the connection string to
+- `connection_url` `(string: "")` – Specifies the connection string to
   use to authenticate and connect to PostgreSQL. The connection URL can also be
   set using the `BAO_PG_CONNECTION_URL` environment variable. A full list of supported
   parameters can be found in the [pgx library][pgxlib] and [PostgreSQL connection string][pg_conn_docs]
   documentation. For example connection string URLs, see the examples section below.
+  OpenBao supports standard PostgreSQL component environment variables as well,
+  [including `PGHOST`](https://www.postgresql.org/docs/current/libpq-envars.html);
+  see [`pgconn.ParseConfig(...)`](https://pkg.go.dev/github.com/jackc/pgconn)
+  for more information. This configuration option may be blank.
 
 - `table` `(string: "openbao_kv_store")` – Specifies the name of the table in
   which to write OpenBao data. OpenBao will attempt to create it if missing and


### PR DESCRIPTION
When using the PostgreSQL storage implementation, libpgx supports component-wise standard environment variables for connection information. This means that one complete connection string may not be present but the connection would still succeed. Support empty connection information as a result.
