### PR TITLE
Fix ergonomics around self-init, add documentation

### DIFF
--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -226,7 +226,7 @@ func (p *ProfileEngine) validateRequestNameUniqueness() error {
 
 // 3. All names conform exclude some special characters (.[](){}_ /-) or we limit to a-zA-Z0-9
 func validateNameConvention(kind, name string) error {
-	validName := regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`)
+	validName := regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
 	if !validName.MatchString(name) {
 		return fmt.Errorf("%s name '%s' is invalid: must start with a letter or underscore and contain only letters, digits", kind, name)
 	}

--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -547,7 +547,7 @@ func (p *ProfileEngine) convertToType(val interface{}, objType string) (interfac
 		}
 		return result, nil
 
-	case "map[string]interface{}":
+	case "map", "map[string]interface{}":
 		var result map[string]interface{}
 		if err := mapstructure.WeakDecode(val, &result); err != nil {
 			return nil, fmt.Errorf("cannot convert to map[string]interface{}: %w", err)

--- a/helper/profiles/request_source.go
+++ b/helper/profiles/request_source.go
@@ -51,14 +51,14 @@ func (s *RequestSource) Validate(_ context.Context) ([]string, []string, error) 
 		s.outerName = outerName
 	}
 
-	rawReqName, present := s.field["req_name"]
+	rawReqName, present := s.field["request_name"]
 	if !present {
-		return nil, nil, fmt.Errorf("request source is missing required field %q", "req_name")
+		return nil, nil, fmt.Errorf("request source is missing required field %q", "request_name")
 	}
 
 	reqName, ok := rawReqName.(string)
 	if !ok {
-		return nil, nil, fmt.Errorf("field 'req_name' is of wrong type: expected 'string' got '%T'", rawReqName)
+		return nil, nil, fmt.Errorf("field 'request_name' is of wrong type: expected 'string' got '%T'", rawReqName)
 	}
 
 	s.requestName = reqName

--- a/helper/profiles/request_source_test.go
+++ b/helper/profiles/request_source_test.go
@@ -50,10 +50,10 @@ func TestRequestSource_ValidateMissingField(t *testing.T) {
 
 	_, _, err := source.Validate(ctx)
 	if err == nil {
-		t.Fatal("expected error for missing 'req_name' field, got nil")
+		t.Fatal("expected error for missing 'request_name' field, got nil")
 	}
 
-	if !strings.HasPrefix(err.Error(), "request source is missing required field \"req_name\"") {
+	if !strings.HasPrefix(err.Error(), "request source is missing required field \"request_name\"") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -61,7 +61,7 @@ func TestRequestSource_ValidateMissingField(t *testing.T) {
 func TestRequestSource_Validate_MissingOuterNameField(t *testing.T) {
 	rs := &RequestSource{
 		outer: "profile",
-		field: map[string]interface{}{"req_name": "r1"},
+		field: map[string]interface{}{"request_name": "r1"},
 	}
 
 	_, _, err := rs.Validate(context.Background())
@@ -77,7 +77,7 @@ func TestRequestSource_Validate_MissingOuterNameField(t *testing.T) {
 func TestRequestSource_Validate_Success(t *testing.T) {
 	source := &RequestSource{
 		field: map[string]interface{}{
-			"req_name":       "mount-userpass",
+			"request_name":   "mount-userpass",
 			"field_selector": "",
 		},
 	}
@@ -98,7 +98,7 @@ func TestRequestSource_Validate_Success(t *testing.T) {
 func TestRequestValidate_OuterNameWrongType(t *testing.T) {
 	rs := &RequestSource{
 		outer: "profile",
-		field: map[string]interface{}{"profile_name": 123, "req_name": "r1"},
+		field: map[string]interface{}{"profile_name": 123, "request_name": "r1"},
 	}
 
 	_, _, err := rs.Validate(context.Background())
@@ -116,7 +116,7 @@ func TestRequestValidate_OuterNameOK(t *testing.T) {
 		outer: "profile",
 		field: map[string]interface{}{
 			"profile_name":   "outer1",
-			"req_name":       "r1",
+			"request_name":   "r1",
 			"field_selector": "",
 		},
 	}
@@ -148,7 +148,7 @@ func TestRequestSource_Evaluate_WithFieldSelector_String(t *testing.T) {
 	ctx := context.Background()
 	history := &EvaluationHistory{}
 	source := &RequestSource{
-		field: map[string]interface{}{"req_name": "mount-userpass", "field_selector": "userPass"},
+		field: map[string]interface{}{"request_name": "mount-userpass", "field_selector": "userPass"},
 	}
 
 	if _, _, err := source.Validate(ctx); err != nil {

--- a/helper/profiles/response_source.go
+++ b/helper/profiles/response_source.go
@@ -51,14 +51,14 @@ func (s *ResponseSource) Validate(_ context.Context) ([]string, []string, error)
 		s.outerName = outerName
 	}
 
-	rawReqName, present := s.field["resp_name"]
+	rawReqName, present := s.field["response_name"]
 	if !present {
-		return nil, nil, fmt.Errorf("response source is missing required field '%v'", "resp_name")
+		return nil, nil, fmt.Errorf("response source is missing required field '%v'", "response_name")
 	}
 
 	respName, ok := rawReqName.(string)
 	if !ok {
-		return nil, nil, fmt.Errorf("field 'resp_name' is of wrong type: expected 'string' got '%T'", rawReqName)
+		return nil, nil, fmt.Errorf("field 'response_name' is of wrong type: expected 'string' got '%T'", rawReqName)
 	}
 
 	s.responseName = respName

--- a/helper/profiles/response_source_test.go
+++ b/helper/profiles/response_source_test.go
@@ -9,7 +9,7 @@ import (
 func TestSourceBuilder_Success(t *testing.T) {
 	ctx := context.Background()
 	engine := &ProfileEngine{outerBlockName: "outer", sourceBuilders: make(map[string]SourceBuilder)}
-	field := map[string]interface{}{"resp_name": "mount-userpass"}
+	field := map[string]interface{}{"response_name": "mount-userpass"}
 
 	src := ResponseSourceBuilder(ctx, engine, field)
 	respSrc, ok := src.(*ResponseSource)
@@ -32,7 +32,7 @@ func TestWithResponseSource(t *testing.T) {
 		t.Fatal("expected sourceBuilders['response'] to be set")
 	}
 
-	src := builder(context.Background(), engine, map[string]interface{}{"resp_name": "x"})
+	src := builder(context.Background(), engine, map[string]interface{}{"response_name": "x"})
 	if src == nil {
 		t.Fatalf("builder returned nil")
 	}
@@ -45,7 +45,7 @@ func TestValidate_MissingField(t *testing.T) {
 	source := &ResponseSource{field: map[string]interface{}{}}
 	_, _, err := source.Validate(context.Background())
 	if err == nil {
-		t.Fatal("expected error for missing 'resp_name', got nil")
+		t.Fatal("expected error for missing 'response_name', got nil")
 	}
 }
 
@@ -53,7 +53,7 @@ func TestValidate_MissingOuterNameField(t *testing.T) {
 	rs := &ResponseSource{
 		outer: "profile",
 		field: map[string]interface{}{
-			"resp_name": "r1",
+			"response_name": "r1",
 		},
 	}
 	_, _, err := rs.Validate(context.Background())
@@ -64,10 +64,10 @@ func TestValidate_MissingOuterNameField(t *testing.T) {
 }
 
 func TestValidate_WrongType(t *testing.T) {
-	source := &ResponseSource{field: map[string]interface{}{"resp_name": 1}}
+	source := &ResponseSource{field: map[string]interface{}{"response_name": 1}}
 	_, _, err := source.Validate(context.Background())
 	if err == nil {
-		t.Fatal("expected type error for 'resp_name', got nil")
+		t.Fatal("expected type error for 'response_name', got nil")
 	}
 }
 
@@ -75,8 +75,8 @@ func TestValidate_OuterNameWrongType(t *testing.T) {
 	rs := &ResponseSource{
 		outer: "profile",
 		field: map[string]interface{}{
-			"profile_name": 123,
-			"resp_name":    "r1",
+			"profile_name":  123,
+			"response_name": "r1",
 		},
 	}
 	_, _, err := rs.Validate(context.Background())
@@ -89,7 +89,7 @@ func TestValidate_OuterNameWrongType(t *testing.T) {
 func TestEvaluate_WithFieldSelector_String(t *testing.T) {
 	ctx := context.Background()
 	source := &ResponseSource{
-		field: map[string]interface{}{"resp_name": "mount-userpass", "field_selector": "status"},
+		field: map[string]interface{}{"response_name": "mount-userpass", "field_selector": "status"},
 	}
 
 	if _, _, err := source.Validate(ctx); err != nil {

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -125,6 +125,9 @@ to specify where the configuration is.
   the read cache used by the physical storage subsystem. This will very
   significantly impact performance.
 
+- `initialize` `([Initialize][initialize]: <none>)` – Specifies one-time
+  declarative self-initialization.
+
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. OpenBao must have permission to read files in this
   directory to successfully load plugins, and the value cannot be a symbolic link.
@@ -258,6 +261,7 @@ The following parameters are used on backends that support [High Availability][h
 [listener]: /docs/configuration/listener
 [seal]: /docs/configuration/seal
 [telemetry]: /docs/configuration/telemetry
+[initialize]: /docs/configuration/self-init
 [sentinel]: /docs/configuration/sentinel
 [high-availability]: /docs/concepts/ha
 [plugins]: /docs/plugins

--- a/website/content/docs/configuration/self-init.mdx
+++ b/website/content/docs/configuration/self-init.mdx
@@ -1,0 +1,265 @@
+---
+sidebar_label: initialize
+description: |-
+  The initialize stanza allows request-based one-time initialization of OpenBao
+  from the configuration file.
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# `initialize` stanza
+
+The `initialize` stanza specifies various configurations for OpenBao to
+initialize itself once, on initial startup. To repeat the operation, remove
+all storage and re-initialize from scratch. Debugging can be performed by
+starting OpenBao with the `TRACE` log level, which shows all request/response
+pairs and thus **contains sensitive information**.
+
+When self-initialization fails, it logs an error to the server; this allows
+operators to debug partial failures and remediate as necessary. The intention
+is to give operators enough facility to bootstrap a proper initialization
+process without requiring one-time side-effecting setup like generating the
+initial root token and handling recovery keys.
+
+<Tabs groupId="config">
+<TabItem value="JSON">
+
+```json
+{
+  "initialize": [
+    {
+      "audit": {
+        "request": [
+          {
+            "enable-audit": {
+              "operation": "update",
+              "path": "sys/audit/stdout",
+              "data": {
+                "type": "file",
+                "options": {
+                  "file_path": "/dev/stdout",
+                  "log_raw": true
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+</TabItem>
+<TabItem value="HCL">
+
+```hcl
+initialize "audit" {
+  request "enable-audit" {
+    operation = "update"
+    path = "sys/audit/stdout"
+    data = {
+      type = "file"
+      options = {
+        file_path = "/dev/stdout"
+        log_raw = true
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+
+Use of this feature requires using an [auto-unseal](/docs/configuration/seal)
+mechanism. No recovery keys are generated; instead, use the [authenticated
+recovery key rotation](/api-docs/system/rotate) endpoints.
+
+The root token is not returned to the caller and is revoked after use.
+
+:::
+
+Multiple `initialize` stanzas may exist and are executed in the order they
+are specified in the configuration file(s). Multiple `request` blocks may
+exist inside a single `initialize` stanza and are executed in the order they
+appear in the specified `initialize` block. No two blocks of either type may
+share a name. Names must conform to the regex `^[A-Za-z_][A-Za-z0-9_-]*$`.
+
+## `initialize` parameters
+
+The `initialize` stanza can only contain one or more `request` stanzas. Each
+`initialize` and `request` stanza must have a single name.
+
+### `request` parameters
+
+- `operation` `(value[string]: <required>)` - type of operation to perform; see
+  [ACL Capabilities](/docs/concepts/policies#capabilities) for a list.
+- `path` `(value[string]: <required>)` - path to perform the given operation
+  on.
+- `token` `(value[string]: <optional>)` - the OpenBao API token to use for
+  authentication. When not specified, defaults to the root token.
+- `data` `(value[map]: <optional>)` - the request data for this call.
+- `allow_failure` `(value[bool]: false)` - when true, allows this call to fail
+  without erring out the entire self-initialization process.
+
+## `value` Type
+
+Values may be of the following types:
+
+- A literal, such as a `string` or `map`. For example the following are valid
+  literals:
+
+  ```hcl
+  path = "sys/audit/stdout"
+  ```
+
+  or
+
+  ```hcl
+  data = {
+    type = "file"
+  }
+  ```
+
+- A data source evaluation. These take the form:
+
+  ```hcl
+  {
+    eval_source = "<source name>"
+    eval_type = "<resulting type>"
+
+    ... additional source-specific parameters ...
+  }
+  ```
+
+  where
+
+  - `eval_source` `(string: <required>)` - the name of the given source; valid
+    values are defined below.
+  - `eval_type` `(string: <required>)` - the output type after evaluation;
+    recognized Go types are `string`, `int`, `float64`, `bool`, `[]string`,
+    `map` (alias for `map[string]interface{}`), and `any` (alias for
+    `interface{}`). If the output of the source evaluation is not convertable
+    to the desired type, a runtime error will occur.
+
+Note that fields within a source evaluation statement may not be themselves
+be source evaluations.
+
+#### `env` source
+
+- `env_var` `(string: <required>)` - the name of an environment variable to
+  return the value of.
+- `require_present` `(bool: false)` - when asserted, require that the named
+  environment variable must be present and err otherwise.
+
+For example, to reference an initial admin password from an environment
+variable:
+
+```hcl
+initialize "identity" {
+  request "userpass-add-admin" {
+    operation = "update"
+    path = "auth/userpass/users/admin"
+    data = {
+      "password" = {
+        eval_type = "string"
+        eval_source = "env"
+        env_var = "INITIAL_ADMIN_PASSWORD"
+        require_present = true
+      }
+      "token_policies" = ["superuser"]
+    }
+  }
+}
+```
+
+#### `file` source
+
+- `path` `(string: <required>)` - the path to the file to read. This file is
+  only ever read once and is closed after use; thus a single piece of data
+  could be provided on `/dev/stdin`. Errs if the file is not readable.
+
+For example, to load a X.509 root CA into a PKI engine:
+
+```hcl
+initialize "ca-setup" {
+  request "provision-root-ca" {
+    operation = "update"
+    path = "pki/issuers/import/cert"
+    data = {
+      "pem_bundle" = {
+        eval_type = "string"
+        eval_source = "file"
+        path = "/data/root-ca.pem"
+      }
+    }
+  }
+}
+```
+
+#### `request` source
+
+- `initialize_name` `(string: <required>)` - name of the initialize block to
+  reference.
+- `request_name` `(string: <required>)` - name of the request block inside the
+  initialize block to reference. Must have already been executed.
+- `field_selector` `(string or []string: <required>)` - field within the request
+  to reference; for nesting, specify multiple values as a list. The request is
+  marshalled directly; for example, to reference the path, use
+  `field_selector = "path"`; to reference a specific field of input data, use
+  `field_selector = ["data", "my_top_level_field"]`.
+
+For example, to reference a previous request's input for a subsequent call:
+
+```hcl
+initialize "namespace-identity" {
+  request "namespace-userpass-add-admin" {
+    operation = "update"
+    path = "ns1/auth/userpass/users/admin"
+    data = {
+      "password" = {
+        eval_type = "string"
+        eval_source = "request"
+        initialize_name = "identity"
+        request_name = "userpass-add-admin"
+        field_selector = ["data", "password"]
+      }
+      "token_policies" = ["superuser"]
+    }
+  }
+}
+```
+
+#### `response` source
+
+- `initialize_name` `(string: <required>)` - name of the initialize block to
+  reference.
+- `request_name` `(string: <required>)` - name of the request block inside the
+  initialize block, to reference the corresponding response of. Must have
+  already been executed.
+- `field_selector` `(string or []string: <required>)` - field within the
+  response to reference; for nesting, specify multiple values as a list. The
+  response is marshalled directly; for example, to reference a specific field
+  of output data, use `field_selector = ["data", "my_top_level_field"]`.
+
+For example, to reference a login token in a subsequent call:
+
+```hcl
+initialize "example" {
+  request "use-auth" {
+    operation = "update"
+    path = "sys/namespaces/ns1"
+    token = {
+      eval_type = "string"
+      eval_source = "response"
+      initialize_name = "authenticate"
+      request_name = "admin-userpass"
+      field_selector = ["auth", "client_token"]
+    }
+    data = {}
+  }
+}
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
             ],
             Configuration: [
                 "configuration/index",
+                "configuration/self-init",
                 {
                     listener: [
                         "configuration/listener/index",


### PR DESCRIPTION
This fixes a few ergonomics around self-init (making names a little more legible, expanding field names, &c) and provides documentation for the feature.

---

@KrzysztofKornalewski-Reply Do you mind splitting this document (as you see fit) into a page under `/docs/concepts/profiles` for reference and reuse? I think it makes sense to avoid duplicating this when we go to add the rest of the profile system. 

Probably it is worth keeping the bit about the `initialize` block(s), that `request` and `response` sources take a `initialize_name` parameter, and declaring the (four) types of sources we support, but moving a lot of the rest over to the concepts page. 

Thanks!