### PR TITLE
Address login MFA TOTP reuse vulnerability

### DIFF
--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -48,6 +48,24 @@ func doTwoPhaseLogin(t *testing.T, client *api.Client, totpCodePath, methodID, u
 	if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
 		t.Fatalf("MFA validation failed to return a ClientToken in secret: %v", secret)
 	}
+
+	// Redo the test, ensuring that the TOTP cannot be reused. This validates
+	// against HCSEC-2025-19 / CVE-2025-6015.
+	mfaSecret, err = client.Auth().MFALogin(context.Background(), upMethod)
+	if err != nil {
+		t.Fatalf("failed to initiate second login with userpass auth method: %v", err)
+	}
+
+	secret, err = client.Auth().MFAValidate(
+		context.Background(),
+		mfaSecret,
+		map[string]interface{}{
+			methodID: []string{totpPasscode},
+		},
+	)
+	if err == nil || secret != nil {
+		t.Fatalf("MFA validation succeeded when it should fail: err=%v / secret=%v", err, secret)
+	}
 }
 
 func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
@@ -301,7 +319,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 		_, maxErr = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 			"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 			"mfa_payload": map[string][]string{
-				methodID: {fmt.Sprintf("%d", i)},
+				methodID: {fmt.Sprintf("%d23456", i)},
 			},
 		})
 		if maxErr == nil {

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2329,8 +2329,19 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 }
 
 func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMethodSecret *mfa.Secret, configID, entityID string, usedCodes *cache.Cache, maximumValidationAttempts uint32) error {
+	// In HCSEC-2025-19, HashiCorp writes:
+	//
+	// > The TOTP validation will now return a generic error if the passcode
+	// > was already used.
+	//
+	// While such error message is of limited utility, as multiple error paths
+	// yielding the same error will likely still yield timing differences and
+	// thus are distinguishable to a determined attacker, we attempt to follow
+	// the same and yield the error "MFA credentials not supplied or incorrect"
+	// from multiple code paths here.
+
 	if mfaFactors == nil || mfaFactors.passcode == "" {
-		return errors.New("MFA credentials not supplied")
+		return errors.New("MFA credentials not supplied or incorrect")
 	}
 	passcode := mfaFactors.passcode
 
@@ -2339,16 +2350,22 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 		return errors.New("entity does not contain the TOTP secret")
 	}
 
+	// Validate the passcode has the right format for this totp.
+	if strings.TrimSpace(passcode) != passcode || len(passcode) != int(totpSecret.Digits) {
+		return errors.New("MFA credentials not supplied or incorrect")
+	}
+
 	usedName := fmt.Sprintf("%s_%s", configID, passcode)
 
 	_, ok := usedCodes.Get(usedName)
 	if ok {
-		return fmt.Errorf("code already used; new code is available in %v seconds", totpSecret.Period)
+		return errors.New("MFA credentials not supplied or incorrect")
 	}
 
 	// The duration in which a passcode is stored in cache to enforce
-	// rate limit on failed totp passcode validation
-	passcodeTTL := time.Duration(int64(time.Second) * int64(totpSecret.Period))
+	// rate limit on failed totp passcode validation. See note in
+	// totp/path_code.go for duration calculation.
+	passcodeTTL := time.Duration(int64(time.Second)*int64(totpSecret.Period) + int64(2*totpSecret.Skew))
 
 	// Enforcing rate limit per MethodID per EntityID
 	rateLimitID := fmt.Sprintf("%s_%s", configID, entityID)
@@ -2392,7 +2409,7 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 	}
 
 	if !valid {
-		return errors.New("failed to validate TOTP passcode")
+		return errors.New("MFA credentials not supplied or incorrect")
 	}
 
 	// Take the key skew, add two for behind and in front, and multiply that by


### PR DESCRIPTION
When validating the provided TOTP code during login MFA, the underlying library silently allowed trimming of the provided TOTP code. This meant the cache potentially did not contain the correct format of the passcode and would no be used for limiting future reused requests, allowing an attacker to successfully acquire a token by injecting whitespace from exfiltrated credentials.

We additionally adjust the error message and cache condition here to ensure full coverage of this secret.

See also: https://discuss.hashicorp.com/t/hcsec-2025-19-vault-login-mfa-bypass-of-rate-limiting-and-totp-token-reuse/76038
