### PR TITLE
doc(contributing): adjust link to meeting recordings

### DIFF
--- a/website/content/docs/contributing/index.mdx
+++ b/website/content/docs/contributing/index.mdx
@@ -40,8 +40,7 @@ the call.
 Feel free to join and/or send agenda topics via email, GitHub discussion, or
 on the Matrix server!
 
-[Meeting recordings](https://openprofile.dev/my-meetings)
-are available on your personal Openprofile site.
+Meeting recordings are linked in the [Comunity Call Agenda document](https://docs.google.com/document/d/1HZOjDpm0i2fD-W26FkmMQQStVYFgX3evP-nMpgiGmsA).
 
 ## TSC calls
 
@@ -52,8 +51,7 @@ below.
 
 Feel free to join!
 
-[Meeting recordings](https://openprofile.dev/my-meetings)
-and agendas are available on your personal Openprofile site.
+Meeting recordings are linked in the [Comunity Call Agenda document](https://docs.google.com/document/d/1HZOjDpm0i2fD-W26FkmMQQStVYFgX3evP-nMpgiGmsA).
 
 ### TSC charter
 


### PR DESCRIPTION
Not sure if there is a better link. Feels wierd having to login and be part of the OpenBao Main list to see the recordings.
