### PR TITLE
Add SAP to OpenBao TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | Julian Cassignol | jcassignol@wallix.com     |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
 | Michael Hofer    | michael.hofer@adfinis.com | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Member       |
 | Alexander Scheel | ascheel@gitlab.com        | [@cipherboy](https://github.com/cipherboy) | Ken McDonald (kmcdonald@gitlab.com)             | GitLab               | Chair        |
+| Klaus Kiefer     | klaus.kiefer@sap.com      | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
 
 To view the process for joining the TSC, see [GOVERNANCE.md](GOVERNANCE.md) in
 the root of this repository. That document is considered part of this document.


### PR DESCRIPTION
As voted on at the September 11th, 2025 TSC meeting, add SAP with backup from Reply to the TSC.

See also: https://docs.google.com/document/d/1oNqm4GXCsIZbcNHsIqft4kgciRcuwS9rrIRGXlMz1yg/edit?pli=1&tab=t.0#heading=h.v8tq37ynp1xu
See also: https://lists.openssf.org/g/OpenBao-TSC/message/180

---