### PR TITLE
Disable audit mount creation via API + disable audit log prefixing

### DIFF
--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/builtin/audit/file"
+	"github.com/openbao/openbao/command/server"
 	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
@@ -24,6 +25,9 @@ import (
 
 func TestTransit_Issue_2958(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
+		RawConfig: &server.Config{
+			UnsafeAllowAPIAuditCreation: true,
+		},
 		LogicalBackends: map[string]logical.Factory{
 			"transit": Factory,
 		},

--- a/changelog/1634.txt
+++ b/changelog/1634.txt
@@ -1,0 +1,5 @@
+```release-note:security
+audit: Add server configuration options to disable audit mount creation via the API and to disable audit log prefixing.
+  - `unsafe_allow_api_audit_creation (default: false)` controls the ability to create audit mounts via the API
+  - `allow_audit_log_prefixing (default: false)` controls the availability of the prefix audit mount option
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -113,6 +113,9 @@ type Config struct {
 
 	UnsafeCrossNamespaceIdentity bool `hcl:"unsafe_cross_namespace_identity"`
 
+	UnsafeAllowAPIAuditCreation bool `hcl:"unsafe_allow_api_audit_creation"`
+	AllowAuditLogPrefixing      bool `hcl:"allow_audit_log_prefixing"`
+
 	// Initialization is a configuration object that helps to initialize
 	// OpenBao. It can be specified multiple times and each instance can
 	// contain one or more `request` objects. This is used by the
@@ -417,6 +420,21 @@ func (c *Config) Merge(c2 *Config) *Config {
 	result.EnableResponseHeaderRaftNodeID = c.EnableResponseHeaderRaftNodeID
 	if c2.EnableResponseHeaderRaftNodeID {
 		result.EnableResponseHeaderRaftNodeID = c2.EnableResponseHeaderRaftNodeID
+	}
+
+	result.UnsafeCrossNamespaceIdentity = c.UnsafeCrossNamespaceIdentity
+	if c2.UnsafeCrossNamespaceIdentity {
+		result.UnsafeCrossNamespaceIdentity = c2.UnsafeCrossNamespaceIdentity
+	}
+
+	result.UnsafeAllowAPIAuditCreation = c.UnsafeAllowAPIAuditCreation
+	if c2.UnsafeAllowAPIAuditCreation {
+		result.UnsafeAllowAPIAuditCreation = c2.UnsafeAllowAPIAuditCreation
+	}
+
+	result.AllowAuditLogPrefixing = c.AllowAuditLogPrefixing
+	if c2.AllowAuditLogPrefixing {
+		result.AllowAuditLogPrefixing = c2.AllowAuditLogPrefixing
 	}
 
 	// Use values from top-level configuration for storage if set
@@ -1087,6 +1105,11 @@ func (c *Config) Sanitized() map[string]interface{} {
 		"detect_deadlocks": c.DetectDeadlocks,
 
 		"imprecise_lease_role_tracking": c.ImpreciseLeaseRoleTracking,
+
+		"unsafe_cross_namespace_identity": c.UnsafeCrossNamespaceIdentity,
+
+		"unsafe_allow_api_audit_creation": c.UnsafeAllowAPIAuditCreation,
+		"allow_audit_log_prefixing":       c.AllowAuditLogPrefixing,
 	}
 	for k, v := range sharedResult {
 		result[k] = v

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -777,8 +777,11 @@ func testConfig_Sanitized(t *testing.T) {
 			"num_lease_metrics_buckets":              168,
 			"add_lease_metrics_namespace_labels":     false,
 		},
-		"administrative_namespace_path": "admin/",
-		"imprecise_lease_role_tracking": false,
+		"administrative_namespace_path":   "admin/",
+		"imprecise_lease_role_tracking":   false,
+		"unsafe_cross_namespace_identity": false,
+		"unsafe_allow_api_audit_creation": false,
+		"allow_audit_log_prefixing":       false,
 	}
 
 	addExpectedEntSanitizedConfig(expected, []string{"http"})

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -21,6 +21,7 @@ import (
 	auditFile "github.com/openbao/openbao/builtin/audit/file"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	kv "github.com/openbao/openbao/builtin/logical/kv"
+	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/internalshared/configutil"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -611,6 +612,7 @@ func TestLogical_Audit_invalidWrappingToken(t *testing.T) {
 	// Create a noop audit backend
 	noop := corehelpers.TestNoopAudit(t, nil)
 	c, _, root := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
 		AuditBackends: map[string]audit.Factory{
 			"noop": func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
 				return noop, nil
@@ -986,6 +988,9 @@ func TestLogical_AuditEnabled_ShouldLogPluginMetadata_Auth(t *testing.T) {
 // in audit log when it is enabled
 func TestLogical_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
+		RawConfig: &server.Config{
+			UnsafeAllowAPIAuditCreation: true,
+		},
 		LogicalBackends: map[string]logical.Factory{
 			"kv": kv.VersionedKVFactory,
 		},

--- a/http/sys_audit_test.go
+++ b/http/sys_audit_test.go
@@ -8,11 +8,20 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openbao/openbao/audit"
+	"github.com/openbao/openbao/command/server"
+	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/vault"
 )
 
 func TestSysAudit(t *testing.T) {
-	core, _, token := vault.TestCoreUnsealed(t)
+	core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 	TestServerAuth(t, addr, token)
@@ -60,7 +69,13 @@ func TestSysAudit(t *testing.T) {
 }
 
 func TestSysDisableAudit(t *testing.T) {
-	core, _, token := vault.TestCoreUnsealed(t)
+	core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 	TestServerAuth(t, addr, token)
@@ -97,7 +112,13 @@ func TestSysDisableAudit(t *testing.T) {
 }
 
 func TestSysAuditHash(t *testing.T) {
-	core, _, token := vault.TestCoreUnsealed(t)
+	core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 	TestServerAuth(t, addr, token)

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -171,9 +171,12 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 						"type":   "tcp",
 					},
 				},
-				"storage":                       tc.expectedStorageOutput,
-				"administrative_namespace_path": "",
-				"imprecise_lease_role_tracking": false,
+				"storage":                         tc.expectedStorageOutput,
+				"administrative_namespace_path":   "",
+				"imprecise_lease_role_tracking":   false,
+				"unsafe_cross_namespace_identity": false,
+				"unsafe_allow_api_audit_creation": false,
+				"allow_audit_log_prefixing":       false,
 			}
 
 			if tc.expectedHAStorageOutput != nil {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 	semver "github.com/hashicorp/go-version"
 	"github.com/openbao/openbao/audit"
+	auditFile "github.com/openbao/openbao/builtin/audit/file"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
+	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/builtinplugins"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
@@ -2266,15 +2268,21 @@ func TestSystemBackend_tuneAuth(t *testing.T) {
 func TestSystemBackend_tuneSys(t *testing.T) {
 	// Create a noop audit backend
 	var noop *corehelpers.NoopAudit
-	c, b, root := testCoreSystemBackend(t)
-	c.auditBackends["noop"] = func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
-		var err error
-		noop, err = corehelpers.NewNoopAudit(config.Config)
-		if err != nil {
-			return nil, err
-		}
-		return noop, nil
-	}
+	c, _, root := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"noop": func(ctx context.Context, config *audit.BackendConfig) (audit.Backend, error) {
+				var err error
+				noop, err = corehelpers.NewNoopAudit(config.Config)
+				if err != nil {
+					return nil, err
+				}
+				return noop, nil
+			},
+		},
+	})
+
+	b := c.systemBackend
 
 	// Validate Tune behavior.
 	req := logical.TestRequest(t, logical.UpdateOperation, "mounts/sys/tune")
@@ -2561,13 +2569,12 @@ func TestSystemBackend_PoliciesDetailedAcl(t *testing.T) {
 }
 
 func TestSystemBackend_enableAudit(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
-	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
+	b := testSystemBackendUnsafeAuditCreation(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
 	req.Data["type"] = "noop"
 
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	resp, err := b.HandleRequest(namespace.RootContext(context.Background()), req)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2631,8 +2638,7 @@ func TestSystemBackend_decodeToken(t *testing.T) {
 }
 
 func TestSystemBackend_auditHash(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
-	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
+	b := testSystemBackendUnsafeAuditCreation(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
 	req.Data["type"] = "noop"
@@ -2680,10 +2686,12 @@ func TestSystemBackend_auditHash(t *testing.T) {
 }
 
 func TestSystemBackend_enableAudit_invalid(t *testing.T) {
-	b := testSystemBackend(t)
+	b := testSystemBackendUnsafeAuditCreation(t)
+
 	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
 	req.Data["type"] = "nope"
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+
+	resp, err := b.HandleRequest(namespace.RootContext(context.Background()), req)
 	if err != logical.ErrInvalidRequest {
 		t.Fatalf("err: %v", err)
 	}
@@ -2692,9 +2700,61 @@ func TestSystemBackend_enableAudit_invalid(t *testing.T) {
 	}
 }
 
+func TestSystemBackend_enableAudit_apiCreationDisabled(t *testing.T) {
+	// Note: this is not 'testSystemBackendUnsafeAuditCreation',
+	// so unsafe audit creation is false.
+	b := testSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
+	req.Data["type"] = "noop"
+
+	_, err := b.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.ErrorIs(t, err, logical.ErrInvalidRequest)
+}
+
+func TestSystemBackend_enableAudit_withPrefix(t *testing.T) {
+	c, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		RawConfig: &server.Config{
+			UnsafeAllowAPIAuditCreation: true,
+			AllowAuditLogPrefixing:      false,
+		},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+
+	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
+	req.Data["type"] = "noop"
+	req.Data["options"] = map[string]any{"prefix": "foo"}
+
+	_, err := c.systemBackend.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.ErrorIs(t, err, logical.ErrInvalidRequest)
+
+	req = logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
+	req.Data["type"] = "noop"
+	_, err = c.systemBackend.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.NoError(t, err)
+
+	c, _, _ = TestCoreUnsealedWithConfig(t, &CoreConfig{
+		RawConfig: &server.Config{
+			UnsafeAllowAPIAuditCreation: true,
+			AllowAuditLogPrefixing:      true,
+		},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+
+	req = logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
+	req.Data["type"] = "noop"
+	req.Data["options"] = map[string]any{"prefix": "foo"}
+
+	_, err = c.systemBackend.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.NoError(t, err)
+}
+
 func TestSystemBackend_auditTable(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
-	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
+	b := testSystemBackendUnsafeAuditCreation(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
 	req.Data["type"] = "noop"
@@ -2728,26 +2788,23 @@ func TestSystemBackend_auditTable(t *testing.T) {
 }
 
 func TestSystemBackend_disableAudit(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
-	c.auditBackends["noop"] = corehelpers.NoopAuditFactory(nil)
+	b := testSystemBackendUnsafeAuditCreation(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "audit/foo")
 	req.Data["type"] = "noop"
 	req.Data["description"] = "testing"
-	req.Data["options"] = map[string]interface{}{
-		"foo": "bar",
-	}
-	b.HandleRequest(namespace.RootContext(nil), req)
+	req.Data["options"] = map[string]any{"foo": "bar"}
+
+	// Register it
+	resp, err := b.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
 
 	// Deregister it
 	req = logical.TestRequest(t, logical.DeleteOperation, "audit/foo")
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp != nil {
-		t.Fatalf("bad: %v", resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.Background()), req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
 }
 
 func TestSystemBackend_rawRead_Compressed(t *testing.T) {
@@ -3533,6 +3590,17 @@ func testCoreSystemBackendRaw(t *testing.T) (*Core, logical.Backend, string) {
 	return c, c.systemBackend, root
 }
 
+func testSystemBackendUnsafeAuditCreation(t *testing.T) logical.Backend {
+	t.Helper()
+	c, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"noop": corehelpers.NoopAuditFactory(nil),
+		},
+	})
+	return c.systemBackend
+}
+
 func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	c, b, _ := testCoreSystemBackend(t)
 	// Bootstrap the pluginCatalog
@@ -3709,7 +3777,12 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 }
 
 func TestSystemBackend_PluginCatalog_ListPlugins_SucceedsWithAuditLogEnabled(t *testing.T) {
-	core, b, root := testCoreSystemBackend(t)
+	c, _, root := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true},
+		AuditBackends: map[string]audit.Factory{
+			"file": auditFile.Factory,
+		},
+	})
 
 	tempDir := t.TempDir()
 	f, err := os.CreateTemp(tempDir, "")
@@ -3726,7 +3799,7 @@ func TestSystemBackend_PluginCatalog_ListPlugins_SucceedsWithAuditLogEnabled(t *
 		},
 	}
 	ctx := namespace.RootContext(nil)
-	resp, err := b.HandleRequest(ctx, req)
+	resp, err := c.systemBackend.HandleRequest(ctx, req)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("resp: %#v, err: %v", resp, err)
 	}
@@ -3734,7 +3807,7 @@ func TestSystemBackend_PluginCatalog_ListPlugins_SucceedsWithAuditLogEnabled(t *
 	// List plugins
 	req = logical.TestRequest(t, logical.ReadOperation, "sys/plugins/catalog")
 	req.ClientToken = root
-	resp, err = core.HandleRequest(ctx, req)
+	resp, err = c.HandleRequest(ctx, req)
 	if err != nil || resp == nil || resp.IsError() {
 		t.Fatalf("resp: %#v, err: %v", resp, err)
 	}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1642,6 +1642,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	if coreConfig.RawConfig == nil {
 		c := new(server.Config)
 		c.SharedConfig = &configutil.SharedConfig{LogFormat: logging.UnspecifiedFormat.String()}
+		c.UnsafeAllowAPIAuditCreation = true
 		coreConfig.RawConfig = c
 	}
 


### PR DESCRIPTION
Audit mount creation via the API places too much control over the underlying host in the operator's hands, as [^1] has shown. This introduces two new server configuration options:

- `unsafe_allow_api_audit_creation (default: false)` controls the ability to create audit mounts via the API
- `allow_audit_log_prefixing (default: false)` controls the availability of the `prefix` audit mount option

In the future (v2.4) we plan to move audit mount management almost entirely into the configuration file, providing an alternative to the now deprecated management via API. For now, the creation of new audit mounts will require setting `unsafe_allow_api_audit_creation = true`. This option can be reloaded at runtime via SIGHUP. Existing audit mounts are unaffected, unless they use the `prefix` option, in which case `allow_audit_log_prefixing = true` is required.

[^1]: https://discuss.hashicorp.com/t/hcsec-2025-14-privileged-vault-operator-may-execute-code-on-the-underlying-host/76033