### PR TITLE
Prevent information disclosure on invalid request

### DIFF
--- a/changelog/1323.txt
+++ b/changelog/1323.txt
@@ -1,0 +1,3 @@
+```release-note:security
+sdk/framework: prevent information disclosure on invalid request. HCSEC-2025-09 / CVE-2025-4166.
+```

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/mapstructure"
@@ -34,7 +33,7 @@ type FieldData struct {
 // trying to get data out.  Data not in the schema is not
 // an error at this point, so we don't worry about it.
 func (d *FieldData) Validate() error {
-	for field, value := range d.Raw {
+	for field := range d.Raw {
 
 		schema, ok := d.Schema[field]
 		if !ok {
@@ -47,7 +46,7 @@ func (d *FieldData) Validate() error {
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
-				return errwrap.Wrapf(fmt.Sprintf("error converting input %v for field %q: {{err}}", value, field), err)
+				return fmt.Errorf("error converting input for field %q: %w", field, err)
 			}
 		default:
 			return fmt.Errorf("unknown field type %q for field %q", schema.Type, field)

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1271,6 +1272,15 @@ func TestValidateStrict(t *testing.T) {
 			}
 			if err != nil && tc.ExpectError == false {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil {
+				for _, valueRaw := range tc.Raw {
+					if value, ok := valueRaw.(string); ok {
+						if strings.Contains(err.Error(), value) {
+							t.Fatalf("error contained value: value=%v / err=%v", value, err)
+						}
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
When sending an API request with incorrect typing of request data, OpenBao (and HashiCorp Vault) would leak information in service and audit logs. The original disclosure from HashiCorp states this is limited to KVv2, but this is applicable to any secrets engine.

See also: https://discuss.hashicorp.com/t/hcsec-2025-09-vault-may-expose-sensitive-information-in-error-logs-when-processing-malformed-data-with-the-kv-v2-plugin/74717