### PR TITLE
Revert sys/health status code changes

### DIFF
--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -20,9 +20,13 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or
 	// inited, so we force this code to be something else so we parse correctly
-	r.Params.Add("uninitcode", "299")
-	r.Params.Add("sealedcode", "299")
 	r.Params.Add("standbycode", "299")
+	r.Params.Add("drsecondarycode", "299")
+	r.Params.Add("haunhealhty", "299")
+	r.Params.Add("performancestandbycode", "299")
+	r.Params.Add("removedcode", "299")
+	r.Params.Add("sealedcode", "299")
+	r.Params.Add("uninitcode", "299")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -36,12 +40,15 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 }
 
 type HealthResponse struct {
-	Initialized   bool   `json:"initialized"`
-	Sealed        bool   `json:"sealed"`
-	Standby       bool   `json:"standby"`
-	ServerTimeUTC int64  `json:"server_time_utc"`
-	Version       string `json:"version"`
-	ClusterName   string `json:"cluster_name,omitempty"`
-	ClusterID     string `json:"cluster_id,omitempty"`
-	LastWAL       uint64 `json:"last_wal,omitempty"`
+	Initialized                bool   `json:"initialized"`
+	Sealed                     bool   `json:"sealed"`
+	Standby                    bool   `json:"standby"`
+	PerformanceStandby         bool   `json:"performance_standby"`
+	ReplicationPerformanceMode string `json:"replication_performance_mode"`
+	ReplicationDRMode          string `json:"replication_dr_mode"`
+	ServerTimeUTC              int64  `json:"server_time_utc"`
+	Version                    string `json:"version"`
+	ClusterName                string `json:"cluster_name,omitempty"`
+	ClusterID                  string `json:"cluster_id,omitempty"`
+	LastWAL                    uint64 `json:"last_wal,omitempty"`
 }

--- a/changelog/1730.txt
+++ b/changelog/1730.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix compatibility with sys/health from Vault Enterprise
+```


### PR DESCRIPTION
In ab940910d4edb1449f3091d9deb3c1adc9fded68, I pruned status code parameters only supported by Vault Enterprise. This means clients using OpenBao's API to talk to Vault Enterprise will receive 4xx or 5xx errors from these endpoints instead. Vault has since added more parameters, which we've opted to remap as well.

See also: https://developer.hashicorp.com/vault/api-docs/system/health
See also: https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/5733#note_2708003264
