### PR TITLE
Refuse setting irregular/executable file modes in file audit

### DIFF
--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -104,8 +105,23 @@ func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, err
 		default:
 			mode = os.FileMode(m)
 
-		}
+			// Refuse setting an irregular file mode.
+			if !mode.IsRegular() {
+				return nil, errors.New("file mode does not represent a regular file")
+			}
 
+			const execBitMask = uint32(1<<32-1) ^ 0o111
+			//                  ---------------   -----
+			//                         ^            ^
+			//                     all ones         |
+			//                                      |
+			//                       set all 3 exec bits to zeroes
+
+			// Strip executable bits. Part of the exploit for HCSEC-2025-14 /
+			// CVE-2025-6000 / CVE-2025-54997 consists of abusing the ability
+			// to create executable files.
+			mode = mode & fs.FileMode(execBitMask)
+		}
 	}
 
 	b := &Backend{

--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -5,6 +5,7 @@ package file
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,10 +16,11 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/salt"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuditFile_fileModeNew(t *testing.T) {
-	modeStr := "0777"
+	modeStr := "0644"
 	mode, err := strconv.ParseUint(modeStr, 8, 32)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +65,7 @@ func TestAuditFile_fileModeExisting(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 
-	err = os.Chmod(f.Name(), 0o777)
+	err = os.Chmod(f.Name(), 0o644)
 	if err != nil {
 		t.Fatal("Failure to chmod temp file for testing.")
 	}
@@ -132,6 +134,74 @@ func TestAuditFile_fileMode0000(t *testing.T) {
 	}
 	if info.Mode() != os.FileMode(0o777) {
 		t.Fatal("File mode does not match.")
+	}
+}
+
+func TestAuditFile_fileModeExecutable(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "audit.txt")
+
+	tcases := []struct {
+		name string
+		mode fs.FileMode
+		want fs.FileMode
+	}{
+		{name: "777", mode: fs.FileMode(0o777), want: fs.FileMode(0o666)},
+		{name: "755", mode: fs.FileMode(0o755), want: fs.FileMode(0o644)},
+		{name: "James Bond", mode: fs.FileMode(0o007), want: fs.FileMode(0o006)},
+	}
+
+	for _, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Factory(context.Background(), &audit.BackendConfig{
+				SaltConfig: &salt.Config{},
+				SaltView:   &logical.InmemStorage{},
+				Config: map[string]string{
+					"path": file,
+					"mode": strconv.FormatUint(uint64(tt.mode), 8),
+				},
+			})
+
+			// These should be stripped of exec bits without erroring.
+			require.NoError(t, err)
+
+			info, err := os.Stat(file)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, info.Mode(),
+				"input: %s, have: %s, want: %s",
+				strconv.FormatUint(uint64(tt.mode), 8),
+				strconv.FormatUint(uint64(info.Mode()), 8),
+				strconv.FormatUint(uint64(tt.want), 8),
+			)
+		})
+	}
+}
+
+func TestAuditFile_fileModeIrregular(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "audit.txt")
+
+	tcases := []struct {
+		name string
+		mode fs.FileMode
+	}{
+		{"directory", fs.ModeDir + fs.FileMode(0o644)},
+		{"symlink", fs.ModeSymlink + fs.FileMode(0o644)},
+	}
+
+	for _, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Factory(context.Background(), &audit.BackendConfig{
+				SaltConfig: &salt.Config{},
+				SaltView:   &logical.InmemStorage{},
+				Config: map[string]string{
+					"path": file,
+					"mode": strconv.FormatUint(uint64(tt.mode), 8),
+				},
+			})
+
+			// We expect all test cases to be rejected.
+			require.Error(t, err)
+		})
 	}
 }
 

--- a/changelog/1651.txt
+++ b/changelog/1651.txt
@@ -1,0 +1,5 @@
+```release-note:security
+audit/file: Restrict `mode` parameter
+  - Refuse setting an [irregular](https://pkg.go.dev/io/fs#FileMode.IsRegular) file mode
+  - Silently strip any executable bits
+```

--- a/website/content/docs/audit/file.mdx
+++ b/website/content/docs/audit/file.mdx
@@ -57,7 +57,15 @@ these device-specific options:
   the bit pattern for the file mode, similar to `chmod`. Set to `"0000"` to
   prevent OpenBao from modifying the file mode.
 
+:::warning
 
+Note: Starting with OpenBao v2.4.0, any executable bits set in `mode` are zeroed
+automatically, for security purposes. For example, `mode = 777` will convert to
+`mode = 666`. Furthermore, `mode` values that are
+[irregular](https://pkg.go.dev/io/fs#FileMode.IsRegular) are rejected with an
+error.
+
+:::
 
 ## Log file rotation
 


### PR DESCRIPTION
Additional hardening around HCSEC-2025-14, limiting the range of accepted values for `mode` in the file audit backend.

This could cause breakage in theory -- on the other hand, I'm not sure why you would set an executable audit file without questionable or malicious intent. So, open to discarding this suggestion if we think it's not worth it.