### PR TITLE
Move inline auth to Client from Logical

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -6,6 +6,8 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -92,6 +94,9 @@ const (
 		"    BAO_ADDR=http://<address> vault <command>\n\n" +
 		"where <address> is replaced by the actual address to the server."
 )
+
+// InlineAuthOpts represents an option for inline authentication
+type InlineAuthOpts func() map[string][]string
 
 // Deprecated values
 const (
@@ -1571,6 +1576,77 @@ func (c *Client) WithResponseCallbacks(callbacks ...ResponseCallback) *Client {
 	c2.modifyLock = sync.RWMutex{}
 	c2.responseCallbacks = callbacks
 	return &c2
+}
+
+// InlineWithNamespace is used with WithInlineAuth(...) to set the namespace
+// of the inline authentication call.
+func InlineWithNamespace(ns string) InlineAuthOpts {
+	return func() map[string][]string {
+		return map[string][]string{
+			InlineAuthNamespaceHeaderName: {ns},
+		}
+	}
+}
+
+// InlineWithOperation is used with WithInlineAuth(...) to set the operation
+// of the inline authentication call.
+func InlineWithOperation(op string) InlineAuthOpts {
+	return func() map[string][]string {
+		return map[string][]string{
+			InlineAuthOperationHeaderName: {op},
+		}
+	}
+}
+
+// WithInlineAuth returns a client with no authentication information but
+// which sets headers which perform inline authentication. This
+// re-authenticates on every request and does not persist any token.
+// Operations which result in lease creation will not work.
+//
+// Refer to the OpenBao documentation for more information.
+func (c *Client) WithInlineAuth(path string, data map[string]interface{}, opts ...InlineAuthOpts) (*Client, error) {
+	client, err := c.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("error cloning client: %w", err)
+	}
+
+	headers := client.Headers()
+	for h := range client.Headers() {
+		if strings.HasPrefix(h, InlineAuthParameterHeaderPrefix) {
+			delete(headers, h)
+		}
+	}
+
+	delete(headers, InlineAuthOperationHeaderName)
+	delete(headers, InlineAuthNamespaceHeaderName)
+	delete(headers, AuthHeaderName)
+
+	headers[InlineAuthPathHeaderName] = []string{path}
+
+	for _, opt := range opts {
+		oHeader := opt()
+		for name, value := range oHeader {
+			headers[name] = value
+		}
+	}
+
+	for key, value := range data {
+		jEncoded, err := json.Marshal(map[string]interface{}{
+			"key":   key,
+			"value": value,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode inline auth data key `%v`: %w", key, err)
+		}
+
+		b64Encoded := base64.RawURLEncoding.EncodeToString(jEncoded)
+		headers[fmt.Sprintf("%v%v", InlineAuthParameterHeaderPrefix, key)] = []string{b64Encoded}
+	}
+
+	client.ClearToken()
+	client.SetHeaders(headers)
+
+	return client, nil
 }
 
 // withConfiguredTimeout wraps the context with a timeout from the client configuration.

--- a/api/logical.go
+++ b/api/logical.go
@@ -6,7 +6,6 @@ package api
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,8 +17,6 @@ import (
 const (
 	wrappedResponseLocation = "cubbyhole/response"
 )
-
-type InlineAuthOpts func() map[string][]string
 
 var (
 	// The default TTL that will be used with `sys/wrapping/wrap`, can be
@@ -50,77 +47,6 @@ type Logical struct {
 // Logical is used to return the client for logical-backend API calls.
 func (c *Client) Logical() *Logical {
 	return &Logical{c: c}
-}
-
-// InlineWithNamespace is used with WithInlineAuth(...) to set the namespace
-// of the inline authentication call.
-func InlineWithNamespace(ns string) InlineAuthOpts {
-	return func() map[string][]string {
-		return map[string][]string{
-			InlineAuthNamespaceHeaderName: {ns},
-		}
-	}
-}
-
-// InlineWithOperation is used with WithInlineAuth(...) to set the operation
-// of the inline authentication call.
-func InlineWithOperation(op string) InlineAuthOpts {
-	return func() map[string][]string {
-		return map[string][]string{
-			InlineAuthOperationHeaderName: {op},
-		}
-	}
-}
-
-// WithInlineAuth returns a client with no authentication information but
-// which sets headers which perform inline authentication. This
-// re-authenticates on every request and does not persist any token.
-// Operations which result in lease creation will not work.
-//
-// Refer to the OpenBao documentation for more information.
-func (c *Logical) WithInlineAuth(path string, data map[string]interface{}, opts ...InlineAuthOpts) (*Logical, error) {
-	client, err := c.c.Clone()
-	if err != nil {
-		return nil, fmt.Errorf("error cloning client: %w", err)
-	}
-
-	headers := client.Headers()
-	for h := range client.Headers() {
-		if strings.HasPrefix(h, InlineAuthParameterHeaderPrefix) {
-			delete(headers, h)
-		}
-	}
-
-	delete(headers, InlineAuthOperationHeaderName)
-	delete(headers, InlineAuthNamespaceHeaderName)
-	delete(headers, AuthHeaderName)
-
-	headers[InlineAuthPathHeaderName] = []string{path}
-
-	for _, opt := range opts {
-		oHeader := opt()
-		for name, value := range oHeader {
-			headers[name] = value
-		}
-	}
-
-	for key, value := range data {
-		jEncoded, err := json.Marshal(map[string]interface{}{
-			"key":   key,
-			"value": value,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode inline auth data key `%v`: %w", key, err)
-		}
-
-		b64Encoded := base64.RawURLEncoding.EncodeToString(jEncoded)
-		headers[fmt.Sprintf("%v%v", InlineAuthParameterHeaderPrefix, key)] = []string{b64Encoded}
-	}
-
-	client.ClearToken()
-	client.SetHeaders(headers)
-
-	return &Logical{c: client}, nil
 }
 
 func (c *Logical) Read(path string) (*Secret, error) {

--- a/vault/external_tests/api/secret_test.go
+++ b/vault/external_tests/api/secret_test.go
@@ -2059,10 +2059,12 @@ path "sys/mounts/pki" {
 	require.NoError(t, err)
 
 	// Try inline authentication.
-	logical, err := client.Logical().WithInlineAuth("auth/userpass/login/admin", map[string]interface{}{
+	inlineClient, err := client.WithInlineAuth("auth/userpass/login/admin", map[string]interface{}{
 		"password": "admin",
 	})
 	require.NoError(t, err)
+
+	logical := inlineClient.Logical()
 
 	resp, err := logical.Read("sys/policies/acl/my-admin")
 	require.NoError(t, err)


### PR DESCRIPTION
Keeping this on Logical() limits the consumption; uses like Sys() and KVv2() and other top-level clients cannot also use this without reimplementing it. By moving it to Client, it sits alongside SetToken(...) and thus should be more discoverable.

As this has not landed in a release, it shouldn't require a changelog entry.

---

cc: @fcbajao 