### PR TITLE
Change JSON policy example from 'paths' to 'path'

### DIFF
--- a/changelog/1721.txt
+++ b/changelog/1721.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-website: fix typo in Policy Syntax documentation
-```


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

The documentation erroneously pluralizes the `"paths"` key in its JSON policy sample. The correct key is `"path"`
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1720
