### PR TITLE
Ensure lowercase policy in entities to forbid root policy

### DIFF
--- a/changelog/1627.txt
+++ b/changelog/1627.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/identity: Correctly lowercase policy names to prevent root policy assignment. HCSEC-2025-13 / CVE-2025-5999.
+```

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -355,7 +355,7 @@ func (i *IdentityStore) handleEntityUpdateCommon() framework.OperationFunc {
 		// Update the policies if supplied
 		entityPoliciesRaw, ok := d.GetOk("policies")
 		if ok {
-			entity.Policies = strutil.RemoveDuplicates(entityPoliciesRaw.([]string), false)
+			entity.Policies = strutil.RemoveDuplicates(entityPoliciesRaw.([]string), true /* lowercase */)
 		}
 
 		if strutil.StrListContains(entity.Policies, "root") {
@@ -470,7 +470,7 @@ func (i *IdentityStore) handleEntityReadCommon(ctx context.Context, entity *iden
 	respData["name"] = entity.Name
 	respData["metadata"] = entity.Metadata
 	respData["merged_entity_ids"] = entity.MergedEntityIDs
-	respData["policies"] = strutil.RemoveDuplicates(entity.Policies, false)
+	respData["policies"] = strutil.RemoveDuplicates(entity.Policies, true /* lowercase */)
 	respData["disabled"] = entity.Disabled
 	respData["namespace_id"] = entity.NamespaceID
 
@@ -1061,7 +1061,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 		// If told to, merge policies
 		if mergePolicies {
-			toEntity.Policies = strutil.RemoveDuplicates(strutil.MergeSlices(toEntity.Policies, fromEntity.Policies), false)
+			toEntity.Policies = strutil.RemoveDuplicates(strutil.MergeSlices(toEntity.Policies, fromEntity.Policies), true /* lowercase */)
 		}
 
 		// If the entity from which we are merging from was already a merged

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1392,7 +1392,7 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 
 	// Remove duplicate policies
 	if group.Policies != nil {
-		group.Policies = strutil.RemoveDuplicates(group.Policies, false)
+		group.Policies = strutil.RemoveDuplicates(group.Policies, true /* lowercase */)
 	}
 
 	txn := i.db(ctx).Txn(true)

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -203,7 +203,7 @@ func (c *Core) filterGroupPoliciesByNS(ctx context.Context, tokenNS *namespace.N
 		if err != nil && err != ErrNoApplicablePolicies {
 			return nil, err
 		}
-		filteredPolicies = strutil.RemoveDuplicates(filteredPolicies, false)
+		filteredPolicies = strutil.RemoveDuplicates(filteredPolicies, true /* lowercase */)
 		if len(filteredPolicies) != 0 {
 			policies[nsID] = append(policies[nsID], filteredPolicies...)
 		}


### PR DESCRIPTION
When validating a policy is not the root policy, ensure we first lowercase policy names before comparing. This ensures a malicious entity administrator cannot directly escalate to the root policy. While this is nominally bad, any access to identity subsystem is highly privileged and should be adequately restricted as it allows granting access to additional policies. These policies may in turn allow writing new or modifying existing policies, which means practically root-like access anyways.

See also: https://discuss.hashicorp.com/t/hcsec-2025-13-vault-root-namespace-operator-may-elevate-token-privileges/76032