### PR TITLE
External Keys: Parse configuration stanzas

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1528,6 +1528,9 @@ func (c *ServerCommand) Run(args []string) int {
 				core.SetLogLevel(level)
 			}
 
+			// Reload external key configurations
+			core.ReloadExternalKeys()
+
 		RUNRELOADFUNCS:
 			if err := c.Reload(c.reloadFuncsLock, c.reloadFuncs, c.flagConfigs, core); err != nil {
 				c.UI.Error(fmt.Sprintf("Error(s) were encountered during reload: %s", err))

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -62,6 +62,12 @@ func TestParseStorage(t *testing.T) {
 	testParseStorageTemplate(t)
 }
 
+// TestParseExternalKeys tests parsing of 'external_keys "type" { ... }'
+// stanzas.
+func TestParseExternalKeys(t *testing.T) {
+	testParseExternalKeys(t)
+}
+
 // TestConfigWithAdministrativeNamespace tests that .hcl and .json configurations are correctly parsed when the administrative_namespace_path is present.
 func TestConfigWithAdministrativeNamespace(t *testing.T) {
 	testConfigWithAdministrativeNamespaceHcl(t)

--- a/command/server/config_test_helpers_util.go
+++ b/command/server/config_test_helpers_util.go
@@ -1,8 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
-package server
-
-func addExpectedEntConfig(c *Config, sentinelModules []string)                         {}
-func addExpectedDefaultEntConfig(c *Config)                                            {}
-func addExpectedEntSanitizedConfig(c map[string]interface{}, sentinelModules []string) {}

--- a/vault/core.go
+++ b/vault/core.go
@@ -3619,6 +3619,15 @@ func (c *Core) ReloadIntrospectionEndpointEnabled() {
 	c.introspectionEnabled = conf.(*server.Config).EnableIntrospectionEndpoint
 }
 
+func (c *Core) ReloadExternalKeys() {
+	conf := c.rawConfig.Load()
+	if conf == nil {
+		return
+	}
+	// TODO(satoqz): Reload all affected external key configs.
+	// externalKeyStanzas := conf.(*server.Config).ExternalKeys
+}
+
 type PeerNode struct {
 	Hostname       string    `json:"hostname"`
 	APIAddress     string    `json:"api_address"`


### PR DESCRIPTION
Load (and reload) `external_keys` stanzas. I think keeping these in `Core.rawConfig` with easy map lookup by name might be enough.

Also removed some enterprise hooks that crossed my path.