### PR TITLE
Namespace sealing POC

### DIFF
--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -4,7 +4,11 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/cli"
@@ -19,7 +23,8 @@ var (
 type NamespaceCreateCommand struct {
 	*BaseCommand
 
-	flagCustomMetadata map[string]string
+	flagCustomMetadata  map[string]string
+	flagSealsConfigPath string
 }
 
 func (c *NamespaceCreateCommand) Synopsis() string {
@@ -59,6 +64,14 @@ func (c *NamespaceCreateCommand) Flags() *FlagSets {
 			"This can be specified multiple times to add multiple pieces of metadata.",
 	})
 
+	f.StringVar(&StringVar{
+		Name:       "seals",
+		Target:     &c.flagSealsConfigPath,
+		Completion: complete.PredictFiles("*.json"),
+		Usage: "Path to a JSON file with at least one or several SealConfigs." +
+			"MUST be an JSON array.",
+	})
+
 	return set
 }
 
@@ -96,8 +109,15 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
+	seals, err := c.parseSeals()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error while parsing seal configs: %s", err))
+		return 2
+	}
+
 	data := map[string]interface{}{
 		"custom_metadata": c.flagCustomMetadata,
+		"seals":           seals,
 	}
 
 	secret, err := client.Logical().Write("sys/namespaces/"+namespacePath, data)
@@ -112,4 +132,31 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 	}
 
 	return OutputSecret(c.UI, secret)
+}
+
+func (c *NamespaceCreateCommand) parseSeals() ([]map[string]interface{}, error) {
+	path := c.flagSealsConfigPath
+	var rawSeals []map[string]interface{}
+
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(absolutePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &rawSeals); err != nil {
+		return nil, err
+	}
+
+	return rawSeals, nil
 }

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -117,7 +117,10 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 
 	data := map[string]interface{}{
 		"custom_metadata": c.flagCustomMetadata,
-		"seals":           seals,
+	}
+
+	if seals != nil {
+		data["seals"] = seals
 	}
 
 	secret, err := client.Logical().Write("sys/namespaces/"+namespacePath, data)

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -131,11 +131,38 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
+	if len(seals) > 0 {
+		// TODO Handle Output for multiple seals
+		keySharesMap := secret.Data["key_shares"].(map[string]interface{})
+		if keySharesMap != nil {
+			defaultKeyShares := keySharesMap["default"].([]interface{})
+			for i, key := range defaultKeyShares {
+				c.UI.Output(fmt.Sprintf("Unseal Key %d: %s", i+1, key))
+			}
+		}
+		secretShares := int(seals[0]["secret_shares"].(float64))
+		secretThreshold := int(seals[0]["secret_threshold"].(float64))
+
+		c.UI.Output("")
+		c.UI.Output(wrapAtLength(fmt.Sprintf(
+			"Namespace initialized with %d key shares and a key threshold of %d. Please "+
+				"securely distribute the key shares printed above. When the Namespace is "+
+				"re-sealed you must supply at least %d of "+
+				"these keys to unseal it before it can start servicing requests.",
+			secretShares,
+			secretThreshold,
+			secretThreshold)))
+		c.UI.Output("")
+	}
+
 	return OutputSecret(c.UI, secret)
 }
 
 func (c *NamespaceCreateCommand) parseSeals() ([]map[string]interface{}, error) {
 	path := c.flagSealsConfigPath
+	if path == "" {
+		return nil, nil
+	}
 	var rawSeals []map[string]interface{}
 
 	absolutePath, err := filepath.Abs(path)

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -597,7 +597,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
-		view := NamespaceView(barrier, ns)
+		view := c.NamespaceView(ns)
 
 		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)
 		if err != nil {
@@ -629,7 +629,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		}
 
 		for nsIndex, ns := range allNamespaces {
-			view := NamespaceView(barrier, ns)
+			view := c.NamespaceView(ns)
 			for index, uuid := range globalEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreAuthConfigPath, uuid)
 				if err != nil {
@@ -646,7 +646,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 
 	if len(localEntries) > 0 {
 		for nsIndex, ns := range allNamespaces {
-			view := NamespaceView(barrier, ns)
+			view := c.NamespaceView(ns)
 
 			for index, uuid := range localEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
@@ -917,7 +917,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 					continue
 				}
 
-				view := NamespaceView(barrier, mtEntry.Namespace())
+				view := c.NamespaceView(mtEntry.Namespace())
 
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
@@ -956,7 +956,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
+					view := c.NamespaceView(ns)
 					path := path.Join(prefix, mount)
 					if err := view.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
@@ -971,7 +971,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
+					view := c.NamespaceView(ns)
 
 					// List all entries and remove any deleted ones.
 					presentEntries, err := view.List(ctx, prefix+"/")

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -89,7 +89,7 @@ type SecurityBarrierCore interface {
 
 	// Sealed checks if the barrier has been unlocked yet. The Barrier
 	// is not expected to be able to perform any CRUD until it is unsealed.
-	Sealed() (bool, error)
+	Sealed() bool
 
 	// Unseal is used to provide the unseal key which permits the barrier
 	// to be unsealed. If the key is not correct, the barrier remains sealed.

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -69,6 +69,8 @@ type AESGCMBarrier struct {
 	l      sync.RWMutex
 	sealed bool
 
+	metaPrefix string
+
 	// keyring is used to maintain all of the encryption keys, including
 	// the active key used for encryption, but also prior keys to allow
 	// decryption of keys encrypted under previous terms.
@@ -127,9 +129,10 @@ func (b *AESGCMBarrier) SetRotationConfig(ctx context.Context, rotConfig KeyRota
 
 // NewAESGCMBarrier is used to construct a new barrier that uses
 // the provided physical backend for storage.
-func NewAESGCMBarrier(storage physical.Backend) (SecurityBarrier, error) {
+func NewAESGCMBarrier(storage physical.Backend, metaPrefix string) (SecurityBarrier, error) {
 	b := &AESGCMBarrier{
 		backend:                  storage,
+		metaPrefix:               metaPrefix,
 		sealed:                   true,
 		cache:                    make(map[uint32]cipher.AEAD),
 		currentAESGCMVersionByte: byte(AESGCMVersion2),
@@ -155,7 +158,7 @@ func (b *AESGCMBarrier) Initialized(ctx context.Context) (bool, error) {
 	}
 
 	// Read the keyring file
-	entry, err := b.backend.Get(ctx, keyringPath)
+	entry, err := b.backend.Get(ctx, b.metaPrefix+keyringPath)
 	if err != nil {
 		return false, fmt.Errorf("failed to check for initialization: %w", err)
 	}
@@ -211,7 +214,7 @@ func (b *AESGCMBarrier) Initialize(ctx context.Context, key, sealKey []byte, rea
 		}
 
 		err = b.putInternal(ctx, b.backend, 1, primary, &logical.StorageEntry{
-			Key:   shamirKekPath,
+			Key:   b.metaPrefix + shamirKekPath,
 			Value: sealKey,
 		})
 		if err != nil {
@@ -251,14 +254,14 @@ func (b *AESGCMBarrier) persistKeyringInternal(ctx context.Context, keyring *Key
 	}
 
 	// Encrypt the barrier init value
-	value, err := b.encrypt(keyringPath, initialKeyTerm, gcm, keyringBuf)
+	value, err := b.encrypt(b.metaPrefix+keyringPath, initialKeyTerm, gcm, keyringBuf)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt barrier initial value: %w", err)
 	}
 
 	// Create the keyring physical entry
 	pe := &physical.Entry{
-		Key:   keyringPath,
+		Key:   b.metaPrefix + keyringPath,
 		Value: value,
 	}
 
@@ -294,14 +297,14 @@ func (b *AESGCMBarrier) persistKeyringInternal(ctx context.Context, keyring *Key
 	if err != nil {
 		return fmt.Errorf("failed to retrieve AES-GCM AEAD from active key: %w", err)
 	}
-	value, err = b.encryptTracked(rootKeyPath, activeKey.Term, aead, keyBuf)
+	value, err = b.encryptTracked(b.metaPrefix+rootKeyPath, activeKey.Term, aead, keyBuf)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt and track active key value: %w", err)
 	}
 
 	// Update the rootKeyPath for standby instances
 	pe = &physical.Entry{
-		Key:   rootKeyPath,
+		Key:   b.metaPrefix + rootKeyPath,
 		Value: value,
 	}
 
@@ -369,7 +372,7 @@ func (b *AESGCMBarrier) ReloadKeyring(ctx context.Context) error {
 	}
 
 	// Read in the keyring
-	out, err := b.backend.Get(ctx, keyringPath)
+	out, err := b.backend.Get(ctx, b.metaPrefix+keyringPath)
 	if err != nil {
 		return fmt.Errorf("failed to check for keyring: %w", err)
 	}
@@ -387,7 +390,7 @@ func (b *AESGCMBarrier) ReloadKeyring(ctx context.Context) error {
 	}
 
 	// Decrypt the barrier init key
-	plain, err := b.decrypt(keyringPath, gcm, out.Value)
+	plain, err := b.decrypt(b.metaPrefix+keyringPath, gcm, out.Value)
 	defer memzero(plain)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
@@ -422,7 +425,7 @@ func (b *AESGCMBarrier) recoverKeyring(plaintext []byte) error {
 // is available for keyring reloading.
 func (b *AESGCMBarrier) ReloadRootKey(ctx context.Context) error {
 	// Read the rootKeyPath upgrade
-	out, err := b.Get(ctx, rootKeyPath)
+	out, err := b.Get(ctx, b.metaPrefix+rootKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read root key path: %w", err)
 	}
@@ -445,7 +448,7 @@ func (b *AESGCMBarrier) ReloadRootKey(ctx context.Context) error {
 	b.l.Lock()
 	defer b.l.Unlock()
 
-	out, err = b.lockSwitchedGet(ctx, b.backend, rootKeyPath, false)
+	out, err = b.lockSwitchedGet(ctx, b.backend, b.metaPrefix+rootKeyPath, false)
 	if err != nil {
 		return fmt.Errorf("failed to read root key path: %w", err)
 	}
@@ -498,7 +501,7 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	}
 
 	// Read in the keyring
-	out, err := b.backend.Get(ctx, keyringPath)
+	out, err := b.backend.Get(ctx, b.metaPrefix+keyringPath)
 	if err != nil {
 		return fmt.Errorf("failed to check for keyring: %w", err)
 	}
@@ -513,7 +516,7 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	}
 
 	// Decrypt the barrier init key
-	plain, err := b.decrypt(keyringPath, gcm, out.Value)
+	plain, err := b.decrypt(b.metaPrefix+keyringPath, gcm, out.Value)
 	defer memzero(plain)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
@@ -617,7 +620,7 @@ func (b *AESGCMBarrier) CreateUpgrade(ctx context.Context, term uint32) error {
 		return err
 	}
 
-	key := fmt.Sprintf("%s%d", keyringUpgradePrefix, prevTerm)
+	key := fmt.Sprintf("%s%d", b.metaPrefix+keyringUpgradePrefix, prevTerm)
 	value, err := b.encryptTracked(key, prevTerm, primary, buf)
 	b.l.RUnlock()
 	if err != nil {
@@ -633,7 +636,7 @@ func (b *AESGCMBarrier) CreateUpgrade(ctx context.Context, term uint32) error {
 
 // DestroyUpgrade destroys the upgrade path key to the given term
 func (b *AESGCMBarrier) DestroyUpgrade(ctx context.Context, term uint32) error {
-	path := fmt.Sprintf("%s%d", keyringUpgradePrefix, term-1)
+	path := fmt.Sprintf("%s%d", b.metaPrefix+keyringUpgradePrefix, term-1)
 	return b.Delete(ctx, path)
 }
 
@@ -649,7 +652,7 @@ func (b *AESGCMBarrier) CheckUpgrade(ctx context.Context) (bool, uint32, error) 
 	activeTerm := b.keyring.ActiveTerm()
 
 	// Check for an upgrade key
-	upgrade := fmt.Sprintf("%s%d", keyringUpgradePrefix, activeTerm)
+	upgrade := fmt.Sprintf("%s%d", b.metaPrefix+keyringUpgradePrefix, activeTerm)
 	entry, err := b.lockSwitchedGet(ctx, b.backend, upgrade, false)
 	if err != nil {
 		b.l.RUnlock()
@@ -675,7 +678,7 @@ func (b *AESGCMBarrier) CheckUpgrade(ctx context.Context) (bool, uint32, error) 
 
 	activeTerm = b.keyring.ActiveTerm()
 
-	upgrade = fmt.Sprintf("%s%d", keyringUpgradePrefix, activeTerm)
+	upgrade = fmt.Sprintf("%s%d", b.metaPrefix+keyringUpgradePrefix, activeTerm)
 	entry, err = b.lockSwitchedGet(ctx, b.backend, upgrade, false)
 	if err != nil {
 		return false, 0, err

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -338,11 +338,11 @@ func (b *AESGCMBarrier) KeyLength() (int, int) {
 
 // Sealed checks if the barrier has been unlocked yet. The Barrier
 // is not expected to be able to perform any CRUD until it is unsealed.
-func (b *AESGCMBarrier) Sealed() (bool, error) {
+func (b *AESGCMBarrier) Sealed() bool {
 	b.l.RLock()
 	sealed := b.sealed
 	b.l.RUnlock()
-	return sealed, nil
+	return sealed
 }
 
 // VerifyRoot is used to check if the given key matches the root key

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -27,7 +27,7 @@ func mockBarrier(t testing.TB) (physical.Backend, SecurityBarrier, []byte) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b, err := NewAESGCMBarrier(inm)
+	b, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestAESGCMBarrier_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b, err := NewAESGCMBarrier(inm)
+	b, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestAESGCMBarrier_Rotate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b, err := NewAESGCMBarrier(inm)
+	b, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestAESGCMBarrier_MissingRotateConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -97,11 +97,11 @@ func TestAESGCMBarrier_Upgrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b1, err := NewAESGCMBarrier(inm)
+	b1, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b2, err := NewAESGCMBarrier(inm)
+	b2, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -113,11 +113,11 @@ func TestAESGCMBarrier_Upgrade_Rekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b1, err := NewAESGCMBarrier(inm)
+	b1, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b2, err := NewAESGCMBarrier(inm)
+	b2, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestAESGCMBarrier_Rekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b, err := NewAESGCMBarrier(inm)
+	b, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestAESGCMBarrier_Confidential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestAESGCMBarrier_Integrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 	}
 
 	// Open again as version 2
-	sb, err = NewAESGCMBarrier(inm)
+	sb, err = NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestEncrypt_Unique(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestInitialize_KeyLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestEncrypt_BarrierEncryptor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestDecrypt_InvalidCipherLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb, err := NewAESGCMBarrier(inm)
+	sb, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 
 	{
 		// Create a second barrier and rotate the keyring
-		sb2, err := NewAESGCMBarrier(inm)
+		sb2, err := NewAESGCMBarrier(inm, "")
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -591,7 +591,7 @@ func TestBarrier_LegacyRotate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	sb1, err := NewAESGCMBarrier(inm)
+	sb1, err := NewAESGCMBarrier(inm, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	} // Initialize the barrier
@@ -658,7 +658,7 @@ func TestBarrier_persistKeyring_Context(t *testing.T) {
 			// Set up barrier
 			backend, err := inmem.NewInmem(nil, corehelpers.NewTestLogger(t))
 			require.NoError(t, err)
-			security_barrier, err := NewAESGCMBarrier(backend)
+			security_barrier, err := NewAESGCMBarrier(backend, "")
 			require.NoError(t, err)
 			barrier := security_barrier.(*TransactionalAESGCMBarrier)
 			key, err := barrier.GenerateKey(rand.Reader)
@@ -695,4 +695,101 @@ func TestBarrier_persistKeyring_Context(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAESGCMBarrier_Prefix_Basic(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier(t, b.(*TransactionalAESGCMBarrier))
+}
+
+func TestAESGCMBarrier_Prefix_Rotate(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Rotate(t, b.(*TransactionalAESGCMBarrier))
+}
+
+func TestAESGCMBarrier_Prefix_MissingRotateConfig(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sb, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b := sb.(*TransactionalAESGCMBarrier)
+
+	// Initialize and unseal
+	key, _ := b.GenerateKey(rand.Reader)
+	b.Initialize(context.Background(), key, nil, rand.Reader)
+	b.Unseal(context.Background(), key)
+
+	// Write a keyring which lacks rotation config settings
+	oldKeyring := b.keyring.Clone()
+	oldKeyring.rotationConfig = KeyRotationConfig{}
+	b.persistKeyring(context.Background(), oldKeyring)
+
+	b.ReloadKeyring(context.Background())
+
+	// At this point, the rotation config should match the default
+	if !defaultRotationConfig.Equals(b.keyring.rotationConfig) {
+		t.Fatal("expected empty rotation config to recover as default config")
+	}
+}
+
+func TestAESGCMBarrier_Prefix_Upgrade(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b1, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b2, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Upgrade(t, b1.(*TransactionalAESGCMBarrier), b2.(*TransactionalAESGCMBarrier))
+}
+
+func TestAESGCMBarrier_Prefix_Upgrade_Rekey(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b1, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b2, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Upgrade_Rekey(t, b1.(*TransactionalAESGCMBarrier), b2.(*TransactionalAESGCMBarrier))
+}
+
+func TestAESGCMBarrier_Prefix_Rekey(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, err := NewAESGCMBarrier(inm, "prefix/")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Rekey(t, b.(*TransactionalAESGCMBarrier))
 }

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -123,8 +123,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.False(t, init, "should not be initialized")
 
 	// Should start sealed
-	sealed, err := b.Sealed()
-	require.NoError(t, err)
+	sealed := b.Sealed()
 	require.True(t, sealed, "should be sealed")
 
 	// Sealing should be a no-op
@@ -169,8 +168,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.True(t, init, "should be initialized")
 
 	// Should still be sealed
-	sealed, err = b.Sealed()
-	require.NoError(t, err)
+	sealed = b.Sealed()
 	require.True(t, sealed, "should be sealed")
 
 	// Unseal should work
@@ -182,8 +180,7 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (error, *logical.Storage
 	require.NoError(t, err)
 
 	// Should no longer be sealed
-	sealed, err = b.Sealed()
-	require.NoError(t, err)
+	sealed = b.Sealed()
 	require.False(t, sealed, "should be unsealed")
 
 	// Verify the root key

--- a/vault/core.go
+++ b/vault/core.go
@@ -1059,7 +1059,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	// Construct a new AES-GCM barrier
-	c.barrier, err = NewAESGCMBarrier(c.physical)
+	c.barrier, err = NewAESGCMBarrier(c.physical, "")
 	if err != nil {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -379,6 +379,9 @@ type Core struct {
 	// namespace Store is used to manage namespaces
 	namespaceStore *NamespaceStore
 
+	// sealManager is used to manage seals per namespace
+	sealManager *SealManager
+
 	// identityStore is used to manage client entities
 	identityStore *IdentityStore
 
@@ -1639,7 +1642,7 @@ func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
 		// configuration.
 		config = raftInfo.leaderBarrierConfig
 	default:
-		config, err = seal.BarrierConfig(ctx)
+		config, err = seal.BarrierConfig(ctx, namespace.RootNamespace)
 	}
 	if err != nil {
 		return nil, err
@@ -2269,6 +2272,9 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.setupNamespaceStore(ctx); err != nil {
 		return err
 	}
+	if err := c.setupSealManager(ctx); err != nil {
+		return err
+	}
 	if err := c.loadMounts(ctx); err != nil {
 		return err
 	}
@@ -2375,7 +2381,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	}
 
 	// Purge these for safety in case of a rekey
-	_ = c.seal.SetBarrierConfig(ctx, nil)
+	_ = c.seal.SetBarrierConfig(ctx, nil, namespace.RootNamespace)
 	if c.seal.RecoveryKeySupported() {
 		_ = c.seal.SetRecoveryConfig(ctx, nil)
 	}
@@ -2496,6 +2502,9 @@ func (c *Core) preSeal() error {
 	}
 	if err := c.unloadMounts(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
+	}
+	if err := c.teardownSealManager(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("error tearing down seal manager: %w", err))
 	}
 	if err := c.teardownNamespaceStore(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down namespaces store: %w", err))
@@ -2725,7 +2734,7 @@ func (c *Core) migrateSealConfig(ctx context.Context) error {
 		rc.StoredShares = 0
 	}
 
-	if err := c.seal.SetBarrierConfig(ctx, bc); err != nil {
+	if err := c.seal.SetBarrierConfig(ctx, bc, namespace.RootNamespace); err != nil {
 		return fmt.Errorf("error storing barrier config after migration: %w", err)
 	}
 
@@ -2810,7 +2819,7 @@ func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []
 		if useTestSeal {
 			testseal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
 			testseal.SetCore(c)
-			cfg, err := seal.BarrierConfig(ctx)
+			cfg, err := seal.BarrierConfig(ctx, namespace.RootNamespace)
 			if err != nil {
 				return nil, fmt.Errorf("failed to setup test barrier config: %w", err)
 			}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1067,6 +1067,10 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("barrier setup failed: %w", err)
 	}
 
+	if err := c.setupSealManager(); err != nil {
+		return nil, fmt.Errorf("seal manager setup failed: %w", err)
+	}
+
 	// We create the funcs here, then populate the given config with it so that
 	// the caller can share state
 	conf.ReloadFuncsLock = &c.reloadFuncsLock
@@ -2272,9 +2276,6 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.setupNamespaceStore(ctx); err != nil {
 		return err
 	}
-	if err := c.setupSealManager(ctx); err != nil {
-		return err
-	}
 	if err := c.loadMounts(ctx); err != nil {
 		return err
 	}
@@ -2502,9 +2503,6 @@ func (c *Core) preSeal() error {
 	}
 	if err := c.unloadMounts(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
-	}
-	if err := c.teardownSealManager(); err != nil {
-		result = multierror.Append(result, fmt.Errorf("error tearing down seal manager: %w", err))
 	}
 	if err := c.teardownNamespaceStore(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down namespaces store: %w", err))

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -449,17 +449,11 @@ func (c *Core) stopExpiration() error {
 }
 
 func (m *ExpirationManager) leaseView(ns *namespace.Namespace) BarrierView {
-	if ns.ID == namespace.RootNamespaceID {
-		return m.core.systemBarrierView.SubView(expirationSubPath + leaseViewPrefix)
-	}
-	return m.core.namespaceMountEntryView(ns, systemBarrierPrefix+expirationSubPath+leaseViewPrefix)
+	return m.core.NamespaceView(ns).SubView(systemBarrierPrefix + expirationSubPath + leaseViewPrefix)
 }
 
 func (m *ExpirationManager) tokenIndexView(ns *namespace.Namespace) BarrierView {
-	if ns.ID == namespace.RootNamespaceID {
-		return m.core.systemBarrierView.SubView(expirationSubPath + tokenViewPrefix)
-	}
-	return m.core.namespaceMountEntryView(ns, systemBarrierPrefix+expirationSubPath+tokenViewPrefix)
+	return m.core.NamespaceView(ns).SubView(systemBarrierPrefix + expirationSubPath + tokenViewPrefix)
 }
 
 func (m *ExpirationManager) collectLeases() (map[*namespace.Namespace][]string, int, error) {

--- a/vault/external_tests/storage/crosstest/cross_test.go
+++ b/vault/external_tests/storage/crosstest/cross_test.go
@@ -205,7 +205,7 @@ func allLogical(t *testing.T) (map[string]logical.Storage, func()) {
 }
 
 func newAESBarrier(t *testing.T, parent physical.Backend) vault.SecurityBarrier {
-	b, err := vault.NewAESGCMBarrier(parent)
+	b, err := vault.NewAESGCMBarrier(parent, "")
 	require.NoError(t, err, "failed wrapping parent in AES-GCM barrier")
 
 	key, err := b.GenerateKey(crand.Reader)

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -154,10 +154,7 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 	if c.Sealed() && !c.recoveryMode {
 		return consts.ErrSealed
 	}
-	barrierSealed, err := c.barrier.Sealed()
-	if err != nil {
-		return errors.New("unable to check barrier seal status")
-	}
+	barrierSealed := c.barrier.Sealed()
 	if !barrierSealed && c.recoveryMode {
 		return errors.New("attempt to generate recovery operation token when already unsealed")
 	}
@@ -240,10 +237,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, consts.ErrSealed
 	}
 
-	barrierSealed, err := c.barrier.Sealed()
-	if err != nil {
-		return nil, errors.New("unable to check barrier seal status")
-	}
+	barrierSealed := c.barrier.Sealed()
 	if !barrierSealed && c.recoveryMode {
 		return nil, errors.New("attempt to generate recovery operation token when already unsealed")
 	}

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
@@ -221,7 +222,7 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 			return nil, err
 		}
 	} else {
-		config, err = c.seal.BarrierConfig(ctx)
+		config, err = c.seal.BarrierConfig(ctx, namespace.RootNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -570,7 +570,7 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 		// everything is sane. If we have no sanity in the barrier, we actually
 		// seal, as there's little we can do.
 		{
-			c.seal.SetBarrierConfig(activeCtx, nil)
+			c.seal.SetBarrierConfig(activeCtx, nil, namespace.RootNamespace)
 			if c.seal.RecoveryKeySupported() {
 				c.seal.SetRecoveryConfig(activeCtx, nil)
 			}
@@ -956,8 +956,8 @@ func (c *Core) reloadRootKey(ctx context.Context) error {
 }
 
 func (c *Core) reloadShamirKey(ctx context.Context) error {
-	_ = c.seal.SetBarrierConfig(ctx, nil)
-	if cfg, _ := c.seal.BarrierConfig(ctx); cfg == nil {
+	_ = c.seal.SetBarrierConfig(ctx, nil, namespace.RootNamespace)
+	if cfg, _ := c.seal.BarrierConfig(ctx, namespace.RootNamespace); cfg == nil {
 		return nil
 	}
 	var shamirKey []byte

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -1023,11 +1023,7 @@ func (c *Core) scheduleUpgradeCleanup(ctx context.Context) error {
 
 	// Schedule cleanup for all of them
 	time.AfterFunc(c.KeyRotateGracePeriod(), func() {
-		sealed, err := c.barrier.Sealed()
-		if err != nil {
-			c.logger.Warn("failed to check barrier status at upgrade cleanup time")
-			return
-		}
+		sealed := c.barrier.Sealed()
 		if sealed {
 			c.logger.Warn("barrier sealed at upgrade cleanup time")
 			return

--- a/vault/init.go
+++ b/vault/init.go
@@ -250,6 +250,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		return nil, fmt.Errorf("error initializing seal: %w", err)
 	}
 
+	// TODO: we are here
 	barrierKey, deprecatedBarrierKeyShares, err := c.generateShares(barrierConfig)
 	if err != nil {
 		c.logger.Error("error generating shares", "error", err)

--- a/vault/init.go
+++ b/vault/init.go
@@ -105,7 +105,7 @@ func (c *Core) InitializedLocally(ctx context.Context) (bool, error) {
 	}
 
 	// Verify the seal configuration
-	sealConf, err := c.seal.BarrierConfig(ctx)
+	sealConf, err := c.seal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		return false, err
 	}
@@ -250,7 +250,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		return nil, fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	barrierKey, barrierKeyShares, err := c.generateShares(barrierConfig)
+	barrierKey, deprecatedBarrierKeyShares, err := c.generateShares(barrierConfig)
 	if err != nil {
 		c.logger.Error("error generating shares", "error", err)
 		return nil, err
@@ -292,7 +292,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		}
 	}()
 
-	err = c.seal.SetBarrierConfig(ctx, barrierConfig)
+	err = c.seal.SetBarrierConfig(ctx, barrierConfig, namespace.RootNamespace)
 	if err != nil {
 		c.logger.Error("failed to save barrier configuration", "error", err)
 		return nil, fmt.Errorf("barrier configuration saving failed: %w", err)
@@ -329,7 +329,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	default:
 		// We don't support initializing an old-style Shamir seal anymore, so
 		// this case is only reachable by tests.
-		results.SecretShares = barrierKeyShares
+		results.SecretShares = deprecatedBarrierKeyShares
 	}
 
 	// Perform initial setup

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -65,7 +66,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err := c.seal.BarrierConfig(context.Background())
+	outConf, err := c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -121,7 +122,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err = c.seal.BarrierConfig(context.Background())
+	outConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -162,7 +163,7 @@ func testCore_Init_Common(t *testing.T, c *Core, conf *CoreConfig, barrierConf, 
 	}
 
 	// Check the seal configuration
-	outConf, err = c2.seal.BarrierConfig(context.Background())
+	outConf, err = c2.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/logical_raw.go
+++ b/vault/logical_raw.go
@@ -27,7 +27,7 @@ var protectedPaths = []string{
 
 type RawBackend struct {
 	*framework.Backend
-	barrier      SecurityBarrier
+	core         *Core
 	logger       log.Logger
 	checkRaw     func(path string) error
 	recoveryMode bool
@@ -35,8 +35,8 @@ type RawBackend struct {
 
 func NewRawBackend(core *Core) *RawBackend {
 	r := &RawBackend{
-		barrier: core.barrier,
-		logger:  core.logger.Named("raw"),
+		core:   core,
+		logger: core.logger.Named("raw"),
 		checkRaw: func(path string) error {
 			return nil
 		},
@@ -75,28 +75,28 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 		}
 	}
 
-	entry, err := b.barrier.Get(ctx, path)
+	barrier := b.core.sealManager.StorageAccessForPath(path)
+	valueBytes, err := barrier.Get(ctx, path)
 	if err != nil {
 		return handleErrorNoReadOnlyForward(err)
 	}
-	if entry == nil {
+	if valueBytes == nil {
 		return nil, nil
 	}
 
-	valueBytes := entry.Value
 	if compressed {
 		// Run this through the decompression helper to see if it's been compressed.
 		// If the input contained the compression canary, `valueBytes` will hold
 		// the decompressed data. If the input was not compressed, then `valueBytes`
 		// will be nil.
-		valueBytes, _, err = compressutil.Decompress(entry.Value)
+		decompData, _, err := compressutil.Decompress(valueBytes)
 		if err != nil {
 			return handleErrorNoReadOnlyForward(err)
 		}
 
 		// `valueBytes` is nil if the input is uncompressed. In that case set it to the original input.
-		if valueBytes == nil {
-			valueBytes = entry.Value
+		if decompData != nil {
+			valueBytes = decompData
 		}
 	}
 
@@ -150,19 +150,21 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 		}
 	}
 
+	barrier := b.core.sealManager.StorageAccessForPath(path)
+
 	if req.Operation == logical.UpdateOperation {
 		// Check if this is an existing value with compression applied, if so, use the same compression (or no compression)
-		entry, err := b.barrier.Get(ctx, path)
+		valueBytes, err := barrier.Get(ctx, path)
 		if err != nil {
 			return handleErrorNoReadOnlyForward(err)
 		}
-		if entry == nil {
+		if valueBytes == nil {
 			err := fmt.Sprintf("cannot figure out compression type because entry does not exist")
 			return logical.ErrorResponse(err), logical.ErrInvalidRequest
 		}
 
 		// For cases where DecompressWithCanary errored, treat entry as non-compressed data.
-		_, existingCompressionType, _, _ := compressutil.DecompressWithCanary(entry.Value)
+		_, existingCompressionType, _, _ := compressutil.DecompressWithCanary(valueBytes)
 
 		// Ensure compression_type matches existing entries' compression
 		// except allow writing non-compressed data over compressed data
@@ -212,12 +214,7 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 		}
 	}
 
-	entry := &logical.StorageEntry{
-		Key:   path,
-		Value: value,
-	}
-
-	if err := b.barrier.Put(ctx, entry); err != nil {
+	if err := barrier.Put(ctx, path, value); err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 	return nil, nil
@@ -239,7 +236,8 @@ func (b *RawBackend) handleRawDelete(ctx context.Context, req *logical.Request, 
 		}
 	}
 
-	if err := b.barrier.Delete(ctx, path); err != nil {
+	barrier := b.core.sealManager.StorageAccessForPath(path)
+	if err := barrier.Delete(ctx, path); err != nil {
 		return handleErrorNoReadOnlyForward(err)
 	}
 	return nil, nil
@@ -270,7 +268,8 @@ func (b *RawBackend) handleRawList(ctx context.Context, req *logical.Request, da
 		}
 	}
 
-	keys, err := b.barrier.ListPage(ctx, path, after, limit)
+	barrier := b.core.sealManager.StorageAccessForPath(path)
+	keys, err := barrier.ListPage(ctx, path, after, limit)
 	if err != nil {
 		return handleErrorNoReadOnlyForward(err)
 	}
@@ -280,7 +279,8 @@ func (b *RawBackend) handleRawList(ctx context.Context, req *logical.Request, da
 // existenceCheck checks if entry exists, used in handleRawWrite for update or create operations
 func (b *RawBackend) existenceCheck(ctx context.Context, request *logical.Request, data *framework.FieldData) (bool, error) {
 	path := data.Get("path").(string)
-	entry, err := b.barrier.Get(ctx, path)
+	barrier := b.core.sealManager.StorageAccessForPath(path)
+	entry, err := barrier.Get(ctx, path)
 	if err != nil {
 		return false, err
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -173,8 +173,8 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 
 func (b *SystemBackend) rawPaths() []*framework.Path {
 	r := &RawBackend{
-		barrier: b.Core.barrier,
-		logger:  b.logger,
+		core:   b.Core,
+		logger: b.logger,
 	}
 	return rawPaths("", r)
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5818,6 +5818,12 @@ This path responds to the following HTTP methods.
 	PATCH /<path>
 		Update a namespace's custom metadata.
 
+	POST /seal/<path>
+		Seal a namespace.
+
+	POST /unseal/<path>
+		Unseal a namespace.
+
 	DELETE /<path>
 		Delete a namespace.
 		`,

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5818,14 +5818,14 @@ This path responds to the following HTTP methods.
 	PATCH /<path>
 		Update a namespace's custom metadata.
 
-	POST /seal/<path>
-		Seal a namespace.
-
-	POST /unseal/<path>
-		Unseal a namespace.
-
 	DELETE /<path>
 		Delete a namespace.
+
+	POST /<name>/seal
+		Seal a namespace.
+
+	POST /<name/unseal
+		Unseal a namespace.
 		`,
 	},
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -97,6 +97,10 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 					Type:        framework.TypeMap,
 					Description: "User provided key-value pairs.",
 				},
+				"seals": {
+					Type:        framework.TypeSlice,
+					Description: "User provided seal configs.",
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -249,12 +253,41 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
+		var sealConfigs []*SealConfig
+		seals, ok := data.GetOk("seals")
+		if ok {
+			sealsArray, ok := seals.([]interface{})
+			if ok {
+				for _, seal := range sealsArray {
+					sealMap := seal.(map[string]interface{})
+					byteSeal, err := json.Marshal(sealMap)
+					if err != nil {
+						return logical.ErrorResponse("invalid seal configuration provided"), logical.ErrInvalidRequest
+					}
+
+					var sealConfig SealConfig
+					err = json.Unmarshal(byteSeal, &sealConfig)
+					if err != nil {
+						return logical.ErrorResponse("invalid seal configuration provided"), logical.ErrInvalidRequest
+					}
+					sealConfigs = append(sealConfigs, &sealConfig)
+				}
+			}
+		}
+
 		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			ns.CustomMetadata = metadata
 			return ns, nil
 		})
 		if err != nil {
 			return handleError(err)
+		}
+
+		// TODO(wslabosz): write all the provided configs
+		if len(sealConfigs) > 0 {
+			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry.Clone()); err != nil {
+				return nil, err
+			}
 		}
 
 		return &logical.Response{Data: createNamespaceDataResponse(entry)}, nil

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -288,6 +288,15 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry.Clone()); err != nil {
 				return nil, err
 			}
+			nsSealKeyShares, err := b.Core.sealManager.InitializeBarrier(ctx, entry)
+			if err != nil {
+				return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
+			}
+
+			// TODO Remove
+			for i, keyShare := range nsSealKeyShares {
+				fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+			}
 		}
 
 		return &logical.Response{Data: createNamespaceDataResponse(entry)}, nil

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -81,6 +81,67 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 		},
 
 		{
+			Pattern: "namespaces/seal(?:$|/(?P<path>.+))",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Path of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Seal a namespace.",
+					Callback: b.handleNamespacesSeal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+		},
+		{
+			Pattern: "namespaces/unseal(?:$|/(?P<path>.+))",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Path of the namespace.",
+				},
+				"key": {
+					Type:        framework.TypeNameString,
+					Description: "Specifies a single namespace unseal key share.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Unseal a namespace.",
+					Callback: b.handleNamespacesUnseal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+		},
+
+		{
 			Pattern: "namespaces/(?P<path>.+)",
 
 			DisplayAttrs: &framework.DisplayAttributes{
@@ -378,5 +439,34 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 				"status": status,
 			},
 		}, nil
+	}
+}
+
+// handleNamespacesSeal handles the "/sys/namespaces/seal/<path>" endpoint to seal the namespace.
+func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+
+		err := b.Core.namespaceStore.SealNamespace(ctx, path)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
+	}
+}
+
+// handleNamespacesUnseal handles the "/sys/namespaces/unseal/<path>" endpoint to unseal the namespace.
+func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+		key := data.Get("key").(string)
+
+		err := b.Core.namespaceStore.UnsealNamespace(ctx, path, []byte(key))
+		if err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
 	}
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,6 +49,11 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 			Type:        framework.TypeMap,
 			Required:    true,
 			Description: "User provided key-value pairs.",
+		},
+		"key_shares": {
+			Type:        framework.TypeMap,
+			Required:    false,
+			Description: "Generated key shares per seal for the namespace.",
 		},
 	}
 
@@ -214,13 +220,18 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 
 // createNamespaceDataResponse is the standard response object
 // for any operations concerning a namespace
-func createNamespaceDataResponse(ns *namespace.Namespace) map[string]any {
+func createNamespaceDataResponse(ns *namespace.Namespace, keySharesMap ...map[string][]string) map[string]any {
+	var keySharesPerSeal map[string][]string
+	if len(keySharesMap) > 0 {
+		keySharesPerSeal = keySharesMap[0]
+	}
 	return map[string]any{
 		"uuid":            ns.UUID,
 		"path":            ns.Path,
 		"id":              ns.ID,
 		"tainted":         ns.Tainted,
 		"custom_metadata": ns.CustomMetadata,
+		"key_shares":      keySharesPerSeal,
 	}
 }
 
@@ -331,6 +342,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		if err != nil {
 			return handleError(err)
 		}
+		keySharesMap := make(map[string][]string)
 		if new {
 			// TODO(wslabosz): write all the provided configs
 			if len(sealConfigs) > 0 {
@@ -342,10 +354,12 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 				if err != nil {
 					return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
 				}
-
-				// TODO Remove
-				for i, keyShare := range nsSealKeyShares {
-					fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+				var keyShares []string
+				for _, keyShare := range nsSealKeyShares {
+					keyShares = append(keyShares, hex.EncodeToString(keyShare))
+				}
+				if len(keyShares) > 0 {
+					keySharesMap["default"] = keyShares
 				}
 			}
 
@@ -354,7 +368,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
-		return &logical.Response{Data: createNamespaceDataResponse(entry)}, nil
+		return &logical.Response{Data: createNamespaceDataResponse(entry, keySharesMap)}, nil
 	}
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -275,27 +275,33 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
-		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+		entry, new, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			ns.CustomMetadata = metadata
 			return ns, nil
 		})
 		if err != nil {
 			return handleError(err)
 		}
+		if new {
+			// TODO(wslabosz): write all the provided configs
+			if len(sealConfigs) > 0 {
+				if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry); err != nil {
+					return handleError(err)
+				}
 
-		// TODO(wslabosz): write all the provided configs
-		if len(sealConfigs) > 0 {
-			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry.Clone()); err != nil {
-				return nil, err
-			}
-			nsSealKeyShares, err := b.Core.sealManager.InitializeBarrier(ctx, entry)
-			if err != nil {
-				return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
+				nsSealKeyShares, err := b.Core.sealManager.InitializeBarrier(ctx, entry)
+				if err != nil {
+					return logical.ErrorResponse(fmt.Sprintf("%s", err.Error())), err
+				}
+
+				// TODO Remove
+				for i, keyShare := range nsSealKeyShares {
+					fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+				}
 			}
 
-			// TODO Remove
-			for i, keyShare := range nsSealKeyShares {
-				fmt.Println("Key Share", i, ":", fmt.Sprintf("%x", keyShare))
+			if err := b.Core.namespaceStore.initializeNamespace(ctx, entry); err != nil {
+				return handleError(err)
 			}
 		}
 
@@ -328,7 +334,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
-		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+		ns, _, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			if ns.UUID == "" {
 				return nil, fmt.Errorf("requested namespace does not exist")
 			}

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -256,22 +256,10 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		var sealConfigs []*SealConfig
 		seals, ok := data.GetOk("seals")
 		if ok {
-			sealsArray, ok := seals.([]interface{})
-			if ok {
-				for _, seal := range sealsArray {
-					sealMap := seal.(map[string]interface{})
-					byteSeal, err := json.Marshal(sealMap)
-					if err != nil {
-						return logical.ErrorResponse("invalid seal configuration provided"), logical.ErrInvalidRequest
-					}
-
-					var sealConfig SealConfig
-					err = json.Unmarshal(byteSeal, &sealConfig)
-					if err != nil {
-						return logical.ErrorResponse("invalid seal configuration provided"), logical.ErrInvalidRequest
-					}
-					sealConfigs = append(sealConfigs, &sealConfig)
-				}
+			var err error
+			sealConfigs, err = b.Core.sealManager.ExtractSealConfigs(seals)
+			if err != nil {
+				return logical.ErrorResponse("error while extracting seal configs"), err
 			}
 		}
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -378,7 +378,7 @@ func (b *SystemBackend) handleRaftBootstrapChallengeWrite() framework.OperationF
 			return nil, err
 		}
 
-		sealConfig, err := b.Core.seal.BarrierConfig(ctx)
+		sealConfig, err := b.Core.seal.BarrierConfig(ctx, namespace.RootNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1268,7 +1268,7 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 		}
 	}
 
-	srcEntryView := NamespaceView(barrier, src.Namespace)
+	srcEntryView := c.NamespaceView(src.Namespace)
 	var coreLocalPath, corePath string
 
 	switch me.Table {
@@ -1386,7 +1386,7 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
-		view := NamespaceView(barrier, ns)
+		view := c.NamespaceView(ns)
 		nsGlobal, nsLocal, err := listTransactionalMountsForNamespace(ctx, view)
 		if err != nil {
 			c.logger.Error("failed to list transactional mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
@@ -1414,7 +1414,7 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 		}
 
 		for nsIndex, ns := range allNamespaces {
-			view := NamespaceView(barrier, ns)
+			view := c.NamespaceView(ns)
 			for index, uuid := range globalEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreMountConfigPath, uuid)
 				if err != nil {
@@ -1430,7 +1430,7 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 
 	if len(localEntries) > 0 {
 		for nsIndex, ns := range allNamespaces {
-			view := NamespaceView(barrier, ns)
+			view := c.NamespaceView(ns)
 			for index, uuid := range localEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalMountConfigPath, uuid)
 				if err != nil {
@@ -1740,7 +1740,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 					continue
 				}
 
-				view := NamespaceView(barrier, mtEntry.Namespace())
+				view := c.NamespaceView(mtEntry.Namespace())
 
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
@@ -1779,7 +1779,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
+					view := c.NamespaceView(ns)
 					path := path.Join(prefix, mount)
 					if err := view.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
@@ -1794,7 +1794,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
+					view := c.NamespaceView(ns)
 
 					// List all entries and remove any deleted ones.
 					presentEntries, err := view.List(ctx, prefix+"/")
@@ -2313,10 +2313,6 @@ func (c *Core) readMigrationStatus(migrationID string) *MountMigrationInfo {
 	return &migrationInfo
 }
 
-func (c *Core) namespaceMountEntryView(namespace *namespace.Namespace, prefix string) BarrierView {
-	return NamespaceView(c.barrier, namespace).SubView(prefix)
-}
-
 // mountEntryView returns the barrier view object with prefix depending on the mount entry type, table and namespace
 func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 	if me.Namespace() != nil && me.Namespace().ID != me.NamespaceID {
@@ -2325,8 +2321,8 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 
 	switch me.Type {
 	case mountTypeSystem, mountTypeNSSystem:
-		if me.Namespace() != nil && me.NamespaceID != namespace.RootNamespaceID {
-			return c.namespaceMountEntryView(me.Namespace(), systemBarrierPrefix), nil
+		if me.Namespace() != nil {
+			return c.NamespaceView(me.Namespace()).SubView(systemBarrierPrefix), nil
 		}
 		return NewBarrierView(c.barrier, systemBarrierPrefix), nil
 	case mountTypeToken:
@@ -2335,13 +2331,13 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 
 	switch me.Table {
 	case mountTableType:
-		if me.Namespace() != nil && me.NamespaceID != namespace.RootNamespaceID {
-			return c.namespaceMountEntryView(me.Namespace(), backendBarrierPrefix+me.UUID+"/"), nil
+		if me.Namespace() != nil {
+			return c.NamespaceView(me.Namespace()).SubView(backendBarrierPrefix + me.UUID + "/"), nil
 		}
 		return NewBarrierView(c.barrier, backendBarrierPrefix+me.UUID+"/"), nil
 	case credentialTableType:
-		if me.Namespace() != nil && me.NamespaceID != namespace.RootNamespaceID {
-			return c.namespaceMountEntryView(me.Namespace(), credentialBarrierPrefix+me.UUID+"/"), nil
+		if me.Namespace() != nil {
+			return c.NamespaceView(me.Namespace()).SubView(credentialBarrierPrefix + me.UUID + "/"), nil
 		}
 		return NewBarrierView(c.barrier, credentialBarrierPrefix+me.UUID+"/"), nil
 	case auditTableType:

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1459,7 +1459,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err := c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1467,7 +1467,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	// object lying around. This meant that list and subsequent create
 	// namespace operations returned this ghost structure and did not error
 	// properly. Retrying the create ensures no ghost object exists.
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1481,16 +1481,16 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
 	// Creating a new namespace should succeed.
-	nsBar, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
+	nsBar, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
 	require.NoError(t, err)
 	require.NotNil(t, nsBar)
 
@@ -1506,11 +1506,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1523,11 +1523,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1459,16 +1459,18 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err := c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, new, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// In openbao#1198, the first creation erred but left a ghost namespace
 	// object lying around. This meant that list and subsequent create
 	// namespace operations returned this ghost structure and did not error
 	// properly. Retrying the create ensures no ghost object exists.
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a deeply nested mount should also cause failures.
@@ -1481,18 +1483,23 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(namespace.RootContext(nil), me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a new namespace should succeed.
-	nsBar, _, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
+	nsBar, new, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(nil), "bar/", nil)
 	require.NoError(t, err)
+	require.True(t, new)
 	require.NotNil(t, nsBar)
+	err = c.namespaceStore.initializeNamespace(namespace.RootContext(nil), nsBar)
+	require.NoError(t, err)
 
 	barCtx := namespace.ContextWithNamespace(context.Background(), nsBar)
 
@@ -1506,12 +1513,14 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	me = &MountEntry{
@@ -1523,12 +1532,14 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
-	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, new, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
 	require.Error(t, err)
+	require.False(t, new)
 	require.Nil(t, ns)
 
 	// Creating a mount at the root level that conflicts with bar/ should fail.

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -309,7 +309,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	nsEntry.ID = entry.ID
 	nsEntry.Path = entry.Path
 
-	return true, nil
+	return !exists, nil
 }
 
 func (ns *NamespaceStore) writeNamespace(ctx context.Context, entry *namespace.Namespace) error {

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -742,7 +742,8 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 	return
 }
 
-// TODO:
+// SealNamespace seals namespace with provided path, failing to do so if the namespace
+// doesn't exist, is a root namespace, is tainted or is actively deleting.
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 
@@ -757,8 +758,9 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 	if err != nil {
 		return err
 	}
+
 	if namespaceToSeal == nil {
-		return nil
+		return errors.New("namespace doesn't exist")
 	}
 
 	if namespaceToSeal.ID == namespace.RootNamespaceID {
@@ -777,7 +779,8 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 	return nil
 }
 
-// TODO:
+// UnsealNamespace unseals namespace with a given path, using provided key
+// TODO(wslabosz): track the unsealing progress in a SealManager
 func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key []byte) error {
 	defer metrics.MeasureSince([]string{"namespace", "unseal_namespace"}, time.Now())
 
@@ -796,7 +799,6 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return nil
 	}
 
-	// TODO: verify the namespace is actualy sealed
 	if namespaceToUnseal.ID == namespace.RootNamespaceID {
 		return errors.New("unable to unseal root namespace")
 	}

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -223,66 +223,55 @@ func (ns *NamespaceStore) SetNamespace(ctx context.Context, namespace *namespace
 
 	// Now grab write lock so that we can write to storage.
 	ns.lock.Lock()
-	return ns.setNamespaceLocked(ctx, namespace)
+	new, err := ns.setNamespaceLocked(ctx, namespace)
+	ns.lock.Unlock()
+	// TODO: might want to support calling (*SealManager).SetSeal here
+	if new {
+		ns.initializeNamespace(ctx, namespace)
+	}
+	return err
 }
 
 // setNamespaceLocked must be called while holding a write lock over the
-// NamespaceStore. This function unlocks the lock once finished.
-func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace) error {
-	// If we are creating a net-new namespace, we have to unlock before
-	// creating required mounts as the mount type will call
-	// GetNamespaceByAccessor. In that case, we will manually call
-	// ns.lock.Unlock() but in all other cases (including early exit)
-	// we _also_ need to unlock. So using a defer is preferable. Calling
-	// unlock twice may fail (either incorrectly releasing the write lock
-	// if someone else grabbed it or panicing if it was double unlocked)
-	// so we need a boolean here to determine whether or not our deferred
-	// unlock should actually be run.
-	var unlocked bool
-	defer func() {
-		if !unlocked {
-			ns.lock.Unlock()
-			unlocked = true
-		}
-	}()
-
+// NamespaceStore.
+func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace) (new bool, err error) {
 	// Copy the entry before validating and potentially mutating it.
 	entry := nsEntry.Clone()
 	if err := entry.Validate(); err != nil {
-		return logical.CodedError(http.StatusBadRequest, err.Error())
+		return false, logical.CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Validate that we have a parent namespace.
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("error loading parent namespace from context: %w", err)
+		return false, fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
 	var exists bool
 	if entry.UUID == "" {
 		id, err := ns.assignIdentifier(entry.Path)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		entry.ID = id
 		entry.UUID, err = uuid.GenerateUUID()
 		if err != nil {
-			return err
+			return false, err
 		}
 	} else {
 		var existing *namespace.Namespace
 		existing, exists = ns.namespacesByUUID[entry.UUID]
 		if !exists {
-			return errors.New("trying to update a non-existent namespace")
+			return false, errors.New("trying to update a non-existent namespace")
 		}
 
 		if existing.ID != entry.ID {
-			return errors.New("accessor ID does not match")
+			return false, errors.New("accessor ID does not match")
 		}
 
 		if existing.Path != entry.Path {
-			return errors.New("unable to remount namespace at new path")
+			return false, errors.New("unable to remount namespace at new path")
 		}
 	}
 
@@ -296,7 +285,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		path := entry.Path
 		if parent.ID != namespace.RootNamespaceID {
 			if !entry.HasParent(parent) {
-				return errors.New("namespace path lacks parent as a prefix")
+				return false, errors.New("namespace path lacks parent as a prefix")
 			}
 
 			path = namespace.Canonicalize(parent.TrimmedPath(entry.Path))
@@ -304,12 +293,12 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 
 		conflict := ns.core.router.matchingPrefixInternal(ctx, path)
 		if conflict != "" {
-			return fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
+			return false, fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
 		}
 	}
 
 	if err := ns.writeNamespace(ctx, entry); err != nil {
-		return fmt.Errorf("failed to persist namespace: %w", err)
+		return false, fmt.Errorf("failed to persist namespace: %w", err)
 	}
 	ns.namespacesByPath.Insert(entry)
 	ns.namespacesByUUID[entry.UUID] = entry
@@ -320,18 +309,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	nsEntry.ID = entry.ID
 	nsEntry.Path = entry.Path
 
-	if !exists {
-		// unlock before initializeNamespace since that will re-acquire the lock
-		ns.lock.Unlock()
-		unlocked = true
-
-		// Create sys/, token/ mounts and policies for the new namespace.
-		if err := ns.initializeNamespace(ctx, entry); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return true, nil
 }
 
 func (ns *NamespaceStore) writeNamespace(ctx context.Context, entry *namespace.Namespace) error {
@@ -515,30 +493,30 @@ func (ns *NamespaceStore) getNamespaceByPathLocked(ctx context.Context, path str
 // ModifyNamespace is used to perform modifications to a namespace while
 // holding a write lock to prevent other changes to namespaces from occurring
 // at the same time.
-func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, error) {
+func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, bool, error) {
 	defer metrics.MeasureSince([]string{"namespace", "modify_namespace"}, time.Now())
 
 	if err := ns.checkInvalidation(ctx); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	path = namespace.Canonicalize(parent.Path + path)
 	if path == "" {
-		return nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
+		return nil, false, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
 	}
 
 	ns.lock.Lock()
+	defer ns.lock.Unlock()
 
 	entry := ns.namespacesByPath.Get(path)
 	if entry != nil {
 		if entry.Tainted {
-			ns.lock.Unlock()
-			return nil, errors.New("namespace with that name exists and is currently tainted")
+			return nil, false, errors.New("namespace with that name exists and is currently tainted")
 		}
 		entry = entry.Clone()
 	} else {
@@ -551,17 +529,16 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 	if callback != nil {
 		entry, err = callback(ctx, entry)
 		if err != nil {
-			ns.lock.Unlock()
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	// setNamespaceLocked will unlock ns.lock
-	if err := ns.setNamespaceLocked(ctx, entry); err != nil {
-		return nil, err
+	new, err := ns.setNamespaceLocked(ctx, entry)
+	if err != nil {
+		return nil, new, err
 	}
 
-	return entry.Clone(), nil
+	return entry.Clone(), new, nil
 }
 
 // ListAllNamespaces lists all available namespaces, optionally including the

--- a/vault/namespaces_store.go
+++ b/vault/namespaces_store.go
@@ -175,7 +175,7 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 			return false, err
 		}
 
-		childView := NamespaceView(barrier, &namespace).SubView(namespaceStoreSubPath)
+		childView := ns.core.NamespaceView(&namespace).SubView(namespaceStoreSubPath)
 		if err := ns.loadNamespacesRecursive(ctx, barrier, childView, callback); err != nil {
 			return false, err
 		}
@@ -340,7 +340,7 @@ func (ns *NamespaceStore) writeNamespace(ctx context.Context, entry *namespace.N
 		return err
 	}
 
-	view := NamespaceView(ns.storage, parent).SubView(namespaceStoreSubPath)
+	view := ns.core.NamespaceView(parent).SubView(namespaceStoreSubPath)
 	if err := logical.WithTransaction(ctx, view, func(s logical.Storage) error {
 		item, err := logical.StorageEntryJSON(entry.UUID, &entry)
 		if err != nil {
@@ -754,7 +754,7 @@ func (ns *NamespaceStore) clearNamespaceResources(ctx context.Context, namespace
 		return
 	}
 
-	view := NamespaceView(ns.storage, parent).SubView(namespaceStoreSubPath)
+	view := ns.core.NamespaceView(parent).SubView(namespaceStoreSubPath)
 	err = logical.WithTransaction(ctx, view, func(s logical.Storage) error {
 		return s.Delete(ctx, namespaceToDelete.UUID)
 	})

--- a/vault/password_policy_util.go
+++ b/vault/password_policy_util.go
@@ -22,7 +22,7 @@ func (d dynamicSystemView) retrievePasswordPolicy(ctx context.Context, policyNam
 		return nil, err
 	}
 
-	storage := d.core.namespaceMountEntryView(ns, passwordPolicySubPath)
+	storage := d.core.NamespaceView(ns).SubView(passwordPolicySubPath)
 	entry, err := storage.Get(ctx, policyName)
 	if err != nil {
 		return nil, err

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -357,11 +357,7 @@ func (ps *PolicyStore) GetNonEGPPolicyType(nsID string, name string) (*PolicyTyp
 
 // getACLView returns the ACL view for the given namespace
 func (ps *PolicyStore) getACLView(ns *namespace.Namespace) BarrierView {
-	if ns.ID == namespace.RootNamespaceID {
-		return ps.core.systemBarrierView.SubView(policyACLSubPath)
-	}
-
-	return ps.core.namespaceMountEntryView(ns, systemBarrierPrefix+policyACLSubPath)
+	return ps.core.NamespaceView(ns).SubView(systemBarrierPrefix + policyACLSubPath)
 }
 
 // getBarrierView returns the appropriate barrier view for the given namespace and policy type.

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -928,7 +929,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 		// false.
 		if c.seal.BarrierType() == wrapping.WrapperTypeShamir && !c.isRaftHAOnly() {
 			c.raftInfo.Store(raftInfo)
-			if err := c.seal.SetBarrierConfig(ctx, raftInfo.leaderBarrierConfig); err != nil {
+			if err := c.seal.SetBarrierConfig(ctx, raftInfo.leaderBarrierConfig, namespace.RootNamespace); err != nil {
 				return err
 			}
 

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -213,7 +214,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	if recovery {
 		sealConf, err = c.seal.RecoveryConfig(context.Background())
 	} else {
-		sealConf, err = c.seal.BarrierConfig(context.Background())
+		sealConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	}
 	if err != nil {
 		t.Fatalf("seal config retrieval error: %v", err)
@@ -314,7 +315,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	if recovery {
 		sealConf, err = c.seal.RecoveryConfig(context.Background())
 	} else {
-		sealConf, err = c.seal.BarrierConfig(context.Background())
+		sealConf, err = c.seal.BarrierConfig(context.Background(), namespace.RootNamespace)
 	}
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -160,7 +160,7 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace
 		return nil, err
 	}
 
-	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
 
 	// Fetch the core configuration
 	pe, err := d.core.physical.Get(ctx, view.Prefix())
@@ -230,7 +230,7 @@ func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig, 
 		return fmt.Errorf("failed to encode seal configuration: %w", err)
 	}
 
-	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
 
 	// Store the seal configuration
 	pe := &physical.Entry{

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -61,6 +61,7 @@ const (
 type Seal interface {
 	SetCore(*Core)
 	Init(context.Context) error
+	SetMetaPrefix(string)
 	Finalize(context.Context) error
 	StoredKeysSupported() seal.StoredKeysSupport // SealAccess
 	SealWrapable() bool
@@ -83,9 +84,10 @@ type Seal interface {
 }
 
 type defaultSeal struct {
-	access seal.Access
-	config atomic.Value
-	core   *Core
+	access     seal.Access
+	config     atomic.Value
+	core       *Core
+	metaPrefix string
 }
 
 var _ Seal = (*defaultSeal)(nil)
@@ -125,6 +127,10 @@ func (d *defaultSeal) Init(ctx context.Context) error {
 	return nil
 }
 
+func (d *defaultSeal) SetMetaPrefix(metaPrefix string) {
+	d.metaPrefix = metaPrefix
+}
+
 func (d *defaultSeal) Finalize(ctx context.Context) error {
 	return nil
 }
@@ -142,11 +148,11 @@ func (d *defaultSeal) RecoveryKeySupported() bool {
 }
 
 func (d *defaultSeal) SetStoredKeys(ctx context.Context, keys [][]byte) error {
-	return writeStoredKeys(ctx, d.core.physical, d.access, keys)
+	return writeStoredKeys(ctx, d.core.physical, d.metaPrefix, d.access, keys)
 }
 
 func (d *defaultSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {
-	keys, err := readStoredKeys(ctx, d.core.physical, d.access)
+	keys, err := readStoredKeys(ctx, d.core.physical, d.metaPrefix, d.access)
 	return keys, err
 }
 
@@ -161,16 +167,17 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace
 	}
 
 	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
+	barrier := d.core.sealManager.StorageAccessForPath(view.Prefix())
 
 	// Fetch the core configuration
-	pe, err := d.core.physical.Get(ctx, view.Prefix())
+	valueBytes, err := barrier.Get(ctx, view.Prefix())
 	if err != nil {
 		d.core.logger.Error("failed to read seal configuration", "error", err)
 		return nil, fmt.Errorf("failed to check seal configuration: %w", err)
 	}
 
 	// If the seal configuration is missing, we are not initialized
-	if pe == nil {
+	if valueBytes == nil {
 		d.core.logger.Info("seal configuration missing, not initialized")
 		return nil, nil
 	}
@@ -178,7 +185,7 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace
 	var conf SealConfig
 
 	// Decode the barrier entry
-	if err := jsonutil.DecodeJSON(pe.Value, &conf); err != nil {
+	if err := jsonutil.DecodeJSON(valueBytes, &conf); err != nil {
 		d.core.logger.Error("failed to decode seal configuration", "error", err)
 		return nil, fmt.Errorf("failed to decode seal configuration: %w", err)
 	}
@@ -231,14 +238,8 @@ func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig, 
 	}
 
 	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
-
-	// Store the seal configuration
-	pe := &physical.Entry{
-		Key:   view.Prefix(),
-		Value: buf,
-	}
-
-	if err := d.core.physical.Put(ctx, pe); err != nil {
+	barrier := d.core.sealManager.StorageAccessForPath(view.Prefix())
+	if err := barrier.Put(ctx, view.Prefix(), buf); err != nil {
 		d.core.logger.Error("failed to write seal configuration", "error", err)
 		return fmt.Errorf("failed to write seal configuration: %w", err)
 	}
@@ -433,7 +434,7 @@ func (e *ErrDecrypt) Is(target error) bool {
 	return ok || errors.Is(e.Err, target)
 }
 
-func writeStoredKeys(ctx context.Context, storage physical.Backend, encryptor seal.Access, keys [][]byte) error {
+func writeStoredKeys(ctx context.Context, storage physical.Backend, metaPrefix string, encryptor seal.Access, keys [][]byte) error {
 	if keys == nil {
 		return errors.New("keys were nil")
 	}
@@ -459,7 +460,7 @@ func writeStoredKeys(ctx context.Context, storage physical.Backend, encryptor se
 
 	// Store the seal configuration.
 	pe := &physical.Entry{
-		Key:   StoredBarrierKeysPath, // TODO(SEALHA): will we need to store more than one set of keys?
+		Key:   metaPrefix + StoredBarrierKeysPath, // TODO(SEALHA): will we need to store more than one set of keys?
 		Value: value,
 	}
 
@@ -470,8 +471,8 @@ func writeStoredKeys(ctx context.Context, storage physical.Backend, encryptor se
 	return nil
 }
 
-func readStoredKeys(ctx context.Context, storage physical.Backend, encryptor seal.Access) ([][]byte, error) {
-	pe, err := storage.Get(ctx, StoredBarrierKeysPath)
+func readStoredKeys(ctx context.Context, storage physical.Backend, metaPrefix string, encryptor seal.Access) ([][]byte, error) {
+	pe, err := storage.Get(ctx, metaPrefix+StoredBarrierKeysPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch stored keys: %w", err)
 	}

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -15,6 +15,7 @@ import (
 
 	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 
@@ -65,9 +66,9 @@ type Seal interface {
 	SealWrapable() bool
 	SetStoredKeys(context.Context, [][]byte) error
 	GetStoredKeys(context.Context) ([][]byte, error)
-	BarrierType() wrapping.WrapperType                  // SealAccess
-	BarrierConfig(context.Context) (*SealConfig, error) // SealAccess
-	SetBarrierConfig(context.Context, *SealConfig) error
+	BarrierType() wrapping.WrapperType                                        // SealAccess
+	BarrierConfig(context.Context, *namespace.Namespace) (*SealConfig, error) // SealAccess
+	SetBarrierConfig(context.Context, *SealConfig, *namespace.Namespace) error
 	SetCachedBarrierConfig(*SealConfig)
 	RecoveryKeySupported() bool // SealAccess
 	RecoveryType() string
@@ -149,7 +150,7 @@ func (d *defaultSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {
 	return keys, err
 }
 
-func (d *defaultSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
+func (d *defaultSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace) (*SealConfig, error) {
 	cfg := d.config.Load().(*SealConfig)
 	if cfg != nil {
 		return cfg.Clone(), nil
@@ -159,8 +160,10 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 		return nil, err
 	}
 
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+
 	// Fetch the core configuration
-	pe, err := d.core.physical.Get(ctx, barrierSealConfigPath)
+	pe, err := d.core.physical.Get(ctx, view.Prefix())
 	if err != nil {
 		d.core.logger.Error("failed to read seal configuration", "error", err)
 		return nil, fmt.Errorf("failed to check seal configuration: %w", err)
@@ -200,7 +203,7 @@ func (d *defaultSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 	return conf.Clone(), nil
 }
 
-func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig) error {
+func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig, ns *namespace.Namespace) error {
 	if err := d.checkCore(); err != nil {
 		return err
 	}
@@ -227,9 +230,11 @@ func (d *defaultSeal) SetBarrierConfig(ctx context.Context, config *SealConfig) 
 		return fmt.Errorf("failed to encode seal configuration: %w", err)
 	}
 
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+
 	// Store the seal configuration
 	pe := &physical.Entry{
-		Key:   barrierSealConfigPath,
+		Key:   view.Prefix(),
 		Value: buf,
 	}
 

--- a/vault/seal_access.go
+++ b/vault/seal_access.go
@@ -8,6 +8,7 @@ import (
 
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/vault/seal"
 )
 
@@ -31,7 +32,7 @@ func (s *SealAccess) BarrierType() wrapping.WrapperType {
 }
 
 func (s *SealAccess) BarrierConfig(ctx context.Context) (*SealConfig, error) {
-	return s.seal.BarrierConfig(ctx)
+	return s.seal.BarrierConfig(ctx, namespace.RootNamespace)
 }
 
 func (s *SealAccess) RecoveryKeySupported() bool {
@@ -48,7 +49,7 @@ func (s *SealAccess) VerifyRecoveryKey(ctx context.Context, key []byte) error {
 
 // TODO(SEALHA): This looks like it belongs in Seal instead, it only has two callers
 func (s *SealAccess) ClearCaches(ctx context.Context) {
-	s.seal.SetBarrierConfig(ctx, nil)
+	s.seal.SetBarrierConfig(ctx, nil, namespace.RootNamespace)
 	if s.RecoveryKeySupported() {
 		s.seal.SetRecoveryConfig(ctx, nil)
 	}

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -199,7 +199,7 @@ func (d *autoSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace) (
 	}
 
 	sealType := "barrier"
-	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
 
 	entry, err := d.core.physical.Get(ctx, view.Prefix())
 	if err != nil {
@@ -255,7 +255,7 @@ func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig, ns *n
 		return fmt.Errorf("failed to encode barrier seal configuration: %w", err)
 	}
 
-	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+	view := d.core.NamespaceView(ns).SubView(barrierSealConfigPath)
 
 	// Store the seal configuration
 	pe := &physical.Entry{

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -45,6 +45,7 @@ type autoSeal struct {
 	recoveryConfig atomic.Value
 	core           *Core
 	logger         log.Logger
+	metaPrefix     string
 
 	hcLock          sync.Mutex
 	healthCheckStop chan struct{}
@@ -98,6 +99,10 @@ func (d *autoSeal) Init(ctx context.Context) error {
 	return d.Access.Init(ctx)
 }
 
+func (d *autoSeal) SetMetaPrefix(metaPrefix string) {
+	d.metaPrefix = metaPrefix
+}
+
 func (d *autoSeal) Finalize(ctx context.Context) error {
 	return d.Access.Finalize(ctx)
 }
@@ -121,13 +126,13 @@ func (d *autoSeal) RecoveryKeySupported() bool {
 // SetStoredKeys uses the autoSeal.Access.Encrypts method to wrap the keys. The stored entry
 // does not need to be seal wrapped in this case.
 func (d *autoSeal) SetStoredKeys(ctx context.Context, keys [][]byte) error {
-	return writeStoredKeys(ctx, d.core.physical, d.Access, keys)
+	return writeStoredKeys(ctx, d.core.physical, d.metaPrefix, d.Access, keys)
 }
 
 // GetStoredKeys retrieves the key shares by unwrapping the encrypted key using the
 // autoseal.
 func (d *autoSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {
-	return readStoredKeys(ctx, d.core.physical, d.Access)
+	return readStoredKeys(ctx, d.core.physical, d.metaPrefix, d.Access)
 }
 
 func (d *autoSeal) upgradeStoredKeys(ctx context.Context) error {

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -20,6 +20,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/seal"
 )
@@ -188,7 +189,7 @@ func (d *autoSeal) UpgradeKeys(ctx context.Context) error {
 	return nil
 }
 
-func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
+func (d *autoSeal) BarrierConfig(ctx context.Context, ns *namespace.Namespace) (*SealConfig, error) {
 	if d.barrierConfig.Load().(*SealConfig) != nil {
 		return d.barrierConfig.Load().(*SealConfig).Clone(), nil
 	}
@@ -198,8 +199,9 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 	}
 
 	sealType := "barrier"
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
 
-	entry, err := d.core.physical.Get(ctx, barrierSealConfigPath)
+	entry, err := d.core.physical.Get(ctx, view.Prefix())
 	if err != nil {
 		d.logger.Error("failed to read seal configuration", "seal_type", sealType, "error", err)
 		return nil, fmt.Errorf("failed to read %q seal configuration: %w", sealType, err)
@@ -235,7 +237,7 @@ func (d *autoSeal) BarrierConfig(ctx context.Context) (*SealConfig, error) {
 	return conf.Clone(), nil
 }
 
-func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig) error {
+func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig, ns *namespace.Namespace) error {
 	if err := d.checkCore(); err != nil {
 		return err
 	}
@@ -253,9 +255,11 @@ func (d *autoSeal) SetBarrierConfig(ctx context.Context, conf *SealConfig) error
 		return fmt.Errorf("failed to encode barrier seal configuration: %w", err)
 	}
 
+	view := NamespaceView(d.core.barrier, ns).SubView(barrierSealConfigPath)
+
 	// Store the seal configuration
 	pe := &physical.Entry{
-		Key:   barrierSealConfigPath,
+		Key:   view.Prefix(),
 		Value: buf,
 	}
 

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -1,0 +1,77 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	vaultseal "github.com/openbao/openbao/vault/seal"
+)
+
+// SealManager is used to provide storage for the seals.
+// It's a singleton that associates seals (configs) to the namespaces.
+type SealManager struct {
+	core    *Core
+	storage logical.Storage
+
+	// lock        sync.RWMutex
+	// invalidated atomic.Bool
+
+	sealsByNamespace map[string][]*Seal
+
+	// logger is the server logger copied over from core
+	logger hclog.Logger
+}
+
+// NewSealManager creates a new seal manager with core reference and logger.
+func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*SealManager, error) {
+	return &SealManager{
+		core:             core,
+		storage:          core.barrier,
+		sealsByNamespace: make(map[string][]*Seal),
+		logger:           logger,
+	}, nil
+}
+
+// setupSealManager is used to initialize the seal manager
+// when the vault is being unsealed.
+func (c *Core) setupSealManager(ctx context.Context) error {
+	var err error
+	sealLogger := c.baseLogger.Named("seal")
+	c.AddLogger(sealLogger)
+	c.sealManager, err = NewSealManager(ctx, c, sealLogger)
+	return err
+}
+
+// teardownSealManager is used to remove seal manager
+// when the vault is being sealed.
+func (c *Core) teardownSealManager() error {
+	c.sealManager = nil
+	return nil
+}
+
+// TODO(wslabosz): add logs
+func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *namespace.Namespace) error {
+	if err := sealConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid seal configuration: %w", err)
+	}
+
+	// Seal type would depend on the provided arguments
+	defaultSeal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+	defaultSeal.SetCore(sm.core)
+
+	if err := defaultSeal.Init(ctx); err != nil {
+		return fmt.Errorf("error initializing seal: %w", err)
+	}
+
+	sm.sealsByNamespace[ns.UUID] = []*Seal{&defaultSeal}
+	err := defaultSeal.SetBarrierConfig(ctx, sealConfig, ns)
+	if err != nil {
+		return fmt.Errorf("failed to set barrier config: %w", err)
+	}
+
+	return nil
+}

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -233,6 +234,35 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 	}
 
 	return nsSealKeyShares, nil
+}
+
+func (sm *SealManager) ExtractSealConfigs(seals interface{}) ([]*SealConfig, error) {
+	sealsArray, ok := seals.([]interface{})
+	var sealConfigs []*SealConfig
+	if !ok {
+		return nil, fmt.Errorf("seals is not an array")
+	}
+
+	for _, seal := range sealsArray {
+		sealMap, ok := seal.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("seal is not a map")
+		}
+
+		byteSeal, err := json.Marshal(sealMap)
+		if err != nil {
+			return nil, err
+		}
+
+		var sealConfig SealConfig
+		err = json.Unmarshal(byteSeal, &sealConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		sealConfigs = append(sealConfigs, &sealConfig)
+	}
+	return sealConfigs, nil
 }
 
 type StorageAccess interface {

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -10,6 +10,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/seal"
 	vaultseal "github.com/openbao/openbao/vault/seal"
 )
@@ -22,31 +24,35 @@ type SealManager struct {
 	// lock        sync.RWMutex
 	// invalidated atomic.Bool
 
-	sealsByNamespace   map[string][]*Seal
-	barrierByNamespace *radix.Tree
+	sealsByNamespace     map[string][]*Seal
+	barrierByNamespace   *radix.Tree
+	barrierByStoragePath *radix.Tree
 
 	// logger is the server logger copied over from core
 	logger hclog.Logger
 }
 
 // NewSealManager creates a new seal manager with core reference and logger.
-func NewSealManager(ctx context.Context, core *Core, logger hclog.Logger) (*SealManager, error) {
+func NewSealManager(core *Core, logger hclog.Logger) (*SealManager, error) {
 	return &SealManager{
-		core:               core,
-		sealsByNamespace:   make(map[string][]*Seal),
-		barrierByNamespace: radix.New(),
-		logger:             logger,
+		core:                 core,
+		sealsByNamespace:     make(map[string][]*Seal),
+		barrierByNamespace:   radix.New(),
+		barrierByStoragePath: radix.New(),
+		logger:               logger,
 	}, nil
 }
 
 // setupSealManager is used to initialize the seal manager
 // when the vault is being unsealed.
-func (c *Core) setupSealManager(ctx context.Context) error {
+func (c *Core) setupSealManager() error {
 	var err error
 	sealLogger := c.baseLogger.Named("seal")
 	c.AddLogger(sealLogger)
-	c.sealManager, err = NewSealManager(ctx, c, sealLogger)
+	c.sealManager, err = NewSealManager(c, sealLogger)
 	c.sealManager.barrierByNamespace.Insert("", c.barrier)
+	c.sealManager.barrierByStoragePath.Insert("", c.barrier)
+	c.sealManager.barrierByStoragePath.Insert("core/seal-config", nil)
 	return err
 }
 
@@ -67,20 +73,28 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 		return fmt.Errorf("invalid seal configuration: %w", err)
 	}
 
+	metaPrefix := namespaceBarrierPrefix + ns.UUID + "/"
+
 	// Seal type would depend on the provided arguments
 	defaultSeal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
 	defaultSeal.SetCore(sm.core)
+	defaultSeal.SetMetaPrefix(metaPrefix)
 
 	if err := defaultSeal.Init(ctx); err != nil {
 		return fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	barrier, err := NewAESGCMBarrier(sm.core.physical, namespaceBarrierPrefix+ns.UUID+"/")
+	barrier, err := NewAESGCMBarrier(sm.core.physical, metaPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to construct namespace barrier: %w", err)
 	}
 	// barrier.Initialize(ctx context.Context, rootKey []byte, sealKey []byte, random io.Reader)
 	sm.barrierByNamespace.Insert(ns.Path, barrier)
+	sm.barrierByStoragePath.Insert(metaPrefix, barrier)
+	parentBarrier := sm.ParentNamespaceBarrier(ns)
+	if parentBarrier != nil {
+		sm.barrierByStoragePath.Insert(metaPrefix+barrierSealConfigPath, parentBarrier)
+	}
 	sm.sealsByNamespace[ns.UUID] = []*Seal{&defaultSeal}
 	err = defaultSeal.SetBarrierConfig(ctx, sealConfig, ns)
 	if err != nil {
@@ -88,6 +102,15 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	}
 
 	return nil
+}
+
+func (sm *SealManager) StorageAccessForPath(path string) StorageAccess {
+	_, v, _ := sm.barrierByStoragePath.LongestPrefix(path)
+	if v == nil {
+		return &directStorageAccess{physical: sm.core.physical}
+	}
+	barrier := v.(SecurityBarrier)
+	return &secureStorageAccess{barrier: barrier}
 }
 
 // SealNamespace seals the barriers of the given namespace and all of its children.
@@ -106,17 +129,28 @@ func (sm *SealManager) SealNamespace(ns *namespace.Namespace) error {
 	return errs
 }
 
+func (sm *SealManager) ParentNamespaceBarrier(ns *namespace.Namespace) SecurityBarrier {
+	parentPath, ok := ns.ParentPath()
+	if !ok {
+		return nil
+	}
+
+	_, v, _ := sm.barrierByNamespace.LongestPrefix(parentPath)
+	barrier := v.(SecurityBarrier)
+	return barrier
+}
+
+func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier {
+	_, v, _ := sm.barrierByNamespace.LongestPrefix(ns.Path)
+	barrier := v.(SecurityBarrier)
+
+	return barrier
+}
+
 // NamespaceView finds the correct barrier to use for the namespace and returns
 // the a BarrierView restricted to the data of the given namespace.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
-	// TODO: NamespaceView is called somewhere before sealManager is
-	// initialized. Figure out if we can fix the init sequence to make this go
-	// away
-	if c.sealManager == nil {
-		return NamespaceView(c.barrier, ns)
-	}
-	_, v, _ := c.sealManager.barrierByNamespace.LongestPrefix(ns.Path)
-	barrier := v.(SecurityBarrier)
+	barrier := c.sealManager.NamespaceBarrier(ns)
 	return NamespaceView(barrier, ns)
 }
 
@@ -199,4 +233,78 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 	}
 
 	return nsSealKeyShares, nil
+}
+
+type StorageAccess interface {
+	Put(context.Context, string, []byte) error
+	Get(context.Context, string) ([]byte, error)
+	Delete(context.Context, string) error
+	ListPage(context.Context, string, string, int) ([]string, error)
+}
+
+var (
+	_ StorageAccess = (*directStorageAccess)(nil)
+	_ StorageAccess = (*secureStorageAccess)(nil)
+)
+
+type directStorageAccess struct {
+	physical physical.Backend
+}
+
+func (p *directStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	pe := &physical.Entry{
+		Key:   path,
+		Value: value,
+	}
+	return p.physical.Put(ctx, pe)
+}
+
+func (p *directStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	pe, err := p.physical.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if pe == nil {
+		return nil, nil
+	}
+	return pe.Value, nil
+}
+
+func (p *directStorageAccess) Delete(ctx context.Context, key string) error {
+	return p.physical.Delete(ctx, key)
+}
+
+func (p *directStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return p.physical.ListPage(ctx, prefix, after, limit)
+}
+
+type secureStorageAccess struct {
+	barrier SecurityBarrier
+}
+
+func (b *secureStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	se := &logical.StorageEntry{
+		Key:   path,
+		Value: value,
+	}
+	return b.barrier.Put(ctx, se)
+}
+
+func (b *secureStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	se, err := b.barrier.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if se == nil {
+		return nil, nil
+	}
+	return se.Value, nil
+}
+
+func (b *secureStorageAccess) Delete(ctx context.Context, key string) error {
+	return b.barrier.Delete(ctx, key)
+}
+
+func (b *secureStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return b.barrier.ListPage(ctx, prefix, after, limit)
 }

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -148,6 +148,18 @@ func (sm *SealManager) NamespaceBarrier(ns *namespace.Namespace) SecurityBarrier
 	return barrier
 }
 
+// TODO(wslabosz): [PLACEHOLDER] UnsealNamespace unseals the barriers of the given namespace and all of its children.
+func (sm *SealManager) UnsealNamespace(ctx context.Context, path string, key []byte) error {
+	v, exists := sm.barrierByNamespace.Get(path)
+	if !exists {
+		return errors.New("barrier for the namespace doesn't exist")
+	}
+
+	sb := v.(SecurityBarrier)
+	err := sb.Unseal(ctx, key)
+	return err
+}
+
 // NamespaceView finds the correct barrier to use for the namespace and returns
 // the a BarrierView restricted to the data of the given namespace.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
 )
 
 // TestDefaultSeal_Config exercises Shamir SetBarrierConfig and BarrierConfig.
 // Note that this is a little questionable, because we're doing an init and
 // unseal, then changing the barrier config using an internal function instead
-// of an API.  In other words if your change break this test, it might be more
+// of an API. In other words if your change break this test, it might be more
 // the test's fault than your changes.
 func TestDefaultSeal_Config(t *testing.T) {
 	bc := &SealConfig{
@@ -20,15 +22,16 @@ func TestDefaultSeal_Config(t *testing.T) {
 		SecretThreshold: 2,
 	}
 	core, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
 	defSeal := NewDefaultSeal(nil)
 	defSeal.SetCore(core)
-	err := defSeal.SetBarrierConfig(context.Background(), bc)
+	err := defSeal.SetBarrierConfig(ctx, bc, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newBc, err := defSeal.BarrierConfig(context.Background())
+	newBc, err := defSeal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,11 +42,45 @@ func TestDefaultSeal_Config(t *testing.T) {
 	// Now, test without the benefit of the cached value in the seal
 	defSeal = NewDefaultSeal(nil)
 	defSeal.SetCore(core)
-	newBc, err = defSeal.BarrierConfig(context.Background())
+	newBc, err = defSeal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*bc, *newBc) {
+		t.Fatal("config mismatch")
+	}
+
+	nsSealConfig := &SealConfig{
+		SecretShares:    10,
+		SecretThreshold: 5,
+	}
+
+	nsTest := &namespace.Namespace{Path: "test/"}
+	TestCoreCreateNamespaces(t, core, nsTest)
+
+	defSeal = NewDefaultSeal(nil)
+	defSeal.SetCore(core)
+	err = defSeal.SetBarrierConfig(ctx, nsSealConfig, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newNSSealConfig, err := defSeal.BarrierConfig(ctx, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*nsSealConfig, *newNSSealConfig) {
+		t.Fatal("config mismatch")
+	}
+
+	// Now, test without the benefit of the cached value in the seal
+	defSeal = NewDefaultSeal(nil)
+	defSeal.SetCore(core)
+	newNSSealConfig, err = defSeal.BarrierConfig(ctx, nsTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*nsSealConfig, *newNSSealConfig) {
 		t.Fatal("config mismatch")
 	}
 }

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -327,9 +327,8 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 	barrierConfig := &SealConfig{
 		SecretShares:    3,
 		SecretThreshold: 3,
+		StoredShares:    1,
 	}
-
-	barrierConfig.StoredShares = 1
 
 	recoveryConfig := &SealConfig{
 		SecretShares:    3,
@@ -340,7 +339,7 @@ func TestCoreInitClusterWrapperSetup(t testing.T, core *Core, handler http.Handl
 		BarrierConfig:  barrierConfig,
 		RecoveryConfig: recoveryConfig,
 	}
-	result, err := core.Initialize(context.Background(), initParams)
+	result, err := core.Initialize(namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace), initParams)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -2111,7 +2110,7 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 		t.Fatal(err)
 	}
 
-	cfg, err := leader.Core.seal.BarrierConfig(ctx)
+	cfg, err := leader.Core.seal.BarrierConfig(ctx, namespace.RootNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -837,7 +837,7 @@ func (ts *TokenStore) teardown() {
 }
 
 func (ts *TokenStore) baseView(ns *namespace.Namespace) BarrierView {
-	return ts.core.namespaceMountEntryView(ns, systemBarrierPrefix+tokenSubPath)
+	return ts.core.NamespaceView(ns).SubView(systemBarrierPrefix + tokenSubPath)
 }
 
 func (ts *TokenStore) idView(ns *namespace.Namespace) BarrierView {


### PR DESCRIPTION
POC for #1357 / #1170 

Currently implemented features:
- per namespace barriers, root keys, keyrings (data is encrypted only once)
- create sealable namespace (incl. support in cli command) using a seal config
    - currently only supports shamir
    - namespace is unsealed after creation for now, we could reseal after namespace initialization
- store seal config permanently, encrypted with closest parent barrier
- `/sys/raw` works for keys encrypted with non-root barriers

Missing in this POC (not exhaustive):
- loading/unloading of sealed namespaces from storage
- sealing/unsealing lifecycle functionality, api, cli command
- remembering seal shares when calling unseal api
- most other api actions (rekeying, recovery, generate-root, key rotation, seal status, ...)
  - most should be straight forward to implement since we are reusing the existing AESGCMBarrier implementation
- handling requests towards sealed namespaces

Example for creating a sealable namespace:

```sh
bao namespace create -seals=seals.json ns1
```

with seals.json (hcl not supported yet):

```json
[
  {
    "type":"shamir",
    "secret_shares":3,
    "secret_threshold":2
  }
]
```

/cc @cipherboy, @driif, @voigt, @wslabosz-reply, @rencooo, @satoqz