### PR TITLE
Implement cache invalidation for physical.Cache

### DIFF
--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -412,3 +412,13 @@ func (c *cacheTransaction) Rollback(ctx context.Context) error {
 
 	return nil
 }
+
+// Invalidate removes the value for key from the cache.
+// This will not affect transactions that have already been started.
+func (c *cache) Invalidate(ctx context.Context, key string) {
+	lock := locksutil.LockForKey(c.locks, key)
+	lock.Lock()
+	defer lock.Unlock()
+
+	c.lru.Remove(key)
+}

--- a/sdk/physical/inmem/cache_test.go
+++ b/sdk/physical/inmem/cache_test.go
@@ -103,6 +103,63 @@ func TestCache_Purge(t *testing.T) {
 	}
 }
 
+func TestCache_Invalidate(t *testing.T) {
+	logger := logging.NewVaultLogger(log.Debug)
+	require := require.New(t)
+
+	inm, err := NewInmem(nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := physical.NewCache(inm, 0, logger, &metrics.BlackholeSink{})
+	cache.SetEnabled(true)
+
+	// Store some value
+	require.NoError(cache.Put(context.Background(), &physical.Entry{
+		Key:   "foo",
+		Value: []byte("bar"),
+	}))
+
+	// Start a transaction
+	tx, err := cache.(physical.TransactionalBackend).BeginTx(context.Background())
+	require.NoError(err)
+
+	// Modify in under
+	require.NoError(inm.Put(context.Background(), &physical.Entry{
+		Key:   "foo",
+		Value: []byte("bazz"),
+	}))
+
+	// Read should return old value
+	out, err := cache.Get(context.Background(), "foo")
+	require.NoError(err)
+	require.NotNil(out, "should have key")
+	require.EqualValues("bar", out.Value)
+
+	// Read from transaction should return old value
+	out, err = tx.Get(context.Background(), "foo")
+	require.NoError(err)
+	require.NotNil(out, "transaction should have key")
+	require.EqualValues("bar", out.Value)
+
+	// Clear the cache
+	cache.Invalidate(context.Background(), "foo")
+
+	// Read should return new value
+	out, err = cache.Get(context.Background(), "foo")
+	require.NoError(err)
+	require.NotNil(out, "should have key")
+	require.EqualValues("bazz", out.Value)
+
+	// Read from transaction should still return old value
+	out, err = tx.Get(context.Background(), "foo")
+	require.NoError(err)
+	require.NotNil(out, "transaction should have key")
+	require.EqualValues("bar", out.Value)
+
+	require.NoError(tx.Rollback(context.Background()))
+}
+
 func TestCache_Disable(t *testing.T) {
 	logger := logging.NewVaultLogger(log.Debug)
 

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -150,6 +150,7 @@ func IsUnfencedWrite(ctx context.Context) bool {
 // cache, don't use it for other things.
 type ToggleablePurgemonster interface {
 	Purge(ctx context.Context)
+	Invalidate(ctx context.Context, key string)
 	SetEnabled(bool)
 }
 

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -23,6 +23,8 @@ func (c *Core) Invalidate(key string) {
 }
 
 func (c *Core) invalidateInternal(ctx context.Context, key string) error {
+	c.physicalCache.Invalidate(ctx, key)
+
 	namespacedKey := key
 	ns := namespace.RootNamespace
 	namespaceUUID := namespace.RootNamespaceUUID


### PR DESCRIPTION
Implement cache invalidation for `physical.Cache` and call it from `core.Invalidate`
Required as a prerequisite for enabling standby nodes to handle read requests.

See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch
