### PR TITLE
Implement cache invalidation for namespaces and policies

### DIFF
--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -49,11 +49,18 @@ func (c *Core) invalidateInternal(ctx context.Context, key string) error {
 		if err != nil {
 			return err
 		}
-		c.policyStore.invalidateNamespace(strings.TrimPrefix(namespacedKey, namespaceStoreSubPath))
+
+		err = c.policyStore.invalidateNamespace(ctx, strings.TrimPrefix(namespacedKey, namespaceStoreSubPath))
+		if err != nil {
+			return err
+		}
 
 	case strings.HasPrefix(namespacedKey, systemBarrierPrefix+policyACLSubPath):
 		policyType := PolicyTypeACL // for now it is safe to assume type is ACL
-		c.policyStore.invalidate(ctx, strings.TrimPrefix(namespacedKey, systemBarrierPrefix+policyACLSubPath), policyType)
+		err := c.policyStore.invalidate(ctx, strings.TrimPrefix(namespacedKey, systemBarrierPrefix+policyACLSubPath), policyType)
+		if err != nil {
+			return err
+		}
 
 	default:
 		c.logger.Warn("no idea how to invalidate cache. Maybe it's not cached and this is fine, maybe not", "key", key)

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"strings"
+
+	"github.com/openbao/openbao/helper/namespace"
+)
+
+func (c *Core) Invalidate(key string) {
+	ctx := c.activeContext
+
+	namespacedKey := key
+	ns := namespace.RootNamespace
+	namespaceUUID := namespace.RootNamespaceUUID
+
+	if keySuffix, ok := strings.CutPrefix(key, namespaceBarrierPrefix); ok {
+		namespaceUUID, namespacedKey, _ = strings.Cut(keySuffix, "/")
+		var err error
+		ns, err = c.namespaceStore.GetNamespace(ctx, namespaceUUID)
+
+		if err != nil {
+			c.logger.Error("error while invalidating cache: could not find namespace", "key", key, "error", err.Error())
+			// We can't find the namespace, but let's still try to invalidate the cache
+			ns = namespace.RootNamespace
+		}
+	}
+
+	ctx = namespace.ContextWithNamespace(ctx, ns)
+
+	switch {
+	case strings.HasPrefix(namespacedKey, namespaceStoreSubPath):
+		c.namespaceStore.invalidate(ctx, "")
+
+	case strings.HasPrefix(namespacedKey, "sys/policy/"):
+		policyType := PolicyTypeACL // for now it is safe to assume type is ACL
+		c.policyStore.invalidate(ctx, strings.TrimPrefix(namespacedKey, "sys/policy/"), policyType)
+
+	default:
+		c.logger.Warn("no idea how to invalidate cache. Maybe it's not cached and this is fine, maybe not", "key", key)
+	}
+
+}

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -34,12 +34,11 @@ func (c *Core) Invalidate(key string) {
 	case strings.HasPrefix(namespacedKey, namespaceStoreSubPath):
 		c.namespaceStore.invalidate(ctx, "")
 
-	case strings.HasPrefix(namespacedKey, "sys/policy/"):
+	case strings.HasPrefix(namespacedKey, systemBarrierPrefix+policyACLSubPath):
 		policyType := PolicyTypeACL // for now it is safe to assume type is ACL
-		c.policyStore.invalidate(ctx, strings.TrimPrefix(namespacedKey, "sys/policy/"), policyType)
+		c.policyStore.invalidate(ctx, strings.TrimPrefix(namespacedKey, systemBarrierPrefix+policyACLSubPath), policyType)
 
 	default:
 		c.logger.Warn("no idea how to invalidate cache. Maybe it's not cached and this is fine, maybe not", "key", key)
 	}
-
 }

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func TestCore_Invalidate_Namespaces(t *testing.T) {
+	c, _, root := TestCoreUnsealed(t)
+
+	// 1. Create some namespace to populate cache
+	ns := &namespace.Namespace{
+		ID:   "ns",
+		Path: "ns",
+		CustomMetadata: map[string]string{
+			"testkey": "initial value",
+		},
+	}
+
+	TestCoreCreateNamespaces(t, c, ns)
+
+	// 2. Manipulate Storage
+	clone := *ns
+	clone.CustomMetadata["testkey"] = "updated value"
+
+	storagePath := "core/namespaces/" + ns.UUID
+	newEntry, err := logical.StorageEntryJSON(storagePath, clone)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	err = c.barrier.Put(context.TODO(), newEntry)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// 3. Invalidate Path
+	c.Invalidate(storagePath)
+
+	// 4. Check cache was properly invalidated
+	req := logical.TestRequest(t, logical.ReadOperation, "sys/namespaces/ns")
+	req.ClientToken = root
+	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if diff := deep.Equal(resp.Data["custom_metadata"], map[string]string{
+		"testkey": "updated value",
+	}); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestCore_Invalidate_Policy(t *testing.T) {
+
+	testCases := map[string]func(t *testing.T, c *Core) (storagePath string, ctx context.Context){
+		"global": func(t *testing.T, c *Core) (storagePath string, ctx context.Context) {
+			return "sys/policy/test-policy", namespace.RootContext(t.Context())
+		},
+
+		"local": func(t *testing.T, c *Core) (storagePath string, ctx context.Context) {
+			ns := &namespace.Namespace{
+				ID:   "ns",
+				Path: "ns",
+			}
+			TestCoreCreateNamespaces(t, c, ns)
+
+			return fmt.Sprintf("namespaces/%s/sys/policy/test-policy", ns.UUID), namespace.ContextWithNamespace(t.Context(), ns)
+		},
+	}
+
+	for name, init := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c, _, root := TestCoreUnsealed(t)
+			storagePath, ctx := init(t, c)
+
+			// 1. Create some policy to populate cache
+			req := logical.TestRequest(t, logical.CreateOperation, "sys/policy/test-policy")
+			req.ClientToken = root
+			req.Data = map[string]interface{}{
+				"policy": `
+					path "test/path/*" {
+						capabilities = ["read"]
+					}
+			`}
+			resp, err := c.HandleRequest(ctx, req)
+
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if resp.IsError() {
+				t.Fatalf("err: %v", resp.Error())
+			}
+
+			// 2. Manipulate Storage
+			policy, err := c.policyStore.GetPolicy(ctx, "test-policy", PolicyTypeACL)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			clone := policy.ShallowClone()
+			clone.Expiration = time.Date(2099, 1, 1, 12, 0, 0, 0, time.UTC)
+
+			newEntry, err := logical.StorageEntryJSON(storagePath, clone)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			err = c.barrier.Put(ctx, newEntry)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			// 3. Invalidate Path
+			c.Invalidate(storagePath)
+
+			// 4. Check cache was properly invalidated
+			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", PolicyTypeACL)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if updatedPolicy.Expiration != clone.Expiration {
+				t.Errorf("invalidation did not work: expected to see updated expiry time, got: %v", updatedPolicy.Expiration)
+			}
+		})
+	}
+}

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -50,7 +50,6 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	req := logical.TestRequest(t, logical.ReadOperation, "sys/namespaces/ns")
 	req.ClientToken = root
 	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
-
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -63,7 +62,6 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 }
 
 func TestCore_Invalidate_Policy(t *testing.T) {
-
 	testCases := map[string]func(t *testing.T, c *Core) (storagePath string, ctx context.Context){
 		"global": func(t *testing.T, c *Core) (storagePath string, ctx context.Context) {
 			return "sys/policy/test-policy", namespace.RootContext(t.Context())
@@ -93,9 +91,9 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 					path "test/path/*" {
 						capabilities = ["read"]
 					}
-			`}
+			`,
+			}
 			resp, err := c.HandleRequest(ctx, req)
-
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -237,6 +237,17 @@ func (c *Core) teardownPolicyStore() error {
 	return nil
 }
 
+func (ps *PolicyStore) invalidateNamespace(uuid string) {
+	ps.modifyLock.Lock()
+	defer ps.modifyLock.Unlock()
+
+	for _, key := range ps.tokenPoliciesLRU.Keys() {
+		if strings.HasPrefix(key, uuid) {
+			ps.tokenPoliciesLRU.Remove(key)
+		}
+	}
+}
+
 func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType PolicyType) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
@@ -774,7 +785,7 @@ func (ps *PolicyStore) sanitizeName(name string) string {
 }
 
 func (ps *PolicyStore) cacheKey(ns *namespace.Namespace, name string) string {
-	return path.Join(ns.ID, name)
+	return path.Join(ns.UUID, name)
 }
 
 // loadDefaultPolicies loads default policies for the namespace in the provided context


### PR DESCRIPTION
Implement cache invalidation for namespaces and policies.
Required as a prerequisite for enabling standby nodes to handle read requests.

See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch