### PR TITLE
Post-PoC updates to the per-ns sealing feature (Part #1)

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -30,6 +30,9 @@ var reservedNames = []string{
 	"auth",
 	"cubbyhole",
 	"identity",
+	"seal",
+	"unseal",
+	"seal-status",
 }
 
 type (

--- a/sdk/helper/consts/error.go
+++ b/sdk/helper/consts/error.go
@@ -10,6 +10,10 @@ var (
 	// No operation is expected to succeed before unsealing
 	ErrSealed = errors.New("Vault is sealed")
 
+	// ErrNamespaceSealed is returned if an operation is performed on a sealed namesapce barrier.
+	// No operation is expected to succeed before unsealing
+	ErrNamespaceSealed = errors.New("Namespace is sealed")
+
 	// ErrAPILocked is returned if an operation is performed when the API is
 	// locked for the request namespace.
 	ErrAPILocked = errors.New("API access to this namespace has been locked by an administrator")

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -160,7 +160,7 @@ func AdjustErrorStatusCode(status *int, err error) {
 	}
 
 	// Adjust status code when sealed
-	if errwrap.Contains(err, consts.ErrSealed.Error()) {
+	if errwrap.Contains(err, consts.ErrSealed.Error()) || errwrap.Contains(err, consts.ErrNamespaceSealed.Error()) {
 		*status = http.StatusServiceUnavailable
 	}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -597,6 +597,10 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
+		if c.IsNSSealed(ns) {
+			c.logger.Info(fmt.Sprintf("Barrier for namespace %v is sealed\n", ns.Path))
+			continue
+		}
 		view := c.NamespaceView(ns)
 
 		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -1183,21 +1183,30 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 	if c.auth != nil {
 		authTable := c.auth.shallowClone()
-		for _, e := range authTable.Entries {
-			backend := c.router.MatchingBackend(namespace.ContextWithNamespace(ctx, e.namespace), credentialRoutePrefix+e.Path)
-			if backend != nil {
-				backend.Cleanup(ctx)
-			}
-		}
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, false, func(e *MountEntry) bool { return true })
 	}
 
 	c.auth = nil
-
 	if c.tokenStore != nil {
 		c.tokenStore.teardown()
 		c.tokenStore = nil
 	}
+	return nil
+}
 
+// UnloadNamespaceCredentialMounts is used before we seal the namespace to reset the mounts to
+// their unloaded state, calling Cleanup if defined
+func (c *Core) UnloadNamespaceCredentialMounts(ctx context.Context, ns *namespace.Namespace, predicate func(*MountEntry) bool) error {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	if c.auth != nil {
+		authTable := c.auth.shallowClone()
+		c.cleanupMountBackends(ctx, authTable, credentialRoutePrefix, false, predicate)
+	}
+	if c.logger.IsInfo() {
+		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from auth table", ns.Path))
+	}
 	return nil
 }
 

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -15,15 +15,15 @@ import (
 var (
 	// ErrBarrierSealed is returned if an operation is performed on
 	// a sealed barrier. No operation is expected to succeed before unsealing
-	ErrBarrierSealed = errors.New("Vault is sealed")
+	ErrBarrierSealed = errors.New("Barrier is sealed")
 
 	// ErrBarrierAlreadyInit is returned if the barrier is already
 	// initialized. This prevents a re-initialization.
-	ErrBarrierAlreadyInit = errors.New("Vault is already initialized")
+	ErrBarrierAlreadyInit = errors.New("Barrier is already initialized")
 
 	// ErrBarrierNotInit is returned if a non-initialized barrier
 	// is attempted to be unsealed.
-	ErrBarrierNotInit = errors.New("Vault is not initialized")
+	ErrBarrierNotInit = errors.New("Barrier is not initialized")
 
 	// ErrBarrierInvalidKey is returned if the Unseal key is invalid
 	ErrBarrierInvalidKey = errors.New("Unseal failed, invalid key")

--- a/vault/core.go
+++ b/vault/core.go
@@ -1075,9 +1075,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 	// Construct a new AES-GCM barrier
 	c.barrier = NewAESGCMBarrier(c.physical, "")
-	if err := c.setupSealManager(); err != nil {
-		return nil, fmt.Errorf("seal manager setup failed: %w", err)
-	}
+	c.setupSealManager()
 
 	// We create the funcs here, then populate the given config with it so that
 	// the caller can share state
@@ -1405,6 +1403,11 @@ func (c *Core) GetContext() (context.Context, context.CancelFunc) {
 // Sealed checks if the Vault is current sealed
 func (c *Core) Sealed() bool {
 	return atomic.LoadUint32(c.sealed) == 1
+}
+
+// IsNSSealed checks if the namespace is current sealed
+func (c *Core) IsNSSealed(ns *namespace.Namespace) bool {
+	return c.sealManager.NamespaceBarrier(ns).Sealed()
 }
 
 // SecretProgress returns the number of keys provided so far. Lock
@@ -2292,6 +2295,9 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.setupNamespaceStore(ctx); err != nil {
 		return err
 	}
+
+	c.setupSealManager()
+
 	if err := c.loadMounts(ctx); err != nil {
 		return err
 	}
@@ -2522,6 +2528,9 @@ func (c *Core) preSeal() error {
 	}
 	if err := c.teardownLoginMFA(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down login MFA: %w", err))
+	}
+	if err := c.teardownSealManager(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("error tearing down seal manager: %w", err))
 	}
 	if err := c.teardownNamespaceStore(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down namespace store: %w", err))

--- a/vault/core.go
+++ b/vault/core.go
@@ -1407,7 +1407,7 @@ func (c *Core) Sealed() bool {
 
 // IsNSSealed checks if the namespace is current sealed
 func (c *Core) IsNSSealed(ns *namespace.Namespace) bool {
-	return c.sealManager.NamespaceBarrier(ns).Sealed()
+	return c.sealManager.NamespaceBarrier(ns.Path).Sealed()
 }
 
 // SecretProgress returns the number of keys provided so far. Lock

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -2011,6 +2011,9 @@ func (i *IdentityStore) oidcPeriodicFunc(ctx context.Context) {
 			i.Logger().Error("error listing namespaces", "err", err)
 		}
 		for _, ns := range allNs {
+			if i.namespacer.IsNSSealed(ns) {
+				continue
+			}
 			nsPath := ns.Path
 
 			s := i.router.MatchingStorageByAPIPath(ctx, nsPath+"identity/oidc")

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -131,6 +131,7 @@ var _ LocalNode = &Core{}
 type Namespacer interface {
 	NamespaceByID(context.Context, string) (*namespace.Namespace, error)
 	ListNamespaces(context.Context) ([]*namespace.Namespace, error)
+	IsNSSealed(ns *namespace.Namespace) bool
 }
 
 var _ Namespacer = &Core{}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -151,6 +151,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	b.Backend.Paths = append(b.Backend.Paths, b.lockedUserPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.leasePaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.policyPaths()...)
+	b.Backend.Paths = append(b.Backend.Paths, b.namespaceSealPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.namespacePaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.wrappingPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.toolsPaths()...)
@@ -5838,12 +5839,21 @@ This path responds to the following HTTP methods.
 
 	DELETE /<name>
 		Delete a namespace.
+		`,
+	},
+	"namespaces-seal": {
+		"Seal, unseal and check seal status of a namespace.",
+		`
+This path responds to the following HTTP methods.
 
 	POST /<name>/seal
 		Seal a namespace.
 
 	POST /<name>/unseal
 		Unseal a namespace.
+		
+    GET /<name>/seal-status
+        Returns the seal status of the namespace.
 		`,
 	},
 	"namespaces-lock": {

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -427,7 +427,7 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		keySharesMap := make(map[string][]string)
 		// TODO(wslabosz): write all the provided configs
 		if len(sealConfigs) > 0 {
-			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry); err != nil {
+			if err := b.Core.sealManager.SetSeal(ctx, sealConfigs[0], entry, true); err != nil {
 				return handleError(err)
 			}
 

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "namespaces/(?P<name>.+)/seal-status",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+				OperationVerb:   "status",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Summary:  "Check the seal status of an OpenBao namespace.",
+					Callback: b.handleNamespaceSealStatus(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Fields: map[string]*framework.FieldSchema{
+								"type": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"initialized": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"sealed": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"t": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"n": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"progress": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"nonce": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"version": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"build_date": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"migration": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"cluster_name": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+								"cluster_id": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+								"recovery_seal": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"storage_type": {
+									Type:     framework.TypeString,
+									Required: false,
+								},
+							},
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+
+		{
+			Pattern: "namespaces/(?P<name>.+)/seal",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Seal a namespace.",
+					Callback: b.handleNamespacesSeal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+		{
+			Pattern: "namespaces/(?P<name>.+)/unseal",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Name of the namespace.",
+				},
+				"key": {
+					Type:        framework.TypeString,
+					Description: "Specifies a single namespace unseal key share.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Unseal a namespace.",
+					Callback: b.handleNamespacesUnseal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{Description: http.StatusText(http.StatusNoContent)}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["namespaces-seal"][1]),
+		},
+	}
+}
+
+// TODO: adjust comment when known what it does
+// handleNamespaceSealStatus handles the "/sys/namespaces/<name>/seal-status" endpoint to .
+func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", name)
+		}
+
+		status, err := b.Core.sealManager.GetSealStatus(ctx, ns, false)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if status == nil {
+			return nil, nil
+		}
+
+		return &logical.Response{Data: map[string]interface{}{"seal_status": status}}, nil
+	}
+}
+
+// handleNamespacesSeal handles the "/sys/namespaces/<name>/seal" endpoint to seal the namespace.
+func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		err := b.Core.namespaceStore.SealNamespace(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
+	}
+}
+
+// handleNamespacesUnseal handles the "/sys/namespaces/<name>/unseal" endpoint to unseal the namespace.
+func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		name := namespace.Canonicalize(data.Get("name").(string))
+		key := data.Get("key").(string)
+
+		if len(name) > 0 && strings.Contains(name[:len(name)-1], "/") {
+			return nil, errors.New("name must not contain /")
+		}
+
+		if key == "" {
+			return nil, errors.New("provided key is empty")
+		}
+
+		var decodedKey []byte
+		decodedKey, err := hex.DecodeString(key)
+		if err != nil {
+			decodedKey, err = base64.StdEncoding.DecodeString(key)
+			if err != nil {
+				return handleError(err)
+			}
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, name)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", name)
+		}
+
+		err = b.Core.sealManager.UnsealNamespace(ctx, ns, decodedKey)
+		if err != nil {
+			invalidKeyErr := &ErrInvalidKey{}
+			switch {
+			case errors.As(err, &invalidKeyErr):
+			case errors.Is(err, ErrBarrierInvalidKey):
+			case errors.Is(err, ErrBarrierNotInit):
+			case errors.Is(err, ErrBarrierSealed):
+			default:
+				return logical.RespondWithStatusCode(logical.ErrorResponse(err.Error()), req, http.StatusInternalServerError)
+			}
+			return handleError(err)
+		}
+
+		status, err := b.Core.sealManager.GetSealStatus(ctx, ns, true)
+		if err != nil {
+			return nil, err
+		}
+
+		return &logical.Response{Data: map[string]interface{}{
+			"seal_status": status,
+		}}, nil
+	}
+}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1386,6 +1386,9 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	globalEntries := make(map[string][]string, len(allNamespaces))
 	localEntries := make(map[string][]string, len(allNamespaces))
 	for index, ns := range allNamespaces {
+		if c.IsNSSealed(ns) {
+			continue
+		}
 		view := c.NamespaceView(ns)
 		nsGlobal, nsLocal, err := listTransactionalMountsForNamespace(ctx, view)
 		if err != nil {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1997,17 +1997,48 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 
 	if c.mounts != nil {
 		mountTable := c.mounts.shallowClone()
-		for _, e := range mountTable.Entries {
-			backend := c.router.MatchingBackend(namespace.ContextWithNamespace(ctx, e.namespace), e.Path)
-			if backend != nil {
-				backend.Cleanup(ctx)
-			}
-		}
+		c.cleanupMountBackends(ctx, mountTable, "", false, func(*MountEntry) bool { return true })
 	}
 
 	c.mounts = nil
 	c.router.reset()
 	c.systemBarrierView = nil
+	return nil
+}
+
+// unloadNamespaceMounts is used before we seal the namespace to reset the mounts to
+// their unloaded state, calling Cleanup if defined
+func (c *Core) UnloadNamespaceMounts(ctx context.Context, ns *namespace.Namespace, predicate func(*MountEntry) bool) error {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	if c.mounts != nil {
+		mountTable := c.mounts.shallowClone()
+		if err := c.cleanupMountBackends(ctx, mountTable, "", true, predicate); err != nil {
+			return err
+		}
+	}
+	if c.logger.IsInfo() {
+		c.logger.Info(fmt.Sprintf("successfully unmounted namespace %q mounts from mount table", ns.Path))
+	}
+	return nil
+}
+
+func (c *Core) cleanupMountBackends(ctx context.Context, mountTable *MountTable, pathPrefix string, unmountRouter bool, predicate func(*MountEntry) bool) error {
+	for _, e := range mountTable.Entries {
+		if predicate(e) {
+			nsCtx := namespace.ContextWithNamespace(ctx, e.namespace)
+			backend := c.router.MatchingBackend(nsCtx, pathPrefix+e.Path)
+			if backend != nil {
+				backend.Cleanup(ctx)
+			}
+			if unmountRouter {
+				if err := c.router.Unmount(nsCtx, e.Path); err != nil {
+					return err
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -832,7 +832,7 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 }
 
 // SealNamespace seals namespace with provided path, failing to do so if the namespace
-// doesn't exist, is a root namespace, is tainted or is actively deleting.
+// doesn't exist, is a root namespace or is tainted.
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -773,18 +773,8 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 
 func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespaceToDelete *namespace.Namespace) bool {
 	// clear ACL policies
-	policiesToClear, err := ns.core.policyStore.ListPolicies(nsCtx, PolicyTypeACL, false)
-	if err != nil {
-		ns.logger.Error("failed to retrieve namespace policies", "namespace", namespaceToDelete.Path, "error", err.Error())
+	if err := ns.clearNamespacePolicies(nsCtx, namespaceToDelete, true); err != nil {
 		return false
-	}
-
-	for _, policy := range policiesToClear {
-		err := ns.core.policyStore.deletePolicyForce(nsCtx, policy, PolicyTypeACL)
-		if err != nil {
-			ns.logger.Error(fmt.Sprintf("failed to delete policy %q", policy), "namespace", namespaceToDelete.Path, "error", err.Error())
-			return false
-		}
 	}
 
 	// clear auth mounts
@@ -839,6 +829,42 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 	return true
 }
 
+func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace *namespace.Namespace, physicalDeletion bool) error {
+	policiesToClear, err := ns.core.policyStore.ListPolicies(ctx, PolicyTypeACL, false)
+	if err != nil {
+		ns.logger.Error("failed to retrieve namespace policies", "namespace", namespace.Path, "error", err.Error())
+		return err
+	}
+
+	for _, policy := range policiesToClear {
+		if physicalDeletion {
+			err := ns.core.policyStore.deletePolicyForce(ctx, policy, PolicyTypeACL)
+			if err != nil {
+				ns.logger.Error(fmt.Sprintf("failed to delete policy %q", policy), "namespace", namespace.Path, "error", err.Error())
+				return err
+			}
+		} else {
+			ns.core.policyStore.invalidate(ctx, policy, PolicyTypeACL)
+		}
+	}
+	return nil
+}
+
+func (ns *NamespaceStore) UnloadNamespaceCredentials(ctx context.Context, namespace *namespace.Namespace) error {
+	return ns.core.UnloadNamespaceCredentialMounts(ctx, namespace, namespaceMatchPredicate(namespace))
+}
+
+func (ns *NamespaceStore) UnloadNamespaceMounts(ctx context.Context, namespace *namespace.Namespace) error {
+	return ns.core.UnloadNamespaceMounts(ctx, namespace, namespaceMatchPredicate(namespace))
+}
+
+// Returns true if mount entry namespace UUID matches the given namespace UUID
+func namespaceMatchPredicate(targetNS *namespace.Namespace) func(*MountEntry) bool {
+	return func(e *MountEntry) bool {
+		return e.namespace.UUID == targetNS.UUID
+	}
+}
+
 // SealNamespace seals namespace with provided path, failing to do so if the namespace
 // doesn't exist, is a root namespace or is tainted.
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
@@ -867,7 +893,7 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal tainted namespace")
 	}
 
-	return ns.core.sealManager.SealNamespace(namespaceToSeal)
+	return ns.core.sealManager.SealNamespace(ctx, namespaceToSeal)
 }
 
 // UnsealNamespace unseals namespace with a given path, using provided key

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -236,6 +236,14 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 			return false, err
 		}
 
+		isSealed, err := ns.core.sealManager.RegisterNamespace(ctx, &namespace)
+		if err != nil {
+			return false, fmt.Errorf("failed to register namespace %s with seal manager: %w", namespace.ID, err)
+		}
+		if isSealed {
+			return true, nil
+		}
+
 		childView := ns.core.NamespaceView(&namespace).SubView(namespaceStoreSubPath)
 		if err := ns.loadNamespacesRecursive(ctx, barrier, childView, callback); err != nil {
 			return false, err

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -886,7 +886,7 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return errors.New("unable to unseal root namespace")
 	}
 
-	return ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal.Path, key)
+	return ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal, key)
 }
 
 // ResolveNamespaceFromRequest resolves a namespace from the 'X-Vault-Namespace'

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -181,9 +181,14 @@ func (sm *SealManager) SecretProgress(ns *namespace.Namespace, lock bool) (int, 
 }
 
 func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespace, lock bool) (*SealStatusResponse, error) {
+	// Verify that any kind of seal exists for a namespace
+	seals, ok := sm.sealsByNamespace[ns.UUID]
+	if !ok {
+		return nil, nil
+	}
+
 	// Check the barrier first
 	barrier := sm.NamespaceBarrier(ns.Path)
-
 	init, err := barrier.Initialized(ctx)
 	if err != nil {
 		sm.logger.Error("namespace barrier init check failed", "namespace", ns.Path, "error", err)
@@ -194,7 +199,7 @@ func (sm *SealManager) GetSealStatus(ctx context.Context, ns *namespace.Namespac
 		return nil, nil
 	}
 
-	seal := sm.sealsByNamespace[ns.UUID]["default"]
+	seal := seals["default"]
 	// Verify the seal configuration
 	sealConf, err := seal.Config(ctx)
 	if err != nil {

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -104,7 +104,7 @@ func TestDefaultSeal_IsNSSealed(t *testing.T) {
 	err := sm.SetSeal(ctx, sealConfig, ns, true)
 	require.NoError(t, err)
 
-	err = sm.SealNamespace(ns)
+	err = sm.SealNamespace(ctx, ns)
 	require.NoError(t, err)
 	require.True(t, c.IsNSSealed(ns))
 }


### PR DESCRIPTION
Implements parts of #1170

List of changes:
- Added request rejection for the sealed namespaces
- Implemented namespace unsealing
- Implemented loading of sealed namespaces after unsealing
- Implemented unmounting mounts on seal of the namespace