### PR TITLE
Affirm Level 1: OSPS-LE-03.01

### DIFF
--- a/website/content/docs/policies/osps-baseline.mdx
+++ b/website/content/docs/policies/osps-baseline.mdx
@@ -24,7 +24,7 @@ This pages tracks the implementation status of [Open Source Project Security Bas
 | [OSPS-GV-03.01](#osps-gv-03-01) | ✅     |
 | [OSPS-LE-02.01](#osps-le-02-01) | ✅     |
 | [OSPS-LE-02.02](#osps-le-02-02) |        |
-| [OSPS-LE-03.01](#osps-le-03-01) |        |
+| [OSPS-LE-03.01](#osps-le-03-01) | ✅     |
 | [OSPS-LE-03.02](#osps-le-03-02) |        |
 | [OSPS-QA-01.01](#osps-qa-01-01) | ✅     |
 | [OSPS-QA-01.02](#osps-qa-01-02) | ✅     |
@@ -89,7 +89,9 @@ The source code is released under Mozilla Public License 2.0 (see [`LICENSE`](ht
 While active, the license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
 
 ## OSPS-LE-03.01 {#osps-le-03-01}
-While active, the license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, or LICENSE/ directory.
+> **Requirement:** *While active, the license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, or LICENSE/ directory.*
+
+The OpenBao license is stored in the repository's [LICENSE file](https://github.com/openbao/openbao/blob/main/LICENSE).
 
 ## OSPS-LE-03.02 {#osps-le-03-02}
 While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.


### PR DESCRIPTION
> While active, the license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, or LICENSE/ directory.

The OpenBao license is stored in the repository's [LICENSE file](https://github.com/openbao/openbao/blob/main/LICENSE).

Resolves [dev-wg #18](https://github.com/openbao/dev-wg/issues/31)
