### PR TITLE
Add feature flag for read replication and fix some forwarding bugs

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -310,6 +310,10 @@ jobs:
           path: test-results/go-test
           pattern: test-results-*
           merge-multiple: true
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test-results/go-test/results-*.xml"
       - env:
           EXPECTED_IDS: ${{ needs.test-matrix.outputs.matrix_ids }}
         run: |

--- a/builtin/logical/kv/passthrough.go
+++ b/builtin/logical/kv/passthrough.go
@@ -229,7 +229,7 @@ func (b *PassthroughBackend) handleWrite() framework.OperationFunc {
 			Value: buf,
 		}
 		if err := req.Storage.Put(ctx, entry); err != nil {
-			return nil, fmt.Errorf("failed to write: %v", err)
+			return nil, fmt.Errorf("failed to write: %w", err)
 		}
 
 		return nil, nil

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -57,6 +57,8 @@ type SharedConfig struct {
 	ClusterName string `hcl:"cluster_name"`
 
 	AdministrativeNamespacePath string `hcl:"administrative_namespace_path"`
+
+	DisableStandbyReads bool `hcl:"disable_standby_reads"`
 }
 
 func ParseConfig(d string) (*SharedConfig, error) {

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -209,7 +209,15 @@ type RaftBackend struct {
 // HookInvalidate implements physical.CacheInvalidationBackend.
 func (r *RaftBackend) HookInvalidate(hook physical.InvalidateFunc) {
 	r.fsm.hookInvalidate(func(key string) {
-		_, leaderId := r.raft.LeaderWithID()
+		r.l.RLock()
+		raft := r.raft
+		r.l.RUnlock()
+
+		if raft == nil {
+			return
+		}
+		_, leaderId := raft.LeaderWithID()
+
 		if r.localID != string(leaderId) {
 			hook(key)
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1076,6 +1076,10 @@ func coreInit(c *Core, conf *CoreConfig) error {
 		c.physical = physical.NewStorageEncoding(c.physical)
 	}
 
+	if cib, ok := c.underlyingPhysical.(physical.CacheInvalidationBackend); ok && !c.rawConfig.Load().(*server.Config).DisableStandbyReads {
+		cib.HookInvalidate(c.Invalidate)
+	}
+
 	return nil
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1076,8 +1076,8 @@ func coreInit(c *Core, conf *CoreConfig) error {
 		c.physical = physical.NewStorageEncoding(c.physical)
 	}
 
-	if cib, ok := c.underlyingPhysical.(physical.CacheInvalidationBackend); ok && !c.rawConfig.Load().(*server.Config).DisableStandbyReads {
-		cib.HookInvalidate(c.Invalidate)
+	if c.StandbyReadsEnabled() {
+		c.underlyingPhysical.(physical.CacheInvalidationBackend).HookInvalidate(c.Invalidate)
 	}
 
 	return nil

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (c *Core) Invalidate(key string) {
+	c.stateLock.RLock()
+	ctx := c.activeContext
+	c.stateLock.RUnlock()
+	if ctx == nil {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(c.activeContext, 2*time.Second)
 	defer cancel()
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -583,6 +583,9 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	}
 
 	if c.activeContext == nil || c.activeContext.Err() != nil {
+		if c.standby.Load() {
+			return nil, logical.ErrPerfStandbyPleaseForward
+		}
 		return nil, errors.New("active context canceled after getting state lock")
 	}
 

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -245,6 +245,9 @@ can have a negative effect on performance due to the tracking of each lock attem
   like the above option, this one is best toggled only temporarily to enable the
   desired audit device.
 
+- `disable_standby_reads` `(bool: false)` - Disable the handling of read-only
+  requests on standby nodes.
+
 ### High Availability parameters
 
 The following parameters are used on backends that support [High Availability][high-availability].


### PR DESCRIPTION
This PR:

- ~Adds a `feature_flags` stanza to the configuration~ Add a top level configuration `disable_standby_reads` (and documentation)
- ~Adds `ForwardPerformanceStandby` to kv engine "CUD" (CRUD without R) operations.~ change error wrapping in KVv1 put to support forwarding on standby.
- Fix a panic when invalidations arrive before an `activeContext` is created
- Fix requests are not forwarded, if the standby node does not have an `activeContext` (either because read replication is disabled or it is not done with post unseal).
- Fix potential nil pointer during shutdown in raft cache invalidation logic
- Actually call `HookInvalidate` (upps)

See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch