### PR TITLE
Point goreleaser and container image contacts to new OpenSSF domain (…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.openssf.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \
@@ -84,7 +84,7 @@ ARG PRODUCT_REVISION
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.
 LABEL name="OpenBao" \
-      maintainer="OpenBao <openbao@lists.lfedge.org>" \
+      maintainer="OpenBao <openbao@lists.openssf.org>" \
       vendor="OpenBao" \
       version=${PRODUCT_VERSION} \
       release=${PRODUCT_REVISION} \

--- a/goreleaser.hsm.yaml
+++ b/goreleaser.hsm.yaml
@@ -52,7 +52,7 @@ nfpms:
   - vendor: OpenBao
     package_name: bao-hsm
     homepage: https://openbao.org
-    maintainer: OpenBao <openbao@lists.lfedge.org>
+    maintainer: OpenBao <openbao@lists.openssf.org>
     description: |
       OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -45,7 +45,7 @@ report_sizes: true
 nfpms:
   - vendor: OpenBao
     homepage: https://openbao.org
-    maintainer: OpenBao <openbao@lists.lfedge.org>
+    maintainer: OpenBao <openbao@lists.openssf.org>
     description: |
       OpenBao exists to provide a software solution to manage, store, and distribute
       sensitive data including secrets, certificates, and keys.


### PR DESCRIPTION
…#1415)

* Point contact information in container images to new OpenSSF domain



* Point contact information in goreleaser to new OpenSSF domain



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Backport of https://github.com/openbao/openbao/pull/1415