### PR TITLE
fix(docs): remove space to render warning box correctly

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -264,7 +264,7 @@ in the root of the TCP listener configuration.
 - `tls_acme_domains` `([]string: nil)` - An optional but strongly recommended
   allow-list of domains to allow acquiring certificates for.
 
-::: warning
+:::warning
 
 Failing to specify `tls_acme_domains` on a publicly listening server issuing
 against a publicly trusted CA will allow anyone (including an attacker) to


### PR DESCRIPTION
Remove's the space in https://openbao.org/docs/configuration/listener/tcp/#acme-parameters so that the box is rendered correctly.