### PR TITLE
Point mailing list references from LF Edge to OpenSSF domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,9 +9,9 @@ assignees: ''
 
 <!-- Please reserve GitHub issues for bug reports and feature requests.
 
-For questions, the best place to get answers is on our [mailing list](https://lists.lfedge.org/g/openbao), as they will get more visibility from experienced users than the issue tracker.
+For questions, the best place to get answers is on our [mailing list](https://lists.openssf.org/g/openbao), as they will get more visibility from experienced users than the issue tracker.
 
-Please note: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at openbao-security@lists.lfedge.org.
+Please note: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at openbao-security@lists.openssf.org.
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,5 @@
 
 contact_links:
   - name: Ask a question
-    url: https://lists.lfedge.org/g/openbao
+    url: https://lists.openssf.org/g/openbao
     about: For increased visibility, please send questions to our mailing list

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 **Please note:** We take OpenBao's security and our users' trust very seriously.
 If you believe you have found a security issue in OpenBao, please responsibly
-disclose by contacting us at openbao-security@lists.lfedge.org.
+disclose by contacting us at openbao-security@lists.openssf.org.
 
 **First:** if you're unsure or afraid of _anything_, just ask or submit the
 issue or pull request anyways. You won't be yelled at for giving it your best

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,7 +17,7 @@ There are two types of membership on OpenBao's TSC:
 
 Individual memberships are eligible for only a single position with no backup.
 
-Corporate memberships may designate a primary representative and a single backup representative, both with voting permissions on behalf of the organization (counting towards a single vote). Either official representative may designate, in writing to the [TSC mailing list](https://lists.lfedge.org/g/openbao-tsc), a fallback individual with voting permissions specifically for a particular meeting(s). Other employees of the company, not expressly authorized, will not have voting permissions.
+Corporate memberships may designate a primary representative and a single backup representative, both with voting permissions on behalf of the organization (counting towards a single vote). Either official representative may designate, in writing to the [TSC mailing list](https://lists.openssf.org/g/openbao-tsc), a fallback individual with voting permissions specifically for a particular meeting(s). Other employees of the company, not expressly authorized, will not have voting permissions.
 
 Individuals may not be both a corporate representative and an individual member. An individual may either be a designated corporate representative or an individual member at a given time; they resign their existing position upon successful acceptance as a member in another role (either by voting of the TSC to become an individual member if their employer no longer wishes to be a member but they wish to continue in a personal capacity; or by appointment as a primary or backup member of a TSC corporate member if their employment changes or their company becomes a TSC member directly). Only one vote on the TSC is allowed per corporate entity, in the broadest sense including subsidiaries, parent company, and employer/employee relationships, is permitted.
 
@@ -47,7 +47,7 @@ These criteria are to be evaluated by the TSC based on the membership applicatio
 
 ## Membership Application
 
-Any eligible member may submit an application to the [TSC mailing list](https://lists.lfedge.org/g/openbao-tsc). This email should document evidence of meeting one or more of the above eligibility criteria.
+Any eligible member may submit an application to the [TSC mailing list](https://lists.openssf.org/g/openbao-tsc). This email should document evidence of meeting one or more of the above eligibility criteria.
 
 At the next TSC meeting and immediately via email, the TSC will consider the validity of the request and ask any necessary clarifying questions of the individual or corporation. It is encouraged the individual or corporation be present at the meeting, though in lieu, may answer questions via email.
 
@@ -67,7 +67,7 @@ While charter clause 2.g implies that TSC Chair appointments are indefinite barr
 
 Membership lasts for a period of 2 years from approval, or for founding TSC members, 2 years from the approval of the TSC Charter (June 13th, 2024). Members are subsequently eligible to re-apply indefinitely.
 
-A member may opt to terminate their membership at any time, by sending an email to the [TSC mailing list](https://lists.lfedge.org/g/openbao-tsc).
+A member may opt to terminate their membership at any time, by sending an email to the [TSC mailing list](https://lists.openssf.org/g/openbao-tsc).
 
 Under charter clause 8.a, removing a member may occur through 2/3rds vote of the existing TSC, subject to approval by OpenSSF.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -94,7 +94,7 @@ Eligibility requirements may be waived by 2/3rds majority TSC vote.
 #### Applications
 
 Applications to become organization-level maintainers will be sent to the
-[OpenBao mailing list](https://lists.lfedge.org/g/openbao) and should contain
+[OpenBao mailing list](https://lists.openssf.org/g/openbao) and should contain
 motivation and confirmation of eligibility.
 
 #### Elections
@@ -133,7 +133,7 @@ Eligibility requirements may be waived by simple majority TSC vote.
 #### Applications
 
 Applications to become committers will be sent to the
-[OpenBao mailing list](https://lists.lfedge.org/g/openbao) and should contain
+[OpenBao mailing list](https://lists.openssf.org/g/openbao) and should contain
 brief motivation, confirmation of eligibility, and the repository/repositories
 to receive committer access.
 
@@ -167,7 +167,7 @@ organization-level maintainers vote.
 
 #### Applications
 
-Applications to become moderators will be sent to the [OpenBao mailing list](https://lists.lfedge.org/g/openbao).
+Applications to become moderators will be sent to the [OpenBao mailing list](https://lists.openssf.org/g/openbao).
 
 #### Elections
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ----
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ----
 
 - [Website](https://www.openbao.org)
-- [Mailing List](https://lists.lfedge.org/g/openbao)
+- [Mailing List](https://lists.openssf.org/g/openbao)
 - [GitHub Discussions](https://github.com/openbao/openbao/discussions)
 - [Chat Server](https://chat.lfx.linuxfoundation.org/)
   - `#openbao-announcements` ([matrix client](https://matrix.to/#/#openbao-announcements:chat.lfx.linuxfoundation.org), [home server](https://chat.lfx.linuxfoundation.org/#/room/#openbao-announcements:chat.lfx.linuxfoundation.org))

--- a/builtin/credential/jwt/README.md
+++ b/builtin/credential/jwt/README.md
@@ -1,9 +1,9 @@
 # Vault Plugin: JWT Auth Backend
 
-This is a standalone backend plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault).
+This is a standalone backend plugin for use with [HashiCorp Vault](https://www.github.com/hashicorp/vault).
 This plugin allows for JWTs (including OIDC tokens) to authenticate with Vault.
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## Quick Links
     - Vault Website: https://www.vaultproject.io

--- a/builtin/credential/kubernetes/README.md
+++ b/builtin/credential/kubernetes/README.md
@@ -1,9 +1,9 @@
 # Vault Plugin: Kubernetes Auth Backend
 
-This is a standalone backend plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault).
+This is a standalone backend plugin for use with [HashiCorp Vault](https://www.github.com/hashicorp/vault).
 This plugin allows for Kubernetes Service Accounts to authenticate with Vault.
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## Quick Links
 

--- a/builtin/logical/kubernetes/README.md
+++ b/builtin/logical/kubernetes/README.md
@@ -1,9 +1,9 @@
 # Vault Plugin: Kubernetes Secrets Backend
 
-This is a standalone backend plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault).
+This is a standalone backend plugin for use with [HashiCorp Vault](https://www.github.com/hashicorp/vault).
 This plugin generates Kubernetes Service Accounts.
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## Quick Links
 

--- a/builtin/logical/kv/README.md
+++ b/builtin/logical/kv/README.md
@@ -1,9 +1,9 @@
 # Vault Plugin: Key-Value Secrets Backend [![Build Status](https://travis-ci.org/hashicorp/vault-plugin-secrets-kv.svg?branch=master)](https://travis-ci.org/hashicorp/vault-plugin-secrets-kv)
 
-This is a standalone backend plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault).
+This is a standalone backend plugin for use with [HashiCorp Vault](https://www.github.com/hashicorp/vault).
 This plugin provides Key-Value functionality to Vault.
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## Quick Links
     - Vault Website: https://www.vaultproject.io

--- a/builtin/logical/openldap/README.md
+++ b/builtin/logical/openldap/README.md
@@ -1,9 +1,9 @@
 # Vault Plugin: OpenLDAP Secrets Backend
 
-This is a standalone backend plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault).
+This is a standalone backend plugin for use with [HashiCorp Vault](https://www.github.com/hashicorp/vault).
 This plugin provides OpenLDAP functionality to Vault.
 
-**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+**Please note**: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## Quick Links
 - Vault Website: https://developer.hashicorp.com/vault/docs

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -817,7 +817,7 @@ $ curl \
 ```json
 {
   "contact": {
-    "email": "openbao@lists.lfedge.org",
+    "email": "openbao@lists.openssf.org",
     "phone_number": "123-456-7890"
   },
   "groups": [

--- a/website/content/blog/2024-10-03-maintainers.md
+++ b/website/content/blog/2024-10-03-maintainers.md
@@ -21,7 +21,7 @@ Good news: Our community roles are [approved and live](https://github.com/openba
 
 ## How were the community roles created?
 
-Open discussions on what roles should exist in the community started [early in the community's history](https://github.com/orgs/openbao/discussions/228). Eventually, I put forward [a proposal](https://lists.lfedge.org/g/openbao/topic/proposal_community/108163995) for review [by the community](https://lf-edge.atlassian.net/wiki/spaces/OP/pages/15211863/OpenBao+Meetings) (on August 29th, 2024) and with the support of the [TSC](https://lf-edge.atlassian.net/wiki/spaces/OP/pages/15212291/2024-08-08+OpenBao+TSC+Meeting). This was adopted officially on September 30th, 2024 thanks to unanimous votes [by the TSC](https://lists.lfedge.org/g/OpenBao-TSC/topic/announce_roadmap/108738128)!
+Open discussions on what roles should exist in the community started [early in the community's history](https://github.com/orgs/openbao/discussions/228). Eventually, I put forward [a proposal](https://lists.openssf.org/g/openbao/topic/proposal_community/108163995) for review [by the community](https://lf-edge.atlassian.net/wiki/spaces/OP/pages/15211863/OpenBao+Meetings) (on August 29th, 2024) and with the support of the [TSC](https://lf-edge.atlassian.net/wiki/spaces/OP/pages/15212291/2024-08-08+OpenBao+TSC+Meeting). This was adopted officially on September 30th, 2024 thanks to unanimous votes [by the TSC](https://lists.openssf.org/g/OpenBao-TSC/topic/announce_roadmap/108738128)!
 
 ## What are our community roles?
 
@@ -35,7 +35,7 @@ These roles have _increasing barriers to entry_: being a security-sensitive proj
 
 ## How do I apply?
 
-When eligibility requirements are met, application is usually as simple as collecting some evidence and accomplishments in the community and sending an email to [the mailing list](https://lists.lfedge.org/g/openbao)! Then a relevant body of contributors will vote on applicants.
+When eligibility requirements are met, application is usually as simple as collecting some evidence and accomplishments in the community and sending an email to [the mailing list](https://lists.openssf.org/g/openbao)! Then a relevant body of contributors will vote on applicants.
 
 ## Why is this important?
 

--- a/website/content/blog/2024-12-11-rfcs-dec-2024.md
+++ b/website/content/blog/2024-12-11-rfcs-dec-2024.md
@@ -26,7 +26,7 @@ The second half of 2024 saw several fabulous RFCs from different contributors to
 
 ### [openbao#787 - Add Namespace Support](https://github.com/openbao/openbao/issues/787)
 
-**Description**: Vault Enterpise supports Namespaces, a way of creating multi-tenancy and delegating permissions without running multiple clusters. [Users](https://lists.lfedge.org/g/OpenBao-TSC/topic/openbao_dev_wg_proposal_to/108266694) [have](https://github.com/openbao/openbao/issues/486) [requested](https://github.com/orgs/openbao/discussions/293) similar abilities with OpenBao, so a temporary working group was formed to create the design and initial implementation. This RFC, published by [Peter](https://github.com/genelet/), proposes API compatibility for consuming applications but suggests many future improvements to scalability and tenant isolation.
+**Description**: Vault Enterpise supports Namespaces, a way of creating multi-tenancy and delegating permissions without running multiple clusters. [Users](https://lists.openssf.org/g/OpenBao-TSC/topic/openbao_dev_wg_proposal_to/108266694) [have](https://github.com/openbao/openbao/issues/486) [requested](https://github.com/orgs/openbao/discussions/293) similar abilities with OpenBao, so a temporary working group was formed to create the design and initial implementation. This RFC, published by [Peter](https://github.com/genelet/), proposes API compatibility for consuming applications but suggests many future improvements to scalability and tenant isolation.
 
 **How you can help**: While the initial implementation will be done by the Namespace WG, we welcome feedback on the design, testing of the feature, and designs and implementations for future enhancements.
 

--- a/website/content/blog/2025-05-30-namespaces-announcement.md
+++ b/website/content/blog/2025-05-30-namespaces-announcement.md
@@ -150,7 +150,7 @@ While we have many plans on extending namespace capabilities in the future to ma
 
 Namespaces will give organisations the possibility to better structure and isolate secret information. However, the introduction of namespaces is just the first step. Our vision includes supporting _lazy loading_ of namespaces and mounts, allowing OpenBao clusters to efficiently serve workloads with many infrequently accessed resources. This will enable even greater scalability and resilience, as nodes will no longer need to load the entire system state at once. 
 
-[Here](https://openbao.org/blog/vision-for-namespaces/) is another article that you can read more about OpenBaos' scalability efforts. Sounds interesting? Reach out to the project via [Github](https://github.com/orgs/openbao/discussions), [Matrix](https://github.com/openbao#contact), or [Mailinglist](https://lists.lfedge.org/g/openbao) if you want to support our work in the areas of namespaces or scalability.
+[Here](https://openbao.org/blog/vision-for-namespaces/) is another article that you can read more about OpenBaos' scalability efforts. Sounds interesting? Reach out to the project via [Github](https://github.com/orgs/openbao/discussions), [Matrix](https://github.com/openbao#contact), or [Mailinglist](https://lists.openssf.org/g/openbao) if you want to support our work in the areas of namespaces or scalability.
 
 ## Get Started
 

--- a/website/content/docs/contributing/index.mdx
+++ b/website/content/docs/contributing/index.mdx
@@ -33,7 +33,7 @@ and the following channels:
 
 The public community call is hosted every non-holiday Thursday, at 8AM Pacific,
 11AM Eastern for 30 minutes on Zoom. After joining the [mailing
-list](https://lists.lfedge.org/g/openbao), the [calendar](https://lists.lfedge.org/g/openbao/calendar)
+list](https://lists.openssf.org/g/openbao), the [calendar](https://lists.openssf.org/g/openbao/calendar)
 includes a link to subscribe to invite notifications and the Zoom bridge for
 the call.
 

--- a/website/content/docs/policies/brand.mdx
+++ b/website/content/docs/policies/brand.mdx
@@ -210,6 +210,6 @@ to image shape.
 
 ## Press releases
 
-For any press releases, please reach out the OpenBao TSC (`openbao-tsc@lists.lfedge.org`)
+For any press releases, please reach out the OpenBao TSC (`openbao-tsc@lists.openssf.org`)
 and to Jill Lovato at the Linux Foundation; the LF must review and approve all press
 releases prior to publication.

--- a/website/content/docs/policies/osps-baseline.mdx
+++ b/website/content/docs/policies/osps-baseline.mdx
@@ -125,4 +125,4 @@ Artifacts, such as executables, binaries, or similar blobs, belong in designated
 
 > **Requirement:** *While active, the project documentation MUST contain security contacts.*
 
-Security issues can be reported via the [private mailing list](https://lists.lfedge.org/g/openbao-security), which is referenced in [`SECURITY.md`](https://github.com/openbao/.github/blob/main/SECURITY.md).
+Security issues can be reported via the [private mailing list](https://lists.openssf.org/g/openbao-security), which is referenced in [`SECURITY.md`](https://github.com/openbao/.github/blob/main/SECURITY.md).

--- a/website/content/docs/policies/support.mdx
+++ b/website/content/docs/policies/support.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # OpenBao Support & Release EoL Policy
 
-This policy was originally discussed [via email](https://lists.lfedge.org/g/OpenBao-TSC/topic/support_eol_policy_for/107532538)
+This policy was originally discussed [via email](https://lists.openssf.org/g/OpenBao-TSC/topic/support_eol_policy_for/107532538)
 and [approved by the OpenBao TSC](https://lf-edge.atlassian.net/wiki/spaces/OP/pages/62586881/2024-10-10+OpenBao+TSC+Meeting)
 on the October 10th, 2024 meeting.
 


### PR DESCRIPTION
Small PR to point various ML references to the new OpenSSF domain. References in the Dockerfile, goreleaser, etc. should be tackled in a separate PR. Also we'd want to update the signing GPG key contacts first before adjusting the [install docs](https://openbao.org/docs/install/#gpg).

Related to #1413.
