### PR TITLE
Add response_keys_filter_path to filter lists

### DIFF
--- a/sdk/logical/auth.go
+++ b/sdk/logical/auth.go
@@ -114,6 +114,11 @@ type Auth struct {
 
 	// EntityCreated is set to true if an entity is created as part of a login request
 	EntityCreated bool `json:"entity_created"`
+
+	// ResponseKeysFilterPath is set to a non-empty value if the given list
+	// or scan request requires filtering of the response keys and keysInfo
+	// values for entries that are readable by the current token.
+	ResponseKeysFilterPath string `json:"list_scan_response_keys_filter_path"`
 }
 
 func (a *Auth) GoString() string {

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -125,13 +125,14 @@ type PathRules struct {
 
 	// These keys are used at the top level to make the HCL nicer; we store in
 	// the ACLPermissions object though
-	MinWrappingTTLHCL     interface{}              `hcl:"min_wrapping_ttl"`
-	MaxWrappingTTLHCL     interface{}              `hcl:"max_wrapping_ttl"`
-	AllowedParametersHCL  map[string][]interface{} `hcl:"allowed_parameters"`
-	DeniedParametersHCL   map[string][]interface{} `hcl:"denied_parameters"`
-	RequiredParametersHCL []string                 `hcl:"required_parameters"`
-	MFAMethodsHCL         []string                 `hcl:"mfa_methods"`
-	PaginationLimitHCL    int                      `hcl:"pagination_limit"`
+	MinWrappingTTLHCL         interface{}              `hcl:"min_wrapping_ttl"`
+	MaxWrappingTTLHCL         interface{}              `hcl:"max_wrapping_ttl"`
+	AllowedParametersHCL      map[string][]interface{} `hcl:"allowed_parameters"`
+	DeniedParametersHCL       map[string][]interface{} `hcl:"denied_parameters"`
+	RequiredParametersHCL     []string                 `hcl:"required_parameters"`
+	MFAMethodsHCL             []string                 `hcl:"mfa_methods"`
+	PaginationLimitHCL        int                      `hcl:"pagination_limit"`
+	ResponseKeysFilterPathHCL string                   `hcl:"list_scan_response_keys_filter_path"`
 }
 
 type IdentityFactor struct {
@@ -141,24 +142,26 @@ type IdentityFactor struct {
 }
 
 type ACLPermissions struct {
-	CapabilitiesBitmap  uint32
-	MinWrappingTTL      time.Duration
-	MaxWrappingTTL      time.Duration
-	AllowedParameters   map[string][]interface{}
-	DeniedParameters    map[string][]interface{}
-	RequiredParameters  []string
-	MFAMethods          []string
-	PaginationLimit     int
-	GrantingPoliciesMap map[uint32][]logical.PolicyInfo
+	CapabilitiesBitmap     uint32
+	MinWrappingTTL         time.Duration
+	MaxWrappingTTL         time.Duration
+	AllowedParameters      map[string][]interface{}
+	DeniedParameters       map[string][]interface{}
+	RequiredParameters     []string
+	MFAMethods             []string
+	PaginationLimit        int
+	GrantingPoliciesMap    map[uint32][]logical.PolicyInfo
+	ResponseKeysFilterPath string
 }
 
 func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 	ret := &ACLPermissions{
-		CapabilitiesBitmap: p.CapabilitiesBitmap,
-		MinWrappingTTL:     p.MinWrappingTTL,
-		MaxWrappingTTL:     p.MaxWrappingTTL,
-		RequiredParameters: p.RequiredParameters[:],
-		PaginationLimit:    p.PaginationLimit,
+		CapabilitiesBitmap:     p.CapabilitiesBitmap,
+		MinWrappingTTL:         p.MinWrappingTTL,
+		MaxWrappingTTL:         p.MaxWrappingTTL,
+		RequiredParameters:     p.RequiredParameters[:],
+		PaginationLimit:        p.PaginationLimit,
+		ResponseKeysFilterPath: p.ResponseKeysFilterPath,
 	}
 
 	switch {
@@ -334,6 +337,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			"mfa_methods",
 			"pagination_limit",
 			"expiration",
+			"list_scan_response_keys_filter_path",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -463,6 +467,15 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		}
 		if len(pc.RequiredParametersHCL) > 0 {
 			pc.Permissions.RequiredParameters = pc.RequiredParametersHCL[:]
+		}
+		if len(pc.ResponseKeysFilterPathHCL) > 0 {
+			pc.Permissions.ResponseKeysFilterPath = pc.ResponseKeysFilterPathHCL
+			if (pc.Permissions.CapabilitiesBitmap & ListCapabilityInt) == 0 {
+				return errors.New("list_scan_response_keys_filter_path needs to be used on a path with the list capability")
+			}
+			if !strings.Contains(pc.Permissions.ResponseKeysFilterPath, "{{ .key }}") && !strings.Contains(pc.Permissions.ResponseKeysFilterPath, "{{.key}}") {
+				return errors.New("literal string `{{ .key }}` must be present in list_scan_response_keys_filter_path")
+			}
 		}
 
 		pc.Permissions.PaginationLimit = pc.PaginationLimitHCL

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -123,6 +123,10 @@ path "some-expired-path" {
 	capabilities = ["list"]
 	expiration = "2006-01-02T15:04:05Z"
 }
+path "test/metadata/*" {
+	capabilities = ["list"]
+	response_keys_filter_path = "test/metadata/{{ .key }}"
+}
 `)
 
 var rawPolicyJSON = strings.TrimSpace(`
@@ -177,7 +181,7 @@ var rawPolicyJSON = strings.TrimSpace(`
     "test/types": {
       "capabilities": ["create", "sudo"],
       "allowed_parameters": {
-		"map": [{"good": "one"}],
+        "map": [{"good": "one"}],
         "int": [1, 2]
       },
       "denied_parameters": {
@@ -220,6 +224,10 @@ var rawPolicyJSON = strings.TrimSpace(`
     },
     "unpaginated-kv/metadata": {
       "capabilities": ["list"]
+    },
+    "test/metadata/*": {
+      "capabilities": ["list"],
+      "response_keys_filter_path": "test/metadata/{{ .key }}"
     }
   }
 }
@@ -495,6 +503,16 @@ func validatePolicy(t *testing.T, p *Policy) {
 			Permissions: &ACLPermissions{
 				CapabilitiesBitmap: ListCapabilityInt,
 			},
+		},
+		{
+			Path:         "test/metadata/*",
+			Capabilities: []string{"list"},
+			Permissions: &ACLPermissions{
+				CapabilitiesBitmap:     ListCapabilityInt,
+				ResponseKeysFilterPath: "test/metadata/{{ .key }}",
+			},
+			ResponseKeysFilterPathHCL: "test/metadata/{{ .key }}",
+			HasSegmentWildcards:       true,
 		},
 	}
 

--- a/vault/request_handling_list_filtering.go
+++ b/vault/request_handling_list_filtering.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openbao/openbao/helper/identity"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, unauth bool, auth *logical.Auth, acl *ACL, te *logical.TokenEntry, entity *identity.Entity, resp *logical.Response) error {
+	// Ignore lists with no results.
+	if resp == nil {
+		return nil
+	}
+
+	// Ignore non-list operations.
+	switch req.Operation {
+	case logical.ListOperation:
+	case logical.ScanOperation:
+	default:
+		return nil
+	}
+
+	// No filtering, so nothing to do.
+	if auth.ResponseKeysFilterPath == "" {
+		return nil
+	}
+
+	// Secret and Auth should not be set on List operation responses which
+	// expect to be filtered.
+	if resp.Secret != nil {
+		c.logger.Error("non-empty secret on filtered list response", "path", req.Path)
+		return ErrInternalError
+	}
+	if resp.Auth != nil {
+		c.logger.Error("non-empty secret on filtered list response", "path", req.Path)
+		return ErrInternalError
+	}
+
+	// Exit early when there is no data.
+	if resp.Data == nil {
+		return nil
+	}
+
+	// Validate we have all required data fields and no unexpected ones.
+	keysRaw, present := resp.Data["keys"]
+	keyInfoRaw, keyInfoPresent := resp.Data["key_info"]
+	if !present {
+		c.logger.Error("missing required parameter keys on filtered list response", "path", req.Path)
+		return ErrInternalError
+	}
+	for keyName := range resp.Data {
+		if keyName == "keys" || keyName == "key_info" {
+			continue
+		}
+
+		c.logger.Error("unknown parameter on filtered list response", "path", req.Path, "field", keyName)
+		return ErrInternalError
+	}
+	keys, ok := keysRaw.([]string)
+	if !ok {
+		c.logger.Error("invalid type for parameter keys on filtered list response", "path", req.Path, "type", fmt.Sprintf("%T", keysRaw))
+		return ErrInternalError
+	}
+	var keyInfo map[string]interface{}
+	if keyInfoPresent {
+		keyInfo, ok = keyInfoRaw.(map[string]interface{})
+		if !ok {
+			c.logger.Error("invalid type for parameter key_info on filtered list response", "path", req.Path, "type", fmt.Sprintf("%T", keysRaw))
+			return ErrInternalError
+		}
+	}
+
+	filteredKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		// This can be replaced by a proper Go template in the future if necessary
+		checkPath := strings.ReplaceAll(strings.ReplaceAll(auth.ResponseKeysFilterPath, "{{ .key }}", key), "{{.key}}", key)
+
+		var op logical.Operation = logical.ReadOperation
+		if strings.HasSuffix(key, "/") {
+			op = logical.ListOperation
+		}
+
+		// n.b., no required parameter or wrap handling is currently supported.
+		checkReq := &logical.Request{
+			Operation: op,
+			Path:      checkPath,
+			Headers:   req.Headers,
+			Data:      map[string]interface{}{},
+		}
+
+		rootPath := c.router.RootPath(ctx, checkPath)
+		if rootPath && unauth {
+			// Per note in c.CheckToken(...), we cannot access root path in
+			// unauthenticated request, even if authentication data is
+			// attached to the login request. This is because login requests
+			// cannot be root paths.
+			continue
+		}
+
+		authResults := c.performPolicyChecks(ctx, acl, te, checkReq, entity, &PolicyCheckOpts{
+			Unauth:            unauth,
+			RootPrivsRequired: rootPath,
+		})
+
+		if authResults.Allowed {
+			filteredKeys = append(filteredKeys, key)
+		}
+	}
+
+	resp.Data["keys"] = filteredKeys
+
+	if keyInfoPresent {
+		filteredInfo := make(map[string]interface{}, len(filteredKeys))
+		for _, key := range filteredKeys {
+			if data, present := keyInfo[key]; present {
+				filteredInfo[key] = data
+			}
+		}
+		resp.Data["key_info"] = filteredInfo
+	}
+
+	return nil
+}

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -13,8 +14,10 @@ import (
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/builtin/credential/approle"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
+	"github.com/openbao/openbao/builtin/logical/kv"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestHandling_Wrapping(t *testing.T) {
@@ -472,4 +475,250 @@ func TestRequestHandling_SecretLeaseMetric(t *testing.T) {
 			"creation_ttl":  "+Inf",
 		},
 	)
+}
+
+func TestRequestHandling_ListFiltering(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+
+	if err := core.loadMounts(namespace.RootContext(nil)); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	core.credentialBackends["userpass"] = credUserpass.Factory
+
+	// Upgrade to kv-v2
+	req := &logical.Request{
+		Path:        "sys/mounts/secret",
+		ClientToken: root,
+		Operation:   logical.DeleteOperation,
+	}
+
+	resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	core.logicalBackends["kv"] = kv.VersionedKVFactory
+	core.logicalBackends["kv-v2"] = kv.VersionedKVFactory
+
+	req.Path = "sys/mounts/secret"
+	req.Operation = logical.UpdateOperation
+	req.Data = map[string]interface{}{
+		"type": "kv-v2",
+	}
+
+	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	// Enable userpass
+	req.Path = "sys/auth/userpass"
+	req.Data = map[string]interface{}{
+		"type": "userpass",
+	}
+
+	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	// Add policy
+	req.Path = "sys/policies/acl/list-filtered"
+	req.Data = map[string]interface{}{
+		"policy": `
+path "secret/metadata/by-data" {
+	capabilities = ["list", "scan"]
+	list_scan_response_keys_filter_path = "secret/data/by-data/{{ .key }}"
+}
+
+path "secret/detailed-metadata/by-data" {
+	capabilities = ["list", "scan"]
+	list_scan_response_keys_filter_path = "secret/data/by-data/{{ .key }}"
+}
+
+path "secret/data/by-data/data-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-data/data-no" {
+	capabilities = ["deny"]
+}
+
+path "secret/metadata/by-data/metadata-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-data/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-data/both" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-data/subdir/data-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-data/subdir/data-no" {
+	capabilities = ["deny"]
+}
+
+path "secret/metadata/by-data/subdir/metadata-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-data/subdir/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-data/subdir/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata" {
+	capabilities = ["list", "scan"]
+	list_scan_response_keys_filter_path = "secret/metadata/by-metadata/{{ .key }}"
+}
+
+path "secret/detailed-metadata/by-metadata" {
+	capabilities = ["list", "scan"]
+	list_scan_response_keys_filter_path = "secret/metadata/by-metadata/{{ .key }}"
+}
+
+path "secret/metadata/by-metadata/metadata-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata/metadata-no" {
+	capabilities = ["deny"]
+}
+
+path "secret/data/by-metadata/data-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-metadata/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata/subdir/metadata-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata/subdir/metadata-no" {
+	capabilities = ["deny"]
+}
+
+path "secret/data/by-metadata/subdir/data-yes" {
+	capabilities = ["read"]
+}
+
+path "secret/data/by-metadata/subdir/both" {
+	capabilities = ["read"]
+}
+
+path "secret/metadata/by-metadata/subdir/both" {
+	capabilities = ["read"]
+}
+`,
+	}
+
+	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	req.Path = "auth/userpass/users/filtered"
+	req.Data = map[string]interface{}{
+		"password":       "filtered",
+		"token_policies": "list-filtered",
+	}
+
+	resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	req.Path = "auth/userpass/login/filtered"
+	tokenResp, err := core.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err)
+	require.NotNil(t, tokenResp)
+	require.False(t, tokenResp.IsError())
+
+	// Create all entries.
+	for _, prefix := range []string{"by-data", "by-metadata", "by-data/subdir", "by-metadata/subdir"} {
+		for _, name := range []string{"data-yes", "data-no", "metadata-yes", "metadata-no", "elided", "both"} {
+			req.Path = fmt.Sprintf("secret/data/%v/%v", prefix, name)
+			req.Data = map[string]interface{}{
+				"data": map[string]interface{}{
+					"key-name": req.Path,
+				},
+			}
+
+			resp, err = core.HandleRequest(namespace.RootContext(nil), req)
+			require.NoError(t, err)
+			require.False(t, resp.IsError())
+		}
+	}
+
+	// map from prefix (by-data or by-metadata) to allowed keys, with
+	// indication whether it shows on list and scan (true) vs just scan
+	// (false).
+	allowed := map[string]map[string]bool{
+		"by-data": {
+			"data-yes":        true,
+			"both":            true,
+			"subdir/data-yes": false,
+			"subdir/both":     false,
+		},
+		"by-metadata": {
+			"metadata-yes":        true,
+			"both":                true,
+			"subdir/metadata-yes": false,
+			"subdir/both":         false,
+		},
+	}
+
+	req.ClientToken = tokenResp.Auth.ClientToken
+	req.ClientTokenAccessor = tokenResp.Auth.Accessor
+
+	for prefix, entries := range allowed {
+		for _, op := range []string{"list", "scan"} {
+			for _, listType := range []string{"metadata", "detailed-metadata"} {
+				isDetailed := strings.Contains(listType, "detailed")
+
+				req.Operation = logical.Operation(op)
+				req.Data = nil
+				req.Path = fmt.Sprintf("secret/%v/%v/", listType, prefix)
+
+				resp, err := core.HandleRequest(namespace.RootContext(nil), req)
+				require.NoError(t, err, "[%v] path: %v", req.Operation, req.Path)
+				require.NotNil(t, resp, "[%v] path: %v", req.Operation, req.Path)
+				require.False(t, resp.IsError())
+
+				require.NotEmpty(t, resp.Data, "[%v] path: %v\n\tresp: %#v", req.Operation, req.Path, resp)
+				require.NotEmpty(t, resp.Data["keys"], "[%v] path: %v\n\tresp: %#v", req.Operation, req.Path, resp)
+
+				if isDetailed {
+					require.NotEmpty(t, resp.Data["key_info"], "[%v] path: %v\n\tresp: %#v", req.Operation, req.Path, resp)
+				}
+
+				for _, entry := range resp.Data["keys"].([]string) {
+					if strings.HasSuffix(entry, "/") {
+						continue
+					}
+
+					onList, present := entries[entry]
+					if !present {
+						t.Fatalf("list included %v but shouldn't have; path: %v\n\texpected: %#v\n\tactual: %#v", entry, req.Path, entries, resp.Data["keys"].([]string))
+					}
+
+					if req.Operation == logical.ListOperation && !onList {
+						t.Fatalf("list operation included recursive entry %v\n\tactual: %#v", entry, resp.Data["keys"].([]string))
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This adds a new policy parameter, list_scan_response_keys_filter_path, to create a path (containing `{{ .key }}` as a required substring for replacement) for evaluating each list response item against the token's ACL. Keys and associated data whose templated path are allowed read access (or if it ends with a `/`, list access) to the given path are preserved in the response; otherwise, they are filtered and removed.

Note that desired path for filtering is potentially application and plugin-dependent and thus is best left to the policy author to do rather than have plugin authors indicate best paths.

In the future, there are two possible avenues for expansion: using text/template as a templating engine, giving more control to policy authors over destination paths, and using a language like CEL for fully controlling response filtering regardless of request type and allowing it to dispatch additional ACL policy checks.

Note that this implementation is limited: only `read` and `list` operations are considered.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves: #769

---

Blocked on #1388; will be rebased once that merges.
