### PR TITLE
fix(test-go): Verify test results before passing

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -310,7 +310,34 @@ jobs:
           path: test-results/go-test
           pattern: test-results-*
           merge-multiple: true
-      - run: |
-          ls -lhR test-results/go-test
-          find test-results/go-test -type f -mindepth 1 -mtime +3 -delete
-          ls -lhR test-results/go-test
+      - env:
+          EXPECTED_IDS: ${{ needs.test-matrix.outputs.matrix_ids }}
+        run: |
+          echo "Expected matrix IDs: $EXPECTED_IDS"
+
+          # Parse expected IDs and check for corresponding result files
+          missing_results=0
+          for id in $(echo "$EXPECTED_IDS" | jq -r '.[]'); do
+            if ! ls test-results/go-test/results-${id}.* 2>/dev/null; then
+              echo "Error: Missing results for matrix ID $id"
+              missing_results=1
+            else
+              echo "Found results for matrix ID: $id"
+            fi
+          done
+
+          # Exit with error if any results are missing
+          if [ $missing_results -eq 1 ]; then
+            echo ""
+            echo "Some Go test matrix jobs did not upload results"
+            echo "Failed matrix IDs:"
+            for id in $(echo "$EXPECTED_IDS" | jq -r '.[]'); do
+              if ! ls test-results/go-test/results-${id}.* >/dev/null 2>&1; then
+                echo "  - $id"
+              fi
+            done
+            exit 1
+          fi
+
+          echo ""
+          echo "All Go test matrix jobs completed successfully"

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -297,7 +297,7 @@ jobs:
 
   test-collect-reports:
     if: ${{ ! cancelled() }}
-    needs: test-go
+    needs: [test-go, test-matrix]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
## Fix test-collect-reports validation to verify all Go test matrix jobs

Implemented fix in the `test-collect-reports` step. It retrieves the expected matrix IDs from the `test-matrix` job output and validates each matrix job individually by checking for the presence of `results-{id}.*` files. If any expected Go test matrix job results are missing, the job fails.

Resolves #1065
