### PR TITLE
Fix nil panic with unsafe_cross_namespace_identity

### DIFF
--- a/changelog/1715.txt
+++ b/changelog/1715.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: fix nil panic when collecting metrics with unsafe_cross_namespace_identity=true.
+```

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"errors"
 	"sort"
 	"strings"
@@ -262,9 +263,20 @@ func metricLabelsMatch(t *testing.T, actual []metrics.Label, expected map[string
 }
 
 func TestCoreMetrics_EntityGauges(t *testing.T) {
-	ctx := namespace.RootContext(nil)
-	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t)
+	ctx := namespace.RootContext(context.Background())
+	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
 
+	testCoreMetricsEntityGauges(t, ctx, is, approleAccessor, upAccessor, core)
+}
+
+func TestCoreMetrics_EntityGaugesUnsafeSharedIdentity(t *testing.T) {
+	ctx := namespace.RootContext(context.Background())
+	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
+
+	testCoreMetricsEntityGauges(t, ctx, is, approleAccessor, upAccessor, core)
+}
+
+func testCoreMetricsEntityGauges(t *testing.T, ctx context.Context, is *IdentityStore, approleAccessor string, upAccessor string, core *Core) {
 	// Create an entity
 	alias1 := &logical.Alias{
 		MountType:     "approle",

--- a/vault/identity_store_entities_test.go
+++ b/vault/identity_store_entities_test.go
@@ -1009,12 +1009,20 @@ func TestIdentityStore_EntityCRUD(t *testing.T) {
 }
 
 func TestIdentityStore_MergeEntitiesByID(t *testing.T) {
+	ctx := namespace.RootContext(context.Background())
+	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
+	testIdentityStoreMergeEntitiesById(t, ctx, is, approleAccessor, upAccessor, core)
+}
+
+func TestIdentityStore_MergeEntitiesByID_UnsafeShared(t *testing.T) {
+	ctx := namespace.RootContext(context.Background())
+	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
+	testIdentityStoreMergeEntitiesById(t, ctx, is, approleAccessor, upAccessor, core)
+}
+
+func testIdentityStoreMergeEntitiesById(t *testing.T, ctx context.Context, is *IdentityStore, approleAccessor string, upAccessor string, core *Core) {
 	var err error
 	var resp *logical.Response
-
-	ctx := namespace.RootContext(nil)
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t)
-
 	registerData := map[string]interface{}{
 		"name":     "testentityname2",
 		"metadata": []string{"someusefulkey=someusefulvalue"},

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -722,8 +722,7 @@ func testIdentityStoreWithAppRoleUserpassAuth(ctx context.Context, t *testing.T,
 			"file": auditFile.Factory,
 		},
 	}
-	core := TestCoreWithSealAndUI(t, conf)
-	c, _, _ := testCoreUnsealed(t, core)
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
 
 	githubMe := &MountEntry{
 		Table:       credentialTableType,

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -257,13 +257,13 @@ func TestIdentityStore_EntityIDPassthrough(t *testing.T) {
 }
 
 func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
-	ctx := namespace.RootContext(nil)
+	ctx := namespace.RootContext(t.Context())
 	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
 	testIdentityStoreCreateOrFetchEntity(t, ctx, is, approleAccessor, upAccessor, core)
 }
 
 func TestIdentityStore_CreateOrFetchEntity_UnsafeShared(t *testing.T) {
-	ctx := namespace.RootContext(nil)
+	ctx := namespace.RootContext(t.Context())
 	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
 	testIdentityStoreCreateOrFetchEntity(t, ctx, is, approleAccessor, upAccessor, core)
 }

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -2435,11 +2435,22 @@ func (i *IdentityStore) handleAliasListCommon(ctx context.Context, groupAlias bo
 func (i *IdentityStore) countEntities(ctx context.Context) (int, error) {
 	var count int
 	var outErr error
+
+	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
+	if !ok || rootViewRaw == nil {
+		return -1, fmt.Errorf("failed to load root namespace")
+	}
+	rootView := rootViewRaw.(*identityStoreNamespaceView)
+
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
+		db := views.db
+		if db == nil {
+			db = rootView.db
+		}
 
-		txn := views.db.Txn(false)
+		txn := db.Txn(false)
 
 		iter, err := txn.Get(entitiesTable, "id")
 		if err != nil {
@@ -2467,12 +2478,22 @@ func (i *IdentityStore) countEntities(ctx context.Context) (int, error) {
 func (i *IdentityStore) countEntitiesByNamespace(ctx context.Context) (map[string]int, error) {
 	byNamespace := make(map[string]int)
 
+	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
+	if !ok || rootViewRaw == nil {
+		return nil, fmt.Errorf("failed to load root namespace")
+	}
+	rootView := rootViewRaw.(*identityStoreNamespaceView)
+
 	var err error
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
+		db := views.db
+		if db == nil {
+			db = rootView.db
+		}
 
-		txn := views.db.Txn(false)
+		txn := db.Txn(false)
 
 		var iter memdb.ResultIterator
 		iter, err = txn.Get(entitiesTable, "id")
@@ -2510,12 +2531,22 @@ func (i *IdentityStore) countEntitiesByNamespace(ctx context.Context) (map[strin
 func (i *IdentityStore) countEntitiesByMountAccessor(ctx context.Context) (map[string]int, error) {
 	byMountAccessor := make(map[string]int)
 
+	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
+	if !ok || rootViewRaw == nil {
+		return nil, fmt.Errorf("failed to load root namespace")
+	}
+	rootView := rootViewRaw.(*identityStoreNamespaceView)
+
 	var err error
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
+		db := views.db
+		if db == nil {
+			db = rootView.db
+		}
 
-		txn := views.db.Txn(false)
+		txn := db.Txn(false)
 
 		var iter memdb.ResultIterator
 		iter, err = txn.Get(entitiesTable, "id")


### PR DESCRIPTION
The only place where IdentityStore.db(...) is not called is when ranging over all views to collect metrics. This did not handle the unsafe cross-namespace identity behavior of using a single memdb (only available on the root namespace's view entry), leading to a nil panic.

Resolves: #1708
