### PR TITLE
Namespaces: Test flake, deadlock, race condition cleanup

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1164,7 +1164,12 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 	}
 
 	c.auth = nil
-	c.tokenStore = nil
+
+	if c.tokenStore != nil {
+		c.tokenStore.teardown()
+		c.tokenStore = nil
+	}
+
 	return nil
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -326,30 +326,21 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
-		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, path)
+		status, err := b.Core.namespaceStore.DeleteNamespace(ctx, path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load namespace: %w", err)
+			return handleError(err)
 		}
 
-		if ns == nil {
+		if status == "" {
 			resp := &logical.Response{}
 			resp.AddWarning("requested namespace does not exist")
 			return resp, nil
 		}
 
-		status, err := b.Core.namespaceStore.DeleteNamespace(ctx, ns.UUID)
-		if err != nil {
-			return handleError(err)
-		}
-
-		if status != "" {
-			return &logical.Response{
-				Data: map[string]interface{}{
-					"status": status,
-				},
-			}, nil
-		}
-
-		return nil, nil
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"status": status,
+			},
+		}, nil
 	}
 }


### PR DESCRIPTION
[namespace deletion: avoid outdated reads](https://github.com/openbao/openbao/pull/1311/commits/3b8663123f3ab88aa5b930cdfbefcc3eec453299) fixes an edge case where tests reached
https://github.com/openbao/openbao/blob/7e053be408876c51c35d54d1763f02828b50e8c1/vault/logical_system_namespaces.go#L353
on my machine :-)

[expiration manager: fix deadlock on seal](https://github.com/openbao/openbao/pull/1311/commits/f370e97c1973010c774fc2d809a250594ed73127) fixes https://github.com/openbao/openbao/actions/runs/14926238096/job/41931694374

[token store: wait for tidy before teardown](https://github.com/openbao/openbao/pull/1311/commits/047f2786ac59098390d0e3b1109d84a66475830b) fixes https://github.com/openbao/openbao/actions/runs/14969013713/job/42045556523