### PR TITLE
Fix login renewal with CEL

### DIFF
--- a/builtin/credential/jwt/path_cel_login.go
+++ b/builtin/credential/jwt/path_cel_login.go
@@ -69,6 +69,7 @@ func (b *jwtAuthBackend) pathResolveCelRole(ctx context.Context, req *logical.Re
 	if config == nil {
 		return logical.ErrorResponse("could not load configuration"), nil
 	}
+
 	celRole, resp, err := b.getCelRoleFromLoginRequest(config, ctx, req, d)
 	if resp != nil || err != nil {
 		return resp, err
@@ -168,6 +169,13 @@ func (b *jwtAuthBackend) pathCelLogin(ctx context.Context, req *logical.Request,
 	if err != nil {
 		return logical.ErrorResponse("error converting proto auth: %s", err.Error()), nil
 	}
+
+	// Set required fields.
+	if len(auth.InternalData) == 0 {
+		auth.InternalData = make(map[string]interface{}, 2)
+	}
+	auth.InternalData["role"] = celRoleEntry.Name
+	auth.InternalData["role_type"] = "cel"
 
 	if err := logical.EndTxStorage(ctx, req); err != nil {
 		return nil, err

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -180,7 +180,8 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		Alias:        alias,
 		GroupAliases: groupAliases,
 		InternalData: map[string]interface{}{
-			"role": roleName,
+			"role":      roleName,
+			"role_type": "native",
 		},
 		Metadata: tokenMetadata,
 	}
@@ -199,6 +200,37 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 }
 
 func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := req.Auth.InternalData["role"].(string)
+	if roleName == "" {
+		return nil, errors.New("failed to fetch role_name during renewal")
+	}
+
+	roleType := req.Auth.InternalData["role_type"].(string)
+
+	switch roleType {
+	case "cel":
+		return b.pathCelLoginRenew(ctx, req, data)
+	case "native":
+		return b.pathNativeLoginRenew(ctx, req, data)
+	case "":
+		// Check if this is a native role.
+		role, err := b.role(ctx, req.Storage, roleName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate role %s during renewal: %w", roleName, err)
+		}
+		if role == nil {
+			// Assume it is a CEL role.
+			return b.pathCelLoginRenew(ctx, req, data)
+		}
+
+		// Otherwise, the role exists so presume it is a native role.
+		return b.pathNativeLoginRenew(ctx, req, data)
+	default:
+		return nil, fmt.Errorf("unknown role type: %v", roleType)
+	}
+}
+
+func (b *jwtAuthBackend) pathNativeLoginRenew(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	roleName := req.Auth.InternalData["role"].(string)
 	if roleName == "" {
 		return nil, errors.New("failed to fetch role_name during renewal")

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -213,7 +213,7 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	case "native":
 		return b.pathNativeLoginRenew(ctx, req, data)
 	case "":
-		// Check if this is a native role.
+		// Check if this is a native role. This is a fallback for earlier versions which didn't write role type.
 		role, err := b.role(ctx, req.Storage, roleName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to validate role %s during renewal: %w", roleName, err)

--- a/changelog/1776.txt
+++ b/changelog/1776.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/jwt: Support token renewal with CEL roles.
+```


### PR DESCRIPTION
OpenBao only allows a single login renewal handler. This works fine for the most part, but we need to begin differentiating native roles from CEL program roles, handling renewal separately.

This adds a new internal data field which we can use to disambiguate the two and wires up the pathLoginRenew handler.

---

Related: https://github.com/openbao/openbao/pull/1771#discussion_r2325072988