### PR TITLE
Document that MFA is enforced as part of OSPS-AC-01.01

### DIFF
--- a/website/content/docs/policies/osps-baseline.mdx
+++ b/website/content/docs/policies/osps-baseline.mdx
@@ -12,7 +12,7 @@ This pages tracks the implementation status of [Open Source Project Security Bas
 
 | Control                         | Status |
 | ------------------------------- | ------ |
-| [OSPS-AC-01.01](#osps-ac-01-01) |        |
+| [OSPS-AC-01.01](#osps-ac-01-01) | ✅     |
 | [OSPS-AC-02.01](#osps-ac-02-01) | ✅     |
 | [OSPS-AC-03.01](#osps-ac-03-01) |        |
 | [OSPS-AC-03.02](#osps-ac-03-02) |        |
@@ -34,7 +34,10 @@ This pages tracks the implementation status of [Open Source Project Security Bas
 | [OSPS-VM-02.01](#osps-vm-02-01) | ✅     |
 
 ## OSPS-AC-01.01 {#osps-ac-01-01}
-When a user attempts to access a sensitive resource in the project's version control system, the system MUST require the user to complete a multi-factor authentication process.
+
+> **Requirement:** *When a user attempts to access a sensitive resource in the project's [version control system](https://baseline.openssf.org/versions/2025-02-25#version-control-system), the system MUST require the user to complete a [multi-factor authentication](https://baseline.openssf.org/versions/2025-02-25#multi-factor-authentication) process.*
+
+The [OpenBao GitHub organization](https://github.com/openbao) enforces multi-factor authentication (MFA) for all its members.
 
 ## OSPS-AC-02.01 {#osps-ac-02-01}
 


### PR DESCRIPTION
Documents that we cover OSPS-AC-01.01 for the time being. We'll have to circle back to this topic at some point and ensure all 3rd party services (e.g. external container registries) are also covered, if applicable.

Resolves https://github.com/openbao/dev-wg/issues/22
