### PR TITLE
Fix TOTP engine verification reuse bypass (#1625)

### DIFF
--- a/changelog/1625.txt
+++ b/changelog/1625.txt
@@ -1,0 +1,3 @@
+```release-note:security
+secrets/totp: Fix TOTP verification reuse bypass when the TOTP code contains spaces. HCSEC-2025-17 / CVE-2025-6014.
+```

--- a/website/content/api-docs/secret/totp.mdx
+++ b/website/content/api-docs/secret/totp.mdx
@@ -247,6 +247,13 @@ key.
 
 - `code` `(string: <required>)` – Specifies the password you want to validate.
 
+:::info
+
+As of OpenBao v2.3.2, this endpoint will error if the code is not given
+verbatim; whitespace is no longer allowed.
+
+:::
+
 ### Sample payload
 
 ```json


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/1625. 