### PR TITLE
Automatically seal newly created sealable namespaces

### DIFF
--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -23,7 +23,7 @@ func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
 func TestCore_NS_GenerateRoot_Lifecycle(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "test1/"}
-	keysPerNamespace := TestCoreCreateSealedNamespaces(t, c, ns)
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
 	testCore_GenerateRoot_Lifecycle_Common(t, c, keysPerNamespace[ns.Path], ns)
 }
 
@@ -104,7 +104,7 @@ func TestCore_GenerateRoot_Init(t *testing.T) {
 func TestCore_NS_GenerateRoot_Init(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "test1/"}
-	TestCoreCreateSealedNamespaces(t, c, ns)
+	TestCoreCreateUnsealedNamespaces(t, c, ns)
 	testCore_GenerateRoot_Init_Common(t, c, ns)
 }
 
@@ -140,7 +140,7 @@ func TestCore_GenerateRoot_InvalidRootNonce(t *testing.T) {
 func TestCore_NS_GenerateRoot_InvalidRootNonce(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "test1/"}
-	keysPerNamespace := TestCoreCreateSealedNamespaces(t, c, ns)
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
 	keys := keysPerNamespace[ns.Path]
 	keys[0][0]++
 	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, keys, ns)
@@ -195,7 +195,7 @@ func TestCore_GenerateRoot_Update_OTP(t *testing.T) {
 func TestCore_NS_GenerateRoot_Update_OTP(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "test1/"}
-	keysPerNamespace := TestCoreCreateSealedNamespaces(t, c, ns)
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
 	testCore_GenerateRoot_Update_OTP_Common(t, c, keysPerNamespace[ns.Path], ns)
 }
 
@@ -291,7 +291,7 @@ func TestCore_GenerateRoot_Update_PGP(t *testing.T) {
 func TestCore_NS_GenerateRoot_Update_PGP(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "test1/"}
-	keysPerNamespace := TestCoreCreateSealedNamespaces(t, c, ns)
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
 	testCore_GenerateRoot_Update_PGP_Common(t, c, keysPerNamespace[ns.Path], ns)
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -398,10 +398,11 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			if len(keyShares) > 0 {
 				keySharesMap["default"] = keyShares
 			}
-		}
-
-		if err := b.Core.namespaceStore.initializeNamespace(ctx, entry); err != nil {
-			return handleError(err)
+		} else {
+			// if there's no seal config provided we need to initialize the namespace
+			if err := b.Core.namespaceStore.initializeNamespace(ctx, entry); err != nil {
+				return handleError(err)
+			}
 		}
 
 		return &logical.Response{Data: createNamespaceDataResponse(entry, keySharesMap)}, nil

--- a/vault/logical_system_namespaces_rotate_test.go
+++ b/vault/logical_system_namespaces_rotate_test.go
@@ -35,8 +35,7 @@ func TestNamespaceBackend_Rotate(t *testing.T) {
 	})
 
 	t.Run("rotates the barrier key for a sealable namespace", func(t *testing.T) {
-		sealConfig := map[string]any{"type": "shamir", "secret_shares": 3, "secret_threshold": 2}
-		testCreateNamespace(t, rootCtx, b, "foobar", map[string]any{"seals": sealConfig})
+		_ = TestCoreCreateUnsealedNamespaces(t, b.Core, &namespace.Namespace{Path: "foobar/"})
 
 		req := logical.TestRequest(t, logical.ReadOperation, "namespaces/foobar/key-status")
 		res, err := b.HandleRequest(rootCtx, req)
@@ -91,8 +90,7 @@ func TestNamespaceBackend_RotateConfig(t *testing.T) {
 	})
 
 	t.Run("update the key rotation config for a sealable namespace", func(t *testing.T) {
-		sealConfig := map[string]any{"type": "shamir", "secret_shares": 3, "secret_threshold": 2}
-		testCreateNamespace(t, rootCtx, b, "foobar", map[string]any{"seals": sealConfig})
+		_ = TestCoreCreateUnsealedNamespaces(t, b.Core, &namespace.Namespace{Path: "foobar/"})
 
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/rotate/keyring/config")
 		req.Data["max_operations"] = 1_234_567
@@ -136,7 +134,7 @@ func TestNamespaceBackend_RotateInitStatus(t *testing.T) {
 	})
 
 	t.Run("rotate init responds with rotation status", func(t *testing.T) {
-		_ = TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
+		_ = TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
 
 		// read root rotation status without initializing beforehand
 		req := logical.TestRequest(t, logical.ReadOperation, "namespaces/foo/rotate/root/init")
@@ -193,7 +191,7 @@ func TestNamespaceBackend_RotateInitDispatch(t *testing.T) {
 	})
 
 	t.Run("only one rotation can be in progress at a time", func(t *testing.T) {
-		_ = TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
+		_ = TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
 
 		// initialize rotation
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/foo/rotate/root/init")
@@ -212,7 +210,7 @@ func TestNamespaceBackend_RotateInitDispatch(t *testing.T) {
 	})
 
 	t.Run("can cancel the rotation and dispatch again", func(t *testing.T) {
-		_ = TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "bar/"})
+		_ = TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "bar/"})
 
 		// initialize rotation
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/bar/rotate/root/init")
@@ -247,7 +245,7 @@ func TestNamespaceBackend_RotateUpdate(t *testing.T) {
 	rootCtx := namespace.RootContext(context.Background())
 
 	t.Run("rotate update missing required data", func(t *testing.T) {
-		unsealShares := TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
+		unsealShares := TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
 
 		// init root rotation
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/foo/rotate/root/init")
@@ -282,7 +280,7 @@ func TestNamespaceBackend_RotateUpdate(t *testing.T) {
 	})
 
 	t.Run("rotate update complete", func(t *testing.T) {
-		unsealShares := TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "bar/"})
+		unsealShares := TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "bar/"})
 
 		// init root rotation
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/bar/rotate/root/init")

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -282,6 +282,32 @@ func (ns *NamespaceStore) invalidate(ctx context.Context, path string) error {
 	return nil
 }
 
+// SetNamespaceSealed is used to create or update a given sealable namespace.
+// Note that you cannot change the seal config of a namespace with this operation.
+func (ns *NamespaceStore) SetNamespaceSealed(ctx context.Context, entry *namespace.Namespace, sealConfig *SealConfig) ([][]byte, error) {
+	unlock, err := ns.lockWithInvalidation(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	new, err := ns.setNamespaceLocked(ctx, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	if new && sealConfig != nil {
+		nsCtx := namespace.ContextWithNamespace(ctx, entry)
+		err = ns.core.sealManager.SetSeal(nsCtx, sealConfig, entry, true)
+		if err != nil {
+			return nil, err
+		}
+		return ns.core.sealManager.InitializeBarrier(nsCtx, entry)
+	}
+
+	return nil, nil
+}
+
 // SetNamespace is used to create or update a given namespace.
 func (ns *NamespaceStore) SetNamespace(ctx context.Context, namespace *namespace.Namespace) error {
 	defer metrics.MeasureSince([]string{"namespace", "set_namespace"}, time.Now())
@@ -298,7 +324,6 @@ func (ns *NamespaceStore) SetNamespace(ctx context.Context, namespace *namespace
 	}
 
 	unlock()
-	// TODO: might want to support calling (*SealManager).SetSeal here
 	if new {
 		return ns.initializeNamespace(ctx, namespace)
 	}
@@ -887,6 +912,8 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal tainted namespace")
 	}
 
+	// override the namespace in context to the one we want to seal
+	ctx = namespace.ContextWithNamespace(ctx, namespaceToSeal)
 	return ns.core.sealManager.SealNamespace(ctx, namespaceToSeal)
 }
 

--- a/vault/seal_test.go
+++ b/vault/seal_test.go
@@ -95,7 +95,7 @@ func TestDefaultSeal_IsNSSealed(t *testing.T) {
 	}
 	c, _, _ := TestCoreUnsealed(t)
 	sm := c.sealManager
-	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	ctx := namespace.RootContext(context.Background())
 
 	ns := &namespace.Namespace{Path: "test/"}
 	TestCoreCreateNamespaces(t, c, ns)
@@ -113,7 +113,7 @@ func TestRegisterNamespace(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
 
 	ns := &namespace.Namespace{Path: "test/"}
-	TestCoreCreateSealedNamespaces(t, c, ns)
+	_ = TestCoreCreateUnsealedNamespaces(t, c, ns)
 	require.False(t, c.NamespaceSealed(ns))
 
 	err := TestCoreSeal(c)

--- a/vault/storage_access.go
+++ b/vault/storage_access.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+type StorageAccess interface {
+	Put(context.Context, string, []byte) error
+	Get(context.Context, string) ([]byte, error)
+	Delete(context.Context, string) error
+	ListPage(context.Context, string, string, int) ([]string, error)
+}
+
+var (
+	_ StorageAccess = (*directStorageAccess)(nil)
+	_ StorageAccess = (*secureStorageAccess)(nil)
+)
+
+type directStorageAccess struct {
+	physical physical.Backend
+}
+
+func (p *directStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	pe := &physical.Entry{
+		Key:   path,
+		Value: value,
+	}
+	return p.physical.Put(ctx, pe)
+}
+
+func (p *directStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	pe, err := p.physical.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if pe == nil {
+		return nil, nil
+	}
+	return pe.Value, nil
+}
+
+func (p *directStorageAccess) Delete(ctx context.Context, key string) error {
+	return p.physical.Delete(ctx, key)
+}
+
+func (p *directStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return p.physical.ListPage(ctx, prefix, after, limit)
+}
+
+type secureStorageAccess struct {
+	barrier SecurityBarrier
+}
+
+func (b *secureStorageAccess) Put(ctx context.Context, path string, value []byte) error {
+	se := &logical.StorageEntry{
+		Key:   path,
+		Value: value,
+	}
+	return b.barrier.Put(ctx, se)
+}
+
+func (b *secureStorageAccess) Get(ctx context.Context, path string) ([]byte, error) {
+	se, err := b.barrier.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if se == nil {
+		return nil, nil
+	}
+	return se.Value, nil
+}
+
+func (b *secureStorageAccess) Delete(ctx context.Context, key string) error {
+	return b.barrier.Delete(ctx, key)
+}
+
+func (b *secureStorageAccess) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return b.barrier.ListPage(ctx, prefix, after, limit)
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -374,7 +374,7 @@ func TestCoreCreateNamespaces(t testing.T, core *Core, namespaces ...*namespace.
 }
 
 // TestCoreCreateSealedNamespaces creates sealed namespaces with 3 key shares and returns the
-// key for each created namespace in a map.
+// key shares for each namespace in a map with namespace path as key.
 func TestCoreCreateSealedNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) map[string][][]byte {
 	t.Helper()
 	sealConfig := &SealConfig{
@@ -388,14 +388,31 @@ func TestCoreCreateSealedNamespaces(t testing.T, core *Core, namespaces ...*name
 		parentPath, _ := ns.ParentPath()
 		parent, err := core.namespaceStore.GetNamespaceByPath(ctx, parentPath)
 		require.NoError(t, err)
-		parentCtx := namespace.ContextWithNamespace(ctx, parent)
-		err = core.namespaceStore.SetNamespace(parentCtx, ns)
-		require.NoError(t, err)
-		err = core.sealManager.SetSeal(namespace.ContextWithNamespace(ctx, ns), sealConfig, ns, true)
-		require.NoError(t, err)
-		nsSealKeyShares, err := core.sealManager.InitializeBarrier(ctx, ns)
+
+		nsSealKeyShares, err := core.namespaceStore.SetNamespaceSealed(namespace.ContextWithNamespace(ctx, parent), ns, sealConfig)
 		require.NoError(t, err)
 		keysPerNamespace[ns.Path] = nsSealKeyShares
+	}
+	return keysPerNamespace
+}
+
+// TestCoreCreateUnsealedNamespaces creates sealed namespaces with 3 key shares, unseals the namespaces
+// and returns back the key shares for each namespace in a map with namespace path as key.
+func TestCoreCreateUnsealedNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) map[string][][]byte {
+	t.Helper()
+	keysPerNamespace := make(map[string][][]byte)
+	for _, ns := range namespaces {
+		keys := TestCoreCreateSealedNamespaces(t, core, ns)
+		for _, key := range keys[ns.Path] {
+			unsealed, err := core.sealManager.UnsealNamespace(namespace.ContextWithNamespace(context.Background(), ns), ns, TestKeyCopy(key))
+			require.NoError(t, err)
+			if unsealed {
+				break
+			}
+		}
+
+		require.False(t, core.NamespaceSealed(ns))
+		keysPerNamespace[ns.Path] = keys[ns.Path]
 	}
 	return keysPerNamespace
 }


### PR DESCRIPTION
This PR changes the behavior on the creation of a sealable namespace.

Changed:
- namespaces created with a seal config (sealable) are now sealed by default after creation
- moved `StorageAccess` interface to separate file `storage_access`
- tweaked tests related to namespace sealing