### PR TITLE
Fix missing pipe character in table column

### DIFF
--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -694,7 +694,7 @@ parameters of the AppRole can be updated using the `/auth/approle/role/:role_nam
 endpoint directly. The endpoints for each field is provided separately
 to be able to delegate specific endpoints using OpenBao's ACL system.
 
-| Method            | Path                                                  |
+| Method            | Path                                                  | Code      |
 | :---------------- | :---------------------------------------------------- | --------- |
 | `GET/POST/DELETE` | `/auth/approle/role/:role_name/policies`              | `200/204` |
 | `GET/POST/DELETE` | `/auth/approle/role/:role_name/secret-id-num-uses`    | `200/204` |


### PR DESCRIPTION
There is a missing pipe character (`|`) in the documentation. Added the character and give it a header.