### PR TITLE
use "bit clear" to simplify executable bit strip

### DIFF
--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -110,17 +109,10 @@ func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, err
 				return nil, errors.New("file mode does not represent a regular file")
 			}
 
-			const execBitMask = uint32(1<<32-1) ^ 0o111
-			//                  ---------------   -----
-			//                         ^            ^
-			//                     all ones         |
-			//                                      |
-			//                       set all 3 exec bits to zeroes
-
 			// Strip executable bits. Part of the exploit for HCSEC-2025-14 /
 			// CVE-2025-6000 / CVE-2025-54997 consists of abusing the ability
 			// to create executable files.
-			mode = mode & fs.FileMode(execBitMask)
+			mode &^= 0o111 // &^ means "bit clear", a combination of "bitwise complement" (^) and "bitwise and" (&)
 		}
 	}
 


### PR DESCRIPTION
#1651 was merged before I could mention this.

@satoqz  creating an all ones int and xor it with a mask is the same as the "bitwise complement" `^` unary operator (in go it even uses the same symbol as xor, most other languages use `~`)
Go even has a "bit clear" binary operator `&^`, a combination of "bitwise complement" (`^`) and "bitwise and" (`&`)

But I like your ASCII art :+1: 
