### PR TITLE
drop legacy mapstructure hook in favor of upstream alternative 

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openbao/openbao/command/agentproxyshared"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/internalshared/configutil"
-	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/pointerutil"
 )
 
@@ -1168,7 +1167,7 @@ func parseTemplates(result *Config, list *ast.ObjectList) error {
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
 				ctconfig.StringToFileModeFunc(),
 				ctconfig.StringToWaitDurationHookFunc(),
-				framework.LegacyStringToSliceHookFunc(","),
+				mapstructure.StringToWeakSliceHookFunc(","),
 				mapstructure.StringToTimeDurationHookFunc(),
 			),
 			ErrorUnused: true,
@@ -1216,7 +1215,7 @@ func parseExec(result *Config, list *ast.ObjectList) error {
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			ctconfig.StringToFileModeFunc(),
 			ctconfig.StringToWaitDurationHookFunc(),
-			framework.LegacyStringToSliceHookFunc(","),
+			mapstructure.StringToWeakSliceHookFunc(","),
 			mapstructure.StringToTimeDurationHookFunc(),
 			ctsignals.StringToSignalFunc(),
 		),
@@ -1273,7 +1272,7 @@ func parseEnvTemplates(result *Config, list *ast.ObjectList) error {
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
 				ctconfig.StringToFileModeFunc(),
 				ctconfig.StringToWaitDurationHookFunc(),
-				framework.LegacyStringToSliceHookFunc(","),
+				mapstructure.StringToWeakSliceHookFunc(","),
 				mapstructure.StringToTimeDurationHookFunc(),
 				ctsignals.StringToSignalFunc(),
 			),

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -290,7 +289,7 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 		config := &mapstructure.DecoderConfig{
 			Result:           &result,
 			WeaklyTypedInput: true,
-			DecodeHook:       LegacyStringToSliceHookFunc(","),
+			DecodeHook:       mapstructure.StringToWeakSliceHookFunc(","),
 		}
 		decoder, err := mapstructure.NewDecoder(config)
 		if err != nil {
@@ -480,24 +479,4 @@ func (d *FieldData) GetTimeWithExplicitDefault(field string, defaultValue time.D
 		return time.Duration(assignedValue.(int)) * time.Second
 	}
 	return defaultValue
-}
-
-// LegacyStringToSliceHookFunc(sep string) is a duplicates the old mapstructure's StringToSliceHookFunc, which supports weak conversion.
-func LegacyStringToSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
-	return func(
-		f reflect.Kind,
-		t reflect.Kind,
-		data interface{},
-	) (interface{}, error) {
-		if f != reflect.String || t != reflect.Slice {
-			return data, nil
-		}
-
-		raw := data.(string)
-		if raw == "" {
-			return []string{}, nil
-		}
-
-		return strings.Split(raw, sep), nil
-	}
 }


### PR DESCRIPTION
We should be able to drop our own `LegacyStringToSliceHookFunc` now that a version of it was added upstream in https://github.com/go-viper/mapstructure/releases/tag/v2.4.0.