### PR TITLE
Allow lazy discovery of OIDC connection information

### DIFF
--- a/changelog/1306.txt
+++ b/changelog/1306.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/jwt: Support lazy resolution of oidc_discovery_url or jwks_url when skip_jwks_validation=true is specified on auth/jwt/config; OIDC status is now reported on reading the configuration.
+```

--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -52,6 +52,7 @@ set.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth, IBM ISAM. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt/oidc-providers).
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in OpenBao and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
+- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url` or `jwks_url` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
 
 ### Sample payload
 


### PR DESCRIPTION
When OpenBao is brought up alongside other infrastructure, the OIDC discovery URL may not be valid yet. Rather than delaying OpenBao configuration until OIDC is available, add a lazy validation parameter, `skip_jwks_validation`, to allow OIDC and JWKS URLs to be lazily validated.

Reading the auth config (`/auth/jwt/config`) will now report status of the issuer.

---

@DrDaveD This needs docs &c, but this is roughly what I was thinking. Let me know your thoughts. :-) 