### PR TITLE
Corrected misspellings across codebase

### DIFF
--- a/api/env_test.go
+++ b/api/env_test.go
@@ -10,7 +10,7 @@ func TestReadBaoVariable_Vault(t *testing.T) {
 	os.Setenv("VAULT_TEST", actual)
 	expected := ReadBaoVariable("BAO_TEST")
 	if actual != expected {
-		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+		t.Fatalf("bad: Failed to Read Environment Variable actual: %s expected: %s", actual, expected)
 	}
 }
 
@@ -19,7 +19,7 @@ func TestReadBaoVariable_Bao(t *testing.T) {
 	os.Setenv("BAO_TEST", actual)
 	expected := ReadBaoVariable("BAO_TEST")
 	if actual != expected {
-		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+		t.Fatalf("bad: Failed to Read Environment Variable actual: %s expected: %s", actual, expected)
 	}
 }
 
@@ -29,7 +29,7 @@ func TestReadBaoVariable_BothSame(t *testing.T) {
 	os.Setenv("BAO_TEST", actual)
 	expected := ReadBaoVariable("BAO_TEST")
 	if actual != expected {
-		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+		t.Fatalf("bad: Failed to Read Environment Variable actual: %s expected: %s", actual, expected)
 	}
 }
 
@@ -39,6 +39,6 @@ func TestReadBaoVariable_BoaWins(t *testing.T) {
 	os.Setenv("BAO_TEST", actual)
 	expected := ReadBaoVariable("BAO_TEST")
 	if actual != expected {
-		t.Fatalf("bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+		t.Fatalf("bad: Failed to Read Environment Variable actual: %s expected: %s", actual, expected)
 	}
 }

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -3637,7 +3637,7 @@ defined on the role, can access the role.`,
 		`If a SecretID is generated/assigned against a role using the
 'role/<role_name>/secret-id' or 'role/<role_name>/custom-secret-id' endpoint,
 then the number of times this SecretID can be used is defined by this option.
-However, this option may be overriden by the request's 'num_uses' field.`,
+However, this option may be overridden by the request's 'num_uses' field.`,
 	},
 	"role-secret-id-ttl": {
 		"Duration in seconds of the SecretID generated against the role.",

--- a/builtin/credential/jwt/provider_gsuite.go
+++ b/builtin/credential/jwt/provider_gsuite.go
@@ -45,7 +45,7 @@ type GSuiteProviderConfig struct {
 	// without using a service account key. The service account vault is
 	// running under must be granted the `iam.serviceAccounts.signJwt`
 	// permission on this service account. If AdminImpersonateEmail is
-	// specifed, that Workspace user will be impersonated.
+	// specified, that Workspace user will be impersonated.
 	ImpersonatePrincipal string `mapstructure:"impersonate_principal"`
 
 	// If set to true, groups will be fetched from the Google Workspace

--- a/builtin/credential/jwt/provider_ibmisam.go
+++ b/builtin/credential/jwt/provider_ibmisam.go
@@ -25,13 +25,13 @@ func (a *IBMISAMProvider) SensitiveKeys() []string {
 }
 
 // FetchGroups - custom groups fetching for ibmisam - satisfying GroupsFetcher interface
-// IBMISAM by default will return groups not as a json list but as a list of space seperated strings
+// IBMISAM by default will return groups not as a json list but as a list of space separated strings
 // We need to convert this to a json list
 func (a *IBMISAMProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
 	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
 
 	if groupsClaimRaw != nil {
-		// Try to convert the comma seperated list of strings into a list
+		// Try to convert the comma separated list of strings into a list
 		if groupsstr, ok := groupsClaimRaw.(string); ok {
 			rawibmisamGroups := strings.Split(groupsstr, " ")
 

--- a/builtin/credential/jwt/provider_secureauth.go
+++ b/builtin/credential/jwt/provider_secureauth.go
@@ -25,13 +25,13 @@ func (a *SecureAuthProvider) SensitiveKeys() []string {
 }
 
 // FetchGroups - custom groups fetching for secureauth - satisfying GroupsFetcher interface
-// SecureAuth by default will return groups not as a json list but as a list of comma seperated strings
+// SecureAuth by default will return groups not as a json list but as a list of comma separated strings
 // We need to convert this to a json list
 func (a *SecureAuthProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
 	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
 
 	if groupsClaimRaw != nil {
-		// Try to convert the comma seperated list of strings into a list
+		// Try to convert the comma separated list of strings into a list
 		if groupsstr, ok := groupsClaimRaw.(string); ok {
 			rawsecureauthGroups := strings.Split(groupsstr, ",")
 

--- a/builtin/logical/kubernetes/path_roles_test.go
+++ b/builtin/logical/kubernetes/path_roles_test.go
@@ -103,7 +103,7 @@ func TestRoles(t *testing.T) {
 		assert.EqualError(t, resp.Error(), "unable to initialize name template: unable to parse template: template: template:1: unclosed action")
 	})
 
-	t.Run("delete role - non-existant and blank", func(t *testing.T) {
+	t.Run("delete role - non-existent and blank", func(t *testing.T) {
 		resp, err := testRolesDelete(t, b, s, "nope")
 		assert.NoError(t, err)
 		assert.Nil(t, resp)

--- a/builtin/logical/pki/acme_wrappers_test.go
+++ b/builtin/logical/pki/acme_wrappers_test.go
@@ -45,7 +45,7 @@ func TestACMEIssuerRoleLoading(t *testing.T) {
 	require.NoError(t, err, "failed creating issuer issuer-2")
 
 	_, err = CBWrite(b, s, "roles/role-bad-issuer", map[string]interface{}{
-		issuerRefParam: "non-existant",
+		issuerRefParam: "non-existent",
 		"no_store":     "false",
 	})
 	require.NoError(t, err, "failed creating role role-bad-issuer")
@@ -75,8 +75,8 @@ func TestACMEIssuerRoleLoading(t *testing.T) {
 		{name: "fail-role-has-bad-issuer", roleName: "role-bad-issuer", issuerName: "", expectedIssuerName: "", expectErr: true},
 		{name: "fail-role-no-store-enabled", roleName: "role-no-store-enabled", issuerName: "", expectedIssuerName: "", expectErr: true},
 		{name: "fail-role-no-store-enabled", roleName: "role-no-store-enabled", issuerName: "", expectedIssuerName: "", expectErr: true},
-		{name: "fail-role-does-not-exist", roleName: "non-existant", issuerName: "", expectedIssuerName: "", expectErr: true},
-		{name: "fail-issuer-does-not-exist", roleName: "", issuerName: "non-existant", expectedIssuerName: "", expectErr: true},
+		{name: "fail-role-does-not-exist", roleName: "non-existent", issuerName: "", expectedIssuerName: "", expectErr: true},
+		{name: "fail-issuer-does-not-exist", roleName: "", issuerName: "non-existent", expectedIssuerName: "", expectErr: true},
 	}
 
 	for _, tt := range tc {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3842,7 +3842,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("response should have been emtpy but was:\n%#v", resp)
+		t.Fatalf("response should have been empty but was:\n%#v", resp)
 	}
 
 	// Write role PKI.
@@ -4800,7 +4800,7 @@ func requireCertInCaChainArray(t *testing.T, chain []string, cert string, msgAnd
 func requireCertInCaChainString(t *testing.T, chain string, cert string, msgAndArgs ...interface{}) {
 	count := strings.Count(chain, cert)
 	if count != 1 {
-		failMsg := fmt.Sprintf("Found %d occurrances of the cert in the provided chain", count)
+		failMsg := fmt.Sprintf("Found %d occurrences of the cert in the provided chain", count)
 		require.FailNow(t, failMsg, msgAndArgs...)
 	}
 }

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -275,7 +275,7 @@ to be set on all PR secondary clusters.`,
 				},
 				"revocation_signature_algorithm": {
 					Type:        framework.TypeString,
-					Description: `Revocation Signature Alogrithm`,
+					Description: `Revocation Signature Algorithm`,
 					Required:    false,
 				},
 				"revoked": {

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -3105,7 +3105,7 @@ func TestSSHBackend_BasicIssuerOperations(t *testing.T) {
 		t.Fatalf("expected key signing to have failed as no issuer is configured, got resp: %+v, err: %v", resp, err)
 	}
 
-	// submit an issuer to be used by the role and don't set it explicity
+	// submit an issuer to be used by the role and don't set it explicitly
 	// as the first issuer imported is set as default
 	importIssuerReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -3268,7 +3268,7 @@ func TestSSHBackend_RoleIssuerBinding(t *testing.T) {
 
 		require.NotEqual(t, issuer1ID, issuer2ID, "issuer IDs should be different")
 
-		// Create role with issuer1 explicity bound
+		// Create role with issuer1 explicitly bound
 		role1Name := "role-with-issuer1"
 		role1Req := &logical.Request{
 			Operation: logical.UpdateOperation,

--- a/builtin/logical/ssh/path_issuers.go
+++ b/builtin/logical/ssh/path_issuers.go
@@ -393,7 +393,7 @@ func (b *backend) pathWriteIssuerHandler(ctx context.Context, req *logical.Reque
 	defer b.issuersLock.Unlock()
 
 	// This handler is used by two endpoints, `config/ca` and `issuers/import/{issuer_name}`
-	// If called from `config/ca`, we don't want to explicity set a name neither check if `set_default` is set
+	// If called from `config/ca`, we don't want to explicitly set a name neither check if `set_default` is set
 	isConfigCARequest := req.Path == "config/ca"
 
 	publicKey, privateKey, generatedKeyMaterial, err := b.handleKeyGeneration(d)

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -98,7 +98,7 @@ func TestTransit_Restore(t *testing.T) {
 		// The error we expect, if any
 		ExpectedErr error
 
-		// RestoreName is used to restore the key to a differnt name
+		// RestoreName is used to restore the key to a different name
 		RestoreName string
 	}{
 		{

--- a/command/agentproxyshared/auth/kerberos/kerberos_test.go
+++ b/command/agentproxyshared/auth/kerberos/kerberos_test.go
@@ -56,7 +56,7 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 
 	// False by default
 	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; actual {
-		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t", actual)
+		t.Fatalf("disable_fast_negotiation should be false, it wasn't: %t", actual)
 	}
 
 	authConfig.Config["disable_fast_negotiation"] = "true"
@@ -67,7 +67,7 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 
 	// True from override
 	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; !actual {
-		t.Fatalf("disable_fast_negotation should be true, it wasn't: %t", actual)
+		t.Fatalf("disable_fast_negotiation should be true, it wasn't: %t", actual)
 	}
 }
 

--- a/command/auth_move.go
+++ b/command/auth_move.go
@@ -35,7 +35,7 @@ Usage: bao auth move [options] SOURCE DESTINATION
   exiting if a final state is reached.
 
   This command works within or across namespaces, both source and destination paths
-  can be prefixed with a namespace heirarchy relative to the current namespace.
+  can be prefixed with a namespace hierarchy relative to the current namespace.
 
   WARNING! Moving an auth method will revoke any leases from the
   old method.

--- a/command/config/util.go
+++ b/command/config/util.go
@@ -25,7 +25,7 @@ func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
 		return nil, err
 	}
 
-	// If the user specifed the address to connect to on the command line instead
+	// If the user specified the address to connect to on the command line instead
 	// of through an environment variable, we propagate the address to the token
 	// helper through an environment variable. Otherwise the token helper may
 	// read BAO_ADDR and assume a different address than the one we are using.

--- a/command/pki_issue_intermediate.go
+++ b/command/pki_issue_intermediate.go
@@ -323,7 +323,7 @@ func (state inCaseOfFailure) toContinue() string {
 	if !state.csrSigned {
 		message += fmt.Sprintf("You can continue to work with this Certificate Signing Request CSR PEM, by saving"+
 			" it as `pki_int.csr`: %v \n Then call `vault write %v/sign-intermediate csr=@pki_int.csr ...` adding the "+
-			"same key-value arguements as to `pki issue` (except key_type and issuer_name) to generate the certificate "+
+			"same key-value arguments as to `pki issue` (except key_type and issuer_name) to generate the certificate "+
 			"and ca_chain", state.csr, state.parentIssuer)
 	}
 	if !state.certImported {

--- a/command/pki_reissue_intermediate_test.go
+++ b/command/pki_reissue_intermediate_test.go
@@ -188,7 +188,7 @@ func createComplicatedIssuerSetUpWithReIssueIntermediate(t *testing.T, client *a
 	intX3AdaptedCallArgs := []string{
 		"pki", "reissue", "-format=json", "-issuer_name=intX3also", "-type=existing",
 		"pki-int/issuer/intX2", // This is a EC key
-		"pki-int/issuer/intX3", // This template includes use_pss = true which can't be accomodated
+		"pki-int/issuer/intX3", // This template includes use_pss = true which can't be accommodated
 		"pki-int/",
 	}
 	codeOut = RunCustom(intX3AdaptedCallArgs, runOpts)

--- a/command/secrets_move.go
+++ b/command/secrets_move.go
@@ -40,7 +40,7 @@ Usage: bao secrets move [options] SOURCE DESTINATION
   exiting if a final state is reached.
 
   This command works within or across namespaces, both source and destination paths
-  can be prefixed with a namespace heirarchy relative to the current namespace.
+  can be prefixed with a namespace hierarchy relative to the current namespace.
 
   WARNING! Moving a secrets engine will revoke any leases from the
   old engine.

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -394,7 +394,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 		return nil, nil, false, err
 	}
 
-	// Intialize a wrapper around the global sink; this will be passed to Core
+	// Initialize a wrapper around the global sink; this will be passed to Core
 	// and to any backend.
 	wrapper := metricsutil.NewClusterMetricSink(opts.ClusterName, globalMetrics)
 	wrapper.MaxGaugeCardinality = opts.Config.MaximumGaugeCardinality

--- a/sdk/helper/stepwise/stepwise_test.go
+++ b/sdk/helper/stepwise/stepwise_test.go
@@ -28,7 +28,7 @@ type testRun struct {
 }
 
 // TestStepwise_Run_SkipIfNotAcc tests if the Stepwise Run function skips tests
-// if the VAULT_ACC environment variable is not set. This test is seperate from
+// if the VAULT_ACC environment variable is not set. This test is separate from
 // the table tests due to the unsetting/re-setting of the environment variable,
 // which is assumed/needed for all other tests.
 func TestStepwise_Run_SkipIfNotAcc(t *testing.T) {

--- a/sdk/helper/testhelpers/schema/response_validation.go
+++ b/sdk/helper/testhelpers/schema/response_validation.go
@@ -33,7 +33,7 @@ func ValidateResponse(t *testing.T, schema *framework.Response, response *logica
 // response data map conforms to the response schema (schema.Fields). It cycles
 // through the data map and validates conversions in the schema. In "strict"
 // mode, this function will also ensure that the data map has all schema's
-// requred fields and does not have any fields outside of the schema.
+// required fields and does not have any fields outside of the schema.
 func ValidateResponseData(t *testing.T, schema *framework.Response, data map[string]interface{}, strict bool) {
 	t.Helper()
 

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2587,7 +2587,7 @@ func (m *ExpirationManager) getIrrevocableLeaseCounts(ctx context.Context, inclu
 		leaseID := k.(string)
 		leaseNS, err := m.getNamespaceFromLeaseID(ctx, leaseID)
 		if err != nil {
-			// We should probably note that an error occured, but continue counting
+			// We should probably note that an error occurred, but continue counting
 			m.logger.Warn("could not get lease namespace from ID", "error", err)
 			return true
 		}
@@ -2644,7 +2644,7 @@ func (m *ExpirationManager) listIrrevocableLeases(ctx context.Context, includeCh
 
 		leaseNS, err := m.getNamespaceFromLeaseID(ctx, leaseID)
 		if err != nil {
-			// We probably want to track that an error occured, but continue counting
+			// We probably want to track that an error occurred, but continue counting
 			m.logger.Warn("could not get lease namespace from ID", "error", err)
 			return true
 		}

--- a/vault/inspectable_test.go
+++ b/vault/inspectable_test.go
@@ -120,7 +120,7 @@ func TestInspectAPIReload(t *testing.T) {
 		t.Fatal("expected invalid configuration error")
 	}
 	if !strings.Contains(resp.Error().Error(), ErrIntrospectionNotEnabled.Error()) {
-		t.Fatalf("expected invalid configuration error but recieved: %s", resp.Error())
+		t.Fatalf("expected invalid configuration error but received: %s", resp.Error())
 	}
 
 	originalConfig := core.rawConfig.Load().(*server.Config)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5515,7 +5515,7 @@ Enable a new audit backend or disable an existing backend.
 		"",
 	},
 	"rotate_init": {
-		"Intialize, read status or cancel the process of the rotation of the root or recovery key",
+		"Initialize, read status or cancel the process of the rotation of the root or recovery key",
 		"",
 	},
 	"rotate_update": {

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2083,7 +2083,7 @@ func (c *Core) validateOkta(ctx context.Context, mConfig *mfa.Config, username s
 
 	for {
 		// Okta provides an SDK method `GetFactorTransactionStatus` but does not provide the transaction id in
-		// the VerifyFactor respone. This code effectively reimplements that method.
+		// the VerifyFactor response. This code effectively reimplements that method.
 		rq := client.CloneRequestExecutor()
 		req, err := rq.WithAccept("application/json").WithContentType("application/json").NewRequest("GET", url.String(), nil)
 		if err != nil {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -194,7 +194,7 @@ type MountMigrationInfo struct {
 // Note that the reported storage sizes are pre-encryption
 // sizes. Currently barrier uses aes-gcm for encryption, which
 // preserves plaintext size, adding a constant of 30 bytes of
-// padding, which is negligable and subject to change, and thus
+// padding, which is negligible and subject to change, and thus
 // not accounted for.
 func (c *Core) tableMetrics(entryCount int, isLocal bool, isAuth bool, compressedTableLen int) {
 	if c.metricsHelper == nil {

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -797,7 +797,7 @@ func TestCore_Remount_Namespaces(t *testing.T) {
 			SrcParentCtx: rootCtx,
 			SrcNS: namespace.MountPathDetails{
 				Namespace: namespace.RootNamespace,
-				MountPath: "secretFoo/", // Note that this is depending on pervious test case
+				MountPath: "secretFoo/", // Note that this is depending on previous test case
 			},
 			DstParentCtx: ns1Ctx,
 			DstNs: namespace.MountPathDetails{

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -651,7 +651,7 @@ func (ns *NamespaceStore) ListAllNamespaces(ctx context.Context, includeRoot boo
 
 // ListNamespaces is used to list namespaces below a parent namespace.
 // Optionally it can include the parent namespace itself and/or include all
-// decendents of the child namespaces.
+// descendants of the child namespaces.
 func (ns *NamespaceStore) ListNamespaces(ctx context.Context, includeParent bool, recursive bool) ([]*namespace.Namespace, error) {
 	defer metrics.MeasureSince([]string{"namespace", "list_namespace_entries"}, time.Now())
 

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -116,7 +116,7 @@ func (c *Core) InitRotation(ctx context.Context, config *SealConfig, recovery bo
 			return nil, initErr
 		}
 
-		// if no key shares exist, meaning we've initalized the instance
+		// if no key shares exist, meaning we've initialized the instance
 		// without creating them at time, then return the keys immediately
 		existingRecoveryConfig, err := c.seal.RecoveryConfig(ctx)
 		if err != nil {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -6291,7 +6291,7 @@ func expectInGaugeCollection(t *testing.T, expectedLabels map[string]string, exp
 		}
 		if labelsMatch(actualLabels, expectedLabels) {
 			if expectedValue != glv.Value {
-				t.Errorf("expeced %v for %v, got %v", expectedValue, expectedLabels, glv.Value)
+				t.Errorf("expected %v for %v, got %v", expectedValue, expectedLabels, glv.Value)
 			}
 			return
 		}


### PR DESCRIPTION
This Resolves #1578. I corrected all misspellings that were noted in the issue findings, except for: 

vault/policy_test.go:548:2: `capabilites` is a misspelling of `capabilities` (misspell)
	capabilites  = ["read"]
vault/policy_test.go:555:50: `capabilites` is a misspelling of `capabilities` (misspell)
	if !strings.Contains(err.Error(), `invalid key "capabilites" on line 3`)
	
These misspellings appear to be on purpose according to the code: 

```
func TestPolicy_ParseBadPath(t *testing.T) {
	// The wrong spelling is intended here
	_, err := ParseACLPolicy(namespace.RootNamespace, strings.TrimSpace(`
path "/" {
	capabilities = ["read"]
	capabilites  = ["read"]
}
`))
	if err == nil {
		t.Fatal("expected error")
	}

	if !strings.Contains(err.Error(), `invalid key "capabilites" on line 3`) {
		t.Errorf("bad error: %s", err)
	}
}
```

I ran golangci-lint run locally and noticed a two additional misspellings, so I fixed those as well: 
```
vault/logical_system.go:5518:4: `Intialize` is a misspelling of `Initialize` (misspell)
		"Intialize, read status or cancel the process of the rotation of the root or recovery key",
		 ^
vault/rotate.go:119:44: `initalized` is a misspelling of `initialized` (misspell)
		// if no key shares exist, meaning we've initalized the instance
```

Please let me know if any further changes are necessary! 