### PR TITLE
Add Jonas Köhnen and Andrii Fedorchuk as new Dev WG voting members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,9 @@ the root of this repository. That document is considered part of this document.
 
 ### OpenBao Working Groups
 
-| Working Group                                                  | Chair       | Voting Members                                      |
-|----------------------------------------------------------------|-------------| --------------------------------------------------- |
-| [Development Working Group](https://github.com/openbao/dev-wg) | Alex Scheel | Dan Ghita, Nathan Phelps, Jan Martens, Dave Dykstra |
+| Working Group                                                  | Chair       | Voting Members                                                                      |
+|----------------------------------------------------------------|-------------| ----------------------------------------------------------------------------------- |
+| [Development Working Group](https://github.com/openbao/dev-wg) | Alex Scheel | Dan Ghita, Nathan Phelps, Jan Martens, Dave Dykstra, Jonas Köhnen, Andrii Fedorchuk |
 
 ## Issues
 


### PR DESCRIPTION
Based on the recent Dev WG voting outcome, this PR adds @satoqz and @driif as new voting members.

Quoting @cipherboy in Matrix:

> I'm happy to share that on Friday, the Dev WG vote finished and both of you were accepted as voting members to the committee!