### PR TITLE
Add missing sidebar entry for Static Key seal doc page

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
                         "configuration/seal/kmip",
                         "configuration/seal/ocikms",
                         "configuration/seal/pkcs11",
+                        "configuration/seal/static",
                         "configuration/seal/transit",
                     ],
                     service_registration: [


### PR DESCRIPTION
Adds the missing sidebar entry for the recent Static Key seal functionality.

Related to #1425 
