### PR TITLE
PostgreSQL - Remove redundant PermitPool

### DIFF
--- a/changelog/1299.txt
+++ b/changelog/1299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/postgresql: Remove redundant PermitPool enforced by db.SetMaxOpenConns(...).
+```

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -542,7 +542,7 @@ func TestPostgreSQLBackend_Parallel(t *testing.T) {
 
 	b := bRaw.(physical.TransactionalBackend)
 
-	// Put should succeed with an error even with massively parallel
+	// Put should succeed without an error even with massively parallel
 	// requests.
 	errors := make([]error, 100)
 	var wg sync.WaitGroup

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -620,12 +620,13 @@ func TestPostgreSQLBackend_Parallel(t *testing.T) {
 			defer count.Add(-1)
 		}(j)
 
-		wg.Wait()
+	}
 
-		for j := range errors {
-			if errors[j] != nil {
-				t.Fatalf("process %v: %v", j, errors[j])
-			}
+	wg.Wait()
+
+	for j := range errors {
+		if errors[j] != nil {
+			t.Fatalf("process %v: %v", j, errors[j])
 		}
 	}
 }

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -551,7 +551,7 @@ func TestPostgreSQLBackend_Parallel(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			entry := &physical.Entry{Key: fmt.Sprintf("foo-%v", i), Value: []byte("data")}
-			err = b.Put(context.Background(), entry)
+			err := b.Put(context.Background(), entry)
 			if err != nil {
 				errors[i] = err
 			}


### PR DESCRIPTION
Calling `db.SetMaxOpenConns(...)` has the same effect as using a permit
pool; Go will internally do locking and ensure that no more connections
are created.

Adds a test case to verify this behavior, which should allow us to avoid
double locking and the latency that brings with.

---

This is based on #1280 and will be rebased when it lands. 