### PR TITLE
Update goreleaser to latest, add license

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,8 +270,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
-          # TODO: remove version pinning when Goreleaser 2.8 is released
-          version: v2.5.1
+          version: v2.11.2
 
       - name: Install C compiler for arm64 CGO cross-compilation
         if: inputs.dogorelease && matrix.release_os == 'hsm'
@@ -294,6 +293,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           NFPM_DEFAULT_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
           NIGHTLY_RELEASE: ${{ inputs.nightly }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Remove GPG Signing Key File
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ ifneq ($(FDB_ENABLED), )
 	BUILD_TAGS+=foundationdb
 endif
 
+GORELEASER_VERSION=v2.11.2
+
 default: dev
 
 # bin generates the equivalent of releasable binaries for OpenBao
@@ -324,13 +326,13 @@ dev-gorelease:
 	@echo GORELEASER_CURRENT_TAG: $(GORELEASER_CURRENT_TAG)
 	@$(SED) 's/REPLACE_WITH_RELEASE_GOOS/linux/g' $(CURDIR)/.goreleaser-template.yaml > $(CURDIR)/.goreleaser.yaml
 	@$(SED) -i 's/^#LINUXONLY#//g' $(CURDIR)/.goreleaser.yaml
-	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@latest release --clean --timeout=60m --verbose --parallelism 2 --snapshot --skip docker,sbom,sign
+	@$(GO_CMD) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) release --clean --timeout=60m --verbose --parallelism 2 --snapshot --skip docker,sbom,sign
 
 .PHONY: goreleaser-check
 goreleaser-check:
-	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@v2.5.1 check -f goreleaser.hsm.yaml
-	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@v2.5.1 check -f goreleaser.linux.yaml
-	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@v2.5.1 check -f goreleaser.other.yaml
+	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) check -f goreleaser.hsm.yaml
+	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) check -f goreleaser.linux.yaml
+	$(GO_CMD) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) check -f goreleaser.other.yaml
 
 .PHONY: sync-deps
 sync-deps:

--- a/goreleaser.hsm.yaml
+++ b/goreleaser.hsm.yaml
@@ -383,7 +383,7 @@ docker_manifests:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-hsm-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}-hsm_{{ .Version }}_{{- title .Os }}_

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -654,7 +654,7 @@ docker_manifests:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_

--- a/goreleaser.other.yaml
+++ b/goreleaser.other.yaml
@@ -74,7 +74,7 @@ checksum:
   disable: false
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_
@@ -85,7 +85,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     files:
       - "LICENSE"
       - "README.md"


### PR DESCRIPTION
After the previous issues fixed in goreleaser v2.8, we had pinned to an earlier v2.5.x series, which was stable but no longer supported. This updates the pinning to the latest version.

We also introduce the goreleaser license key.

---

Running: https://github.com/openbao/openbao-nightly/actions/runs/17357488329 