### PR TITLE
Fix incorrect conversion between integer types (on <64 bit systems)

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -678,8 +678,10 @@ type FlagSet struct {
 // NewFlagSet creates a new flag set.
 func NewFlagSet(name string) *FlagSet {
 	return &FlagSet{
-		name:    name,
-		flagSet: flag.NewFlagSet(name, flag.ContinueOnError),
+		name:        name,
+		flagSet:     flag.NewFlagSet(name, flag.ContinueOnError),
+		mainSet:     flag.NewFlagSet(name, flag.ContinueOnError),
+		completions: make(complete.Flags),
 	}
 }
 

--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -342,7 +342,7 @@ type UintVar struct {
 func (f *FlagSet) UintVar(i *UintVar) {
 	initial := i.Default
 	if v, exist := api.LookupBaoVariable(i.EnvVar); exist {
-		if i, err := strconv.ParseUint(v, 0, 64); err == nil {
+		if i, err := strconv.ParseUint(v, 0, strconv.IntSize); err == nil {
 			initial = uint(i)
 		}
 	}

--- a/command/base_flags_test.go
+++ b/command/base_flags_test.go
@@ -4,11 +4,39 @@
 package command
 
 import (
+	"fmt"
+	"math"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// Test_Uint tests the parsing of uint values from an environment variable
+func Test_Uint(t *testing.T) {
+	f := NewFlagSet("test")
+	var tgt uint
+	defaultVal := uint(12)
+	v := UintVar{
+		Name:    "test",
+		EnvVar:  "TEST_UINT",
+		Target:  &tgt,
+		Default: defaultVal,
+		Hidden:  false,
+	}
+	var value uint64 = math.MaxUint64
+	os.Setenv("TEST_UINT", fmt.Sprintf("%d", value))
+
+	f.UintVar(&v)
+	expected := value
+	// on 32 bit machines, this will be true
+	if value > math.MaxUint {
+		expected = uint64(defaultVal)
+	}
+
+	require.Equal(t, expected, uint64(tgt))
+}
 
 func Test_BoolPtr(t *testing.T) {
 	var boolPtr BoolPtr


### PR DESCRIPTION
Fixes two integer conversion issues on 32 bit systems. Both are unlikely to occur in real life (both are config related and only occur on numbers > MaxInt if MaxInt < MaxInt64), but better safe than sorry.
