### PR TITLE
Fix DockerCluster with non-HA backend

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -74,6 +74,9 @@ type DockerCluster struct {
 	builtTags map[string]struct{}
 
 	storage testcluster.ClusterStorage
+
+	// Whether HA mode is disabled
+	HADisabled bool
 }
 
 func (dc *DockerCluster) NamedLogger(s string) log.Logger {
@@ -208,15 +211,17 @@ func (dc *DockerCluster) setupNode0(ctx context.Context) error {
 		return err
 	}
 
-	err = ensureLeaderMatches(ctx, client, func(leader *api.LeaderResponse) error {
-		if !leader.IsSelf {
-			return fmt.Errorf("node %d leader=%v, expected=%v", 0, leader.IsSelf, true)
-		}
+	if !dc.HADisabled {
+		err = ensureLeaderMatches(ctx, client, func(leader *api.LeaderResponse) error {
+			if !leader.IsSelf {
+				return fmt.Errorf("node %d leader=%v, expected=%v", 0, leader.IsSelf, true)
+			}
 
-		return nil
-	})
-	if err != nil {
-		return err
+			return nil
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	status, err := client.Sys().SealStatusWithContext(ctx)
@@ -443,6 +448,11 @@ func NewDockerCluster(ctx context.Context, opts *DockerClusterOptions) (*DockerC
 		builtTags:   map[string]struct{}{},
 		CA:          opts.CA,
 		storage:     opts.Storage,
+		HADisabled:  opts.HADisabled,
+	}
+
+	if dc.HADisabled && opts.NumCores > 1 {
+		return nil, fmt.Errorf("expected at most one core (%v) when HA mode is disabled", opts.NumCores)
 	}
 
 	if err := dc.setupDockerCluster(ctx, opts); err != nil {
@@ -950,6 +960,7 @@ type DockerClusterOptions struct {
 	Storage     testcluster.ClusterStorage
 	Root        bool
 	Entrypoint  string
+	HADisabled  bool
 }
 
 func DefaultOptions(t *testing.T) *DockerClusterOptions {
@@ -1012,7 +1023,11 @@ func (dc *DockerCluster) setupDockerCluster(ctx context.Context, opts *DockerClu
 
 	var numCores int
 	if opts.NumCores == 0 {
-		numCores = DefaultNumCores
+		if dc.HADisabled {
+			numCores = 1
+		} else {
+			numCores = DefaultNumCores
+		}
 	} else {
 		numCores = opts.NumCores
 	}
@@ -1040,7 +1055,7 @@ func (dc *DockerCluster) setupDockerCluster(ctx context.Context, opts *DockerClu
 		}
 		if i == 0 {
 			if err := dc.setupNode0(ctx); err != nil {
-				return nil
+				return err
 			}
 		} else {
 			if err := dc.joinNode(ctx, i, 0); err != nil {


### PR DESCRIPTION
When running a non-HA storage backend, such as inmem, `ensureLeaderMatches` will timeout through the context as `leader.IsSelf` never reports true in a non-HA environment. Ensure we only have a single node during cluster setup and annotate it as being HA disabled.

`setupNode0`'s return code was not checked. This made the HA support _technically_ work, if we used a scoped context which had a shorter timeout (but, longer than the Docker calls took), but was hard to accurately time.
