### PR TITLE
Add External Keys registry & API endpoints

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -246,14 +246,11 @@ func (b *ServiceRegistration) GoString() string {
 	return fmt.Sprintf("*%#v", *b)
 }
 
-// ExternalKeys is the server configuration for external keys.
+// ExternalKeys is the server-level configuration for External Keys.
 type ExternalKeysConfig struct {
-	// Type of external keys stanza, e.g. "pkcs11".
-	Type string // E.g. "pkcs11"
-	// Namespaces to whitelist this configuration in.
-	Namespaces []*NamespaceSpecifier
-	// Type-specific parameters, e.g. lib="/usr/lib/..." for type "pkcs11".
-	Config map[string]string
+	Type       string                // Type of external_keys stanza, e.g. "pkcs11".
+	Values     map[string]string     // Type-specific parameters, e.g. lib="/usr/lib/..." for type "pkcs11".
+	Namespaces []*NamespaceSpecifier // Namespaces to enable this configuration in.
 }
 
 func (e *ExternalKeysConfig) GoString() string {
@@ -263,10 +260,8 @@ func (e *ExternalKeysConfig) GoString() string {
 // NamespaceSpecifier references a namespace to whitelist as part of an
 // [ExternalKeysConfig] configuration. Also see [namespace.ParseSpecifier].
 type NamespaceSpecifier struct {
-	// One of "path", "id", "uuid".
-	Kind string
-	// Matching value for Kind.
-	Value string
+	Kind  string // One of "path", "id", "uuid".
+	Value string // Matching value for Kind.
 }
 
 func (n *NamespaceSpecifier) GoString() string {
@@ -1085,20 +1080,20 @@ func parseExternalKeys(result *Config, list *ast.ObjectList, blockName string) e
 		}
 
 		// Convert all remaining fields to strings:
-		e.Config = make(map[string]string, len(m))
+		e.Values = make(map[string]string, len(m))
 		for k, v := range m {
 			s, err := parseutil.ParseString(v)
 			if err != nil {
 				return fmt.Errorf("%s.%s: %w", blockName, key, err)
 			}
-			e.Config[k] = s
+			e.Values[k] = s
 		}
 
-		name, ok := e.Config["name"]
+		name, ok := e.Values["name"]
 		if !ok {
 			return fmt.Errorf("%s.%s: missing 'name'", blockName, key)
 		}
-		delete(e.Config, "name")
+		delete(e.Values, "name")
 
 		if _, ok := cfgs[blockName]; ok {
 			return fmt.Errorf("%s.%s: duplicate 'name' %q", blockName, key, name)

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -1092,7 +1092,7 @@ external_keys "pkcs11" {
 				Namespaces: []*NamespaceSpecifier{
 					{Kind: "id", Value: "root"},
 				},
-				Config: map[string]string{
+				Values: map[string]string{
 					"lib": "/usr/lib/softhsm/libsofthsm2.so",
 				},
 			},
@@ -1102,7 +1102,7 @@ external_keys "pkcs11" {
 					{Kind: "id", Value: "root"},
 					{Kind: "path", Value: "my-namespace"},
 				},
-				Config: map[string]string{
+				Values: map[string]string{
 					"lib": "/usr/lib/pkcs11_R2/libcs_pkcs11_R2.so",
 				},
 			},

--- a/vault/external_key_registry.go
+++ b/vault/external_key_registry.go
@@ -1,0 +1,659 @@
+// Copyright The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+const (
+	// externalKeyRegistrySubPath is the storage sub path for
+	// [ExternalKeyRegistry]. This is nested under the system view.
+	externalKeyRegistrySubPath = "external-keys/"
+
+	// externalKeyRegistryKeyPrefix is the storage prefix for key entries.
+	externalKeyRegistryKeyPrefix = "keys/"
+
+	// externalKeyRegistryConfigPrefix is the storage prefix for config entries.
+	externalKeyRegistryConfigPrefix = "configs/"
+)
+
+// ExternalKeyRegistry provides durable storage of config and key mappings and
+// uses these to expose KMS operations to mounts via [logical.ExternalKey].
+type ExternalKeyRegistry struct {
+	core   *Core
+	logger hclog.Logger
+
+	// storageLock is used in some edge cases where transactions are not enough
+	// to ensure config <-> key consistency, essentially because we have no
+	// concept of foreign key constraints.
+	storageLock sync.RWMutex
+}
+
+// ExternalKey is the storage representation of a key.
+type ExternalKey struct {
+	// KMS-specific key parameters.
+	Values map[string]string `json:"values"`
+
+	// List of mount paths of plugins that may use this key.
+	// Paths are relative to the key's namespace.
+	Grants []string `json:"grants"`
+}
+
+// ExternalKeyConfig is the storage representation a config.
+type ExternalKeyConfig struct {
+	// Type of KMS. May be user-defined via the server config.
+	Type string `json:"type"`
+
+	// Name of a config in the parent namespace to inherit into this config's
+	// namespace. Setting this field requires that Type and Values are empty.
+	Inherits string `json:"inherits"`
+
+	// KMS-specific client parameters.
+	Values map[string]string `json:"values"`
+}
+
+// NewExternalKeyRegistry creates a new [ExternalKeyRegistry].
+func NewExternalKeyRegistry(core *Core, logger hclog.Logger) *ExternalKeyRegistry {
+	return &ExternalKeyRegistry{
+		core:   core,
+		logger: logger,
+	}
+}
+
+// setupExternalKeys initializes [Core.externalKeys].
+func (c *Core) setupExternalKeys() error {
+	logger := c.baseLogger.Named("external-keys")
+	c.AddLogger(logger)
+	c.externalKeys = NewExternalKeyRegistry(c, logger)
+	return nil
+}
+
+// teardownExternalKeys finalizes and zeroes [Core.externalKeys].
+func (c *Core) teardownExternalKeys() error {
+	if c.externalKeys == nil {
+		return nil
+	}
+	c.externalKeys.Finalize()
+	c.externalKeys = nil
+	return nil
+}
+
+// storageViewForRequest returns the registry's root storage view based on the
+// storage field of a [logical.Request], which should automatically be routed to
+// the system barrier by the system backend.
+func (r *ExternalKeyRegistry) storageViewForRequest(req *logical.Request) logical.Storage {
+	return logical.NewStorageView(req.Storage, externalKeyRegistrySubPath)
+}
+
+// configPath returns the storage path for a config.
+func (r *ExternalKeyRegistry) configPath(name string) string {
+	return path.Join(externalKeyRegistryConfigPrefix, name)
+}
+
+// configListPath returns the storage path to list configs at.
+func (r *ExternalKeyRegistry) configListPath() string {
+	return externalKeyRegistryConfigPrefix
+}
+
+// keyPath returns the storage path for a key.
+func (r *ExternalKeyRegistry) keyPath(name string) string {
+	return path.Join(externalKeyRegistryKeyPrefix, name)
+}
+
+// keyListPath returns the storage path to list keys at.
+func (r *ExternalKeyRegistry) keyListPath(name string) string {
+	return path.Join(externalKeyRegistryKeyPrefix, name) + "/"
+}
+
+// getConfigCommon is a helper to read and deserialize a config from storage.
+func (r *ExternalKeyRegistry) getConfigCommon(
+	ctx context.Context, storage logical.Storage, name string,
+) (*ExternalKeyConfig, error) {
+	entry, err := storage.Get(ctx, r.configPath(name))
+	if err != nil || entry == nil {
+		return nil, err
+	}
+	var config ExternalKeyConfig
+	return &config, entry.DecodeJSON(&config)
+}
+
+// getKeyCommon is a helper to read and deserialize a key from storage.
+func (r *ExternalKeyRegistry) getKeyCommon(
+	ctx context.Context, storage logical.Storage, name string,
+) (*ExternalKey, error) {
+	entry, err := storage.Get(ctx, r.keyPath(name))
+	if err != nil || entry == nil {
+		return nil, err
+	}
+	var key ExternalKey
+	return &key, entry.DecodeJSON(&key)
+}
+
+// putConfigCommon is a helper to serialize and write a config to storage.
+func (r *ExternalKeyRegistry) putConfigCommon(
+	ctx context.Context, storage logical.Storage, name string, config *ExternalKeyConfig,
+) error {
+	entry, err := logical.StorageEntryJSON(r.configPath(name), config)
+	if err != nil {
+		return err
+	}
+	return storage.Put(ctx, entry)
+}
+
+// putKeyCommon is a helper to serialize and write a key to storage.
+func (r *ExternalKeyRegistry) putKeyCommon(
+	ctx context.Context, storage logical.Storage, name string, key *ExternalKey,
+) error {
+	entry, err := logical.StorageEntryJSON(r.keyPath(name), key)
+	if err != nil {
+		return err
+	}
+	return storage.Put(ctx, entry)
+}
+
+// LIST /sys/external-keys/configs
+func (r *ExternalKeyRegistry) ListConfigs(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	storage := r.storageViewForRequest(req)
+
+	keys, err := storage.List(ctx, r.configListPath())
+	if err != nil {
+		return handleError(err)
+	}
+
+	return logical.ListResponse(keys), nil
+}
+
+// GET /sys/external-keys/configs/:config-name
+func (r *ExternalKeyRegistry) GetConfig(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := data.Get("config").(string)
+	storage := r.storageViewForRequest(req)
+
+	config, err := r.getConfigCommon(ctx, storage, name)
+	switch {
+	case err != nil:
+		return handleError(err)
+	case config == nil:
+		return nil, logical.CodedError(http.StatusNotFound, "config not found")
+	}
+
+	resp := &logical.Response{Data: make(map[string]any)}
+
+	// We merge these down into a unified map on the API level.
+	switch {
+	case config.Type != "":
+		resp.Data["type"] = config.Type
+	case config.Inherits != "":
+		resp.Data["inherits"] = config.Inherits
+	}
+
+	for k, v := range config.Values {
+		resp.Data[k] = v
+	}
+
+	return resp, nil
+}
+
+// PUT /sys/external-keys/configs/:config-name
+func (r *ExternalKeyRegistry) PutConfig(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	values := make(map[string]string)
+	for k, v := range req.Data {
+		str, ok := v.(string)
+		if !ok {
+			return handleError(fmt.Errorf("expected field %q to be a string", k))
+		}
+		values[k] = str
+	}
+
+	// We remove these from the values map and place them in their own dedicated
+	// fields. This is not strictly needed, but should make it easy to pass the
+	// the remaining values right to the KMS interface.
+	ty, inherits := values["type"], values["inherits"]
+	delete(values, "type")
+	delete(values, "inherits")
+
+	name := data.Get("config").(string)
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		// Check for an existing config, we may have a conflict e.g. when trying
+		// to change a a typed config to an inherited config.
+		config, err := r.getConfigCommon(ctx, storage, name)
+		if err != nil {
+			return err
+		}
+
+		// Create a new config if it doesn't exist yet.
+		if config == nil {
+			config = &ExternalKeyConfig{}
+		}
+
+		if err := r.validateConfigTransition(
+			config.Type != "", ty != "", config.Inherits != "", inherits != "",
+		); err != nil {
+			return err
+		}
+
+		config.Type = ty
+		config.Inherits = inherits
+		config.Values = values
+
+		if config.Inherits != "" && len(config.Values) != 0 {
+			return fmt.Errorf("setting field %q requires that no other fields are set", "inherits")
+		}
+
+		return r.putConfigCommon(ctx, storage, name, config)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// PATCH /sys/external-keys/configs/:config-name
+func (r *ExternalKeyRegistry) PatchConfig(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := data.Get("config").(string)
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		config, err := r.getConfigCommon(ctx, storage, name)
+		switch {
+		case err != nil:
+			return err
+		case config == nil:
+			return logical.CodedError(http.StatusNotFound, "config not found")
+		}
+
+		// Bit of a hack, but makes patching easier.
+		config.Values["type"] = config.Type
+		config.Values["inherits"] = config.Inherits
+
+		// This is effectively a JSON merge patch (https://datatracker.ietf.org/doc/html/rfc7386).
+		// We could use the json-patch library, but that's overkill for single-level string maps.
+		for k, v := range req.Data {
+			switch v := v.(type) {
+			case string:
+				config.Values[k] = v
+			case nil:
+				delete(config.Values, k)
+			default:
+				return fmt.Errorf("expected field %q to be a string or null", k)
+			}
+		}
+
+		ty, inherits := config.Values["type"], config.Values["inherits"]
+		delete(config.Values, "type")
+		delete(config.Values, "inherits")
+
+		if err := r.validateConfigTransition(
+			config.Type != "", ty != "", config.Inherits != "", inherits != "",
+		); err != nil {
+			return err
+		}
+
+		config.Type = ty
+		config.Inherits = inherits
+
+		if config.Inherits != "" && len(config.Values) != 0 {
+			return fmt.Errorf("setting field %q requires that no other fields are set", "inherits")
+		}
+
+		return r.putConfigCommon(ctx, storage, name, config)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// validateConfigTransition enforces the invariants defined below.
+func (r *ExternalKeyRegistry) validateConfigTransition(
+	// Whether the "type" field was set before the change
+	typeBefore bool,
+	// Whether the "type" field will be set after the change
+	typeAfter bool,
+	// Whether the "inherits" field was set before the change
+	inheritsBefore bool,
+	// Whether the "inherits" field will be set after the change
+	inheritsAfter bool,
+) error {
+	for _, invariant := range externalKeyConfigTransitionInvariants {
+		if invariant.cond(typeBefore, typeAfter, inheritsBefore, inheritsAfter) {
+			return errors.New(invariant.err)
+		}
+	}
+
+	return nil
+}
+
+// externalKeyConfigTransitionInvariants holds invariants for modifications to
+// External Key config entries. There are a few here, but the general idea is
+// that a config must be either inherited or "typed", and we can move from an
+// inherited config to a typed config, but not the other way.
+var externalKeyConfigTransitionInvariants = []struct {
+	err  string
+	cond func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool
+}{
+	{
+		`the "type" and "inherits" fields are mutually exclusive`,
+		func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool {
+			return (typeBefore && inheritsBefore) || (typeAfter && inheritsAfter)
+		},
+	},
+	{
+		`either the "type" or the "inherits" field must be set`,
+		func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool {
+			return !typeAfter && !inheritsAfter
+		},
+	},
+	{
+		`cannot remove field "type"`,
+		func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool {
+			return typeBefore && !typeAfter
+		},
+	},
+	{
+		`removing field "inherits" requires adding field "type"`,
+		func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool {
+			return inheritsBefore && !inheritsAfter && !typeAfter
+		},
+	},
+	{
+		`adding field "type" requires removing field "inherits"`,
+		func(typeBefore, typeAfter, inheritsBefore, inheritsAfter bool) bool {
+			return inheritsBefore && inheritsAfter && typeAfter
+		},
+	},
+}
+
+// DELETE /sys/external-keys/configs/:config-name
+func (r *ExternalKeyRegistry) DeleteConfig(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := data.Get("config").(string)
+	storage := r.storageViewForRequest(req)
+
+	// We need to lock here to ensure config deletion doesn't race against key
+	// creation and leaves a dangling key. Also see comment in PutKey(...).
+	r.storageLock.Lock()
+	defer r.storageLock.Unlock()
+
+	keysView := logical.NewStorageView(storage, r.keyListPath(name))
+	if err := logical.ClearViewWithLogging(ctx, keysView, r.logger); err != nil {
+		return handleError(err)
+	}
+
+	if err := storage.Delete(ctx, r.configPath(name)); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// LIST /sys/external-keys/configs/:config-name/keys
+func (r *ExternalKeyRegistry) ListKeys(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := data.Get("config").(string)
+	storage := r.storageViewForRequest(req)
+
+	keys, err := storage.List(ctx, r.keyListPath(name))
+	if err != nil {
+		return handleError(err)
+	}
+
+	return logical.ListResponse(keys), nil
+}
+
+// GET /sys/external-keys/configs/:config-name/keys/:key-name
+func (r *ExternalKeyRegistry) GetKey(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+	storage := r.storageViewForRequest(req)
+
+	key, err := r.getKeyCommon(ctx, storage, name)
+	switch {
+	case err != nil:
+		return handleError(err)
+	case key == nil:
+		return nil, logical.CodedError(http.StatusNotFound, "key not found")
+	}
+
+	resp := &logical.Response{Data: make(map[string]any)}
+	for k, v := range key.Values {
+		resp.Data[k] = v
+	}
+
+	return resp, nil
+}
+
+// PUT /sys/external-keys/configs/:config-name/keys/:key-name
+func (r *ExternalKeyRegistry) PutKey(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	values := make(map[string]string)
+	for k, v := range req.Data {
+		str, ok := v.(string)
+		if !ok {
+			return handleError(fmt.Errorf("expected field %q to be a string", k))
+		}
+		values[k] = str
+	}
+
+	configName, keyName := data.Get("config").(string), data.Get("key").(string)
+	fullName := path.Join(configName, keyName)
+
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		key, err := r.getKeyCommon(ctx, storage, fullName)
+		if err != nil {
+			return err
+		}
+
+		// Create a new key if it doesn't exist yet.
+		if key == nil {
+			// If the corresponding config gets deleted before we create a new
+			// key, that wouldn't fail this transaction and we'd create a
+			// dangling key. Thus lock within the application. We don't need to
+			// do this if the key already exists, since config deletion deletes
+			// all its keys first, which _would_ fail the transaction.
+			r.storageLock.RLock()
+			defer r.storageLock.RUnlock()
+
+			// Ensure that the config we're creating this key in actually exists.
+			config, err := r.getConfigCommon(ctx, storage, configName)
+			switch {
+			case err != nil:
+				return err
+			case config == nil:
+				return logical.CodedError(http.StatusNotFound, "config not found")
+			}
+
+			if config.Inherits != "" {
+				return fmt.Errorf(
+					"cannot create key for inherited config, create it for the original one")
+			}
+
+			key = &ExternalKey{
+				Grants: []string{}, // For consistency.
+			}
+		}
+
+		// Update Values, make sure not to override Grants, these should stay
+		// if the key already existed.
+		key.Values = values
+
+		return r.putKeyCommon(ctx, storage, fullName, key)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// PATCH /sys/external-keys/configs/:config-name/keys/:key-name
+func (r *ExternalKeyRegistry) PatchKey(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		key, err := r.getKeyCommon(ctx, storage, name)
+		switch {
+		case err != nil:
+			return err
+		case key == nil:
+			return logical.CodedError(http.StatusNotFound, "key not found")
+		}
+
+		// This is effectively a JSON merge patch (https://datatracker.ietf.org/doc/html/rfc7386).
+		// We could use the json-patch library, but that's overkill for single-level string maps.
+		for k, v := range req.Data {
+			switch v := v.(type) {
+			case string:
+				key.Values[k] = v
+			case nil:
+				delete(key.Values, k)
+			default:
+				return fmt.Errorf("expected field %q to be a string or null", k)
+			}
+		}
+
+		return r.putKeyCommon(ctx, storage, name, key)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// DELETE /sys/external-keys/configs/:config-name/keys/:key-name
+func (r *ExternalKeyRegistry) DeleteKey(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+	storage := r.storageViewForRequest(req)
+
+	if err := storage.Delete(ctx, r.keyPath(name)); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// LIST /sys/external-keys/configs/:config-name/keys/:key-name/grants
+func (r *ExternalKeyRegistry) ListGrants(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+	storage := r.storageViewForRequest(req)
+
+	key, err := r.getKeyCommon(ctx, storage, name)
+	switch {
+	case err != nil:
+		return handleError(err)
+	case key == nil:
+		return nil, logical.CodedError(http.StatusNotFound, "key not found")
+	}
+
+	return logical.ListResponse(key.Grants), nil
+}
+
+// PUT /sys/external-keys/configs/:config-name/keys/:key-name/grants/:mount-path
+func (r *ExternalKeyRegistry) PutGrant(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	mount := data.Get("mount").(string)
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		key, err := r.getKeyCommon(ctx, storage, name)
+		switch {
+		case err != nil:
+			return err
+		case key == nil:
+			return logical.CodedError(http.StatusNotFound, "key not found")
+		}
+
+		// Canonicalize the mount path; both for comparison with other paths and
+		// to get a consistent representation for display.
+		mount = strings.Trim(mount, "/") + "/"
+
+		if slices.Contains(key.Grants, mount) {
+			return nil
+		}
+
+		key.Grants = append(key.Grants, mount)
+
+		return r.putKeyCommon(ctx, storage, name, key)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+// DELETE /sys/external-keys/configs/:config-name/keys/:key-name/grants/:mount-path
+func (r *ExternalKeyRegistry) DeleteGrant(
+	ctx context.Context, req *logical.Request, data *framework.FieldData,
+) (*logical.Response, error) {
+	mount := data.Get("mount").(string)
+	name := path.Join(data.Get("config").(string), data.Get("key").(string))
+
+	storage := r.storageViewForRequest(req)
+
+	if err := logical.WithTransaction(ctx, storage, func(storage logical.Storage) error {
+		key, err := r.getKeyCommon(ctx, storage, name)
+		switch {
+		case err != nil:
+			return err
+		case key == nil:
+			return logical.CodedError(http.StatusNotFound, "key not found")
+		}
+
+		// Canonicalize the mount path; both for comparison with other paths and
+		// to get a consistent representation for display.
+		mount = strings.Trim(mount, "/") + "/"
+
+		if !slices.Contains(key.Grants, mount) {
+			return nil
+		}
+
+		key.Grants = slices.DeleteFunc(key.Grants, func(grant string) bool {
+			return grant == mount
+		})
+
+		return r.putKeyCommon(ctx, storage, name, key)
+	}); err != nil {
+		return handleError(err)
+	}
+
+	return nil, nil
+}
+
+func (r *ExternalKeyRegistry) Finalize() {}

--- a/vault/external_key_registry_test.go
+++ b/vault/external_key_registry_test.go
@@ -1,0 +1,791 @@
+// Copyright The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalKeysBackend(t *testing.T) {
+	sys := testSystemBackend(t)
+	ctx := namespace.RootContext(context.Background())
+
+	type request struct {
+		path string            // /sys/external-keys/:path
+		op   logical.Operation // The operation
+
+		input  map[string]any // The request data we send
+		output map[string]any // The response data we expect back
+
+		noverify bool // Disable automatically verifying an UpdateOperation via a ReadOperation
+		err      bool // Should this request fail?
+	}
+
+	tests := []struct {
+		name     string
+		requests []request
+	}{
+		{
+			name: "create empty config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create untyped and uninherited config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"foo": "bar", "bar": "baz"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create ambiguous config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red", "inherits": "their-config"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create typed config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+			},
+		},
+		{
+			name: "list configs",
+			requests: []request{
+				{
+					path:   "configs",
+					op:     logical.ListOperation,
+					output: map[string]any{},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-other-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "blue"},
+				},
+				{
+					path:   "configs",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-config", "my-other-config"}},
+				},
+			},
+		},
+		{
+			name: "create typed config with additional values",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+			},
+		},
+		{
+			name: "create typed config with non-string additional values",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red", "timeout": 100},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update typed config to add additional values",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+			},
+		},
+		{
+			name: "update typed config to remove additional values",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+			},
+		},
+		{
+			name: "patch typed config to remove additional values",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.PatchOperation,
+					input: map[string]any{"endpoint": nil, "project": nil, "foo": nil},
+				},
+				{
+					path:   "configs/my-config",
+					op:     logical.ReadOperation,
+					output: map[string]any{"type": "red"},
+				},
+			},
+		},
+		{
+			name: "update typed config to modify additional values",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao-eu",
+					},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://us.red.kms", "project": "openbao-us",
+					},
+				},
+			},
+		},
+		{
+			name: "update typed config to change type",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "blue", "endpoint": "https://eu.blue.kms", "project": "openbao",
+					},
+				},
+			},
+		},
+		{
+			name: "update typed config to remove type",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"endpoint": "https://eu.red.kms", "project": "openbao"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update typed config to be an inherited config",
+			requests: []request{
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update typed config to be an ambigous config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red", "inherits": "their-config"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create inherited config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+			},
+		},
+		{
+			name: "create inherited config with additional values",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config", "project": "openbao"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update inherited config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-other-red-config"},
+				},
+			},
+		},
+		{
+			name: "patch inherited config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.PatchOperation,
+					input: map[string]any{"inherits": "their-other-config"},
+				},
+				{
+					path:   "configs/my-config",
+					op:     logical.ReadOperation,
+					output: map[string]any{"inherits": "their-other-config"},
+				},
+			},
+		},
+		{
+			name: "update inherited config to add additional values",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config", "project": "openbao"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update inherited config to remove inherits field",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update inherited config into ambiguous config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config", "type": "red"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "update inherited config into typed config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.UpdateOperation,
+					input: map[string]any{
+						"type": "red", "endpoint": "https://eu.red.kms", "project": "openbao",
+					},
+				},
+			},
+		},
+		{
+			name: "patch inherited config into typed config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.PatchOperation,
+					input: map[string]any{
+						"inherits": nil, "type": "red", "endpoint": "https://eu.red.kms",
+					},
+				},
+				{
+					path:   "configs/my-config",
+					op:     logical.ReadOperation,
+					output: map[string]any{"type": "red", "endpoint": "https://eu.red.kms"},
+				},
+			},
+		},
+		{
+			name: "patch non-existing config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.PatchOperation,
+					input: map[string]any{"type": "red"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create key for non-existing config",
+			requests: []request{
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create key for inherited config",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"inherits": "their-config"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "create key",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:  "configs/my-config/keys/my-other-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{},
+				},
+			},
+		},
+		{
+			name: "update key",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-other-key", "capabilities": "sign"},
+				},
+			},
+		},
+		{
+			name: "patch key",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.PatchOperation,
+					input: map[string]any{"label": nil, "capabilities": "sign"},
+				},
+				{
+					path:   "configs/my-config/keys/my-key",
+					op:     logical.ReadOperation,
+					output: map[string]any{"capabilities": "sign"},
+				},
+			},
+		},
+		{
+			name: "patch non-existing key",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.PatchOperation,
+					input: map[string]any{"label": nil, "capabilities": "sign"},
+					err:   true,
+				},
+			},
+		},
+		{
+			name: "list keys",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-other-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "blue"},
+				},
+				{
+					path:   "configs/my-config/keys",
+					op:     logical.ListOperation,
+					output: map[string]any{},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:   "configs/my-other-config/keys",
+					op:     logical.ListOperation,
+					output: map[string]any{},
+				},
+				{
+					path:  "configs/my-other-config/keys/my-other-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:   "configs/my-config/keys",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-key"}},
+				},
+				{
+					path:   "configs/my-other-config/keys",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-other-key"}},
+				},
+			},
+		},
+		{
+			name: "delete key",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path: "configs/my-config/keys/my-key",
+					op:   logical.DeleteOperation,
+				},
+				{
+					path: "configs/my-config/keys/my-key",
+					op:   logical.ReadOperation,
+					err:  true,
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.DeleteOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+			},
+		},
+		{
+			name: "delete config and keys",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:  "configs/my-config/keys/my-other-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-other-key"},
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.DeleteOperation,
+				},
+				{
+					path: "configs/my-config",
+					op:   logical.ReadOperation,
+					err:  true,
+				},
+				{
+					path:   "configs/my-config/keys",
+					op:     logical.ListOperation,
+					output: map[string]any{},
+				},
+			},
+		},
+		{
+			name: "update key without affecting grants",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/my-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.PatchOperation,
+					input: map[string]any{"capabilities": "sign"},
+				},
+				{
+					path:   "configs/my-config/keys/my-key/grants",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-mount/"}},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-other-key"},
+				},
+				{
+					path:   "configs/my-config/keys/my-key/grants",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-mount/"}},
+				},
+			},
+		},
+
+		{
+			name: "add grants",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/my-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/another-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/my-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path:   "configs/my-config/keys/my-key/grants",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"my-mount/", "another-mount/"}},
+				},
+			},
+		},
+		{
+			name: "remove grants",
+			requests: []request{
+				{
+					path:  "configs/my-config",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"type": "red"},
+				},
+				{
+					path:  "configs/my-config/keys/my-key",
+					op:    logical.UpdateOperation,
+					input: map[string]any{"label": "my-key"},
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/my-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path:     "configs/my-config/keys/my-key/grants/another-mount",
+					op:       logical.UpdateOperation,
+					noverify: true,
+				},
+				{
+					path: "configs/my-config/keys/my-key/grants/my-mount",
+					op:   logical.DeleteOperation,
+				},
+				{
+					path:   "configs/my-config/keys/my-key/grants",
+					op:     logical.ListOperation,
+					output: map[string]any{"keys": []string{"another-mount/"}},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// We keep storage across requests per test, but not across tests.
+			storage := &logical.InmemStorage{}
+
+			for _, req := range test.requests {
+				r := logical.TestRequest(t, req.op, "external-keys/"+req.path)
+				r.Storage = storage
+				r.Data = req.input
+
+				resp, err := sys.HandleRequest(ctx, r)
+
+				if req.err {
+					require.Error(t, err)
+					continue
+				}
+
+				require.NoError(t, err, resp)
+
+				if req.output == nil {
+					require.Nil(t, resp)
+				} else {
+					require.Equal(t, req.output, resp.Data)
+				}
+
+				// Automatically verify that a ReadOperation following a
+				// successful UpdateOperation results in the same data.
+				if req.noverify || req.op != logical.UpdateOperation {
+					continue
+				}
+
+				r = logical.TestRequest(t, logical.ReadOperation, "external-keys/"+req.path)
+				r.Storage = storage
+
+				resp, err = sys.HandleRequest(ctx, r)
+				require.NoError(t, err)
+
+				require.Equal(t, req.input, resp.Data)
+			}
+		})
+	}
+}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -160,6 +160,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	b.Backend.Paths = append(b.Backend.Paths, b.quotasPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.loginMFAPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.introspectionPaths()...)
+	b.Backend.Paths = append(b.Backend.Paths, b.externalKeyPaths()...)
 
 	if core.rawEnabled {
 		b.Backend.Paths = append(b.Backend.Paths, b.rawPaths()...)

--- a/vault/logical_system_external_keys.go
+++ b/vault/logical_system_external_keys.go
@@ -1,0 +1,322 @@
+// Copyright The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (b *SystemBackend) externalKeyPaths() []*framework.Path {
+	fieldConfig := &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Required:    true,
+		Description: "Name of the config.",
+	}
+
+	fieldKey := &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Required:    true,
+		Description: "Name of the key.",
+	}
+
+	fieldMount := &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Required:    true,
+		Description: "Path of the mount.",
+	}
+
+	return []*framework.Path{
+		{
+			Pattern: "external-keys/configs/?",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "configs",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.ListConfigs,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:        framework.TypeStringSlice,
+									Description: "List of configuration names",
+								},
+							},
+						}},
+					},
+					Summary: "List configs.",
+				},
+			},
+
+			HelpSynopsis:    "List configs.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["list-configs"]),
+		},
+
+		{
+			Pattern: "external-keys/configs/" + framework.GenericNameRegex("config"),
+
+			Fields: map[string]*framework.FieldSchema{
+				"config": fieldConfig,
+			},
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "configs",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.GetConfig,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: http.StatusText(http.StatusOK)}},
+					},
+					Summary: "Read a config.",
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.PutConfig,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Create or overwrite a config.",
+				},
+				logical.PatchOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.PatchConfig,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Patch a config.",
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.DeleteConfig,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Remove a config.",
+				},
+			},
+
+			HelpSynopsis:    "Manage configs.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["manage-configs"]),
+		},
+
+		{
+			Pattern: "external-keys/configs/" + framework.GenericNameRegex("config") + "/keys/?",
+
+			Fields: map[string]*framework.FieldSchema{
+				"config": fieldConfig,
+			},
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "keys",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.ListKeys,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:        framework.TypeStringSlice,
+									Description: "List of key names",
+								},
+							},
+						}},
+					},
+					Summary: "List keys.",
+				},
+			},
+
+			HelpSynopsis:    "List keys.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["list-keys"]),
+		},
+
+		{
+			Pattern: "external-keys/configs/" + framework.GenericNameRegex("config") +
+				"/keys/" + framework.GenericNameRegex("key"),
+
+			Fields: map[string]*framework.FieldSchema{
+				"config": fieldConfig, "key": fieldKey,
+			},
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "keys",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.GetKey,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: http.StatusText(http.StatusOK)}},
+					},
+					Summary: "Read a key.",
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.PutKey,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Create or overwrite a key.",
+				},
+				logical.PatchOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.PatchKey,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Update a key.",
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.DeleteKey,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Remove a key.",
+				},
+			},
+
+			HelpSynopsis:    "Manage keys.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["manage-keys"]),
+		},
+
+		{
+			Pattern: "external-keys/configs/" + framework.GenericNameRegex("config") +
+				"/keys/" + framework.GenericNameRegex("key") + "/grants/?",
+
+			Fields: map[string]*framework.FieldSchema{
+				"config": fieldConfig, "key": fieldKey,
+			},
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "grants",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.ListGrants,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:        framework.TypeStringSlice,
+									Description: "List of grant paths",
+								},
+							},
+						}},
+					},
+					Summary: "List grants.",
+				},
+			},
+
+			HelpSynopsis:    "List grants.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["list-grants"]),
+		},
+
+		{
+			Pattern: "external-keys/configs/" + framework.GenericNameRegex("config") +
+				"/keys/" + framework.GenericNameRegex("key") + "/grants/(?P<mount>.+)",
+
+			Fields: map[string]*framework.FieldSchema{
+				"config": fieldConfig, "key": fieldKey, "mount": fieldMount,
+			},
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "external-keys",
+				OperationSuffix: "grants",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.PutGrant,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Create a grant.",
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.Core.externalKeys.DeleteGrant,
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+					Summary: "Remove a grant.",
+				},
+			},
+
+			HelpSynopsis:    "Manage grants.",
+			HelpDescription: strings.TrimSpace(sysExternalKeysHelp["manage-grants"]),
+		},
+	}
+}
+
+var sysExternalKeysHelp = map[string]string{
+	"list-configs": `
+This path responds to the following HTTP methods.
+
+	LIST /configs
+		List configs.
+`,
+	"manage-configs": `
+This path responds to the following HTTP methods.
+
+	GET /configs/<config>
+		Read a config.
+
+	PUT /configs/<config>
+		Create or overwrite a config.
+
+	PATCH /configs/<config>
+		Patch a config.
+
+	DELETE /configs/<config>
+		Remove a config.
+`,
+	"list-keys": `
+This path responds to the following HTTP methods.
+
+	LIST /configs/<config>/keys
+		List keys.
+`,
+	"manage-keys": `
+This path responds to the following HTTP methods.
+
+	GET /configs/<config>/keys/<key>
+		Read a key.
+
+	PUT /configs/<config>/keys/<key>
+		Create or overwrite a key.
+
+	PATCH /configs/<config>/keys/<key>
+		Patch a key.
+
+	DELETE /configs/<config>/keys/<key>
+		Remove a key.
+`,
+	"list-grants": `
+This path responds to the following HTTP methods.
+
+	LIST /configs/<config>/keys/<key>/grants
+		List grants.
+`,
+	"manage-grants": `
+This path responds to the following HTTP methods.
+
+	PUT /configs/<config>/keys/<key>/grants/<mount>
+		Create a grant.
+
+	DELETE /configs/<config>/keys/<key>/grants/<mount>
+		Remove a grant.
+`,
+}


### PR DESCRIPTION
Adds the `/sys/external-keys` endpoints described in #1320. 

Validation of configs / keys and client creation / cache management is of course missing, since we don't have the KMS interface for that yet.

I'd be happy if someone could take extra care to review the handling of transactions/locks to achieve consistency between configs and keys.. I wasn't so sure in all cases.

---

cc @phyrog @Huy-Dinh-Reply since you offered to review -- I hope you'll find that I was right saying this was 90% boilerplate 😄