### PR TITLE
reject JSON bodies which consume large amounts of RAM (#1756)

### DIFF
--- a/changelog/1756.txt
+++ b/changelog/1756.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Limit the complexity of JSON in HTTP request bodies. HCSEC-2025-24 / CVE-2025-6203.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -853,6 +853,11 @@ func (c *ServerCommand) InitListeners(logger hclog.Logger, config *server.Config
 			Config:   lnConfig,
 		})
 
+		if lnConfig.MaxRequestJsonComplexity == 0 {
+			lnConfig.MaxRequestJsonComplexity = vault.DefaultMaxJsonComplexity
+		}
+		props["max_request_json_complexity"] = fmt.Sprintf("%d", lnConfig.MaxRequestJsonComplexity)
+
 		// Store the listener props for output later
 		key := fmt.Sprintf("listener %d", i+1)
 		propsList := make([]string, 0, len(props))

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -49,14 +49,16 @@ type Listener struct {
 	PurposeRaw interface{} `hcl:"purpose"`
 	Role       string      `hcl:"role"`
 
-	Address                 string        `hcl:"address"`
-	ClusterAddress          string        `hcl:"cluster_address"`
-	MaxRequestSize          int64         `hcl:"-"`
-	MaxRequestSizeRaw       interface{}   `hcl:"max_request_size"`
-	MaxRequestDuration      time.Duration `hcl:"-"`
-	MaxRequestDurationRaw   interface{}   `hcl:"max_request_duration"`
-	RequireRequestHeader    bool          `hcl:"-"`
-	RequireRequestHeaderRaw interface{}   `hcl:"require_request_header"`
+	Address                     string        `hcl:"address"`
+	ClusterAddress              string        `hcl:"cluster_address"`
+	MaxRequestSize              int64         `hcl:"-"`
+	MaxRequestSizeRaw           interface{}   `hcl:"max_request_size"`
+	MaxRequestJsonComplexity    int64         `hcl:"-"`
+	MaxRequestJsonComplexityRaw interface{}   `hcl:"max_request_json_complexity"`
+	MaxRequestDuration          time.Duration `hcl:"-"`
+	MaxRequestDurationRaw       interface{}   `hcl:"max_request_duration"`
+	RequireRequestHeader        bool          `hcl:"-"`
+	RequireRequestHeaderRaw     interface{}   `hcl:"require_request_header"`
 
 	TLSDisable    bool        `hcl:"-"`
 	TLSDisableRaw interface{} `hcl:"tls_disable"`
@@ -254,6 +256,14 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				}
 
 				l.RequireRequestHeaderRaw = nil
+			}
+
+			if l.MaxRequestJsonComplexityRaw != nil {
+				if l.MaxRequestJsonComplexity, err = parseutil.ParseInt(l.MaxRequestJsonComplexityRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("error parsing max_request_json_complexity: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.MaxRequestJsonComplexityRaw = nil
 			}
 		}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -57,6 +57,10 @@ var (
 	// to complete, unless overridden on a per-handler basis
 	DefaultMaxRequestDuration = 90 * time.Second
 
+	// DefaultMaxJsonComplexity is the number of JSON tokens allowed in a
+	// request body, unless overridden on a per-handler basis
+	DefaultMaxJsonComplexity = int64(10000)
+
 	ErrNoApplicablePolicies = errors.New("no applicable policies")
 	ErrPolicyNotExist       = errors.New("policy does not exist")
 

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -88,6 +88,10 @@ default value in the `"/sys/config/ui"` [API endpoint](/api-docs/system/config-u
   request duration allowed before OpenBao cancels the request. This overrides
   `default_max_request_duration` for this listener.
 
+- `max_request_json_complexity` `(int: 10000)` – Specifies the hard maximum
+  of JSON tokens allowed in the request body. Defaults to `10000` if not set or `0`.
+  A value lower than 0 disables this option altogether.
+
 - `proxy_protocol_behavior` `(string: "")` – When specified, enables a PROXY
   protocol version 1 behavior for the listener.
   Accepted Values:

--- a/website/content/docs/internals/limits.mdx
+++ b/website/content/docs/internals/limits.mdx
@@ -242,6 +242,19 @@ operation on a remote service, the OpenBao client will see a failure.
 The environment variable [`VAULT_CLIENT_TIMEOUT`](/docs/commands#vault_client_timeout) sets a client-side maximum duration as well,
 which is 60 seconds by default.
 
+### Request JSON Complexity
+
+The maximum number of tokens in a request body JSON is limited by the
+`max_request_json_complexity` option in the [listener
+stanza](/docs/configuration/listener/tcp). It defaults to 10000. This limit is
+in place to prevent attackers from sending specially crafted JSON bodies that,
+once unmarshaled, consume significantly more memory than the original request body (circumventing the
+`max_request_size` limit). This limit should not affect valid requests, as even
+large requests use a small number of tokens (a large string still counts as a
+single token).
+
+The definition for "JSON complexity" might change in the future.
+
 ### Lease limits
 
 A systemwide [maximum TTL](/docs/configuration#max_lease_ttl), and a


### PR DESCRIPTION
Backport of #1756