### PR TITLE
Dependabot: Group `@docusaurus/*` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
     directory: "/website"
     schedule:
       interval: "weekly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
See the recent surge of Docusaurus updates: https://github.com/openbao/openbao/pull/1421, https://github.com/openbao/openbao/pull/1420, https://github.com/openbao/openbao/pull/1419, https://github.com/openbao/openbao/pull/1418, https://github.com/openbao/openbao/pull/1417

From https://github.com/openbao/openbao/actions/runs/15523975718/job/43700894961?pr=1421:

```
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.8.0).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```

This should group them into a single PR next time.