### PR TITLE
Fix release-dist checkout failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          # "fetch-tags: true" instead of "fetch-depth: 0" should be enough
+          # but it fails in combination with dogorelease
+          # https://github.com/actions/checkout/issues/1467
+          fetch-depth: 0
 
       - name: Create release if necessary
         if: ${{ !inputs.dogorelease }}


### PR DESCRIPTION
The [2.4.0 release-dist step](https://github.com/openbao/openbao/actions/runs/17307089336/job/49135074501) failed and this should prevent it from happening again.