### PR TITLE
Add declarative audit device creation mechanism

### DIFF
--- a/changelog/1700.txt
+++ b/changelog/1700.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Configuration-Based Audit Devices**: Create and remove audit devices through server configuration updates. Changes are applied on restart and SIGHUP with issues appearing in the logs.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1526,6 +1526,10 @@ func (c *ServerCommand) Run(args []string) int {
 			// Setting log request with the new value in the config after reload
 			core.ReloadLogRequestsLevel()
 
+			// Update audit devices if necessary. This cannot be done as part of
+			// c.Reload as it needs the reloadFuncsLock.
+			core.ReloadAuditLogs()
+
 			// Reload log level for loggers
 			if config.LogLevel != "" {
 				level, err := loghelper.ParseLogLevel(config.LogLevel)

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -475,6 +475,18 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.AdministrativeNamespacePath = c2.AdministrativeNamespacePath
 	}
 
+	if len(c.Initialization) > 0 || len(c2.Initialization) > 0 {
+		result.Initialization = make([]*profiles.OuterConfig, len(c.Initialization)+len(c2.Initialization))
+		copy(result.Initialization[0:len(c.Initialization)], c.Initialization)
+		copy(result.Initialization[len(c.Initialization):], c2.Initialization)
+	}
+
+	if len(c.Audits) > 0 || len(c2.Audits) > 0 {
+		result.Audits = make([]*AuditDevice, len(c.Audits)+len(c2.Audits))
+		copy(result.Audits[0:len(c.Audits)], c.Audits)
+		copy(result.Audits[len(c.Audits):], c2.Audits)
+	}
+
 	return result
 }
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -784,7 +784,7 @@ func ParseConfig(d, source string) (*Config, error) {
 	// Parse self-initialization stanzas.
 	if o := list.Filter("initialize"); len(o.Items) > 0 {
 		delete(result.UnusedKeys, "initialize")
-		init, err := profiles.ParseOuterConfig("initialize", result.Initialization, o)
+		init, err := profiles.ParseOuterConfig("initialize", o)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing 'initialize': %w", err)
 		}
@@ -795,7 +795,7 @@ func ParseConfig(d, source string) (*Config, error) {
 	// Parse audit device stanzas.
 	if o := list.Filter("audit"); len(o.Items) > 0 {
 		delete(result.UnusedKeys, "audit")
-		audits, err := parseAuditDevices("audit", result.Audits, o)
+		audits, err := parseAuditDevices("audit", o)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing 'audit': %w", err)
 		}
@@ -1286,9 +1286,8 @@ func (a *AuditDevice) GoString() string {
 	return fmt.Sprintf("*%#v", *a)
 }
 
-func parseAuditDevices(name string, result []*AuditDevice, list *ast.ObjectList) ([]*AuditDevice, error) {
-	result = make([]*AuditDevice, 0, len(list.Items))
-
+func parseAuditDevices(name string, list *ast.ObjectList) ([]*AuditDevice, error) {
+	result := make([]*AuditDevice, 0, len(list.Items))
 	for index, item := range list.Items {
 		var i AuditDevice
 		if err := hcl.DecodeObject(&i, item.Val); err != nil {

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -79,6 +79,16 @@ cloud {
     client_secret = "N9JtHZyOnHrIvJZs82pqa54vd4jnkyU3xCcqhFXuQKJZZuxqxxbP1xCfBZVB82vY"
 }
 `
+
+	auditHCL = `
+audit "file" "to-stdout" {
+  description = "This audit device should never fail."
+  options {
+    file_path = "/dev/stdout"
+    log_raw = "true"
+  }
+}
+`
 )
 
 func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
@@ -275,6 +285,13 @@ func TestServer(t *testing.T) {
 			"",
 			0,
 			[]string{"-test-verify-only", "-recovery"},
+		},
+		{
+			"audit_config",
+			testBaseHCL(t, "") + inmemHCL + auditHCL,
+			"",
+			0,
+			[]string{"-test-verify-only"},
 		},
 	}
 

--- a/helper/profiles/config.go
+++ b/helper/profiles/config.go
@@ -39,8 +39,8 @@ type RequestConfig struct {
 // self-initialization subsystem). Callers wishing to only have a single
 // outer block but which may support multiple requests may directly call
 // ParseRequestConfig(...) and assign the result via CreateOuterConfig(...).
-func ParseOuterConfig(outerBlockType string, result []*OuterConfig, list *ast.ObjectList) ([]*OuterConfig, error) {
-	result = make([]*OuterConfig, 0, len(list.Items))
+func ParseOuterConfig(outerBlockType string, list *ast.ObjectList) ([]*OuterConfig, error) {
+	result := make([]*OuterConfig, 0, len(list.Items))
 	for index, item := range list.Items {
 		var i OuterConfig
 		if err := hcl.DecodeObject(&i, item.Val); err != nil {

--- a/helper/profiles/config_test.go
+++ b/helper/profiles/config_test.go
@@ -42,7 +42,7 @@ initialize "auth" {
 	if err != nil {
 		t.Fatalf("parseBlockList error: %v", err)
 	}
-	outers, err := ParseOuterConfig("initialize", nil, list)
+	outers, err := ParseOuterConfig("initialize", list)
 	if err != nil {
 		t.Fatalf("ParseOuterConfig returned error: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestParseOuterConfig_EmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseBlockList error: %v", err)
 	}
-	outers, err := ParseOuterConfig("initialize", nil, list)
+	outers, err := ParseOuterConfig("initialize", list)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -105,7 +105,7 @@ initialize {
 	if err != nil {
 		t.Fatalf("parseBlockList error: %v", err)
 	}
-	_, err = ParseOuterConfig("initialize", nil, list)
+	_, err = ParseOuterConfig("initialize", list)
 	if err == nil || !strings.Contains(err.Error(), "type must be specified") {
 		t.Fatalf("expected type-specification error, got %v", err)
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -2339,6 +2339,9 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.setupAudits(ctx); err != nil {
 		return err
 	}
+	if err := c.handleAuditLogSetup(ctx); err != nil {
+		return err
+	}
 	if err := c.loadIdentityStoreArtifacts(ctx); err != nil {
 		return err
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3150,6 +3150,7 @@ func (b *SystemBackend) handleEnableAudit(ctx context.Context, req *logical.Requ
 
 	// Create the mount entry
 	me := &MountEntry{
+		// API-created
 		Table:       auditTableType,
 		Path:        path,
 		Type:        backendType,
@@ -3188,6 +3189,10 @@ func (b *SystemBackend) handleDisableAudit(ctx context.Context, req *logical.Req
 	}
 	if entry == nil {
 		return nil, nil
+	}
+
+	if entry.Table == configAuditTableType {
+		return handleError(errors.New("cannot disable configuration-managed audit device"))
 	}
 
 	// Attempt disable

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2343,7 +2343,7 @@ func (c *Core) mountEntryView(me *MountEntry) (BarrierView, error) {
 			return c.namespaceMountEntryView(me.Namespace(), credentialBarrierPrefix+me.UUID+"/"), nil
 		}
 		return NewBarrierView(c.barrier, credentialBarrierPrefix+me.UUID+"/"), nil
-	case auditTableType:
+	case auditTableType, configAuditTableType:
 		return NewBarrierView(c.barrier, auditBarrierPrefix+me.UUID+"/"), nil
 	}
 

--- a/website/content/docs/concepts/profiles.mdx
+++ b/website/content/docs/concepts/profiles.mdx
@@ -1,4 +1,5 @@
 ---
+sidebar_label: Profile System
 description: >- 
     This is a reference for OpenBao’s profile system and declarative self-initialization. It describes the four supported source types and the initialize_name mechanism.
 ---
@@ -6,6 +7,14 @@ description: >-
 The Profiles processes declarative API requests with dynamic data source evaluation. 
 The system implements the request/response pattern, supporting chained operations and accepting request handlers and parsed profile configurations. 
 These are then transformed into templates for one or more API requests.
+
+:::info
+
+All requests are subject to the same restrictions as if they were executed
+normally: audit logging, authentication, and API variable restrictions (such as
+unauthenticated rotation and audit device creation) still apply.
+
+:::
 
 ## Profiles end to end workflow
 

--- a/website/content/docs/configuration/audit.mdx
+++ b/website/content/docs/configuration/audit.mdx
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-# Audit Devices
+# Declarative Audit Devices
 
 The `audit` stanza allows definition of [audit devices](/docs/audit) from the
 OpenBao server configuration file. These audit devices are created and removed

--- a/website/content/docs/configuration/audit.mdx
+++ b/website/content/docs/configuration/audit.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_label: audit
+description: |-
+  The audit stanza allows definition of audit devices from the configuration
+  file, reloaded on server restart and on SIGHUP.
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+
+# Audit Devices
+
+The `audit` stanza allows definition of [audit devices](/docs/audit) from the
+OpenBao server configuration file. These audit devices are created and removed
+on the active node during restarts and `SIGHUP` events. Audit devices cannot
+be modified and cannot duplicate existing API-created devices. Removal of the
+configuration stanza will result in the audit device being removed; it is
+important to have the same configuration across all servers.
+
+# `audit` stanza
+
+The `audit` stanza specifies various configurations for OpenBao to create
+new audit devices. It takes two keyword parameters: `type`, the type of the
+audit device to create; and `path`, the path of the audit device in the root
+namespace. Devices take [the same parameters](/api-docs/system/audit) as
+the API: `description` and other parameters are defined at the top level and
+`options` for the audit device is a `string->string` map.
+
+<Tabs groupId="config">
+<TabItem value="JSON">
+
+```json
+{
+  "audit": [
+    {
+      "file": {
+        "to-stdout": {
+          "description": "This audit device should never fail.",
+          "options": {
+            "file_path": "/dev/stdout",
+            "log_raw": "true"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+</TabItem>
+<TabItem value="HCL">
+
+```hcl
+audit "file" "to-stdout" {
+  description = "This audit device should never fail."
+  options {
+    file_path = "/dev/stdout"
+    log_raw = "true"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Multiple `audit` stanzas may exist and are executed in the order they
+are specified in the configuration file(s). No two blocks may share the
+same `path`. 
+
+## Audit Devices
+
+For more information, see the [API documentation for audit
+devices](/api-docs/system/audit/) or the [audit device](/docs/audit)
+documentation.

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -86,7 +86,10 @@ to specify where the configuration is.
 
 ## Parameters
 
-- `storage` `([StorageBackend][storage-backend]: <required>)` –
+- `audit` <code>([Audit][audit]: &lt;none&gt;)</code> – Specifies [audit device
+  configuration][audit]. Can be specified multiple times.
+
+- `storage` <code>([StorageBackend][storage-backend]: &lt;required&gt;)</code> –
   Configures the storage backend where OpenBao data is stored. Please see the
   [storage backends documentation][storage-backend] for the full list of
   available storage backends. Running OpenBao in HA mode would require
@@ -96,21 +99,21 @@ to specify where the configuration is.
   configured with a backend that supports HA, along with corresponding HA
   options.
 
-- `ha_storage` `([StorageBackend][storage-backend]: nil)` – Configures
+- `ha_storage` <code>([StorageBackend][storage-backend]: nil)</code> – Configures
   the storage backend where OpenBao HA coordination will take place. This must be
   an HA-supporting backend. If not set, HA will be attempted on the backend
   given in the `storage` parameter. This parameter is not required if the
   storage backend supports HA coordination and if HA specific options are
   already specified with `storage` parameter.
 
-- `listener` `([Listener][listener]: <required>)` – Configures how
+- `listener` <code>([Listener][listener]: &lt;required&gt;)</code> – Configures how
   OpenBao is listening for API requests.
 
-- `user_lockout` `([UserLockout][user-lockout]: nil)` –
+- `user_lockout` <code>([UserLockout][userlockout]: nil)</code>. –
   Configures the user-lockout behaviour for failed logins. For more information, please see the
   [user lockout configuration documentation](/docs/configuration/user-lockout). 
 
-- `seal` `([Seal][seal]: nil)` – Configures the seal type to use for
+- `seal` <code>([Seal][seal]: nil)</code> – Configures the seal type to use for
   auto-unsealing, as well as for
   [seal wrapping][sealwrap] as an additional layer of data protection.
 
@@ -125,8 +128,8 @@ to specify where the configuration is.
   the read cache used by the physical storage subsystem. This will very
   significantly impact performance.
 
-- `initialize` `([Initialize][initialize]: <none>)` – Specifies one-time
-  declarative self-initialization.
+- `initialize` <code>([Initialize][initialize]: &lt;none&gt;)</code> – Specifies one-time
+  [declarative self-initialization][initialize]. Can be specified multiple times.
 
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. OpenBao must have permission to read files in this
@@ -143,7 +146,7 @@ to specify where the configuration is.
   This only needs to be set if the file permissions check is enabled via the environment variable
   `VAULT_ENABLE_FILE_PERMISSIONS_CHECK`.
 
-- `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
+- `telemetry` <code>([Telemetry][telemetry]: &lt;none&gt;)</code> – Specifies the telemetry
   reporting system.
 
 - `default_lease_ttl` `(string: "768h")` – Specifies the default lease duration
@@ -267,6 +270,7 @@ The following parameters are used on backends that support [High Availability][h
   will disable these features _only when that node is the active node_. This
   parameter cannot be set to `true` if `raft` is the storage type.
 
+[audit]: /docs/configuration/audit
 [storage-backend]: /docs/configuration/storage
 [listener]: /docs/configuration/listener
 [seal]: /docs/configuration/seal
@@ -275,3 +279,4 @@ The following parameters are used on backends that support [High Availability][h
 [sentinel]: /docs/configuration/sentinel
 [high-availability]: /docs/concepts/ha
 [plugins]: /docs/plugins
+[userlockout]: /docs/configuration/user-lockout

--- a/website/content/docs/configuration/self-init.mdx
+++ b/website/content/docs/configuration/self-init.mdx
@@ -18,6 +18,14 @@ mounts in addition to having full control over general requests.
 Instead of manually executing multiple API commands after starting the server, 
 all necessary settings can be defined in advance.
 
+:::info
+
+All requests are subject to the same restrictions as if they were executed
+normally: audit logging, authentication, and API variable restrictions (such as
+unauthenticated rotation and audit device creation) still apply.
+
+:::
+
 # `initialize` stanza
 
 The `initialize` stanza specifies various configurations for OpenBao to

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -62,7 +62,7 @@ configuration parsing, with the exception of two necessary hooks:
 
 1. The standard unseal strategy now updates audit devices based on the
    configuration.
-2. The reload handlers triggered on `SIGHUP` now will reload the seal as
+2. The reload handlers triggered on `SIGHUP` now will reload the audit devices as
    well.
 
 We differentiate API-created and configuration-based audit devices to prevent

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -1,0 +1,112 @@
+---
+sidebar_label: Audit Device Configuration
+description: |-
+  An OpenBao RFC for defining audit devices in the server configuration
+  file through the complete audit device life cycle.
+---
+
+# Audit Device Configuration
+
+## Summary
+
+After [Vault HCSEC-2025-14 / CVE-2025-6000](https://discuss.hashicorp.com/t/hcsec-2025-14-privileged-vault-operator-may-execute-code-on-the-underlying-host/76033)
+and [OpenBao CVE-2025-54997](https://github.com/openbao/openbao/security/advisories/GHSA-xp75-r577-cvhp),
+it became apparent that _any_ API-driven audit device creation is unsafe.
+We remediate this fully by allowing full management of audit devices from
+the configuration file, throughout the life cycle of the device.
+
+## Problem Statement
+
+API-driven audit device creation is fundamentally unsafe. Even without control
+over `prefix`, audit devices such as `file` allow writing to arbitrary files
+and `socket` allow writing to arbitrary Unix or network sockets. These
+operations are usually reserved for system-level operators, not API-level
+administrators, breaching privilege separation expectations. These issues
+were exacerbated in conjunction with the various privilege escalation bypasses
+disclosed alongside this vulnerability.
+
+Like introducing new, authenticated key rotation endpoints, we need a deeper
+fix for the fundamental risks associated with this.
+
+In a design similar to the [declarative self-initialization](/docs/rfcs/self-init),
+we opt to define audit devices in the configuration file. We need to make
+sure we handle the following scenarios:
+
+1. Creating a new audit device
+2. Preventing duplicate audit devices (across API- and config-based creation)
+3. Deleting an existing audit device
+4. Preventing modification to an existing audit device.
+
+## User-facing Description
+
+We introduce a new repeatable configuration stanza, `audit "<type>" "<path>"`
+which configures a new audit device:
+
+```hcl
+audit "file" "to-stdout" {
+  description = "Default audit device"
+  options = {
+    file_path = "/dev/stdout"
+    log_raw = "false"
+  }
+}
+```
+
+This can be added or removed and will be reprocessed on server restarts and
+when `SIGHUP` is sent to the server. It will be ignored on standby nodes.
+
+## Technical Description
+
+This change is largely self-contained to the audit system and server
+configuration parsing, with the exception of two necessary hooks:
+
+1. The standard unseal strategy now updates audit devices based on the
+   configuration.
+2. The reload handlers triggered on `SIGHUP` now will reload the seal as
+   well.
+
+We differentiate API-created and configuration-based audit devices to prevent
+confusion and deletion.
+
+Otherwise, this change mostly reuses existing components.
+
+## Rationale and Alternatives
+
+This greatly improves the discoverability of audit devices, the configuration
+and management of audit devices, and restores the usability of audit devices
+after the fix for safety.
+
+## Downsides
+
+This has very limited downsides.
+
+## Security Implications
+
+This fixes the security definition of audit devices, reflecting their
+privileged nature.
+
+One observation remains: a malicious operator _could_ set `log_raw=true` on
+audit devices, scraping all fetches or modifications made via the API. This
+would be detectable by the consumer as the audit device HMAC endpoint would
+be unable to create matching entries for known-logged strings.
+
+However, said operator could also enable the `sys/raw` API and thus remains
+equivalently privileged either way.
+
+## User/Developer Experience
+
+This change does not impact end-consumers of the OpenBao API.
+
+## Unresolved Questions
+
+n/a
+
+## Related Issues
+
+- https://github.com/openbao/openbao/pull/1634
+- https://github.com/openbao/openbao/security/advisories/GHSA-xp75-r577-cvhp
+- https://github.com/orgs/openbao/discussions/1115
+
+## Proof of Concept
+
+n/a; submitted with working code

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -19,7 +19,7 @@ the configuration file, throughout the life cycle of the device.
 
 API-driven audit device creation is fundamentally unsafe. Even without control
 over `prefix`, audit devices of type `file` allow writing to arbitrary files
-and `socket` allow writing to arbitrary Unix or network sockets. These
+and type `socket` allows writing to arbitrary Unix or network sockets. These
 operations are usually reserved for system-level operators, not API-level
 administrators, breaching privilege separation expectations. These issues
 were exacerbated in conjunction with the various privilege escalation bypasses

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Audit Device Configuration
+sidebar_label: Declarative Audit Devices
 description: |-
   An OpenBao RFC for defining audit devices in the server configuration
   file through the complete audit device life cycle.

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -5,7 +5,7 @@ description: |-
   file through the complete audit device life cycle.
 ---
 
-# Audit Device Configuration
+# Declarative Audit Device Configuration
 
 ## Summary
 

--- a/website/content/docs/rfcs/config-audit-devices.mdx
+++ b/website/content/docs/rfcs/config-audit-devices.mdx
@@ -18,7 +18,7 @@ the configuration file, throughout the life cycle of the device.
 ## Problem Statement
 
 API-driven audit device creation is fundamentally unsafe. Even without control
-over `prefix`, audit devices such as `file` allow writing to arbitrary files
+over `prefix`, audit devices of type `file` allow writing to arbitrary files
 and `socket` allow writing to arbitrary Unix or network sockets. These
 operations are usually reserved for system-level operators, not API-level
 administrators, breaching privilege separation expectations. These issues

--- a/website/content/docs/rfcs/index.mdx
+++ b/website/content/docs/rfcs/index.mdx
@@ -70,6 +70,9 @@ Steering Committee.
    to discuss how to incorporate authentication sent via the main operation,
    without returning or storing the resulting token, for operations that do
    not create leases. Landed in [PR #1433](https://github.com/openbao/openbao/pull/1433).
+ - [Define audit devices in the configuration file](/docs/rfcs/config-audit-devices),
+   solving the security and usability gaps after HCSEC-2025-14.
+   Landed in [PR #1700](https://github.com/openbao/openbao/pull/1700).
 
 ## Strategic
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -531,6 +531,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/authenticated-rekey",
                 "rfcs/self-init",
                 "rfcs/external-keys",
+                "rfcs/config-audit-devices",
                 {
                   "UI/UX": ["rfcs/web-ui-modernization"],
                 },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -94,6 +94,7 @@ const sidebars: SidebarsConfig = {
             ],
             Configuration: [
                 "configuration/index",
+                "configuration/audit",
                 "configuration/self-init",
                 {
                     listener: [


### PR DESCRIPTION
In solving HCSEC-2025-14 / CVE-2025-6000 / CVE-2025-54997, we opted to introduce a new flag, unsafe_allow_api_audit_creation=false, which disables audit device creation via API. This is because creating audit devices is fundamentally a service operator (and not, an internal root-token) permission: many of these audit devices allow escaping the API sandbox of the service and allow e.g., writing to arbitrary files or opening arbitrary TCP or Unix sockets.

This change introduces a new server configuration block, audit, which takes two parameters (device plugin type and desired device path), plus the regular request body of a sys/audit enable request. This allows creating in a fully-declarative manner configuration.

When device configuration fails on startup/leadership election, the server will err and fail to load. Detailed error are written including on reload allowing configurations to be debugged.

---

Early look at the proof of concept for this. Will add RFC, docs, and tests before opening for broader review. 