### PR TITLE
Fix various govet warnings

### DIFF
--- a/builtin/credential/kubernetes/backend_test.go
+++ b/builtin/credential/kubernetes/backend_test.go
@@ -325,7 +325,8 @@ func Test_kubeAuthBackend_initialize(t *testing.T) {
 			}
 			b.tlsMu.RUnlock()
 
-			ctx, _ := context.WithTimeout(tt.ctx, time.Second*30)
+			ctx, cancel := context.WithTimeout(tt.ctx, time.Second*30)
+			defer cancel()
 			err := b.initialize(ctx, tt.req)
 			if tt.wantErr && err == nil {
 				t.Errorf("initialize() error = %v, wantErr %v", err, tt.wantErr)

--- a/builtin/credential/userpass/backend_test.go
+++ b/builtin/credential/userpass/backend_test.go
@@ -80,7 +80,7 @@ func TestBackend_CRUD(t *testing.T) {
 	if diff := deep.Equal(resp.Data["token_policies"], []string{"foo"}); diff != nil {
 		t.Fatal(diff)
 	}
-	if diff := deep.Equal(resp.Data["token_bound_cidrs"], []*sockaddr.SockAddrMarshaler{{localhostSockAddr}}); diff != nil {
+	if diff := deep.Equal(resp.Data["token_bound_cidrs"], []*sockaddr.SockAddrMarshaler{{SockAddr: localhostSockAddr}}); diff != nil {
 		t.Fatal(diff)
 	}
 
@@ -126,10 +126,10 @@ func TestBackend_CRUD(t *testing.T) {
 	if diff := deep.Equal(resp.Data["token_policies"], []string{"bar"}); diff != nil {
 		t.Fatal(diff)
 	}
-	if diff := deep.Equal(resp.Data["bound_cidrs"], []*sockaddr.SockAddrMarshaler{{localhostSockAddr}}); diff != nil {
+	if diff := deep.Equal(resp.Data["bound_cidrs"], []*sockaddr.SockAddrMarshaler{{SockAddr: localhostSockAddr}}); diff != nil {
 		t.Fatal(diff)
 	}
-	if diff := deep.Equal(resp.Data["token_bound_cidrs"], []*sockaddr.SockAddrMarshaler{{localhostSockAddr}}); diff != nil {
+	if diff := deep.Equal(resp.Data["token_bound_cidrs"], []*sockaddr.SockAddrMarshaler{{SockAddr: localhostSockAddr}}); diff != nil {
 		t.Fatal(diff)
 	}
 }

--- a/builtin/logical/openldap/client/client_test.go
+++ b/builtin/logical/openldap/client/client_test.go
@@ -24,7 +24,7 @@ func TestSearch(t *testing.T) {
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldap: ldapClient}
@@ -75,7 +75,7 @@ func TestUpdateEntry(t *testing.T) {
 	conn.ModifyRequestToExpect.Replace("cn", []string{"Blue", "Red"})
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldapClient}
@@ -112,7 +112,7 @@ func TestUpdatePasswordOpenLDAP(t *testing.T) {
 	conn.ModifyRequestToExpect.Replace("userPassword", []string{testPass})
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldapClient}
@@ -152,7 +152,7 @@ func TestUpdatePasswordRACF(t *testing.T) {
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldapClient}
@@ -195,7 +195,7 @@ func TestUpdatePasswordAD(t *testing.T) {
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldapClient}
@@ -245,7 +245,7 @@ func TestUpdateRootPassword(t *testing.T) {
 	conn.ModifyRequestToExpect.Replace("userPassword", []string{testPass})
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
-		LDAP:   &ldapifc.FakeLDAPClient{conn},
+		LDAP:   &ldapifc.FakeLDAPClient{ConnToReturn: conn},
 	}
 
 	client := &Client{ldapClient}

--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -6,7 +6,6 @@ package pki
 import (
 	"container/list"
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -238,8 +237,6 @@ func (ace *ACMEChallengeEngine) _run(b *backend, state *acmeState) error {
 		}
 		ace.ValidationLock.Unlock()
 	}
-
-	return errors.New("unexpectedly exited from ACMEChallengeEngine._run()")
 }
 
 func (ace *ACMEChallengeEngine) AcceptChallenge(sc *storageContext, account string, authz *ACMEAuthorization, challenge *ACMEChallenge, thumbprint string) error {

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -358,7 +358,7 @@ func (b *backend) metricsWrap(callType string, roleMode int, ofunc roleOperation
 			if role == nil && (roleMode == roleRequired || len(roleName) > 0) {
 				return logical.ErrorResponse(fmt.Sprintf("unknown role: %s", roleName)), nil
 			}
-			labels = []metrics.Label{{"role", roleName}}
+			labels = []metrics.Label{{Name: "role", Value: roleName}}
 		}
 
 		ns, err := namespace.FromContext(ctx)

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1714,7 +1714,7 @@ func TestACMEClientRequestLimits(t *testing.T) {
 		{
 			"validate-only-cn",
 			[]acme.AuthzID{
-				{"dns", "localhost"},
+				{Type: "dns", Value: "localhost"},
 			},
 			x509.CertificateRequest{
 				Subject: pkix.Name{CommonName: "localhost"},
@@ -1724,7 +1724,7 @@ func TestACMEClientRequestLimits(t *testing.T) {
 		{
 			"validate-only-san",
 			[]acme.AuthzID{
-				{"dns", "localhost"},
+				{Type: "dns", Value: "localhost"},
 			},
 			x509.CertificateRequest{
 				DNSNames: []string{"localhost"},
@@ -1734,7 +1734,7 @@ func TestACMEClientRequestLimits(t *testing.T) {
 		{
 			"validate-only-ip-address",
 			[]acme.AuthzID{
-				{"ip", "127.0.0.1"},
+				{Type: "ip", Value: "127.0.0.1"},
 			},
 			x509.CertificateRequest{
 				IPAddresses: []net.IP{{127, 0, 0, 1}},

--- a/builtin/logical/pki/path_config_acme_test.go
+++ b/builtin/logical/pki/path_config_acme_test.go
@@ -92,7 +92,8 @@ func TestAcmeConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		deadline := time.Now().Add(1 * time.Minute)
-		subTestCtx, _ := context.WithDeadline(testCtx, deadline)
+		subTestCtx, cancel := context.WithDeadline(testCtx, deadline)
+		defer cancel()
 
 		_, err := client.Logical().WriteWithContext(subTestCtx, "pki/roles/exists", roleConfig)
 		require.NoError(t, err)

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -1109,7 +1109,7 @@ func getDockerLog(t *testing.T) (func(s string), *pkiext.LogConsumerWriter, *pki
 		t.Log(s)
 	}
 
-	logStdout := &pkiext.LogConsumerWriter{logConsumer}
-	logStderr := &pkiext.LogConsumerWriter{logConsumer}
+	logStdout := &pkiext.LogConsumerWriter{Consumer: logConsumer}
+	logStderr := &pkiext.LogConsumerWriter{Consumer: logConsumer}
 	return logConsumer, logStdout, logStderr
 }

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -1073,7 +1073,8 @@ func testTransit_NoDeadlock_SignVerify(t *testing.T, keyType string, cachingDisa
 	// causing future read locks calls to also block until the write lock is
 	// able to succeed. Setting a timeout should let us return and fail the
 	// test (as the context should be cancelled).
-	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	_, err = client.Logical().ReadWithContext(ctx, "transit/keys/broken_transit_key")
 	require.NoError(t, err)
 }

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -361,7 +361,8 @@ func TestServerRun(t *testing.T) {
 				templatesToRender = append(templatesToRender, templateTest.template)
 			}
 
-			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
 			sc := ServerConfig{
 				Logger: logging.NewVaultLogger(hclog.Trace),
 				AgentConfig: &config.Config{

--- a/command/agentproxyshared/auth/auth_test.go
+++ b/command/agentproxyshared/auth/auth_test.go
@@ -75,6 +75,7 @@ func TestAuthHandler(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
 	ah := NewAuthHandler(&AuthHandlerConfig{
 		Logger: logger.Named("auth.handler"),

--- a/command/agentproxyshared/cache/listener.go
+++ b/command/agentproxyshared/cache/listener.go
@@ -44,7 +44,7 @@ func StartListener(lnConfig *configutil.Listener) (*ListenerBundle, error) {
 		if err != nil {
 			return nil, err
 		}
-		ln = &server.TCPKeepAliveListener{ln.(*net.TCPListener)}
+		ln = &server.TCPKeepAliveListener{TCPListener: ln.(*net.TCPListener)}
 
 	case "unix":
 		var uConfig *listenerutil.UnixSocketsConfig

--- a/command/auth_move.go
+++ b/command/auth_move.go
@@ -121,6 +121,4 @@ func (c *AuthMoveCommand) Run(args []string) int {
 		c.UI.Output(fmt.Sprintf("Waiting for terminal status in migration of auth method %s to %s, with migration ID %s", source, destination, remountResp.MigrationID))
 		time.Sleep(10 * time.Second)
 	}
-
-	return 0
 }

--- a/command/proxy/config/config.go
+++ b/command/proxy/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	AutoAuth                  *AutoAuth `hcl:"auto_auth"`
 	ExitAfterAuth             bool      `hcl:"exit_after_auth"`
 	Cache                     *Cache    `hcl:"cache"`
-	APIProxy                  *APIProxy `hcl:"api_proxy""`
+	APIProxy                  *APIProxy `hcl:"api_proxy"`
 	Vault                     *Vault    `hcl:"vault"`
 	DisableIdleConns          []string  `hcl:"disable_idle_connections"`
 	DisableIdleConnsAPIProxy  bool      `hcl:"-"`

--- a/command/secrets_move.go
+++ b/command/secrets_move.go
@@ -126,6 +126,4 @@ func (c *SecretsMoveCommand) Run(args []string) int {
 		c.UI.Output(fmt.Sprintf("Waiting for terminal status in migration of secrets engine %s to %s, with migration ID %s", source, destination, remountResp.MigrationID))
 		time.Sleep(10 * time.Second)
 	}
-
-	return 0
 }

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -121,7 +121,7 @@ func (j *JobManager) AddJob(job Job, queueID string) {
 	j.totalJobs++
 
 	if j.metricSink != nil {
-		j.metricSink.AddSampleWithLabels([]string{j.name, "job_manager", "queue_length"}, float32(j.queues[queueID].Len()), []metrics.Label{{"queue_id", queueID}})
+		j.metricSink.AddSampleWithLabels([]string{j.name, "job_manager", "queue_length"}, float32(j.queues[queueID].Len()), []metrics.Label{{Name: "queue_id", Value: queueID}})
 		j.metricSink.AddSample([]string{j.name, "job_manager", "total_jobs"}, float32(j.totalJobs))
 	}
 }
@@ -181,7 +181,7 @@ func (j *JobManager) getNextJob() (Job, string) {
 	j.totalJobs--
 
 	if j.metricSink != nil {
-		j.metricSink.AddSampleWithLabels([]string{j.name, "job_manager", "queue_length"}, float32(j.queues[queueID].Len()), []metrics.Label{{"queue_id", queueID}})
+		j.metricSink.AddSampleWithLabels([]string{j.name, "job_manager", "queue_length"}, float32(j.queues[queueID].Len()), []metrics.Label{{Name: "queue_id", Value: queueID}})
 		j.metricSink.AddSample([]string{j.name, "job_manager", "total_jobs"}, float32(j.totalJobs))
 	}
 

--- a/helper/metricsutil/gauge_process_test.go
+++ b/helper/metricsutil/gauge_process_test.go
@@ -111,7 +111,7 @@ func TestGauge_Creation(t *testing.T) {
 	sink.GaugeInterval = 33 * time.Minute
 
 	key := []string{"example", "count"}
-	labels := []Label{{"gauge", "test"}}
+	labels := []Label{{Name: "gauge", Value: "test"}}
 
 	p, err := sink.NewGaugeCollectionProcess(
 		key,
@@ -154,7 +154,7 @@ func TestGauge_StartDelay(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		c.EmptyCollectionFunction,
 		sink,
 		sink.GaugeInterval,
@@ -219,7 +219,7 @@ func TestGauge_StoppedDuringInitialDelay(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		c.EmptyCollectionFunction,
 		sink,
 		sink.GaugeInterval,
@@ -248,7 +248,7 @@ func TestGauge_StoppedAfterInitialDelay(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		c.EmptyCollectionFunction,
 		sink,
 		sink.GaugeInterval,
@@ -290,7 +290,7 @@ func TestGauge_Backoff(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		f,
 		sink,
 		sink.GaugeInterval,
@@ -319,7 +319,7 @@ func TestGauge_RestartTimer(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		c.EmptyCollectionFunction,
 		sink,
 		sink.GaugeInterval,
@@ -371,8 +371,8 @@ func makeLabels(numLabels int) []GaugeLabelValues {
 	values := make([]GaugeLabelValues, numLabels)
 	for i := range values {
 		values[i].Labels = []Label{
-			{"test", "true"},
-			{"which", fmt.Sprintf("%v", i)},
+			{Name: "test", Value: "true"},
+			{Name: "which", Value: fmt.Sprintf("%v", i)},
 		}
 		values[i].Value = float32(i + 1)
 	}
@@ -392,7 +392,7 @@ func TestGauge_InterruptedStreaming(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		nil, // shouldn't be called
 		sink,
 		sink.GaugeInterval,
@@ -470,7 +470,7 @@ func TestGauge_MaximumMeasurements(t *testing.T) {
 	advance := time.Duration(int(0.005 * float32(sink.GaugeInterval)))
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		c.makeFunctionForValues(values, s, advance),
 		sink,
 		sink.GaugeInterval,
@@ -538,8 +538,8 @@ func TestGauge_MeasurementError(t *testing.T) {
 	values := make([]GaugeLabelValues, numGauges)
 	for i := range values {
 		values[i].Labels = []Label{
-			{"test", "true"},
-			{"which", fmt.Sprintf("%v", i)},
+			{Name: "test", Value: "true"},
+			{Name: "which", Value: fmt.Sprintf("%v", i)},
 		}
 		values[i].Value = float32(i + 1)
 	}
@@ -552,7 +552,7 @@ func TestGauge_MeasurementError(t *testing.T) {
 
 	p, err := newGaugeCollectionProcessWithClock(
 		[]string{"example", "count"},
-		[]Label{{"gauge", "test"}},
+		[]Label{{Name: "gauge", Value: "test"}},
 		f,
 		sink,
 		sink.GaugeInterval,

--- a/helper/metricsutil/wrapped_metrics.go
+++ b/helper/metricsutil/wrapped_metrics.go
@@ -75,26 +75,26 @@ var _ Metrics = SinkWrapper{}
 type Label = metrics.Label
 
 func (m *ClusterMetricSink) SetGauge(key []string, val float32) {
-	m.Sink.SetGaugeWithLabels(key, val, []Label{{"cluster", m.ClusterName.Load().(string)}})
+	m.Sink.SetGaugeWithLabels(key, val, []Label{{Name: "cluster", Value: m.ClusterName.Load().(string)}})
 }
 
 func (m *ClusterMetricSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	m.Sink.SetGaugeWithLabels(key, val,
-		append(labels, Label{"cluster", m.ClusterName.Load().(string)}))
+		append(labels, Label{Name: "cluster", Value: m.ClusterName.Load().(string)}))
 }
 
 func (m *ClusterMetricSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	m.Sink.IncrCounterWithLabels(key, val,
-		append(labels, Label{"cluster", m.ClusterName.Load().(string)}))
+		append(labels, Label{Name: "cluster", Value: m.ClusterName.Load().(string)}))
 }
 
 func (m *ClusterMetricSink) AddSample(key []string, val float32) {
-	m.Sink.AddSampleWithLabels(key, val, []Label{{"cluster", m.ClusterName.Load().(string)}})
+	m.Sink.AddSampleWithLabels(key, val, []Label{{Name: "cluster", Value: m.ClusterName.Load().(string)}})
 }
 
 func (m *ClusterMetricSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
 	m.Sink.AddSampleWithLabels(key, val,
-		append(labels, Label{"cluster", m.ClusterName.Load().(string)}))
+		append(labels, Label{Name: "cluster", Value: m.ClusterName.Load().(string)}))
 }
 
 func (m *ClusterMetricSink) AddDurationWithLabels(key []string, d time.Duration, labels []Label) {
@@ -147,13 +147,13 @@ func (m *ClusterMetricSink) SetDefaultClusterName(clusterName string) {
 func NamespaceLabel(ns *namespace.Namespace) metrics.Label {
 	switch {
 	case ns == nil:
-		return metrics.Label{"namespace", "root"}
+		return metrics.Label{Name: "namespace", Value: "root"}
 	case ns.ID == namespace.RootNamespaceID:
-		return metrics.Label{"namespace", "root"}
+		return metrics.Label{Name: "namespace", Value: "root"}
 	default:
 		return metrics.Label{
-			"namespace",
-			strings.Trim(ns.Path, "/"),
+			Name:  "namespace",
+			Value: strings.Trim(ns.Path, "/"),
 		}
 	}
 }

--- a/helper/metricsutil/wrapped_metrics_test.go
+++ b/helper/metricsutil/wrapped_metrics_test.go
@@ -46,10 +46,10 @@ func TestClusterLabelPresent(t *testing.T) {
 	key1 := []string{"aaa", "bbb"}
 	key2 := []string{"ccc", "ddd"}
 	key3 := []string{"eee", "fff"}
-	labels1 := []Label{{"dim1", "val1"}}
-	labels2 := []Label{{"dim2", "val2"}}
-	labels3 := []Label{{"dim3", "val3"}}
-	clusterLabel := Label{"cluster", testClusterName}
+	labels1 := []Label{{Name: "dim1", Value: "val1"}}
+	labels2 := []Label{{Name: "dim2", Value: "val2"}}
+	labels3 := []Label{{Name: "dim3", Value: "val3"}}
+	clusterLabel := Label{Name: "cluster", Value: testClusterName}
 	expectedKey1 := "aaa.bbb;dim1=val1;cluster=" + testClusterName
 	expectedKey2 := "ccc.ddd;dim2=val2;cluster=" + testClusterName
 	expectedKey3 := "eee.fff;dim3=val3;cluster=" + testClusterName

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -661,7 +661,7 @@ func (b *RaftBackend) CollectMetrics(sink *metricsutil.ClusterMetricSink) {
 
 func (b *RaftBackend) collectMetricsWithStats(stats bolt.Stats, sink *metricsutil.ClusterMetricSink, database string) {
 	txstats := stats.TxStats
-	labels := []metricsutil.Label{{"database", database}}
+	labels := []metricsutil.Label{{Name: "database", Value: database}}
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "freelist", "free_pages"}, float32(stats.FreePageN), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "freelist", "pending_pages"}, float32(stats.PendingPageN), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "freelist", "allocated_bytes"}, float32(stats.FreeAlloc), labels)

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -203,7 +203,7 @@ func RespondErrorAndData(w http.ResponseWriter, status int, data interface{}, er
 
 	type ErrorAndDataResponse struct {
 		Errors []string    `json:"errors"`
-		Data   interface{} `json:"data""`
+		Data   interface{} `json:"data"`
 	}
 	resp := &ErrorAndDataResponse{Errors: make([]string, 0, 1)}
 	if err != nil {

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -181,49 +181,49 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 	}{
 		{
 			[]string{"token", "count"},
-			[]metrics.Label{{"gauge", "token_by_namespace"}},
+			[]metrics.Label{{Name: "gauge", Value: "token_by_namespace"}},
 			c.tokenGaugeCollector,
 			"",
 		},
 		{
 			[]string{"token", "count", "by_policy"},
-			[]metrics.Label{{"gauge", "token_by_policy"}},
+			[]metrics.Label{{Name: "gauge", Value: "token_by_policy"}},
 			c.tokenGaugePolicyCollector,
 			"",
 		},
 		{
 			[]string{"expire", "leases", "by_expiration"},
-			[]metrics.Label{{"gauge", "leases_by_expiration"}},
+			[]metrics.Label{{Name: "gauge", Value: "leases_by_expiration"}},
 			c.leaseExpiryGaugeCollector,
 			"",
 		},
 		{
 			[]string{"token", "count", "by_auth"},
-			[]metrics.Label{{"gauge", "token_by_auth"}},
+			[]metrics.Label{{Name: "gauge", Value: "token_by_auth"}},
 			c.tokenGaugeMethodCollector,
 			"",
 		},
 		{
 			[]string{"token", "count", "by_ttl"},
-			[]metrics.Label{{"gauge", "token_by_ttl"}},
+			[]metrics.Label{{Name: "gauge", Value: "token_by_ttl"}},
 			c.tokenGaugeTtlCollector,
 			"",
 		},
 		{
 			[]string{"secret", "kv", "count"},
-			[]metrics.Label{{"gauge", "kv_secrets_by_mountpoint"}},
+			[]metrics.Label{{Name: "gauge", Value: "kv_secrets_by_mountpoint"}},
 			c.kvSecretGaugeCollector,
 			"BAO_DISABLE_KV_GAUGE",
 		},
 		{
 			[]string{"identity", "entity", "count"},
-			[]metrics.Label{{"gauge", "identity_by_namespace"}},
+			[]metrics.Label{{Name: "gauge", Value: "identity_by_namespace"}},
 			c.entityGaugeCollector,
 			"",
 		},
 		{
 			[]string{"identity", "entity", "alias", "count"},
-			[]metrics.Label{{"gauge", "identity_by_mountpoint"}},
+			[]metrics.Label{{Name: "gauge", Value: "identity_by_mountpoint"}},
 			c.entityGaugeCollectorByMount,
 			"",
 		},
@@ -302,7 +302,7 @@ func (c *Core) kvCollectionErrorCount() {
 	c.MetricSink().IncrCounterWithLabels(
 		[]string{"metrics", "collection", "error"},
 		1,
-		[]metrics.Label{{"gauge", "kv_secrets_by_mountpoint"}},
+		[]metrics.Label{{Name: "gauge", Value: "kv_secrets_by_mountpoint"}},
 	)
 }
 
@@ -389,7 +389,7 @@ func (c *Core) kvSecretGaugeCollector(ctx context.Context) ([]metricsutil.GaugeL
 
 		results[i].Labels = []metrics.Label{
 			metricsutil.NamespaceLabel(m.Namespace),
-			{"mount_point", m.MountPoint},
+			{Name: "mount_point", Value: m.MountPoint},
 		}
 
 		c.walkKvMountSecrets(ctx, m)
@@ -459,8 +459,8 @@ func (c *Core) entityGaugeCollectorByMount(ctx context.Context) ([]metricsutil.G
 		values = append(values, metricsutil.GaugeLabelValues{
 			Labels: []metrics.Label{
 				metricsutil.NamespaceLabel(mountEntry.namespace),
-				{"auth_method", mountEntry.Type},
-				{"mount_point", "auth/" + mountEntry.Path},
+				{Name: "auth_method", Value: mountEntry.Type},
+				{Name: "mount_point", Value: "auth/" + mountEntry.Path},
 			},
 			Value: float32(count),
 		})

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -970,7 +970,8 @@ func (m *ExpirationManager) attemptIrrevocableLeasesRevoke() {
 			}
 
 			ctxWithNS := namespace.ContextWithNamespace(m.core.activeContext, leaseNS)
-			ctxWithNSAndTimeout, _ := context.WithTimeout(ctxWithNS, time.Minute)
+			ctxWithNSAndTimeout, cancel := context.WithTimeout(ctxWithNS, time.Minute)
+			defer cancel()
 			if err := m.revokeCommon(ctxWithNSAndTimeout, leaseID, false, false); err != nil {
 				// on failure, force some delay to mitigate resource spike while
 				// this is running. if revocations succeed, we are okay with

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2404,13 +2404,13 @@ func (m *ExpirationManager) leaseAggregationMetrics(ctx context.Context, consts 
 		if nsLabel {
 			flattenedResults = append(flattenedResults,
 				metricsutil.GaugeLabelValues{
-					Labels: []metrics.Label{{"expiring", bucket.LabelName}, {"namespace", bucket.LabelNS}},
+					Labels: []metrics.Label{{Name: "expiring", Value: bucket.LabelName}, {Name: "namespace", Value: bucket.LabelNS}},
 					Value:  float32(count),
 				})
 		} else {
 			flattenedResults = append(flattenedResults,
 				metricsutil.GaugeLabelValues{
-					Labels: []metrics.Label{{"expiring", bucket.LabelName}},
+					Labels: []metrics.Label{{Name: "expiring", Value: bucket.LabelName}},
 					Value:  float32(count),
 				})
 		}

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -162,10 +162,10 @@ func TestExpiration_Metrics(t *testing.T) {
 		t.Fatal("lease aggregation returns nil metrics")
 	}
 
-	labelOneHour := metrics.Label{"expiring", time.Now().Add(time.Hour).Round(time.Hour).String()}
-	labelTwoHours := metrics.Label{"expiring", time.Now().Add(2 * time.Hour).Round(time.Hour).String()}
-	nsLabel := metrics.Label{"namespace", "root"}
-	nsLabelNonRoot := metrics.Label{"namespace", "nsid"}
+	labelOneHour := metrics.Label{Name: "expiring", Value: time.Now().Add(time.Hour).Round(time.Hour).String()}
+	labelTwoHours := metrics.Label{Name: "expiring", Value: time.Now().Add(2 * time.Hour).Round(time.Hour).String()}
+	nsLabel := metrics.Label{Name: "namespace", Value: "root"}
+	nsLabelNonRoot := metrics.Label{Name: "namespace", Value: "nsid"}
 
 	foundLabelOne := false
 	foundLabelTwo := false

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -1288,8 +1288,8 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 			1,
 			[]metrics.Label{
 				metricsutil.NamespaceLabel(ns),
-				{"auth_method", newAlias.MountType},
-				{"mount_point", newAlias.MountPath},
+				{Name: "auth_method", Value: newAlias.MountType},
+				{Name: "mount_point", Value: newAlias.MountPath},
 			})
 		entityCreated = true
 	}

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -695,6 +695,11 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool) framework.Ope
 			}()
 
 			ctx, ctxCancel := context.WithCancel(namespace.RootContext(nil))
+			defer func() {
+				if retErr != nil {
+					ctxCancel()
+				}
+			}()
 
 			// We are calling the callback function synchronously here while we
 			// have the lock. So set it to nil and restore the callback when we

--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -304,7 +304,7 @@ func (rlq *RateLimitQuota) allow(ctx context.Context, req *Request) (Response, e
 	defer func() {
 		if !resp.Allowed {
 			resp.Headers[httplimit.HeaderRetryAfter] = retryAfter
-			rlq.metricSink.IncrCounterWithLabels([]string{"quota", "rate_limit", "violation"}, 1, []metrics.Label{{"name", rlq.Name}})
+			rlq.metricSink.IncrCounterWithLabels([]string{"quota", "rate_limit", "violation"}, 1, []metrics.Label{{Name: "name", Value: rlq.Name}})
 		}
 	}()
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1142,9 +1142,9 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 				1,
 				[]metrics.Label{
 					metricsutil.NamespaceLabel(ns),
-					{"secret_engine", req.MountType},
-					{"mount_point", mountPointWithoutNs},
-					{"creation_ttl", ttl_label},
+					{Name: "secret_engine", Value: req.MountType},
+					{Name: "mount_point", Value: mountPointWithoutNs},
+					{Name: "creation_ttl", Value: ttl_label},
 				},
 			)
 		}
@@ -1708,10 +1708,10 @@ func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, re
 		1,
 		[]metrics.Label{
 			metricsutil.NamespaceLabel(ns),
-			{"auth_method", mountEntry.Type},
-			{"mount_point", mountPointWithoutNs},
-			{"creation_ttl", ttl_label},
-			{"token_type", auth.TokenType.String()},
+			{Name: "auth_method", Value: mountEntry.Type},
+			{Name: "mount_point", Value: mountPointWithoutNs},
+			{Name: "creation_ttl", Value: ttl_label},
+			{Name: "token_type", Value: auth.TokenType.String()},
 		},
 	)
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3174,10 +3174,10 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 		1,
 		[]metrics.Label{
 			metricsutil.NamespaceLabel(ns),
-			{"auth_method", "token"},
-			{"mount_point", mountPointWithoutNs}, // path, not accessor
-			{"creation_ttl", ttl_label},
-			{"token_type", tokenType.String()},
+			{Name: "auth_method", Value: "token"},
+			{Name: "mount_point", Value: mountPointWithoutNs}, // path, not accessor
+			{Name: "creation_ttl", Value: ttl_label},
+			{Name: "token_type", Value: tokenType.String()},
 		},
 	)
 
@@ -3985,7 +3985,7 @@ func (ts *TokenStore) gaugeCollectorByPolicy(ctx context.Context) ([]metricsutil
 				metricsutil.GaugeLabelValues{
 					Labels: []metrics.Label{
 						metricsutil.NamespaceLabel(ns),
-						{"policy", policy},
+						{Name: "policy", Value: policy},
 					},
 					Value: float32(count),
 				})
@@ -4052,7 +4052,7 @@ func (ts *TokenStore) gaugeCollectorByTtl(ctx context.Context) ([]metricsutil.Ga
 				metricsutil.GaugeLabelValues{
 					Labels: []metrics.Label{
 						metricsutil.NamespaceLabel(ns),
-						{"creation_ttl", bucket},
+						{Name: "creation_ttl", Value: bucket},
 					},
 					Value: float32(count),
 				})
@@ -4151,7 +4151,7 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 				metricsutil.GaugeLabelValues{
 					Labels: []metrics.Label{
 						metricsutil.NamespaceLabel(ns),
-						{"auth_method", method},
+						{Name: "auth_method", Value: method},
 					},
 					Value: float32(count),
 				})

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -156,11 +156,11 @@ DONELISTHANDLING:
 			// The type of the secret engine is not all that useful;
 			// we could use "token" but let's be more descriptive,
 			// even if it's not a real auth method.
-			{"auth_method", "response_wrapping"},
-			{"mount_point", mountPointWithoutNs},
-			{"creation_ttl", ttl_label},
+			{Name: "auth_method", Value: "response_wrapping"},
+			{Name: "mount_point", Value: mountPointWithoutNs},
+			{Name: "creation_ttl", Value: ttl_label},
 			// *Should* be service, but let's use whatever create() did..
-			{"token_type", te.Type.String()},
+			{Name: "token_type", Value: te.Type.String()},
 		},
 	)
 


### PR DESCRIPTION
Fixes:
- unreachable code
- ctxCancel function is not used on all paths (possible context leak)
- malformed struct field tag
- struct literal uses unkeyes fields
- discarded ctx cancel functions

There are still a lot of warnings left after this that might need some closer look:
- calling (*testing.T).Fatal from non-test goroutine
- copying lock values (at least most of these should be ok, the lock is recreated after the copy)