### PR TITLE
Fix bug in tidy leading to infinite loop

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -1058,7 +1058,7 @@ func (b *backend) doTidyCertStore(ctx context.Context, req *logical.Request, log
 	}
 
 	// Use HandleListPage to process paginated results
-	err := logical.HandleListPage(req.Storage, "certs/", config.PageSize, itemCallback, batchCallback)
+	err := logical.HandleListPage(ctx, req.Storage, "certs/", config.PageSize, itemCallback, batchCallback)
 	if err != nil {
 		return 0, err
 	}
@@ -1238,7 +1238,7 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 	}
 
 	// Use handleListPage to process paginated results
-	err = logical.HandleListPage(req.Storage, "revoked/", config.PageSize, itemCallback, batchCallback)
+	err = logical.HandleListPage(ctx, req.Storage, "revoked/", config.PageSize, itemCallback, batchCallback)
 	if err != nil {
 		return false, err
 	}
@@ -1493,7 +1493,7 @@ func (b *backend) doTidyAcme(ctx context.Context, req *logical.Request, logger h
 	}
 
 	// Use HandleListPage to process paginated results
-	err := logical.HandleListPage(req.Storage, acmeThumbprintPrefix, config.PageSize, itemCallback, batchCallback)
+	err := logical.HandleListPage(ctx, req.Storage, acmeThumbprintPrefix, config.PageSize, itemCallback, batchCallback)
 	if err != nil {
 		return err
 	}

--- a/changelog/1696.txt
+++ b/changelog/1696.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+secrets/pki: Prevent infinite loop in tidy stemming from incorrect list pagination
+```
+```release-note:bug
+core/namespaces: Prevent infinite loop in namespace loading due to incorrect list pagination
+```
+```release-note:change
+sdk/logical: Introduce context to logical.HandleListPage(...).
+```

--- a/changelog/1696.txt
+++ b/changelog/1696.txt
@@ -2,7 +2,7 @@
 secrets/pki: Prevent infinite loop in tidy stemming from incorrect list pagination
 ```
 ```release-note:bug
-core/namespaces: Prevent infinite loop in namespace loading due to incorrect list pagination
+core/namespaces: Prevent infinite loop in namespace loading due to incorrect list pagination when more than 100 sibling namespaces exist under a given parent
 ```
 ```release-note:change
 sdk/logical: Introduce context to logical.HandleListPage(...).

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -215,7 +215,7 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 	ctx context.Context, barrier, view logical.Storage,
 	callback func(*namespace.Namespace) error,
 ) error {
-	return logical.HandleListPage(view, "", 100, func(page int, index int, entry string) (bool, error) {
+	return logical.HandleListPage(ctx, view, "", 100, func(page int, index int, entry string) (bool, error) {
 		item, err := view.Get(ctx, entry)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch namespace %v (page %v / index %v): %w", entry, page, index, err)


### PR DESCRIPTION
In `logical.HandleListPage(...)`, after was being redefined each loop, leading to the previous loop iteration limits not being tracked. Add a test case for this and correctly keep track of the last seen storage entry.

This also adjusts `logical.HandleListPage(...)` to take a context and check for cancellation between outer paginated calls and before processing each entry in the batch. This will ensure we have bounded iteration in the event of another issue with `ListPage(...)`. We also validate context cancellation.