### PR TITLE
Track lock in namespace entry directly

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -146,20 +146,25 @@ func (n *Namespace) TrimmedPath(path string) string {
 	return strings.TrimPrefix(path, n.Path)
 }
 
-func (n *Namespace) Clone() *Namespace {
+func (n *Namespace) Clone(withUnlock bool) *Namespace {
 	meta := make(map[string]string, len(n.CustomMetadata))
 	maps.Copy(meta, n.CustomMetadata)
 
-	return &Namespace{
+	data := &Namespace{
 		ID:             n.ID,
 		UUID:           n.UUID,
 		Path:           n.Path,
 		Tainted:        n.Tainted,
 		Locked:         n.Locked,
-		UnlockKey:      n.UnlockKey,
 		IsDeleting:     n.IsDeleting,
 		CustomMetadata: meta,
 	}
+
+	if withUnlock {
+		data.UnlockKey = n.UnlockKey
+	}
+
+	return data
 }
 
 // ContextWithNamespace adds the given namespace to the given context

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -307,6 +307,19 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	require.Equal(t, true, ret.Locked)
 	require.Contains(t, ret.CustomMetadata, "testing")
 	require.Empty(t, ret.UnlockKey)
+
+	// Verify that listing does not return locks.
+	all, err := c.namespaceStore.ListAllNamespaces(ctx, true)
+	require.NoError(t, err)
+	for index, ns := range all {
+		require.Empty(t, ns.UnlockKey, "namespace: %v / index: %v", ns, index)
+	}
+
+	all, err = c.namespaceStore.ListNamespaces(ctx, true, true)
+	require.NoError(t, err)
+	for index, ns := range all {
+		require.Empty(t, ns.UnlockKey, "namespace: %v / index: %v", ns, index)
+	}
 }
 
 // TestNamespaceStore_UnlockNamespace tests the unlock namespace method of the namespace store

--- a/vault/namespace_store_tree.go
+++ b/vault/namespace_store_tree.go
@@ -134,7 +134,7 @@ func (nt *namespaceTree) List(path string, includeParent bool, recursive bool) (
 	for idx := 0; idx < len(nodes); idx++ {
 		node = nodes[idx]
 		for _, child := range node.children {
-			entries = append(entries, child.entry.Clone())
+			entries = append(entries, child.entry.Clone(false))
 			if recursive {
 				nodes = append(nodes, child)
 			}


### PR DESCRIPTION
This moves the lock to the existing namespace entry, removing the need to track another separate storage entry. We hide the unlock key from callers to the namespace store, exposing only the boolean locked status.
