### PR TITLE
Add bao operator subcommand for config validation

### DIFF
--- a/changelog/1609.txt
+++ b/changelog/1609.txt
@@ -1,5 +1,3 @@
 ```release-note:improvement
-cli: add new subcommand "bao operator validate-config" to validate a config.
-It is similar to "bao operator diagnose", but it only validates the config and not the system it is running on (e.g. it will not check that the raft directory is writable).
-This allows it to be used on an operators Laptop or in CI validations.
+cli: add new subcommand "bao operator validate-config" to validate a configuration file syntax
 ```

--- a/changelog/1609.txt
+++ b/changelog/1609.txt
@@ -1,0 +1,5 @@
+```release-note:feature
+cli: add new subcommand "bao operator validate-config" to validate a config.
+It is similar to "bao operator diagnose", but it only validates the config and not the system it is running on (e.g. it will not check that the raft directory is writable).
+This allows it to be used on an operators Laptop or in CI validations.
+```

--- a/changelog/1609.txt
+++ b/changelog/1609.txt
@@ -1,4 +1,4 @@
-```release-note:feature
+```release-note:improvement
 cli: add new subcommand "bao operator validate-config" to validate a config.
 It is similar to "bao operator diagnose", but it only validates the config and not the system it is running on (e.g. it will not check that the raft directory is writable).
 This allows it to be used on an operators Laptop or in CI validations.

--- a/command/commands.go
+++ b/command/commands.go
@@ -367,6 +367,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"operator members": func() (cli.Command, error) {
+			return &OperatorMembersCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"operator migrate": func() (cli.Command, error) {
 			return &OperatorMigrateCommand{
 				BaseCommand:      getBaseCommand(),
@@ -459,8 +464,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
-		"operator members": func() (cli.Command, error) {
-			return &OperatorMembersCommand{
+		"operator validate-config": func() (cli.Command, error) {
+			return &OperatorValidateConfigCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -179,9 +179,12 @@ func (c *OperatorDiagnoseCommand) RunWithParsedFlags() int {
 		c.UI.Output("\nResults:")
 		w, _, err := term.GetSize(0)
 		if err == nil {
-			results.Write(os.Stdout, w)
-		} else {
-			results.Write(os.Stdout, 0)
+			w = 0
+		}
+		err = results.Write(os.Stdout, w)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error printing results: %v.", err)
+			return 4
 		}
 	}
 

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -526,22 +526,22 @@ func compareResult(exp *diagnose.Result, act *diagnose.Result) error {
 	}
 	if exp.Status != act.Status {
 		if act.Status != diagnose.OkStatus {
-			return fmt.Errorf("section %s, status mismatch: %s vs %s, got error %s", exp.Name, exp.Status, act.Status, act.Message)
+			return fmt.Errorf("section %q, status mismatch: %s vs %s, got error %s", exp.Name, exp.Status, act.Status, act.Message)
 		}
-		return fmt.Errorf("section %s, status mismatch: %s vs %s", exp.Name, exp.Status, act.Status)
+		return fmt.Errorf("section %q, status mismatch: %s vs %s", exp.Name, exp.Status, act.Status)
 	}
 	if exp.Message != "" && exp.Message != act.Message && !strings.Contains(act.Message, exp.Message) {
-		return fmt.Errorf("section %s, message not found: %s in %s", exp.Name, exp.Message, act.Message)
+		return fmt.Errorf("section %q, message not found: %q in %q", exp.Name, exp.Message, act.Message)
 	}
 	if exp.Advice != "" && exp.Advice != act.Advice && !strings.Contains(act.Advice, exp.Advice) {
-		return fmt.Errorf("section %s, advice not found: %s in %s", exp.Name, exp.Advice, act.Advice)
+		return fmt.Errorf("section %q, advice not found: %q in %q", exp.Name, exp.Advice, act.Advice)
 	}
 	if len(exp.Warnings) != len(act.Warnings) {
-		return fmt.Errorf("section %s, warning count mismatch: %d vs %d", exp.Name, len(exp.Warnings), len(act.Warnings))
+		return fmt.Errorf("section %q, warning count mismatch: %d vs %d", exp.Name, len(exp.Warnings), len(act.Warnings))
 	}
 	for j := range exp.Warnings {
 		if !strings.Contains(act.Warnings[j], exp.Warnings[j]) {
-			return fmt.Errorf("section %s, warning message not found: %s in %s", exp.Name, exp.Warnings[j], act.Warnings[j])
+			return fmt.Errorf("section %q, warning message not found: %q in %q", exp.Name, exp.Warnings[j], act.Warnings[j])
 		}
 	}
 	if len(exp.Children) > len(act.Children) {

--- a/command/operator_validate_config.go
+++ b/command/operator_validate_config.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	log "github.com/hashicorp/go-hclog"
+
+	"github.com/openbao/openbao/vault/diagnose"
+	"github.com/openbao/openbao/version"
+	"github.com/posener/complete"
+	"golang.org/x/term"
+)
+
+var (
+	_ cli.Command             = (*OperatorValidateConfigCommand)(nil)
+	_ cli.CommandAutocomplete = (*OperatorValidateConfigCommand)(nil)
+)
+
+type OperatorValidateConfigCommand struct {
+	*BaseCommand
+	diagnose *diagnose.Session
+
+	flagConfigs []string
+}
+
+func (c *OperatorValidateConfigCommand) Synopsis() string {
+	return "Validate OpenBao configuration files"
+}
+
+func (c *OperatorValidateConfigCommand) Help() string {
+	helpText := `
+Usage: bao operator validate-config
+
+  This command validates OpenBao configuration.
+  It will detect invalid syntax, unknown properties and invalid types.
+  Some problems like wrong cluster_addr (i.e. a missing DNS entry) won't be
+  detected as this can only be detected at runtime.
+  Some problems are deliberately not detected, e.g. that the raft path is writable.
+  This is to ensure that a configuration can be validated on a different machine
+  for example an operators laptop or during Pull Request validation.
+  To include this kind of tests use  "bao operator diagnose" instead.
+
+  Validate a configuration file:
+
+     $ bao operator validate-config -config=/etc/openbao/config.hcl
+
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorValidateConfigCommand) Flags() *FlagSets {
+	set := NewFlagSets(c.UI)
+	f := set.NewFlagSet("Command Options")
+
+	f.StringSliceVar(&StringSliceVar{
+		Name:   "config",
+		Target: &c.flagConfigs,
+		Completion: complete.PredictOr(
+			complete.PredictFiles("*.hcl"),
+			complete.PredictFiles("*.json"),
+			complete.PredictDirs("*"),
+		),
+		Usage: "Path to an OpenBao configuration file or directory of configuration " +
+			"files. This flag can be specified multiple times to load multiple " +
+			"configurations. If the path is a directory, all files which end in " +
+			".hcl or .json are loaded.",
+	})
+
+	f.StringVar(&StringVar{
+		Name:   "format",
+		Target: &c.flagFormat,
+		Usage:  "The output format",
+	})
+
+	return set
+}
+
+func (c *OperatorValidateConfigCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *OperatorValidateConfigCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorValidateConfigCommand) Run(args []string) int {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 3
+	}
+	return c.RunWithParsedFlags()
+}
+
+func (c *OperatorValidateConfigCommand) RunWithParsedFlags() int {
+	if len(c.flagConfigs) == 0 {
+		c.UI.Error("Must specify a configuration file using -config.")
+		return 3
+	}
+
+	if c.diagnose == nil {
+		if c.flagFormat == "json" {
+			c.diagnose = diagnose.New(io.Discard)
+		} else {
+			c.UI.Output(version.GetVersion().FullVersionNumber(true))
+			c.diagnose = diagnose.New(os.Stdout)
+		}
+	}
+	ctx := diagnose.Context(context.Background(), c.diagnose)
+	c.validateConfig(ctx)
+
+	results := c.diagnose.Finalize(ctx)
+	if c.flagFormat == "json" {
+		resultsJS, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error marshalling results: %v.", err)
+			return 4
+		}
+		c.UI.Output(string(resultsJS))
+	} else {
+		w, _, err := term.GetSize(0)
+		if err == nil {
+			w = 0
+		}
+		err = results.Write(os.Stdout, w)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error printing results: %v.", err)
+			return 4
+		}
+	}
+
+	// Use a different return code
+	switch results.Status {
+	case diagnose.WarningStatus:
+		return 2
+	case diagnose.ErrorStatus:
+		return 1
+	}
+	return 0
+}
+
+func (c *OperatorValidateConfigCommand) validateConfig(ctx context.Context) {
+	server := &ServerCommand{
+		BaseCommand: c.BaseCommand,
+
+		logger: log.NewInterceptLogger(&log.LoggerOptions{
+			Level: log.Off,
+		}),
+		allLoggers: []log.Logger{},
+	}
+
+	ctx, span := diagnose.StartSpan(ctx, "Validate Config")
+	defer span.End()
+
+	server.flagConfigs = c.flagConfigs
+
+	_, configErrors, err := server.parseConfig()
+	if err != nil {
+		diagnose.Fail(ctx, fmt.Sprintf("Could not parse configuration: %v.", err))
+		return
+	}
+	for _, ce := range configErrors {
+		diagnose.Warn(ctx, diagnose.CapitalizeFirstLetter(ce.String())+".")
+		return
+	}
+
+	diagnose.Success(ctx, "Vault configuration syntax is ok.")
+}

--- a/command/operator_validate_config_test.go
+++ b/command/operator_validate_config_test.go
@@ -7,10 +7,13 @@ package command
 
 import (
 	"io"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/vault/diagnose"
+	"github.com/stretchr/testify/require"
 )
 
 func testOperatorValidateConfigCommand(tb testing.TB) *OperatorValidateConfigCommand {
@@ -27,57 +30,70 @@ func testOperatorValidateConfigCommand(tb testing.TB) *OperatorValidateConfigCom
 
 func TestOperatorValidateConfigCommand_Run(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		name     string
-		args     []string
-		expected diagnose.Result
-	}{
-		{
-			"file_not_found",
-			[]string{
-				"-config", "./file/not.found",
-			},
-			diagnose.Result{
-				Name:    "Validate Config",
-				Status:  diagnose.ErrorStatus,
-				Message: "no such file or directory.",
-			},
-		}, {
-			"invalid_syntax",
-			[]string{
-				"-config", "./server/test-fixtures/diagnose_bad_syntax.hcl",
-			},
-			diagnose.Result{
-				Name:    "Validate Config",
-				Status:  diagnose.ErrorStatus,
-				Message: "expected: IDENT | STRING got: LBRACE",
-			},
-		}, {
-			"unknown_property",
-			[]string{
-				"-config", "./server/test-fixtures/diagnose_unknown_property.hcl",
-			},
-			diagnose.Result{
-				Name:     "Validate Config",
-				Status:   diagnose.WarningStatus,
-				Message:  "",
-				Warnings: []string{"Unknown or unsupported field unknown found in configuration"},
-			},
+
+	warn := func(warnings ...string) diagnose.Result {
+		return diagnose.Result{
+			Name:     "Validate Config",
+			Status:   diagnose.WarningStatus,
+			Message:  "",
+			Warnings: warnings,
+		}
+	}
+
+	expectedErrors := map[string]diagnose.Result{
+		"config2.hcl.json":                        warn("Unknown or unsupported field sentinel found in configuration"),
+		"config2.hcl":                             warn("Unknown or unsupported field sentinel found in configuration"),
+		"config3.hcl":                             warn("Unknown or unsupported field sentinel found in configuration"),
+		"config.hcl":                              warn("Unknown or unsupported field sentinel found in configuration"),
+		"config_raft.hcl":                         warn("Unknown or unsupported field sentinel found in configuration"),
+		"tls_config_ok.hcl":                       warn("Unknown or unsupported field sentinel found in configuration"),
+		"diagnose_unknown_property.hcl":           warn("Unknown or unsupported field unknown found in configuration"),
+		"hcp_link_config.hcl":                     warn("Unknown or unsupported field cloud found in configuration"),
+		"config_bad_https_storage.hcl":            warn("Unknown or unsupported field sentinel found in configuration"),
+		"diagnose_bad_https_consul_sr.hcl":        warn("Unknown or unsupported field sentinel found in configuration"),
+		"config5.hcl":                             warn("Unknown or unsupported field sentinel found in configuration"),
+		"config.hcl.json":                         warn("Unknown or unsupported field sentinel found in configuration"),
+		"config_diagnose_hastorage_bad_https.hcl": warn("Unknown or unsupported field sentinel found in configuration"),
+		"diagnose_bad_syntax.hcl": {
+			Name:    "Validate Config",
+			Status:  diagnose.ErrorStatus,
+			Message: "expected: IDENT | STRING got: LBRACE",
 		},
 	}
 
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	files, err := os.ReadDir("./server/test-fixtures/")
+	require.NoError(t, err)
+
+	test := func(filename string, expected diagnose.Result) {
+		t.Run(filename, func(t *testing.T) {
 			t.Parallel()
 			cmd := testOperatorValidateConfigCommand(t)
 
-			cmd.Run(tc.args)
+			cmd.Run([]string{"-config", path.Join("./server/test-fixtures/", filename)})
 			result := cmd.diagnose.Finalize(t.Context())
 
-			if err := compareResult(&tc.expected, result); err != nil {
+			if err := compareResult(&expected, result); err != nil {
 				t.Fatalf("Did not find expected test results: %v", err)
 			}
 		})
 	}
+
+	for _, file := range files {
+		expected, ok := expectedErrors[file.Name()]
+		if !ok {
+			expected = diagnose.Result{
+				Name:    "Validate Config",
+				Status:  diagnose.OkStatus,
+				Message: "",
+			}
+		}
+
+		test(file.Name(), expected)
+	}
+
+	test("./file/not.found", diagnose.Result{
+		Name:    "Validate Config",
+		Status:  diagnose.ErrorStatus,
+		Message: "no such file or directory",
+	})
 }

--- a/command/operator_validate_config_test.go
+++ b/command/operator_validate_config_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !race
+
+package command
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/vault/diagnose"
+)
+
+func testOperatorValidateConfigCommand(tb testing.TB) *OperatorValidateConfigCommand {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return &OperatorValidateConfigCommand{
+		diagnose: diagnose.New(io.Discard),
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestOperatorValidateConfigCommand_Run(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		args     []string
+		expected diagnose.Result
+	}{
+		{
+			"file_not_found",
+			[]string{
+				"-config", "./file/not.found",
+			},
+			diagnose.Result{
+				Name:    "Validate Config",
+				Status:  diagnose.ErrorStatus,
+				Message: "no such file or directory.",
+			},
+		}, {
+			"invalid_syntax",
+			[]string{
+				"-config", "./server/test-fixtures/diagnose_bad_syntax.hcl",
+			},
+			diagnose.Result{
+				Name:    "Validate Config",
+				Status:  diagnose.ErrorStatus,
+				Message: "expected: IDENT | STRING got: LBRACE",
+			},
+		}, {
+			"unknown_property",
+			[]string{
+				"-config", "./server/test-fixtures/diagnose_unknown_property.hcl",
+			},
+			diagnose.Result{
+				Name:     "Validate Config",
+				Status:   diagnose.WarningStatus,
+				Message:  "",
+				Warnings: []string{"Unknown or unsupported field unknown found in configuration"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := testOperatorValidateConfigCommand(t)
+
+			cmd.Run(tc.args)
+			result := cmd.diagnose.Finalize(t.Context())
+
+			if err := compareResult(&tc.expected, result); err != nil {
+				t.Fatalf("Did not find expected test results: %v", err)
+			}
+		})
+	}
+}

--- a/command/server/test-fixtures/diagnose_bad_syntax.hcl
+++ b/command/server/test-fixtures/diagnose_bad_syntax.hcl
@@ -1,0 +1,4 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+invalid = {{}

--- a/command/server/test-fixtures/diagnose_unknown_property.hcl
+++ b/command/server/test-fixtures/diagnose_unknown_property.hcl
@@ -1,0 +1,4 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+unknown = {}

--- a/website/content/docs/commands/operator/diagnose.mdx
+++ b/website/content/docs/commands/operator/diagnose.mdx
@@ -27,8 +27,8 @@ flags](/docs/commands) included on all commands.
 ### Output options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
-  `BAO_FORMAT` environment variable.
+  formats are "table" or "json". This can also be specified via the `BAO_FORMAT`
+  environment variable.
 
 #### Output layout
 

--- a/website/content/docs/commands/operator/validate-config.mdx
+++ b/website/content/docs/commands/operator/validate-config.mdx
@@ -1,0 +1,36 @@
+---
+sidebar_label: validate-config
+description: |-
+  "bao operator validate-config" is a new operator-centric command, focused on 
+  validating OpenBao configuration. It is similar to "bao operator diagnose",
+  but it only validates the config and not the system it is running on (e.g. it 
+  will not check that the raft directory is writable). This allows it to be 
+  used on an operators Laptop or in CI validations.
+
+---
+
+# validate-config
+
+The operator diagnose command should be used primarily before the configuration
+is copied to the OpenBao nodes. For example on the operators Laptop and/or in
+CI validations, if you manage your configuration with git.
+You might also want to run it on the OpenBao node after updating the configuration
+and before restarting the node.
+In case your OpenBao nodes does not start, running [`bao operator disgnose`](
+../diagnose) should be preferred.
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](/docs/commands) included on all commands.
+
+### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table" or "json". This can also be specified via the `BAO_FORMAT`
+  environment variable.
+
+### Command options
+
+- `-config` `(string; "")` - The path to the OpenBao configuration file used by
+the OpenBao server on startup.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -191,6 +191,7 @@ const sidebars: SidebarsConfig = {
                         "commands/operator/seal",
                         "commands/operator/step-down",
                         "commands/operator/unseal",
+                        "commands/operator/validate-config",
                     ],
                 },
                 "commands/patch",


### PR DESCRIPTION
Resolves https://github.com/openbao/openbao/issues/1591

Useage:

```command
$ bao operator validate-config -config node-000.json
OpenBao v2.0.0-HEAD ('3918fbaa775aaaf228fbffdf4176960047a2a873+CHANGES'), built 2025-07-31T12:58:01Z
[ warning ] Validate Config: Unknown or unsupported field unknown found in configuration at node-000.json.
```