### PR TITLE
Recovery rotation init CLI operation returns the recovery keys

### DIFF
--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -23,6 +23,9 @@ type RotateInitRequest struct {
 }
 
 type RotateStatusResponse struct {
+	Complete             bool     `json:"complete,omitempty"`
+	Keys                 []string `json:"keys,omitempty"`
+	KeysB64              []string `json:"keys_base64,omitempty"`
 	Nonce                string   `json:"nonce"`
 	Started              bool     `json:"started"`
 	T                    int      `json:"t"`

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -34,10 +34,8 @@ type OperatorInitCommand struct {
 }
 
 const (
-	defKeyShares         = 5
-	defKeyThreshold      = 3
-	defRecoveryShares    = 5
-	defRecoveryThreshold = 3
+	defKeyShares    = 5
+	defKeyThreshold = 3
 )
 
 func (c *OperatorInitCommand) Synopsis() string {
@@ -143,7 +141,7 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Target:     &c.flagRecoveryShares,
 		Completion: complete.PredictAnything,
 		Usage: "Number of key shares to split the recovery key into. " +
-			"This is only used in auto-unseal mode.",
+			"This is only used in Auto Unseal mode.",
 	})
 
 	f.IntVar(&IntVar{
@@ -212,15 +210,7 @@ func (c *OperatorInitCommand) Run(args []string) int {
 	client.SetOutputCurlString(currentOutputCurlString)
 	client.SetOutputPolicy(outputPolicy)
 
-	switch sealInfo.RecoverySeal {
-	case true:
-		if c.flagRecoveryShares == 0 {
-			c.flagRecoveryShares = defRecoveryShares
-		}
-		if c.flagRecoveryThreshold == 0 {
-			c.flagRecoveryThreshold = defRecoveryThreshold
-		}
-	default:
+	if !sealInfo.RecoverySeal {
 		if c.flagKeyShares == 0 {
 			c.flagKeyShares = defKeyShares
 		}

--- a/command/operator_rotate_keys.go
+++ b/command/operator_rotate_keys.go
@@ -291,7 +291,7 @@ func (c *OperatorRotateKeysCommand) init(client *api.Client) int {
 	}
 
 	// Make the request
-	status, err := fn(&api.RotateInitRequest{
+	resp, err := fn(&api.RotateInitRequest{
 		SecretShares:        c.flagKeyShares,
 		SecretThreshold:     c.flagKeyThreshold,
 		PGPKeys:             c.flagPGPKeys,
@@ -303,35 +303,76 @@ func (c *OperatorRotateKeysCommand) init(client *api.Client) int {
 		return 2
 	}
 
-	// Print warnings about recovery, etc.
-	if len(c.flagPGPKeys) == 0 {
-		if Format(c.UI) == "table" {
-			c.UI.Warn(wrapAtLength(
-				fmt.Sprintf("WARNING! If you lose the keys after they are returned, there is no "+
-					"recovery. Consider canceling this operation and re-initializing "+
-					"with the -pgp-keys flag to protect the returned %s keys along "+
-					"with -backup to allow recovery of the encrypted keys in case of "+
-					"emergency. You can delete the stored keys later using the -delete "+
-					"flag.", strings.ToLower(keyTypeRequired))))
-			c.UI.Output("")
+	if !resp.Complete {
+		// Print warnings about recovery, etc.
+		if len(c.flagPGPKeys) == 0 {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength(
+					fmt.Sprintf("WARNING! If you lose the keys after they are returned, there is no "+
+						"recovery. Consider canceling this operation and re-initializing "+
+						"with the -pgp-keys flag to protect the returned %s keys along "+
+						"with -backup to allow recovery of the encrypted keys in case of "+
+						"emergency. You can delete the stored keys later using the -delete "+
+						"flag.", strings.ToLower(keyTypeRequired))))
+				c.UI.Output("")
+			}
 		}
-	}
-	if len(c.flagPGPKeys) > 0 && !c.flagBackup {
-		if Format(c.UI) == "table" {
-			c.UI.Warn(wrapAtLength(
-				fmt.Sprintf("WARNING! You are using PGP keys for encrypted the resulting %s "+
-					"keys, but you did not enable the option to backup the keys to "+
-					"OpenBao's core. If you lose the encrypted keys after they are "+
-					"returned, you will not be able to recover them. Consider canceling "+
-					"this operation and re-running with -backup to allow recovery of the "+
-					"encrypted unseal keys in case of emergency. You can delete the "+
-					"stored keys later using the -delete flag.", strings.ToLower(keyTypeRequired))))
-			c.UI.Output("")
+		if len(c.flagPGPKeys) > 0 && !c.flagBackup {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength(
+					fmt.Sprintf("WARNING! You are using PGP keys for encrypted the resulting %s "+
+						"keys, but you did not enable the option to backup the keys to "+
+						"OpenBao's core. If you lose the encrypted keys after they are "+
+						"returned, you will not be able to recover them. Consider canceling "+
+						"this operation and re-running with -backup to allow recovery of the "+
+						"encrypted unseal keys in case of emergency. You can delete the "+
+						"stored keys later using the -delete flag.", strings.ToLower(keyTypeRequired))))
+				c.UI.Output("")
+			}
 		}
+	} else {
+		// if the rotation is complete, meaning we've immediately
+		// returned the unseal (recovery) keys, print them out
+		if len(c.flagPGPKeys) == 0 {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength(
+					fmt.Sprintf("WARNING! If you lose the keys, there "+
+						"is no recovery. Consider rerunning this operation and "+
+						"re-initializing with the -pgp-keys flag to protect the "+
+						"returned %s keys along with -backup to allow recovery "+
+						"of the encrypted keys in case of emergency. You can "+
+						"delete the stored keys later using the -delete flag.",
+						strings.ToLower(keyTypeRequired))))
+				c.UI.Output("")
+			}
+		}
+		if len(c.flagPGPKeys) > 0 && !c.flagBackup {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength(
+					fmt.Sprintf("WARNING! You've used PGP keys for "+
+						"encryption of the resulting %s keys, but you did not "+
+						"enable the option to backup the keys to OpenBao's core. "+
+						"If you lose the encrypted keys you will not be able to "+
+						"recover them. Consider rerunning this operation and "+
+						"re-initializing with -backup to allow recovery of the "+
+						"encrypted unseal keys in case of emergency. You can "+
+						"delete the stored keys later using the -delete flag.",
+						strings.ToLower(keyTypeRequired))))
+				c.UI.Output("")
+			}
+		}
+
+		return c.printUnsealKeys(client, resp, &api.RotateUpdateResponse{
+			Complete:        resp.Complete,
+			Keys:            resp.Keys,
+			KeysB64:         resp.KeysB64,
+			Backup:          resp.Backup,
+			PGPFingerprints: resp.PGPFingerprints,
+		})
 	}
 
-	// Provide the current status
-	return c.printStatus(status)
+	// otherwise provide the current status
+	return c.printStatus(resp)
 }
 
 // cancel is used to abort the rotation process.
@@ -710,8 +751,10 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 		}
 	}
 
-	c.UI.Output("")
-	c.UI.Output(fmt.Sprintf("Operation nonce: %s", resp.Nonce))
+	if resp.Nonce != "" {
+		c.UI.Output("")
+		c.UI.Output(fmt.Sprintf("Operation nonce: %s", resp.Nonce))
+	}
 
 	if len(resp.PGPFingerprints) > 0 && resp.Backup {
 		c.UI.Output("")
@@ -739,8 +782,8 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 		switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 		case "barrier":
 			c.UI.Output(wrapAtLength(fmt.Sprintf(
-				"Vault unseal keys rotated to %d key shares and a key threshold of %d. Please "+
-					"securely distribute the key shares printed above. When Vault is "+
+				"OpenBao unseal keys rotated to %d key shares and a key threshold of %d. Please "+
+					"securely distribute the key shares printed above. When OpenBao is "+
 					"re-sealed, restarted, or stopped, you must supply at least %d of "+
 					"these keys to unseal it before it can start servicing requests.",
 				status.N,
@@ -748,7 +791,7 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 				status.T)))
 		case "recovery", "hsm":
 			c.UI.Output(wrapAtLength(fmt.Sprintf(
-				"Vault recovery keys rotated to %d key shares and a key threshold of %d. Please "+
+				"OpenBao recovery keys rotated to %d key shares and a key threshold of %d. Please "+
 					"securely distribute the key shares printed above.",
 				status.N,
 				status.T)))
@@ -760,9 +803,9 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 		switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 		case "barrier":
 			c.UI.Output(wrapAtLength(fmt.Sprintf(
-				"Vault has created a new unseal key, split into %d key shares and a key threshold "+
+				"OpenBao has created a new unseal key, split into %d key shares and a key threshold "+
 					"of %d. These will not be active until after verification is complete. "+
-					"Please securely distribute the key shares printed above. When Vault "+
+					"Please securely distribute the key shares printed above. When OpenBao "+
 					"is re-sealed, restarted, or stopped, you must supply at least %d of "+
 					"these keys to unseal it before it can start servicing requests.",
 				status.N,
@@ -771,7 +814,7 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 			warningText = "unseal"
 		case "recovery", "hsm":
 			c.UI.Output(wrapAtLength(fmt.Sprintf(
-				"Vault has created a new recovery key, split into %d key shares and a key threshold "+
+				"OpenBao has created a new recovery key, split into %d key shares and a key threshold "+
 					"of %d. These will not be active until after verification is complete. "+
 					"Please securely distribute the key shares printed above.",
 				status.N,
@@ -783,8 +826,8 @@ func (c *OperatorRotateKeysCommand) printUnsealKeys(client *api.Client, status *
 		c.UI.Warn(wrapAtLength(fmt.Sprintf(
 			"Again, these key shares are _not_ valid until verification is performed. "+
 				"Do not lose or discard your current key shares until after verification "+
-				"is complete or you will be unable to %s Vault. If you cancel the "+
-				"rotation process or seal Vault before verification is complete the new "+
+				"is complete or you will be unable to %s OpenBao. If you cancel the "+
+				"rotation process or seal OpenBao before verification is complete the new "+
 				"shares will be discarded and the current shares will remain valid.", warningText)))
 		c.UI.Output("")
 		c.UI.Warn(wrapAtLength(

--- a/vault/logical_system_rotate.go
+++ b/vault/logical_system_rotate.go
@@ -48,39 +48,31 @@ func (b *SystemBackend) rotatePaths() []*framework.Path {
 
 	rotateStatusSchema := map[string]*framework.FieldSchema{
 		"nonce": {
-			Type:     framework.TypeString,
-			Required: true,
+			Type: framework.TypeString,
 		},
 		"complete": {
 			Type: framework.TypeBool,
 		},
 		"started": {
-			Type:     framework.TypeBool,
-			Required: true,
+			Type: framework.TypeBool,
 		},
 		"t": {
-			Type:     framework.TypeInt,
-			Required: true,
+			Type: framework.TypeInt,
 		},
 		"n": {
-			Type:     framework.TypeInt,
-			Required: true,
+			Type: framework.TypeInt,
 		},
 		"progress": {
-			Type:     framework.TypeInt,
-			Required: true,
+			Type: framework.TypeInt,
 		},
 		"required": {
-			Type:     framework.TypeInt,
-			Required: true,
+			Type: framework.TypeInt,
 		},
 		"verification_required": {
-			Type:     framework.TypeBool,
-			Required: true,
+			Type: framework.TypeBool,
 		},
 		"verification_nonce": {
-			Type:     framework.TypeString,
-			Required: true,
+			Type: framework.TypeString,
 		},
 		"keys": {
 			Type: framework.TypeCommaStringSlice,
@@ -556,10 +548,10 @@ func (b *SystemBackend) handleRotateInitGet() framework.OperationFunc {
 
 		resp := &logical.Response{
 			Data: map[string]interface{}{
-				"started":        false,
-				"t":              0,
-				"n":              0,
-				"seal_threshold": sealThreshold,
+				"started":  false,
+				"t":        0,
+				"n":        0,
+				"required": sealThreshold,
 			},
 		}
 
@@ -653,6 +645,8 @@ func (b *SystemBackend) handleRotateInitPut() framework.OperationFunc {
 			return &logical.Response{
 				Data: map[string]interface{}{
 					"complete":              true,
+					"t":                     secretThreshold,
+					"n":                     secretShares,
 					"backup":                result.Backup,
 					"pgp_fingerprints":      result.PGPFingerprints,
 					"verification_required": result.VerificationRequired,

--- a/website/content/docs/commands/operator/init.mdx
+++ b/website/content/docs/commands/operator/init.mdx
@@ -86,7 +86,7 @@ flags](/docs/commands) included on all commands.
   generated root token will be encrypted and base64-encoded with the given
   public key.
 
-- `-status` `(bool": false)` - Print the current initialization status. An exit
+- `-status` `(bool: false)` - Print the current initialization status. An exit
   code of 0 means the OpenBao is already initialized. An exit code of 1 means an
   error occurred. An exit code of 2 means the OpenBao is not initialized.
 


### PR DESCRIPTION
Resolves #1751

While implementing the "initialization without generation of recovery keys" feature, we've missed to implement the support of returning newly generated keys with the new CLI operation (`operator rotate-keys`). This PR introduces support of that, while also allowing for the `operator init` command to specify the `recovery_shares` and `recovery_threshold` values as 0.

```
// run bao server
bao server -log-level debug -config <config>

// init the server
bao operator init -recovery-shares=0 -recovery-threshold=0

// get the root token and provide it with the command
bao operator rotate-keys -init -target=recovery -key-shares=3 -key-threshold=2
```