### PR TITLE
Fix bump-critical-deps & tidy-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ vulncheck:
 
 .PHONY: tidy-all
 tidy-all:
-	bash -c 'find . -name go.mod | while read go_mod; do ( cd "$$(dirname "$$go_mod")" && go mod tidy ) ; done'
+	find . -name 'go.mod' -execdir go mod tidy \;
 
 .PHONY: ci-tidy-all
 ci-tidy-all:

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ tidy-all:
 .PHONY: ci-tidy-all
 ci-tidy-all:
 	git diff --quiet
-	bash -c 'find . -name go.mod | while read go_mod; do ( cd "$$(dirname "$$go_mod")" && go mod tidy ) ; done'
+	sh -c 'find . -name go.mod | while read go_mod; do ( cd "$$(dirname "$$go_mod")" && go mod tidy ) ; done'
 	git diff --quiet || (echo -e "\n\nModified files:" && git status --short && echo -e "\n\nRun 'make tidy-all' locally and commit the changes.\n" && exit 1)
 
 .PHONY: release-changelog

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ tidy-all:
 .PHONY: ci-tidy-all
 ci-tidy-all:
 	git diff --quiet
-	sh -c 'find . -name go.mod | while read go_mod; do ( cd "$$(dirname "$$go_mod")" && go mod tidy ) ; done'
+	find . -name 'go.mod' -execdir go mod tidy \;
 	git diff --quiet || (echo -e "\n\nModified files:" && git status --short && echo -e "\n\nRun 'make tidy-all' locally and commit the changes.\n" && exit 1)
 
 .PHONY: release-changelog

--- a/scripts/sync-deps-gkw.sh
+++ b/scripts/sync-deps-gkw.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+grep '^	' go.mod | while read line; do
+	pkg="$(awk '{print $1}' <<< "$line")"
+	version="$(awk '{print $2}' <<< "$line")"
+
+	(
+		cd "$GO_KMS_WRAPPING"
+		find . -name go.mod | while read gkw_mod; do
+			dir="$(dirname "$gkw_mod")"
+			if grep -q "^	$pkg" "$gkw_mod" && grep "$pkg" "$gkw_mod" | grep -qv "$pkg $version"; then
+	  			( cd "$dir" && go get "$pkg"@"$version" )
+			fi
+	  	done
+	)
+done
+
+cd "$GO_KMS_WRAPPING" && make tidy-all

--- a/scripts/sync-deps-gkw.sh
+++ b/scripts/sync-deps-gkw.sh
@@ -9,9 +9,9 @@ grep '^	' go.mod | while read line; do
 		find . -name go.mod | while read gkw_mod; do
 			dir="$(dirname "$gkw_mod")"
 			if grep -q "^	$pkg" "$gkw_mod" && grep "$pkg" "$gkw_mod" | grep -qv "$pkg $version"; then
-	  			( cd "$dir" && go get "$pkg"@"$version" )
+	  		( cd "$dir" && go get "$pkg"@"$version" )
 			fi
-	  	done
+	  done
 	)
 done
 

--- a/scripts/sync-deps.sh
+++ b/scripts/sync-deps.sh
@@ -4,29 +4,12 @@ grep '^	' go.mod | while read line; do
 	pkg="$(awk '{print $1}' <<< "$line")"
 	version="$(awk '{print $2}' <<< "$line")"
 
-	if grep -q "^	$pkg" api/go.mod && grep "$pkg" api/go.mod | grep -qv "$pkg $version"; then
-	  ( cd api && go get "$pkg"@"$version" )
-	fi
-
-    if grep -q "^	$pkg" api/auth/approle/go.mod && grep "$pkg" api/auth/approle/go.mod | grep -qv "$pkg $version"; then
-	  ( cd api/auth/approle && go get "$pkg"@"$version" )
-	fi
-
-    if grep -q "^	$pkg" api/auth/kubernetes/go.mod && grep "$pkg" api/auth/kubernetes/go.mod | grep -qv "$pkg $version"; then
-	  ( cd api/auth/kubernetes && go get "$pkg"@"$version" )
-	fi
-
-    if grep -q "^	$pkg" api/auth/ldap/go.mod && grep "$pkg" api/auth/ldap/go.mod | grep -qv "$pkg $version"; then
-	  ( cd api/auth/ldap && go get "$pkg"@"$version" )
-    fi
-
-    if grep -q "^	$pkg" api/auth/userpass/go.mod && grep "$pkg" api/auth/userpass/go.mod | grep -qv "$pkg $version"; then
-	  ( cd api/auth/userpass && go get "$pkg"@"$version" )
-	fi
-
-	if grep -q "^	$pkg" sdk/go.mod && grep "$pkg" sdk/go.mod | grep -qv "$pkg $version"; then
-	  ( cd sdk && go get "$pkg"@"$version" )
-	fi
+	find . -name go.mod | while read go_mod; do
+		dir="$(dirname "$go_mod")"
+		if grep -q "^	$pkg" "$go_mod" && grep "$pkg" "$go_mod" | grep -qv "$pkg $version"; then
+			( cd "$dir" && go get "$pkg"@"$version" )
+		fi
+	done
 done
 
 make tidy-all


### PR DESCRIPTION
Several of our release automation steps left off the new api/auth/jwt module along with the tools/ module. This switches to uses find statements to locate all go.mod files and adds a variant of sync-deps to update an out-of-tree go-kms-wrapping to the versions of dependencies pinned here.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

