### PR TITLE
Update PKCS#11 seal docs

### DIFF
--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -104,24 +104,24 @@ differently as determined by the HSM in use.
 - `key_label` `(string: <required>)`: The label of the key to use. May also be specified by the `BAO_HSM_KEY_LABEL`
   environment variable.
 
-- `default_key_label` `(string: "")`: This is the default key label for decryption
-  operations. Prior to 0.10.1, key labels were not stored with the ciphertext.
-  Seal entries now track the label used in encryption operations. The default value
-  for this field is the `key_label`. If `key_label` is rotated and this value is not
-  set, decryption may fail. May also be specified by the `BAO_HSM_DEFAULT_KEY_LABEL`
-  environment variable. This value is ignored in new installations.
-
 - `key_id` `(string: "")`: The ID of the key to use. The value should be a hexadecimal
   string (e.g., "0x33333435363434373537"). May also be specified by the
   `BAO_HSM_KEY_ID` environment variable.
 
-- `mechanism` `(string: <best available>)`: The encryption/decryption mechanism to use,
-  specified as a decimal or hexadecimal (prefixed by `0x`) string. May also be
-  specified by the `BAO_HSM_MECHANISM` environment variable.
-  Currently supported mechanisms (in order of precedence):
+- `mechanism` `(string: <best available>)`: The encryption/decryption mechanism
+  to use, specified either by name, or by decimal or hexadecimal (prefixed by
+  `0x`) string. May also be specified by the `BAO_HSM_MECHANISM` environment
+  variable. Currently supported mechanisms (in order of precedence):
 
-  - `0x1087` `CKM_AES_GCM`
-  - `0x0009` `CKM_RSA_PKCS_OAEP`
+  - Names: `AES_GCM`, `CKM_AES_GCM`, Hexadecimal: `0x1087`
+  - Names: `RSA_PKCS_OAEP`, `CKM_RSA_PKCS_OAEP`, Hexadecimal: `0x0009`
+
+- `disable_software_encryption` `(bool: false)`: For RSA-based mechanisms,
+  OpenBao performs the encryption operation locally in memory by exporting the
+  public key from the HSM. Set this option to `true` to force calling out to the
+  HSM for all encryption operations. This option is available starting with
+  OpenBao v2.4.0. All prior versions always call out to the HSM for encryption
+  and never perform encryption in software.
 
 :::warning
 
@@ -134,7 +134,7 @@ explicit HMACing).
 - `disabled` `(string: "")`: Set this to `true` if OpenBao is migrating from an auto seal configuration. Otherwise, set to `false`.
 
 Refer to the [Seal Migration](/docs/concepts/seal#seal-migration) documentation for more information about the seal migration process.
-  
+
 ### Mechanism specific flags
 
 - `rsa_oaep_hash` `(string: "sha256")`: Specify the hash algorithm to use for RSA


### PR DESCRIPTION
- Remove old `default_key_label` option, this never existed in OpenBao
- Clarify that `mechanism` can also be a named mechanism
- Document new `disable_software_encryption` option (see
  https://github.com/openbao/go-kms-wrapping/pull/41)
