### PR TITLE
Expand audit error message to reference config-based devices

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3141,7 +3141,7 @@ func (b *SystemBackend) handleEnableAudit(ctx context.Context, req *logical.Requ
 	conf := b.Core.rawConfig.Load().(*server.Config)
 
 	if !conf.UnsafeAllowAPIAuditCreation {
-		return handleError(fmt.Errorf("cannot enable audit device via API"))
+		return handleError(fmt.Errorf("cannot enable audit device via API; use declarative, config-based audit device management instead"))
 	}
 
 	if _, hasPrefix := options["prefix"]; hasPrefix && !conf.AllowAuditLogPrefixing {


### PR DESCRIPTION
This should help clarify some reports we've had around audit devices, as we now have a replacement in v2.4.x.