### PR TITLE
website: let user fully collapse accordion

### DIFF
--- a/website/src/components/FAQSection/index.tsx
+++ b/website/src/components/FAQSection/index.tsx
@@ -93,7 +93,7 @@ export default function FAQSection() {
                 key={index}
                 item={item}
                 isExpanded={index === expanded}
-                onClick={() => setExpanded(index)}
+                onClick={() => setExpanded(index === expanded ? -1 : index)}
               />
             ))}
           </div>


### PR DESCRIPTION
The "-" button on the front page accordion doesn't actually do anything, and I haven't been able to forget about it again. This lets you manually collapse the item by clicking the button, other existing behavior is retained.

<img width="1832" height="850" alt="image" src="https://github.com/user-attachments/assets/8ac05b3e-261a-41af-aef2-edc9ee94c8b0" />

