### PR TITLE
Unseal standby nodes

### DIFF
--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -483,7 +484,7 @@ func attemptUnsealMigrate(client *api.Client, keys [][]byte, transitServerAvaila
 
 // awaitMigration waits for migration to finish.
 func awaitMigration(t *testing.T, client *api.Client) {
-	timeout := time.Now().Add(60 * time.Second)
+	timeout := time.Now().Add(120 * time.Second)
 	for {
 		if time.Now().After(timeout) {
 			break
@@ -491,6 +492,14 @@ func awaitMigration(t *testing.T, client *api.Client) {
 
 		resp, err := client.Sys().SealStatus()
 		if err != nil {
+			// When a node is started and unsealed, it is still in standby
+			// mode before it steps up and completes seal migration.
+			// During that time, SealStatus() returns "barrier seal type of ..."
+			// error until the node adopts the new seal config.
+			// Ignore that error and keep trying until seal is migrated.
+			if strings.Contains(err.Error(), "barrier seal type of") {
+				continue
+			}
 			t.Fatal(err)
 		}
 		if !resp.Migration {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -395,6 +395,18 @@ func (c *Core) runStandby(doneCh, manualStepDownCh, stopCh chan struct{}) {
 	defer close(manualStepDownCh)
 	c.logger.Info("entering standby mode")
 
+	// wipe any existing mount tables
+	if err := c.preSeal(); err != nil {
+		c.logger.Error("pre-seal teardown failed", "error", err)
+	}
+
+	perfCtx, perfCancel := context.WithCancel(namespace.RootContext(nil))
+	if err := c.postUnseal(perfCtx, perfCancel, readonlyUnsealStrategy{}); err != nil {
+		c.logger.Error("read-only post-unseal setup failed", "error", err)
+		c.barrier.Seal()
+		c.logger.Warn("vault is sealed")
+	}
+
 	var g run.Group
 	newLeaderCh := addEnterpriseHaActors(c, &g)
 	{
@@ -628,6 +640,11 @@ func (c *Core) waitForLeadership(newLeaderCh chan func(), manualStepDownCh, stop
 			c.logger.Error("leader advertisement setup failed", "error", err)
 			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
 			continue
+		}
+
+		// wipe any existing mount tables before stepping up as leader
+		if err := c.preSeal(); err != nil {
+			c.logger.Error("pre-seal teardown failed", "error", err)
 		}
 
 		// Attempt the post-unseal process

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -963,7 +963,7 @@ func (c *TestCluster) UnsealCoresWithError(useStoredKeys bool) error {
 	}
 
 	// Let them come fully up to standby
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// Ensure cluster connection info is populated.
 	// Other cores should not come up as leaders.


### PR DESCRIPTION
Enabling standby nodes to handle read request has 2 main steps:
1. unsealing standby nodes.
2. handling read request and forwarding writes.

I was having a bunch of bugs tryna shoot both down in one PR, so implementing them in separate steps will help with debugging and review :))

This PR targets step 1. 

---

Resolves #
