### PR TITLE
Always do git checkout in release-dist job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,6 @@ jobs:
       TAGNAME: v${{ needs.build-ui-dist.outputs.version }}
     steps:
       - name: Checkout
-        if: ${{ !inputs.dogorelease }}
         uses: actions/checkout@v4
         with:
           fetch-tags: true


### PR DESCRIPTION
This is to correct a [failure to upload](https://github.com/openbao/openbao/actions/runs/16821517603/job/47650673183) that happened during the 2.3.2 release.