### PR TITLE
Add Adfinis as TSC member

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,12 +65,13 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 
 ## Technical Steering Committee (TSC) Members
 
-| Member            | Email                               | GitHub                                     | Alternate                               | Company/Organization      | TSC Position       |
-|-------------------|-------------------------------------|--------------------------------------------|-----------------------------------------|---------------------------|--------------------|
-| Nathan Phelps     | naphelps@us.ibm.com                 | [@naphelps](https://github.com/naphelps)   |                                         | IBM                       | Member             |
-| James Butcher     | james@iotechsys.com                 |                                            | Brad Corrion (brad@iotechsys.com)       | IOTech Systems            | Member             |
-| Julian Cassignol  | jcassignol@wallix.com               |                                            | Dan Ghita (dghita@wallix.com)           | Wallix                    | Member             |
-| Alexander Scheel  | ascheel@gitlab.com                  | [@cipherboy](https://github.com/cipherboy) | Jocelyn Eillis (jeillis@gitlab.com)     | GitLab                    | Chair              |
+| Member           | Email                     | GitHub                                     | Alternate                                       | Company/Organization | TSC Position |
+|------------------|---------------------------|--------------------------------------------|-------------------------------------------------|----------------------|--------------|
+| Nathan Phelps    | naphelps@us.ibm.com       | [@naphelps](https://github.com/naphelps)   |                                                 | IBM                  | Member       |
+| James Butcher    | james@iotechsys.com       |                                            | Brad Corrion (brad@iotechsys.com)               | IOTech Systems       | Member       |
+| Julian Cassignol | jcassignol@wallix.com     |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
+| Michael Hofer    | michael.hofer@adfinis.com | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Member       |
+| Alexander Scheel | ascheel@gitlab.com        | [@cipherboy](https://github.com/cipherboy) | Jocelyn Eillis (jeillis@gitlab.com)             | GitLab               | Chair        |
 
 To view the process for joining the TSC, see [GOVERNANCE.md](GOVERNANCE.md) in
 the root of this repository. That document is considered part of this document.


### PR DESCRIPTION
Adds Adfinis a newly appointed TSC member as accepted by the TSC on 2025-06-12:

* https://lf-edge.atlassian.net/wiki/spaces/OP/pages/472973313/2025-06-12+OpenBao+TSC+Meeting