### PR TITLE
MFA Login namespace adjustments

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -3361,9 +3361,7 @@ func (c *Core) runLockedUserEntryUpdates(ctx context.Context) error {
 		// else check if the userFailedLoginInfo map has correct failed login information
 		// if incorrect, update the entry in userFailedLoginInfo map
 		for _, mountAccessorPath := range mountAccessors {
-			// lockedAliasesCount, err := c.runLockedUserEntryUpdatesForMountAccessor(ctx, mountAccessor, view.Prefix()+mountAccessorPath)
-			view = view.SubView(mountAccessorPath)
-			lockedAliasesCount, err := c.runLockedUserEntryUpdatesForMountAccessor(ctx, view, mountAccessorPath)
+			lockedAliasesCount, err := c.runLockedUserEntryUpdatesForMountAccessor(ctx, view.SubView(mountAccessorPath), mountAccessorPath)
 			if err != nil {
 				return err
 			}

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -415,7 +415,11 @@ func (c *Core) entityGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLab
 
 	// No check for expiration here; the bulk of the work should be in
 	// counting the entities.
-	allNamespaces := c.collectNamespaces()
+	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return []metricsutil.GaugeLabelValues{}, err
+	}
+
 	values := make([]metricsutil.GaugeLabelValues, len(allNamespaces))
 	for i := range values {
 		values[i].Labels = []metrics.Label{

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -5,9 +5,7 @@ package vault
 
 import (
 	"context"
-	"errors"
 
-	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/physical"
 )
 
@@ -27,14 +25,6 @@ func coreInit(c *Core, conf *CoreConfig) error {
 	return nil
 }
 
-func (c *Core) barrierViewForNamespace(namespaceId string) (BarrierView, error) {
-	if namespaceId != namespace.RootNamespaceID {
-		return nil, errors.New("failed to find barrier view for non-root namespace")
-	}
-
-	return c.systemBarrierView, nil
-}
-
 func preSealPhysical(c *Core) {
 	// Purge the cache
 	c.physicalCache.SetEnabled(false)
@@ -43,10 +33,4 @@ func preSealPhysical(c *Core) {
 
 func postUnsealPhysical(c *Core) error {
 	return nil
-}
-
-func (c *Core) collectNamespaces() []*namespace.Namespace {
-	return []*namespace.Namespace{
-		namespace.RootNamespace,
-	}
 }

--- a/vault/counters.go
+++ b/vault/counters.go
@@ -30,12 +30,15 @@ type TokenCounter struct {
 // countActiveTokens returns the number of active tokens
 func (c *Core) countActiveTokens(ctx context.Context) (*ActiveTokens, error) {
 	// Get all of the namespaces
-	ns := c.collectNamespaces()
+	allNamespaces, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return nil, err
+	}
 
 	// Count the tokens under each namespace
 	total := 0
-	for i := range ns {
-		ids, err := c.tokenStore.idView(ns[i]).List(ctx, "")
+	for _, ns := range allNamespaces {
+		ids, err := c.tokenStore.idView(ns).List(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
 type LockedUsersResponse struct {
@@ -141,7 +142,7 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 
 // getMountAccessorsLockedUsers returns the locked users for all the mountAccessors
 // of locked users for a namespace. Result is sorted in the desc order of locked users.
-func (b *SystemBackend) getMountAccessorsLockedUsers(ctx context.Context, view BarrierView, mountAccessors ...string) (int, []*ResponseMountAccessors, error) {
+func (b *SystemBackend) getMountAccessorsLockedUsers(ctx context.Context, view logical.Storage, mountAccessors ...string) (int, []*ResponseMountAccessors, error) {
 	byMountAccessorsResponse := make([]*ResponseMountAccessors, 0)
 	totalCountForMountAccessors := 0
 

--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -26,18 +25,17 @@ type ResponseMountAccessors struct {
 }
 
 // unlockUser deletes the entry for locked user from storage and userFailedLoginInfo map
-func unlockUser(ctx context.Context, core *Core, mountAccessor string, aliasName string) error {
+func unlockUser(ctx context.Context, core *Core, mountAccessor, aliasName string) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	lockedUserStoragePath := coreLockedUsersPath + ns.ID + "/" + mountAccessor + "/" + aliasName
-
 	// remove entry for locked user from storage
 	// if read only error, the error is handled by handleError in logical_system.go
 	// this will be forwarded to the active node
-	if err := core.barrier.Delete(ctx, lockedUserStoragePath); err != nil {
+	view := NamespaceView(core.barrier, ns).SubView(coreLockedUsersPath).SubView(mountAccessor + "/")
+	if err := view.Delete(ctx, aliasName); err != nil {
 		return err
 	}
 
@@ -54,8 +52,8 @@ func unlockUser(ctx context.Context, core *Core, mountAccessor string, aliasName
 	return nil
 }
 
-// handleLockedUsersQuery reports the locked user metrics by namespace in the decreasing order
-// of locked users
+// handleLockedUsersQuery reports the locked user metrics
+// by namespace in the decreasing order of locked users
 func (b *SystemBackend) handleLockedUsersQuery(ctx context.Context, mountAccessor string) (map[string]interface{}, error) {
 	// Calculate the namespace response breakdowns of locked users for query namespace and child namespaces (if needed)
 	totalCount, byNamespaceResponse, err := b.getLockedUsersResponses(ctx, mountAccessor)
@@ -70,10 +68,9 @@ func (b *SystemBackend) handleLockedUsersQuery(ctx context.Context, mountAccesso
 	return responseData, nil
 }
 
-// getLockedUsersResponses returns the locked users
-// for a particular mount_accessor if provided in request
-// else returns it for the current namespace and all the child namespaces that has locked users
-// they are sorted in the decreasing order of locked users count
+// getLockedUsersResponses returns the locked users for a particular mount_accessor
+// if provided in request otherwise returns locked users for the current namespace
+// and all the child namespaces, entries are sorted in the decreasing count order
 func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccessor string) (int, []*LockedUsersResponse, error) {
 	lockedUsersResponse := make([]*LockedUsersResponse, 0)
 	totalCounts := 0
@@ -84,18 +81,19 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 	}
 
 	if mountAccessor != "" {
-		// get the locked user response for mount_accessor, here for mount_accessor in request
-		totalCountForNSID, mountAccessorsResponse, err := b.getMountAccessorsLockedUsers(ctx, []string{mountAccessor + "/"},
-			coreLockedUsersPath+queryNS.ID+"/")
+		// get the locked user response for mount_accessor provided with request
+		view := NamespaceView(b.Core.barrier, queryNS).SubView(coreLockedUsersPath)
+		totalCountForNS, mountAccessorsResponse, err := b.getMountAccessorsLockedUsers(ctx,
+			view, mountAccessor+"/")
 		if err != nil {
 			return 0, nil, err
 		}
 
-		totalCounts += totalCountForNSID
+		totalCounts += totalCountForNS
 		lockedUsersResponse = append(lockedUsersResponse, &LockedUsersResponse{
 			NamespaceID:    queryNS.ID,
 			NamespacePath:  queryNS.Path,
-			Counts:         totalCountForNSID,
+			Counts:         totalCountForNS,
 			MountAccessors: mountAccessorsResponse,
 		})
 		return totalCounts, lockedUsersResponse, nil
@@ -103,50 +101,34 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 
 	// no mount_accessor is provided in request, get information for current namespace and its child namespaces
 
-	// get all the namespaces of locked users
-	nsIDs, err := b.Core.barrier.List(ctx, coreLockedUsersPath)
+	// get all the namespaces
+	nsList, err := b.Core.namespaceStore.ListNamespaces(ctx, true, true)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	// identify if the namespaces must be included in response and get counts
-	for _, nsID := range nsIDs {
-		nsID = strings.TrimSuffix(nsID, "/")
-		ns, err := b.Core.NamespaceByID(ctx, nsID)
+	for _, ns := range nsList {
+		// get mount accessors of locked users for this namespace
+		view := NamespaceView(b.Core.barrier, ns).SubView(coreLockedUsersPath)
+		mountAccessors, err := view.List(ctx, "")
 		if err != nil {
 			return 0, nil, err
 		}
 
-		if b.includeNSInLockedUsersResponse(queryNS, ns) {
-			var displayPath string
-			if ns == nil {
-				// deleted namespace
-				displayPath = fmt.Sprintf("deleted namespace %q", nsID)
-			} else {
-				displayPath = ns.Path
-			}
-
-			// get mount accessors of locked users for this namespace
-			mountAccessors, err := b.Core.barrier.List(ctx, coreLockedUsersPath+nsID+"/")
-			if err != nil {
-				return 0, nil, err
-			}
-
-			// get the locked user response for mount_accessor list
-			totalCountForNSID, mountAccessorsResponse, err := b.getMountAccessorsLockedUsers(ctx, mountAccessors, coreLockedUsersPath+nsID+"/")
-			if err != nil {
-				return 0, nil, err
-			}
-
-			totalCounts += totalCountForNSID
-			lockedUsersResponse = append(lockedUsersResponse, &LockedUsersResponse{
-				NamespaceID:    strings.TrimSuffix(nsID, "/"),
-				NamespacePath:  displayPath,
-				Counts:         totalCountForNSID,
-				MountAccessors: mountAccessorsResponse,
-			})
-
+		// get the locked user response for mount_accessor list
+		totalCountForNS, mountAccessorsResponse, err := b.getMountAccessorsLockedUsers(ctx, view, mountAccessors...)
+		if err != nil {
+			return 0, nil, err
 		}
+
+		totalCounts += totalCountForNS
+		lockedUsersResponse = append(lockedUsersResponse, &LockedUsersResponse{
+			NamespaceID:    ns.ID,
+			NamespacePath:  ns.Path,
+			Counts:         totalCountForNS,
+			MountAccessors: mountAccessorsResponse,
+		})
+
 	}
 
 	// sort namespaces in response by decreasing order of counts
@@ -157,16 +139,15 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 	return totalCounts, lockedUsersResponse, nil
 }
 
-// getMountAccessorsLockedUsers returns the locked users for all the mount_accessors of locked users for a namespace
-// they are sorted in the decreasing order of locked users
-// returns the total locked users for the namespace and  locked users response for every mount_accessor for a namespace that has locked users
-func (b *SystemBackend) getMountAccessorsLockedUsers(ctx context.Context, mountAccessors []string, lockedUsersPath string) (int, []*ResponseMountAccessors, error) {
+// getMountAccessorsLockedUsers returns the locked users for all the mountAccessors
+// of locked users for a namespace. Result is sorted in the desc order of locked users.
+func (b *SystemBackend) getMountAccessorsLockedUsers(ctx context.Context, view BarrierView, mountAccessors ...string) (int, []*ResponseMountAccessors, error) {
 	byMountAccessorsResponse := make([]*ResponseMountAccessors, 0)
 	totalCountForMountAccessors := 0
 
 	for _, mountAccessor := range mountAccessors {
 		// get the list of aliases of locked users for a mount accessor
-		aliasIdentifiers, err := b.Core.barrier.List(ctx, lockedUsersPath+mountAccessor)
+		aliasIdentifiers, err := view.List(ctx, mountAccessor)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -186,15 +167,4 @@ func (b *SystemBackend) getMountAccessorsLockedUsers(ctx context.Context, mountA
 	})
 
 	return totalCountForMountAccessors, byMountAccessorsResponse, nil
-}
-
-// includeNSInLockedUsersResponse checks if the namespace is the child namespace of namespace in query
-// if child namespace, it can be included in response
-// locked users from deleted namespaces are listed under root namespace
-func (b *SystemBackend) includeNSInLockedUsersResponse(query *namespace.Namespace, record *namespace.Namespace) bool {
-	if record == nil {
-		// Deleted namespace, only include in root queries
-		return query.ID == namespace.RootNamespaceID
-	}
-	return record.HasParent(query)
 }

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -511,6 +511,7 @@ func (i *IdentityStore) handleLoginMFAGenerateCommon(ctx context.Context, req *l
 	}
 }
 
+// handleLoginMFAAdminDestroyUpdate does not remove the totp secret key from the storage
 func (i *IdentityStore) handleLoginMFAAdminDestroyUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	var entity *identity.Entity
 	var err error
@@ -590,7 +591,7 @@ func (i *IdentityStore) handleLoginMFAAdminDestroyUpdate(ctx context.Context, re
 func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespace.Namespace) error {
 	b.mfaLogger.Trace("loading login MFA configurations")
 	barrierView := NamespaceView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(loginMFAConfigPrefix)
-	existing, err := barrierView.List(ctx, loginMFAConfigPrefix)
+	existing, err := barrierView.List(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to list MFA configurations for namespace %s and prefix %s: %w", ns.Path, loginMFAConfigPrefix, err)
 	}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -738,7 +738,6 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 
 	// Now grab write lock so that we can write to storage.
 	ns.lock.Lock()
-	defer ns.lock.Unlock()
 
 	err = ns.namespacesByPath.Delete(namespaceToDelete.Path)
 	if err != nil {
@@ -760,6 +759,14 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 	})
 	if err != nil {
 		ns.logger.Error("failed to delete namespace storage", "namespace", namespaceToDelete.Path, "error", err.Error())
+	}
+
+	ns.lock.Unlock()
+
+	// clear locked users entries
+	_, err = ns.core.runLockedUserEntryUpdatesForNamespace(ctx, namespaceToDelete)
+	if err != nil {
+		ns.logger.Error("failed to clean up locked user entries", "namespace", namespaceToDelete.Path, "error", err.Error())
 	}
 
 	return

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -2115,7 +2115,7 @@ func (c *Core) LocalUpdateUserFailedLoginInfo(ctx context.Context, userKey Faile
 		}
 
 		// Write to the physical backend
-		view := NamespaceView(c.barrier, mountEntry.namespace).SubView(userKey.mountAccessor + "/")
+		view := NamespaceView(c.barrier, mountEntry.namespace).SubView(coreLockedUsersPath).SubView(userKey.mountAccessor + "/")
 		if err := view.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist failed login user entry", "namespace", mountEntry.namespace.Path, "error", err)
 			return err

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3886,7 +3886,11 @@ func (ts *TokenStore) gaugeCollector(ctx context.Context) ([]metricsutil.GaugeLa
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces := ts.core.collectNamespaces()
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return []metricsutil.GaugeLabelValues{}, err
+	}
+
 	values := make([]metricsutil.GaugeLabelValues, len(allNamespaces))
 	namespacePosition := make(map[string]int)
 
@@ -3899,7 +3903,7 @@ func (ts *TokenStore) gaugeCollector(ctx context.Context) ([]metricsutil.GaugeLa
 		namespacePosition[ns.ID] = i
 	}
 
-	err := ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
+	err = ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
 		select {
 		// Abort and return empty collection if it's taking too much time, nonblocking check.
 		case <-ctx.Done():
@@ -3941,10 +3945,14 @@ func (ts *TokenStore) gaugeCollectorByPolicy(ctx context.Context) ([]metricsutil
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces := ts.core.collectNamespaces()
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return []metricsutil.GaugeLabelValues{}, err
+	}
+
 	byNsAndPolicy := make(map[string]map[string]int)
 
-	err := ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
+	err = ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
 		select {
 		// Abort and return empty collection if it's taking too much time, nonblocking check.
 		case <-ctx.Done():
@@ -3999,10 +4007,14 @@ func (ts *TokenStore) gaugeCollectorByTtl(ctx context.Context) ([]metricsutil.Ga
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces := ts.core.collectNamespaces()
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return []metricsutil.GaugeLabelValues{}, err
+	}
+
 	byNsAndBucket := make(map[string]map[string]int)
 
-	err := ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
+	err = ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
 		select {
 		// Abort and return empty collection if it's taking too much time, nonblocking check.
 		case <-ctx.Done():
@@ -4067,7 +4079,11 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 	}
 
 	rootContext := namespace.RootContext(ctx)
-	allNamespaces := ts.core.collectNamespaces()
+	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true)
+	if err != nil {
+		return []metricsutil.GaugeLabelValues{}, err
+	}
+
 	byNsAndMethod := make(map[string]map[string]int)
 
 	// Cache the prefixes that we find locally rather than
@@ -4111,7 +4127,7 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 		return mountEntry.Type
 	}
 
-	err := ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
+	err = ts.expiration.WalkTokens(func(leaseID string, auth *logical.Auth, path string) bool {
 		select {
 		// Abort and return empty collection if it's taking too much time, nonblocking check.
 		case <-ctx.Done():


### PR DESCRIPTION
Resolves comment raised here https://github.com/openbao/openbao/pull/1165#discussion_r2082603412

- Removes `barrierViewForNamespace` and `collectNamespaces` from `core_util.go`, replacing it's usage with `NamespaceView` and `List(All)Namespaces` respectively
- Adjusts `LockedUsers` feature storage location, moving it from root's `core/login/locked-users/<ns-id>/<mount-accessor>/<aliasName>` to `(namespaces/<ns_uuid>)/core/login/locked-users/<mount-accessor>/<aliasName>`
- Adjusts the storage considerations of MFA configs and MFA login-enforcements and TOTP keys
- Moves the `teardownLoginMFA()` before `teardownNamespaceStore()` in `PreSeal()`
- Simplifies `getLockedUsersResponses` as with namespace deletion the storage containing locked users entries also gets deleted we no longer have to verify it with `includeNSInLockedUsersResponse` checking for deleted namespace entries (doc [link](https://openbao.org/api-docs/system/user-lockout/#list-locked-users))


1. Storing and reading the example MFA config:
```
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"issuer": "openbao"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp"
{"request_id":"e800533c-ce1f-8eae-030e-863dc14e9bce","lease_id":"","renewable":false,"lease_duration":0,"data":{"method_id":"<method-id>"},"wrap_info":null,"warnings":null,"auth":null}
...
curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"
{"request_id":"d5001b6d-e637-cf51-ed47-84d5c4f77516","lease_id":"","renewable":false,"lease_duration":0,"data":{"algorithm":"SHA1","digits":6,"id":"<method-id>","issuer":"openbao","key_size":20,"max_validation_attempts":5,"name":"","namespace_id":"Xxl0dg","namespace_path":"test/","period":30,"qr_size":200,"skew":1,"type":"totp"},"wrap_info":null,"warnings":null,"auth":null}
...
// MFA config can be also read by any ancestor or descendant of the namespace
curl -X GET -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"          
{"request_id":"843a2a56-df2f-cda0-3be3-1cf202736a5a","lease_id":"","renewable":false,"lease_duration":0,"data":{(...)},"wrap_info":null,"warnings":null,"auth":null}

curl -X GET -H "X-Vault-Namespace: test/test2/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"
{"request_id":"7bb79fcf-184c-2415-c244-0cefdec35d8c","lease_id":"","renewable":false,"lease_duration":0,"data":{(...)},"wrap_info":null,"warnings":null,"auth":null}

// now seal and unseal the instance
bao operator seal
bao operator unseal
...
curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"
{"request_id":"d5001b6d-e637-cf51-ed47-84d5c4f77516","lease_id":"","renewable":false,"lease_duration":0,"data":{"algorithm":"SHA1","digits":6,"id":"<method-id>","issuer":"openbao","key_size":20,"max_validation_attempts":5,"name":"","namespace_id":"Xxl0dg","namespace_path":"test/","period":30,"qr_size":200,"skew":1,"type":"totp"},"wrap_info":null,"warnings":null,"auth":null}
```

2. MFA Config deletion:
```
curl -X DELETE -H "X-Vault-Namespace: test/test2/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"

{"errors":["1 error occurred:\n\t* request namespace does not match method namespace\n\n"]}
(...)
curl -X DELETE -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"

curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"
{"errors":[]}

// cannot delete mfa config if it's currently in use by login-enforcement
curl -X DELETE -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"
{"errors":["1 error occurred:\n\t* methodID is still used by an enforcement configuration with ID: <enforcement-id>\n\n"]}
```

3. MFA Config listing:
```
// root does not have any configs
curl -X LIST -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp"

{"errors":[]}
(...)
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"issuer": "openbao"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp"
{"request_id":"63f3e75f-c15a-b878-ca01-d106fe372260","lease_id":"","renewable":false,"lease_duration":0,"data":{"method_id":"<method-id>"},"wrap_info":null,"warnings":null,"auth":null}

curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"issuer": "reply"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp"
{"request_id":"7500ec2d-93c7-2a04-3d2b-13e95ca5239c","lease_id":"","renewable":false,"lease_duration":0,"data":{"method_id":"<method-id>"},"wrap_info":null,"warnings":null,"auth":null}

curl -X LIST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp"
{"request_id":"5cd0bd97-6e62-05c6-31bd-922bc90bb900","lease_id":"","renewable":false,"lease_duration":0,"data":{"key_info":{"<method-id1>":{(...)},"<method-id2>":{(...)},"keys":["<method-id1>","<method-id2>"]},"wrap_info":null,"warnings":null,"auth":null}

// you can list mfa configs if the config belongs to the namespace in request, or if configs are in direct parent of the namespace in request
curl -X LIST -H "X-Vault-Namespace: test/test2/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp"

{"request_id":"e1e75695-0852-db56-20d5-6e4efe3fd182","lease_id":"","renewable":false,"lease_duration":0,"data":{"key_info":{"<method-id1>":{(...)},"<method-id2>":{(...)},"keys":["<method-id1>","<method-id2>"]},"wrap_info":null,"warnings":null,"auth":null}
```

4. Login enforcement operations:
```
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"issuer": "openbao"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp"
{"request_id":"fb355115-4c12-164d-e02d-aa80c18a5343","lease_id":"","renewable":false,"lease_duration":0,"data":{"method_id":"<method-id>"},"wrap_info":null,"warnings":null,"auth":null}

bao auth enable -ns=test userpass
Success! Enabled userpass auth method at: userpass/

// creating
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"mfa_method_ids": ["<method-id>"], "auth_method_types": ["userpass"]}' "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement/test-login"

// getting
curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement/test-login"
{"request_id":"4249b3f4-1dd6-78aa-b97c-1b7f5e05df6c","lease_id":"","renewable":false,"lease_duration":0,"data":{"auth_method_accessors":[],"auth_method_types":["userpass"],"id":"300e551c-98fe-0a3b-e3fd-be757a105205","identity_entity_ids":[],"identity_group_ids":[],"mfa_method_ids":["<method-id>"],"name":"test-login","namespace_id":"xBX2is","namespace_path":"test/"},"wrap_info":null,"warnings":null,"auth":null}

// listing
curl -X LIST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement"
{"request_id":"72073494-628f-0156-719c-7c836fcb003d","lease_id":"","renewable":false,"lease_duration":0,"data":{"key_info":{"test-login":{"auth_method_accessors":[],"auth_method_types":["userpass"],"id":"300e551c-98fe-0a3b-e3fd-be757a105205","identity_entity_ids":[],"identity_group_ids":[],"mfa_method_ids":["<method-id>"],"name":"test-login","namespace_id":"xBX2is","namespace_path":"test/"}},"keys":["test-login"]},"wrap_info":null,"warnings":null,"auth":null}

// deleting
curl -X DELETE -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement/test-login"

curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement/test-login"
{"errors":[]}
```

5. TOTP MFA secret generation:
```
// create an entity
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"metadata": {"organization": "openbao","team": "openbao"}}' "http://127.0.0.1:8200/v1/identity/entity"
{"request_id":"64fcf1b4-d00c-533f-d910-4859de5ec26e","lease_id":"","renewable":false,"lease_duration":0,"data":{"aliases":null,"id":"<entity-id>","name":"entity_86fe9d76"},"wrap_info":null,"warnings":null,"auth":null}

curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"method_id": "<method-id>", "entity_id": "<entity-id>"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp/admin-generate"
{"request_id":"f7541563-8a0b-68cb-afb3-53e40b28024f","lease_id":"","renewable":false,"lease_duration":0,"data":{"barcode":"(...)","url":"otpauth://totp/openbao:0ca592fc-4e08-78af-5285-a5c89d092340?algorithm=SHA1\u0026digits=6\u0026issuer=openbao\u0026period=30\u0026secret=V37OR4CTECGWMURCWN45CNHUUG2SBOXY"},"wrap_info":null,"warnings":null,"auth":null}

bao read sys/raw/namespaces/<namespace-id>/sys/mfa/totpkeys/<method-id>/<entity-id>
Key      Value
---      -----
value    {"key":"V37OR4CTECGWMURCWN45CNHUUG2SBOXY"}

// deleting the secret key does not delete it from the storage
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"method_id": "<method-id>, "entity_id": "<entity-id>"}' "http://127.0.0.1:8200/v1/identity/mfa/method/totp/admin-destroy"

bao read sys/raw/namespaces/<namespace-id>/sys/mfa/totpkeys/<method-id>/<entity-id>
Key      Value
---      -----
value    {"key":"V37OR4CTECGWMURCWN45CNHUUG2SBOXY"}

// deleting the MFA config method cleans up the TOTP key

// first remove the enforcement
curl -X DELETE -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/login-enforcement/test-login"

// then remove the method
curl -X DELETE -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/mfa/method/totp/<method-id>"

// no key
bao read sys/raw/namespaces/<namespace-id>/sys/mfa/totpkeys/<method-id>/<entity-id>
No value found at sys/raw/namespaces/<namespace-id>/sys/mfa/totpkeys/<method-id>/<entity-id>

(...)
// deleting the namespace which contains the TOTP key also deletes the key
bao read sys/raw/namespaces/<namespace-uuid>/sys/mfa/totpkeys/<method-id>/<entity-id>
Key      Value
---      -----
value    {"key":"ZLJKEAPM2PB76XNXLZS7CN5WP4IHWB6K"}

bao namespace delete test
Key       Value
---       -----
status    in-progress
bao read sys/raw/namespaces/<namespace-uuid>/sys/mfa/totpkeys/<method-id>/<entity-id>
No value found at sys/raw/namespaces/<namespace-uuid>/sys/mfa/totpkeys/<method-id>/<entity-id>
```

6. `bao read sys/internal/counters/tokens` correctly counts all tokens including namespace owned ones.

7. Locked users
```
bao auth enable -ns=test userpass
bao auth tune -ns=test -user-lockout-threshold=1 userpass
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"password": "123"}' "http://127.0.0.1:8200/v1/auth/userpass/users/user1"

bao login -ns=test -method=userpass username=user1 password=wrong
Error authenticating: Error making API request.

Namespace: test/
URL: PUT http://127.0.0.1:8200/v1/auth/userpass/login/user1
Code: 400. Errors:

* invalid username or password

bao read sys/raw/namespaces/75e90c68-db29-6b39-ffe6-353a839eacfc/core/login/lockedUsers/auth_userpass_60cf4ef6/user1:
1747837659

curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/sys/locked-users"
{"request_id":"2d04a88b-ebbb-fa0f-39d2-d841f1eb91f1","lease_id":"","renewable":false,"lease_duration":0,"data":{"by_namespace":[{"namespace_id":"cWEd8h","namespace_path":"test/","counts":1,"mount_accessors":[{"mount_accessor":"auth_userpass_60cf4ef6","counts":1,"alias_identifiers":["user1"]}]}],"total":1},"wrap_info":null,"warnings":null,"auth":null}

curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/sys/locked-users/auth_userpass_60cf4ef6/unlock/user1"

curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/sys/locked-users"
{"request_id":"c760999e-65b5-699c-cc5c-426aaea6d8fe","lease_id":"","renewable":false,"lease_duration":0,"data":{"by_namespace":[{"namespace_id":"cWEd8h","namespace_path":"test/","counts":0,"mount_accessors":[]}],"total":0},"wrap_info":null,"warnings":null,"auth":null}

// also verified correct cron cleanup of locked login entries
// Namespace owned failed login entries are removed on namespace deletion
bao auth enable -ns=test userpass
Success! Enabled userpass auth method at: userpass/
bao auth tune -ns=test -user-lockout-threshold=1 -user-lockout-duration=1m userpass
Success! Tuned the auth method at: userpass/
curl -X POST -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" -d '{"password": "123"}' "http://127.0.0.1:8200/v1/auth/userpass/users/user1"
bao login -ns=test -method=userpass username=user1 password=wrong

bao read sys/raw/namespaces/3e62a7d1-b8b9-a6e9-837a-6fdf866d5f21/core/login/lockedUsers/auth_userpass_4650b2f8/user1:
1747841982

bao namespace delete test
Key       Value
---       -----
status    in-progress
bao read sys/raw/namespaces/3e62a7d1-b8b9-a6e9-837a-6fdf866d5f21/core/login/lockedUsers/auth_userpass_4650b2f8/user1 
No value found at sys/raw/namespaces/3e62a7d1-b8b9-a6e9-837a-6fdf866d5f21/core/login/lockedUsers/auth_userpass_4650b2f8/user1

// note: providing empty password does not count as towards failed login attempts
bao login -ns=test -method=userpass username=user1 password=
Password (will be hidden): 
Error authenticating: Error making API request.

Namespace: test/
URL: PUT http://127.0.0.1:8200/v1/auth/userpass/login/user1
Code: 500. Errors:

* missing password
curl -X GET -H "X-Vault-Namespace: test/" -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/sys/locked-users"
{"request_id":"495ddb35-9770-af13-8c1b-4fdfc6eeb460","lease_id":"","renewable":false,"lease_duration":0,"data":{"by_namespace":[{"namespace_id":"xDketo","namespace_path":"test/","counts":0,"mount_accessors":[]}],"total":0},"wrap_info":null,"warnings":null,"auth":null}
```

----
cc @cipherboy @voigt @satoqz @phyrog