### PR TITLE
Fix detailed metadata on list results

### DIFF
--- a/builtin/logical/kv/path_metadata.go
+++ b/builtin/logical/kv/path_metadata.go
@@ -207,6 +207,12 @@ func (b *versionedKVBackend) pathMetadataList() framework.OperationFunc {
 				return nil, fmt.Errorf("[%d] failed to read entry: %w", index, err)
 			}
 
+			// No metadata for a directory or deleted entry.
+			if meta == nil {
+				keyInfos[subKey] = map[string]interface{}{}
+				continue
+			}
+
 			data, err := b.metadataResponseData(meta)
 			if err != nil {
 				return nil, fmt.Errorf("[%d] failed to format metadata: %w", index, err)

--- a/changelog/1388.txt
+++ b/changelog/1388.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: Fix panic on detailed metadata list when results include a directory.
+```


### PR DESCRIPTION
Unlike scan, list results include directories in their results. This results in KVv2 panicing when attempting to fetch metadata about the entry, as it doesn't exist and thus returns nil. We should handle this gracefully.