### PR TITLE
Add FIPS-140-3 Build of OpenBao

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -593,6 +594,12 @@ func (c *ServerCommand) runRecoveryMode() int {
 	if verInfo.Revision != "" {
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
+	}
+
+	infoKeys = append(infoKeys, "fips140")
+	info["fips140"] = "disabled"
+	if fips140.Enabled() {
+		info["fips140"] = "enabled"
 	}
 
 	infoKeys = append(infoKeys, "recovery mode")
@@ -1291,6 +1298,12 @@ func (c *ServerCommand) Run(args []string) int {
 		info["cgo"] = "enabled"
 	}
 
+	infoKeys = append(infoKeys, "fips140")
+	info["fips140"] = "disabled"
+	if fips140.Enabled() {
+		info["fips140"] = "enabled"
+	}
+
 	infoKeys = append(infoKeys, "recovery mode")
 	info["recovery mode"] = "false"
 
@@ -1858,6 +1871,12 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	info["cgo"] = "disabled"
 	if version.CgoEnabled {
 		info["cgo"] = "enabled"
+	}
+
+	infoKeys = append(infoKeys, "fips140")
+	info["fips140"] = "disabled"
+	if fips140.Enabled() {
+		info["fips140"] = "enabled"
 	}
 
 	infoKeys = append(infoKeys, "go version")

--- a/goreleaser.hsm.yaml
+++ b/goreleaser.hsm.yaml
@@ -20,6 +20,7 @@ builds:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }} -X github.com/openbao/openbao/version.VersionMetadata=hsm
     env:
       - CGO_ENABLED=1
+      - GOFIPS140=v1.0.0
     goos:
       - linux
     goarch:

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -19,6 +19,7 @@ builds:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }}
     env:
       - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
     goos:
       - linux
     goarch:

--- a/goreleaser.other.yaml
+++ b/goreleaser.other.yaml
@@ -19,6 +19,7 @@ builds:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }}
     env:
       - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
     goos:
       - darwin
       - freebsd


### PR DESCRIPTION
This PR adresses #1409, by providing a FIPS-140-3 build of OpenBao.
It furthermore extends InfoKeys by a field indicating whether FIPS-140 is enabled, similar to the existing `cgo` InfoKey.
