### PR TITLE
chore: adding link for OpenBao CSI Provider

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -65,7 +65,7 @@ of each integration.
 <!-- - Reduced load on OpenBao. Secrets are synced per CRD instead of per consuming pod. -->
 <!-- - Better OpenBao secret availability. Kubernetes secrets act as a durable cluster-local cache of OpenBao secrets. -->
 
-#### OpenBao CSI provider
+#### [OpenBao CSI provider](https://github.com/openbao/openbao-csi-provider)
 
 - The CSI driver that the provider is based on is vendor neutral.
 - No durable secret storage outside OpenBao if the secret sync feature isn't used. All secrets written to disk are in ephemeral in-memory volumes.


### PR DESCRIPTION
This PR updates the documentation related to the OpenBao CSI provider integration in Kubernetes.

Changes proposed:

1. Replaces the section title OpenBao CSI provider with a Markdown link to the CSI provider GitHub repository: [OpenBao CSI provider](https://github.com/openbao/openbao-csi-provider)


No functional code changes; this is a documentation cleanup and enhancement for clarity and navigability.

Rationale
The goal is to improve the readability and usefulness of the documentation by:

1. Providing a direct link to the OpenBao CSI provider repository for easier navigation.
