### PR TITLE
Fix identity store resolution

### DIFF
--- a/changelog/1432.txt
+++ b/changelog/1432.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+core/identity: load namespace entities, groups into MemDB preventing them from disappearing on restart.
+```
+```release-note:improvement
+core/identity: add unsafe_cross_namespace_identity to give compatibility with Vault Enterprise's cross-namespace group membership.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -2590,6 +2590,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		EnableResponseHeaderHostname:   config.EnableResponseHeaderHostname,
 		EnableResponseHeaderRaftNodeID: config.EnableResponseHeaderRaftNodeID,
 		AdministrativeNamespacePath:    config.AdministrativeNamespacePath,
+		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity,
 	}
 
 	if config.DisableSSCTokens != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -109,6 +109,8 @@ type Config struct {
 	EnableResponseHeaderRaftNodeIDRaw interface{} `hcl:"enable_response_header_raft_node_id"`
 
 	DisableSSCTokens *bool `hcl:"-"`
+
+	UnsafeCrossNamespaceIdentity bool `hcl:"unsafe_cross_namespace_identity"`
 }
 
 const (

--- a/helper/storagepacker/storagepacker.go
+++ b/helper/storagepacker/storagepacker.go
@@ -45,6 +45,10 @@ func (s *StoragePacker) View() logical.Storage {
 
 // GetBucket returns a bucket for a given key
 func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, error) {
+	return s.GetBucketWithStorage(ctx, s.view, key)
+}
+
+func (s *StoragePacker) GetBucketWithStorage(ctx context.Context, view logical.Storage, key string) (*Bucket, error) {
 	if key == "" {
 		return nil, errors.New("missing bucket key")
 	}
@@ -54,7 +58,7 @@ func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, err
 	defer lock.RUnlock()
 
 	// Read from storage
-	storageEntry, err := s.view.Get(ctx, key)
+	storageEntry, err := view.Get(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read packed storage entry: %w", err)
 	}
@@ -130,10 +134,18 @@ func (s *StoragePacker) BucketKey(itemID string) string {
 
 // DeleteItem removes the item from the respective bucket
 func (s *StoragePacker) DeleteItem(ctx context.Context, itemID string) error {
-	return s.DeleteMultipleItems(ctx, nil, []string{itemID})
+	return s.DeleteItemWithStorage(ctx, s.view, itemID)
+}
+
+func (s *StoragePacker) DeleteItemWithStorage(ctx context.Context, view logical.Storage, itemID string) error {
+	return s.DeleteMultipleItemsWithStorage(ctx, nil, view, []string{itemID})
 }
 
 func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Logger, itemIDs []string) error {
+	return s.DeleteMultipleItemsWithStorage(ctx, logger, s.view, itemIDs)
+}
+
+func (s *StoragePacker) DeleteMultipleItemsWithStorage(ctx context.Context, logger hclog.Logger, view logical.Storage, itemIDs []string) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "delete_items"}, time.Now())
 	if len(itemIDs) == 0 {
 		return nil
@@ -174,7 +186,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 	idx := 0
 	for bucketKey, itemsToRemove := range byBucket {
 		// Read bucket from storage
-		storageEntry, err := s.view.Get(ctx, bucketKey)
+		storageEntry, err := view.Get(ctx, bucketKey)
 		if err != nil {
 			return fmt.Errorf("failed to read packed storage value: %w", err)
 		}
@@ -214,7 +226,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 			return ctx.Err()
 		}
 
-		err = s.putBucket(ctx, bucket)
+		err = s.putBucket(ctx, view, bucket)
 		if err != nil {
 			return err
 		}
@@ -231,7 +243,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 	return nil
 }
 
-func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
+func (s *StoragePacker) putBucket(ctx context.Context, view logical.Storage, bucket *Bucket) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_bucket"}, time.Now())
 	if bucket == nil {
 		return errors.New("nil bucket entry")
@@ -258,7 +270,7 @@ func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
 	}
 
 	// Store the compressed value
-	err = s.view.Put(ctx, &logical.StorageEntry{
+	err = view.Put(ctx, &logical.StorageEntry{
 		Key:   bucket.Key,
 		Value: compressedBucket,
 	})
@@ -272,6 +284,10 @@ func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
 // GetItem fetches the storage entry for a given key from its corresponding
 // bucket.
 func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
+	return s.GetItemWithStorage(s.view, itemID)
+}
+
+func (s *StoragePacker) GetItemWithStorage(view logical.Storage, itemID string) (*Item, error) {
 	defer metrics.MeasureSince([]string{"storage_packer", "get_item"}, time.Now())
 
 	if itemID == "" {
@@ -281,7 +297,7 @@ func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
 	bucketKey := s.BucketKey(itemID)
 
 	// Fetch the bucket entry
-	bucket, err := s.GetBucket(context.Background(), bucketKey)
+	bucket, err := s.GetBucketWithStorage(context.Background(), view, bucketKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read packed storage item: %w", err)
 	}
@@ -301,6 +317,10 @@ func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
 
 // PutItem stores the given item in its respective bucket
 func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
+	return s.PutItemWithStorage(ctx, s.view, item)
+}
+
+func (s *StoragePacker) PutItemWithStorage(ctx context.Context, view logical.Storage, item *Item) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_item"}, time.Now())
 
 	if item == nil {
@@ -326,7 +346,7 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 	defer lock.Unlock()
 
 	// Check if there is an existing bucket for a given key
-	storageEntry, err := s.view.Get(ctx, bucketKey)
+	storageEntry, err := view.Get(ctx, bucketKey)
 	if err != nil {
 		return fmt.Errorf("failed to read packed storage bucket entry: %w", err)
 	}
@@ -357,7 +377,25 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 		}
 	}
 
-	return s.putBucket(ctx, bucket)
+	return s.putBucket(ctx, view, bucket)
+}
+
+func (s *StoragePacker) SwapItem(ctx context.Context, oldId string, item *Item) error {
+	if err := logical.WithTransaction(ctx, s.view, func(v logical.Storage) error {
+		if err := s.DeleteItemWithStorage(ctx, v, oldId); err != nil {
+			return fmt.Errorf("failed to remove old item: %w", err)
+		}
+
+		if err := s.PutItemWithStorage(ctx, v, item); err != nil {
+			return fmt.Errorf("failed to write new item: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NewStoragePacker creates a new storage packer for a given view

--- a/vault/core.go
+++ b/vault/core.go
@@ -638,6 +638,10 @@ type Core struct {
 
 	// Config value for "detect_deadlocks".
 	detectDeadlocks []string
+
+	// Whether we use a single global memdb instance for identity; see
+	// commentary below.
+	unsafeCrossNamespaceIdentity bool
 }
 
 // c.stateLock needs to be held in read mode before calling this function.
@@ -784,6 +788,13 @@ type CoreConfig struct {
 	AdministrativeNamespacePath string
 
 	NumRollbackWorkers int
+
+	// UnsafeCrossNamespaceIdentity is used to comply with Vault Enterprise's
+	// loose tenancy separation afforded by their namespace implementation.
+	// They allow cross-namespace group association.
+	//
+	// See also: https://github.com/openbao/openbao/issues/1110
+	UnsafeCrossNamespaceIdentity bool
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -961,6 +972,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		numRollbackWorkers:             conf.NumRollbackWorkers,
 		impreciseLeaseRoleTracking:     conf.ImpreciseLeaseRoleTracking,
 		detectDeadlocks:                detectDeadlocks,
+		unsafeCrossNamespaceIdentity:   conf.UnsafeCrossNamespaceIdentity,
 	}
 
 	c.standbyStopCh.Store(make(chan struct{}))

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -912,7 +912,7 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 
 		if bucket != nil {
 			for _, item := range bucket.Items {
-				group, err := i.parseGroupFromBucketItem(item)
+				group, err := i.parseGroupFromBucketItem(ctx, item)
 				if err != nil {
 					i.logger.Error("failed to parse group from bucket entry item", "error", err)
 					return
@@ -1076,21 +1076,56 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 }
 
 func (i *IdentityStore) parseLocalAliases(ctx context.Context, entityID string) (*identity.LocalAliases, error) {
-	item, err := i.localAliasPacker(ctx).GetItem(entityID)
-	if err != nil {
+	var localAliases *identity.LocalAliases
+	view := i.localAliasPacker(ctx).View()
+
+	if err := logical.WithTransaction(ctx, view, func(s logical.Storage) error {
+		item, err := i.localAliasPacker(ctx).GetItemWithStorage(s, entityID)
+		if err != nil {
+			return err
+		}
+		if item == nil {
+			return nil
+		}
+
+		localAliases = new(identity.LocalAliases)
+		err = ptypes.UnmarshalAny(item.Message, localAliases)
+		if err != nil {
+			return err
+		}
+
+		persistNeeded := false
+		for _, alias := range localAliases.Aliases {
+			if alias.NamespaceID == "" {
+				alias.NamespaceID = namespace.RootNamespaceID
+			}
+
+			if alias.ID != "" && alias.NamespaceID != "" && alias.NamespaceID != namespace.RootNamespaceID && !strings.HasSuffix(alias.ID, alias.NamespaceID) {
+				alias.ID = fmt.Sprintf("%v.%v", alias.ID, alias.NamespaceID)
+				persistNeeded = true
+			}
+		}
+
+		if persistNeeded {
+			aliasesAsAny, err := ptypes.MarshalAny(localAliases)
+			if err != nil {
+				return err
+			}
+
+			item.Message = aliasesAsAny
+
+			err = i.localAliasPacker(ctx).PutItemWithStorage(ctx, s, item)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	if item == nil {
-		return nil, nil
-	}
 
-	var localAliases identity.LocalAliases
-	err = ptypes.UnmarshalAny(item.Message, &localAliases)
-	if err != nil {
-		return nil, err
-	}
-
-	return &localAliases, nil
+	return localAliases, nil
 }
 
 func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *storagepacker.Item) (*identity.Entity, error) {
@@ -1153,6 +1188,16 @@ func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *sto
 		persistNeeded = true
 	}
 
+	if entity.NamespaceID == "" {
+		entity.NamespaceID = namespace.RootNamespaceID
+	}
+
+	oldId := entity.ID
+	if entity.ID != "" && entity.NamespaceID != "" && entity.NamespaceID != namespace.RootNamespaceID && !strings.HasSuffix(entity.ID, entity.NamespaceID) {
+		entity.ID = fmt.Sprintf("%v.%v", entity.ID, entity.NamespaceID)
+		persistNeeded = true
+	}
+
 	if persistNeeded {
 		entityAsAny, err := ptypes.MarshalAny(&entity)
 		if err != nil {
@@ -1165,14 +1210,33 @@ func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *sto
 		}
 
 		// Store the entity with new format
-		err = i.entityPacker(ctx).PutItem(ctx, item)
-		if err != nil {
-			return nil, err
-		}
-	}
+		if oldId == entity.ID {
+			err = i.entityPacker(ctx).PutItem(ctx, item)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// We may have modified formats, but we likely just changed
+			// identifier. Make sure we update all aliases as well! We leave
+			// the updating of the actual aliases' identifiers to
+			// parseLocalAliases(...).
+			err = i.entityPacker(ctx).SwapItem(ctx, oldId, item)
+			if err != nil {
+				return nil, err
+			}
 
-	if entity.NamespaceID == "" {
-		entity.NamespaceID = namespace.RootNamespaceID
+			aliasItem, err := i.localAliasPacker(ctx).GetItem(oldId)
+			if err != nil {
+				return nil, err
+			}
+			if aliasItem != nil {
+				aliasItem.ID = item.ID
+				err = i.localAliasPacker(ctx).SwapItem(ctx, oldId, aliasItem)
+				if err != nil {
+					return nil, fmt.Errorf("error moving entity alias: %w", err)
+				}
+			}
+		}
 	}
 
 	return &entity, nil
@@ -1196,7 +1260,7 @@ func (i *IdentityStore) parseCachedEntity(item *storagepacker.Item) (*identity.E
 	return &entity, nil
 }
 
-func (i *IdentityStore) parseGroupFromBucketItem(item *storagepacker.Item) (*identity.Group, error) {
+func (i *IdentityStore) parseGroupFromBucketItem(ctx context.Context, item *storagepacker.Item) (*identity.Group, error) {
 	if item == nil {
 		return nil, errors.New("nil item")
 	}
@@ -1209,6 +1273,34 @@ func (i *IdentityStore) parseGroupFromBucketItem(item *storagepacker.Item) (*ide
 
 	if group.NamespaceID == "" {
 		group.NamespaceID = namespace.RootNamespaceID
+	}
+
+	persistNeeded := false
+	oldId := group.ID
+	if group.ID != "" && group.NamespaceID != "" && group.NamespaceID != namespace.RootNamespaceID && !strings.HasSuffix(group.ID, group.NamespaceID) {
+		group.ID = fmt.Sprintf("%v.%v", group.ID, group.NamespaceID)
+		persistNeeded = true
+	}
+
+	if persistNeeded {
+		groupAsAny, err := ptypes.MarshalAny(&group)
+		if err != nil {
+			return nil, err
+		}
+
+		item := &storagepacker.Item{
+			ID:      group.ID,
+			Message: groupAsAny,
+		}
+
+		if oldId == group.ID {
+			err = i.groupPacker(ctx).PutItem(ctx, item)
+		} else {
+			err = i.groupPacker(ctx).SwapItem(ctx, oldId, item)
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &group, nil

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -2632,7 +2632,12 @@ func (i *IdentityStore) lazyGenerateDefaultKey(ctx context.Context, storage logi
 }
 
 func (i *IdentityStore) loadOIDCClients(ctx context.Context) error {
-	i.logger.Debug("identity loading OIDC clients")
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	i.logger.Debug("identity loading OIDC clients", "namespace", ns.Path)
 
 	if err := i.validateCtx(ctx); err != nil {
 		return err

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1455,7 +1455,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("entity_without_namespace", func(t *testing.T) {
 		// Create an entity with no namespace ID to test sanitization
 		entity := &identity.Entity{
-			ID:       "test-no-namespace",
+			ID:       "d9d20def-d59e-4a9b-8379-c927ceb7fe10",
 			Name:     "test-no-namespace",
 			Policies: []string{"default"},
 		}
@@ -1469,7 +1469,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("alias_without_namespace", func(t *testing.T) {
 		// Create an alias with no namespace ID
 		alias := &identity.Alias{
-			ID:            "test-alias-no-namespace",
+			ID:            "d9d20def-d59e-4a9b-8379-c927ceb7fe10." + ns1.ID,
 			CanonicalID:   "test-entity-id",
 			MountType:     "userpass",
 			MountAccessor: rootAccessor, // Use a valid accessor that exists in the root namespace
@@ -1485,7 +1485,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("namespace_mismatch", func(t *testing.T) {
 		// Create an entity in ns1
 		entity := &identity.Entity{
-			ID:          "mismatch-entity",
+			ID:          "d9d20def-d59e-4a9b-8379-c927ceb7fe10",
 			Name:        "mismatch-entity",
 			NamespaceID: ns1.ID,
 		}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -104,7 +104,7 @@ func (i *IdentityStore) loadGroups(ctx context.Context) error {
 		}
 
 		for _, item := range bucket.Items {
-			group, err := i.parseGroupFromBucketItem(item)
+			group, err := i.parseGroupFromBucketItem(ctx, item)
 			if err != nil {
 				return err
 			}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -228,6 +228,7 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	conf.DetectDeadlocks = opts.DetectDeadlocks
 	conf.AdministrativeNamespacePath = opts.AdministrativeNamespacePath
 	conf.ImpreciseLeaseRoleTracking = opts.ImpreciseLeaseRoleTracking
+	conf.UnsafeCrossNamespaceIdentity = opts.UnsafeCrossNamespaceIdentity
 
 	if opts.Logger != nil {
 		conf.Logger = opts.Logger

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1687,6 +1687,11 @@ func (ts *TokenStore) lookupInternal(ctx context.Context, id string, salted, tai
 		persistNeeded = true
 	}
 
+	if entry.EntityID != "" && entry.NamespaceID != namespace.RootNamespaceID && !strings.HasSuffix(entry.EntityID, entry.NamespaceID) {
+		entry.EntityID = fmt.Sprintf("%v.%v", entry.EntityID, entry.NamespaceID)
+		persistNeeded = true
+	}
+
 	// It's a root token with unlimited creation TTL (so never had an
 	// expiration); this may or may not have a lease (based on when it was
 	// generated, for later revocation purposes) but it doesn't matter, it's
@@ -1737,6 +1742,9 @@ func (ts *TokenStore) lookupInternal(ctx context.Context, id string, salted, tai
 		if err != nil {
 			return nil, err
 		}
+
+		// Never persist if we're revoking.
+		persistNeeded = false
 
 	// Only return if we're not past lease expiration (or if tainted is true),
 	// otherwise assume expmgr is working on revocation

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -26,10 +26,13 @@ import (
 	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbao/openbao/audit"
+	auditFile "github.com/openbao/openbao/builtin/audit/file"
 	"github.com/openbao/openbao/helper/benchhelpers"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/helper/tokenutil"
@@ -126,6 +129,26 @@ func TestTokenStore_CubbyholeTidy(t *testing.T) {
 
 func TestTokenStore_CubbyholeTidyNamespace(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
+	ns := &namespace.Namespace{ID: "ns1-id", Path: "ns1"}
+	TestCoreCreateNamespaces(t, c, ns)
+
+	testTokenStore_CubbyholeTidy(t, c, root, ns)
+}
+
+func TestTokenStore_CubbyholeTidyCrossNamespaceIdentity(t *testing.T) {
+	c := TestCoreWithConfig(t, &CoreConfig{
+		Seal:            nil,
+		EnableUI:        false,
+		EnableRaw:       false,
+		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
+		AuditBackends: map[string]audit.Factory{
+			"file": auditFile.Factory,
+		},
+		UnsafeCrossNamespaceIdentity: true,
+	})
+
+	c, _, root := testCoreUnsealed(t, c)
+
 	ns := &namespace.Namespace{ID: "ns1-id", Path: "ns1"}
 	TestCoreCreateNamespaces(t, c, ns)
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

This PR does three things:

1. Fix a bug wherein identities weren't being loaded for non-root namespaces.
2. Attach namespace accessors to automatically generated identifiers in the identity subsystem, similar to tokens. This will provide the basis for any safe group inclusion logic in the future.
3. Add an unsafe, default off, config flag for the identity system to behave like Vault Enterprise and allow weak multi-tenancy in the identity system. All that is needed to do to enable this is to use only a single MemDB instance, rather than attempting to look up entities across MemDBs. 

Resolves: #1110
