### PR TITLE
Address login plugin lookahead contract failures

### DIFF
--- a/builtin/credential/jwt/path_cel_login.go
+++ b/builtin/credential/jwt/path_cel_login.go
@@ -159,7 +159,7 @@ func (b *jwtAuthBackend) pathCelLogin(ctx context.Context, req *logical.Request,
 	}
 
 	// execute celRoleEntry.AuthProgram
-	pbAuth, err := b.runCelProgram(ctx, celRoleEntry, allClaims)
+	pbAuth, err := b.runCelProgram(ctx, req.Operation, celRoleEntry, allClaims)
 	if err != nil {
 		return logical.ErrorResponse("error executing cel program: %s", err.Error()), nil
 	}
@@ -179,8 +179,8 @@ func (b *jwtAuthBackend) pathCelLogin(ctx context.Context, req *logical.Request,
 }
 
 // runCelProgram executes the CelProgram for the celRoleEntry and returns a pb.Auth or error
-func (b *jwtAuthBackend) runCelProgram(ctx context.Context, celRoleEntry *celRoleEntry, allClaims map[string]any) (*pb.Auth, error) {
-	result, err := b.celEvalProgram(celRoleEntry.CelProgram, allClaims)
+func (b *jwtAuthBackend) runCelProgram(ctx context.Context, operation logical.Operation, celRoleEntry *celRoleEntry, allClaims map[string]any) (*pb.Auth, error) {
+	result, err := b.celEvalProgram(celRoleEntry.CelProgram, operation, allClaims)
 	if err != nil {
 		return nil, fmt.Errorf("Cel role auth program failed: %w", err)
 	}

--- a/builtin/credential/jwt/path_cel_login_test.go
+++ b/builtin/credential/jwt/path_cel_login_test.go
@@ -173,7 +173,7 @@ func Test_runCelProgram(t *testing.T) {
 			if !ok {
 				t.Fatalf("Expected jwtAuthBackend, got %T", logicalBackend)
 			}
-			role, err := b.runCelProgram(context.Background(), &tc.celRole, tc.claims)
+			role, err := b.runCelProgram(context.Background(), logical.UpdateOperation, &tc.celRole, tc.claims)
 			if tc.validateResult != nil {
 				tc.validateResult(t, err, role)
 			}

--- a/builtin/credential/jwt/path_cel_role.go
+++ b/builtin/credential/jwt/path_cel_role.go
@@ -99,20 +99,20 @@ func pathCelRole(b *jwtAuthBackend) *framework.Path {
 		},
 		"expiration_leeway": {
 			Type: framework.TypeSignedDurationSecond,
-			Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew. 
-Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
+			Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew.
+ Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 			Default: claimDefaultLeeway,
 		},
 		"not_before_leeway": {
 			Type: framework.TypeSignedDurationSecond,
-			Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew. 
-Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
+			Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew.
+ Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 			Default: claimDefaultLeeway,
 		},
 		"clock_skew_leeway": {
 			Type: framework.TypeSignedDurationSecond,
-			Description: `Duration in seconds of leeway when validating all claims to account for clock skew. 
-Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
+			Description: `Duration in seconds of leeway when validating all claims to account for clock skew.
+ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 			Default: jwt.DefaultLeeway,
 		},
 		"bound_audiences": {
@@ -148,20 +148,20 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 			},
 			"expiration_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew. 
-Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
+				Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew.
+ Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 				Default: claimDefaultLeeway,
 			},
 			"not_before_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew. 
-Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
+				Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew.
+ Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 				Default: claimDefaultLeeway,
 			},
 			"clock_skew_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating all claims to account for clock skew. 
-Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
+				Description: `Duration in seconds of leeway when validating all claims to account for clock skew.
+ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 				Default: jwt.DefaultLeeway,
 			},
 			"bound_audiences": {
@@ -413,14 +413,14 @@ func validateCelRoleCreation(b *jwtAuthBackend, entry *celRoleEntry, ctx context
 
 func (b *jwtAuthBackend) validateCelProgram(program celhelper.CelProgram) (bool, error) {
 	// adding a minimal jwtClaims collection here, for validating usages in CEL expression
-	_, err := b.celEvalProgram(program, map[string]any{"sub": "email@example.com", "aud": "audience", "iss": "issuer"})
+	_, err := b.celEvalProgram(program, logical.UpdateOperation, map[string]any{"sub": "email@example.com", "aud": "audience", "iss": "issuer"})
 	if err != nil {
 		return false, fmt.Errorf("failed to validate CEL program: %w", err)
 	}
 	return true, nil
 }
 
-func (b *jwtAuthBackend) celEvalProgram(program celhelper.CelProgram, jwtClaims map[string]any) (any, error) {
+func (b *jwtAuthBackend) celEvalProgram(program celhelper.CelProgram, operation logical.Operation, jwtClaims map[string]any) (any, error) {
 	env, err := b.celEnv(program)
 	if err != nil {
 		return nil, err
@@ -429,8 +429,9 @@ func (b *jwtAuthBackend) celEvalProgram(program celhelper.CelProgram, jwtClaims 
 	// The "request" key allows CEL expressions to access and evaluate against input fields.
 	// Additional variables and evaluated results will be added dynamically during processing.
 	evaluationData := map[string]interface{}{
-		"claims": jwtClaims,
-		"now":    time.Now(),
+		"claims":    jwtClaims,
+		"now":       time.Now(),
+		"operation": string(operation),
 	}
 
 	// Evaluate all variables

--- a/builtin/credential/radius/path_login.go
+++ b/builtin/credential/radius/path_login.go
@@ -65,7 +65,10 @@ func pathLogin(b *backend) *framework.Path {
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := d.Get("username").(string)
 	if username == "" {
-		return nil, errors.New("missing username")
+		username = d.Get("urlusername").(string)
+		if username == "" {
+			return nil, errors.New("missing username")
+		}
 	}
 
 	return &logical.Response{

--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -59,7 +59,7 @@ func pathLogin(b *backend) *framework.Path {
 }
 
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	username := d.Get("username").(string)
+	username := strings.ToLower(d.Get("username").(string))
 	if username == "" {
 		return nil, errors.New("missing username")
 	}

--- a/changelog/1632.txt
+++ b/changelog/1632.txt
@@ -1,0 +1,5 @@
+```release-note:security
+core/auth: Correctly handle alias lookahead for user lockout consistency. HCSEC-2025-16 / CVE-2025-6004.
+auth/userpass: Consistently handle alias lookahead as case insensitive. HCSEC-2025-16 / CVE-2025-6004.
+auth/ldap: Attempt consistent entity aliasing w.r.t. spacing and casing. HCSEC-2025-16 / CVE-2025-6004 and HCSEC-2025-20 / CVE-2025-6013.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -3294,6 +3294,7 @@ func (c *Core) loadLoginMFAConfigs(ctx context.Context) error {
 
 type MFACachedAuthResponse struct {
 	CachedAuth            *logical.Auth
+	CachedUserLockout     *FailedLoginUser
 	RequestPath           string
 	RequestNSID           string
 	RequestNSPath         string

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -1225,13 +1225,13 @@ func TestExpiration_RegisterAuth_NoTTL(t *testing.T) {
 	}
 
 	// First on core
-	_, err = c.RegisterAuth(ctx, 0, "auth/github/login", auth, "", true)
+	_, err = c.RegisterAuth(ctx, 0, "auth/github/login", auth, "", true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	auth.TokenPolicies[0] = "default"
-	_, err = c.RegisterAuth(ctx, 0, "auth/github/login", auth, "", true)
+	_, err = c.RegisterAuth(ctx, 0, "auth/github/login", auth, "", true, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/vault/external_tests/userpass_binary/ip_token_binding_test.go
+++ b/vault/external_tests/userpass_binary/ip_token_binding_test.go
@@ -135,7 +135,10 @@ func Test_StrictIPBinding(t *testing.T) {
 
 		"-H", "Content-Type: application/json",
 		"--data", `{"password": "password"}`,
-		"https://" + vaultAddr + ":8200/v1/auth/userpass/login/testing",
+		// We switch the username to Testing to ensure case validation
+		// does not affect user lockout attribution. This is a test
+		// to validate our fix for HCSEC-2025-16 / CVE-2025-6004.
+		"https://" + vaultAddr + ":8200/v1/auth/userpass/login/Testing",
 	}
 	stdout, stderr, retcode, err = curlRunner.RunCmdWithOutput(ctx, curlResult.Container.ID, curlCmd)
 	t.Logf("cURL Command: %v\nstdout: %v\nstderr: %v\n", curlCmd, string(stdout), string(stderr))
@@ -145,8 +148,11 @@ func Test_StrictIPBinding(t *testing.T) {
 	var data map[string]interface{}
 	err = json.Unmarshal(stdout, &data)
 	require.NoError(t, err)
+	require.NotContains(t, data, "errors")
+	require.Contains(t, data, "auth")
 
 	auth := data["auth"].(map[string]interface{})
+	require.Contains(t, auth, "client_token")
 	remoteToken := auth["client_token"].(string)
 
 	// Using the remote token locally should fail...

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -795,7 +795,7 @@ func (b *LoginMFABackend) handleMFALoginValidate(ctx context.Context, req *logic
 	}
 
 	// MFA validation has passed. Let's generate the token
-	resp, err := b.Core.LoginMFACreateToken(ctx, cachedResponseAuth.RequestPath, cachedResponseAuth.CachedAuth, req.Data, !req.IsInlineAuth)
+	resp, err := b.Core.LoginMFACreateToken(ctx, cachedResponseAuth.RequestPath, cachedResponseAuth.CachedAuth, req.Data, !req.IsInlineAuth, cachedResponseAuth.CachedUserLockout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a token. error: %v", err)
 	}
@@ -820,7 +820,7 @@ func (c *Core) teardownLoginMFA() error {
 
 // LoginMFACreateToken creates a token after the login MFA is validated.
 // It also applies the lease quotas on the original login request path.
-func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAuth *logical.Auth, loginRequestData map[string]interface{}, persistToken bool) (*logical.Response, error) {
+func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAuth *logical.Auth, loginRequestData map[string]interface{}, persistToken bool, userLockoutInfo *FailedLoginUser) (*logical.Response, error) {
 	auth := cachedAuth
 	resp := &logical.Response{
 		Auth: auth,
@@ -839,7 +839,7 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 		role = reqRole.(string)
 	}
 
-	_, resp, err = c.LoginCreateToken(ctx, ns, reqPath, mountPoint, role, resp, persistToken)
+	_, resp, err = c.LoginCreateToken(ctx, ns, reqPath, mountPoint, role, resp, persistToken, userLockoutInfo)
 	return resp, err
 }
 


### PR DESCRIPTION
```patch
commit 94657267e2730a00e83427b012a648fecbec4952
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Wed Aug 6 13:26:47 2025 -0500

    Address login plugin lookahead contract failures
    
    As part of HCSEC-2025-16, various plugins lacked did not conform to the
    entity alias lookahead contract; a different alias was returned in the
    login request as what is ultimately used at runtime. We have two ways of
    solving this:
    
    1. Only take the value at lookahead time. This means that for two users
       X, Y with different input data but similar aliases (e.g., subtly
       different LDAP bindings which result in accessing the same account),
       lockout will be incorrect.
    2. Or, we could strictly enforce that these two values match. This is
       the approach we opt for and subsequently enforce through
       authentication failures and core log messages in vault/.
    
    This is fundamentally a plugin (programming) failure that it does not
    match the expected interface contract.
    
    In the case of LDAP, this change is rather significant: we now incur a
    full roundtrip to the LDAP server (with authentication) in certain
    code paths.
    
    See also: https://discuss.hashicorp.com/t/hcsec-2025-16-vault-userpass-and-ldap-user-lockout-bypass/76035
    See also: https://discuss.hashicorp.com/t/hcsec-2025-20-vault-ldap-mfa-enforcement-bypass-when-using-username-as-alias/76092
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>

commit d5ffa61442dc73c22d925133715441cb165be1ea
Author: Alexander Scheel <ascheel@gitlab.com>
Date:   Wed Aug 6 13:26:54 2025 -0500

    Refactor user lockout contract
    
    As part of HCSEC-2025-16, the general pattern of expecting the auth
    engine to be consistent between alias lookahead (strictly used for uesr
    lockout cache to prevent brute-forcing) and the final entity (which is
    used for the identity system and login MFA enforcement) is difficult.
    
    Plugins SHOULD return consistent data between the two, but as the
    lookahead needs to be cheap and ideally constant time to avoid user
    enumeration, it is hard to be in systems like LDAP which return
    different data at login time.
    
    This refactor ensures that user lockout behaves consistently regardless
    of whether the plugin responds consistently. In all scenarios, the
    initial response from lookahead is subsequently used to mark either a
    failed login or a valid authentication attempt. However, this first look
    is not used externally (in plugin<->identity entity aliasing) and thus
    is strictly an internal change. Thus, it may not necessarily align with
    effective user lockout.
    
    Plugins must on their own attempt to return consistently in login
    aliases; two inputs with equivalent lookahead values (e.g., spaces
    trimmed in usernames) SHOULD have equivalent alias values. However,
    any discrepancies between lookahead and alias values will not cause
    issues for lockout bypass now.
    
    See also: https://discuss.hashicorp.com/t/hcsec-2025-16-vault-userpass-and-ldap-user-lockout-bypass/76035
    
    Signed-off-by: Alexander Scheel <ascheel@gitlab.com>
```