### PR TITLE
Fix flaky PostgreSQL backend connection test

### DIFF
--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -611,13 +611,13 @@ func TestPostgreSQLBackend_Parallel(t *testing.T) {
 				errors[i] = fmt.Errorf("value for job %v exceeded max_parallel: %v", i, value)
 			}
 
+			count.Add(-1)
+
 			err = tx.Commit(context.Background())
 			if err != nil {
 				errors[i] = err
 				return
 			}
-
-			defer count.Add(-1)
 		}(j)
 
 	}


### PR DESCRIPTION
Fixes flaky test introduced in https://github.com/openbao/openbao/pull/1299.
In the wild: https://github.com/openbao/openbao/actions/runs/15303683740/job/43050865821

Committing the transaction may already decrement std's internal connection count, we need to decrement our own beforehand.