### PR TITLE
HSM: Add arm64 builds & Alpine containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,10 @@ jobs:
           # TODO: remove version pinning when Goreleaser 2.8 is released
           version: v2.5.1
 
+      - name: Install C compiler for arm64 CGO cross-compilation
+        if: matrix.release_os == 'hsm'
+        run: sudo apt install -y gcc-aarch64-linux-gnu
+
       - name: "GoReleaser: Release"
         if: startsWith(github.ref, 'refs/tags/') || inputs.nightly
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ ENV VERSION=$VERSION
 # Create a non-root user to run the software.
 RUN addgroup ${NAME} && adduser -S -G ${NAME} ${NAME}
 
-RUN apk add --no-cache libcap su-exec dumb-init tzdata
+ARG EXTRA_PACKAGES
+RUN apk add --no-cache libcap su-exec dumb-init tzdata ${EXTRA_PACKAGES}
 
 COPY $BIN_NAME /bin/
 

--- a/goreleaser.hsm.yaml
+++ b/goreleaser.hsm.yaml
@@ -20,10 +20,14 @@ builds:
       - -X github.com/openbao/openbao/version.fullVersion={{.Version}} -X github.com/openbao/openbao/version.GitCommit={{.Commit}} -X github.com/openbao/openbao/version.BuildDate={{ .Date }} -X github.com/openbao/openbao/version.VersionMetadata=hsm
     env:
       - CGO_ENABLED=1
+      - >-
+        {{- if eq .Arch "amd64"}}CC=x86_64-linux-gnu-gcc{{- end}}
+        {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end}}
     goos:
       - linux
     goarch:
       - amd64
+      - arm64
     ignore:
       - goos: darwin
       - goos: dragonfly
@@ -35,8 +39,6 @@ builds:
       - goos: windows
       - goos: linux
         goarch: arm
-      - goos: linux
-        goarch: arm64
       - goos: linux
         goarch: ppc64le
       - goos: linux
@@ -113,6 +115,79 @@ checksum:
   disable: false
 
 dockers:
+  - id: hsm-alpine-amd64
+    use: buildx
+    goos: linux
+    goarch: amd64
+    skip_push: false
+    ids:
+      - builds-hsm
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{.ProjectName}}"
+      - "--build-arg=REVISION={{.FullCommit}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=EXTRA_PACKAGES=gcompat"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=default"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/docker-entrypoint.sh
+      - ./CHANGELOG.md
+  - id: hsm-alpine-arm64
+    use: buildx
+    goos: linux
+    goarch: arm64
+    goarm: "8"
+    skip_push: false
+    ids:
+      - builds-hsm
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=EXTRA_PACKAGES=gcompat"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=default"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/docker-entrypoint.sh
+      - ./CHANGELOG.md
   - id: hsm-ubi-amd64
     use: buildx
     goos: linux
@@ -144,6 +219,42 @@ dockers:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
       - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
       - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+    extra_files:
+      - ./LICENSE
+      - ./.release/docker/ubi-docker-entrypoint.sh
+      - ./CHANGELOG.md
+  - id: hsm-ubi-arm64
+    use: buildx
+    goos: linux
+    goarch: arm64
+    goarm: "8"
+    skip_push: false
+    ids:
+      - builds-hsm
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao {{ .Version }}"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=release={{ .Version }}"
+      - "--label=revision={{ .FullCommit }}"
+      - "--label=version={{ .Version }}"
+      - "--target=ubi"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
     extra_files:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh


### PR DESCRIPTION
See https://github.com/openbao/openbao/issues/1407#issuecomment-2952858958, we install cross-compiling GCC from the Ubuntu repositories and build a single `aarch64-unknown-linux-gnu` binary, then reuse it in Alpine images via `gcompat`.

We could easily add support for other architectures with the same pattern if there is interest.

Resolves https://github.com/openbao/openbao/issues/1407
