### PR TITLE
Add {LICENSE|SPDX|VERSION}_NODE_MODULES.txt to the release dist tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,12 +108,33 @@ jobs:
         run: |
           make static-dist
 
+      - name: Make LICENSE_NODE_MODULES.txt
+        if: inputs.dodistrelease
+        run: |
+          set -e
+          sudo npm install --global generate-license-file
+          cd ui
+          generate-license-file --input package.json --output ../LICENSE_NODE_MODULES.txt
+
+      - name: Make SPDX_NODE_MODULES.txt
+        if: inputs.dodistrelease
+        run: |
+          sudo apt install -y jq
+          jq -r .license ui/node_modules/*/package.json | \
+            grep -v url | \
+            sed 's/.*"type": "//;s/",//' | \
+            grep -v { | grep -v } | grep -v ^null$ | \
+            awk '{if ((($2 == "OR") || ($2 == "AND")) && (substr($1, 0, 1) != "(")) { print "(" $0 ")"} else {print $0}}' | \
+            sort -u >SPDX_NODE_MODULES.txt
+
+      - name: Make VERSION_NODE_MODULES.txt
+        if: inputs.dodistrelease
+        run: jq -r '"\(.name) \(.version)"'  ui/node_modules/*/package.json >VERSION_NODE_MODULES.txt
+
       - name: Golang Setup
-        if: inputs.dogorelease
         uses: ./.github/actions/set-up-go
 
       - name: go-check
-        if: inputs.dogorelease
         run: go version
 
       - name: Make LICENSE_DEPENDENCIES.md


### PR DESCRIPTION
This collects licensing and version information for the node modules to put into the release distribution tarball, as required by the Fedora/EPEL package reviewers.