### PR TITLE
doc: fix the number of kubernetes integration

### DIFF
--- a/website/content/docs/platform/k8s/index.mdx
+++ b/website/content/docs/platform/k8s/index.mdx
@@ -44,7 +44,7 @@ There are several ways to try OpenBao with Kubernetes in different environments.
 
 ### High level comparison of integrations
 
-There are currently 3 different integrations to help Kubernetes workloads
+There are currently 2 different integrations to help Kubernetes workloads
 seamlessly consume secrets from OpenBao, without the need to modify the
 application to interact directly with OpenBao. Each integration addresses
 slightly different use-cases. The following is a brief overview of the strengths


### PR DESCRIPTION
Since Vault Secret operator is currently not working and so, not included in documentation, the documentation should only count the 2 working and documented integrations. This avoid users looking for the missing third integration.
