### PR TITLE
feat(sys/seal-status): send both barrier and recovery seal types

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -96,21 +96,22 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 }
 
 type SealStatusResponse struct {
-	Type         string   `json:"type"`
-	Initialized  bool     `json:"initialized"`
-	Sealed       bool     `json:"sealed"`
-	T            int      `json:"t"`
-	N            int      `json:"n"`
-	Progress     int      `json:"progress"`
-	Nonce        string   `json:"nonce"`
-	Version      string   `json:"version"`
-	BuildDate    string   `json:"build_date"`
-	Migration    bool     `json:"migration"`
-	ClusterName  string   `json:"cluster_name,omitempty"`
-	ClusterID    string   `json:"cluster_id,omitempty"`
-	RecoverySeal bool     `json:"recovery_seal"`
-	StorageType  string   `json:"storage_type,omitempty"`
-	Warnings     []string `json:"warnings,omitempty"`
+	Type             string   `json:"type"`
+	Initialized      bool     `json:"initialized"`
+	Sealed           bool     `json:"sealed"`
+	T                int      `json:"t"`
+	N                int      `json:"n"`
+	Progress         int      `json:"progress"`
+	Nonce            string   `json:"nonce"`
+	Version          string   `json:"version"`
+	BuildDate        string   `json:"build_date"`
+	Migration        bool     `json:"migration"`
+	ClusterName      string   `json:"cluster_name,omitempty"`
+	ClusterID        string   `json:"cluster_id,omitempty"`
+	RecoverySeal     bool     `json:"recovery_seal"`
+	RecoverySealType string   `json:"recover_seal_type,omitempty"`
+	StorageType      string   `json:"storage_type,omitempty"`
+	Warnings         []string `json:"warnings,omitempty"`
 }
 
 type UnsealOpts struct {

--- a/command/format.go
+++ b/command/format.go
@@ -290,13 +290,16 @@ func (t TableFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) 
 func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, secret *api.Secret, data interface{}) error {
 	var status SealStatusOutput = data.(SealStatusOutput)
 	var sealPrefix string
-	if status.RecoverySeal {
-		sealPrefix = "Recovery "
-	}
 
 	out := []string{}
 	out = append(out, "Key | Value")
-	out = append(out, fmt.Sprintf("%sSeal Type | %s", sealPrefix, status.Type))
+	out = append(out, fmt.Sprintf("Seal Type | %s", status.Type))
+
+	if status.RecoverySeal {
+		sealPrefix = "Recovery "
+		out = append(out, fmt.Sprintf("Recovery Seal Type | %s", status.RecoverySealType))
+	}
+
 	out = append(out, fmt.Sprintf("Initialized | %t", status.Initialized))
 	out = append(out, fmt.Sprintf("Sealed | %t", status.Sealed))
 	out = append(out, fmt.Sprintf("Total %sShares | %d", sealPrefix, status.N))

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4497,21 +4497,22 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 }
 
 type SealStatusResponse struct {
-	Type         string   `json:"type"`
-	Initialized  bool     `json:"initialized"`
-	Sealed       bool     `json:"sealed"`
-	T            int      `json:"t"`
-	N            int      `json:"n"`
-	Progress     int      `json:"progress"`
-	Nonce        string   `json:"nonce"`
-	Version      string   `json:"version"`
-	BuildDate    string   `json:"build_date"`
-	Migration    bool     `json:"migration"`
-	ClusterName  string   `json:"cluster_name,omitempty"`
-	ClusterID    string   `json:"cluster_id,omitempty"`
-	RecoverySeal bool     `json:"recovery_seal"`
-	StorageType  string   `json:"storage_type,omitempty"`
-	Warnings     []string `json:"warnings,omitempty"`
+	Type             string   `json:"type"`
+	Initialized      bool     `json:"initialized"`
+	Sealed           bool     `json:"sealed"`
+	T                int      `json:"t"`
+	N                int      `json:"n"`
+	Progress         int      `json:"progress"`
+	Nonce            string   `json:"nonce"`
+	Version          string   `json:"version"`
+	BuildDate        string   `json:"build_date"`
+	Migration        bool     `json:"migration"`
+	ClusterName      string   `json:"cluster_name,omitempty"`
+	ClusterID        string   `json:"cluster_id,omitempty"`
+	RecoverySeal     bool     `json:"recovery_seal"`
+	RecoverySealType string   `json:"recover_seal_type,omitempty"`
+	StorageType      string   `json:"storage_type,omitempty"`
+	Warnings         []string `json:"warnings,omitempty"`
 }
 
 func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResponse, error) {
@@ -4523,8 +4524,10 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 	}
 
 	var sealConfig *SealConfig
+	var recoveryType string
 	if core.SealAccess().RecoveryKeySupported() {
 		sealConfig, err = core.SealAccess().RecoveryConfig(ctx)
+		recoveryType = core.SealAccess().RecoveryType()
 	} else {
 		sealConfig, err = core.SealAccess().BarrierConfig(ctx)
 	}
@@ -4534,13 +4537,14 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 
 	if sealConfig == nil {
 		s := &SealStatusResponse{
-			Type:         core.SealAccess().BarrierType().String(),
-			Initialized:  initialized,
-			Sealed:       true,
-			RecoverySeal: core.SealAccess().RecoveryKeySupported(),
-			StorageType:  core.StorageType(),
-			Version:      version.GetVersion().VersionNumber(),
-			BuildDate:    version.BuildDate,
+			Type:             core.SealAccess().BarrierType().String(),
+			Initialized:      initialized,
+			Sealed:           true,
+			RecoverySeal:     core.SealAccess().RecoveryKeySupported(),
+			RecoverySealType: recoveryType,
+			StorageType:      core.StorageType(),
+			Version:          version.GetVersion().VersionNumber(),
+			BuildDate:        version.BuildDate,
 		}
 
 		return s, nil
@@ -4563,20 +4567,21 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResp
 	progress, nonce := core.SecretProgress(lock)
 
 	s := &SealStatusResponse{
-		Type:         sealConfig.Type,
-		Initialized:  initialized,
-		Sealed:       sealed,
-		T:            sealConfig.SecretThreshold,
-		N:            sealConfig.SecretShares,
-		Progress:     progress,
-		Nonce:        nonce,
-		Version:      version.GetVersion().VersionNumber(),
-		BuildDate:    version.BuildDate,
-		Migration:    core.IsInSealMigrationMode(lock) && !core.IsSealMigrated(lock),
-		ClusterName:  clusterName,
-		ClusterID:    clusterID,
-		RecoverySeal: core.SealAccess().RecoveryKeySupported(),
-		StorageType:  core.StorageType(),
+		Type:             core.SealAccess().BarrierType().String(),
+		Initialized:      initialized,
+		Sealed:           sealed,
+		T:                sealConfig.SecretThreshold,
+		N:                sealConfig.SecretShares,
+		Progress:         progress,
+		Nonce:            nonce,
+		Version:          version.GetVersion().VersionNumber(),
+		BuildDate:        version.BuildDate,
+		Migration:        core.IsInSealMigrationMode(lock) && !core.IsSealMigrated(lock),
+		ClusterName:      clusterName,
+		ClusterID:        clusterID,
+		RecoverySeal:     core.SealAccess().RecoveryKeySupported(),
+		RecoverySealType: recoveryType,
+		StorageType:      core.StorageType(),
 	}
 
 	return s, nil

--- a/vault/seal_access.go
+++ b/vault/seal_access.go
@@ -38,6 +38,10 @@ func (s *SealAccess) RecoveryKeySupported() bool {
 	return s.seal.RecoveryKeySupported()
 }
 
+func (s *SealAccess) RecoveryType() string {
+	return s.seal.RecoveryType()
+}
+
 func (s *SealAccess) RecoveryConfig(ctx context.Context) (*SealConfig, error) {
 	return s.seal.RecoveryConfig(ctx)
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

Currently the `type` return on `v1/sys/seal-status` will always return `shamir`, as it references the barrier seal on manual unsealed clusters and the recovery seal on auto unsealed clusters.

With this PR it will be changed, so that the `type` will always return the barrier seal type and on auto unsealed clusters an additional `recovery_seal_type` will be sent.

This aligns with how Vault responds:
```
curl http://localhost:8200/v1/sys/seal-status | jq
{
  "type": "azurekeyvault",
  "initialized": true,
  "sealed": false,
  "t": 3,
  "n": 5,
  "progress": 0,
  "nonce": "",
  "version": "1.19.5",
  "build_date": "2024-08-06T20:45:58Z",
  "migration": false,
  "cluster_name": "vault-cluster-1acf9bdd",
  "cluster_id": "c43a6842-8e9d-ef17-d31c-0edc588956d1",
  "recovery_seal": true,
  "storage_type": "inmem",
  "recovery_seal_type": "shamir"
}
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves https://github.com/openbao/openbao-helm/issues/79
