### PR TITLE
Add OpenBao to OpenSSF blog post

### DIFF
--- a/website/content/blog/2025-05-30-namespaces-announcement.md
+++ b/website/content/blog/2025-05-30-namespaces-announcement.md
@@ -4,18 +4,17 @@ description: "Enabling Multi-Tenancy within OpenBao"
 slug: namespaces-announcement
 authors: ChristophVoigt
 tags: [announcement, community, collaboration]
-image: https://www.edgexfoundry.org/cmsfiles/image/company-logo-lg.png
 ---
 
 We are excited to introduce **Namespaces** to the OpenBao Secret Manager – a powerful feature designed to bring robust multi-tenancy and fine-grained isolation to your secrets management workflows.
-
-<!-- truncate -->
 
 ## What Are Namespaces?
 
 Namespaces in OpenBao are logical partitions within a single OpenBao instance, functioning as isolated environments where teams, organizations, or applications can operate independently.
 
 Each namespace acts like a mini-OpenBao, with its own policies, authentication methods, secret engines, tokens, and identity groups. This architecture enables organizations to implement a true _OpenBao-as-a-Service_ model, empowering internal customers to self-manage their environments securely and efficiently.
+
+<!-- truncate -->
 
 ## Why Namespaces?
 

--- a/website/content/blog/2025-06-17-openbao-to-openssf.md
+++ b/website/content/blog/2025-06-17-openbao-to-openssf.md
@@ -1,0 +1,47 @@
+---
+title: "OpenBao Joins the OpenSSF to Advance Secure Secrets Management in Open Source"
+description: "OpenBao has moved into the OpenSSF, building stronger partnerships for the future."
+slug: openbao-joins-the-openssf
+authors: OpenSSF
+tags: [announcement, community, collaboration]
+image: https://openssf.org/wp-content/uploads/2025/06/OpenSSF-Blog-Graphics-53-1.png
+---
+
+![OpenBao Joins the OpenSSF to Advance Secure Secrets Management in Open Source](https://openssf.org/wp-content/uploads/2025/06/OpenSSF-Blog-Graphics-53-1.png)
+
+We’re excited to welcome [OpenBao](https://openssf.org/projects/openbao/) to the [Open Source Security Foundation (OpenSSF)](https://openssf.org) as a newly accepted [sandbox project](https://openssf.org/projects/openbao/)!
+
+OpenBao is an open source identity-based secrets and encryption management system that helps organizations securely store, manage, and audit access to sensitive data like API keys, passwords, and certificates. Originally developed under LF Edge and forked from HashiCorp Vault, OpenBao has now found its new home in the OpenSSF, where it aligns more directly with the needs of security professionals and open source maintainers.
+
+“Joining OpenSSF has been a dream come true,” said **Alex Scheel**, Chair of the OpenBao Technical Steering Committee. “This wouldn’t be possible without the support of OpenSSF’s Technical Advisory Council—many thanks for their help and consideration!”
+
+<!-- truncate -->
+
+## Why OpenBao?
+
+Modern systems rely on a growing number of secrets to operate securely—from database credentials to cloud service API tokens. Managing and auditing access to these secrets is complex, and building custom solutions can introduce more risk than reward. OpenBao solves this problem by providing robust encryption services that are tightly gated by authentication and authorization controls. It integrates with the tools and ecosystems open source developers and security teams already use, including Sigstore and SLSA.
+
+Through its CLI, UI, and HTTP API, OpenBao makes it easier to:
+
+ - Securely manage and distribute secrets across teams and environments
+ - Apply fine-grained access controls
+ - Rotate keys and credentials automatically
+ - Maintain detailed audit trails for compliance and incident response
+
+## Moving to the OpenSSF
+
+The move from LF Edge to OpenSSF reflects a strategic decision by OpenBao’s Technical Steering Committee to better align with its contributor base and project mission. While the project is deeply grateful for the support from LF Edge during its early development, the OpenSSF offers a broader and more targeted platform to grow its community and expand adoption.
+
+“We’re looking forward to collaborating with various working groups and SIGs within OpenSSF—especially to help strengthen secrets management best practices in open source policy and guidance,” said Scheel. “We also remain committed to maintaining partnerships with LF Edge and other Linux Foundation projects as our ecosystems evolve.”
+
+## What’s Next
+
+Now in the sandbox stage of OpenSSF’s project lifecycle, OpenBao is focused on increasing transparency, improving governance, and deepening integration with other OpenSSF initiatives. Its ongoing work will support supply chain security, secrets hygiene, and broader security-by-design efforts across open source projects.
+
+We’re thrilled to support the OpenBao community and look forward to seeing its impact grow across the open source security landscape.
+
+🔐 Get Involved: [Visit the OpenBao GitHub repository](https://github.com/openbao/openbao) and join the conversation on the [OpenSSF Slack](https://linuxfoundation.slack.com/archives/C02H1G4TH) and [Matrix](https://chat.lfx.linuxfoundation.org/#/room/#openbao-general:chat.lfx.linuxfoundation.org).
+
+---
+
+This post was originally authored by the OpenSSF marketing team and posted on [the OpenSSF blog](https://openssf.org/blog/2025/06/17/openbao-joins-the-openssf-to-advance-secure-secrets-management-in-open-source/).

--- a/website/content/blog/authors.yml
+++ b/website/content/blog/authors.yml
@@ -28,3 +28,12 @@ ChristophVoigt:
     github: https://github.com/voigt
     linkedin: https://www.linkedin.com/in/chris-cloud-native/
     mastodon: https://hachyderm.io/@cv
+
+OpenSSF:
+  name: OpenSSF
+  url: https://openssf.org
+  image_url: https://raw.githubusercontent.com/ossf/artwork/refs/heads/main/openssf/stacked/color/openssf-stacked-color.png
+  socials:
+    github: https://github.com/ossf
+    linkedin: https://www.linkedin.com/company/openssf/
+    mastodon: https://social.lfx.dev/@openssf


### PR DESCRIPTION
See also: https://openssf.org/blog/2025/06/17/openbao-joins-the-openssf-to-advance-secure-secrets-management-in-open-source/

