### PR TITLE
Implement cache invalidation for audits

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/helper/namespace"
@@ -220,7 +221,7 @@ func (c *Core) disableAudit(ctx context.Context, path string, updateStorage bool
 }
 
 // loadAudits is invoked as part of postUnseal to load the audit table
-func (c *Core) loadAudits(ctx context.Context) error {
+func (c *Core) loadAudits(ctx context.Context, readonly bool) error {
 	auditTable := &MountTable{}
 	localAuditTable := &MountTable{}
 
@@ -235,9 +236,6 @@ func (c *Core) loadAudits(ctx context.Context) error {
 		c.logger.Error("failed to read local audit table", "error", err)
 		return errLoadAuditFailed
 	}
-
-	c.auditLock.Lock()
-	defer c.auditLock.Unlock()
 
 	if raw != nil {
 		if err := jsonutil.DecodeJSON(raw.Value, auditTable); err != nil {
@@ -300,6 +298,11 @@ func (c *Core) loadAudits(ctx context.Context) error {
 	}
 
 	if !needPersist {
+		return nil
+	}
+
+	if readonly {
+		c.logger.Warn("audit table needs update")
 		return nil
 	}
 
@@ -383,15 +386,64 @@ func (c *Core) persistAudit(ctx context.Context, table *MountTable, localOnly bo
 func (c *Core) setupAudits(ctx context.Context) error {
 	brokerLogger := c.baseLogger.Named("audit")
 	c.AddLogger(brokerLogger)
-	broker := NewAuditBroker(brokerLogger)
+	c.auditBroker = NewAuditBroker(brokerLogger)
 
+	err := c.reconcileAudits(reconcileAuditsRequests{
+		ctx:       ctx,
+		readonly:  false,
+		isInitial: true,
+	})
+	if err != nil {
+		if multiErr, ok := err.(*multierror.Error); ok {
+			for _, err := range multiErr.Errors {
+				c.logger.Error(err.Error())
+			}
+		} else {
+			return err
+		}
+	}
+
+	if len(c.audit.Entries) > 0 && c.auditBroker.Count() == 0 {
+		return errLoadAuditFailed
+	}
+
+	return nil
+}
+
+type reconcileAuditsRequests struct {
+	ctx       context.Context
+	readonly  bool
+	isInitial bool
+}
+
+func (c *Core) reconcileAudits(req reconcileAuditsRequests) error {
 	c.auditLock.Lock()
 	defer c.auditLock.Unlock()
 
-	var successCount int
+	var oldTable *MountTable
+	if c.audit != nil {
+		oldTable = c.audit.shallowClone()
+	}
 
-	for _, entry := range c.audit.Entries {
-		// Create a barrier view using the UUID
+	if err := c.loadAudits(req.ctx, req.readonly); err != nil {
+		c.audit = oldTable
+		return err
+	}
+
+	additions, deletions := oldTable.delta(c.audit)
+
+	var multiErr *multierror.Error
+
+	for _, entry := range deletions {
+		c.removeAuditReloadFunc(entry)
+
+		c.auditBroker.Deregister(entry.Path)
+		if c.logger.IsInfo() {
+			c.logger.Info("disabled audit backend", "path", entry.Path)
+		}
+	}
+
+	for _, entry := range additions {
 		view, err := c.mountEntryView(entry)
 		if err != nil {
 			return err
@@ -403,33 +455,33 @@ func (c *Core) setupAudits(ctx context.Context) error {
 		// ensure that it is reset after. This ensures that there will be no
 		// writes during the construction of the backend.
 		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			view.SetReadOnlyErr(origViewReadOnlyErr)
-		})
+		if req.isInitial {
+			c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
+				view.SetReadOnlyErr(origViewReadOnlyErr)
+			})
+		} else {
+			defer view.SetReadOnlyErr(origViewReadOnlyErr)
+		}
 
 		// Initialize the backend
-		backend, err := c.newAuditBackend(ctx, entry, view, entry.Options)
+		backend, err := c.newAuditBackend(req.ctx, entry, view, entry.Options)
 		if err != nil {
-			c.logger.Error("failed to create audit entry", "path", entry.Path, "error", err)
+			multiErr = multierror.Append(multiErr, err)
 			continue
 		}
 		if backend == nil {
-			c.logger.Error("created audit entry was nil", "path", entry.Path, "type", entry.Type)
+			multiErr = multierror.Append(multiErr, fmt.Errorf("nil audit backend of type %q returned from factory at path %q", entry.Type, entry.Path))
 			continue
 		}
 
-		// Mount the backend
-		broker.Register(entry.Path, backend, view, entry.Local)
-
-		successCount++
+		// Register the backend
+		c.auditBroker.Register(entry.Path, backend, view, entry.Local)
+		if c.logger.IsInfo() {
+			c.logger.Info("enabled audit backend", "path", entry.Path, "type", entry.Type)
+		}
 	}
 
-	if len(c.audit.Entries) > 0 && successCount == 0 {
-		return errLoadAuditFailed
-	}
-
-	c.auditBroker = broker
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 // teardownAudit is used before we seal the vault to reset the audit

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -220,7 +220,7 @@ func (c *Core) disableAudit(ctx context.Context, path string, updateStorage bool
 	return true, nil
 }
 
-// loadAudits is invoked as part of postUnseal to load the audit table
+// loadAudits is invoked as part of reconcileAudits (which holds the lock) to load the audit table
 func (c *Core) loadAudits(ctx context.Context, readonly bool) error {
 	auditTable := &MountTable{}
 	localAuditTable := &MountTable{}

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -67,9 +67,10 @@ func (a *AuditBroker) IsRegistered(name string) bool {
 	return ok
 }
 
-// Count returns the number of regiesterd backends
+// Count returns the number of registered backends
 func (a *AuditBroker) Count() int {
 	a.RLock()
+	defer a.RUnlock()
 	return len(a.backends)
 }
 

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -67,6 +67,12 @@ func (a *AuditBroker) IsRegistered(name string) bool {
 	return ok
 }
 
+// Count returns the number of regiesterd backends
+func (a *AuditBroker) Count() int {
+	a.RLock()
+	return len(a.backends)
+}
+
 // IsLocal is used to check if a given audit backend is registered
 func (a *AuditBroker) IsLocal(name string) (bool, error) {
 	a.RLock()

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,7 +105,7 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 		return nil, errors.New("failing enabling")
 	}
 
-	c.audit = &MountTable{
+	if err := c.persistAudit(context.Background(), &MountTable{
 		Type: auditTableType,
 		Entries: []*MountEntry{
 			{
@@ -121,6 +121,8 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 				UUID:  "bcde",
 			},
 		},
+	}, false); err != nil {
+		t.Fatal(err)
 	}
 
 	// Both should set up successfully
@@ -131,6 +133,12 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 
 	// We expect this to work because the other entry is still valid
 	c.audit.Entries[0].Type = "fail"
+	if err := c.persistAudit(context.Background(), c.audit, false); err != nil {
+		t.Fatal(err)
+	}
+
+	c.audit = nil
+
 	err = c.setupAudits(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -138,6 +146,12 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 
 	// No audit backend set up successfully, so expect error
 	c.audit.Entries[1].Type = "fail"
+	if err := c.persistAudit(context.Background(), c.audit, false); err != nil {
+		t.Fatal(err)
+	}
+
+	c.audit = nil
+
 	err = c.setupAudits(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
@@ -154,7 +168,7 @@ func TestCore_EnableAudit_Local(t *testing.T) {
 		return nil, errors.New("failing enabling")
 	}
 
-	c.audit = &MountTable{
+	if err := c.persistAudit(context.Background(), &MountTable{
 		Type: auditTableType,
 		Entries: []*MountEntry{
 			{
@@ -176,6 +190,8 @@ func TestCore_EnableAudit_Local(t *testing.T) {
 				namespace:   namespace.RootNamespace,
 			},
 		},
+	}, false); err != nil {
+		t.Fatal(err)
 	}
 
 	// Both should set up successfully
@@ -220,7 +236,7 @@ func TestCore_EnableAudit_Local(t *testing.T) {
 	}
 
 	oldAudit := c.audit
-	if err := c.loadAudits(context.Background()); err != nil {
+	if err := c.loadAudits(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -2364,9 +2364,6 @@ func (readonlyUnsealStrategy) unseal(
 	if err := c.setupExpiration(expireLeaseStrategyFairsharing); err != nil {
 		return err
 	}
-	if err := c.loadAudits(ctx); err != nil {
-		return err
-	}
 	if err := c.setupAudits(ctx); err != nil {
 		return err
 	}

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -69,7 +69,17 @@ func (c *Core) invalidateInternal(ctx context.Context, key string) error {
 		c.quotaManager.Invalidate(strings.TrimPrefix(key, systemBarrierPrefix+quotas.StoragePrefix))
 
 	case c.router.Invalidate(ctx, key):
-		// if router.Invalidate returns true, a matching plugin was found and the invalidation is therefore dispatched
+	// if router.Invalidate returns true, a matching plugin was found and the invalidation is therefore dispatched
+
+	case key == coreAuditConfigPath || key == coreLocalAuditConfigPath:
+		err := c.reconcileAudits(reconcileAuditsRequests{
+			ctx:       ctx,
+			readonly:  true,
+			isInitial: false,
+		})
+		if err != nil {
+			return err
+		}
 
 	default:
 		c.logger.Warn("no idea how to invalidate cache. Maybe it's not cached and this is fine, maybe not", "key", key)

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -12,14 +12,18 @@ import (
 	"github.com/openbao/openbao/vault/quotas"
 )
 
+func (c *Core) processInvalidationFailure(key string, err error) {
+	c.logger.Error("cache invalidation failed", "key", key, "error", err.Error())
+	// TODO(phil9909): It's not save to continue, restart the core
+}
+
 func (c *Core) Invalidate(key string) {
 	ctx, cancel := context.WithTimeout(c.activeContext, 2*time.Second)
 	defer cancel()
 
 	err := c.invalidateInternal(ctx, key)
 	if err != nil {
-		c.logger.Error("cache invalidation failed", "key", key, "error", err.Error())
-		// TODO(phil9909): It's not save to continue, restart the core
+		c.processInvalidationFailure(key, err)
 	}
 }
 
@@ -72,14 +76,16 @@ func (c *Core) invalidateInternal(ctx context.Context, key string) error {
 	// if router.Invalidate returns true, a matching plugin was found and the invalidation is therefore dispatched
 
 	case key == coreAuditConfigPath || key == coreLocalAuditConfigPath:
-		err := c.reconcileAudits(reconcileAuditsRequests{
-			ctx:       ctx,
-			readonly:  true,
-			isInitial: false,
-		})
-		if err != nil {
-			return err
-		}
+		go func() {
+			err := c.reconcileAudits(reconcileAuditsRequests{
+				ctx:       c.activeContext,
+				readonly:  true,
+				isInitial: false,
+			})
+			if err != nil {
+				c.processInvalidationFailure(key, err)
+			}
+		}()
 
 	default:
 		c.logger.Warn("no idea how to invalidate cache. Maybe it's not cached and this is fine, maybe not", "key", key)

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -311,6 +311,10 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	// 5. call invalidate
 	c.Invalidate("core/audit")
 
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.Equal(collect, 0, c.auditBroker.Count())
+	}, 10*time.Second, 10*time.Millisecond)
+
 	require.EqualValues(t, 1, callCount.Load(), "expected audit factory to be called exactly once")
 
 	// 6. Trigger audit event (but audit should be disabled)
@@ -324,7 +328,10 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	// 8. call invalidate
 	c.Invalidate("core/audit")
 
-	require.EqualValues(t, 2, callCount.Load(), "expected audit factory to be called exactly twice")
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.EqualValues(collect, 2, callCount.Load(), "expected audit factory to be called exactly twice")
+		require.Equal(collect, 1, c.auditBroker.Count())
+	}, 10*time.Second, 10*time.Millisecond)
 
 	require.Len(t, currentBackend.Req, 0, "expected 0 audit request event") // factory is called again, storage will be reset
 

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -7,12 +7,16 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/quotas"
 	"github.com/stretchr/testify/assert"
@@ -240,4 +244,92 @@ func TestCore_Invalidate_Plugin(t *testing.T) {
 			assert.Equal(t, invalidatedKey, []string{"foo", "bar/bazz"})
 		})
 	}
+}
+
+func TestCore_Invalidate_Audit(t *testing.T) {
+	t.Parallel()
+	c, _, root := TestCoreUnsealed(t)
+
+	// 1. Inject a dummy audit factory
+	var callCount atomic.Int32
+	var currentBackend *corehelpers.NoopAudit
+	factory := corehelpers.NoopAuditFactory(nil)
+	c.auditBackends["noop"] = func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
+		callCount.Add(1)
+		backend, err := factory(ctx, config)
+		currentBackend = backend.(*corehelpers.NoopAudit)
+		return backend, err
+	}
+
+	// 2. Enable dummy audit
+	registerReq := &logical.Request{
+		Operation:   logical.CreateOperation,
+		ClientToken: root,
+		Path:        "sys/audit/my-noop-audit",
+		Data: map[string]any{
+			"type": "noop",
+			"options": map[string]any{
+				"prefix": "my-test-prefix",
+			},
+		},
+	}
+
+	testCore_Invalidate_handleRequest(t, t.Context(), c, registerReq)
+
+	require.EqualValues(t, 1, callCount.Load(), "expected audit factory to be called exactly once")
+
+	// 3. Trigger audit event
+	triggerAuditEvent := func() {
+		testCore_Invalidate_handleRequest(t, t.Context(), c, &logical.Request{
+			Operation:   logical.ReadOperation,
+			ClientToken: root,
+			Path:        "secret/kv/dummy",
+		})
+	}
+	triggerAuditEvent()
+
+	require.Len(t, currentBackend.Req, 1, "expected 1 audit request event")
+
+	// 4. Manipulate audit table in storage: delete audit
+	entry, err := c.barrier.Get(t.Context(), "core/audit")
+	require.NoError(t, err)
+	require.NotNil(t, entry, "expected audit table to be written")
+
+	auditTable := &MountTable{}
+	require.NoError(t, jsonutil.DecodeJSON(entry.Value, auditTable), "failed to decode audit table")
+
+	auditTable.Entries = make([]*MountEntry, 0)
+
+	data, err := jsonutil.EncodeJSON(auditTable)
+	require.NoError(t, err)
+
+	testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
+		Key:   "core/audit",
+		Value: data,
+	})
+
+	// 5. call invalidate
+	c.Invalidate("core/audit")
+
+	require.EqualValues(t, 1, callCount.Load(), "expected audit factory to be called exactly once")
+
+	// 6. Trigger audit event (but audit should be disabled)
+	triggerAuditEvent()
+
+	require.Len(t, currentBackend.Req, 1, "expected still 1 audit request event")
+
+	// 7. Manipulate audit table in storage: restore audit
+	testCore_Invalidate_sneakValueAroundCache(t, c, entry)
+
+	// 8. call invalidate
+	c.Invalidate("core/audit")
+
+	require.EqualValues(t, 2, callCount.Load(), "expected audit factory to be called exactly twice")
+
+	require.Len(t, currentBackend.Req, 0, "expected 0 audit request event") // factory is called again, storage will be reset
+
+	// 9. Trigger audit event
+	triggerAuditEvent()
+
+	require.Len(t, currentBackend.Req, 1, "expected 1 audit request event")
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -252,6 +252,42 @@ func (t *MountTable) shallowClone() *MountTable {
 	return mt
 }
 
+func (old *MountTable) delta(new *MountTable) (additions []*MountEntry, deletions []*MountEntry) {
+	if old == nil {
+		additions = new.Entries
+		return
+	}
+
+	additions = slices.Clone(new.Entries)
+	deletions = slices.Clone(old.Entries)
+
+	slices.SortFunc(additions, func(a, b *MountEntry) int {
+		return strings.Compare(a.Accessor, b.Accessor)
+	})
+
+	slices.SortFunc(deletions, func(a, b *MountEntry) int {
+		return strings.Compare(a.Accessor, b.Accessor)
+	})
+
+	idxOld := 0
+	idxNew := 0
+
+	for idxNew < len(additions) && idxOld < len(deletions) {
+		diff := strings.Compare(additions[idxNew].Accessor, deletions[idxOld].Accessor)
+		switch {
+		case diff == 0:
+			additions = slices.Delete(additions, idxNew, idxNew+1)
+			deletions = slices.Delete(deletions, idxOld, idxOld+1)
+		case diff < 0:
+			idxNew += 1
+		case diff > 0:
+			idxOld += 1
+		}
+	}
+
+	return
+}
+
 // setTaint is used to set the taint on given entry Accepts either the mount
 // entry's path or namespace + path, i.e. <ns-path>/secret/ or <ns-path>/token/
 func (t *MountTable) setTaint(nsID, path string, tainted bool, mountState string) (*MountEntry, error) {


### PR DESCRIPTION
Implement cache invalidation for audits
Required as a prerequisite for enabling standby nodes to handle read requests.

See #1550
See #1528 

This change is a bit more involved than the previous PRs for cache invalidation (e.g. #1551, #1584), because the storage key does not contain an identifier for the audit, instead all audits are stored as an array in a single key (actually it's two keys, `core/audit` and `core/local-audit`) so if we are notified about a change we only know something changed, but not what. So I added a `reconcileAudits` method (naming inspired by [Kubernetes](https://book.kubebuilder.io/getting-started#reconciliation-process)) which will figure out the difference between the "desired" mount table and the "actual" mount table and add or remove audit backends as needed.

Also, I modified `setupAudits` to use `reconcileAudits` to limit duplication.

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch