### PR TITLE
Display seal configuration info keys in logs

### DIFF
--- a/changelog/1346.txt
+++ b/changelog/1346.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+When using auto-unseal via KMS, KMS-specific configuration information (non-sensitive) is now logged at server startup.
+```

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -386,7 +386,8 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 	var seals []vault.Seal
 	var sealConfigError error
 
-	barrierSeal, barrierWrapper, unwrapSeal, seals, sealConfigError, err := setSeal(server, config, make([]string, 0), make(map[string]string))
+	infoKeys := make([]string, 0)
+	barrierSeal, barrierWrapper, unwrapSeal, seals, sealConfigError, err := setSeal(server, config, &infoKeys, make(map[string]string))
 	// Check error here
 	if err != nil {
 		diagnose.Advise(ctx, "For assistance with the seal stanza, see the Vault configuration documentation.")

--- a/command/server.go
+++ b/command/server.go
@@ -1115,7 +1115,7 @@ func (c *ServerCommand) Run(args []string) int {
 	info[key] = strings.Join(envVarKeys, ", ")
 	infoKeys = append(infoKeys, key)
 
-	barrierSeal, barrierWrapper, unwrapSeal, seals, sealConfigError, err := setSeal(c, config, infoKeys, info)
+	barrierSeal, barrierWrapper, unwrapSeal, seals, sealConfigError, err := setSeal(c, config, &infoKeys, info)
 	// Check error here
 	if err != nil {
 		c.UI.Error(err.Error())
@@ -2282,7 +2282,7 @@ func CheckStorageMigration(b physical.Backend) (*StorageMigrationStatus, error) 
 
 // setSeal return barrierSeal, barrierWrapper, unwrapSeal, and all the created seals from the configs so we can close them in Run
 // The two errors are the sealConfigError and the regular error
-func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info map[string]string) (vault.Seal, wrapping.Wrapper, vault.Seal, []vault.Seal, error, error) {
+func setSeal(c *ServerCommand, config *server.Config, infoKeys *[]string, info map[string]string) (vault.Seal, wrapping.Wrapper, vault.Seal, []vault.Seal, error, error) {
 	var barrierSeal vault.Seal
 	var unwrapSeal vault.Seal
 
@@ -2351,7 +2351,7 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys []string, info ma
 			barrierWrapper = wrapper
 		}
 		for _, k := range sealInfoKeys {
-			infoKeys = append(infoKeys, infoPrefix+k)
+			*infoKeys = append(*infoKeys, infoPrefix+k)
 			info[infoPrefix+k] = sealInfoMap[k]
 		}
 		createdSeals = append(createdSeals, seal)

--- a/internalshared/configutil/pkcs11.go
+++ b/internalshared/configutil/pkcs11.go
@@ -19,8 +19,12 @@ func GetPKCS11KMSFunc(kms *KMS, opts ...wrapping.Option) (wrapping.Wrapper, map[
 	info := make(map[string]string)
 	if wrapperInfo != nil {
 		info["PKCS#11 KMS Library"] = wrapperInfo.Metadata["lib"]
-		info["PKCS#11 KMS Key Label"] = wrapperInfo.Metadata["key_label"]
-		info["PKCS#11 KMS Key ID"] = wrapperInfo.Metadata["key_id"]
+		if val, present := wrapperInfo.Metadata["key_id"]; present {
+			info["PKCS#11 KMS Key ID"] = val
+		}
+		if val, present := wrapperInfo.Metadata["key_label"]; present {
+			info["PKCS#11 KMS Key Label"] = val
+		}
 		if val, present := wrapperInfo.Metadata["slot"]; present {
 			info["PKCS#11 KMS Slot"] = val
 		}


### PR DESCRIPTION
Seal configuration collects "info keys" from e.g. KMS configuration but fails to ultimately display these in log output because Go slices are complicated.

With this fix, the configuration is printed as intended:

```
==> OpenBao server configuration:

   PKCS#11 KMS Key Label: bao-root-key-aes
     PKCS#11 KMS Library: /opt/homebrew/lib/softhsm/libsofthsm2.so
 PKCS#11 KMS Token Label: OpenBao
Administrative Namespace:
             Api Address: http://127.0.0.1:8200
                     Cgo: enabled
         Cluster Address: https://127.0.0.1:8201
```

I'm a bit unhappy with how all the "PKCS#11 KMS" prefixes align here (same issue for different KMS types) but not sure what to do about it 😄
