### PR TITLE
Add a guard rail if CA cert is expired while using the truncate behavior

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1739,6 +1739,11 @@ func getCertificateNotAfter(b *backend, data *inputBundle, caSign *certutil.CAIn
 		case certutil.PermitNotAfterBehavior:
 			// Explicitly do nothing.
 		case certutil.TruncateNotAfterBehavior:
+			// Error out if notAfter is in the past
+			if notAfter.Before(time.Now()) {
+				return time.Time{}, warnings, errutil.UserError{Err: fmt.Sprintf(
+					"cannot satisfy request, as NotAfter date %s is in the past", notAfter)}
+			}
 			notAfter = caSign.Certificate.NotAfter
 		case certutil.ErrNotAfterBehavior:
 			fallthrough

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -263,22 +263,7 @@ func TestPki_getCertificateNotBefore(t *testing.T) {
 func TestPki_getCertificateNotAfter_PastDate(t *testing.T) {
 	t.Parallel()
 
-	// Create a system view with default TTLs
-	sysView := logical.TestSystemView()
-	sysView.DefaultLeaseTTLVal = 24 * time.Hour
-	sysView.MaxLeaseTTLVal = 24 * time.Hour
-
-	// Create backend with the system view
-	config := &logical.BackendConfig{
-		StorageView: &logical.InmemStorage{},
-		System:      sysView,
-	}
-
-	b := Backend(config)
-	require.NotNil(t, b, "failed to create backend")
-
-	err := b.Setup(context.Background(), config)
-	require.NoError(t, err, "failed to setup backend")
+	b, _ := CreateBackendWithStorage(t)
 
 	// Create a CA certificate with NotAfter in the future
 	now := time.Now()

--- a/changelog/1369.txt
+++ b/changelog/1369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: Truncate should error on expired certificates
+```


### PR DESCRIPTION

Add a guard rail if CA cert is expired while using the truncate behavior

Followed this doc to replicate created an expired CA/int CA - https://developer.hashicorp.com/vault/tutorials/pki/pki-engine

Resolves #1322