### PR TITLE
Point goreleaser and container image contacts to new OpenSSF domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.openssf.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \
@@ -84,7 +84,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.openssf.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \

--- a/goreleaser.hsm.yaml
+++ b/goreleaser.hsm.yaml
@@ -52,7 +52,7 @@ nfpms:
   - vendor: OpenBao
     package_name: bao-hsm
     homepage: https://openbao.org
-    maintainer: OpenBao <openbao@lists.lfedge.org>
+    maintainer: OpenBao <openbao@lists.openssf.org>
     description: |
       OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -45,7 +45,7 @@ report_sizes: true
 nfpms:
   - vendor: OpenBao
     homepage: https://openbao.org
-    maintainer: OpenBao <openbao@lists.lfedge.org>
+    maintainer: OpenBao <openbao@lists.openssf.org>
     description: |
       OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.


### PR DESCRIPTION
Replaces the contact information in our go and container image builds with the new OpenSSF address. Please let me know if a changelog entry is needed or not.

Related to #1413.