### PR TITLE
[Per-NS-Sealing] Seal Manager lifecycle adjustment

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1433,6 +1433,8 @@ func (c *Core) SecretProgress(lock bool) (int, string) {
 // ResetUnsealProcess removes the current unlock parts from memory,
 // to reset the unsealing process for the root namespace.
 func (c *Core) ResetUnsealProcess() {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
 	c.sealManager.ResetUnsealProcess(namespace.RootNamespaceUUID)
 }
 
@@ -3061,43 +3063,6 @@ func (c *Core) SetKeyRotateGracePeriod(t time.Duration) {
 	atomic.StoreInt64(c.keyRotateGracePeriod, int64(t))
 }
 
-func (c *Core) rotateBarrierKey(ctx context.Context) error {
-	// Rotate to the new term
-	newTerm, err := c.barrier.Rotate(ctx, c.secureRandomReader)
-	if err != nil {
-		return errwrap.Wrap(errors.New("failed to create new encryption key"), err)
-	}
-	c.Logger().Info("installed new encryption key")
-
-	// In HA mode, we need to an upgrade path for the standby instances
-	if c.ha != nil && c.KeyRotateGracePeriod() > 0 {
-		// Create the upgrade path to the new term
-		if err := c.barrier.CreateUpgrade(ctx, newTerm); err != nil {
-			c.Logger().Error("failed to create new upgrade", "term", newTerm, "error", err)
-		}
-
-		// Schedule the destroy of the upgrade path
-		time.AfterFunc(c.KeyRotateGracePeriod(), func() {
-			c.Logger().Debug("cleaning up upgrade keys", "waited", c.KeyRotateGracePeriod())
-			if err := c.barrier.DestroyUpgrade(c.activeContext, newTerm); err != nil {
-				c.Logger().Error("failed to destroy upgrade", "term", newTerm, "error", err)
-			}
-		})
-	}
-
-	// Write to the canary path, which will force a synchronous truing during
-	// replication
-	if err := c.barrier.Put(ctx, &logical.StorageEntry{
-		Key:   coreKeyringCanaryPath,
-		Value: []byte(fmt.Sprintf("new-rotation-term-%d", newTerm)),
-	}); err != nil {
-		c.logger.Error("error saving keyring canary", "error", err)
-		return errwrap.Wrap(errors.New("failed to save keyring canary"), err)
-	}
-
-	return nil
-}
-
 // Periodically test whether to automatically rotate the barrier key
 func (c *Core) autoRotateBarrierLoop(ctx context.Context) {
 	t := time.NewTicker(autoRotateCheckInterval)
@@ -3135,7 +3100,7 @@ func (c *Core) checkBarrierAutoRotate(ctx context.Context) {
 		// the replication canary
 		c.logger.Info("automatic barrier key rotation triggered", "reason", reason)
 
-		if err := c.rotateBarrierKey(ctx); err != nil {
+		if err := c.sealManager.RotateNamespaceBarrierKey(ctx, namespace.RootNamespace); err != nil {
 			c.logger.Error("error automatically rotating barrier key", "error", err)
 		} else {
 			metrics.IncrCounter(barrierRotationsMetric, 1)

--- a/vault/core.go
+++ b/vault/core.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -32,7 +31,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
-	"github.com/hashicorp/go-uuid"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
 	"github.com/openbao/go-kms-wrapping/wrappers/awskms/v2"
@@ -195,11 +193,6 @@ type activeAdvertisement struct {
 	ClusterKeyParams *certutil.ClusterKeyParams `json:"cluster_key_params,omitempty"`
 }
 
-type unlockInformation struct {
-	Parts [][]byte
-	Nonce string
-}
-
 type raftInformation struct {
 	challenge           *wrapping.BlobInfo
 	leaderClient        *api.Client
@@ -311,9 +304,6 @@ type Core struct {
 	// release the stateLock. This channel is marked atomic to prevent race
 	// conditions.
 	shutdownDoneCh *atomic.Value
-
-	// unlockInfo has the keys provided to Unseal until the threshold number of parts is available, as well as the operation nonce
-	unlockInfo *unlockInformation
 
 	// namespaceRootGens holds the shares for each namespace
 	// until we reach enough to verify the root key
@@ -1086,7 +1076,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 	// Construct a new AES-GCM barrier
 	c.barrier = NewAESGCMBarrier(c.physical, "")
-	c.setupSealManager()
+	c.SetupSealManager()
 
 	// We create the funcs here, then populate the given config with it so that
 	// the caller can share state
@@ -1430,20 +1420,20 @@ func (c *Core) SecretProgress(lock bool) (int, string) {
 		c.stateLock.RLock()
 		defer c.stateLock.RUnlock()
 	}
-	switch c.unlockInfo {
+
+	info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID)
+	switch info {
 	case nil:
 		return 0, ""
 	default:
-		return len(c.unlockInfo.Parts), c.unlockInfo.Nonce
+		return len(info.Parts), info.Nonce
 	}
 }
 
-// ResetUnsealProcess removes the current unlock parts from memory, to reset
-// the unsealing process
+// ResetUnsealProcess removes the current unlock parts from memory,
+// to reset the unsealing process for the root namespace.
 func (c *Core) ResetUnsealProcess() {
-	c.stateLock.Lock()
-	defer c.stateLock.Unlock()
-	c.unlockInfo = nil
+	c.sealManager.ResetUnsealProcess(namespace.RootNamespaceUUID)
 }
 
 func (c *Core) UnsealMigrate(key []byte) (bool, error) {
@@ -1535,14 +1525,14 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 		sealToUse = c.migrationInfo.seal
 	}
 
-	newKey, err := c.recordUnsealPart(key)
+	newKey, err := c.sealManager.recordUnsealPart(namespace.RootNamespace, key)
 	if !newKey || err != nil {
 		return err
 	}
 
 	// getUnsealKey returns either a recovery key (in the case of an autoseal)
 	// or an unseal key (new-style shamir).
-	combinedKey, err := c.getUnsealKey(ctx, sealToUse)
+	combinedKey, err := c.sealManager.getUnsealKey(ctx, sealToUse, namespace.RootNamespace)
 	if err != nil || combinedKey == nil {
 		return err
 	}
@@ -1633,92 +1623,6 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 	}()
 
 	return nil
-}
-
-// recordUnsealPart takes in a key fragment, and returns true if it's a new fragment.
-func (c *Core) recordUnsealPart(key []byte) (bool, error) {
-	// Check if we already have this piece
-	if c.unlockInfo != nil {
-		for _, existing := range c.unlockInfo.Parts {
-			if subtle.ConstantTimeCompare(existing, key) == 1 {
-				return false, nil
-			}
-		}
-	} else {
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			return false, err
-		}
-		c.unlockInfo = &unlockInformation{
-			Nonce: uuid,
-		}
-	}
-
-	// Store this key
-	c.unlockInfo.Parts = append(c.unlockInfo.Parts, key)
-	return true, nil
-}
-
-// getUnsealKey uses key fragments recorded by recordUnsealPart and
-// returns the combined key if the key share threshold is met.
-// If the key fragments are part of a recovery key, also verify that
-// it matches the stored recovery key on disk.
-func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
-	var config *SealConfig
-	var err error
-
-	raftInfo := c.raftInfo.Load().(*raftInformation)
-
-	switch {
-	case seal.RecoveryKeySupported():
-		config, err = seal.RecoveryConfig(ctx)
-	case c.isRaftUnseal():
-		// Ignore follower's seal config and refer to leader's barrier
-		// configuration.
-		config = raftInfo.leaderBarrierConfig
-	default:
-		config, err = seal.Config(ctx)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return nil, errors.New("failed to obtain seal/recovery configuration")
-	}
-
-	// Check if we don't have enough keys to unlock, proceed through the rest of
-	// the call only if we have met the threshold
-	if len(c.unlockInfo.Parts) < config.SecretThreshold {
-		if c.logger.IsDebug() {
-			c.logger.Debug("cannot unseal, not enough keys", "keys", len(c.unlockInfo.Parts), "threshold", config.SecretThreshold, "nonce", c.unlockInfo.Nonce)
-		}
-		return nil, nil
-	}
-
-	defer func() {
-		c.unlockInfo = nil
-	}()
-
-	// Recover the split key. recoveredKey is the shamir combined
-	// key, or the single provided key if the threshold is 1.
-	var unsealKey []byte
-	if config.SecretThreshold == 1 {
-		unsealKey = make([]byte, len(c.unlockInfo.Parts[0]))
-		copy(unsealKey, c.unlockInfo.Parts[0])
-	} else {
-		unsealKey, err = shamir.Combine(c.unlockInfo.Parts)
-		if err != nil {
-			return nil, &ErrInvalidKey{fmt.Sprintf("failed to compute combined key: %v", err)}
-		}
-	}
-
-	if seal.RecoveryKeySupported() {
-		if err := seal.VerifyRecoveryKey(ctx, unsealKey); err != nil {
-			return nil, &ErrInvalidKey{fmt.Sprintf("failed to verify recovery key: %v", err)}
-		}
-	}
-
-	return unsealKey, nil
 }
 
 // sealMigrated must be called with the stateLock held.  It returns true if
@@ -2128,7 +2032,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		retErr = multierror.Append(retErr, sealErr)
 	}
 
-	return
+	return retErr
 }
 
 // UIEnabled returns if the UI is enabled
@@ -2506,11 +2410,6 @@ func (c *Core) preSeal() error {
 	c.postUnsealFuncs = nil
 	c.activeTime = time.Time{}
 
-	// Clear any rotation progress;
-	// errors are ignored as root namespace has to be sealable
-	_ = c.sealManager.SetRotationConfig(namespace.RootNamespace, true, nil)
-	_ = c.sealManager.SetRotationConfig(namespace.RootNamespace, false, nil)
-
 	if c.metricsCh != nil {
 		close(c.metricsCh)
 		c.metricsCh = nil
@@ -2521,6 +2420,9 @@ func (c *Core) preSeal() error {
 	c.stopRaftActiveNode()
 	c.cancelNamespaceDeletion()
 
+	if err := c.sealManager.Reset(context.Background()); err != nil {
+		result = multierror.Append(result, fmt.Errorf("error reseting seal manager: %w", err))
+	}
 	if err := c.teardownAudits(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down audits: %w", err))
 	}
@@ -2590,7 +2492,7 @@ func (c *Core) Logger() log.Logger {
 func (c *Core) BarrierKeyLength() (min, max int) {
 	min, max = c.barrier.KeyLength()
 	max += shamir.ShareOverhead
-	return
+	return min, max
 }
 
 func (c *Core) AuditedHeadersConfig() *AuditedHeadersConfig {

--- a/vault/core.go
+++ b/vault/core.go
@@ -2422,14 +2422,14 @@ func (c *Core) preSeal() error {
 	c.stopRaftActiveNode()
 	c.cancelNamespaceDeletion()
 
-	if err := c.sealManager.Reset(context.Background()); err != nil {
-		result = multierror.Append(result, fmt.Errorf("error reseting seal manager: %w", err))
-	}
 	if err := c.teardownAudits(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down audits: %w", err))
 	}
 	if err := c.stopExpiration(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error stopping expiration: %w", err))
+	}
+	if err := c.sealManager.Reset(context.Background()); err != nil {
+		result = multierror.Append(result, fmt.Errorf("error reseting seal manager: %w", err))
 	}
 	if err := c.teardownCredentials(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down credentials: %w", err))

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -415,7 +415,16 @@ func (c *Core) setupExpiration(e ExpireLeaseStrategy) error {
 			c.logger.Error("error shutting down core", "error", err)
 		}
 	}
-	go c.expiration.Restore(errorFunc)
+
+	// Accumulate existing leases
+	c.logger.Debug("collecting leases")
+	leases, leaseCount, err := expMgr.collectLeases()
+	if err != nil {
+		return err
+	}
+	c.logger.Debug("leases collected", "num_existing", leaseCount)
+
+	go c.expiration.Restore(leases, leaseCount, errorFunc)
 
 	quit := c.expiration.quitCh
 	go func() {
@@ -676,7 +685,8 @@ func (m *ExpirationManager) Tidy(ctx context.Context) error {
 
 // Restore is used to recover the lease states when starting.
 // This is used after starting the vault.
-func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
+func (m *ExpirationManager) Restore(leases map[*namespace.Namespace][]string, leaseCount int, errorFunc func()) {
+	var retErr error
 	defer func() {
 		// Turn off restore mode. We can do this safely without the lock because
 		// if restore mode finished successfully, restore mode was already
@@ -701,14 +711,6 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 			}
 		}
 	}()
-
-	// Accumulate existing leases
-	m.logger.Debug("collecting leases")
-	existing, leaseCount, err := m.collectLeases()
-	if err != nil {
-		return err
-	}
-	m.logger.Debug("leases collected", "num_existing", leaseCount)
 
 	// Make the channels used for the worker pool
 	type lease struct {
@@ -764,8 +766,8 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 	go func() {
 		defer wg.Done()
 		i := 0
-		for ns := range existing {
-			for _, leaseID := range existing[ns] {
+		for ns := range leases {
+			for _, leaseID := range leases[ns] {
 				i++
 				if i%500 == 0 {
 					m.logger.Debug("leases loading", "progress", i)
@@ -795,7 +797,7 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 LOOP:
 	for i := 0; i < leaseCount; i++ {
 		select {
-		case err = <-errs:
+		case retErr = <-errs:
 			// Close all go routines
 			close(quit)
 			break LOOP
@@ -810,8 +812,8 @@ LOOP:
 
 	// Let all go routines finish
 	wg.Wait()
-	if err != nil {
-		return err
+	if retErr != nil {
+		return
 	}
 
 	m.restoreModeLock.Lock()
@@ -824,7 +826,6 @@ LOOP:
 	m.restoreModeLock.Unlock()
 
 	m.logger.Info("lease restore complete")
-	return nil
 }
 
 // processRestore takes a lease and restores it in the expiration manager if it has

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
-	"github.com/stretchr/testify/require"
 )
 
 var testImagePull sync.Once
@@ -63,10 +62,7 @@ func TestExpiration_Metrics(t *testing.T) {
 	testCoreUnsealed(t, testCore)
 
 	exp := testCore.expiration
-
-	leases, leaseCount, err := exp.collectLeases()
-	require.NoError(t, err)
-	exp.Restore(leases, leaseCount, nil)
+	exp.Restore(nil)
 
 	// Set up a count function to calculate number of leases
 	count := 0
@@ -447,10 +443,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	testCoreUnsealed(t, testCore)
 
 	exp := testCore.expiration
-
-	leases, leaseCount, err := exp.collectLeases()
-	require.NoError(t, err)
-	exp.Restore(leases, leaseCount, nil)
+	exp.Restore(nil)
 
 	// Set up a count function to calculate number of leases
 	count := 0
@@ -494,7 +487,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	// Run the tidy operation
-	err = exp.Tidy(ctx)
+	err := exp.Tidy(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,9 +755,7 @@ func benchmarkExpirationBackend(b *testing.B, physicalBackend physical.Backend, 
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		leases, leaseCount, err := exp.collectLeases()
-		require.NoError(b, err)
-		exp.Restore(leases, leaseCount, nil)
+		exp.Restore(nil)
 	}
 	b.StopTimer()
 }
@@ -874,9 +865,7 @@ func TestExpiration_Restore(t *testing.T) {
 	}
 
 	// Restore
-	leases, leaseCount, err := exp.collectLeases()
-	require.NoError(t, err)
-	exp.Restore(leases, leaseCount, nil)
+	exp.Restore(nil)
 
 	// Would like to test here, but this is a race with the expiration of the leases.
 
@@ -3089,9 +3078,7 @@ func TestExpiration_MarkIrrevocable(t *testing.T) {
 		t.Fatalf("error stopping expiration manager: %v", err)
 	}
 
-	leases, leaseCount, err := exp.collectLeases()
-	require.NoError(t, err)
-	exp.Restore(leases, leaseCount, nil)
+	exp.Restore(nil)
 
 	loadedLE, err = exp.loadEntry(ctx, leaseID)
 	if err != nil {

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -377,8 +377,6 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			return &logical.Response{Data: createNamespaceDataResponse(entry, nil)}, nil
 		}
 
-		// overwrite namespace in context with the one just created
-		ctx = namespace.ContextWithNamespace(ctx, entry)
 		keySharesMap := make(map[string][]string)
 		// TODO(wslabosz): write all the provided configs
 		if len(sealConfigs) > 0 {

--- a/vault/logical_system_namespaces_rotate.go
+++ b/vault/logical_system_namespaces_rotate.go
@@ -39,7 +39,7 @@ func (b *SystemBackend) namespaceRotatePaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handleNamespacesRotate(),
+					Callback: b.handleRotate(b.parseNamespaceFromRequest),
 					Summary:  "Rotate the namespace encryption key.",
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
@@ -341,24 +341,6 @@ func (b *SystemBackend) parseNamespaceFromRequest(ctx context.Context, data *fra
 	}
 
 	return ns, nil
-}
-
-// handleNamespacesRotate handles the `/sys/namespaces/<namespace>/rotate` and
-// `/sys/namespaces/<namespace>/rotate/keyring` endpoints to rotate the namespace
-// encryption key.
-func (b *SystemBackend) handleNamespacesRotate() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-		ns, err := b.parseNamespaceFromRequest(ctx, data)
-		if err != nil {
-			return handleError(err)
-		}
-
-		if err := b.Core.sealManager.RotateNamespaceBarrierKey(ctx, ns); err != nil {
-			return handleError(err)
-		}
-
-		return nil, nil
-	}
 }
 
 var sysNamespacesRotateHelp = map[string][2]string{

--- a/vault/logical_system_namespaces_rotate_test.go
+++ b/vault/logical_system_namespaces_rotate_test.go
@@ -53,7 +53,7 @@ func TestNamespaceBackend_Rotate(t *testing.T) {
 		res, err = b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
 		require.Equal(t, 2, res.Data["term"])
-		require.Empty(t, res.Data["encryptions"])
+		require.Equal(t, int64(1), res.Data["encryptions"])
 		require.NotEmpty(t, res.Data["install_time"])
 	})
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2475,7 +2475,7 @@ func (c *Core) singletonMountTables() (mounts, auth *MountTable) {
 	}
 	c.authLock.RUnlock()
 
-	return
+	return mounts, auth
 }
 
 func (c *Core) setCoreBackend(entry *MountEntry, backend logical.Backend, view BarrierView) {

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -297,12 +297,10 @@ func (ns *NamespaceStore) SetNamespaceSealed(ctx context.Context, entry *namespa
 	}
 
 	if new && sealConfig != nil {
-		nsCtx := namespace.ContextWithNamespace(ctx, entry)
-		err = ns.core.sealManager.SetSeal(nsCtx, sealConfig, entry, true)
-		if err != nil {
+		if err = ns.core.sealManager.SetSeal(ctx, sealConfig, entry, true); err != nil {
 			return nil, err
 		}
-		return ns.core.sealManager.InitializeBarrier(nsCtx, entry)
+		return ns.core.sealManager.InitializeBarrier(ctx, entry)
 	}
 
 	return nil, nil
@@ -838,6 +836,9 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 		ns.logger.Error("failed to update quotas after deleting namespace", "namespace", namespaceToDelete.Path, "error", err.Error())
 		return false
 	}
+
+	// clear seal manager entries
+	ns.core.sealManager.RemoveNamespace(namespaceToDelete)
 
 	// clear locked users entries
 	_, err = ns.core.runLockedUserEntryUpdatesForNamespace(nsCtx, namespaceToDelete, true)

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -283,7 +283,8 @@ func (ns *NamespaceStore) invalidate(ctx context.Context, path string) error {
 }
 
 // SetNamespaceSealed is used to create or update a given sealable namespace.
-// Note that you cannot change the seal config of a namespace with this operation.
+// Note that you cannot change the Seal config of a namespace with this;
+// only add a seal config to a net-new namespace.
 func (ns *NamespaceStore) SetNamespaceSealed(ctx context.Context, entry *namespace.Namespace, sealConfig *SealConfig) ([][]byte, error) {
 	unlock, err := ns.lockWithInvalidation(ctx, true)
 	if err != nil {
@@ -913,8 +914,6 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal tainted namespace")
 	}
 
-	// override the namespace in context to the one we want to seal
-	ctx = namespace.ContextWithNamespace(ctx, namespaceToSeal)
 	return ns.core.sealManager.SealNamespace(ctx, namespaceToSeal)
 }
 

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"path"
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -31,7 +30,7 @@ func NamespaceView(barrier logical.Storage, ns *namespace.Namespace) BarrierView
 		return NewBarrierView(barrier, "")
 	}
 
-	return NewBarrierView(barrier, path.Join(namespaceBarrierPrefix, ns.UUID)+"/")
+	return NewBarrierView(barrier, namespaceLogicalStoragePath(ns))
 }
 
 // NamespaceByPath returns the namespace and the path prefix for the given path.

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -310,9 +310,9 @@ func (sm *SealManager) performRecoveryRotation(ctx context.Context, ns *namespac
 
 	// Write to the canary path, which will force a synchronous truing during
 	// replication
-	view := sm.core.NamespaceView(ns).SubView(coreKeyringCanaryPath)
-	barrier := sm.StorageAccessForPath(view.Prefix())
-	if err := barrier.Put(ctx, view.Prefix(), []byte(rotationConfig.Nonce)); err != nil {
+	keyringCanaryPath := namespaceLogicalStoragePath(ns) + coreKeyringCanaryPath
+	barrier := sm.StorageAccessForPath(keyringCanaryPath)
+	if err := barrier.Put(ctx, keyringCanaryPath, []byte(rotationConfig.Nonce)); err != nil {
 		sm.logger.Error("error saving keyring canary", "error", err)
 		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save keyring canary: %w", err).Error())
 	}
@@ -357,10 +357,10 @@ func (sm *SealManager) performRootRotation(ctx context.Context, ns *namespace.Na
 		sm.logger.Info("root key rotated", "namespace", ns.Path, "stored", rotationConfig.StoredShares, "shares", rotationConfig.SecretShares, "threshold", rotationConfig.SecretThreshold)
 	}
 
-	view := sm.core.NamespaceView(ns).SubView(shamirKekPath)
-	storage := sm.StorageAccessForPath(view.Prefix())
+	kekPath := namespaceLogicalStoragePath(ns) + shamirKekPath
+	storage := sm.StorageAccessForPath(kekPath)
 	if len(newSealKey) > 0 {
-		err := storage.Put(ctx, view.Prefix(), newSealKey)
+		err := storage.Put(ctx, kekPath, newSealKey)
 		if err != nil {
 			sm.logger.Error("failed to store new seal key", "error", err)
 			return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to store new seal key: %w", err).Error())
@@ -376,9 +376,9 @@ func (sm *SealManager) performRootRotation(ctx context.Context, ns *namespace.Na
 
 	// Write to the canary path, which will force a synchronous truing during
 	// replication
-	view = sm.core.NamespaceView(ns).SubView(coreKeyringCanaryPath)
-	storage = sm.StorageAccessForPath(view.Prefix())
-	if err := storage.Put(ctx, view.Prefix(), []byte(rotationConfig.Nonce)); err != nil {
+	keyringCanaryPath := namespaceLogicalStoragePath(ns) + coreKeyringCanaryPath
+	storage = sm.StorageAccessForPath(keyringCanaryPath)
+	if err := storage.Put(ctx, keyringCanaryPath, []byte(rotationConfig.Nonce)); err != nil {
 		sm.logger.Error("error saving keyring canary", "error", err)
 		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("failed to save keyring canary: %w", err).Error())
 	}
@@ -501,7 +501,7 @@ func (sm *SealManager) updateRootRotation(ctx context.Context, ns *namespace.Nam
 			testseal := NewDefaultSeal(vaultseal.NewAccess(shamirWrapper))
 			testseal.SetCore(sm.core)
 			if ns.ID != namespace.RootNamespaceID {
-				testseal.SetMetaPrefix(namespaceBarrierPrefix + ns.UUID + "/")
+				testseal.SetMetaPrefix(namespaceLogicalStoragePath(ns))
 			}
 
 			err := shamirWrapper.SetAesGcmKeyBytes(recoveryKey)
@@ -687,9 +687,9 @@ func (sm *SealManager) pgpEncryptShares(ctx context.Context, ns *namespace.Names
 			return nil, fmt.Errorf("failed to marshal key backup: %w", err)
 		}
 
-		view := sm.core.NamespaceView(ns).SubView(coreBarrierUnsealKeysBackupPath)
-		barrier := sm.StorageAccessForPath(view.Prefix())
-		if err = barrier.Put(ctx, view.Prefix(), buf); err != nil {
+		path := namespaceLogicalStoragePath(ns) + coreBarrierUnsealKeysBackupPath
+		barrier := sm.StorageAccessForPath(path)
+		if err = barrier.Put(ctx, path, buf); err != nil {
 			sm.logger.Error("failed to save unseal key backup", "error", err)
 			return nil, fmt.Errorf("failed to save unseal key backup: %w", err)
 		}
@@ -838,15 +838,15 @@ func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, ns *namespace
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
-	var view BarrierView
+	var path string
 	if recovery {
-		view = sm.core.NamespaceView(ns).SubView(coreRecoveryUnsealKeysBackupPath)
+		path = namespaceLogicalStoragePath(ns) + coreRecoveryUnsealKeysBackupPath
 	} else {
-		view = sm.core.NamespaceView(ns).SubView(coreBarrierUnsealKeysBackupPath)
+		path = namespaceLogicalStoragePath(ns) + coreBarrierUnsealKeysBackupPath
 	}
 
-	barrier := sm.StorageAccessForPath(view.Prefix())
-	entry, err := barrier.Get(ctx, view.Prefix())
+	barrier := sm.StorageAccessForPath(path)
+	entry, err := barrier.Get(ctx, path)
 	if err != nil {
 		return nil, logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error getting keys from backup: %w", err).Error())
 	}
@@ -867,15 +867,15 @@ func (sm *SealManager) DeleteRotationBackup(ctx context.Context, ns *namespace.N
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
-	var view BarrierView
+	var path string
 	if recovery {
-		view = sm.core.NamespaceView(ns).SubView(coreRecoveryUnsealKeysBackupPath)
+		path = namespaceLogicalStoragePath(ns) + coreRecoveryUnsealKeysBackupPath
 	} else {
-		view = sm.core.NamespaceView(ns).SubView(coreBarrierUnsealKeysBackupPath)
+		path = namespaceLogicalStoragePath(ns) + coreBarrierUnsealKeysBackupPath
 	}
 
-	barrier := sm.StorageAccessForPath(view.Prefix())
-	if err := barrier.Delete(ctx, view.Prefix()); err != nil {
+	barrier := sm.StorageAccessForPath(path)
+	if err := barrier.Delete(ctx, path); err != nil {
 		return logical.CodedError(http.StatusInternalServerError, fmt.Errorf("error deleting backup keys: %w", err).Error())
 	}
 

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -55,6 +55,7 @@ const (
 type Seal interface {
 	SetCore(*Core)
 	Init(context.Context) error
+	MetaPrefix() string
 	SetMetaPrefix(string)
 	Finalize(context.Context) error
 	StoredKeysSupported() seal.StoredKeysSupport // SealAccess
@@ -119,6 +120,10 @@ func (d *defaultSeal) SetCore(core *Core) {
 
 func (d *defaultSeal) Init(ctx context.Context) error {
 	return nil
+}
+
+func (d *defaultSeal) MetaPrefix() string {
+	return d.metaPrefix
 }
 
 func (d *defaultSeal) SetMetaPrefix(metaPrefix string) {

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -95,6 +95,10 @@ func (d *autoSeal) Init(ctx context.Context) error {
 	return d.Access.Init(ctx)
 }
 
+func (d *autoSeal) MetaPrefix() string {
+	return d.metaPrefix
+}
+
 func (d *autoSeal) SetMetaPrefix(metaPrefix string) {
 	d.metaPrefix = metaPrefix
 }


### PR DESCRIPTION
This PR changes:
- with a core sealing (root namespace) all namespaces are being sealed, and all their related entries in `SealManager` get removed (`(*SealManager) RemoveNamespace` and `(*SealManager) Reset` methods)
- moved `unlockInformation` (and related methods) from core to `SealManager` for streamline of the unlock process
- barrier key rotation process streamlined into one logical handler for both root and other namespaces
- multiple tweaks to `SealManager`
- `(*Core) NamespaceView()` usage refactored in places where the returned view wasn't used, instead a path was only needed - added a `namespaceLogicalStoragePath(*namespace)` function

Open question:
- `(*ExpirationManager) Restore()` runs once on the unseal of the core, we probably should implement similar feature for `Unseal()` of other namespaces.