### PR TITLE
Fix description of OU field in UI

### DIFF
--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -156,8 +156,7 @@ export default class PkiActionModel extends Model {
 
   @attr('string', {
     label: 'Organizational Units (OU)',
-    subText:
-      'A list of allowed serial numbers to be requested during certificate issuance. Shell-style globbing is supported. If empty, custom-specified serial numbers will be forbidden.',
+    subText: 'List of organizational units (parts of an organization) that must appear on the certificate.',
     editType: 'stringArray',
   })
   ou;

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -270,8 +270,7 @@ export default class PkiRoleModel extends Model {
 
   @attr({
     label: 'Organization Units (OU)',
-    subText:
-      'A list of allowed serial numbers to be requested during certificate issuance. Shell-style globbing is supported. If empty, custom-specified serial numbers will be forbidden.',
+    subText: 'List of organizational units (parts of an organization) that must appear on the certificate.',
     editType: 'stringArray',
   })
   ou;


### PR DESCRIPTION
This duplicated the serial number (certificate subject) field, which is incorrect.

Resolves: #1327