### PR TITLE
Update run.mdx: HELM now exposes the web ui

### DIFF
--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -154,13 +154,6 @@ The OpenBao UI is enabled but NOT exposed as service for security reasons. The
 OpenBao UI can also be exposed via port-forwarding or through a [`ui`
 configuration value](/docs/platform/k8s/helm/configuration/#ui).
 
-:::warning
-
-The UI for OpenBao needs to be built from the source (https://github.com/openbao/openbao) 
-The Helm chart does not come with the UI ready at the moment.
-
-:::
-
 Expose the OpenBao UI with port-forwarding:
 
 ```shell-session


### PR DESCRIPTION
When reading the documentation while setting up openbao I was confused that it suddenly told me the web ui was not exposed even though I was already able to access it.

Then I found out that this documentation is out of date :) So here is a small fix :)