### PR TITLE
Fix identity store resolution (#1432)

### DIFF
--- a/changelog/1432.txt
+++ b/changelog/1432.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+core/identity: load namespace entities, groups into MemDB preventing them from disappearing on restart.
+```
+```release-note:improvement
+core/identity: add unsafe_cross_namespace_identity to give compatibility with Vault Enterprise's cross-namespace group membership.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -2590,6 +2590,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		EnableResponseHeaderHostname:   config.EnableResponseHeaderHostname,
 		EnableResponseHeaderRaftNodeID: config.EnableResponseHeaderRaftNodeID,
 		AdministrativeNamespacePath:    config.AdministrativeNamespacePath,
+		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity,
 	}
 
 	if config.DisableSSCTokens != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -109,6 +109,8 @@ type Config struct {
 	EnableResponseHeaderRaftNodeIDRaw interface{} `hcl:"enable_response_header_raft_node_id"`
 
 	DisableSSCTokens *bool `hcl:"-"`
+
+	UnsafeCrossNamespaceIdentity bool `hcl:"unsafe_cross_namespace_identity"`
 }
 
 const (

--- a/helper/storagepacker/storagepacker.go
+++ b/helper/storagepacker/storagepacker.go
@@ -45,6 +45,10 @@ func (s *StoragePacker) View() logical.Storage {
 
 // GetBucket returns a bucket for a given key
 func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, error) {
+	return s.GetBucketWithStorage(ctx, s.view, key)
+}
+
+func (s *StoragePacker) GetBucketWithStorage(ctx context.Context, view logical.Storage, key string) (*Bucket, error) {
 	if key == "" {
 		return nil, errors.New("missing bucket key")
 	}
@@ -54,7 +58,7 @@ func (s *StoragePacker) GetBucket(ctx context.Context, key string) (*Bucket, err
 	defer lock.RUnlock()
 
 	// Read from storage
-	storageEntry, err := s.view.Get(ctx, key)
+	storageEntry, err := view.Get(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read packed storage entry: %w", err)
 	}
@@ -130,10 +134,18 @@ func (s *StoragePacker) BucketKey(itemID string) string {
 
 // DeleteItem removes the item from the respective bucket
 func (s *StoragePacker) DeleteItem(ctx context.Context, itemID string) error {
-	return s.DeleteMultipleItems(ctx, nil, []string{itemID})
+	return s.DeleteItemWithStorage(ctx, s.view, itemID)
+}
+
+func (s *StoragePacker) DeleteItemWithStorage(ctx context.Context, view logical.Storage, itemID string) error {
+	return s.DeleteMultipleItemsWithStorage(ctx, nil, view, []string{itemID})
 }
 
 func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Logger, itemIDs []string) error {
+	return s.DeleteMultipleItemsWithStorage(ctx, logger, s.view, itemIDs)
+}
+
+func (s *StoragePacker) DeleteMultipleItemsWithStorage(ctx context.Context, logger hclog.Logger, view logical.Storage, itemIDs []string) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "delete_items"}, time.Now())
 	if len(itemIDs) == 0 {
 		return nil
@@ -174,7 +186,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 	idx := 0
 	for bucketKey, itemsToRemove := range byBucket {
 		// Read bucket from storage
-		storageEntry, err := s.view.Get(ctx, bucketKey)
+		storageEntry, err := view.Get(ctx, bucketKey)
 		if err != nil {
 			return fmt.Errorf("failed to read packed storage value: %w", err)
 		}
@@ -214,7 +226,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 			return ctx.Err()
 		}
 
-		err = s.putBucket(ctx, bucket)
+		err = s.putBucket(ctx, view, bucket)
 		if err != nil {
 			return err
 		}
@@ -231,7 +243,7 @@ func (s *StoragePacker) DeleteMultipleItems(ctx context.Context, logger hclog.Lo
 	return nil
 }
 
-func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
+func (s *StoragePacker) putBucket(ctx context.Context, view logical.Storage, bucket *Bucket) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_bucket"}, time.Now())
 	if bucket == nil {
 		return errors.New("nil bucket entry")
@@ -258,7 +270,7 @@ func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
 	}
 
 	// Store the compressed value
-	err = s.view.Put(ctx, &logical.StorageEntry{
+	err = view.Put(ctx, &logical.StorageEntry{
 		Key:   bucket.Key,
 		Value: compressedBucket,
 	})
@@ -272,6 +284,10 @@ func (s *StoragePacker) putBucket(ctx context.Context, bucket *Bucket) error {
 // GetItem fetches the storage entry for a given key from its corresponding
 // bucket.
 func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
+	return s.GetItemWithStorage(s.view, itemID)
+}
+
+func (s *StoragePacker) GetItemWithStorage(view logical.Storage, itemID string) (*Item, error) {
 	defer metrics.MeasureSince([]string{"storage_packer", "get_item"}, time.Now())
 
 	if itemID == "" {
@@ -281,7 +297,7 @@ func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
 	bucketKey := s.BucketKey(itemID)
 
 	// Fetch the bucket entry
-	bucket, err := s.GetBucket(context.Background(), bucketKey)
+	bucket, err := s.GetBucketWithStorage(context.Background(), view, bucketKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read packed storage item: %w", err)
 	}
@@ -301,6 +317,10 @@ func (s *StoragePacker) GetItem(itemID string) (*Item, error) {
 
 // PutItem stores the given item in its respective bucket
 func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
+	return s.PutItemWithStorage(ctx, s.view, item)
+}
+
+func (s *StoragePacker) PutItemWithStorage(ctx context.Context, view logical.Storage, item *Item) error {
 	defer metrics.MeasureSince([]string{"storage_packer", "put_item"}, time.Now())
 
 	if item == nil {
@@ -326,7 +346,7 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 	defer lock.Unlock()
 
 	// Check if there is an existing bucket for a given key
-	storageEntry, err := s.view.Get(ctx, bucketKey)
+	storageEntry, err := view.Get(ctx, bucketKey)
 	if err != nil {
 		return fmt.Errorf("failed to read packed storage bucket entry: %w", err)
 	}
@@ -357,7 +377,25 @@ func (s *StoragePacker) PutItem(ctx context.Context, item *Item) error {
 		}
 	}
 
-	return s.putBucket(ctx, bucket)
+	return s.putBucket(ctx, view, bucket)
+}
+
+func (s *StoragePacker) SwapItem(ctx context.Context, oldId string, item *Item) error {
+	if err := logical.WithTransaction(ctx, s.view, func(v logical.Storage) error {
+		if err := s.DeleteItemWithStorage(ctx, v, oldId); err != nil {
+			return fmt.Errorf("failed to remove old item: %w", err)
+		}
+
+		if err := s.PutItemWithStorage(ctx, v, item); err != nil {
+			return fmt.Errorf("failed to write new item: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NewStoragePacker creates a new storage packer for a given view

--- a/vault/core.go
+++ b/vault/core.go
@@ -638,6 +638,10 @@ type Core struct {
 
 	// Config value for "detect_deadlocks".
 	detectDeadlocks []string
+
+	// Whether we use a single global memdb instance for identity; see
+	// commentary below.
+	unsafeCrossNamespaceIdentity bool
 }
 
 // c.stateLock needs to be held in read mode before calling this function.
@@ -784,6 +788,13 @@ type CoreConfig struct {
 	AdministrativeNamespacePath string
 
 	NumRollbackWorkers int
+
+	// UnsafeCrossNamespaceIdentity is used to comply with Vault Enterprise's
+	// loose tenancy separation afforded by their namespace implementation.
+	// They allow cross-namespace group association.
+	//
+	// See also: https://github.com/openbao/openbao/issues/1110
+	UnsafeCrossNamespaceIdentity bool
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -961,6 +972,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		numRollbackWorkers:             conf.NumRollbackWorkers,
 		impreciseLeaseRoleTracking:     conf.ImpreciseLeaseRoleTracking,
 		detectDeadlocks:                detectDeadlocks,
+		unsafeCrossNamespaceIdentity:   conf.UnsafeCrossNamespaceIdentity,
 	}
 
 	c.standbyStopCh.Store(make(chan struct{}))

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -2632,7 +2632,12 @@ func (i *IdentityStore) lazyGenerateDefaultKey(ctx context.Context, storage logi
 }
 
 func (i *IdentityStore) loadOIDCClients(ctx context.Context) error {
-	i.logger.Debug("identity loading OIDC clients")
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	i.logger.Debug("identity loading OIDC clients", "namespace", ns.Path)
 
 	if err := i.validateCtx(ctx); err != nil {
 		return err

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -18,11 +18,14 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/go-test/deep"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/audit"
+	auditFile "github.com/openbao/openbao/builtin/audit/file"
 	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/storagepacker"
+	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -1455,7 +1458,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("entity_without_namespace", func(t *testing.T) {
 		// Create an entity with no namespace ID to test sanitization
 		entity := &identity.Entity{
-			ID:       "test-no-namespace",
+			ID:       "d9d20def-d59e-4a9b-8379-c927ceb7fe10",
 			Name:     "test-no-namespace",
 			Policies: []string{"default"},
 		}
@@ -1469,7 +1472,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("alias_without_namespace", func(t *testing.T) {
 		// Create an alias with no namespace ID
 		alias := &identity.Alias{
-			ID:            "test-alias-no-namespace",
+			ID:            "d9d20def-d59e-4a9b-8379-c927ceb7fe10." + ns1.ID,
 			CanonicalID:   "test-entity-id",
 			MountType:     "userpass",
 			MountAccessor: rootAccessor, // Use a valid accessor that exists in the root namespace
@@ -1485,7 +1488,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 	t.Run("namespace_mismatch", func(t *testing.T) {
 		// Create an entity in ns1
 		entity := &identity.Entity{
-			ID:          "mismatch-entity",
+			ID:          "d9d20def-d59e-4a9b-8379-c927ceb7fe10",
 			Name:        "mismatch-entity",
 			NamespaceID: ns1.ID,
 		}
@@ -1578,22 +1581,15 @@ func setupNamespaces(t *testing.T, c *Core, ctx context.Context) (*namespace.Nam
 	return ns1, ns2
 }
 
-// Test cross-namespace isolation with comprehensive matrix of lookup attempts
-func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
-	// Register auth backend
-	err := AddTestCredentialBackend("userpass", credUserpass.Factory)
-	require.NoError(t, err)
-	defer ClearTestCredentialBackends()
-
-	// Setup core and namespaces
-	c, _, _ := TestCoreUnsealed(t)
+func setupIdentityTestEnv(t *testing.T, c *Core) (rootCtx context.Context, ns1 *namespace.Namespace, ns1Ctx context.Context, ns2 *namespace.Namespace, ns2Ctx context.Context, rootAccessor string, ns1Accessor string, ns2Accessor string, commonUser string, rootAlias *logical.Alias, ns1Alias *logical.Alias, ns2Alias *logical.Alias, rootEntity *identity.Entity, ns1Entity *identity.Entity, ns2Entity *identity.Entity, groupName string, rootGroup *identity.Group, ns1Group *identity.Group, ns2Group *identity.Group) {
+	var err error
 	is := c.identityStore
-	rootCtx := namespace.RootContext(context.Background())
-	ns1, ns2 := setupNamespaces(t, c, rootCtx)
+	rootCtx = namespace.RootContext(context.Background())
+	ns1, ns2 = setupNamespaces(t, c, rootCtx)
 
 	// Create namespace contexts
-	ns1Ctx := namespace.ContextWithNamespace(context.Background(), ns1)
-	ns2Ctx := namespace.ContextWithNamespace(context.Background(), ns2)
+	ns1Ctx = namespace.ContextWithNamespace(context.Background(), ns1)
+	ns2Ctx = namespace.ContextWithNamespace(context.Background(), ns2)
 
 	// Enable auth methods in all namespaces
 	rootMount := &MountEntry{
@@ -1604,7 +1600,7 @@ func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
 	}
 	err = c.enableCredential(rootCtx, rootMount)
 	require.NoError(t, err)
-	rootAccessor := rootMount.Accessor
+	rootAccessor = rootMount.Accessor
 
 	ns1Mount := &MountEntry{
 		Table:       credentialTableType,
@@ -1614,7 +1610,7 @@ func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
 	}
 	err = c.enableCredential(ns1Ctx, ns1Mount)
 	require.NoError(t, err)
-	ns1Accessor := ns1Mount.Accessor
+	ns1Accessor = ns1Mount.Accessor
 
 	ns2Mount := &MountEntry{
 		Table:       credentialTableType,
@@ -1624,42 +1620,88 @@ func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
 	}
 	err = c.enableCredential(ns2Ctx, ns2Mount)
 	require.NoError(t, err)
-	ns2Accessor := ns2Mount.Accessor
+	ns2Accessor = ns2Mount.Accessor
 
 	// Create identical aliases in all three namespaces
-	commonUser := "isolation-user"
+	commonUser = "isolation-user"
 
-	rootAlias := &logical.Alias{
+	rootAlias = &logical.Alias{
 		Name:          commonUser,
 		MountAccessor: rootAccessor,
 		MountType:     "userpass",
 	}
 
-	ns1Alias := &logical.Alias{
+	ns1Alias = &logical.Alias{
 		Name:          commonUser,
 		MountAccessor: ns1Accessor,
 		MountType:     "userpass",
 	}
 
-	ns2Alias := &logical.Alias{
+	ns2Alias = &logical.Alias{
 		Name:          commonUser,
 		MountAccessor: ns2Accessor,
 		MountType:     "userpass",
 	}
 
-	rootEntity, _, err := is.CreateOrFetchEntity(rootCtx, rootAlias)
+	rootEntity, _, err = is.CreateOrFetchEntity(rootCtx, rootAlias)
 	require.NoError(t, err)
 
-	ns1Entity, _, err := is.CreateOrFetchEntity(ns1Ctx, ns1Alias)
+	ns1Entity, _, err = is.CreateOrFetchEntity(ns1Ctx, ns1Alias)
 	require.NoError(t, err)
 
-	ns2Entity, _, err := is.CreateOrFetchEntity(ns2Ctx, ns2Alias)
+	ns2Entity, _, err = is.CreateOrFetchEntity(ns2Ctx, ns2Alias)
 	require.NoError(t, err)
 
 	// Verify all three entities are different
 	require.NotEqual(t, rootEntity.ID, ns1Entity.ID)
 	require.NotEqual(t, rootEntity.ID, ns2Entity.ID)
 	require.NotEqual(t, ns1Entity.ID, ns2Entity.ID)
+
+	// Create group aliases.
+	groupName = "isolation-group"
+
+	rootGroup = &identity.Group{
+		Name: groupName,
+	}
+
+	ns1Group = &identity.Group{
+		Name: groupName,
+	}
+
+	ns2Group = &identity.Group{
+		Name: groupName,
+	}
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns2Ctx, ns2Group, nil, nil)
+	require.NoError(t, err)
+
+	require.NotEqual(t, rootGroup.ID, ns1Group.ID)
+	require.NotEqual(t, rootGroup.ID, ns2Group.ID)
+	require.NotEqual(t, ns1Group.ID, ns2Group.ID)
+
+	t.Logf("setupIdentityTestEnv:\n\tns1: accessor=%v / uuid=%v\n\tns2: accessor=%v / uuid=%v\n\tuserpass accessors root=%v / ns1=%v / ns2=%v\n\tentity alias: name=%v / root=%v / ns1=%v / ns2=%v\n\tentity: root=%v / ns1=%v / ns2=%v\n\tgroup: name=%v / root=%v / ns1=%v / ns2=%v", ns1.ID, ns1.UUID, ns2.ID, ns2.UUID, rootAccessor, ns1Accessor, ns2Accessor, commonUser, rootAlias.ID, ns1Alias.ID, ns2Alias.ID, rootEntity.ID, ns1Entity.ID, ns2Entity.ID, groupName, rootGroup.ID, ns1Group.ID, ns2Group.ID)
+
+	return
+}
+
+// Test cross-namespace isolation with comprehensive matrix of lookup attempts
+func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
+	// Register auth backend
+	err := AddTestCredentialBackend("userpass", credUserpass.Factory)
+	require.NoError(t, err)
+	defer ClearTestCredentialBackends()
+
+	// Setup core and namespaces
+	c, _, _ := TestCoreUnsealed(t)
+	is := c.identityStore
+
+	rootCtx, ns1, ns1Ctx, ns2, ns2Ctx, rootAccessor, ns1Accessor, ns2Accessor, commonUser, _, _, _, rootEntity, ns1Entity, ns2Entity, _, _, _, _ := setupIdentityTestEnv(t, c)
 
 	// Comprehensive matrix of cross-namespace lookups
 	crossLookups := []struct {
@@ -1958,4 +2000,89 @@ func TestIdentityStore_CrossNamespaceIsolation(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestIdentityStore_StrictGroupIsloation(t *testing.T) {
+	// Register auth backend
+	err := AddTestCredentialBackend("userpass", credUserpass.Factory)
+	require.NoError(t, err)
+	defer ClearTestCredentialBackends()
+
+	// Setup core and namespaces
+	c, _, _ := TestCoreUnsealed(t)
+	is := c.identityStore
+
+	rootCtx, _, ns1Ctx, _, _, _, _, _, _, _, _, _, _, _, _, _, rootGroup, ns1Group, ns2Group := setupIdentityTestEnv(t, c)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, []string{ns1Group.ID})
+	require.Error(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, []string{ns2Group.ID})
+	require.Error(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, []string{rootGroup.ID})
+	require.Error(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, []string{ns2Group.ID})
+	require.Error(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
+	require.NoError(t, err)
+}
+
+func TestIdentityStore_UnsafeCrossNamespace(t *testing.T) {
+	// Register auth backend
+	err := AddTestCredentialBackend("userpass", credUserpass.Factory)
+	require.NoError(t, err)
+	defer ClearTestCredentialBackends()
+
+	// Setup core and namespaces
+	c := TestCoreWithConfig(t, &CoreConfig{
+		Seal:            nil,
+		EnableUI:        false,
+		EnableRaw:       false,
+		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
+		AuditBackends: map[string]audit.Factory{
+			"file": auditFile.Factory,
+		},
+		UnsafeCrossNamespaceIdentity: true,
+	})
+
+	c, _, _ = testCoreUnsealed(t, c)
+	is := c.identityStore
+
+	rootCtx, _, ns1Ctx, _, _, _, _, _, _, _, _, _, _, _, _, _, rootGroup, ns1Group, ns2Group := setupIdentityTestEnv(t, c)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, []string{ns1Group.ID})
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, []string{ns2Group.ID})
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(rootCtx, rootGroup, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, []string{rootGroup.ID})
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, []string{ns2Group.ID})
+	require.NoError(t, err)
+
+	err = is.sanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
+	require.NoError(t, err)
 }

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -228,6 +228,7 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	conf.DetectDeadlocks = opts.DetectDeadlocks
 	conf.AdministrativeNamespacePath = opts.AdministrativeNamespacePath
 	conf.ImpreciseLeaseRoleTracking = opts.ImpreciseLeaseRoleTracking
+	conf.UnsafeCrossNamespaceIdentity = opts.UnsafeCrossNamespaceIdentity
 
 	if opts.Logger != nil {
 		conf.Logger = opts.Logger

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1687,6 +1687,11 @@ func (ts *TokenStore) lookupInternal(ctx context.Context, id string, salted, tai
 		persistNeeded = true
 	}
 
+	if entry.EntityID != "" && entry.NamespaceID != namespace.RootNamespaceID && !strings.HasSuffix(entry.EntityID, entry.NamespaceID) {
+		entry.EntityID = fmt.Sprintf("%v.%v", entry.EntityID, entry.NamespaceID)
+		persistNeeded = true
+	}
+
 	// It's a root token with unlimited creation TTL (so never had an
 	// expiration); this may or may not have a lease (based on when it was
 	// generated, for later revocation purposes) but it doesn't matter, it's
@@ -1737,6 +1742,9 @@ func (ts *TokenStore) lookupInternal(ctx context.Context, id string, salted, tai
 		if err != nil {
 			return nil, err
 		}
+
+		// Never persist if we're revoking.
+		persistNeeded = false
 
 	// Only return if we're not past lease expiration (or if tainted is true),
 	// otherwise assume expmgr is working on revocation


### PR DESCRIPTION
* Attach namespace to identity information

When allowing cross-namespace identity store operations, we need to attach namespace information to avoid expensive searches across all child namespaces to find the correct namespace for a given identifier.

This change is not backwards compatible with previous versions; we will fail sanitization for any existing entities in namespaces due to the lack of the namespace identifier suffix.



* Make StoragePacker transaction-friendly

The current StoragePacker design retains a copy of logical.Storage, avoiding the need for callers to use their own. However, it doesn't actually use the View interface, meaning we can apply transactions over the top for sensitive operations.

Expose storage as a parameter so that we can have cross-operation transactions.



* Support upgrading entity ids to new format

This resolves the incompatibilities in the previous entity alias change, restoring compatibility with beta, though potentially affecting callers who retained the entity ID long-term. We also make this change on stored entity IDs in the token store.



* Support unsafe_cross_namespace_identity flag

This flag will allow server operators to opt into Vault Enterprise compatible namespace identity store, which uses a single memdb instance across all tenants to allow for cross-namespace group association.



* Ensure loading identity entries across namespaces

Before this commit, on restarts of OpenBao, identities within namespaces were never loaded into memdb, resulting in a failure to use newly created identities. This has been fixed, ensuring all identities are loaded on startup into their respective MemDB instances.



* Add test for cross-namespace identity behavior

This ensures the new unsafe_cross_namespace_identity flag functions as expected, allowing cross-namespace group inclusion in the identity subsystem.



* Add changelog entry



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Backport of https://github.com/openbao/openbao/pull/1432. Will conflict with https://github.com/openbao/openbao/pull/1488.