### PR TITLE
Skip Container tests by default

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -175,6 +175,8 @@ jobs:
           INPUTS_GO_ARCH: ${{ inputs.go-arch }}
           INPUTS_EXTRA_FLAGS: ${{ inputs.extra-flags }}
           INPUTS_GO_TAGS: ${{ inputs.go-tags }}
+          BAO_RUN_CONTAINER_TESTS: true
+          BAO_ACC: 1
         run: |
           set -exo pipefail
 

--- a/builtin/credential/kerberos/path_login_test.go
+++ b/builtin/credential/kerberos/path_login_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/ory/dockertest/v3"
 )
@@ -90,6 +91,8 @@ func TestLogin(t *testing.T) {
 }
 
 func prepareLDAPTestContainer(t *testing.T) (cleanup func(), retURL string) {
+	docker.CheckSkipContainerTests(t)
+
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		t.Fatalf("Failed to connect to docker: %s", err)

--- a/builtin/credential/radius/backend_test.go
+++ b/builtin/credential/radius/backend_test.go
@@ -35,6 +35,8 @@ func prepareRadiusTestContainer(t *testing.T) (func(), string, int) {
 		return func() {}, os.Getenv(envRadiusRadiusHost), port
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	// Now allow any client to connect to this radiusd instance by writing our
 	// own clients.conf file.
 	//

--- a/builtin/logical/pki/dnstest/server.go
+++ b/builtin/logical/pki/dnstest/server.go
@@ -41,6 +41,8 @@ func SetupResolver(t *testing.T, domain string) *TestServer {
 }
 
 func SetupResolverOnNetwork(t *testing.T, domain string, network string) *TestServer {
+	docker.CheckSkipContainerTests(t)
+
 	var ts TestServer
 	ts.t = t
 	ts.ctx = context.Background()

--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -408,6 +408,8 @@ func CheckWithGo(t *testing.T, rootCert string, clientCert string, clientChain [
 func RunNginxRootTest(t *testing.T, caKeyType string, caKeyBits int, caUsePSS bool, roleKeyType string, roleKeyBits int, roleUsePSS bool) {
 	t.Skip("flaky in CI")
 
+	docker.CheckSkipContainerTests(t)
+
 	b, s := pki.CreateBackendWithStorage(t)
 
 	testSuffix := fmt.Sprintf(" - %v %v %v - %v %v %v", caKeyType, caKeyType, caUsePSS, roleKeyType, roleKeyBits, roleUsePSS)

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openbao/openbao/builtin/logical/pkiext"
 	"github.com/openbao/openbao/helper/testhelpers"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
+	"github.com/openbao/openbao/sdk/v2/helper/docker"
 	hDocker "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +48,8 @@ var caddyConfigTemplateTLSALPN string
 // a bunch of sub-tests against that cluster. It is up to each sub-test to run/configure
 // a new pki mount within the cluster to not interfere with each other.
 func Test_ACME(t *testing.T) {
+	docker.CheckSkipContainerTests(t)
+
 	cluster := NewVaultPkiClusterWithDNS(t)
 	defer cluster.Cleanup()
 

--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -108,6 +108,8 @@ func RunZLintContainer(t *testing.T, certificate string) []byte {
 }
 
 func RunZLintRootTest(t *testing.T, keyType string, keyBits int, usePSS bool, ignored []string) {
+	docker.CheckSkipContainerTests(t)
+
 	b, s := pki.CreateBackendWithStorage(t)
 
 	resp, err := pki.CBWrite(b, s, "root/generate/internal", map[string]interface{}{

--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -41,6 +41,8 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 		return func() {}, os.Getenv(envRabbitMQConnectionURI)
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "docker.mirror.hashicorp.services/library/rabbitmq",
 		ImageTag:      "3-management",

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -165,6 +165,8 @@ cKumubUxOfFdy1ZvAAAAEm5jY0BtYnAudWJudC5sb2NhbA==
 var ctx = context.Background()
 
 func prepareTestContainer(t *testing.T, tag, caPublicKeyPEM string) (func(), string) {
+	docker.CheckSkipContainerTests(t)
+
 	if tag == "" {
 		tag = dockerImageTagSupportsNoRSA1
 	}

--- a/command/server/server_seal_transit_acc_test.go
+++ b/command/server/server_seal_transit_acc_test.go
@@ -120,6 +120,8 @@ func (c *DockerVaultConfig) apiConfig() *api.Config {
 var _ docker.ServiceConfig = &DockerVaultConfig{}
 
 func prepareTestContainer(t *testing.T) (func(), *DockerVaultConfig) {
+	docker.CheckSkipContainerTests(t)
+
 	rootToken, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/helper/testhelpers/cassandra/cassandrahelper.go
+++ b/helper/testhelpers/cassandra/cassandrahelper.go
@@ -92,6 +92,8 @@ func PrepareTestContainer(t *testing.T, opts ...ContainerOpt) (Host, func()) {
 		return h, func() {}
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	containerCfg := &containerConfig{
 		imageName:     "docker.mirror.hashicorp.services/library/cassandra",
 		containerName: "cassandra",

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -14,6 +14,8 @@ import (
 )
 
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ldaputil.ConfigEntry) {
+	docker.CheckSkipContainerTests(t)
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		// Currently set to "michelvocks" until https://github.com/rroemhild/docker-test-openldap/pull/14
 		// has been merged.

--- a/helper/testhelpers/mysql/mysqlhelper.go
+++ b/helper/testhelpers/mysql/mysqlhelper.go
@@ -26,6 +26,8 @@ func PrepareTestContainer(t *testing.T, legacy bool, pw string) (func(), string)
 		return func() {}, os.Getenv("MYSQL_URL")
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	imageVersion := "9.0"
 	if legacy {
 		imageVersion = "5.6"

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -60,6 +60,8 @@ func prepareInfluxdbTestContainer(t *testing.T) (func(), *Config) {
 		return func() {}, c
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "docker.mirror.hashicorp.services/influxdb",
 		ContainerName: "influxdb",

--- a/plugins/database/mysql/connection_producer_test.go
+++ b/plugins/database/mysql/connection_producer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openbao/openbao/helper/testhelpers/certhelpers"
 	"github.com/openbao/openbao/sdk/v2/database/helper/dbutil"
+	"github.com/openbao/openbao/sdk/v2/helper/docker"
 	dockertest "github.com/ory/dockertest/v3"
 )
 
@@ -187,6 +188,8 @@ func startMySQLWithTLS(t *testing.T, version string, confDir string) (retURL str
 	if os.Getenv("MYSQL_URL") != "" {
 		return os.Getenv("MYSQL_URL"), func() {}
 	}
+
+	docker.CheckSkipContainerTests(t)
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {

--- a/plugins/database/valkey/valkey_test.go
+++ b/plugins/database/valkey/valkey_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mediocregopher/radix/v4"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+	"github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 )
@@ -47,6 +48,8 @@ func prepareValkeyTestContainer(t *testing.T) (func(), string, int) {
 	if redver == "" {
 		redver = "latest"
 	}
+
+	docker.CheckSkipContainerTests(t)
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -33,6 +34,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/api/v2"
 )
 
 const DockerAPIVersion = "1.40"
@@ -908,4 +910,10 @@ func (d *Runner) GetNetworkAndAddresses(container string) (map[string]string, er
 	}
 
 	return ret, nil
+}
+
+func CheckSkipContainerTests(t *testing.T) {
+	if value := api.ReadBaoVariable("BAO_RUN_CONTAINER_TESTS"); value != "true" {
+		t.Skip("skipping containerized tests because BAO_RUN_CONTAINER_TESTS was not set to true.")
+	}
 }

--- a/sdk/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/sdk/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -87,6 +87,8 @@ func prepareTestContainer(t *testing.T, name, repo, version, password string,
 		return nil, func() {}, "", os.Getenv("PG_URL")
 	}
 
+	docker.CheckSkipContainerTests(t)
+
 	if version == "" {
 		version = "17"
 	}

--- a/vault/external_tests/misc/misc_binary/recovery_test.go
+++ b/vault/external_tests/misc/misc_binary/recovery_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/openbao/openbao/api/v2"
+	hDocker "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster/docker"
 )
@@ -30,6 +31,9 @@ func TestRecovery_Docker(t *testing.T) {
 	if binary == "" {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}
+
+	hDocker.CheckSkipContainerTests(t)
+
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about

--- a/vault/external_tests/raft/raft_binary/raft_test.go
+++ b/vault/external_tests/raft/raft_binary/raft_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openbao/openbao/api/v2"
+	hDocker "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster/docker"
 	rafttest "github.com/openbao/openbao/vault/external_tests/raft"
@@ -18,6 +19,9 @@ func TestRaft_Configuration_Docker(t *testing.T) {
 	if binary == "" {
 		t.Skip("only running docker test when $VAULT_BINARY present")
 	}
+
+	hDocker.CheckSkipContainerTests(t)
+
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about

--- a/vault/external_tests/tlslistener_binary/tls_test.go
+++ b/vault/external_tests/tlslistener_binary/tls_test.go
@@ -35,6 +35,8 @@ func TestTLSListener_SelfHostedNonStandard(t *testing.T) {
 		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
+	hDocker.CheckSkipContainerTests(t)
+
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
@@ -102,6 +104,8 @@ func TestTLSListener_SelfHostedPrivileged(t *testing.T) {
 		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
+	hDocker.CheckSkipContainerTests(t)
+
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about
@@ -164,6 +168,8 @@ func TestTLSListener_ALPN(t *testing.T) {
 	if binary == "" {
 		t.Skip("only running docker test when $BAO_BINARY present")
 	}
+
+	hDocker.CheckSkipContainerTests(t)
 
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",

--- a/vault/external_tests/userpass_binary/ip_token_binding_test.go
+++ b/vault/external_tests/userpass_binary/ip_token_binding_test.go
@@ -31,6 +31,8 @@ func Test_StrictIPBinding(t *testing.T) {
 		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
+	hDocker.CheckSkipContainerTests(t)
+
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",
 		// We're replacing the binary anyway, so we're not too particular about


### PR DESCRIPTION
Many environments lack container execution environments; let's disable them by default and conditionally re-enable with the `BAO_RUN_CONTAINER_TESTS=true` variable.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
