### PR TITLE
chore(tls): refactor dev certificates to openbao

### DIFF
--- a/changelog/1438.txt
+++ b/changelog/1438.txt
@@ -1,0 +1,3 @@
+```release-note:change
+Refactors openbao's dev server cert naming.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -899,15 +899,15 @@ func configureDevTLS(c *ServerCommand) (func(), *server.Config, string, error) {
 		config, err = server.DevTLSConfig(devStorageType, certDir)
 
 		f = func() {
-			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCAFilename)); err != nil {
+			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.BaoDevCAFilename)); err != nil {
 				c.UI.Error(err.Error())
 			}
 
-			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevCertFilename)); err != nil {
+			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.BaoDevCertFilename)); err != nil {
 				c.UI.Error(err.Error())
 			}
 
-			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.VaultDevKeyFilename)); err != nil {
+			if err := os.Remove(fmt.Sprintf("%s/%s", certDir, server.BaoDevKeyFilename)); err != nil {
 				c.UI.Error(err.Error())
 			}
 
@@ -1420,7 +1420,7 @@ func (c *ServerCommand) Run(args []string) int {
 			},
 		}
 		if c.flagDevTLS {
-			clusterJson.CACertPath = fmt.Sprintf("%s/%s", certDir, server.VaultDevCAFilename)
+			clusterJson.CACertPath = fmt.Sprintf("%s/%s", certDir, server.BaoDevCAFilename)
 		}
 
 		if c.flagDevClusterJson != "" && !c.flagDevThreeNode {

--- a/command/server.go
+++ b/command/server.go
@@ -2701,11 +2701,11 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 					if c.flagDevTLS {
 						if runtime.GOOS == "windows" {
 							c.UI.Warn("PowerShell:")
-							c.UI.Warn(fmt.Sprintf("    $env:BAO_CACERT=\"%s/vault-ca.pem\"", certDir))
+							c.UI.Warn(fmt.Sprintf("    $env:BAO_CACERT=\"%s/openbao-ca.pem\"", certDir))
 							c.UI.Warn("cmd.exe:")
-							c.UI.Warn(fmt.Sprintf("    set BAO_CACERT=%s/vault-ca.pem", certDir))
+							c.UI.Warn(fmt.Sprintf("    set BAO_CACERT=%s/openbao-ca.pem", certDir))
 						} else {
-							c.UI.Warn(fmt.Sprintf("    $ export BAO_CACERT='%s/vault-ca.pem'", certDir))
+							c.UI.Warn(fmt.Sprintf("    $ export BAO_CACERT='%s/openbao-ca.pem'", certDir))
 						}
 						c.UI.Warn("")
 					}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	VaultDevCAFilename   = "vault-ca.pem"
-	VaultDevCertFilename = "vault-cert.pem"
-	VaultDevKeyFilename  = "vault-key.pem"
+	BaoDevCAFilename   = "openbao-ca.pem"
+	BaoDevCertFilename = "openbao-cert.pem"
+	BaoDevKeyFilename  = "openbao-key.pem"
 )
 
 var entConfigValidate = func(_ *Config, _ string) []configutil.ConfigError {
@@ -176,15 +176,15 @@ func DevTLSConfig(storageType, certDir string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, BaoDevCAFilename), []byte(ca.PEM), 0o444); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevCertFilename), []byte(cert), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, BaoDevCertFilename), []byte(cert), 0o400); err != nil {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, VaultDevKeyFilename), []byte(key), 0o400); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", certDir, BaoDevKeyFilename), []byte(key), 0o400); err != nil {
 		return nil, err
 	}
 	return parseDevTLSConfig(storageType, certDir)

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -194,8 +194,8 @@ func parseDevTLSConfig(storageType, certDir string) (*Config, error) {
 	hclStr := `
 listener "tcp" {
 	address = "[::]:8200"
-	tls_cert_file = "%s/vault-cert.pem"
-	tls_key_file = "%s/vault-key.pem"
+	tls_cert_file = "%s/openbao-cert.pem"
+	tls_key_file = "%s/openbao-key.pem"
 	proxy_protocol_behavior = "allow_authorized"
 	proxy_protocol_authorized_addrs = "[::]:8200"
 }

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -104,8 +104,8 @@ func Test_parseDevTLSConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := parseDevTLSConfig("file", tt.certDirectory)
 			require.NoError(t, err)
-			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevCertFilename), cfg.Listeners[0].TLSCertFile)
-			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, VaultDevKeyFilename), cfg.Listeners[0].TLSKeyFile)
+			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, BaoDevCertFilename), cfg.Listeners[0].TLSCertFile)
+			require.Equal(t, fmt.Sprintf("%s/%s", tt.certDirectory, BaoDevKeyFilename), cfg.Listeners[0].TLSKeyFile)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

Refactors the dev certificates. Additionally I saw that `-dev-tls-san` is not implemented yet.
This is required for the current implementation of the `openbao-k8s` integration tests.

For now I will remove the `-dev-tls-san` from the integration tests.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
