### PR TITLE
Fix persistence of tokens created through LoginMFA

### DIFF
--- a/changelog/1753.txt
+++ b/changelog/1753.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
 auth/mfa: Correctly persist tokens created through two-step MFA login enforcement.
 ```
+```release-note:bug
+auth/mfa: Allow single-flow MFA to work with inline authentication.
+```

--- a/changelog/1753.txt
+++ b/changelog/1753.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/mfa: Correctly persist tokens created through two-step MFA login enforcement.
+```

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -797,7 +797,7 @@ func (b *LoginMFABackend) handleMFALoginValidate(ctx context.Context, req *logic
 	}
 
 	// MFA validation has passed. Let's generate the token
-	resp, err := b.Core.LoginMFACreateToken(ctx, cachedResponseAuth.RequestPath, cachedResponseAuth.CachedAuth, req.Data, !req.IsInlineAuth, cachedResponseAuth.CachedUserLockout)
+	resp, err := b.Core.LoginMFACreateToken(ctx, cachedResponseAuth.RequestPath, cachedResponseAuth.CachedAuth, req.Data, req.IsInlineAuth, cachedResponseAuth.CachedUserLockout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a token. error: %v", err)
 	}
@@ -822,7 +822,7 @@ func (c *Core) teardownLoginMFA() error {
 
 // LoginMFACreateToken creates a token after the login MFA is validated.
 // It also applies the lease quotas on the original login request path.
-func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAuth *logical.Auth, loginRequestData map[string]interface{}, persistToken bool, userLockoutInfo *FailedLoginUser) (*logical.Response, error) {
+func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAuth *logical.Auth, loginRequestData map[string]interface{}, isInlineAuth bool, userLockoutInfo *FailedLoginUser) (*logical.Response, error) {
 	auth := cachedAuth
 	resp := &logical.Response{
 		Auth: auth,
@@ -841,7 +841,7 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 		role = reqRole.(string)
 	}
 
-	_, resp, err = c.LoginCreateToken(ctx, ns, reqPath, mountPoint, role, resp, persistToken, userLockoutInfo)
+	_, resp, err = c.LoginCreateToken(ctx, ns, reqPath, mountPoint, role, resp, isInlineAuth, userLockoutInfo)
 	return resp, err
 }
 


### PR DESCRIPTION
In creating inline authentication, I went through renaming the persistToken vs isInlineAuth, failing to correctly update the call in core.LoginMFACreateToken(...) to the latter instead of the negated former. This meant tokens created through the two-step Login MFA flow were not persistent.

This should not occur in the one-step login MFA flow. It was not caught by the existing test in
vault/external_tests/identity/login_mfa_totp_test.go, because this does not use the token after creation.

Resolves: #1752

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
