### PR TITLE
Add "namespace specifier" helpers

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -206,6 +206,37 @@ func (n *Namespace) ValidateUUID(candidate string) error {
 	return nil
 }
 
+// ParseSpecifier parses a "namespace specifier" kind and value from a
+// colon-separated string. Valid namespace specifier kinds are: path, id, uuid.
+func ParseSpecifier(value string) (string, string, error) {
+	kind, value, ok := strings.Cut(value, ":")
+	if !ok {
+		return "", "", fmt.Errorf("invalid namespace specifier")
+	}
+	switch kind {
+	case "path", "id", "uuid":
+	default:
+		return "", "", fmt.Errorf("unknown namespace specifier kind: %q", kind)
+	}
+	return kind, value, nil
+}
+
+// CompareSpecifier returns true if the namespace matches the passed specifier
+// value, comparing by Path, ID and UUID respectively depending on the passed
+// kind. Also see [ParseSpecifier].
+func (n *Namespace) CompareSpecifier(kind, value string) bool {
+	switch kind {
+	case "path":
+		return n.Path == Canonicalize(value)
+	case "id":
+		return n.ID == value
+	case "uuid":
+		return n.UUID == value
+	default:
+		return false
+	}
+}
+
 // ContextWithNamespace adds the given namespace to the given context
 func ContextWithNamespace(ctx context.Context, ns *Namespace) context.Context {
 	return context.WithValue(ctx, contextNamespace, ns)

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -407,3 +407,76 @@ func TestValidate(t *testing.T) {
 		require.Equal(t, tc.wantError, (gotErr != nil))
 	}
 }
+
+// TestParseSpecifier validates the behavior of [ParseSpecifier].
+func TestParseSpecifier(t *testing.T) {
+	tcases := []struct {
+		input     string
+		kind      string
+		value     string
+		rest      string
+		wantError bool
+	}{
+		// Good inputs:
+		{input: "path:foo/bar/", kind: "path", value: "foo/bar/"},
+		{input: "path:foo/bar:baz", kind: "path", value: "foo/bar:baz"},
+		{input: "path:::", kind: "path", value: "::"},
+		{input: "id:De0z6N", kind: "id", value: "De0z6N"},
+		{
+			input: "uuid:013fb57a-c56a-437f-9452-1996c0b68c27",
+			kind:  "uuid",
+			value: "013fb57a-c56a-437f-9452-1996c0b68c27",
+		},
+
+		// Nonsense input, but valid for all we care:
+		{input: "path:", kind: "path", value: ""},
+
+		// Bad inputs:
+		{input: "", wantError: true},
+		{input: ":", wantError: true},
+		{input: "uuid", wantError: true},
+		{input: "pat:foo/bar/", wantError: true},
+	}
+
+	for _, tc := range tcases {
+		kind, spec, err := ParseSpecifier(tc.input)
+		if tc.wantError {
+			require.Error(t, err)
+		} else {
+			require.Equal(t, kind, tc.kind)
+			require.Equal(t, spec, tc.value)
+		}
+	}
+}
+
+// TestCompareSpecifier validates the behavior of [Namespace.CompareSpecifier].
+func TestCompareSpecifier(t *testing.T) {
+	ns := &Namespace{
+		Path: "foo/bar/",
+		ID:   "De0z6N",
+		UUID: "013fb57a-c56a-437f-9452-1996c0b68c27",
+	}
+
+	tcases := []struct {
+		kind string
+		spec string
+		want bool
+	}{
+		// Good inputs:
+		{kind: "path", spec: ns.Path, want: true},
+		{kind: "id", spec: ns.ID, want: true},
+		{kind: "uuid", spec: ns.UUID, want: true},
+
+		// Bad inputs (value don't match):
+		{kind: "path", spec: ns.ID, want: false},
+		{kind: "id", spec: ns.UUID, want: false},
+
+		// Bad inputs (nonsense kinds):
+		{kind: "", spec: "", want: false},
+		{kind: "foo", spec: "bar", want: false},
+	}
+
+	for _, tc := range tcases {
+		require.Equal(t, tc.want, ns.CompareSpecifier(tc.kind, tc.spec))
+	}
+}


### PR DESCRIPTION
From #1320:

> The `external_keys` stanzas take an optional `namespaces = []` parameter, taking items of the form `uuid:<ns-uuid>`, `id:<ns-accessor>`, or `path:<ns-path>`, to identify namespaces that this library is allowed to be used in.

This adds utilities around these "namespace specifier" strings to easily parse them and compare them to an instance of `namespace.Namespace`.

We'll probably want to use them in various places in the future; the logic is quite encapsulated, so I'm extracting this out of the bigger feature.