### PR TITLE
Drop pre-v1.0 Vault database upgrade check

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -80,58 +80,6 @@ func TestBackend_PluginMain_PostgresMultiplexed(t *testing.T) {
 	v5.ServeMultiplex(postgresql.New)
 }
 
-func TestBackend_RoleUpgrade(t *testing.T) {
-	storage := &logical.InmemStorage{}
-	backend := &databaseBackend{}
-
-	roleExpected := &roleEntry{
-		Statements: v4.Statements{
-			CreationStatements: "test",
-			Creation:           []string{"test"},
-		},
-	}
-
-	entry, err := logical.StorageEntryJSON("role/test", &roleEntry{
-		Statements: v4.Statements{
-			CreationStatements: "test",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := storage.Put(context.Background(), entry); err != nil {
-		t.Fatal(err)
-	}
-
-	role, err := backend.Role(context.Background(), storage, "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(role, roleExpected) {
-		t.Fatalf("bad role %#v, %#v", role, roleExpected)
-	}
-
-	// Upgrade case
-	badJSON := `{"statments":{"creation_statments":"test","revocation_statements":"","rollback_statements":"","renew_statements":""}}`
-	entry = &logical.StorageEntry{
-		Key:   "role/test",
-		Value: []byte(badJSON),
-	}
-	if err := storage.Put(context.Background(), entry); err != nil {
-		t.Fatal(err)
-	}
-
-	role, err = backend.Role(context.Background(), storage, "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(role, roleExpected) {
-		t.Fatalf("bad role %#v, %#v", role, roleExpected)
-	}
-}
-
 func TestBackend_config_connection(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -834,7 +834,7 @@ func (s *staticAccount) NextRotationTime() time.Time {
 // be invalidated.
 func (s *staticAccount) CredentialTTL() time.Duration {
 	next := s.NextRotationTime()
-	ttl := next.Sub(time.Now()).Round(time.Second)
+	ttl := time.Until(next).Round(time.Second)
 	if ttl < 0 {
 		ttl = time.Duration(0)
 	}


### PR DESCRIPTION
Drops `(*databaseBackend) roleAtPath()` function upgrade check introduced in `v0.10` of Vault due to `statments` typo in user role schema, also removes the upgrade test.
