### PR TITLE
Describe coverage of OSPS requirement OSPS-QA-01.02

### DIFF
--- a/website/content/docs/policies/osps-baseline.mdx
+++ b/website/content/docs/policies/osps-baseline.mdx
@@ -94,7 +94,7 @@ OpenBao's source code repositories are hosted in the public [OpenBao GitHub orga
 
 > **Requirement:** *The [version control](https://baseline.openssf.org/versions/2025-02-25#version-control-system) system MUST contain a publicly readable record of all [changes](https://baseline.openssf.org/versions/2025-02-25#change) made, who made the [changes](https://baseline.openssf.org/versions/2025-02-25#change), and when the [changes](https://baseline.openssf.org/versions/2025-02-25#change) were made.*
 
-All changes are tracked in git-based repositories, which are hosted in the public [OpenBao GitHub organization](https://github.com/openbao).
+All changes are tracked in Git repositories hosted in the public [OpenBao GitHub organization](https://github.com/openbao). While pull requests can be squashed, authorship is retained and all commits must be signed off with an appropriate [DCO](https://developercertificate.org/) as outlined on the [Contributing](/docs/contributing) page.
 
 ## OSPS-QA-02.01 {#osps-qa-02-01}
 When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies.

--- a/website/content/docs/policies/osps-baseline.mdx
+++ b/website/content/docs/policies/osps-baseline.mdx
@@ -26,8 +26,8 @@ This pages tracks the implementation status of [Open Source Project Security Bas
 | [OSPS-LE-02.02](#osps-le-02-02) | |
 | [OSPS-LE-03.01](#osps-le-03-01) | |
 | [OSPS-LE-03.02](#osps-le-03-02) | |
-| [OSPS-QA-01.01](#osps-qa-01-01) | |
-| [OSPS-QA-01.02](#osps-qa-01-02) | |
+| [OSPS-QA-01.01](#osps-qa-01-01) | ✅ |
+| [OSPS-QA-01.02](#osps-qa-01-02) | ✅ |
 | [OSPS-QA-02.01](#osps-qa-02-01) | |
 | [OSPS-QA-04.01](#osps-qa-04-01) | |
 | [OSPS-QA-05.01](#osps-qa-05-01) | |
@@ -91,7 +91,10 @@ While active, the license for the released software assets MUST be included in t
 OpenBao's source code repositories are hosted in the public [OpenBao GitHub organization](https://github.com/openbao). The main [`openbao/openbao` repository](https://github.com/openbao/openbao) is accessible via HTTPS and SSH.
 
 ## OSPS-QA-01.02 {#osps-qa-01-02}
-The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made.
+
+> **Requirement:** *The [version control](https://baseline.openssf.org/versions/2025-02-25#version-control-system) system MUST contain a publicly readable record of all [changes](https://baseline.openssf.org/versions/2025-02-25#change) made, who made the [changes](https://baseline.openssf.org/versions/2025-02-25#change), and when the [changes](https://baseline.openssf.org/versions/2025-02-25#change) were made.*
+
+All changes are tracked in git-based repositories, which are hosted in the public [OpenBao GitHub organization](https://github.com/openbao).
 
 ## OSPS-QA-02.01 {#osps-qa-02-01}
 When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies.


### PR DESCRIPTION
Describes how [OSPS-QA-01.02](https://baseline.openssf.org/versions/2025-02-25#osps-qa-0102) of the OSPS baseline is covered currently. Also adds a missing check mark to OSPS-QA-01.01, which was covered in https://github.com/openbao/openbao/pull/1289.

@cipherboy: What's the current PR merging strategy? Do we squash changes?

> Recommendation: Use a common VCS such as GitHub, GitLab, or Bitbucket to maintain a publicly readable commit history. Avoid squashing or rewriting commits in a way that would obscure the author of any commits.

Resolves https://github.com/openbao/dev-wg/issues/34
