### PR TITLE
Add http audit method

### DIFF
--- a/builtin/audit/http/backend.go
+++ b/builtin/audit/http/backend.go
@@ -1,0 +1,314 @@
+// Copyright (c) The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/openbao/openbao/audit"
+	"github.com/openbao/openbao/sdk/v2/helper/salt"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/version"
+)
+
+// Backend is the audit backend for the http-based audit store.
+//
+// This presently has little logic to handle retrying failed requests.
+type Backend struct {
+	uri     string
+	headers http.Header
+
+	formatter    audit.AuditFormatter
+	formatConfig audit.FormatterConfig
+
+	clientLock sync.RWMutex
+	client     *http.Client
+
+	saltMutex  sync.RWMutex
+	salt       *atomic.Value
+	saltConfig *salt.Config
+	saltView   logical.Storage
+}
+
+var _ audit.Backend = (*Backend)(nil)
+
+func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, error) {
+	if conf.SaltConfig == nil {
+		return nil, errors.New("nil salt config")
+	}
+	if conf.SaltView == nil {
+		return nil, errors.New("nil salt view")
+	}
+
+	uriRaw, ok := conf.Config["uri"]
+	if !ok {
+		return nil, errors.New("uri is required")
+	}
+
+	// resolve URI to a concrete value
+	uri, err := parseutil.ParsePath(uriRaw, parseutil.WithNoTrimSpaces(true), parseutil.WithErrorOnMissingEnv(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve uri: %w", err)
+	}
+
+	if _, err := url.Parse(uri); err != nil {
+		return nil, fmt.Errorf("failed to parse uri: %w", err)
+	}
+
+	// config is string->string, so we need to handle JSON decoding headers.
+	headers := http.Header{}
+	headersRaw, ok := conf.Config["headers"]
+	if ok {
+		var decodedHeaders map[string][]string
+		if err := json.Unmarshal([]byte(headersRaw), &decodedHeaders); err != nil {
+			return nil, fmt.Errorf("failed to parse headers: %w", err)
+		}
+
+		// Also perform URI based replacement on header values to allow
+		// environment variables and files to provide token authentication for
+		// external servers. With API-based audits this is unsafe but the new
+		// declarative config-driven audit device creation this is fully
+		// controlled by the operator.
+		for header, values := range decodedHeaders {
+			for _, value := range values {
+				modified, err := parseutil.ParsePath(value, parseutil.WithNoTrimSpaces(true), parseutil.WithErrorOnMissingEnv(true))
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse header %v: %w", header, nil)
+				}
+
+				headers.Add(header, modified)
+			}
+		}
+	}
+
+	// Handle output format.
+	format, ok := conf.Config["format"]
+	if !ok {
+		format = "json"
+	}
+	switch format {
+	case "json", "jsonx":
+	default:
+		return nil, fmt.Errorf("unknown format type %q", format)
+	}
+
+	// Check if hashing of accessor is disabled
+	hmacAccessor := true
+	if hmacAccessorRaw, ok := conf.Config["hmac_accessor"]; ok {
+		value, err := strconv.ParseBool(hmacAccessorRaw)
+		if err != nil {
+			return nil, err
+		}
+		hmacAccessor = value
+	}
+
+	// Check if raw logging is enabled
+	logRaw := false
+	if raw, ok := conf.Config["log_raw"]; ok {
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, err
+		}
+		logRaw = b
+	}
+
+	elideListResponses := false
+	if elideListResponsesRaw, ok := conf.Config["elide_list_responses"]; ok {
+		value, err := strconv.ParseBool(elideListResponsesRaw)
+		if err != nil {
+			return nil, err
+		}
+		elideListResponses = value
+	}
+
+	b := &Backend{
+		uri:     uri,
+		headers: headers,
+
+		formatConfig: audit.FormatterConfig{
+			Raw:                logRaw,
+			HMACAccessor:       hmacAccessor,
+			ElideListResponses: elideListResponses,
+		},
+
+		saltConfig: conf.SaltConfig,
+		saltView:   conf.SaltView,
+		salt:       new(atomic.Value),
+	}
+
+	// Ensure we are working with the right type by explicitly storing a nil of
+	// the right type
+	b.salt.Store((*salt.Salt)(nil))
+
+	switch format {
+	case "json":
+		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{
+			Prefix:   conf.Config["prefix"],
+			SaltFunc: b.Salt,
+		}
+	case "jsonx":
+		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{
+			Prefix:   conf.Config["prefix"],
+			SaltFunc: b.Salt,
+		}
+	}
+
+	if _, err := b.getClient(); err != nil {
+		return nil, fmt.Errorf("unable to create http client: %w", err)
+	}
+
+	return b, nil
+}
+
+func (b *Backend) Salt(ctx context.Context) (*salt.Salt, error) {
+	s := b.salt.Load().(*salt.Salt)
+	if s != nil {
+		return s, nil
+	}
+
+	b.saltMutex.Lock()
+	defer b.saltMutex.Unlock()
+
+	s = b.salt.Load().(*salt.Salt)
+	if s != nil {
+		return s, nil
+	}
+
+	newSalt, err := salt.NewSalt(ctx, b.saltView, b.saltConfig)
+	if err != nil {
+		b.salt.Store((*salt.Salt)(nil))
+		return nil, err
+	}
+
+	b.salt.Store(newSalt)
+	return newSalt, nil
+}
+
+func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
+	salt, err := b.Salt(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return audit.HashString(salt, data), nil
+}
+
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
+	buf := bytes.NewBuffer(make([]byte, 0, 2000))
+	err := b.formatter.FormatRequest(ctx, buf, b.formatConfig, in)
+	if err != nil {
+		return err
+	}
+
+	return b.log(ctx, buf)
+}
+
+func (b *Backend) log(ctx context.Context, buf *bytes.Buffer) error {
+	reader := bytes.NewReader(buf.Bytes())
+
+	client, err := b.getClient()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.uri, reader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header = b.headers.Clone()
+
+	if value := b.headers.Get("User-Agent"); value != "" {
+		req.Header.Add("User-Agent", fmt.Sprintf("OpenBaoAuditor/%s", version.GetVersion().VersionNumber()))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil || resp == nil {
+		return fmt.Errorf("failed to perform request: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return fmt.Errorf("failed to close body: %w", err)
+	}
+
+	// Redirects and errors will not be accepted.
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("failed to perform request: status code not 2xx: %v", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
+	buf := bytes.NewBuffer(make([]byte, 0, 6000))
+	err := b.formatter.FormatResponse(ctx, buf, b.formatConfig, in)
+	if err != nil {
+		return err
+	}
+
+	return b.log(ctx, buf)
+}
+
+func (b *Backend) LogTestMessage(ctx context.Context, in *logical.LogInput, config map[string]string) error {
+	var buf bytes.Buffer
+	temporaryFormatter := audit.NewTemporaryFormatter(config["format"], config["prefix"])
+	if err := temporaryFormatter.FormatRequest(ctx, &buf, b.formatConfig, in); err != nil {
+		return err
+	}
+
+	return b.log(ctx, &buf)
+}
+
+func (b *Backend) getClient() (*http.Client, error) {
+	b.clientLock.RLock()
+	client := b.client
+	b.clientLock.RUnlock()
+
+	if client != nil {
+		return client, nil
+	}
+
+	b.clientLock.Lock()
+	defer b.clientLock.Unlock()
+
+	if b.client != nil {
+		return client, nil
+	}
+
+	// TODO (ascheel): use a different HTTP client.
+	b.client = http.DefaultClient
+
+	return b.client, nil
+}
+
+func (b *Backend) Reload(_ context.Context) error {
+	b.clientLock.Lock()
+	defer b.clientLock.Unlock()
+
+	b.client = nil
+
+	_, err := b.getClient()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Backend) Invalidate(_ context.Context) {
+	b.saltMutex.Lock()
+	defer b.saltMutex.Unlock()
+
+	b.salt.Store((*salt.Salt)(nil))
+}

--- a/builtin/audit/http/backend_test.go
+++ b/builtin/audit/http/backend_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openbao/openbao/audit"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/helper/salt"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditHttp_Integration(t *testing.T) {
+	var lock sync.Mutex
+	var badRequests int
+	logs := []map[string]interface{}{}
+	logRoute := "/audit"
+
+	requiredHeaders := http.Header{}
+	requiredHeaders.Add("X-Gitlab-Openbao-Token", "foobarfud")
+
+	testServer := httptest.NewServer(GetTestAuditHandler(t, &lock, &logs, logRoute, requiredHeaders, &badRequests))
+	defer testServer.Close()
+
+	url := testServer.URL + logRoute
+
+	backend, err := Factory(context.Background(), &audit.BackendConfig{
+		SaltConfig: &salt.Config{},
+		SaltView:   &logical.InmemStorage{},
+		Config: map[string]string{
+			"uri":     url,
+			"headers": `{"Content-Type":["application/json"],"Accept":["application/json"],"X-Gitlab-Openbao-Token":["foobarfud"]}`,
+		},
+	})
+
+	// We expect all test cases to be rejected.
+	require.NoError(t, err)
+
+	in := &logical.LogInput{
+		Auth: &logical.Auth{
+			ClientToken:     "foo",
+			Accessor:        "bar",
+			EntityID:        "foobarentity",
+			DisplayName:     "testtoken",
+			NoDefaultPolicy: true,
+			Policies:        []string{"root"},
+			TokenType:       logical.TokenTypeService,
+		},
+		Request: &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "/foo",
+			Connection: &logical.Connection{
+				RemoteAddr: "127.0.0.1",
+			},
+			WrapInfo: &logical.RequestWrapInfo{
+				TTL: 60 * time.Second,
+			},
+			Headers: map[string][]string{
+				"foo": {"bar"},
+			},
+		},
+	}
+
+	ctx := namespace.RootContext(context.Background())
+	err = backend.LogRequest(ctx, in)
+	require.NoError(t, err)
+
+	require.Equal(t, badRequests, 0)
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	require.Equal(t, 1, len(logs))
+	require.Contains(t, logs[0], "request")
+
+	request := logs[0]["request"].(map[string]interface{})
+	require.Contains(t, request, "path")
+	require.Equal(t, request["path"].(string), "/foo")
+}

--- a/builtin/audit/http/testing.go
+++ b/builtin/audit/http/testing.go
@@ -1,0 +1,69 @@
+// Copyright (c) The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+func GetTestAuditHandler(t *testing.T, lock *sync.Mutex, logs *[]map[string]interface{}, path string, requiredHeaders http.Header, badRequests *int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		defer lock.Unlock()
+		t.Logf("got request: %#v", r)
+
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if r.URL.Path != path {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		for header, allowedValues := range requiredHeaders {
+			actualValues := r.Header.Values(header)
+			if len(actualValues) == 0 {
+				t.Logf("missing expected header: %v", header)
+				*badRequests += 1
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+
+			for _, value := range actualValues {
+				var found bool
+				for _, allowedValue := range allowedValues {
+					if allowedValue == value {
+						found = true
+					}
+				}
+
+				if !found {
+					t.Logf("value %v is not allowed for header %v", value, header)
+					*badRequests += 1
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+			}
+		}
+
+		var log map[string]interface{}
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&log); err != nil {
+			t.Logf("failed to decode request: %v", err)
+			*badRequests += 1
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		*logs = append(*logs, log)
+		t.Logf("adding log: %v", log)
+
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/changelog/1709.txt
+++ b/changelog/1709.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Add http audit device for low-volume, webhook-based audit event reporting.
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/openbao/openbao/helper/builtinplugins"
 
 	auditFile "github.com/openbao/openbao/builtin/audit/file"
+	auditHttp "github.com/openbao/openbao/builtin/audit/http"
 	auditSocket "github.com/openbao/openbao/builtin/audit/socket"
 	auditSyslog "github.com/openbao/openbao/builtin/audit/syslog"
 
@@ -129,6 +130,7 @@ const (
 var (
 	auditBackends = map[string]audit.Factory{
 		"file":   auditFile.Factory,
+		"http":   auditHttp.Factory,
 		"socket": auditSocket.Factory,
 		"syslog": auditSyslog.Factory,
 	}

--- a/website/content/docs/audit/file.mdx
+++ b/website/content/docs/audit/file.mdx
@@ -15,6 +15,17 @@ existing tools.
 Sending a `SIGHUP` to the OpenBao process will cause `file` audit devices to close
 and re-open their underlying file, which can assist with log rotation needs.
 
+:::warning
+
+The File audit device is sensitive as it can write to arbitrary files on the
+instance. Be cautious when granting operators the ability to create this
+device via the API when `unsafe_allow_api_audit_creation=true` is set.
+
+Consider using [declarative audit configuration](/docs/configuration/audit/)
+instead.
+
+:::
+
 ## Examples
 
 Enable at the default path:

--- a/website/content/docs/audit/http.mdx
+++ b/website/content/docs/audit/http.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_label: HTTP
+description: The "http" audit device writes audit logs to a remote http server.
+---
+
+# HTTP audit device
+
+The `http` audit device writes audit logs to a remote server over HTTP(S).
+This is a very simple audit device: it does not attempt retry and is fully
+synchronous with the request by default.
+
+Sending a `SIGHUP` to the OpenBao process will cause `http` audit devices to
+close any idle connections and re-open their connection to the HTTP server.
+
+:::info
+
+As audit logs are sensitive, take care to ensure you use a secure transport
+(HTTPS) for all production use cases.
+
+:::
+
+## Examples
+
+Enable at the default path:
+
+```shell-session
+$ bao audit enable http uri=https://my-log-server.local/ingress
+```
+
+Enable at a different path. It is possible to enable multiple copies of an audit
+device:
+
+```shell-session
+$ bao audit enable -path="openbao_audit_1" http uri=https://my-second-log-server.local/ingress
+```
+
+## Configuration
+
+Note the difference between `audit enable` command options and the `http` backend
+configuration options. Use `bao audit enable -help` to see the command options.
+
+The `http` audit device supports the common configuration options documented on
+the [main Audit Devices page](/docs/audit#common-configuration-options), and
+these device-specific options:
+
+- `uri` `(string: <required>)` - The URI of the remote server where the audit
+  logs will be written.
+
+- `headers` `(string: "")` - A JSON object describing headers. Must take the
+  shape `map[string][]string`, i.e., an object of headers, with each having
+  one or more values. Headers without values will be ignored.
+
+Both `uri` and any header values are passed through [`parseutil.ParsePath(...)`](https://pkg.go.dev/github.com/hashicorp/go-secure-stdlib/parseutil),
+allowing environment variables or files to be referenced.

--- a/website/content/docs/audit/http.mdx
+++ b/website/content/docs/audit/http.mdx
@@ -12,6 +12,17 @@ synchronous with the request by default.
 Sending a `SIGHUP` to the OpenBao process will cause `http` audit devices to
 close any idle connections and re-open their connection to the HTTP server.
 
+:::warning
+
+The HTTP audit device is sensitive as it can connect to arbitrary servers.
+Be cautious when granting operators the ability to create this device via
+the API when `unsafe_allow_api_audit_creation=true` is set.
+
+Consider using [declarative audit configuration](/docs/configuration/audit/)
+instead.
+
+:::
+
 :::info
 
 As audit logs are sensitive, take care to ensure you use a secure transport

--- a/website/content/docs/audit/socket.mdx
+++ b/website/content/docs/audit/socket.mdx
@@ -9,6 +9,17 @@ The `socket` audit device writes to a TCP, UDP, or UNIX socket.
 
 :::warning
 
+The socket audit device is sensitive as it can connect to arbitrary servers.
+Be cautious when granting operators the ability to create this device via
+the API when `unsafe_allow_api_audit_creation=true` is set.
+
+Consider using [declarative audit configuration](/docs/configuration/audit/)
+instead.
+
+:::
+
+:::warning
+
 **Warning:** The loss of audit logs may occur when using the UDP socket audit type. Because UDP socket audit type is connectionless, meaning the UDP endpoint becomes unavailable, it’s possible that any number of audit logs written to it may get lost, even though the request will still succeed. OpenBao does not provide an indication for the loss of audit logs. Therefore, we recommend using your device in conjunction with a secondary “non-socket” audit device to ensure accuracy and to guarantee that audit logs will not be lost.
 
 :::

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -410,6 +410,7 @@ const sidebars: SidebarsConfig = {
             "Audit Devices": [
                 "audit/index",
                 "audit/file",
+                "audit/http",
                 "audit/syslog",
                 "audit/socket",
             ],


### PR DESCRIPTION
This adds a new HTTP audit method, allowing collection of audit events by a remote server.

The HTTP audit device behaves like other audit devices, failing closed on failure to send the specified audit message. This is in contrast to a retry queue or batching audit device mechanism, which would also be possible but would violate the audit device contract. This keeps the implementation fairly simple. 

See also: https://gitlab.com/gitlab-org/gitlab/-/issues/470461
See also: https://gitlab.com/gitlab-com/content-sites/handbook/-/merge_requests/15328 