### PR TITLE
Fix detailed metadata on list results (#1388)

### DIFF
--- a/builtin/logical/kv/path_metadata.go
+++ b/builtin/logical/kv/path_metadata.go
@@ -207,6 +207,12 @@ func (b *versionedKVBackend) pathMetadataList() framework.OperationFunc {
 				return nil, fmt.Errorf("[%d] failed to read entry: %w", index, err)
 			}
 
+			// No metadata for a directory or deleted entry.
+			if meta == nil {
+				keyInfos[subKey] = map[string]interface{}{}
+				continue
+			}
+
 			data, err := b.metadataResponseData(meta)
 			if err != nil {
 				return nil, fmt.Errorf("[%d] failed to format metadata: %w", index, err)

--- a/changelog/1388.txt
+++ b/changelog/1388.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: Fix panic on detailed metadata list when results include a directory.
+```


### PR DESCRIPTION
* Fix detailed metadata on list results

Unlike scan, list results include directories in their results. This results in KVv2 panicing when attempting to fetch metadata about the entry, as it doesn't exist and thus returns nil. We should handle this gracefully.



* Add changelog entry



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

---

Backport of https://github.com/openbao/openbao/pull/1388. 