### PR TITLE
Don't mirror from forks

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    if: github.repository == 'openbao/openbao'
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
This should reduce some noise in the failing workflows. 