### PR TITLE
Fix typo in dev mode

### DIFF
--- a/changelog/1527.txt
+++ b/changelog/1527.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command: fixes typo in Windows command for setting BAO_ADDR in development mode
+```

--- a/command/server.go
+++ b/command/server.go
@@ -2702,7 +2702,7 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 						c.UI.Warn("PowerShell:")
 						c.UI.Warn(fmt.Sprintf("    $env:BAO_ADDR=\"%s\"", endpointURL))
 						c.UI.Warn("cmd.exe:")
-						c.UI.Warn(fmt.Sprintf("    set BAOT_ADDR=%s", endpointURL))
+						c.UI.Warn(fmt.Sprintf("    set BAO_ADDR=%s", endpointURL))
 					} else {
 						c.UI.Warn(fmt.Sprintf("    $ export BAO_ADDR='%s'", endpointURL))
 					}


### PR DESCRIPTION
When running in development mode using the Windows version of the binary, there is a typo in the command used to set the "BAO_ADDR" environment variable. This PR aims to correct this typo so that the command works correctly.


As described in the documentation, I did not create an issue for this PR, as it is just a minor typo.
