### PR TITLE
Fix PostgreSQL table creation on replica

### DIFF
--- a/changelog/1478.txt
+++ b/changelog/1478.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/postgresql: skip table creation automatically on PostgreSQL replicas
+```


### PR DESCRIPTION
When using a PostgreSQL replica, creating the tables will fail with a `SQLSTATE 25006` error. Check our first table creation and ensure we're not trying to write to a replica; if we are, skip it.

This also fixes table creation to properly use the given transaction.

