### PR TITLE
feat(OIDC-Provider): Add clientCredentialsFlow to Oidc Provider

### DIFF
--- a/changelog/1732.txt
+++ b/changelog/1732.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**OIDC Provider**: Add Client Credentials flow to OIDC Provider
+```

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.1 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -398,8 +398,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tdakkota/asciicheck v0.4.1 h1:bm0tbcmi0jezRA2b5kg4ozmMuGAFotKI3RZfrhfovg8=

--- a/ui/app/models/oidc/client.js
+++ b/ui/app/models/oidc/client.js
@@ -73,7 +73,7 @@ export default class OidcClientModel extends Model {
   idTokenTtl;
 
   @attr('boolean', {
-    defaultValue: false,
+    defaultValue: true,
     label: 'Allow authorization code flow',
   })
   authorizationCode;

--- a/ui/app/models/oidc/client.js
+++ b/ui/app/models/oidc/client.js
@@ -72,6 +72,18 @@ export default class OidcClientModel extends Model {
   })
   idTokenTtl;
 
+  @attr('boolean', {
+    defaultValue: false,
+    label: 'Allow authorization code flow',
+  })
+  authorizationCode;
+
+  @attr('boolean', {
+    defaultValue: false,
+    label: 'Allow client credential flow',
+  })
+  clientCredentials;
+
   // >> END MORE OPTIONS TOGGLE <<
 
   @attr('array', { label: 'Assign access' }) assignments; // no editType because does not use form-field component

--- a/ui/app/models/oidc/provider.js
+++ b/ui/app/models/oidc/provider.js
@@ -46,7 +46,7 @@ export default class OidcProviderModel extends Model {
   _attributeMeta = null; // cache initial result of expandAttributeMeta in getter and return
   get formFields() {
     if (!this._attributeMeta) {
-      this._attributeMeta = expandAttributeMeta(this, ['name', 'issuer', 'scopesSupported']);
+      this._attributeMeta = expandAttributeMeta(this, ['name', 'issuer', 'scopesSupported','authorizationCode','clientCredentials']);
     }
     return this._attributeMeta;
   }

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -99,7 +99,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with provider not found",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -114,7 +114,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing basic auth header",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -129,7 +129,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client ID not found",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -140,7 +140,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client secret mismatch",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -151,7 +151,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client_id not allowed by provider",
 			args: args{
-				clientReq: testClientReq(s),
+				clientReq: testClientReq(s, true, false),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -166,7 +166,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty grant_type",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -181,7 +181,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with unsupported grant_type",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -196,7 +196,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with invalid code",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -211,7 +211,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing redirect_uri",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -226,7 +226,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with entity not found in client assignment",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "not-entity-id", ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -237,7 +237,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with redirect_uri mismatch",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -252,7 +252,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with group not found in client assignment",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", "not-group-id"),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -263,7 +263,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with scopes claim conflict",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -278,7 +278,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty code_verifier",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -298,7 +298,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with code_verifier provided for non-PKCE flow",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -313,7 +313,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with incorrect plain code_verifier",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -333,7 +333,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with incorrect S256 code_verifier",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -353,7 +353,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with plain code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -372,7 +372,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with default plain code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -391,7 +391,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with S256 code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -410,7 +410,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with max_age and auth_time claim",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -427,7 +427,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with empty nonce in authorize request",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -441,7 +441,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with client_secret_post client authentication method",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -457,7 +457,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request ",
 			args: args{
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -483,7 +483,9 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 			require.NotEmpty(t, te.ID)
 
 			// Reset any configuration modifications
-			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID)
+			authorizationCode := tt.args.clientReq.Data["authorization_code"].(bool)
+			clientCredentials := tt.args.clientReq.Data["client_credentials"].(bool)
+			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID, authorizationCode, clientCredentials)
 
 			// Send the request to the OIDC authorize endpoint
 			tt.args.authorizeReq.EntityID = entityID
@@ -629,7 +631,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing basic auth header",
 			args: args{
-				clientReq:   testClientReq(s),
+				clientReq:   testClientReq(s, false, true),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq: func() *logical.Request {
 					req := testClientCredentialsTokenReq(s, "openid", clientID, clientSecret)
@@ -642,7 +644,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client ID not found",
 			args: args{
-				clientReq:   testClientReq(s),
+				clientReq:   testClientReq(s, false, true),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", "non-existent-client-id", clientSecret),
 			},
@@ -651,7 +653,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client secret mismatch",
 			args: args{
-				clientReq:   testClientReq(s),
+				clientReq:   testClientReq(s, false, true),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, "wrong-client-secret"),
 			},
@@ -660,7 +662,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client_id not allowed by provider",
 			args: args{
-				clientReq: testClientReq(s),
+				clientReq: testClientReq(s, false, true),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -673,7 +675,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty grant_type",
 			args: args{
-				clientReq:   testClientReq(s),
+				clientReq:   testClientReq(s, false, true),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq: func() *logical.Request {
 					req := testClientCredentialsTokenReq(s, "openid", clientID, clientSecret)
@@ -686,7 +688,16 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "valid token request",
 			args: args{
-				clientReq:   testClientReq(s),
+				clientReq:   testClientReq(s, false, false),
+				providerReq: testProviderReq(s, clientID),
+				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, clientSecret),
+			},
+			wantErr: ErrTokenInvalidGrant,
+		},
+		{
+			name: "valid token request",
+			args: args{
+				clientReq:   testClientReq(s, false, true),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, clientSecret),
 			},
@@ -710,7 +721,9 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 			require.NotEmpty(t, te.ID)
 
 			// Reset any configuration modifications
-			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID)
+			authorizationCode := tt.args.clientReq.Data["authorization_code"].(bool)
+			clientCredentials := tt.args.clientReq.Data["client_credentials"].(bool)
+			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID, authorizationCode, clientCredentials)
 
 			// Update the client
 			tt.args.clientReq.Operation = logical.UpdateOperation
@@ -821,7 +834,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with provider not found",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -836,7 +849,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with empty scope",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -851,7 +864,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing openid scope",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -866,7 +879,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing response_type",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -881,7 +894,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with unsupported response_type",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -896,7 +909,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with client_id not found",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -909,7 +922,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with client_id not allowed by provider",
 			args: args{
 				entityID:  entityID,
-				clientReq: testClientReq(s),
+				clientReq: testClientReq(s, true, false),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -924,7 +937,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing redirect_uri",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -940,7 +953,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s)
+					req := testClientReq(s, true, false)
 					req.Data["redirect_uris"] = []string{"https://not.redirect.uri:8251/callback"}
 					return req
 				}(),
@@ -954,7 +967,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with request parameter provided",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -969,7 +982,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with request_uri parameter provided",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -984,7 +997,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with identity entity not associated with the request",
 			args: args{
 				entityID:      "",
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -995,7 +1008,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with identity entity ID not found",
 			args: args{
 				entityID:      "non-existent-entity",
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1006,7 +1019,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with entity not found in client assignment",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "not-entity-id", ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1017,7 +1030,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with group not found in client assignment",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", "not-group-id"),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1028,7 +1041,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with negative max_age",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1043,7 +1056,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with invalid code_challenge_method",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1059,7 +1072,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with code_challenge length < 43 characters",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1075,7 +1088,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with code_challenge length > 128 characters",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1092,10 +1105,25 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			wantErr: ErrAuthInvalidRequest,
 		},
 		{
+			name: "invalid authorize provider does not allow authorization code flow",
+			args: args{
+				entityID:      entityID,
+				clientReq:     testClientReq(s, false, false),
+				providerReq:   testProviderReq(s, clientID),
+				assignmentReq: testAssignmentReq(s, entityID, groupID),
+				authorizeReq: func() *logical.Request {
+					req := testAuthorizeReq(s, clientID)
+					delete(req.Data, "nonce")
+					return req
+				}(),
+			},
+			wantErr: ErrTokenInvalidGrant,
+		},
+		{
 			name: "valid authorize request with empty nonce",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1109,7 +1137,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request with empty state",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1123,7 +1151,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "active re-authentication required with token creation time exceeding max_age requirement",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1141,7 +1169,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request with token creation time within max_age requirement",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1158,7 +1186,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using update operation (HTTP POST)",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1168,7 +1196,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using read operation (HTTP GET)",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1182,7 +1210,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with only entity membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1192,7 +1220,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with only group membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1202,7 +1230,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with inherited group membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s),
+				clientReq:     testClientReq(s, true, false),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", parentGroupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1213,7 +1241,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s)
+					req := testClientReq(s, true, false)
 					req.Data["redirect_uris"] = []string{"http://127.0.0.1/callback"}
 					return req
 				}(),
@@ -1231,7 +1259,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s)
+					req := testClientReq(s, true, false)
 					req.Data["redirect_uris"] = []string{"http://127.0.0.1:8251/callback"}
 					return req
 				}(),
@@ -1249,7 +1277,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s)
+					req := testClientReq(s, true, false)
 					req.Data["redirect_uris"] = []string{"http://localhost:8251/callback"}
 					return req
 				}(),
@@ -1267,7 +1295,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s)
+					req := testClientReq(s, true, false)
 					req.Data["redirect_uris"] = []string{"http://[::1]:8251/callback"}
 					return req
 				}(),
@@ -1394,7 +1422,7 @@ func setupOIDCCommon(t *testing.T, c *Core, s logical.Storage) (string, string, 
 	expectSuccess(t, resp, err)
 
 	// Create a client
-	resp, err = c.identityStore.HandleRequest(ctx, testClientReq(s))
+	resp, err = c.identityStore.HandleRequest(ctx, testClientReq(s, true, true))
 	expectSuccess(t, resp, err)
 
 	// Read the client ID and secret
@@ -1443,7 +1471,7 @@ func setupOIDCCommon(t *testing.T, c *Core, s logical.Storage) (string, string, 
 // (i.e., created by setupOIDCCommon) that are modified during tests. This
 // enables the tests to continue operating using the same underlying storage
 // throughout many test cases that modify the configuration resources.
-func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, groupID, clientID string) {
+func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, groupID, clientID string, authorizationCode, clientCredentials bool) {
 	ctx := namespace.RootContext(nil)
 
 	req := testAssignmentReq(s, entityID, groupID)
@@ -1451,7 +1479,7 @@ func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, g
 	resp, err := c.identityStore.HandleRequest(ctx, req)
 	expectSuccess(t, resp, err)
 
-	req = testClientReq(s)
+	req = testClientReq(s, authorizationCode, clientCredentials)
 	req.Operation = logical.UpdateOperation
 	resp, err = c.identityStore.HandleRequest(ctx, req)
 	expectSuccess(t, resp, err)
@@ -1472,9 +1500,11 @@ func testAuthorizationCodeTokenReq(s logical.Storage, code, clientID, clientSecr
 		},
 		Data: map[string]interface{}{
 			// The code is unknown until returned from the authorization endpoint
-			"code":         code,
-			"grant_type":   "authorization_code",
-			"redirect_uri": "https://localhost:8251/callback",
+			"code":               code,
+			"grant_type":         "authorization_code",
+			"redirect_uri":       "https://localhost:8251/callback",
+			"authorization_code": true,
+			"client_credentials": false,
 		},
 	}
 }
@@ -1489,9 +1519,11 @@ func testClientCredentialsTokenReq(s logical.Storage, scope, clientID, clientSec
 		},
 		Data: map[string]interface{}{
 			// The code is unknown until returned from the authorization endpoint
-			"scope":        scope,
-			"grant_type":   "client_credentials",
-			"redirect_uri": "https://localhost:8251/callback",
+			"scope":              scope,
+			"grant_type":         "client_credentials",
+			"redirect_uri":       "https://localhost:8251/callback",
+			"authorization_code": false,
+			"client_credentials": true,
 		},
 	}
 }
@@ -1524,17 +1556,19 @@ func testAssignmentReq(s logical.Storage, entityID, groupID string) *logical.Req
 	}
 }
 
-func testClientReq(s logical.Storage) *logical.Request {
+func testClientReq(s logical.Storage, authorizationCode, clientCredentials bool) *logical.Request {
 	return &logical.Request{
 		Storage:   s,
 		Path:      "oidc/client/test-client",
 		Operation: logical.CreateOperation,
 		Data: map[string]interface{}{
-			"key":              "test-key",
-			"redirect_uris":    []string{"https://localhost:8251/callback"},
-			"assignments":      []string{"test-assignment"},
-			"id_token_ttl":     "24h",
-			"access_token_ttl": "24h",
+			"key":                "test-key",
+			"redirect_uris":      []string{"https://localhost:8251/callback"},
+			"assignments":        []string{"test-assignment"},
+			"id_token_ttl":       "24h",
+			"access_token_ttl":   "24h",
+			"client_credentials": clientCredentials,
+			"authorization_code": authorizationCode,
 		},
 	}
 }
@@ -2104,14 +2138,16 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"redirect_uris":    []string{},
-		"assignments":      []string{},
-		"key":              "test-key",
-		"id_token_ttl":     int64(60),
-		"access_token_ttl": int64(86400),
-		"client_id":        resp.Data["client_id"],
-		"client_secret":    resp.Data["client_secret"],
-		"client_type":      confidential.String(),
+		"redirect_uris":      []string{},
+		"assignments":        []string{},
+		"key":                "test-key",
+		"id_token_ttl":       int64(60),
+		"access_token_ttl":   int64(86400),
+		"client_id":          resp.Data["client_id"],
+		"client_secret":      resp.Data["client_secret"],
+		"client_type":        confidential.String(),
+		"client_credentials": resp.Data["client_credentials"],
+		"authorization_code": resp.Data["authorization_code"],
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
@@ -2141,11 +2177,13 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 		Path:      "oidc/client/test-client",
 		Operation: logical.UpdateOperation,
 		Data: map[string]interface{}{
-			"redirect_uris":    "http://localhost:3456/callback",
-			"assignments":      "my-assignment",
-			"key":              "test-key",
-			"id_token_ttl":     "90s",
-			"access_token_ttl": "1m",
+			"redirect_uris":      "http://localhost:3456/callback",
+			"assignments":        "my-assignment",
+			"key":                "test-key",
+			"id_token_ttl":       "90s",
+			"access_token_ttl":   "1m",
+			"client_credentials": false,
+			"authorization_code": false,
 		},
 		Storage: storage,
 	})
@@ -2159,14 +2197,16 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"redirect_uris":    []string{"http://localhost:3456/callback"},
-		"assignments":      []string{"my-assignment"},
-		"key":              "test-key",
-		"id_token_ttl":     int64(90),
-		"access_token_ttl": int64(60),
-		"client_id":        resp.Data["client_id"],
-		"client_secret":    resp.Data["client_secret"],
-		"client_type":      confidential.String(),
+		"redirect_uris":      []string{"http://localhost:3456/callback"},
+		"assignments":        []string{"my-assignment"},
+		"key":                "test-key",
+		"id_token_ttl":       int64(90),
+		"access_token_ttl":   int64(60),
+		"client_id":          resp.Data["client_id"],
+		"client_secret":      resp.Data["client_secret"],
+		"client_type":        confidential.String(),
+		"client_credentials": false,
+		"authorization_code": false,
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
@@ -2239,13 +2279,15 @@ func TestOIDC_Path_OIDC_ProviderClient_Deduplication(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"redirect_uris":    []string{"http://example.com", "http://notduplicate.com"},
-		"assignments":      []string{"test-assignment1"},
-		"key":              "test-key",
-		"id_token_ttl":     int64(60),
-		"access_token_ttl": int64(86400),
-		"client_id":        resp.Data["client_id"],
-		"client_type":      public.String(),
+		"redirect_uris":      []string{"http://example.com", "http://notduplicate.com"},
+		"assignments":        []string{"test-assignment1"},
+		"key":                "test-key",
+		"id_token_ttl":       int64(60),
+		"access_token_ttl":   int64(86400),
+		"client_id":          resp.Data["client_id"],
+		"client_type":        public.String(),
+		"client_credentials": resp.Data["client_credentials"],
+		"authorization_code": resp.Data["authorization_code"],
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
@@ -2300,14 +2342,16 @@ func TestOIDC_Path_OIDC_ProviderClient_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"redirect_uris":    []string{"http://localhost:3456/callback"},
-		"assignments":      []string{"my-assignment"},
-		"key":              "test-key",
-		"id_token_ttl":     int64(120),
-		"access_token_ttl": int64(3600),
-		"client_id":        resp.Data["client_id"],
-		"client_secret":    resp.Data["client_secret"],
-		"client_type":      confidential.String(),
+		"redirect_uris":      []string{"http://localhost:3456/callback"},
+		"assignments":        []string{"my-assignment"},
+		"key":                "test-key",
+		"id_token_ttl":       int64(120),
+		"access_token_ttl":   int64(3600),
+		"client_id":          resp.Data["client_id"],
+		"client_secret":      resp.Data["client_secret"],
+		"client_type":        confidential.String(),
+		"client_credentials": resp.Data["client_credentials"],
+		"authorization_code": resp.Data["authorization_code"],
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
@@ -2334,14 +2378,16 @@ func TestOIDC_Path_OIDC_ProviderClient_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"redirect_uris":    []string{"http://localhost:3456/callback2"},
-		"assignments":      []string{"my-assignment"},
-		"key":              "test-key",
-		"id_token_ttl":     int64(30),
-		"access_token_ttl": int64(60),
-		"client_id":        resp.Data["client_id"],
-		"client_secret":    resp.Data["client_secret"],
-		"client_type":      confidential.String(),
+		"redirect_uris":      []string{"http://localhost:3456/callback2"},
+		"assignments":        []string{"my-assignment"},
+		"key":                "test-key",
+		"id_token_ttl":       int64(30),
+		"access_token_ttl":   int64(60),
+		"client_id":          resp.Data["client_id"],
+		"client_secret":      resp.Data["client_secret"],
+		"client_type":        confidential.String(),
+		"client_credentials": resp.Data["client_credentials"],
+		"authorization_code": resp.Data["authorization_code"],
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -2208,6 +2208,10 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 		"client_credentials": false,
 		"authorization_code": false,
 	}
+	// Get value behind pointer so we can do not work on pointers in deep equal
+	if v, ok := resp.Data["authorization_code"].(*bool); ok && v != nil {
+		resp.Data["authorization_code"] = *v
+	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
 	}

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -99,7 +99,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with provider not found",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -114,7 +114,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing basic auth header",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -129,7 +129,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client ID not found",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -140,7 +140,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client secret mismatch",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -151,7 +151,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client_id not allowed by provider",
 			args: args{
-				clientReq: testClientReq(s, true, false),
+				clientReq: testClientReq(s),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -166,7 +166,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty grant_type",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -181,7 +181,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with unsupported grant_type",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -196,7 +196,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with invalid code",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -211,7 +211,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing redirect_uri",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -226,7 +226,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with entity not found in client assignment",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "not-entity-id", ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -237,7 +237,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with redirect_uri mismatch",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -252,7 +252,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with group not found in client assignment",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", "not-group-id"),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -263,7 +263,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with scopes claim conflict",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -278,7 +278,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty code_verifier",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -298,7 +298,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with code_verifier provided for non-PKCE flow",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -313,7 +313,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with incorrect plain code_verifier",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -333,7 +333,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "invalid token request with incorrect S256 code_verifier",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -353,7 +353,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with plain code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -372,7 +372,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with default plain code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -391,7 +391,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with S256 code_challenge_method",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -410,7 +410,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with max_age and auth_time claim",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -427,7 +427,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with empty nonce in authorize request",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -441,7 +441,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request with client_secret_post client authentication method",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -457,7 +457,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 		{
 			name: "valid token request ",
 			args: args{
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -483,9 +483,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 			require.NotEmpty(t, te.ID)
 
 			// Reset any configuration modifications
-			authorizationCode := tt.args.clientReq.Data["authorization_code"].(bool)
-			clientCredentials := tt.args.clientReq.Data["client_credentials"].(bool)
-			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID, authorizationCode, clientCredentials)
+			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID)
 
 			// Send the request to the OIDC authorize endpoint
 			tt.args.authorizeReq.EntityID = entityID
@@ -631,7 +629,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with missing basic auth header",
 			args: args{
-				clientReq:   testClientReq(s, false, true),
+				clientReq:   testClientClientcredentialFlowReq(s),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq: func() *logical.Request {
 					req := testClientCredentialsTokenReq(s, "openid", clientID, clientSecret)
@@ -644,7 +642,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client ID not found",
 			args: args{
-				clientReq:   testClientReq(s, false, true),
+				clientReq:   testClientClientcredentialFlowReq(s),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", "non-existent-client-id", clientSecret),
 			},
@@ -653,7 +651,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client secret mismatch",
 			args: args{
-				clientReq:   testClientReq(s, false, true),
+				clientReq:   testClientClientcredentialFlowReq(s),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, "wrong-client-secret"),
 			},
@@ -662,7 +660,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with client_id not allowed by provider",
 			args: args{
-				clientReq: testClientReq(s, false, true),
+				clientReq: testClientClientcredentialFlowReq(s),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -675,7 +673,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "invalid token request with empty grant_type",
 			args: args{
-				clientReq:   testClientReq(s, false, true),
+				clientReq:   testClientClientcredentialFlowReq(s),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq: func() *logical.Request {
 					req := testClientCredentialsTokenReq(s, "openid", clientID, clientSecret)
@@ -686,9 +684,22 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 			wantErr: ErrTokenUnsupportedGrantType,
 		},
 		{
-			name: "valid token request",
+			name: "token request with client credentials disabled",
 			args: args{
-				clientReq:   testClientReq(s, false, false),
+				clientReq: &logical.Request{
+					Storage:   s,
+					Path:      "oidc/client/test-client",
+					Operation: logical.CreateOperation,
+					Data: map[string]interface{}{
+						"key":                "test-key",
+						"redirect_uris":      []string{"https://localhost:8251/callback"},
+						"assignments":        []string{"test-assignment"},
+						"id_token_ttl":       "24h",
+						"access_token_ttl":   "24h",
+						"client_credentials": false,
+						"authorization_code": true,
+					},
+				},
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, clientSecret),
 			},
@@ -697,7 +708,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 		{
 			name: "valid token request",
 			args: args{
-				clientReq:   testClientReq(s, false, true),
+				clientReq:   testClientClientcredentialFlowReq(s),
 				providerReq: testProviderReq(s, clientID),
 				tokenReq:    testClientCredentialsTokenReq(s, "openid", clientID, clientSecret),
 			},
@@ -721,9 +732,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 			require.NotEmpty(t, te.ID)
 
 			// Reset any configuration modifications
-			authorizationCode := tt.args.clientReq.Data["authorization_code"].(bool)
-			clientCredentials := tt.args.clientReq.Data["client_credentials"].(bool)
-			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID, authorizationCode, clientCredentials)
+			resetCommonOIDCConfig(t, s, c, entityID, groupID, clientID)
 
 			// Update the client
 			tt.args.clientReq.Operation = logical.UpdateOperation
@@ -834,7 +843,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with provider not found",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -849,7 +858,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with empty scope",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -864,7 +873,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing openid scope",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -879,7 +888,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing response_type",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -894,7 +903,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with unsupported response_type",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -909,7 +918,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with client_id not found",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -922,7 +931,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with client_id not allowed by provider",
 			args: args{
 				entityID:  entityID,
-				clientReq: testClientReq(s, true, false),
+				clientReq: testClientReq(s),
 				providerReq: func() *logical.Request {
 					req := testProviderReq(s, clientID)
 					req.Data["allowed_client_ids"] = []string{"not-client-id"}
@@ -937,7 +946,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with missing redirect_uri",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -953,7 +962,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s, true, false)
+					req := testClientReq(s)
 					req.Data["redirect_uris"] = []string{"https://not.redirect.uri:8251/callback"}
 					return req
 				}(),
@@ -967,7 +976,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with request parameter provided",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -982,7 +991,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with request_uri parameter provided",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -997,7 +1006,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with identity entity not associated with the request",
 			args: args{
 				entityID:      "",
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1008,7 +1017,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with identity entity ID not found",
 			args: args{
 				entityID:      "non-existent-entity",
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1019,7 +1028,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with entity not found in client assignment",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "not-entity-id", ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1030,7 +1039,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with group not found in client assignment",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", "not-group-id"),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1041,7 +1050,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with negative max_age",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1056,7 +1065,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with invalid code_challenge_method",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1072,7 +1081,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with code_challenge length < 43 characters",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1088,7 +1097,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "invalid authorize request with code_challenge length > 128 characters",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1105,25 +1114,10 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			wantErr: ErrAuthInvalidRequest,
 		},
 		{
-			name: "invalid authorize provider does not allow authorization code flow",
-			args: args{
-				entityID:      entityID,
-				clientReq:     testClientReq(s, false, false),
-				providerReq:   testProviderReq(s, clientID),
-				assignmentReq: testAssignmentReq(s, entityID, groupID),
-				authorizeReq: func() *logical.Request {
-					req := testAuthorizeReq(s, clientID)
-					delete(req.Data, "nonce")
-					return req
-				}(),
-			},
-			wantErr: ErrTokenInvalidGrant,
-		},
-		{
 			name: "valid authorize request with empty nonce",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1137,7 +1131,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request with empty state",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1151,7 +1145,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "active re-authentication required with token creation time exceeding max_age requirement",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1169,7 +1163,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request with token creation time within max_age requirement",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1186,7 +1180,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using update operation (HTTP POST)",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1196,7 +1190,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using read operation (HTTP GET)",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, groupID),
 				authorizeReq: func() *logical.Request {
@@ -1210,7 +1204,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with only entity membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, entityID, ""),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1220,7 +1214,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with only group membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", groupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1230,7 +1224,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			name: "valid authorize request using client assignment with inherited group membership",
 			args: args{
 				entityID:      entityID,
-				clientReq:     testClientReq(s, true, false),
+				clientReq:     testClientReq(s),
 				providerReq:   testProviderReq(s, clientID),
 				assignmentReq: testAssignmentReq(s, "", parentGroupID),
 				authorizeReq:  testAuthorizeReq(s, clientID),
@@ -1241,7 +1235,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s, true, false)
+					req := testClientReq(s)
 					req.Data["redirect_uris"] = []string{"http://127.0.0.1/callback"}
 					return req
 				}(),
@@ -1259,7 +1253,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s, true, false)
+					req := testClientReq(s)
 					req.Data["redirect_uris"] = []string{"http://127.0.0.1:8251/callback"}
 					return req
 				}(),
@@ -1277,7 +1271,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s, true, false)
+					req := testClientReq(s)
 					req.Data["redirect_uris"] = []string{"http://localhost:8251/callback"}
 					return req
 				}(),
@@ -1295,7 +1289,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			args: args{
 				entityID: entityID,
 				clientReq: func() *logical.Request {
-					req := testClientReq(s, true, false)
+					req := testClientReq(s)
 					req.Data["redirect_uris"] = []string{"http://[::1]:8251/callback"}
 					return req
 				}(),
@@ -1307,6 +1301,31 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 					return req
 				}(),
 			},
+		},
+		{
+			// This needs to be last because we do not reset authorization_code explicitly in testAuthorizeReq so
+			//  it stays on the set false value after and messes with tests.
+			name: "invalid authorize provider does not allow authorization code flow",
+			args: args{
+				entityID: entityID,
+				clientReq: &logical.Request{
+					Storage:   s,
+					Path:      "oidc/client/test-client",
+					Operation: logical.CreateOperation,
+					Data: map[string]interface{}{
+						"key":                "test-key",
+						"redirect_uris":      []string{"https://localhost:8251/callback"},
+						"assignments":        []string{"test-assignment"},
+						"id_token_ttl":       "24h",
+						"access_token_ttl":   "24h",
+						"authorization_code": false,
+					},
+				},
+				providerReq:   testProviderReq(s, clientID),
+				assignmentReq: testAssignmentReq(s, entityID, groupID),
+				authorizeReq:  testAuthorizeReq(s, clientID),
+			},
+			wantErr: ErrTokenInvalidGrant,
 		},
 	}
 
@@ -1422,7 +1441,20 @@ func setupOIDCCommon(t *testing.T, c *Core, s logical.Storage) (string, string, 
 	expectSuccess(t, resp, err)
 
 	// Create a client
-	resp, err = c.identityStore.HandleRequest(ctx, testClientReq(s, true, true))
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Storage:   s,
+		Path:      "oidc/client/test-client",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key":                "test-key",
+			"redirect_uris":      []string{"https://localhost:8251/callback"},
+			"assignments":        []string{"test-assignment"},
+			"id_token_ttl":       "24h",
+			"access_token_ttl":   "24h",
+			"client_credentials": true,
+			"authorization_code": true,
+		},
+	})
 	expectSuccess(t, resp, err)
 
 	// Read the client ID and secret
@@ -1471,7 +1503,7 @@ func setupOIDCCommon(t *testing.T, c *Core, s logical.Storage) (string, string, 
 // (i.e., created by setupOIDCCommon) that are modified during tests. This
 // enables the tests to continue operating using the same underlying storage
 // throughout many test cases that modify the configuration resources.
-func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, groupID, clientID string, authorizationCode, clientCredentials bool) {
+func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, groupID, clientID string) {
 	ctx := namespace.RootContext(nil)
 
 	req := testAssignmentReq(s, entityID, groupID)
@@ -1479,7 +1511,19 @@ func resetCommonOIDCConfig(t *testing.T, s logical.Storage, c *Core, entityID, g
 	resp, err := c.identityStore.HandleRequest(ctx, req)
 	expectSuccess(t, resp, err)
 
-	req = testClientReq(s, authorizationCode, clientCredentials)
+	req = &logical.Request{
+		Storage:   s,
+		Path:      "oidc/client/test-client",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key":              "test-key",
+			"redirect_uris":    []string{"https://localhost:8251/callback"},
+			"assignments":      []string{"test-assignment"},
+			"id_token_ttl":     "24h",
+			"access_token_ttl": "24h",
+		},
+	}
+
 	req.Operation = logical.UpdateOperation
 	resp, err = c.identityStore.HandleRequest(ctx, req)
 	expectSuccess(t, resp, err)
@@ -1556,7 +1600,7 @@ func testAssignmentReq(s logical.Storage, entityID, groupID string) *logical.Req
 	}
 }
 
-func testClientReq(s logical.Storage, authorizationCode, clientCredentials bool) *logical.Request {
+func testClientClientcredentialFlowReq(s logical.Storage) *logical.Request {
 	return &logical.Request{
 		Storage:   s,
 		Path:      "oidc/client/test-client",
@@ -1567,8 +1611,23 @@ func testClientReq(s logical.Storage, authorizationCode, clientCredentials bool)
 			"assignments":        []string{"test-assignment"},
 			"id_token_ttl":       "24h",
 			"access_token_ttl":   "24h",
-			"client_credentials": clientCredentials,
-			"authorization_code": authorizationCode,
+			"authorization_code": false,
+			"client_credentials": true,
+		},
+	}
+}
+
+func testClientReq(s logical.Storage) *logical.Request {
+	return &logical.Request{
+		Storage:   s,
+		Path:      "oidc/client/test-client",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key":              "test-key",
+			"redirect_uris":    []string{"https://localhost:8251/callback"},
+			"assignments":      []string{"test-assignment"},
+			"id_token_ttl":     "24h",
+			"access_token_ttl": "24h",
 		},
 	}
 }

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -176,7 +176,7 @@ func TestOIDC_Path_OIDC_Token_Authorization_Code_Flow(t *testing.T) {
 					return req
 				}(),
 			},
-			wantErr: ErrTokenInvalidRequest,
+			wantErr: ErrTokenUnsupportedGrantType,
 		},
 		{
 			name: "invalid token request with unsupported grant_type",
@@ -681,7 +681,7 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 					return req
 				}(),
 			},
-			wantErr: ErrTokenInvalidRequest,
+			wantErr: ErrTokenUnsupportedGrantType,
 		},
 		{
 			name: "valid token request",

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -598,7 +598,8 @@ $ curl \
     "public"
   ],
   "grant_types_supported": [
-    "authorization_code"
+    "authorization_code",
+    "client_credentials"
   ],
   "token_endpoint_auth_methods_supported": [
     "client_secret_basic",
@@ -728,15 +729,15 @@ for an OIDC provider.
 - `name` `(string: <required>)` - The name of the provider. This parameter is
   specified as part of the URL.
 
-- `code` `(string: <required>)` - The authorization code received from the
-  provider's authorization endpoint.
+- `code` `(string: <required for authorization_code>)` - The authorization code received from the
+  provider's authorization endpoint. Required when using the `authorization_code` grant type.
 
 - `grant_type` `(string: <required>)` - The authorization grant type. The
-  following grant types are supported: `authorization_code`.
+  following grant types are supported: `authorization_code`, `client_credentials`.
 
-- `redirect_uri` `(string: <required>)` - The callback location where the
+- `redirect_uri` `(string: <required for authorization_code>)` - The callback location where the
   authorization request was sent. This must match the `redirect_uri` used when the
-  original authorization code was generated.
+  original authorization code was generated. Required when using the `authorization_code` grant type.
 
 - `client_id` `(string: <optional>)` - The ID of the requesting client. This parameter
   is required for `public` clients which do not have a client secret or `confidential`
@@ -750,6 +751,9 @@ for an OIDC provider.
   `code`. Required for authorization codes that were granted using [PKCE](https://datatracker.ietf.org/doc/html/rfc7636).
   Required for `public` clients.
 
+- `scope` `(string: <required for client_credentials>)` - A space-delimited list of scopes to be requested. 
+  The `openid` scope is required when using the `client_credentials` grant type.
+
 ### Headers
 
 - `Authorization: Basic` `(string: <optional>)` - An HTTP Basic authentication scheme header
@@ -757,7 +761,7 @@ for an OIDC provider.
   authentication method. This header is only required for `confidential` clients using
   the `client_secret_basic` client authentication method.
 
-### Sample request
+### Sample request - Authorization Code Flow
 
 ```shell-session
 $ BASIC_AUTH_CREDS=$(printf "%s:%s" "$CLIENT_ID" "$CLIENT_SECRET" | base64)
@@ -768,6 +772,19 @@ $ curl \
     -d "code=4RL50r78p8HsNJY0GVUNGfjLHnpkRf3N" \
     -d "grant_type=authorization_code" \
     -d "redirect_uri=http://127.0.0.1:8251/callback" \
+    http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider/token
+```
+
+### Sample request - Client Credentials Flow
+
+```shell-session
+$ BASIC_AUTH_CREDS=$(printf "%s:%s" "$CLIENT_ID" "$CLIENT_SECRET" | base64)
+$ curl \
+    --request POST \
+    --header "Authorization: Basic $BASIC_AUTH_CREDS" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d "grant_type=client_credentials" \
+    -d "scope=openid" \
     http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider/token
 ```
 

--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -8,7 +8,7 @@ description: >-
 This document provides conceptual information about the OpenBao **OpenID Connect (OIDC) identity
 provider** feature. This feature enables client applications that speak the OIDC protocol to
 leverage OpenBao's source of [identity](/docs/concepts/identity) and wide range of [authentication methods](/docs/auth)
-when authenticating end-users. For more information about the usage of OpenBao's OIDC provider,
+when authenticating end-users or performing service-to-service authentication. For more information about the usage of OpenBao's OIDC provider,
 refer to the [OIDC identity provider](/docs/secrets/identity/oidc-provider) documentation.
 
 ## Configuration options
@@ -120,6 +120,7 @@ characters from the base62 character set.
 :::warning
 
 **Note**: At least one of the redirect URIs of a client must exactly match the `redirect_uri` parameter used in an authentication request initiated by the client.
+          When Using credentials flow Redirect URIs are not required.
 
 :::
 
@@ -181,19 +182,23 @@ The `default` key will have the following configuration:
 
 ## OIDC flow
 
-:::warning
+OpenBao OIDC providers enable registered clients to authenticate and obtain identity information (or "claims") for their end-users or services.
+They do this by providing the APIs and behavior required to satisfy the OIDC specification for the [authorization code flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) and the [client credentials flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
 
-**Note**: The OpenBao OIDC Provider feature currently only supports the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth).
+### Authorization code flow
 
-:::
-
-The following sections provide implementation details for the OIDC compliant APIs provided by OpenBao OIDC providers.
-
-OpenBao OIDC providers enable registered clients to authenticate and obtain identity information (or "claims") for their end-users. They do this by providing the APIs and behavior required to satisfy the OIDC specification for the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth). All clients are treated as first-party. This means that end-users will not be required to provide consent to the provider as detailed in section [3.1.2.4](https://openid.net/specs/openid-connect-core-1_0.html#Consent) of the OIDC specification. The provider will release information to clients as long as the end-user has ACL access to the provider and their identity has been authorized via an assignment.
+All clients are treated as first-party. This means that end-users will not be required to provide consent to the provider as detailed in section [3.1.2.4](https://openid.net/specs/openid-connect-core-1_0.html#Consent) of the OIDC specification.
+The provider will release information to clients as long as the end-user has ACL access to the provider and their identity has been authorized via an assignment.
 
 OpenBao OIDC providers implement Proof Key for Code Exchange ([PKCE](https://datatracker.ietf.org/doc/html/rfc7636))
 to mitigate authorization code interception attacks. PKCE is required for `public` client types
 and optional for `confidential` client types.
+
+### Client credentials flow
+
+OpenBao OIDC providers also support the [client credentials flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4), which allows confidential clients to directly obtain tokens without end-user interaction. This flow is intended for service-to-service communication.
+
+In this flow, the client authenticates against the token endpoint using its `client_id` and `client_secret`. Upon successful validation, OpenBao issues an access token and, if configured, an ID token. The claims in these tokens are determined by the scopes assigned to the client. No user assignments are required, since the client itself is the subject (`sub`) of the issued tokens.
 
 ### OpenID configuration
 
@@ -205,7 +210,7 @@ Each provider offers an unauthenticated endpoint that provides the public portio
 
 ### Authorization endpoint
 
-Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). The authorization endpoint for each provider is added to OpenBao's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input.
+Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) for the authorization code flow. The authorization endpoint for each provider is added to OpenBao's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input.
 
 The endpoint [validates](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequestValidation) client requests and ensures that all required parameters are present and valid. The `redirect_uri` of the request is validated against the client's `redirect_uris`. The requesting OpenBao entity will be validated against the client's `assignments`. An appropriate [error code](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is returned for invalid requests.
 
@@ -213,9 +218,15 @@ An authorization code is generated with a successful validation of the request. 
 
 ### Token endpoint
 
-Each provider will offer a [token endpoint](/api-docs/secret/identity/oidc-provider#token-endpoint). The endpoint may be unauthenticated in OpenBao but is authenticated by requiring a `client_secret` as described in [client authentication](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). The endpoint ingests all required [token request](/api-docs/secret/identity/oidc-provider#parameters-15) parameters as input. The endpoint [validates](https://openid.net/specs/openid-connect-core-1_0.html#TokenRequestValidation) the client requests and exchanges an authorization code for the ID token and access token. The cache of authorization codes will be verified against the code presented in the exchange. The appropriate [error codes](https://openid.net/specs/openid-connect-core-1_0.html#TokenErrorResponse) are returned for all invalid requests.
+Each provider will offer a [token endpoint](/api-docs/secret/identity/oidc-provider#token-endpoint). The endpoint may be unauthenticated in OpenBao but is authenticated by requiring a `client_secret` as described in [client authentication](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). The endpoint ingests all required [token request](/api-docs/secret/identity/oidc-provider#parameters-15) parameters as input.
 
-The ID token is generated and returned upon successful client authentication and request validation. The ID token will contain a combination of required and configurable claims. The required claims are enumerated in the scopes section above for the `openid` scope. The configurable claims are populated by templates associated with the scopes provided in the authentication request that generated the authorization code.
+The endpoint supports both:
+- **Authorization code flow**: exchanges an authorization code for the ID token and access token. The cache of authorization codes will be verified against the code presented in the exchange.
+- **Client credentials flow**: exchanges a valid client ID and client secret for an access token (and optionally an ID token, depending on requested scopes). Redirect URIs and assignments are not required in this flow.
+
+The appropriate [error codes](https://openid.net/specs/openid-connect-core-1_0.html#TokenErrorResponse) are returned for all invalid requests.
+
+The ID token is generated and returned upon successful client authentication and request validation. The ID token will contain a combination of required and configurable claims. The required claims are enumerated in the scopes section above for the `openid` scope. The configurable claims are populated by templates associated with the scopes provided in the authentication request.
 
 An access token is also generated and returned upon successful client authentication and request validation. The access token is an OpenBao [batch token](/docs/concepts/tokens#batch-tokens) with a policy that only provides read access to the issuing provider's [userinfo endpoint](/api-docs/secret/identity/oidc-provider#userinfo-endpoint). The access token is also a TTL as defined by the `access_token_ttl` of the requesting client.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

Currently, only the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) is supported. This limits OpenBao to interactive, user-centric authentication scenarios.
However, for many modern infrastructures, we also need non-interactive service-to-service authentication. For example, microservices, monitoring agents, or collectors often need to authenticate with each other securely without a user being involved.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1727

Should this approach be accepted I will change the documentation.

