### PR TITLE
Fix marshaling and setting nil request body

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -329,7 +329,7 @@ func (c *Logical) WriteWithContext(ctx context.Context, path string, data map[st
 		return nil, err
 	}
 
-	return c.write(ctx, path, r)
+	return c.write(ctx, r)
 }
 
 func (c *Logical) JSONMergePatch(ctx context.Context, path string, data map[string]interface{}) (*Secret, error) {
@@ -339,7 +339,7 @@ func (c *Logical) JSONMergePatch(ctx context.Context, path string, data map[stri
 		return nil, err
 	}
 
-	return c.write(ctx, path, r)
+	return c.write(ctx, r)
 }
 
 func (c *Logical) WriteBytes(path string, data []byte) (*Secret, error) {
@@ -350,10 +350,10 @@ func (c *Logical) WriteBytesWithContext(ctx context.Context, path string, data [
 	r := c.c.NewRequest(http.MethodPut, "/v1/"+path)
 	r.BodyBytes = data
 
-	return c.write(ctx, path, r)
+	return c.write(ctx, r)
 }
 
-func (c *Logical) write(ctx context.Context, path string, request *Request) (*Secret, error) {
+func (c *Logical) write(ctx context.Context, request *Request) (*Secret, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 

--- a/api/request.go
+++ b/api/request.go
@@ -42,6 +42,10 @@ type Request struct {
 
 // SetJSONBody is used to set a request body that is a JSON-encoded value.
 func (r *Request) SetJSONBody(val interface{}) error {
+	if val == nil {
+		return nil
+	}
+
 	buf, err := json.Marshal(val)
 	if err != nil {
 		return err

--- a/changelog/1315.txt
+++ b/changelog/1315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Stop marshaling nil interface data and adding it as a request body on an api.Request
+```


### PR DESCRIPTION
Caused by discussion on https://github.com/openbao/openbao/pull/1300#discussion_r2084843533

## Issue:
whenever there's explicit `nil` data provided to either `WriteWithContext` or `JSONMergePatch`, `(*request).setJSONBody` would marshal and set the marshaled data as a request body. This introduces a bug in a `output-curl-string` flag usage, as it creates invalid requests with a body of `-d 'null'`

## Fix:
Check for `nil` data in `SetJSONBody` method and return immediately from function if it's encountered.

In the PR also included removal of unused function parameter `path` in `(*Logical).write` method.