### PR TITLE
Ignore missing mount during namespace deletion

### DIFF
--- a/changelog/1594.txt
+++ b/changelog/1594.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Ignore missing mounts when deleting a namespace. This can happen when a mount is unmounted in prallel.
+Ignore missing mounts when deleting a namespace. This can happen when a mount is unmounted in parallel.
 ```

--- a/changelog/1594.txt
+++ b/changelog/1594.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Ignore missing mounts when deleting a namespace. This can happen when a mount is unmounted in prallel.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -142,6 +142,9 @@ var (
 	// enabled in the configuration file
 	ErrIntrospectionNotEnabled = errors.New("The Vault configuration must set \"introspection_endpoint\" to true to enable this endpoint")
 
+	// ErrNoMatchingMount is returned if the mount is not found
+	errNoMatchingMount = errors.New("no matching mount")
+
 	// manualStepDownSleepPeriod is how long to sleep after a user-initiated
 	// step down of the active node, to prevent instantly regrabbing the lock.
 	// It's var not const so that tests can manipulate it.

--- a/vault/core.go
+++ b/vault/core.go
@@ -142,7 +142,7 @@ var (
 	// enabled in the configuration file
 	ErrIntrospectionNotEnabled = errors.New("The Vault configuration must set \"introspection_endpoint\" to true to enable this endpoint")
 
-	// ErrNoMatchingMount is returned if the mount is not found
+	// errNoMatchingMount is returned if the mount is not found
 	errNoMatchingMount = errors.New("no matching mount")
 
 	// manualStepDownSleepPeriod is how long to sleep after a user-initiated

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -855,7 +855,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 	// Verify exact match of the route
 	match := c.router.MatchingMount(ctx, path)
 	if match == "" || ns.Path+path != match {
-		return errors.New("no matching mount")
+		return errNoMatchingMount
 	}
 
 	// Get the view for this backend

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -818,6 +818,9 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 	for _, me := range mountEntries {
 		err := ns.core.unmountInternal(nsCtx, me.Path, true)
 		if err != nil {
+			if err == errNoMatchingMount {
+				continue
+			}
 			ns.logger.Error(fmt.Sprintf("failed to unmount %q", me.Path), "namespace", namespaceToDelete.Path, "error", err.Error())
 			return false
 		}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -818,7 +818,7 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 	for _, me := range mountEntries {
 		err := ns.core.unmountInternal(nsCtx, me.Path, true)
 		if err != nil {
-			if err == errNoMatchingMount {
+			if errors.Is(err, errNoMatchingMount) {
 				continue
 			}
 			ns.logger.Error(fmt.Sprintf("failed to unmount %q", me.Path), "namespace", namespaceToDelete.Path, "error", err.Error())


### PR DESCRIPTION
This can happen, if a mount deletion is requested in parallel.

Resolves https://github.com/openbao/openbao/issues/1543


