### PR TITLE
Drop "go.uber.org/atomic" package

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -12,8 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	atomic2 "go.uber.org/atomic"
-
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-multierror"
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -270,9 +268,9 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.lastTidy = time.Now()
 
 	// Metrics initialization for count of certificates in storage
-	b.certCountEnabled = atomic2.NewBool(false)
-	b.publishCertCountMetrics = atomic2.NewBool(false)
-	b.certsCounted = atomic2.NewBool(false)
+	b.certCountEnabled = &atomic.Bool{}
+	b.publishCertCountMetrics = &atomic.Bool{}
+	b.certsCounted = &atomic.Bool{}
 	b.certCountError = "Initialize Not Yet Run, Cert Counts Unavailable"
 	b.certCount = &atomic.Uint32{}
 	b.revokedCertCount = &atomic.Uint32{}
@@ -296,11 +294,11 @@ type backend struct {
 	tidyStatus     *tidyStatus
 	lastTidy       time.Time
 
-	certCountEnabled                    *atomic2.Bool
-	publishCertCountMetrics             *atomic2.Bool
+	certCountEnabled                    *atomic.Bool
+	publishCertCountMetrics             *atomic.Bool
 	certCount                           *atomic.Uint32
 	revokedCertCount                    *atomic.Uint32
-	certsCounted                        *atomic2.Bool
+	certsCounted                        *atomic.Bool
 	certCountError                      string
 	possibleDoubleCountedSerials        []string
 	possibleDoubleCountedRevokedSerials []string

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -14,9 +14,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-hclog"
@@ -91,8 +90,8 @@ type Server struct {
 func NewServer(conf *ServerConfig) *Server {
 	ts := Server{
 		DoneCh:        make(chan struct{}),
-		stopped:       atomic.NewBool(false),
-		runnerStarted: atomic.NewBool(false),
+		stopped:       &atomic.Bool{},
+		runnerStarted: &atomic.Bool{},
 
 		maxBackoff: conf.MaxBackoff,
 		minBackoff: conf.MinBackoff,

--- a/command/agentproxyshared/cache/lease_cache_test.go
+++ b/command/agentproxyshared/cache/lease_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func testNewLeaseCache(t *testing.T, responses []*SendResponse) *LeaseCache {
@@ -619,7 +619,7 @@ func TestLeaseCache_Concurrent_Cacheable(t *testing.T) {
 				}
 
 				if resp.CacheMeta != nil && resp.CacheMeta.Hit {
-					cacheCount.Inc()
+					cacheCount.Add(1)
 				}
 			}()
 		}

--- a/command/agentproxyshared/sink/inmem/inmem_sink.go
+++ b/command/agentproxyshared/sink/inmem/inmem_sink.go
@@ -5,18 +5,18 @@ package inmem
 
 import (
 	"errors"
+	"sync/atomic"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/command/agentproxyshared/cache"
 	"github.com/openbao/openbao/command/agentproxyshared/sink"
-	"go.uber.org/atomic"
 )
 
 // inmemSink retains the auto-auth token in memory and exposes it via
 // sink.SinkReader interface.
 type inmemSink struct {
 	logger     hclog.Logger
-	token      *atomic.String
+	token      *atomic.Value
 	leaseCache *cache.LeaseCache
 }
 
@@ -29,7 +29,7 @@ func New(conf *sink.SinkConfig, leaseCache *cache.LeaseCache) (sink.Sink, error)
 	return &inmemSink{
 		logger:     conf.Logger,
 		leaseCache: leaseCache,
-		token:      atomic.NewString(""),
+		token:      &atomic.Value{},
 	}, nil
 }
 
@@ -44,5 +44,5 @@ func (s *inmemSink) WriteToken(token string) error {
 }
 
 func (s *inmemSink) Token() string {
-	return s.token.Load()
+	return s.token.Load().(string)
 }

--- a/command/server.go
+++ b/command/server.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	systemd "github.com/coreos/go-systemd/v22/daemon"
@@ -61,7 +62,6 @@ import (
 	"github.com/openbao/openbao/version"
 	"github.com/posener/complete"
 	"github.com/sasha-s/go-deadlock"
-	"go.uber.org/atomic"
 	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -635,7 +635,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 			AllListeners:          lns,
 			DisablePrintableCheck: config.DisablePrintableCheck,
 			RecoveryMode:          c.flagRecovery,
-			RecoveryToken:         atomic.NewString(""),
+			RecoveryToken:         &atomic.Value{},
 		})
 
 		server := &http.Server{

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,6 @@ require (
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.41.0

--- a/http/logical.go
+++ b/http/logical.go
@@ -15,13 +15,13 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
-	"go.uber.org/atomic"
 )
 
 // bufferedReader can be used to replace a request body with a buffered
@@ -347,7 +347,7 @@ func handleLogicalNoForward(core *vault.Core) http.Handler {
 	return handleLogicalInternal(core, false, true)
 }
 
-func handleLogicalRecovery(raw *vault.RawBackend, token *atomic.String) http.Handler {
+func handleLogicalRecovery(raw *vault.RawBackend, token *atomic.Value) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _, statusCode, err := buildLogicalRequestNoAuth(w, r)
 		if err != nil || statusCode != 0 {
@@ -598,5 +598,5 @@ func getConnection(r *http.Request) (connection *logical.Connection) {
 		RemotePort: remotePort,
 		ConnState:  r.TLS,
 	}
-	return
+	return connection
 }

--- a/physical/raft/snapshot.go
+++ b/physical/raft/snapshot.go
@@ -14,16 +14,15 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/raft"
 	"github.com/openbao/openbao/sdk/v2/plugin/pb"
 	"github.com/rboyer/safeio"
 	bolt "go.etcd.io/bbolt"
-	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/hashicorp/raft"
 )
 
 const (

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tink-crypto/tink-go/v2 v2.4.0
-	go.uber.org/atomic v1.11.0
 	golang.org/x/crypto v0.41.0
 	golang.org/x/net v0.43.0
 	golang.org/x/text v0.28.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -312,8 +312,6 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1jgeg=
 go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,7 +41,6 @@ import (
 	dockhelper "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
-	uberAtomic "go.uber.org/atomic"
 	"golang.org/x/net/http2"
 )
 
@@ -702,7 +702,7 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	var seenLogs uberAtomic.Bool
+	var seenLogs atomic.Bool
 	logConsumer := func(s string) {
 		if seenLogs.CompareAndSwap(false, true) {
 			wg.Done()

--- a/serviceregistration/kubernetes/testing/testserver.go
+++ b/serviceregistration/kubernetes/testing/testserver.go
@@ -13,9 +13,8 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
-
-	"go.uber.org/atomic"
 )
 
 const (
@@ -45,7 +44,7 @@ var token string
 var (
 	// ReturnGatewayTimeouts toggles whether the test server should return,
 	// well, gateway timeouts...
-	ReturnGatewayTimeouts = atomic.NewBool(false)
+	ReturnGatewayTimeouts = &atomic.Bool{}
 
 	pathToFiles = func() string {
 		wd, _ := os.Getwd()

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -393,5 +393,5 @@ func (c *Core) SetClusterHandler(handler http.Handler) {
 }
 
 func (c *Core) ClusterID() string {
-	return c.clusterID.Load()
+	return c.clusterID.Load().(string)
 }

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/base62"
-	"go.uber.org/atomic"
 )
 
 // InmemLayer is an in-memory implementation of NetworkLayer. This is
@@ -43,7 +43,7 @@ func NewInmemLayer(addr string, logger log.Logger) *InmemLayer {
 	return &InmemLayer{
 		addr:        addr,
 		logger:      logger,
-		stopped:     atomic.NewBool(false),
+		stopped:     &atomic.Bool{},
 		stopCh:      make(chan struct{}),
 		peers:       make(map[string]*InmemLayer),
 		servConns:   make(map[string][]net.Conn),
@@ -109,7 +109,7 @@ func (l *InmemLayer) Listeners() []NetworkListener {
 		addr:         l.addr,
 		pendingConns: make(chan net.Conn),
 
-		stopped: atomic.NewBool(false),
+		stopped: &atomic.Bool{},
 		stopCh:  make(chan struct{}),
 	}
 

--- a/vault/cluster/inmem_layer_test.go
+++ b/vault/cluster/inmem_layer_test.go
@@ -5,11 +5,11 @@ package cluster
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
-	"go.uber.org/atomic"
 )
 
 func TestInmemCluster_Connect(t *testing.T) {

--- a/vault/cluster/tcp_layer.go
+++ b/vault/cluster/tcp_layer.go
@@ -7,11 +7,11 @@ import (
 	"crypto/tls"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"go.uber.org/atomic"
 )
 
 // TCPLayer implements the NetworkLayer interface and uses TCP as the underlying
@@ -30,7 +30,7 @@ func NewTCPLayer(addrs []*net.TCPAddr, logger log.Logger) *TCPLayer {
 	return &TCPLayer{
 		addrs:   addrs,
 		logger:  logger,
-		stopped: atomic.NewBool(false),
+		stopped: &atomic.Bool{},
 	}
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -59,7 +59,6 @@ import (
 	vaultseal "github.com/openbao/openbao/vault/seal"
 	"github.com/openbao/openbao/version"
 	"github.com/patrickmn/go-cache"
-	uberAtomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -432,7 +431,7 @@ type Core struct {
 	physicalCache physical.ToggleablePurgemonster
 
 	// logRequestsLevel indicates at which level requests should be logged
-	logRequestsLevel *uberAtomic.Int32
+	logRequestsLevel *atomic.Int32
 
 	// reloadFuncs is a map containing reload functions
 	reloadFuncs map[string][]reloadutil.ReloadFunc
@@ -450,7 +449,7 @@ type Core struct {
 	// Name
 	clusterName string
 	// ID
-	clusterID uberAtomic.String
+	clusterID atomic.Value
 	// Specific cipher suites to use for clustering, if any
 	clusterCipherSuites []uint16
 	// Used to modify cluster parameters
@@ -605,7 +604,7 @@ type Core struct {
 	// number of workers to use for lease revocation in the expiration manager
 	numExpirationWorkers int
 
-	IndexHeaderHMACKey uberAtomic.Value
+	IndexHeaderHMACKey atomic.Value
 
 	// disableAutopilot is used to disable the autopilot subsystem in raft storage
 	disableAutopilot bool
@@ -999,7 +998,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	c.inFlightReqData = &InFlightRequests{
 		InFlightReqMap:   &sync.Map{},
-		InFlightReqCount: uberAtomic.NewUint64(0),
+		InFlightReqCount: &atomic.Uint64{},
 	}
 
 	c.SetConfig(conf.RawConfig)
@@ -1203,7 +1202,7 @@ func (c *Core) configureListeners(conf *CoreConfig) error {
 
 // configureLogRequestsLevel configures the Core with the supplied log requests level.
 func (c *Core) configureLogRequestsLevel(level string) {
-	c.logRequestsLevel = uberAtomic.NewInt32(0)
+	c.logRequestsLevel = &atomic.Int32{}
 
 	lvl := log.LevelFromString(level)
 
@@ -1903,7 +1902,7 @@ func (c *Core) unsealInternal(ctx context.Context, rootKey []byte) error {
 			return err
 		}
 
-		ctx, ctxCancel := context.WithCancel(namespace.RootContext(nil))
+		ctx, ctxCancel := context.WithCancel(namespace.RootContext(context.TODO()))
 		if err := c.postUnseal(ctx, ctxCancel, standardUnsealStrategy{}); err != nil {
 			c.logger.Error("post-unseal setup failed", "error", err)
 			c.barrier.Seal()
@@ -1961,7 +1960,7 @@ func (c *Core) SealWithRequest(httpCtx context.Context, req *logical.Request) er
 
 	// This will unlock the read lock
 	// We use background context since we may not be active
-	ctx, cancel := context.WithCancel(namespace.RootContext(nil))
+	ctx, cancel := context.WithCancel(namespace.RootContext(context.TODO()))
 	defer cancel()
 
 	go func() {
@@ -1995,7 +1994,7 @@ func (c *Core) Seal(token string) error {
 
 	// This will unlock the read lock
 	// We use background context since we may not be active
-	return c.sealInitCommon(namespace.RootContext(nil), req)
+	return c.sealInitCommon(namespace.RootContext(context.TODO()), req)
 }
 
 // sealInitCommon is common logic for Seal and SealWithRequest and is used to
@@ -2121,7 +2120,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		retErr = multierror.Append(retErr, sealErr)
 	}
 
-	return
+	return retErr
 }
 
 // UIEnabled returns if the UI is enabled
@@ -2582,7 +2581,7 @@ func (c *Core) Logger() log.Logger {
 func (c *Core) BarrierKeyLength() (min, max int) {
 	min, max = c.barrier.KeyLength()
 	max += shamir.ShareOverhead
-	return
+	return min, max
 }
 
 func (c *Core) AuditedHeadersConfig() *AuditedHeadersConfig {
@@ -3532,7 +3531,7 @@ func (c *Core) SaveMFAResponseAuth(respAuth *MFACachedAuthResponse) error {
 
 type InFlightRequests struct {
 	InFlightReqMap   *sync.Map
-	InFlightReqCount *uberAtomic.Uint64
+	InFlightReqCount *atomic.Uint64
 }
 
 type InFlightReqData struct {
@@ -3545,7 +3544,7 @@ type InFlightReqData struct {
 
 func (c *Core) StoreInFlightReqData(reqID string, data InFlightReqData) {
 	c.inFlightReqData.InFlightReqMap.Store(reqID, data)
-	c.inFlightReqData.InFlightReqCount.Inc()
+	c.inFlightReqData.InFlightReqCount.Add(1)
 }
 
 // FinalizeInFlightReqData is going log the completed request if the
@@ -3558,7 +3557,8 @@ func (c *Core) FinalizeInFlightReqData(reqID string, statusCode int) {
 	}
 
 	c.inFlightReqData.InFlightReqMap.Delete(reqID)
-	c.inFlightReqData.InFlightReqCount.Dec()
+	inFlightReqCount := c.inFlightReqData.InFlightReqCount.Load()
+	c.inFlightReqData.InFlightReqCount.Store(inFlightReqCount - 1)
 }
 
 // LoadInFlightReqData creates a snapshot map of the current
@@ -3603,7 +3603,7 @@ func (c *Core) LogCompletedRequests(reqID string, statusCode int) {
 	reqData := v.(InFlightReqData)
 	c.logger.Log(logLevel, "completed_request",
 		"start_time", reqData.StartTime.Format(time.RFC3339),
-		"duration", fmt.Sprintf("%dms", time.Now().Sub(reqData.StartTime).Milliseconds()),
+		"duration", fmt.Sprintf("%dms", time.Since(reqData.StartTime).Milliseconds()),
 		"client_id", reqData.ClientID,
 		"client_address", reqData.ClientRemoteAddr, "status_code", statusCode, "request_path", reqData.ReqPath,
 		"request_method", reqData.Method)

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
-	uberAtomic "go.uber.org/atomic"
 )
 
 const (
@@ -149,7 +148,7 @@ type ExpirationManager struct {
 	// testRegisterAuthFailure, if set to true, triggers an explicit failure on
 	// RegisterAuth to simulate a partial failure during a token creation
 	// request. This value should only be set by tests.
-	testRegisterAuthFailure uberAtomic.Bool
+	testRegisterAuthFailure atomic.Bool
 
 	jobManager      *fairshare.JobManager
 	revokeRetryBase time.Duration

--- a/vault/external_tests/misc/recovery_test.go
+++ b/vault/external_tests/misc/recovery_test.go
@@ -5,6 +5,7 @@ package misc
 
 import (
 	"path"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -14,7 +15,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/vault"
-	"go.uber.org/atomic"
 )
 
 func TestRecovery(t *testing.T) {
@@ -70,7 +70,7 @@ func TestRecovery(t *testing.T) {
 
 	{
 		// Now bring it up in recovery mode.
-		var tokenRef atomic.String
+		var tokenRef atomic.Value
 		conf := vault.CoreConfig{
 			Physical:     inm,
 			Logger:       logger,

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -5,6 +5,7 @@ package quotas
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/openbao/openbao/builtin/logical/pki"
 	"github.com/openbao/openbao/helper/testhelpers/teststorage"
 	"github.com/openbao/openbao/vault"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -96,8 +96,8 @@ func teardownMounts(t *testing.T, client *api.Client) {
 }
 
 func testRPS(reqFunc func(numSuccess, numFail *atomic.Int32), d time.Duration) (int32, int32, time.Duration) {
-	numSuccess := atomic.NewInt32(0)
-	numFail := atomic.NewInt32(0)
+	numSuccess := &atomic.Int32{}
+	numFail := &atomic.Int32{}
 
 	start := time.Now()
 	end := start.Add(d)
@@ -109,8 +109,8 @@ func testRPS(reqFunc func(numSuccess, numFail *atomic.Int32), d time.Duration) (
 }
 
 func testRPSWithNS(reqFunc func(numSuccess, numFail *atomic.Int32, ns string), d time.Duration, ns string) (int32, int32, time.Duration) {
-	numSuccess := atomic.NewInt32(0)
-	numFail := atomic.NewInt32(0)
+	numSuccess := &atomic.Int32{}
+	numFail := &atomic.Int32{}
 
 	start := time.Now()
 	end := start.Add(d)

--- a/vault/generate_root_recovery.go
+++ b/vault/generate_root_recovery.go
@@ -6,22 +6,22 @@ package vault
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
-	"go.uber.org/atomic"
 )
 
 // GenerateRecoveryTokenStrategy is the strategy used to generate a
 // recovery token
-func GenerateRecoveryTokenStrategy(token *atomic.String) GenerateRootStrategy {
+func GenerateRecoveryTokenStrategy(token *atomic.Value) GenerateRootStrategy {
 	return &generateRecoveryToken{token: token}
 }
 
 // generateRecoveryToken implements the GenerateRootStrategy and is in
 // charge of creating recovery tokens.
 type generateRecoveryToken struct {
-	token *atomic.String
+	token *atomic.Value
 }
 
 func (g *generateRecoveryToken) authenticate(ctx context.Context, c *Core, combinedKey []byte) error {

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 )
 
@@ -104,7 +104,10 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.%d", i)
 		cr, ok := results[addr]
 		if !ok {
-			results[addr] = &clientResult{atomicNumAllow: atomic.NewInt32(0), atomicNumFail: atomic.NewInt32(0)}
+			results[addr] = &clientResult{
+				atomicNumAllow: &atomic.Int32{},
+				atomicNumFail:  &atomic.Int32{},
+			}
 			cr = results[addr]
 		}
 
@@ -180,7 +183,10 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 		addr := fmt.Sprintf("127.0.0.%d", i)
 		cr, ok := results[addr]
 		if !ok {
-			results[addr] = &clientResult{atomicNumAllow: atomic.NewInt32(0), atomicNumFail: atomic.NewInt32(0)}
+			results[addr] = &clientResult{
+				atomicNumAllow: &atomic.Int32{},
+				atomicNumFail:  &atomic.Int32{},
+			}
 			cr = results[addr]
 		}
 


### PR DESCRIPTION
Resolves #1456 

This PR:
- removes all usage of "go.uber.org/atomic"
- adjusts few lint issues
- adds named returns (enforced by `gofumpt`)