### PR TITLE
fix(oidc-provider): correctly lowercase identity IDs (#1539)

### DIFF
--- a/changelog/1539.txt
+++ b/changelog/1539.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Fix unintentional lowercasing of namespace accessor in assignments.
+```

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -783,9 +783,13 @@ func (i *IdentityStore) pathOIDCCreateUpdateAssignment(ctx context.Context, req 
 		assignment.GroupIDs = d.Get("group_ids").([]string)
 	}
 
-	// remove duplicates and lowercase entities and groups
-	assignment.EntityIDs = strutil.RemoveDuplicates(assignment.EntityIDs, true)
-	assignment.GroupIDs = strutil.RemoveDuplicates(assignment.GroupIDs, true)
+	// lowercase UUID segments
+	assignment.EntityIDs = lowercaseIdentityIDs(assignment.EntityIDs)
+	assignment.GroupIDs = lowercaseIdentityIDs(assignment.GroupIDs)
+
+	// remove duplicates
+	assignment.EntityIDs = strutil.RemoveDuplicates(assignment.EntityIDs, false)
+	assignment.GroupIDs = strutil.RemoveDuplicates(assignment.GroupIDs, false)
 
 	// store assignment
 	entry, err := logical.StorageEntryJSON(assignmentPath+name, assignment)

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3721,3 +3721,27 @@ func TestOIDC_Path_OpenIDProviderConfig_ProviderDoesNotExist(t *testing.T) {
 		t.Fatalf("expected empty response but got success; error:\n%v\nresp: %#v", err, resp)
 	}
 }
+
+// TestOIDC_lowercaseIdentityIDs tests the lowercaseIdentityIDs helper function.
+func TestOIDC_lowercaseIdentityIDs(t *testing.T) {
+	mock := []string{
+		"8e226D22-c816-5E00-5b5B-89401D705300.MgXgy3",
+		"818c8a5b-fbc4-6a36-17da-de199b773117.GRwtkZ",
+		"7c4125b3-b3ca-ec6c-1b5f-96e75dd6957e",
+		"9d2a2b65-0D89-62bB-8f19-6A2F0130E056",
+	}
+	expected := []string{
+		"8e226d22-c816-5e00-5b5b-89401d705300.MgXgy3",
+		"818c8a5b-fbc4-6a36-17da-de199b773117.GRwtkZ",
+		"7c4125b3-b3ca-ec6c-1b5f-96e75dd6957e",
+		"9d2a2b65-0d89-62bb-8f19-6a2f0130e056",
+	}
+
+	// test that helper does not mutate the original slice
+	lowercaseIdentityIDs(mock)
+	require.NotEqual(t, expected, mock, "should not mutate the original slice")
+
+	// test the helper
+	mock = lowercaseIdentityIDs(mock)
+	require.Equal(t, expected, mock)
+}

--- a/vault/identity_store_oidc_provider_util.go
+++ b/vault/identity_store_oidc_provider_util.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -107,4 +108,21 @@ func authCodeUsedPKCE(entry *authCodeCacheEntry) bool {
 func basicAuth(req *logical.Request) (string, string, bool) {
 	headerReq := &http.Request{Header: req.Headers}
 	return headerReq.BasicAuth()
+}
+
+// lowercaseIdentityIDs lowercases the UUID segments of given entity IDs
+// without affecting namespace accessor.
+func lowercaseIdentityIDs(identities []string) []string {
+	out := make([]string, len(identities))
+
+	for i, identityID := range identities {
+		id, namespaceID, ok := strings.Cut(identityID, ".")
+		if !ok { // bare ID with no namespace
+			out[i] = strings.ToLower(identityID)
+			continue
+		}
+		out[i] = strings.ToLower(id) + "." + namespaceID
+	}
+
+	return out
 }


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/1539. 