### PR TITLE
Remove deprecated recovery config location fallback

### DIFF
--- a/changelog/1424.txt
+++ b/changelog/1424.txt
@@ -1,0 +1,3 @@
+```release-note:change
+vault/seal: removal of deprecated migration path of an old (encrypted) recovery config location
+```

--- a/changelog/1424.txt
+++ b/changelog/1424.txt
@@ -1,3 +1,3 @@
 ```release-note:change
-vault/seal: removal of deprecated migration path of an old (encrypted) recovery config location
+vault/seal: removal of deprecated migration path of an old pre-Vault v1.0 (encrypted) recovery config location
 ```

--- a/vault/core.go
+++ b/vault/core.go
@@ -2588,7 +2588,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 	}
 
 	var recoveryConf *SealConfig
-	pe, err = c.physical.Get(ctx, recoverySealConfigPlaintextPath)
+	pe, err = c.physical.Get(ctx, recoverySealConfigPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch seal configuration at migration check time: %w", err)
 	}
@@ -2740,7 +2740,7 @@ func (c *Core) migrateSealConfig(ctx context.Context) error {
 		if err := c.seal.SetRecoveryConfig(ctx, rc); err != nil {
 			return fmt.Errorf("error storing recovery config after migration: %w", err)
 		}
-	} else if err := c.physical.Delete(ctx, recoverySealConfigPlaintextPath); err != nil {
+	} else if err := c.physical.Delete(ctx, recoverySealConfigPath); err != nil {
 		return fmt.Errorf("failed to delete old recovery seal configuration during migration: %w", err)
 	}
 

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -32,15 +32,9 @@ const (
 	// parts must be used to reconstruct the unseal key.
 	barrierSealConfigPath = "core/seal-config"
 
-	// recoverySealConfigPath is the path to the recovery key seal
-	// configuration. It lives inside the barrier.
-	// DEPRECATED: Use recoverySealConfigPlaintextPath instead.
-	recoverySealConfigPath = "core/recovery-seal-config"
-
-	// recoverySealConfigPlaintextPath is the path to the recovery key seal
-	// configuration. This is stored in plaintext so that we can perform
-	// auto-unseal.
-	recoverySealConfigPlaintextPath = "core/recovery-config"
+	// recoverySealConfigPath is the path to the recovery key seal configuration.
+	// This is stored in plaintext so that we can perform auto-unseal.
+	recoverySealConfigPath = "core/recovery-config"
 
 	// recoveryKeyPath is the path to the recovery key
 	recoveryKeyPath = "core/recovery-key"

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -295,6 +295,12 @@ func (d *autoSeal) RecoveryConfig(ctx context.Context) (*SealConfig, error) {
 		return nil, fmt.Errorf("failed to read %q seal configuration: %w", sealType, err)
 	}
 
+	// If the seal configuration is missing, we are not initialized
+	if entry == nil {
+		d.logger.Info("seal configuration missing, not initialized")
+		return nil, nil
+	}
+
 	conf := &SealConfig{}
 	if err := json.Unmarshal(entry.Value, conf); err != nil {
 		d.logger.Error("failed to decode seal configuration", "seal_type", sealType, "error", err)


### PR DESCRIPTION
During beta version of upstream (v0.11.4) there was a deprecation of a `recovery-seal-config` entry path of recovery config. This PR removes the fallback checking old location for a possible migration to a new path.

This removal doesn't contradict the [OpenBao compatibility proposal](https://openbao.org/docs/policies/migration/#proposal). OpenBao supports migration from Vault v1.14, not guaranteeing the proper migration path from older versions (especially beta versions of Vault). This change removes complexity from the already complex system of sealing and seal migrations.

---
cc: @cipherboy 

