### PR TITLE
Allow building with HSM support on MacOS

### DIFF
--- a/internalshared/configutil/no_pkcs11.go
+++ b/internalshared/configutil/no_pkcs11.go
@@ -1,4 +1,4 @@
-//go:build !hsm || !linux
+//go:build !hsm || !(linux || darwin)
 
 package configutil
 

--- a/internalshared/configutil/pkcs11.go
+++ b/internalshared/configutil/pkcs11.go
@@ -1,4 +1,4 @@
-//go:build hsm && linux
+//go:build hsm && (linux || darwin)
 
 package configutil
 


### PR DESCRIPTION
Mainly for development convenience as HSM auto-unseal works fine on MacOS with the latest SoftHSM.
