### PR TITLE
doc: Patch command should reference RFC7396

### DIFF
--- a/website/content/docs/commands/patch.mdx
+++ b/website/content/docs/commands/patch.mdx
@@ -8,7 +8,7 @@ description: |-
 # patch
 
 The `patch` command updates data in OpenBao at the given path (wrapper command for
-HTTP PATCH using the [JSON Patch format](https://datatracker.ietf.org/doc/html/rfc6902)).
+HTTP PATCH using [JSON Merge Patch format](https://datatracker.ietf.org/doc/html/rfc7396)).
 The data can be credentials, secrets, configuration, or arbitrary data. The specific
 behavior of the `patch` command is determined at the thing mounted at the path.
 


### PR DESCRIPTION
The `patch` command documentation incorrectly references RFC6902 (JSON Patch) when the actual underlying mechanism is RFC7396 (JSON Merge Patch).  The example cURL equivalent, correctly, shows the latter.

