### PR TITLE
Namespaces locking unlocking implementation

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -492,7 +492,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       "unlock-key",
 				Target:     &c.flagUnlockKey,
-				Default:    notSetValue,
+				Default:    "",
 				Completion: complete.PredictNothing,
 				Usage:      "Key to unlock a namespace API lock.",
 			})

--- a/command/namespace_api_lock.go
+++ b/command/namespace_api_lock.go
@@ -86,10 +86,11 @@ func (c *NamespaceAPILockCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Warn(fmt.Sprintf(`Unlock Key: %s
-	
+	c.UI.Output(fmt.Sprintf("Unlock Key: %s\n", resp.Data["unlock_key"]))
+	c.UI.Info(`
 Namespace is now locked. Please securely store the unlock key printed above.
 You must supply the unlock key to re-enable access to the namespace.
-If the unlock key is lost, sudo capability is required to unlock the namespace without it.`, resp.Data["unlock_key"]))
+If the unlock key is lost, sudo capability is required to unlock the namespace without it.`)
+
 	return 0
 }

--- a/command/namespace_api_lock.go
+++ b/command/namespace_api_lock.go
@@ -86,7 +86,7 @@ func (c *NamespaceAPILockCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Output(fmt.Sprintf("Unlock Key: %s\n", resp.Data["unlock_key"]))
+	c.UI.Output(fmt.Sprintf("Unlock Key: %s", resp.Data["unlock_key"]))
 	c.UI.Info(`
 Namespace is now locked. Please securely store the unlock key printed above.
 You must supply the unlock key to re-enable access to the namespace.

--- a/command/namespace_api_lock.go
+++ b/command/namespace_api_lock.go
@@ -86,6 +86,10 @@ func (c *NamespaceAPILockCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Warn("Copy and store your unlock key, as losing it may cause data loss.\nIn case key gets missing, contact the administrator.\n")
-	return OutputSecret(c.UI, resp)
+	c.UI.Warn(fmt.Sprintf(`Unlock Key: %s
+	
+Namespace is now locked. Please securely store the unlock key printed above.
+You must supply the unlock key to re-enable access to the namespace.
+If the unlock key is lost, sudo capability is required to unlock the namespace without it.`, resp.Data["unlock_key"]))
+	return 0
 }

--- a/command/namespace_api_lock.go
+++ b/command/namespace_api_lock.go
@@ -86,11 +86,16 @@ func (c *NamespaceAPILockCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Output(fmt.Sprintf("Unlock Key: %s", resp.Data["unlock_key"]))
-	c.UI.Info(`
+	switch Format(c.UI) {
+	case "table":
+		c.UI.Output(fmt.Sprintf("Unlock Key: %s", resp.Data["unlock_key"]))
+		c.UI.Info(`
 Namespace is now locked. Please securely store the unlock key printed above.
 You must supply the unlock key to re-enable access to the namespace.
 If the unlock key is lost, sudo capability is required to unlock the namespace without it.`)
+	default:
+		return OutputData(c.UI, resp.Data)
+	}
 
 	return 0
 }

--- a/command/namespace_api_lock.go
+++ b/command/namespace_api_lock.go
@@ -86,5 +86,6 @@ func (c *NamespaceAPILockCommand) Run(args []string) int {
 		return 2
 	}
 
+	c.UI.Warn("Copy and store your unlock key, as losing it may cause data loss.\nIn case key gets missing, contact the administrator.\n")
 	return OutputSecret(c.UI, resp)
 }

--- a/command/namespace_api_unlock.go
+++ b/command/namespace_api_unlock.go
@@ -92,5 +92,6 @@ func (c *NamespaceAPIUnlockCommand) Run(args []string) int {
 		return 2
 	}
 
+	c.UI.Info("Namespace unlocked successfully!")
 	return 0
 }

--- a/command/namespace_api_unlock.go
+++ b/command/namespace_api_unlock.go
@@ -39,7 +39,7 @@ Usage: bao namespace unlock [options] PATH
 
 	Unlock a child namespace, and all of its descendants (e.g. ns1/ns2/):
 
-		$ bao namespace lock -unlock-key=<key> ns1/ns2
+		$ bao namespace unlock -unlock-key=<key> ns1/ns2
 
 ` + c.Flags().Help()
 
@@ -84,7 +84,7 @@ func (c *NamespaceAPIUnlockCommand) Run(args []string) int {
 		optionalChildNSPath = fmt.Sprintf("/%s", namespace.Canonicalize(args[0]))
 	}
 
-	_, err = client.Logical().Write(fmt.Sprintf("sys/namespaces/api-lock/unlock%s", optionalChildNSPath), map[string]interface{}{
+	secret, err := client.Logical().Write(fmt.Sprintf("sys/namespaces/api-lock/unlock%s", optionalChildNSPath), map[string]interface{}{
 		"unlock_key": c.flagUnlockKey,
 	})
 	if err != nil {
@@ -92,6 +92,11 @@ func (c *NamespaceAPIUnlockCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Info("Namespace unlocked successfully!")
+	if secret != nil && len(secret.Warnings) > 0 {
+		c.UI.Warn(secret.Warnings[0])
+	} else {
+		c.UI.Info("Namespace unlocked successfully!")
+	}
+
 	return 0
 }

--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -41,6 +41,7 @@ type Namespace struct {
 	UUID    string `json:"uuid" mapstructure:"uuid"`
 	Path    string `json:"path" mapstructure:"path"`
 	Tainted bool   `json:"tainted" mapstructure:"tainted"`
+	Locked  bool   `json:"-"`
 	// IsDeleting tracks whether there's an ongoing deletion process of the specified namespace
 	// If tainted is true, but IsDeleting not, then namespace deletion operation has to be retried.
 	IsDeleting     bool              `json:"-"`
@@ -101,6 +102,7 @@ var (
 		UUID:           RootNamespaceUUID,
 		Path:           "",
 		Tainted:        false,
+		Locked:         false,
 		IsDeleting:     false,
 		CustomMetadata: make(map[string]string),
 	}
@@ -152,6 +154,7 @@ func (n *Namespace) Clone() *Namespace {
 		UUID:           n.UUID,
 		Path:           n.Path,
 		Tainted:        n.Tainted,
+		Locked:         n.Locked,
 		IsDeleting:     n.IsDeleting,
 		CustomMetadata: meta,
 	}

--- a/sdk/logical/error.go
+++ b/sdk/logical/error.go
@@ -14,6 +14,10 @@ var (
 	// by the logical backend.
 	ErrUnsupportedPath = errors.New("unsupported path")
 
+	// ErrLockedNamespace is returned if the namespace (path)
+	// is locked and cannot be accessed without unlocking.
+	ErrLockedNamespace = errors.New("locked namespace")
+
 	// ErrInvalidRequest is returned if the request is invalid
 	ErrInvalidRequest = errors.New("invalid request")
 

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -122,6 +122,8 @@ func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 			statusCode = http.StatusMethodNotAllowed
 		case errwrap.Contains(err, ErrUnsupportedPath.Error()):
 			statusCode = http.StatusNotFound
+		case errwrap.Contains(err, ErrLockedNamespace.Error()):
+			statusCode = http.StatusServiceUnavailable
 		case errwrap.Contains(err, ErrInvalidRequest.Error()):
 			statusCode = http.StatusBadRequest
 		case errwrap.Contains(err, ErrUpstreamRateLimited.Error()):

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5823,7 +5823,7 @@ This path responds to the following HTTP methods.
 		`
 This path responds to the following HTTP methods.
 
-	POST /<path>
+	PUT /<path>
 		Lock the API for a namespace.
 		`,
 	},
@@ -5832,7 +5832,7 @@ This path responds to the following HTTP methods.
 		`
 This path responds to the following HTTP methods.
 
-	POST /<path>
+	PUT /<path>
 		Unlock the API for a namespace.
 		`,
 	},

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5818,4 +5818,22 @@ This path responds to the following HTTP methods.
 		Delete a namespace.
 		`,
 	},
+	"namespaces-lock": {
+		"Lock a namespace.",
+		`
+This path responds to the following HTTP methods.
+
+	POST /<path>
+		Lock the API for a namespace.
+		`,
+	},
+	"namespaces-unlock": {
+		"Unlock a namespace.",
+		`
+This path responds to the following HTTP methods.
+
+	POST /<path>
+		Unlock the API for a namespace.
+		`,
+	},
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -121,8 +121,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-lock"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-lock"][1]),
 		},
 
 		{
@@ -155,8 +155,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-unlock"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-unlock"][1]),
 		},
 
 		{

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -91,7 +91,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 		},
 
 		{
-			Pattern: "namespaces/api-lock/lock(?P<path>.*)",
+			Pattern: "namespaces/api-lock/lock(?:$|/(?P<path>.+))",
 
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "namespaces",
@@ -126,7 +126,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 		},
 
 		{
-			Pattern: "namespaces/api-lock/unlock(?P<path>.*)",
+			Pattern: "namespaces/api-lock/unlock(?:$|/(?P<path>.+))",
 
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "namespaces",

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -804,12 +804,12 @@ func TestNamespaceBackend_Unlock(t *testing.T) {
 		req.ClientToken = rootToken
 		res, err := b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
-		require.Empty(t, res)
+		require.Equal(t, "Namespace unlocked using root capabilities", res.Warnings[0])
 
 		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/unlock/company_b/team_b")
 		req.ClientToken = rootToken
 		res, err = b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
-		require.Empty(t, res)
+		require.Equal(t, "Namespace unlocked using root capabilities", res.Warnings[0])
 	})
 }

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -618,7 +618,7 @@ func TestNamespaceBackend_Lock(t *testing.T) {
 		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock")
 		res, err = b.HandleRequest(rootCtx, req)
 		require.Error(t, err)
-		require.Equal(t, "cannot lock root namespace", res.Data["error"])
+		require.Equal(t, "root namespace cannot be locked/unlocked", res.Data["error"])
 
 		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/test")
 		res, err = b.HandleRequest(rootCtx, req)

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -28,8 +28,10 @@ func testCreateNamespace(t *testing.T, ctx context.Context, b logical.Backend, n
 
 	return &namespace.Namespace{
 		ID:             res.Data["id"].(string),
+		UUID:           res.Data["uuid"].(string),
 		Path:           res.Data["path"].(string),
 		Tainted:        res.Data["tainted"].(bool),
+		Locked:         res.Data["locked"].(bool),
 		CustomMetadata: res.Data["custom_metadata"].(map[string]string),
 	}
 }
@@ -49,6 +51,8 @@ func TestNamespaceBackend_Set(t *testing.T) {
 		require.NotEmpty(t, res.Data["uuid"].(string), "namespace has no UUID")
 		require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
 		require.Equal(t, res.Data["path"].(string), "foo/")
+		require.Equal(t, res.Data["tainted"].(bool), false)
+		require.Equal(t, res.Data["locked"].(bool), false)
 		require.Equal(t, res.Data["custom_metadata"], customMetadata,
 			"read custom_metadata does not match original custom_metadata")
 	})
@@ -111,8 +115,9 @@ func TestNamespaceBackend_Set(t *testing.T) {
 			if tc.wantError {
 				require.Error(t, err)
 			} else {
-				fmt.Printf("%s", res.Data["path"].(string))
 				require.Equal(t, tc.wantPath, res.Data["path"].(string))
+				require.Equal(t, res.Data["tainted"].(bool), false)
+				require.Equal(t, res.Data["locked"].(bool), false)
 				require.NotEmpty(t, res.Data["uuid"].(string), "namespace has no UUID")
 				require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
 			}
@@ -132,6 +137,8 @@ func TestNamespaceBackend_Set(t *testing.T) {
 		require.NotEmpty(t, res.Data["uuid"].(string), "namespace has no UUID")
 		require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
 		require.Equal(t, res.Data["path"].(string), "foo/")
+		require.Equal(t, res.Data["tainted"].(bool), false)
+		require.Equal(t, res.Data["locked"].(bool), false)
 		require.Equal(t, res.Data["custom_metadata"], newMetadata,
 			"read custom_metadata does not match original custom_metadata")
 	})
@@ -154,6 +161,7 @@ func TestNamespaceBackend_Read(t *testing.T) {
 		require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
 		require.Equal(t, res.Data["path"].(string), "foo/")
 		require.Equal(t, res.Data["tainted"].(bool), false)
+		require.Equal(t, res.Data["locked"].(bool), false)
 		require.Equal(t, res.Data["custom_metadata"], customMetadata,
 			"read custom_metadata does not match original custom_metadata")
 	})
@@ -172,6 +180,7 @@ func TestNamespaceBackend_Read(t *testing.T) {
 		require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
 		require.Equal(t, res.Data["path"].(string), "foo/bar/")
 		require.Equal(t, res.Data["tainted"].(bool), false)
+		require.Equal(t, res.Data["locked"].(bool), false)
 		require.Equal(t, res.Data["custom_metadata"], customMetadata,
 			"read custom_metadata does not match original custom_metadata")
 	})
@@ -398,7 +407,8 @@ func TestNamespaceBackend_List(t *testing.T) {
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
 			require.Equal(t, ns.Path, path, "path in key does not match path in namespace struct")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 		}
@@ -432,7 +442,8 @@ func TestNamespaceBackend_List(t *testing.T) {
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
 			require.Equal(t, ns.Path, path, "path in key does not match path in namespace struct")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 		}
@@ -466,7 +477,8 @@ func TestNamespaceBackend_List(t *testing.T) {
 			require.True(t, ok, fmt.Sprintf("key_info does not have path %q which is present in keys", path))
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 			require.Subset(t, []string{"bar/", "baz/"}, []string{path})
@@ -510,7 +522,8 @@ func TestNamespaceBackend_Scan(t *testing.T) {
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
 			require.Equal(t, ns.Path, path, "path in key does not match path in namespace struct")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 		}
@@ -544,7 +557,8 @@ func TestNamespaceBackend_Scan(t *testing.T) {
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
 			require.Equal(t, ns.Path, path, "path in key does not match path in namespace struct")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 		}
@@ -579,10 +593,104 @@ func TestNamespaceBackend_Scan(t *testing.T) {
 			var ns namespace.Namespace
 			require.NoError(t, mapstructure.Decode(info, &ns), "key_info entry is not a namespace")
 			require.Equal(t, ns.Path, info.(map[string]any)["path"], "path in key does not match path in info struct")
-			require.False(t, ns.Tainted, "tained in key should be false")
+			require.False(t, ns.Tainted, "tainted in key should be false")
+			require.False(t, ns.Locked, "locked in key should be false")
 			require.NotEmpty(t, ns.ID, "namespace ID should not be empty")
 			require.NotEqual(t, ns.ID, namespace.RootNamespaceID, "list should not include root namespace")
 			require.Subset(t, []string{"baz/", "baz/bar/"}, []string{path})
 		}
+	})
+}
+
+func TestNamespaceBackend_Lock(t *testing.T) {
+	b := testSystemBackend(t)
+	rootCtx := namespace.RootContext(context.Background())
+
+	t.Run("cannot lock nonexistent, root or already locked namespaces", func(t *testing.T) {
+		testCreateNamespace(t, rootCtx, b, "test", nil)
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/idontexist")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.ErrorContains(t, err, "requested namespace does not exist")
+		require.Empty(t, res, "response is not empty")
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.ErrorContains(t, err, "cannot lock root namespace")
+		require.Empty(t, res, "response is not empty")
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/test")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data["unlock_key"], "unlock_key is missing")
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/test")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.ErrorContains(t, err, "namespace already locked")
+		require.Empty(t, res, "response is not empty")
+	})
+
+	t.Run("cannot lock child namespace when ancestor is locked", func(t *testing.T) {
+		nsCompanyA := testCreateNamespace(t, rootCtx, b, "company_a", nil)
+		companyACtx := namespace.ContextWithNamespace(rootCtx, nsCompanyA)
+		testCreateNamespace(t, companyACtx, b, "team_a", nil)
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/company_a")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data["unlock_key"], "unlock_key is missing")
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/company_a/team_a")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+		require.Equal(t, res.Data["error"], fmt.Sprintf("cannot lock namespace %q as %q is already locked", "company_a/team_a/", "company_a/"))
+	})
+
+	t.Run("can lock parent namespace when child is locked", func(t *testing.T) {
+		nsCompanyB := testCreateNamespace(t, rootCtx, b, "company_b", nil)
+		companyBCtx := namespace.ContextWithNamespace(rootCtx, nsCompanyB)
+		testCreateNamespace(t, companyBCtx, b, "team_b", nil)
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/company_b/team_b")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data["unlock_key"], "unlock_key is missing")
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/company_b")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data["unlock_key"], "unlock_key is missing")
+	})
+
+	t.Run("locked namespace, and its children do not accept any requests", func(t *testing.T) {
+		company := testCreateNamespace(t, rootCtx, b, "company", nil)
+		companyCtx := namespace.ContextWithNamespace(rootCtx, company)
+		team := testCreateNamespace(t, companyCtx, b, "team", nil)
+		teamCtx := namespace.ContextWithNamespace(rootCtx, team)
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/lock/company")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data["unlock_key"], "unlock_key is missing")
+
+		req = logical.TestRequest(t, logical.CreateOperation, "auth/token/create")
+		res, err = b.HandleRequest(companyCtx, req)
+		require.Error(t, err)
+		require.Empty(t, res, "response is not empty")
+
+		req = logical.TestRequest(t, logical.CreateOperation, "auth/token/create")
+		res, err = b.HandleRequest(teamCtx, req)
+		require.Error(t, err)
+		require.Empty(t, res, "response is not empty")
+
+		req = logical.TestRequest(t, logical.ReadOperation, "cubbyhole/foo")
+		res, err = b.HandleRequest(companyCtx, req)
+		require.Error(t, err)
+		require.Empty(t, res, "response is not empty")
+
+		req = logical.TestRequest(t, logical.ReadOperation, "cubbyhole/foo")
+		res, err = b.HandleRequest(teamCtx, req)
+		require.Error(t, err)
+		require.Empty(t, res, "response is not empty")
 	})
 }

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -804,12 +804,12 @@ func TestNamespaceBackend_Unlock(t *testing.T) {
 		req.ClientToken = rootToken
 		res, err := b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
-		require.Equal(t, "Namespace unlocked using root capabilities", res.Warnings[0])
+		require.Equal(t, "Namespace unlocked using sudo capabilities", res.Warnings[0])
 
 		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/api-lock/unlock/company_b/team_b")
 		req.ClientToken = rootToken
 		res, err = b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
-		require.Equal(t, "Namespace unlocked using root capabilities", res.Warnings[0])
+		require.Equal(t, "Namespace unlocked using sudo capabilities", res.Warnings[0])
 	})
 }

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -850,6 +850,10 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 		return errors.New("requested namespace does not exist")
 	}
 
+	if namespaceToUnlock.ID == namespace.RootNamespaceID {
+		return errors.New("root namespace cannot be locked/unlocked")
+	}
+
 	if !namespaceToUnlock.Locked {
 		return fmt.Errorf("namespace %q is not locked", namespaceToUnlock.Path)
 	}
@@ -930,7 +934,7 @@ func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (strin
 	}
 
 	if namespaceToLock.ID == namespace.RootNamespaceID {
-		return "", errors.New("cannot lock root namespace")
+		return "", errors.New("root namespace cannot be locked/unlocked")
 	}
 
 	lockedNamespace := ns.GetLockingNamespace(namespaceToLock)

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -69,7 +69,7 @@ type NamespaceStore struct {
 
 // namespaceLock marks a locked namespace in storage.
 // It holds the unlock key for the locked namespace.
-type lock struct {
+type namespaceLock struct {
 	Key string `json:"key" mapstructure:"key"`
 }
 
@@ -868,12 +868,12 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 // provided unlock key, with match deletes the storage entry, modifies namespace
 // tree structure and namespace maps changing the 'Locked' field to false.
 func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *namespace.Namespace, unlockKey string, forceUnlock bool) error {
-	lockPath := path.Join(namespaceBarrierPrefix, namespace.UUID, namespaceLockPrefix)
+	lockView := NamespaceView(ns.storage, namespace).SubView(namespaceLockPrefix)
 
 	// read lock from storage
-	var nsLock lock
+	var nsLock namespaceLock
 	err := logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		item, err := s.Get(ctx, lockPath)
+		item, err := lockView.Get(ctx, "")
 		if err != nil {
 			return err
 		}
@@ -895,7 +895,7 @@ func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *
 
 	// delete lock from storage
 	err = logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		return s.Delete(ctx, lockPath)
+		return lockView.Delete(ctx, "")
 	})
 	if err != nil {
 		return fmt.Errorf("error deleting namespace lock: %w", err)
@@ -954,14 +954,14 @@ func (ns *NamespaceStore) lockNamespaceLocked(ctx context.Context, namespace *na
 		return "", fmt.Errorf("unable to generate namespace lock key: %w", err)
 	}
 
-	lock := &lock{
+	lock := &namespaceLock{
 		Key: lockKey,
 	}
 
 	// write lock to storage
 	err = logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		storagePath := path.Join(namespaceBarrierPrefix, namespace.UUID, namespaceLockPrefix)
-		item, err := logical.StorageEntryJSON(storagePath, &lock)
+		lockView := NamespaceView(ns.storage, namespace).SubView(namespaceLockPrefix)
+		item, err := logical.StorageEntryJSON(lockView.Prefix(), &lock)
 		if err != nil {
 			return fmt.Errorf("error marshalling storage entry: %w", err)
 		}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -833,8 +833,8 @@ func (ns *NamespaceStore) GetLockingNamespace(n *namespace.Namespace) *namespace
 	return nil
 }
 
-// UnlockNamespace attempts to unlock the namespace with provided provided uuid.
-func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path string, forceUnlock bool) error {
+// UnlockNamespace attempts to unlock the namespace with provided namespace path.
+func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "unlock_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
@@ -865,13 +865,13 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 
 	ns.lock.Lock()
 	defer ns.lock.Unlock()
-	return ns.unlockNamespaceLocked(ctx, namespaceToUnlock, unlockKey, forceUnlock)
+	return ns.unlockNamespaceLocked(ctx, namespaceToUnlock, unlockKey)
 }
 
 // unlockNamespaceLocked reads namespace lock from the storage, compares it to the
 // provided unlock key, with match deletes the storage entry, modifies namespace
 // tree structure and namespace maps changing the 'Locked' field to false.
-func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *namespace.Namespace, unlockKey string, forceUnlock bool) error {
+func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *namespace.Namespace, unlockKey string) error {
 	lockView := NamespaceView(ns.storage, namespace).SubView(namespaceLockPrefix)
 
 	// read lock from storage
@@ -892,8 +892,9 @@ func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *
 		return fmt.Errorf("error retrieving namespace lock: %w", err)
 	}
 
-	// verify lock or omit when forced unlock
-	if !forceUnlock && nsLock.Key != unlockKey {
+	// verify lock or skip when provided unlock key is empty
+	// (meaning namespace is unlocked using root capability)
+	if unlockKey != "" && nsLock.Key != unlockKey {
 		return errors.New("incorrect unlock key")
 	}
 

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -36,7 +36,7 @@ const (
 	namespaceStoreSubPath = "core/namespaces/"
 
 	// Namespaces lock location.
-	lockPrefix = "core/namespace-lock"
+	namespaceLockPrefix = "core/namespace-lock"
 
 	// namespaceBarrierPrefix is the prefix to the UUID of a namespaces
 	// used in the barrier view for the namespace-owned backends.
@@ -67,10 +67,8 @@ type NamespaceStore struct {
 	logger hclog.Logger
 }
 
-// lock struct is used to represent a lock of the namespace
-// rendering the namespace unable to serve any requests
-// it can be hold by the admin of the same namespace or any
-// admin associated by the parent namespaces
+// namespaceLock marks a locked namespace in storage.
+// It holds the unlock key for the locked namespace.
 type lock struct {
 	Key string `json:"key" mapstructure:"key"`
 }
@@ -178,7 +176,7 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 			return false, fmt.Errorf("%v has an empty namespace definition (page %v / index %v)", entry, page, index)
 		}
 
-		nsLockPath := path.Join(namespaceBarrierPrefix, entry, lockPrefix)
+		nsLockPath := path.Join(namespaceBarrierPrefix, entry, namespaceLockPrefix)
 		nsLock, err := barrier.Get(ctx, nsLockPath)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch namespace lock %v (page %v / index %v): %w", nsLockPath, page, index, err)
@@ -836,23 +834,33 @@ func (ns *NamespaceStore) GetLockingNamespace(n *namespace.Namespace) *namespace
 }
 
 // UnlockNamespace attempts to unlock the namespace with provided provided uuid.
-func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, uuid string, forceUnlock bool) error {
+func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path string, forceUnlock bool) error {
 	defer metrics.MeasureSince([]string{"namespace", "unlock_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
 		return err
 	}
 
-	namespaceToUnlock, err := ns.GetNamespace(ctx, uuid)
+	namespaceToUnlock, err := ns.GetNamespaceByPath(ctx, path)
 	if err != nil {
 		return err
 	}
 
 	if namespaceToUnlock == nil {
-		return nil
+		return errors.New("requested namespace does not exist")
+	}
+
+	if !namespaceToUnlock.Locked {
+		return fmt.Errorf("namespace %q is not locked", namespaceToUnlock.Path)
+	}
+
+	lockingNamespace := ns.GetLockingNamespace(namespaceToUnlock)
+	if lockingNamespace.ID != namespaceToUnlock.ID {
+		return fmt.Errorf("cannot unlock %q with namespace %q being locked", namespaceToUnlock.Path, lockingNamespace.Path)
 	}
 
 	ns.lock.Lock()
+	defer ns.lock.Unlock()
 	return ns.unlockNamespaceLocked(ctx, namespaceToUnlock, unlockKey, forceUnlock)
 }
 
@@ -860,8 +868,7 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, uuid s
 // provided unlock key, with match deletes the storage entry, modifies namespace
 // tree structure and namespace maps changing the 'Locked' field to false.
 func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *namespace.Namespace, unlockKey string, forceUnlock bool) error {
-	lockPath := path.Join(namespaceBarrierPrefix, namespace.UUID, lockPrefix)
-	defer ns.lock.Unlock()
+	lockPath := path.Join(namespaceBarrierPrefix, namespace.UUID, namespaceLockPrefix)
 
 	// read lock from storage
 	var nsLock lock
@@ -905,34 +912,41 @@ func (ns *NamespaceStore) unlockNamespaceLocked(ctx context.Context, namespace *
 	return nil
 }
 
-// LockNamespace attempts to lock the namespace with provided uuid.
-func (ns *NamespaceStore) LockNamespace(ctx context.Context, uuid string) (string, error) {
+// LockNamespace attempts to lock the namespace with provided path.
+func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "lock_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
 		return "", err
 	}
 
-	namespaceToLock, err := ns.GetNamespace(ctx, uuid)
+	namespaceToLock, err := ns.GetNamespaceByPath(ctx, path)
 	if err != nil {
 		return "", err
 	}
 
 	if namespaceToLock == nil {
-		return "", nil
+		return "", errors.New("requested namespace does not exist")
+	}
+
+	if namespaceToLock.ID == namespace.RootNamespaceID {
+		return "", errors.New("cannot lock root namespace")
 	}
 
 	lockedNamespace := ns.GetLockingNamespace(namespaceToLock)
-	if lockedNamespace != nil {
-		return "", fmt.Errorf("cannot lock namespace %q as %q is already locked", namespaceToLock.Path, lockedNamespace.Path)
+	if lockedNamespace != nil && lockedNamespace.ID == namespaceToLock.ID {
+		return "", fmt.Errorf("cannot lock namespace %q: is already locked", namespaceToLock.Path)
+	} else if lockedNamespace != nil {
+		return "", fmt.Errorf("cannot lock namespace %q: ancestor namespace %q is already locked", namespaceToLock.Path, lockedNamespace.Path)
 	}
 
 	ns.lock.Lock()
+	defer ns.lock.Unlock()
 	return ns.lockNamespaceLocked(ctx, namespaceToLock)
 }
 
-// lockNamespaceLocked creates a namespace lock, saves it to the storage, modifies namespace
-// tree structure and namespace maps in memory changing the 'Locked' field to true.
+// lockNamespaceLocked creates a namespace lock in storage
+// and sets the Locked field of the namespace in memory to true.
 func (ns *NamespaceStore) lockNamespaceLocked(ctx context.Context, namespace *namespace.Namespace) (string, error) {
 	// create lock
 	lockKey, err := base62.Random(24)
@@ -946,7 +960,7 @@ func (ns *NamespaceStore) lockNamespaceLocked(ctx context.Context, namespace *na
 
 	// write lock to storage
 	err = logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		storagePath := path.Join(namespaceBarrierPrefix, namespace.UUID, lockPrefix)
+		storagePath := path.Join(namespaceBarrierPrefix, namespace.UUID, namespaceLockPrefix)
 		item, err := logical.StorageEntryJSON(storagePath, &lock)
 		if err != nil {
 			return fmt.Errorf("error marshalling storage entry: %w", err)
@@ -969,8 +983,6 @@ func (ns *NamespaceStore) lockNamespaceLocked(ctx context.Context, namespace *na
 	if err != nil {
 		return "", fmt.Errorf("failed to modify namespace tree: %w", err)
 	}
-
-	ns.lock.Unlock()
 
 	return lockKey, nil
 }

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -258,7 +258,7 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 
 	// root path will return err and empty unlock key
 	unlockKey, err = s.LockNamespace(ctx, "")
-	require.ErrorContains(t, err, "cannot lock root namespace")
+	require.ErrorContains(t, err, "root namespace cannot be locked/unlocked")
 	require.Empty(t, unlockKey)
 
 	// lock parent namespace
@@ -344,6 +344,10 @@ func TestNamespaceStore_UnlockNamespace(t *testing.T) {
 	// nonexistent path will return err
 	err = s.UnlockNamespace(ctx, "key", "nonexistent", false)
 	require.ErrorContains(t, err, "requested namespace does not exist")
+
+	// cannot unlock root as it cannot be locked
+	err = s.UnlockNamespace(ctx, "key", "", false)
+	require.ErrorContains(t, err, "root namespace cannot be locked/unlocked")
 
 	// unlocking not locked namespace will return err
 	err = s.UnlockNamespace(ctx, "key", anotherNamespace.Path, false)

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -342,27 +342,27 @@ func TestNamespaceStore_UnlockNamespace(t *testing.T) {
 	require.Equal(t, true, s.namespacesByPath.Get(testNamespace.Path).Locked)
 
 	// nonexistent path will return err
-	err = s.UnlockNamespace(ctx, "key", "nonexistent", false)
+	err = s.UnlockNamespace(ctx, "key", "nonexistent")
 	require.ErrorContains(t, err, "requested namespace does not exist")
 
 	// cannot unlock root as it cannot be locked
-	err = s.UnlockNamespace(ctx, "key", "", false)
+	err = s.UnlockNamespace(ctx, "key", "")
 	require.ErrorContains(t, err, "root namespace cannot be locked/unlocked")
 
 	// unlocking not locked namespace will return err
-	err = s.UnlockNamespace(ctx, "key", anotherNamespace.Path, false)
+	err = s.UnlockNamespace(ctx, "key", anotherNamespace.Path)
 	require.ErrorContains(t, err, fmt.Sprintf("namespace %q is not locked", anotherNamespace.Path))
 
 	// cannot unlock child namespace of a locked namespace
-	err = s.UnlockNamespace(ctx, unlockKeyChild, childNamespace.Path, false)
+	err = s.UnlockNamespace(ctx, unlockKeyChild, childNamespace.Path)
 	require.ErrorContains(t, err, fmt.Sprintf("cannot unlock %q with namespace %q being locked", childNamespace.Path, testNamespace.Path))
 
 	// try to unlock with wrong key
-	err = s.UnlockNamespace(ctx, "key", testNamespace.Path, false)
+	err = s.UnlockNamespace(ctx, "key", testNamespace.Path)
 	require.ErrorContains(t, err, "e")
 
 	// unlock with correct key
-	err = s.UnlockNamespace(ctx, unlockKeyParent, testNamespace.Path, false)
+	err = s.UnlockNamespace(ctx, unlockKeyParent, testNamespace.Path)
 	require.NoError(t, err)
 
 	// verify empty storage
@@ -376,8 +376,8 @@ func TestNamespaceStore_UnlockNamespace(t *testing.T) {
 	require.Equal(t, false, s.namespacesByUUID[testNamespace.UUID].Locked)
 	require.Equal(t, false, s.namespacesByPath.Get(testNamespace.Path).Locked)
 
-	// force unlock of child namespace (parent is already unlocked)
-	err = s.UnlockNamespace(ctx, "", childNamespace.Path, true)
+	// force unlock of child namespace using empty key (parent is already unlocked)
+	err = s.UnlockNamespace(ctx, "", childNamespace.Path)
 	require.NoError(t, err)
 
 	// verify empty storage

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strconv"
 	"testing"
@@ -247,16 +248,21 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	testNamespaceCtx := namespace.ContextWithNamespace(ctx, testNamespace)
 
 	childNamespace := &namespace.Namespace{Path: "test/child"}
-	err = s.SetNamespace(ctx, childNamespace)
+	err = s.SetNamespace(testNamespaceCtx, childNamespace)
 	require.NoError(t, err)
 
-	// nonexistent uuid will return nil err and no unlock key
+	// nonexistent path will return err and empty unlock key
 	unlockKey, err := s.LockNamespace(ctx, "nonexistent")
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "requested namespace does not exist")
+	require.Empty(t, unlockKey)
+
+	// root path will return err and empty unlock key
+	unlockKey, err = s.LockNamespace(ctx, "")
+	require.ErrorContains(t, err, "cannot lock root namespace")
 	require.Empty(t, unlockKey)
 
 	// lock parent namespace
-	unlockKey, err = s.LockNamespace(testNamespaceCtx, testNamespace.UUID)
+	unlockKey, err = s.LockNamespace(ctx, testNamespace.Path)
 	require.NoError(t, err)
 	require.NotEmpty(t, unlockKey)
 
@@ -266,7 +272,7 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	require.Equal(t, true, s.namespacesByPath.Get(testNamespace.Path).Locked)
 
 	// verify storage
-	nsLockPath := path.Join(namespaceBarrierPrefix, testNamespace.UUID, lockPrefix)
+	nsLockPath := path.Join(namespaceBarrierPrefix, testNamespace.UUID, namespaceLockPrefix)
 	nsLock, err := s.storage.Get(ctx, nsLockPath)
 	require.NoError(t, err)
 
@@ -275,15 +281,15 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, unlockKey, lockItem.Key)
 
-	// verify 'locking namespace'
-	lockingNamespaceForTestNamespace := s.GetLockingNamespace(testNamespace)
-	require.Equal(t, testNamespace.ID, lockingNamespaceForTestNamespace.ID)
-	require.Equal(t, testNamespace.UUID, lockingNamespaceForTestNamespace.UUID)
-	require.Equal(t, testNamespace.Path, lockingNamespaceForTestNamespace.Path)
+	// verify that you cannot lock already locked namespace
+	unlockKey, err = s.LockNamespace(ctx, testNamespace.Path)
+	require.ErrorContains(t, err, fmt.Sprintf("cannot lock namespace %q: is already locked", testNamespace.Path))
+	require.Empty(t, unlockKey)
 
-	// it's the same namespace as the 'locking' namespace
-	lockingNamespaceForChildNamespace := s.GetLockingNamespace(childNamespace)
-	require.Equal(t, lockingNamespaceForTestNamespace, lockingNamespaceForChildNamespace)
+	// verify that you cannot lock children of a locked namespace
+	unlockKey, err = s.LockNamespace(ctx, childNamespace.Path)
+	require.ErrorContains(t, err, fmt.Sprintf("cannot lock namespace %q: ancestor namespace %q is already locked", childNamespace.Path, testNamespace.Path))
+	require.Empty(t, unlockKey)
 
 	err = TestCoreSeal(c)
 	require.NoError(t, err)
@@ -313,30 +319,50 @@ func TestNamespaceStore_UnlockNamespace(t *testing.T) {
 	require.NoError(t, err)
 	testNamespaceCtx := namespace.ContextWithNamespace(ctx, testNamespace)
 
-	// lock namespace
-	unlockKey, err := s.LockNamespace(testNamespaceCtx, testNamespace.UUID)
+	childNamespace := &namespace.Namespace{Path: "test/child"}
+	err = s.SetNamespace(testNamespaceCtx, childNamespace)
 	require.NoError(t, err)
-	require.NotEmpty(t, unlockKey)
+
+	anotherNamespace := &namespace.Namespace{Path: "another"}
+	err = s.SetNamespace(ctx, anotherNamespace)
+	require.NoError(t, err)
+
+	// lock namespace
+	unlockKeyChild, err := s.LockNamespace(ctx, childNamespace.Path)
+	require.NoError(t, err)
+	require.NotEmpty(t, unlockKeyChild)
+
+	unlockKeyParent, err := s.LockNamespace(ctx, testNamespace.Path)
+	require.NoError(t, err)
+	require.NotEmpty(t, unlockKeyParent)
 
 	// verify locked status
 	require.Equal(t, true, s.namespacesByAccessor[testNamespace.ID].Locked)
 	require.Equal(t, true, s.namespacesByUUID[testNamespace.UUID].Locked)
 	require.Equal(t, true, s.namespacesByPath.Get(testNamespace.Path).Locked)
 
-	// nonexistent uuid will return nil
+	// nonexistent path will return err
 	err = s.UnlockNamespace(ctx, "key", "nonexistent", false)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "requested namespace does not exist")
+
+	// unlocking not locked namespace will return err
+	err = s.UnlockNamespace(ctx, "key", anotherNamespace.Path, false)
+	require.ErrorContains(t, err, fmt.Sprintf("namespace %q is not locked", anotherNamespace.Path))
+
+	// cannot unlock child namespace of a locked namespace
+	err = s.UnlockNamespace(ctx, unlockKeyChild, childNamespace.Path, false)
+	require.ErrorContains(t, err, fmt.Sprintf("cannot unlock %q with namespace %q being locked", childNamespace.Path, testNamespace.Path))
 
 	// try to unlock with wrong key
-	err = s.UnlockNamespace(ctx, "key", testNamespace.UUID, false)
-	require.Error(t, err)
+	err = s.UnlockNamespace(ctx, "key", testNamespace.Path, false)
+	require.ErrorContains(t, err, "e")
 
 	// unlock with correct key
-	err = s.UnlockNamespace(ctx, unlockKey, testNamespace.UUID, false)
+	err = s.UnlockNamespace(ctx, unlockKeyParent, testNamespace.Path, false)
 	require.NoError(t, err)
 
 	// verify empty storage
-	nsLockPath := path.Join(namespaceBarrierPrefix, testNamespace.UUID, lockPrefix)
+	nsLockPath := path.Join(namespaceBarrierPrefix, testNamespace.UUID, namespaceLockPrefix)
 	nsLock, err := s.storage.Get(ctx, nsLockPath)
 	require.NoError(t, err)
 	require.Nil(t, nsLock)
@@ -346,23 +372,20 @@ func TestNamespaceStore_UnlockNamespace(t *testing.T) {
 	require.Equal(t, false, s.namespacesByUUID[testNamespace.UUID].Locked)
 	require.Equal(t, false, s.namespacesByPath.Get(testNamespace.Path).Locked)
 
-	// lock namespace
-	_, err = s.LockNamespace(testNamespaceCtx, testNamespace.UUID)
-	require.NoError(t, err)
-
-	// force namespace unlock
-	err = s.UnlockNamespace(ctx, "", testNamespace.UUID, true)
+	// force unlock of child namespace (parent is already unlocked)
+	err = s.UnlockNamespace(ctx, "", childNamespace.Path, true)
 	require.NoError(t, err)
 
 	// verify empty storage
+	nsLockPath = path.Join(namespaceBarrierPrefix, childNamespace.UUID, namespaceLockPrefix)
 	nsLock, err = s.storage.Get(ctx, nsLockPath)
 	require.NoError(t, err)
 	require.Nil(t, nsLock)
 
 	// verify the locked status
-	require.Equal(t, false, s.namespacesByAccessor[testNamespace.ID].Locked)
-	require.Equal(t, false, s.namespacesByUUID[testNamespace.UUID].Locked)
-	require.Equal(t, false, s.namespacesByPath.Get(testNamespace.Path).Locked)
+	require.Equal(t, false, s.namespacesByAccessor[childNamespace.ID].Locked)
+	require.Equal(t, false, s.namespacesByUUID[childNamespace.UUID].Locked)
+	require.Equal(t, false, s.namespacesByPath.Get(childNamespace.Path).Locked)
 }
 
 func TestNamespaceHierarchy(t *testing.T) {

--- a/vault/namespaces_store_test.go
+++ b/vault/namespaces_store_test.go
@@ -276,7 +276,7 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	nsLock, err := s.storage.Get(ctx, nsLockPath)
 	require.NoError(t, err)
 
-	var lockItem lock
+	var lockItem namespaceLock
 	err = nsLock.DecodeJSON(&lockItem)
 	require.NoError(t, err)
 	require.Equal(t, unlockKey, lockItem.Key)

--- a/vault/namespaces_store_tree.go
+++ b/vault/namespaces_store_tree.go
@@ -81,6 +81,28 @@ func (nt *namespaceTree) LongestPrefix(path string) (string, *namespace.Namespac
 	return namespacePrefix, node.entry, pathSuffix
 }
 
+func (nt *namespaceTree) WalkPath(path string, predicate func(namespace *namespace.Namespace) bool) {
+	path = namespace.Canonicalize(path)
+	var segments []string
+	if path != "" {
+		segments = strings.SplitAfter(path, "/")
+		segments = segments[:len(segments)-1]
+	}
+
+	// intentionally not calling the predicate on the root
+	node := nt.root
+	for _, segment := range segments {
+		n, ok := node.children[segment]
+		if !ok || predicate(n.entry) {
+			return
+		}
+
+		node = n
+	}
+
+	return
+}
+
 // List lists child Namespace entries at a given path, optionally including the
 // namespace at the given path, optionally recursing down into all child
 // namespaces.

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -576,7 +576,7 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 		}
 	}
 
-	if ns.ID != namespace.RootNamespace.ID {
+	if ns.ID != namespace.RootNamespaceID {
 		// verify whether the namespace is either directly or inherently locked
 		lockedNS := c.namespaceStore.GetLockingNamespace(ns)
 		if lockedNS != nil && req.Operation != logical.RevokeOperation && req.Operation != logical.RollbackOperation {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -586,6 +586,18 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 
+	if ns != namespace.RootNamespace {
+		// verify whether the namespace is either directly or inherently locked
+		lockedNS := c.namespaceStore.GetLockingNamespace(ns)
+		if lockedNS != nil && req.Operation != logical.RevokeOperation && req.Operation != logical.RollbackOperation {
+			switch req.Path {
+			case "sys/namespaces/api-lock/unlock":
+			default:
+				return logical.ErrorResponse(fmt.Sprintf("API access to this namespace has been locked by an administrator - %q must be unlocked to gain access.", lockedNS.Path)), logical.ErrLockedNamespace
+			}
+		}
+	}
+
 	inFlightReqID, ok := httpCtx.Value(logical.CtxKeyInFlightRequestID{}).(string)
 	if ok {
 		ctx = context.WithValue(ctx, logical.CtxKeyInFlightRequestID{}, inFlightReqID)

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -576,17 +576,7 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 		}
 	}
 
-	isRestrictedSysAPI := ns.ID != namespace.RootNamespaceID &&
-		strings.HasPrefix(req.Path, "sys/") &&
-		restrictedSysAPIs.HasPathSegments(req.Path[len("sys/"):])
-
-	if isRestrictedSysAPI {
-		return nil, logical.CodedError(http.StatusBadRequest, "operation unavailable in namespaces")
-	}
-
-	ctx = namespace.ContextWithNamespace(ctx, ns)
-
-	if ns != namespace.RootNamespace {
+	if ns.ID != namespace.RootNamespace.ID {
 		// verify whether the namespace is either directly or inherently locked
 		lockedNS := c.namespaceStore.GetLockingNamespace(ns)
 		if lockedNS != nil && req.Operation != logical.RevokeOperation && req.Operation != logical.RollbackOperation {
@@ -596,7 +586,13 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 				return logical.ErrorResponse(fmt.Sprintf("API access to this namespace has been locked by an administrator - %q must be unlocked to gain access.", lockedNS.Path)), logical.ErrLockedNamespace
 			}
 		}
+
+		if strings.HasPrefix(req.Path, "sys/") &&
+			restrictedSysAPIs.HasPathSegments(req.Path[len("sys/"):]) {
+			return nil, logical.CodedError(http.StatusBadRequest, "operation unavailable in namespaces")
+		}
 	}
+	ctx = namespace.ContextWithNamespace(ctx, ns)
 
 	inFlightReqID, ok := httpCtx.Value(logical.CtxKeyInFlightRequestID{}).(string)
 	if ok {


### PR DESCRIPTION
(recreated as a copy of #1298)

Resolves #1181

Implements `bao namespace lock <path>` and `bao namespace unlock <path>` operations.

- Locking the namespace results in all requests to that namespace being rejected with `503` error code and a error message
```
bao namespace create test   
bao namespace lock test   
Key           Value
---           -----
unlock_key   <unlock_key>
(...)
bao write -ns=test cubbyhole/foo bar=baz
Error writing data to cubbyhole/foo: Error making API request.

Namespace: test/
URL: PUT http://127.0.0.1:8200/v1/cubbyhole/foo
Code: 503. Errors:

* API access to this namespace has been locked by an administrator - "test/" must be unlocked to gain access.
(...)
bao token create -ns=test
Error creating token: Error making API request.

Namespace: test/
URL: POST http://127.0.0.1:8200/v1/auth/token/create
Code: 503. Errors:

* API access to this namespace has been locked by an administrator - "test/" must be unlocked to gain access.
```

- Namespace locking respects the hierarchy of the namespaces, meaning that you cannot lock a namespace that is already locked or is a descendant of already locked namespace
```
// namespaces: "test/", "test/test2", "test/test2/test3"
bao namespace lock test/test2
// success
bao namespace lock test/test2/test3
Error locking namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/api-lock/lock/test/test2/test3
Code: 400. Errors:

* cannot lock namespace "test/test2/test3/" as "test/test2/" is already locked

// but namespace "test" as an ancestor can be locked.
bao namespace lock test
// success
```

- Namespaces inherit the locked status, meaning that if any namespace in a upwards hierarchy is locked, then all the descendants cannot serve any requests
```
bao write -ns=test/test2/test3 cubbyhole/foo bar=baz
Error writing data to cubbyhole/foo: Error making API request.

Namespace: test/test2/test3/
URL: PUT http://127.0.0.1:8200/v1/cubbyhole/foo
Code: 503. Errors:

* API access to this namespace has been locked by an administrator - "test/" must be unlocked to gain access.
// notice how the error mentions the locked namespace, and not the namespace of the request.
```

- Namespace locks are persisted through sealing of the bao instance
```
bao namespace lookup test
Key                Value
---                -----
custom_metadata    map[]
id                 IiZhx7
locked             true
path               test/
tainted            false
uuid               8f4959b7-7733-4f0c-5a01-22b010e9407b

bao operator seal
bao operator unseal

bao namespace lookup test
Key                Value
---                -----
custom_metadata    map[]
id                 IiZhx7
locked             true
path               test/
tainted            false
uuid               8f4959b7-7733-4f0c-5a01-22b010e9407b
```


- Unlocking can be done using unlock key from the locking operation response, or using the token with `sudo` privileges
```
bao namespace lock test
Key           Value
---           -----
unlock_key   <unlock_key>
(...)
bao namespace unlock -unlock-key=<key> test
bao namespace lookup test
Key                Value
---                -----
custom_metadata    map[]
id                 IiZhx7
locked             false
path               test/
tainted            false
uuid               8f4959b7-7733-4f0c-5a01-22b010e9407b
(...)
bao namespace lock test
bao namespace unlock test // assuming your token has sudo capabilities
// success
```

- Namespace hierarchy has to be respected during unlocking, meaning that you have to unlock the top-most namespace in a hierarchy of locked namespaces
```
// notice how we have to lock namespaces starting from the most deeply nested one
bao namespace lock test/test2/test3
bao namespace lock test/test2
bao namespace lock test
(...)
bao namespace unlock test/test2/test3
Error unlocking namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/api-lock/unlock/test/test2/test3
Code: 500. Errors:

* 1 error occurred:
        * cannot unlock "test/test2/test3/" with namespace "test/" being locked


bao namespace unlock test/test2      
Error unlocking namespace: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/namespaces/api-lock/unlock/test/test2
Code: 500. Errors:

* 1 error occurred:
        * cannot unlock "test/test2/" with namespace "test/" being locked


bao namespace unlock test
// success
bao namespace unlock test/test2
// success
bao namespace unlock test/test2/test3
// success
```

-----
cc: @cipherboy @satoqz @phyrog @voigt @driif