### PR TITLE
Update CEL patch test to ensure compatibility when moving to `go-viper/mapstructure`

### DIFF
--- a/builtin/logical/pki/path_cel_test.go
+++ b/builtin/logical/pki/path_cel_test.go
@@ -85,6 +85,29 @@ func TestCRUDCelRoles(t *testing.T) {
 					"name":       "require_ip_sans",
 					"expression": "size(request.ip_sans) >= 2", // new rule
 				},
+				{
+					"name":       "success",
+					"expression": "request.common_name == 'example.com' && require_ip_sans",
+				},
+				{
+					"name": "cert",
+					"expression": `CertTemplate{
+						Subject: PKIX.Name{
+							CommonName: request.common_name,
+							Country:    ["ZW", "US"],
+						},						
+					}`,
+				},
+				{
+					"name": "output",
+					"expression": `ValidationOutput{
+						template: cert,
+					}`,
+				},
+				{
+					"name":       "err",
+					"expression": "'Request should have atleast 2 IP SANs.'",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR updates the CEL patch test. 

Previously, patching a single rule required: 
```
patchData := map[string]any{
    "cel_program": map[string]any{
        "variables": []map[string]any{
            {
                "name":       "require_ip_sans",
                "expression": "size(request.ip_sans) >= 2", // new rule
            },
        },
    },
}
```

After moving to `go-viper/mapstructure`, the whole variable list needs to be sent over: 
```
patchData := map[string]any{
"cel_program": map[string]any{
    "variables": []map[string]any{
        {
            "name":       "require_ip_sans",
            "expression": "size(request.ip_sans) >= 2", // new rule
        },
        {
            "name":       "success",
            "expression": "request.common_name == 'example.com' && require_ip_sans",
        },
        {
            "name": "cert",
                "expression": `CertTemplate{
                    Subject: PKIX.Name{
                         CommonName: request.common_name,
                         Country:    ["ZW", "US"],
                    },						
                }`,
        },
        {
            "name": "output",
            "expression": `ValidationOutput{
                    template: cert,
                }`,
        },
        {
            "name":       "err",
            "expression": "'Request should have atleast 2 IP SANs.'",
        },
    },
},}
```

In the future, a new PR will be opened to update the patch behavior so that it is more concise and all the CEL rules don't have to be resent.

Related #1459 

---
cc: @KrzysztofKornalewski-Reply @satoqz 
