### PR TITLE
Fix profile field selector for lists, configs

### DIFF
--- a/helper/profiles/history_test.go
+++ b/helper/profiles/history_test.go
@@ -159,7 +159,7 @@ func TestGetRequestField_SingleKey(t *testing.T) {
 		t.Fatalf("AddRequestData: %v", err)
 	}
 
-	value, err := history.GetRequestField("tokenInit", "create-token", "token_ttl")
+	value, err := history.GetRequestField("tokenInit", "create-token", []interface{}{"token_ttl"})
 	if err != nil {
 		t.Fatalf("GetRequestField error: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestGetRequestField_NestedKeyPath(t *testing.T) {
 		t.Fatalf("AddRequestData: %v", err)
 	}
 
-	selector := []string{"data", "data", "config_key"}
+	selector := []interface{}{"data", "data", "config_key"}
 	value, err := history.GetRequestField("secretInit", "write-config", selector)
 	if err != nil {
 		t.Fatalf("GetRequestField nested error: %v", err)
@@ -205,7 +205,7 @@ func TestGetRequestField_MissingKey(t *testing.T) {
 		t.Fatalf("AddRequestData: %v", err)
 	}
 
-	_, err := history.GetRequestField("healthInit", "check-health", "status")
+	_, err := history.GetRequestField("healthInit", "check-health", []interface{}{"status"})
 	if err == nil {
 		t.Fatal("expected error for missing field, got nil")
 	}
@@ -254,7 +254,7 @@ func TestGetResponseField_Success(t *testing.T) {
 		t.Fatalf("AddResponseData: %v", err)
 	}
 
-	selector := []string{"auth", "client_token"}
+	selector := []interface{}{"auth", "client_token"}
 	value, err := history.GetResponseField("tokenInit", "create-token", selector)
 	if err != nil {
 		t.Fatalf("GetResponseField error: %v", err)
@@ -273,7 +273,7 @@ func TestGetResponseField_InvalidSelectorType(t *testing.T) {
 		t.Fatalf("AddResponseData: %v", err)
 	}
 
-	_, err := history.GetResponseField("configInit", "read-config", 42)
+	_, err := history.GetResponseField("configInit", "read-config", []interface{}{42.00})
 	if err == nil {
 		t.Fatal("expected selector type error, got nil")
 	}

--- a/helper/profiles/request_source.go
+++ b/helper/profiles/request_source.go
@@ -27,7 +27,7 @@ type RequestSource struct {
 
 	outerName     string
 	requestName   string
-	fieldSelector interface{}
+	fieldSelector []interface{}
 }
 
 var _ Source = &RequestSource{}
@@ -65,16 +65,23 @@ func (s *RequestSource) Validate(_ context.Context) ([]string, []string, error) 
 	requestName += reqName
 
 	rawFieldSelector := s.field["field_selector"]
-
 	if present {
-		switch rawFieldSelector.(type) {
-		case string:
+		switch fieldSelector := rawFieldSelector.(type) {
+		case int, string:
+			s.fieldSelector = []interface{}{fieldSelector}
+		case []int:
+			for _, item := range fieldSelector {
+				s.fieldSelector = append(s.fieldSelector, item)
+			}
 		case []string:
+			for _, item := range fieldSelector {
+				s.fieldSelector = append(s.fieldSelector, item)
+			}
+		case []interface{}:
+			s.fieldSelector = fieldSelector
 		default:
-			return nil, nil, fmt.Errorf("unknown type for request source field 'field_selector': %T; expected either string or []string", rawFieldSelector)
+			return nil, nil, fmt.Errorf("unknown type for request source field 'field_selector': %T; expected either string, []string, or []interface{}", rawFieldSelector)
 		}
-
-		s.fieldSelector = rawFieldSelector
 	}
 
 	return []string{requestName}, nil, nil

--- a/helper/profiles/request_source_test.go
+++ b/helper/profiles/request_source_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithRequestSource_RegistersBuilder(t *testing.T) {
@@ -170,4 +172,25 @@ func TestRequestSource_Evaluate_WithFieldSelector_String(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("Evaluate result = %#v; want %#v", result, expected)
 	}
+}
+
+func TestRequestSource_Evaluate_WithFieldSelector_Interface(t *testing.T) {
+	ctx := context.Background()
+	history := &EvaluationHistory{}
+	source := &RequestSource{
+		field: map[string]interface{}{"request_name": "mount-userpass", "field_selector": []interface{}{"userPass", 0}},
+	}
+
+	_, _, err := source.Validate(ctx)
+	require.NoError(t, err)
+
+	requestData := map[string]interface{}{
+		"userPass": []interface{}{"test"},
+	}
+	err = history.AddRequestData("", "mount-userpass", requestData)
+	require.NoError(t, err)
+
+	result, err := source.Evaluate(ctx, history)
+	require.NoError(t, err)
+	require.Equal(t, result, "test")
 }

--- a/helper/profiles/response_source.go
+++ b/helper/profiles/response_source.go
@@ -27,7 +27,7 @@ type ResponseSource struct {
 
 	outerName     string
 	responseName  string
-	fieldSelector interface{}
+	fieldSelector []interface{}
 }
 
 var _ Source = &ResponseSource{}
@@ -65,16 +65,23 @@ func (s *ResponseSource) Validate(_ context.Context) ([]string, []string, error)
 	responseName += respName
 
 	rawFieldSelector := s.field["field_selector"]
-
 	if present {
-		switch rawFieldSelector.(type) {
-		case string:
+		switch fieldSelector := rawFieldSelector.(type) {
+		case int, string:
+			s.fieldSelector = []interface{}{fieldSelector}
+		case []int:
+			for _, item := range fieldSelector {
+				s.fieldSelector = append(s.fieldSelector, item)
+			}
 		case []string:
+			for _, item := range fieldSelector {
+				s.fieldSelector = append(s.fieldSelector, item)
+			}
+		case []interface{}:
+			s.fieldSelector = fieldSelector
 		default:
-			return nil, nil, fmt.Errorf("unknown type for response source field 'field_selector': %T; expected either string or []string", rawFieldSelector)
+			return nil, nil, fmt.Errorf("unknown type for response source field 'field_selector': %T; expected either string, []string, []interface{}", rawFieldSelector)
 		}
-
-		s.fieldSelector = rawFieldSelector
 	}
 
 	return []string{responseName}, nil, nil


### PR DESCRIPTION
When parsing from a configuration file, the field selector is of type `[]interface`, not `[]string`. This also gives us the opportunity to handle lists through heterogeneously typed lists (e.g., `["data", "keys", 0]` for instance).

---

cc @KrzysztofKornalewski-Reply @JanMa