### PR TITLE
ci: multi platform build pipeline & weekly mandatory platform workflow

### DIFF
--- a/.github/actions/set-up-cross-compile/action.yml
+++ b/.github/actions/set-up-cross-compile/action.yml
@@ -1,0 +1,25 @@
+name: Set Up Cross Compile
+description: Set up the cross-compile environment
+inputs:
+  goos: { required: true, description: "Operating system" }
+  goarch: { required: true, description: "Architecture" }
+  goarm: { required: false, description: "ARM version (e.g. 6, 7)" }
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/set-up-go
+
+    - name: Export cross-compile vars
+      shell: bash
+      run: |
+        echo "GOOS=${{ inputs.goos }}" >> $GITHUB_ENV
+        echo "GOARCH=${{ inputs.goarch }}" >> $GITHUB_ENV
+        if [ -n "${{ inputs.goarm }}" ]; then echo "GOARM=${{ inputs.goarm }}" >> $GITHUB_ENV; fi
+
+    - name: Go build cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      with:
+        key: go-build-${{ runner.os }}-${{ inputs.goos }}-${{ inputs.goarch }}-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/.cache/go-build

--- a/.github/docker/Dockerfile.cross
+++ b/.github/docker/Dockerfile.cross
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+# Multi-arch builder image
+FROM golang:${VERSION} AS builder
+
+ARG GOOS
+ARG GOARCH
+# Disable CGO for static binary unless explicitly enabled elsewhere
+ENV CGO_ENABLED=0
+
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=${GOOS} GOARCH=${GOARCH} \
+    go build -trimpath -o /out/bao ./cmd/bao
+
+# Export binary only; rely on `--output=type=local` to fetch it
+FROM scratch AS export
+COPY --from=builder /out/bao /bao 

--- a/.github/scripts/cross-compile-binary.sh
+++ b/.github/scripts/cross-compile-binary.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# cross-compile-binary.sh, Build Bao for the specified GOOS/GOARCH
+# Expects GOOS/GOARCH (and optional GOARM) in the environment.
+set -euo pipefail
+
+if [[ -z "${GOOS:-}" || -z "${GOARCH:-}" ]]; then
+  echo "GOOS/GOARCH must be set" >&2
+  exit 1
+fi
+
+# Determine output filename
+EXT=""
+if [[ "$GOOS" == "windows" ]]; then
+  EXT=".exe"
+fi
+BIN="bao-${GOOS}-${GOARCH}${EXT}"
+
+# Clear any previous build artifacts for cleanliness
+rm -f "${BIN}"
+
+# Disable CGO for cross-compilation unless explicitly enabled
+export CGO_ENABLED="${CGO_ENABLED:-0}"
+
+# Respect BUILD_TAGS if the workflow/front-end set them; default to empty
+export BUILD_TAGS="${BUILD_TAGS:-}"
+
+PKG="github.com/openbao/openbao"
+GIT_COMMIT=$(git rev-parse --short=12 HEAD || echo "unknown")
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LD_FLAGS="-s -w -X ${PKG}/version.GitCommit=${GIT_COMMIT} -X ${PKG}/version.BuildDate=${BUILD_DATE}"
+
+echo "Cross-compiling bao for $GOOS/$GOARCH (CGO_ENABLED=$CGO_ENABLED)"
+GOOS=$GOOS GOARCH=$GOARCH GOARM=${GOARM:-} \
+  go build -trimpath -ldflags="$LD_FLAGS" -tags "${BUILD_TAGS:-openbao}" -o "$BIN" ./cmd/bao
+
+echo "Built $BIN"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "out=$BIN" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/generate-platform-matrix.sh
+++ b/.github/scripts/generate-platform-matrix.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# generate-platform-matrix.sh, derive CI matrix from GoReleaser configs.
+# Uses yq to parse GoReleaser configs.
+# Usage: ./generate-platform-matrix.sh [mandatory|pending|all]
+
+set -euo pipefail
+
+SCOPE=${1:-mandatory}
+
+# Helper: map goos/goarch → GitHub runner label
+map_os() {
+  local goos=$1 arch=$2
+  case "$goos" in
+    linux)   echo "ubuntu-latest";;
+    windows) echo "windows-latest${arch:+}";;
+    darwin)
+      if [[ "$arch" == "arm64" ]]; then
+        echo "macos-latest-arm64"  # GitHub's Apple-silicon runners
+      else
+        echo "macos-latest"
+      fi
+      ;;
+    *) echo "ubuntu-latest";;
+  esac
+}
+
+collect_pairs() {
+  local file=$1
+  # Using yq: iterate over builds, expand arrays → print goos|goarch lines
+  yq -r '.builds[] | (.goos[]?) as $g | (.goarch[]?) as $a | "\($g)|\($a)"' "$file" 2>/dev/null || true
+}
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "yq is required but not installed" >&2
+  exit 1
+fi
+
+pairs=$( (collect_pairs goreleaser.linux.yaml; collect_pairs goreleaser.other.yaml) | sort -u )
+if [[ -z "$pairs" ]]; then
+  echo "Failed to derive platform pairs from GoReleaser configs" >&2
+  exit 1
+fi
+
+json="$(echo "$pairs" | awk -F'|' '
+{
+  goos=$1; arch=$2;
+  if (goos=="darwin") {
+    if (arch=="amd64") runner="macos-latest"; else if (arch=="arm64") runner="macos-latest-arm64"; else next;
+  } else if (goos=="windows") {
+    # GitHub offers the same runner label for all Windows arches.
+    if (arch!="amd64" && arch!="arm64") next;
+    runner="windows-latest";
+  } else if (goos=="linux") {
+    runner="ubuntu-latest";
+  } else {
+    # Map *BSD/Illumos etc. to ubuntu runner; cross-compile only
+    runner="ubuntu-latest";
+  }
+  # Determine if this platform should use Docker buildx (exotic archs we cannot compile natively)
+  buildx = "false"
+  if (arch == "riscv64" || arch == "s390x" || arch == "ppc64" || arch == "ppc64le") {
+    buildx = "true"
+  } else if (goos != "linux" && goos != "windows" && goos != "darwin") {
+    buildx = "true"
+  }
+
+  printf "{\"os\":\"%s\",\"goos\":\"%s\",\"goarch\":\"%s\",\"buildx\":%s}\n", runner, goos, arch, buildx;
+}' | jq -s .)"
+
+# Partition into scopes
+mandatory_jq='map(select((.goos=="linux" and .goarch=="amd64") or (.goos=="windows" and .goarch=="amd64") or (.goos=="darwin" and (.goarch=="amd64" or .goarch=="arm64"))))'
+pending_jq='map(select((.goos=="linux" and .goarch=="arm64") or (.goos=="windows" and .goarch=="arm64")))'
+
+case "$SCOPE" in
+  mandatory)
+    echo "$json" | jq -c "$mandatory_jq"
+    ;;
+  pending)
+    echo "$json" | jq -c "$pending_jq"
+    ;;
+  all)
+    echo "$json" | jq -c .
+    ;;
+  *)
+    echo "Usage: $0 [mandatory|pending|all]" >&2
+    exit 1
+    ;;
+esac 

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -1,0 +1,65 @@
+name: cross-platform-build
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: "JSON string for the platform matrix (from generate-platform-matrix.sh)"
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up cross compile
+        if: ${{ matrix.buildx != true }}
+        uses: ./.github/actions/set-up-cross-compile
+        with:
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+
+      - name: Build binary (native)
+        if: ${{ matrix.buildx != true }}
+        id: native
+        run: ./.github/scripts/cross-compile-binary.sh
+
+      - name: Upload artifact (native)
+        if: ${{ matrix.buildx != true }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bao-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ steps.native.outputs.out }}
+
+      - name: Set up QEMU
+        if: ${{ matrix.buildx == true }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: ${{ matrix.buildx == true }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build binary (buildx)
+        if: ${{ matrix.buildx == true }}
+        id: buildx
+        run: |
+          docker buildx build \
+            --platform=${{ matrix.goos }}/${{ matrix.goarch }} \
+            --file .github/docker/Dockerfile.cross \
+            --build-arg GOOS=${{ matrix.goos }} \
+            --build-arg GOARCH=${{ matrix.goarch }} \
+            --output=type=local,dest=out \
+            --progress=plain \
+            .
+
+      - name: Upload artifact (buildx)
+        if: ${{ matrix.buildx == true }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bao-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: out/bao

--- a/.github/workflows/test-platforms-weekly.yml
+++ b/.github/workflows/test-platforms-weekly.yml
@@ -1,0 +1,48 @@
+name: Weekly Platform Tests
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+    inputs:
+      platform_scope:
+        description: "Platform scope to test"
+        required: false
+        default: "mandatory"
+        type: choice
+        options: [mandatory, all]
+
+jobs:
+  gen-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.mk.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Generate platform matrix
+        id: mk
+        run: |
+          SCOPE="${{ github.event.inputs.platform_scope }}"
+          if [ -z "$SCOPE" ]; then
+            SCOPE="mandatory"
+          fi
+          echo "Generating matrix for scope: $SCOPE"
+          echo "matrix=$(./.github/scripts/generate-platform-matrix.sh $SCOPE | jq -c .)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: gen-matrix
+    uses: ./.github/workflows/cross-platform-build.yml
+    with:
+      matrix: ${{ needs.gen-matrix.outputs.matrix }}
+
+  # Run full Go test suite on linux/amd64 only for now
+  tests-linux:
+    needs: gen-matrix
+    # Filter: pick first element matching linux/amd64
+    if: ${{ contains(needs.gen-matrix.outputs.matrix, '"goos":"linux"') }}
+    uses: ./.github/workflows/test-go.yml
+    with:
+      runs-on: ubuntu-latest
+      go-arch: amd64
+      total-runners: 4
+      binary-tests: true
+      name: weekly-linux-amd64


### PR DESCRIPTION
As noted in #711, we’ve already had several surprises:
- v2.1.0-beta failure on Illumos/Solaris
- v2.3.0-beta failure on darwin/amd64
- v2.3.0 GA breakage caused by etcd-io/bbolt #988

Those slipped through because we only compiled & tested on Linux amd64.

When done with the changes in this PR we can catch these issue way earlier.

High-level changes (details to follow once the draft settles):
Reusable build workflow that can:
- run native go build on GH-hosted runners
- fall back to Docker Buildx + QEMU for exotic arches.
- Script to generate a platform matrix directly from our GoReleaser configs.

Weekly orchestration workflow that:
- builds every “mandatory” release platform on Sunday
- runs the full test suite on all supported platform
- is also triggerable on demand.


Resolves #711 
