### PR TITLE
fix: bao instead of boa (typo)

### DIFF
--- a/api/env_test.go
+++ b/api/env_test.go
@@ -33,7 +33,7 @@ func TestReadBaoVariable_BothSame(t *testing.T) {
 	}
 }
 
-func TestReadBaoVariable_BoaWins(t *testing.T) {
+func TestReadBaoVariable_BaoWins(t *testing.T) {
 	actual := "example_value"
 	os.Setenv("VAULT_TEST", actual+"not_valid")
 	os.Setenv("BAO_TEST", actual)


### PR DESCRIPTION
Just a small typo I found along the way. We have no :snake: here