### PR TITLE
website: fix warning/note/danger indentations

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -609,23 +609,24 @@ key from the response, you will need to request a new certificate.
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/issue/:name` path and
-takes its value from the role's `issuer_ref` field.
+  Note: This parameter is not present on the `/pki/issue/:name` path and
+  takes its value from the role's `issuer_ref` field.
 
-:::
+  :::
 
 - `common_name` `(string: "")` - Specifies the requested CN for the
   certificate. If the CN is allowed by role policy, it will be issued. If more
   than one `common_name` is desired, specify the alternative names in the
   `alt_names` list.
 
-:::warning
+  :::warning
 
-Note: A value for `common_name` is required when [require_cn](#require_cn) is set to `true`
+  Note: A value for `common_name` is required when [require_cn](#require_cn) is
+  set to `true`
 
-:::
+  :::
 
 - `alt_names` `(string: "")` - Specifies requested Subject Alternative Names, in
   a comma-delimited list. These can be host names or email addresses; they will
@@ -665,12 +666,12 @@ Note: A value for `common_name` is required when [require_cn](#require_cn) is se
   `format`. The other option is `pkcs8` which will return the key marshalled as
   PEM-encoded PKCS8.
 
-:::warning
+  :::warning
 
-**Note** that this does not apply to the private key within the certificate
-field if `format=pem_bundle` parameter is specified.
+  **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
-:::
+  :::
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
@@ -772,12 +773,12 @@ It is suggested to limit access to the path-overridden sign endpoint (on
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/sign/:name` path and
-takes its value from the role's `issuer_ref` field.
+  Note: This parameter is not present on the `/pki/sign/:name` path and
+  takes its value from the role's `issuer_ref` field.
 
-:::
+  :::
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 
@@ -897,12 +898,12 @@ operators.
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/root/sign-intermediate`
-path and takes the value `default`.
+  Note: This parameter is not present on the `/pki/root/sign-intermediate`
+  path and takes the value `default`.
 
-:::
+  :::
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR to be signed.
 
@@ -1019,27 +1020,27 @@ path and takes the value `default`.
   on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
-:::warning
+  :::warning
 
-**Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-`signature_bits` value; only RSA issuers will change signature types
-based on this parameter.
+  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+  `signature_bits` value; only RSA issuers will change signature types based on
+  this parameter.
 
-:::
+  :::
 
 - `skid` `(string: "")` - Value for the Subject Key Identifier field
   (RFC 5280 Section 4.2.1.2). Specified as a string in hex format. Default
   is empty, allowing OpenBao to automatically calculate the SKID according
   to method one in the above RFC section.
 
-:::warning
+  :::warning
 
-**Note**: This value should ONLY be used when cross-signing to mimic
-the existing certificate's SKID value; this is necessary to allow
-certain TLS implementations (such as OpenSSL) which use SKID/AKID
-matches in chain building to restrict possible valid chains.
+  **Note**: This value should ONLY be used when cross-signing to mimic the
+  existing certificate's SKID value; this is necessary to allow certain TLS
+  implementations (such as OpenSSL) which use SKID/AKID matches in chain
+  building to restrict possible valid chains.
 
-:::
+  :::
 
 - `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
   over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
@@ -1050,9 +1051,13 @@ matches in chain building to restrict possible valid chains.
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
   drop the `KeyUsage` part of the value. Values are not case-sensitive.
 
-~> Note: previous versions of this document incorrectly called this a constraint;
-   this value is only used as a default when the `KeyUsage` extension is missing
-   from the CSR.
+  :::warning
+
+  **Note:** previous versions of this document incorrectly called this a
+  constraint; this value is only used as a default when the `KeyUsage` extension
+  is missing from the CSR.
+
+  :::
 
 - `ext_key_usage` `(list: [])` -
   Specifies the default extended key usage constraint on the issued certificate. Valid
@@ -1060,14 +1065,22 @@ matches in chain building to restrict possible valid chains.
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
   specify no key default usage constraints, set this to an empty list.
 
-~> Note: previous versions of this document incorrectly called this a constraint;
-   this value is only used as a default when the `ExtendedKeyUsage` extension is
-   missing from the CSR.
+  :::warning
+
+  **Note:** previous versions of this document incorrectly called this a
+  constraint; this value is only used as a default when the `ExtendedKeyUsage`
+  extension is missing from the CSR.
+
+  :::
 
 - `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
 
-~> Note: This value is only used as a default when the `ExtendedKeyUsage`
-   extension is missing from the CSR.
+  :::warning
+
+  **Note:** This value is only used as a default when the `ExtendedKeyUsage`
+  extension is missing from the CSR.
+
+  :::
 
 #### Sample payload
 
@@ -1140,12 +1153,12 @@ endpoint, you most likely should be using a different endpoint (such as
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/root/sign-self-issued`
-path and takes the value `default`.
+  Note: This parameter is not present on the `/pki/root/sign-self-issued` path
+  and takes the value `default`.
 
-:::
+  :::
 
 - `certificate` `(string: <required>)` - Specifies the PEM-encoded self-issued certificate.
 
@@ -1207,12 +1220,12 @@ have access.**
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/root/sign-self-issued`
-path and takes the value `default`.
+  Note: This parameter is not present on the `/pki/root/sign-self-issued` path
+  and takes the value `default`.
 
-:::
+  :::
 
 - `name` `(string: "")` - Specifies a role. If set, the following parameters
   from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store`,  `not_before_duration` and `basic_constraints_valid_for_non_ca`.
@@ -1226,13 +1239,13 @@ path and takes the value `default`.
   drop the `KeyUsage` part of the value. Values are not case-sensitive. To
   specify no default key usage constraints, set this to an empty list.
 
-:::warning
+  :::warning
 
-Note: previous versions of this document incorrectly called this a constraint;
-this value is only used as a default when the `KeyUsage` extension is missing
-from the CSR.
+  Note: previous versions of this document incorrectly called this a constraint;
+  this value is only used as a default when the `KeyUsage` extension is missing
+  from the CSR.
 
-:::
+  :::
 
 - `ext_key_usage` `(list: [])` -
   Specifies the default extended key usage constraint on the issued certificate. Valid
@@ -1240,22 +1253,22 @@ from the CSR.
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
   specify no key default usage constraints, set this to an empty list.
 
-:::warning
+  :::warning
 
-Note: previous versions of this document incorrectly called this a constraint;
-this value is only used as a default when the `ExtendedKeyUsage` extension is
-missing from the CSR.
+  Note: previous versions of this document incorrectly called this a constraint;
+  this value is only used as a default when the `ExtendedKeyUsage` extension is
+  missing from the CSR.
 
-:::
+  :::
 
 - `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
 
-:::warning
+  :::warning
 
-Note: This value is only used as a default when the `ExtendedKeyUsage`
-extension is missing from the CSR.
+  Note: This value is only used as a default when the `ExtendedKeyUsage`
+  extension is missing from the CSR.
 
-:::
+  :::
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live. Cannot be greater
   than the engine's `max_ttl` value. If not provided, the engine's `ttl` value
@@ -1285,13 +1298,13 @@ extension is missing from the CSR.
   on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
-:::warning
+  :::warning
 
-**Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-`signature_bits` value; only RSA issuers will change signature types
-based on this parameter.
+  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+  `signature_bits` value; only RSA issuers will change signature types based on
+  this parameter.
 
-:::
+  :::
 
 - `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
   over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
@@ -1929,12 +1942,12 @@ header `Last-Modified` needs to be added to the mount tunable
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/cert/ca` and
-`/pki/ca(/pem)?` paths and takes the implicit value `default`.
+  Note: This parameter is not present on the `/pki/cert/ca` and `/pki/ca(/pem)?`
+  paths and takes the implicit value `default`.
 
-:::
+  :::
 
 #### Sample request
 
@@ -2061,12 +2074,12 @@ header `Last-Modified` needs to be added to the mount tunable
   refer to the currently configured default issuer, or the name assigned
   to an issuer. This parameter is part of the request URL.
 
-:::warning
+  :::warning
 
-Note: This parameter is not present on the `/pki/cert/crl` and
-`/pki/crl(/pem)?` paths and takes the implicit value `default`.
+  Note: This parameter is not present on the `/pki/cert/crl` and
+  `/pki/crl(/pem)?` paths and takes the implicit value `default`.
 
-:::
+  :::
 
 #### Sample request
 
@@ -2201,10 +2214,10 @@ These are unauthenticated endpoints.
 
 <a name="read-certificate-serial-param-values"></a>
 
-  - `<serial>` for the certificate with the given serial number, in hyphen-separated or colon-separated hexadecimal.
-  - `ca` for the _default_ issuer's CA certificate
-  - `crl` for the _default_ issuer's CRL
-  - `ca_chain` for the _default_ issuer's CA trust chain.
+- `<serial>` for the certificate with the given serial number, in hyphen-separated or colon-separated hexadecimal.
+- `ca` for the _default_ issuer's CA certificate
+- `crl` for the _default_ issuer's CRL
+- `ca_chain` for the _default_ issuer's CA trust chain.
 
 :::warning
 
@@ -2322,12 +2335,12 @@ be retrieved later_.
 - `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
   or `ec`.
 
-:::warning
+  :::warning
 
-**Note**: In FIPS 140-2 mode, the following algorithms are not certified
-and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
@@ -2460,22 +2473,22 @@ everything](#delete-all-issuers-and-keys).
   `format`. The other option is `pkcs8` which will return the key marshalled as
   PEM-encoded PKCS8.
 
-:::warning
+  :::warning
 
-**Note** that this does not apply to the private key within the certificate
-field if `format=pem_bundle` parameter is specified.
+  **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
-:::
+  :::
 
 - `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
   or `ec`.
 
-:::warning
+  :::warning
 
-**Note**: In FIPS 140-2 mode, the following algorithms are not certified
-and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
@@ -2554,13 +2567,13 @@ and thus should not be used: `ed25519`.
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
   drop the `KeyUsage` part of the value. Values are not case-sensitive.
 
-:::warning
+  :::warning
 
-   Note: previous versions of this document incorrectly called this a constraint;
-   this value is only used as a default when the `KeyUsage` extension is missing
-   from the CSR.
+  Note: previous versions of this document incorrectly called this a constraint;
+  this value is only used as a default when the `KeyUsage` extension is missing
+  from the CSR.
 
-:::
+  :::
 
 - `ext_key_usage` `(list: [])` -
   Specifies the default extended key usage constraint on the issued certificate. Valid
@@ -2568,13 +2581,13 @@ and thus should not be used: `ed25519`.
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
   specify no key default usage constraints, set this to an empty list.
 
-:::warning
+  :::warning
 
-   Note: previous versions of this document incorrectly called this a constraint;
-   this value is only used as a default when the `ExtendedKeyUsage` extension is
-   missing from the CSR.
+  Note: previous versions of this document incorrectly called this a constraint;
+  this value is only used as a default when the `ExtendedKeyUsage` extension is
+  missing from the CSR.
 
-:::
+  :::
 
 - `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
 
@@ -2701,28 +2714,28 @@ CSR and complete the signing before the signed intermediate certificate is
   `format`. The other option is `pkcs8` which will return the key marshalled as
   PEM-encoded PKCS8.
 
-:::warning
+  :::warning
 
-**Note** that this does not apply to the private key within the certificate
-field if `format=pem_bundle` parameter is specified.
+  **Note** that this does not apply to the private key within the certificate
+  field if `format=pem_bundle` parameter is specified.
 
-:::
+  :::
 
 - `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
   or `ec`. Not suitable for `type=existing` requests.
 
-:::warning
+  :::warning
 
-**Note**: In FIPS 140-2 mode, the following algorithms are not certified
-and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified
+  and thus should not be used: `ed25519`.
 
-:::
+  :::
 
-:::warning
+  :::warning
 
-**Note**: Keys of type `rsa` currently only support PKCS#1 v1.5 signatures.
+  **Note**: Keys of type `rsa` currently only support PKCS#1 v1.5 signatures.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
@@ -2745,13 +2758,13 @@ and thus should not be used: `ed25519`.
   on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
-:::warning
+  :::warning
 
-**Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-`signature_bits` value; only RSA issuers will change signature types
-based on this parameter.
+  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+  `signature_bits` value; only RSA issuers will change signature types based on
+  this parameter.
 
-:::
+  :::
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
@@ -2896,21 +2909,21 @@ shortcomings with CRL building.
 - `pem_bundle` `(string: <required>)` - Specifies the unencrypted private key
   and certificate, concatenated in PEM format.
 
-:::warning
+  :::warning
 
-Note: this parameter is on the `/pki/config/ca` and `/pki/issuers/import/*`
-paths; it is not on the `/pki/intermediate/set-signed` path.
+  Note: this parameter is on the `/pki/config/ca` and `/pki/issuers/import/*`
+  paths; it is not on the `/pki/intermediate/set-signed` path.
 
-:::
+  :::
 
 - `certificate` `(string: <required>)` - Specifies the certificates to import,
   concatenated in PEM format.
 
-:::warning
+  :::warning
 
-Note: this parameter is **only** on the `/pki/intermediate/set-signed` path.
+  Note: this parameter is **only** on the `/pki/intermediate/set-signed` path.
 
-:::
+  :::
 
 #### Sample request
 
@@ -3041,40 +3054,42 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
   - `permit` to allow this issuance to succeed with a `NotAfter` value
     exceeding that of this issuer.
 
-:::warning
+  :::warning
 
-Note: Not all values result in leaf certificates that can be validated
-through the entire validity period. It is suggested to use `truncate` for
-intermediate CAs and `permit` only for root CAs. This is because
-(root) certificates in browsers' trust stores typically aren't checked
-for validity, whereas intermediate CA certificates sent in TLS connections
-are checked for validity at the time of use. This means that a leaf
-certificate permitted to be issued for longer than the intermediate likely
-won't continue to validate after the intermediate has expired.
+  Note: Not all values result in leaf certificates that can be validated through
+  the entire validity period. It is suggested to use `truncate` for intermediate
+  CAs and `permit` only for root CAs. This is because (root) certificates in
+  browsers' trust stores typically aren't checked for validity, whereas
+  intermediate CA certificates sent in TLS connections are checked for validity
+  at the time of use. This means that a leaf certificate permitted to be issued
+  for longer than the intermediate likely won't continue to validate after the
+  intermediate has expired.
 
-:::
+  :::
 
 - `manual_chain` `([]string: nil)` - Chain of issuer references to build this
   issuer's computed CAChain field from, when non-empty.
 
-:::warning
+  :::warning
 
-Note: the `manual_chain` field is an advanced field useful when automatic
-chain building isn't desired. The first element _must_ be the present
-issuer's reference. Subsequent references _should_ validate previous
-entries, terminating with a root certificate. _Ideally_ a single linear
-chain would come first (from this issuer to a single root certificate)
-before any parallel, alternate chains appear.<br /><br />
-This field is especially useful for cross-signed intermediates within
-OpenBao. Because each cross-signed intermediate will only know of the
-one root, but issuance should serve both, update the issuers' entries
-with the desired `manual_chain` value.<br /><br />
-The CA Chain returned by a GET to the issuer configuration is the same
-chain presented during signing and (if this issuer is the default) on
-the `/ca_chain` path. Setting `manual_chain` thus allows controlling
-the presented chain as desired.
+  Note: the `manual_chain` field is an advanced field useful when automatic
+  chain building isn't desired. The first element _must_ be the present
+  issuer's reference. Subsequent references _should_ validate previous
+  entries, terminating with a root certificate. _Ideally_ a single linear
+  chain would come first (from this issuer to a single root certificate)
+  before any parallel, alternate chains appear.
 
-:::
+  This field is especially useful for cross-signed intermediates within
+  OpenBao. Because each cross-signed intermediate will only know of the
+  one root, but issuance should serve both, update the issuers' entries
+  with the desired `manual_chain` value.
+
+  The CA Chain returned by a GET to the issuer configuration is the same
+  chain presented during signing and (if this issuer is the default) on
+  the `/ca_chain` path. Setting `manual_chain` thus allows controlling
+  the presented chain as desired.
+
+  :::
 
 - `usage` `([]string: read-only,issuing-certificates,crl-signing,ocsp-signing)` - Allowed
   usages for this issuer. Valid options are:
@@ -3087,18 +3102,18 @@ the presented chain as desired.
     cannot be set unless that KeyUsage is allowed on the x509 certificate.
   - `ocsp-signing`, to allow this issuer to be used for signing OCSP responses
 
-:::warning
+  :::warning
 
-Note: The `usage` field allows for a soft-delete capability on the issuer,
-or to prevent use of the issuer prior to it being enabled. For example,
-as issuance is rotated to a new issuer, the old issuer could be marked
-`usage=read-only,crl-signing,ocsp-signing`, allowing existing certificates to be revoked
-(and the CRL updated), but preventing new certificate issuance. After all
-certificates issued under this certificate have expired, this certificate
-could be marked `usage=read-only`, freezing the CRL. Finally, after a grace
-period, the issuer could be deleted.
+  Note: The `usage` field allows for a soft-delete capability on the issuer,
+  or to prevent use of the issuer prior to it being enabled. For example,
+  as issuance is rotated to a new issuer, the old issuer could be marked
+  `usage=read-only,crl-signing,ocsp-signing`, allowing existing certificates to be revoked
+  (and the CRL updated), but preventing new certificate issuance. After all
+  certificates issued under this certificate have expired, this certificate
+  could be marked `usage=read-only`, freezing the CRL. Finally, after a grace
+  period, the issuer could be deleted.
 
-:::
+  :::
 
 - `revocation_signature_algorithm` `(string: "")` - Which signature algorithm
   to use when building CRLs. See Go's [`x509.SignatureAlgorithm`](https://pkg.go.dev/crypto/x509#SignatureAlgorithm)
@@ -3107,12 +3122,12 @@ period, the issuer could be deleted.
   is for Go to select the signature algorithm automatically, which may not
   always work.
 
-:::warning
+  :::warning
 
-Note: This can fail if the underlying key does not support the requested
-signature algorithm; this may not always be known at modification time.
+  Note: This can fail if the underlying key does not support the requested
+  signature algorithm; this may not always be known at modification time.
 
-:::
+  :::
 
 - `issuing_certificates` `(array<string>: nil)` - Specifies the URL values for
   the Issuing Certificate field. This can be an array or a comma-separated
@@ -3124,16 +3139,16 @@ signature algorithm; this may not always be known at modification time.
   comma-separated string list. See also [RFC 5280 Section 4.2.1.13](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13)
   for information about the CRL Distribution Points field.
 
-:::warning
+  :::warning
 
-Note: When multiple issuers are in use under a single mount, each issuer will
-have its own CRL distribution point. These separate CRLs should either be
-aggregated into a single CRL (externally; as OpenBao does not support this
-functionality) or multiple `crl_distribution_points` and
-`delta_crl_distribution_points` values should be specified here, pointing to
-each cluster and issuer.
+  Note: When multiple issuers are in use under a single mount, each issuer will
+  have its own CRL distribution point. These separate CRLs should either be
+  aggregated into a single CRL (externally; as OpenBao does not support this
+  functionality) or multiple `crl_distribution_points` and
+  `delta_crl_distribution_points` values should be specified here, pointing to
+  each cluster and issuer.
 
-:::
+  :::
 
 - `delta_crl_distribution_points` `(array<string>: nil)` - Specifies the URL values
   for the Delta CRL Distribution Points field. This can be an array or a
@@ -3156,12 +3171,12 @@ each cluster and issuer.
   literal value `{{cluster_aia_path}}` with the value of `aia_path` from
   the cluster-local configuration endpoint `/config/cluster`.
 
-:::warning
+  :::warning
 
-**Note**: If no cluster-local address is present and templating is used,
-issuance will fail.
+  **Note**: If no cluster-local address is present and templating is used,
+  issuance will fail.
 
-:::
+  :::
 
 #### Sample payload
 
@@ -3667,20 +3682,20 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
   prevent access to the `/pki/issuer/:issuer_ref/{issue,sign}/:name` paths
   to prevent users overriding the role's `issuer_ref` value.
 
-:::warning
+  :::warning
 
-Note: This parameter is stored as-is; if the reference is to a name, it
-is **not** resolve to an identifier. Deletion of issuers (or updating their
-names) **may** result in issuance failing or using an unexpected issuer.
+  Note: This parameter is stored as-is; if the reference is to a name, it is
+  **not** resolve to an identifier. Deletion of issuers (or updating their
+  names) **may** result in issuance failing or using an unexpected issuer.
 
-:::
+  :::
 
-:::warning
+  :::warning
 
-**Note**: existing roles from previous OpenBao versions are migrated to use
-the `issuer_ref=default`.
+  **Note**: existing roles from previous OpenBao versions are migrated to use
+  the `issuer_ref=default`.
 
-:::
+  :::
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
@@ -3697,14 +3712,14 @@ the `issuer_ref=default`.
   certificates for `localhost` as one of the requested common names. This is
   useful for testing and to allow clients on a single host to talk securely.
 
-:::warning
+  :::warning
 
-**Note**: This strictly applies to `localhost` and `localdomain` when this
-option is enabled. Additionally, even if this option is disabled, if either
-name is included in `allowed_domains`, the match rules for that option
-could permit issuance of a certificate for `localhost`.
+  **Note**: This strictly applies to `localhost` and `localdomain` when this
+  option is enabled. Additionally, even if this option is disabled, if either
+  name is included in `allowed_domains`, the match rules for that option could
+  permit issuance of a certificate for `localhost`.
 
-:::
+  :::
 
 - `allowed_domains` `(list: [])` - Specifies the domains this role is allowed
   to issue certificates for. This is used with the `allow_bare_domains`,
@@ -3713,18 +3728,18 @@ could permit issuance of a certificate for `localhost`.
   SAN entries, and Email-typed SAN entries. When `allow_any_name` is used,
   this attribute has no effect.
 
-:::warning
+  :::warning
 
-**Note**: The three options `allow_bare_domains`, `allow_subdomains`, and
-`allow_glob_domains` are each independent of each other. That is, at least
-one type of allowed matching must describe the relationship between the
-`allowed_domains` list and the names on the issued certificate. For example,
-given `allowed_domain=foo.*.example.com` and `allow_subdomains=true` and
-`allow_glob_domains=true`, a request for `bar.foo.baz.example.com` won't
-be permitted, even though it `foo.baz.example.com` matches the glob
-`foo.*.example.com` and `bar` is a subdomain of that.
+  **Note**: The three options `allow_bare_domains`, `allow_subdomains`, and
+  `allow_glob_domains` are each independent of each other. That is, at least one
+  type of allowed matching must describe the relationship between the
+  `allowed_domains` list and the names on the issued certificate. For example,
+  given `allowed_domain=foo.*.example.com` and `allow_subdomains=true` and
+  `allow_glob_domains=true`, a request for `bar.foo.baz.example.com` won't be
+  permitted, even though it `foo.baz.example.com` matches the glob
+  `foo.*.example.com` and `bar` is a subdomain of that.
 
-:::
+  :::
 
 - `allowed_domains_template` `(bool: false)` - When set, `allowed_domains`
   may contain templates, as with [ACL Path Templating](/docs/concepts/policies).
@@ -3753,24 +3768,24 @@ be permitted, even though it `foo.baz.example.com` matches the glob
   will be allowed to request certificates with names matching the glob
   patterns.
 
-:::warning
+  :::warning
 
-**Note**: These globs behave like shell-style globs and can match
-across multiple domain parts. For example, `allowed_domains=*.example.com`
-with `allow_glob_domains` enabled will match not only `foo.example.com` but
-also `baz.bar.foo.example.com`.
+  **Note**: These globs behave like shell-style globs and can match across
+  multiple domain parts. For example, `allowed_domains=*.example.com` with
+  `allow_glob_domains` enabled will match not only `foo.example.com` but also
+  `baz.bar.foo.example.com`.
 
-:::
+  :::
 
-:::warning
+  :::warning
 
-**Warning**: Glob patterns will match wildcard domains and permit their
-issuance unless otherwise restricted by `allow_wildcard_certificates`. For
-instance, with `allowed_domains=*.*.example.com` and both `allow_glob_domains`
-and `allow_wildcard_certificates` enabled, we will permit the issuance of
-a wildcard certificate for `*.foo.example.com`.
+  **Warning**: Glob patterns will match wildcard domains and permit their
+  issuance unless otherwise restricted by `allow_wildcard_certificates`. For
+  instance, with `allowed_domains=*.*.example.com` and both `allow_glob_domains`
+  and `allow_wildcard_certificates` enabled, we will permit the issuance of a
+  wildcard certificate for `*.foo.example.com`.
 
-:::
+  :::
 
 - `allow_wildcard_certificates` `(bool: true)` - Allows the issuance of
   certificates with [RFC 6125](https://tools.ietf.org/html/rfc6125) wildcards
@@ -3843,12 +3858,12 @@ a wildcard certificate for `*.foo.example.com`.
   When `any` is used, this role cannot generate certificates and can only
   be used to sign CSRs.
 
-:::warning
+  :::warning
 
-**Note**: In FIPS 140-2 mode, the following algorithms are not certified
-and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys. Allowed values are 0 (universal default); with
@@ -3863,13 +3878,13 @@ and thus should not be used: `ed25519`.
   on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
-:::warning
+  :::warning
 
-**Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-`signature_bits` value; only RSA issuers will change signature types
-based on this parameter.
+  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+  `signature_bits` value; only RSA issuers will change signature types based on
+  this parameter.
 
-:::
+  :::
 
 - `use_pss` `(bool: false)` - Specifies whether or not to use PSS signatures
   over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for
@@ -4124,16 +4139,16 @@ the cluster-local address in configuration.
   comma-separated string list. See also [RFC 5280 Section 4.2.1.13](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13)
   for information about the CRL Distribution Points field.
 
-:::warning
+  :::warning
 
-Note: When multiple issuers are in use under a single mount, each issuer will
-have its own CRL distribution point. These separate CRLs should either be
-aggregated into a single CRL (externally; as OpenBao does not support this
-functionality) or multiple `crl_distribution_points` and
-`delta_crl_distribution_points` values should be specified here, pointing
-to each cluster and issuer.
+  Note: When multiple issuers are in use under a single mount, each issuer will
+  have its own CRL distribution point. These separate CRLs should either be
+  aggregated into a single CRL (externally; as OpenBao does not support this
+  functionality) or multiple `crl_distribution_points` and
+  `delta_crl_distribution_points` values should be specified here, pointing to
+  each cluster and issuer.
 
-:::
+  :::
 
 - `delta_crl_distribution_points` `(array<string>: nil)` - Specifies the URL values
   for the Delta CRL Distribution Points field. This can be an array or a
@@ -4166,12 +4181,12 @@ to each cluster and issuer.
    - `delta_crl_distribution_points={{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der`
    - `ocsp_servers={{cluster_aia_path}}/ocsp`
 
-:::warning
+  :::warning
 
-**Note**: If no cluster-local address is present and templating is used,
-issuance will fail.
+  **Note**: If no cluster-local address is present and templating is used,
+  issuance will fail.
 
-:::
+  :::
 
 #### Sample payload
 
@@ -4784,14 +4799,14 @@ source and signed by the specified issuer. Values are taken verbatim from the pa
    - `critical` `(type: bool)` - should the extension be marked critical
    - `value` `(type: string)` - base64 encoded bytes for extension value
 
-:::warning
+  :::warning
 
-**Note**: The following extension ids are not allowed to be provided and can be influenced by other parameters
-- `2.5.29.20`: CRL Number
-- `2.5.29.27`: Delta CRL
-- `2.5.29.35`: Authority Key Identifier
+  **Note**: The following extension ids are not allowed to be provided and can be influenced by other parameters
+  - `2.5.29.20`: CRL Number
+  - `2.5.29.27`: Delta CRL
+  - `2.5.29.35`: Authority Key Identifier
 
-:::
+  :::
 
 #### Sample payload
 
@@ -4869,31 +4884,31 @@ to ensure this gets run periodically.
   performance of OCSP and CRL building, by shifting work to a tidy operation
   instead.
 
-:::warning
+  :::warning
 
-Note: With multiple issuers, a CA which issued a particular revoked
-certificate may be removed and re-added, resulting in a different issuer
-ID value. When building CRLs, these links are automatically updated for any
-missing or added issuers, but during OCSP this value is computed and then
-discarded, potentially causing a performance penalty on each request.
-During regular CA operations, it is not necessary to run this operation.
-<br /><br />
-It is suggested to run this tidy when removing or importing new issuers but
-otherwise not to run it during automatic tidy operations.
+  Note: With multiple issuers, a CA which issued a particular revoked
+  certificate may be removed and re-added, resulting in a different issuer ID
+  value. When building CRLs, these links are automatically updated for any
+  missing or added issuers, but during OCSP this value is computed and then
+  discarded, potentially causing a performance penalty on each request. During
+  regular CA operations, it is not necessary to run this operation.
 
-:::
+  It is suggested to run this tidy when removing or importing new issuers but
+  otherwise not to run it during automatic tidy operations.
+
+  :::
 
 - `tidy_expired_issuers` `(bool: false)` - Set to true to automatically remove
   expired issuers after the `issuer_safety_buffer` duration has elapsed. We
   log the issuer certificate on removal to allow recovery; no keys are removed
   during this process.
 
-:::warning
+  :::warning
 
-Note: The default issuer will not be removed even if it has expired and is
-past the `issuer_safety_buffer` specified.
+  Note: The default issuer will not be removed even if it has expired and is
+  past the `issuer_safety_buffer` specified.
 
-:::
+  :::
 
 - `tidy_move_legacy_ca_bundle` `(bool: false)` - Set to true to backup any
   legacy CA/issuers bundle to `config/ca_bundle.bak`. This can be restored with
@@ -4933,14 +4948,14 @@ past the `issuer_safety_buffer` specified.
 
   Does not affect `tidy_expired_issuers`.
 
-:::warning
+  :::warning
 
-Note: Using too long of a `pause_duration` can result in tidy operations
-not concluding during this lifetime! Using too short of a pause duration
-(but non-zero) can lead to lock contention. Use [tidy's cancellation](#cancel-tidy)
-to stop a running operation after the sleep period is over.
+  Note: Using too long of a `pause_duration` can result in tidy operations not
+  concluding during this lifetime! Using too short of a pause duration (but
+  non-zero) can lead to lock contention. Use [tidy's cancellation](#cancel-tidy)
+  to stop a running operation after the sleep period is over.
 
-:::
+  :::
 
 - `page_size` `(int: 1000)` - The number of certificates to process per page 
 during list pagination in tidy. This setting enables tidy to handle certificates 
@@ -5070,14 +5085,14 @@ The below parameters are in addition to the regular parameters accepted by the
   throughout operations like issuance, revocation, and subsequent tidies, the
   figure is updated.
 
-:::warning
+  :::warning
 
-*Note*: It is strongly recommend to not enable this value if 50k or more
-certificates are stored in the mount or if many PKI mounts are in use in
-this cluster. Instead, use audit logs and aggregate this data externally
-to OpenBao so as not to impact OpenBao performance.
+  **Note**: It is strongly recommend to not enable this value if 50k or more
+  certificates are stored in the mount or if many PKI mounts are in use in this
+  cluster. Instead, use audit logs and aggregate this data externally to OpenBao
+  so as not to impact OpenBao performance.
 
-:::
+  :::
 
 - `publish_stored_certificate_count_metrics` `(bool: false)` - When enabled,
   publishes the value computed by `maintain_stored_certificate_counts` to

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -316,36 +316,36 @@ This endpoint creates or updates a named role.
   with `ecdsa-sha2-nistp256` or `ed25519`), the value of the length is ignored (and
   can be zero).
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `algorithm_signer` `(string: "default")` - Algorithm to sign keys with. Valid
   values are `ssh-rsa`, `rsa-sha2-256`, `rsa-sha2-512`, or `default`. This
   value may also be left blank to use the signer's default algorithm, and must
   be left blank or have value `default` for CA key types other than RSA.
 
-:::warning
+  :::warning
 
- **Note**: The value of `default` may change over time as vulnerabilities
-  in algorithms are discovered. The present value for RSA keys is equivalent
-  to `rsa-sha2-256`.
+  **Note**: The value of `default` may change over time as vulnerabilities in
+  algorithms are discovered. The present value for RSA keys is equivalent to
+  `rsa-sha2-256`.
 
-:::
+  :::
 
-:::warning
+  :::warning
 
- **Warning**: The `algorithm_signer` value `ssh-rsa` uses the SHA-1 hash
+  **Warning**: The `algorithm_signer` value `ssh-rsa` uses the SHA-1 hash
   algorithm. This algorithm is now considered insecure and is not supported by
   current OpenSSH versions. As a result, OpenBao has made the new default
   `rsa-sha2-256` for RSA CA keys. It is strongly encouraged for all users to
   migrate to `rsa-sha2-256` or `default` if the role was created with an
   explicit `algorithm_signer=rsa-sha` parameter or has been migrated to such.
 
-:::
+  :::
 
 - `not_before_duration` `(duration: "30s")` – Specifies the duration by which to
   backdate the `ValidAfter` property. Uses [duration format strings](/docs/concepts/duration-format).
@@ -802,12 +802,12 @@ it will be overridden with the new CA information and any reference to it update
   `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, or `ssh-ed25519`) or an
   algorithm (`rsa`, `ec`, or `ed25519`).
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-      and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the desired key bits for the generated SSH
   CA key when `generate_signing_key` is set to `true`. This is only used for
@@ -899,12 +899,12 @@ of this parameter.
   default issuer for performing operations by any role referencing it. Only one
   issuer can be the default and, if there's one set, it will be overridden.
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-      and thus should not be used: `ed25519`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `ed25519`.
 
-:::
+  :::
 
 - `key_bits` `(int: 0)` - Specifies the desired key bits for the generated SSH
   CA key when `generate_signing_key` is set to `true`. This is only used for

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -160,14 +160,14 @@ and encryption, depending on the key type and algorithm, as no private key
 is available.
 
 - `allow_rotation` `(bool: false)` - If set, the imported key can be rotated
-within OpenBao by using the `rotate` endpoint.
+  within OpenBao by using the `rotate` endpoint.
 
-:::warning
+  :::warning
 
-**NOTE**: Once an imported key is rotated within OpenBao, it will no longer
-support importing key material with the `import_version` endpoint.
+  **NOTE**: Once an imported key is rotated within OpenBao, it will no longer
+  support importing key material with the `import_version` endpoint.
 
-:::
+  :::
 
 - `derived` `(bool: false)` – Specifies if key derivation is to be used. If
   enabled, all encrypt/decrypt requests to this named key must provide a context
@@ -506,9 +506,6 @@ rotated within OpenBao, it will not support further import operations.
 - `name` `(string: <required>)` – Specifies the name of the encryption key to
   rotate. This is specified as part of the URL.
 
-
-:::
-
 ### Sample request
 
 ```shell-session
@@ -600,11 +597,11 @@ CLI helper utility.
   wrapping key (from `/transit/wrapping_key`). This is specified as part of
   the URL.
 
-:::warning
+  :::warning
 
-Note: This destination key type must be an RSA key type.
+  Note: This destination key type must be an RSA key type.
 
-:::
+  :::
 
 - `source` `(string: <required>)` - Specifies the source key to encrypt, to
   copy (encrypted) to another cluster. This is specified as part of the URL.
@@ -1221,13 +1218,12 @@ algorithm.
   - `sha3-384`
   - `sha3-512`
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and
-     `sha3-512`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512`.
 
-:::
+  :::
 
 - `input` `(string: <required>)` – Specifies the **base64 encoded** input data.
 
@@ -1295,13 +1291,12 @@ be used.
   - `sha3-384`
   - `sha3-512`
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and
-     `sha3-512`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512`.
 
-:::
+  :::
 
 - `input` `(string: "")` – Specifies the **base64 encoded** input data. One of
   `input` or `batch_input` must be supplied.
@@ -1438,21 +1433,20 @@ supports signing.
   - `sha3-512`
   - `none`
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and
-     `sha3-512`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512`.
 
-:::
+  :::
+  
+  :::warning
 
-:::warning
-
- ** Warning:** `sha1` should be considered a compromised algorithm and used
-  only for legacy applications. Signing using SHA-1 can be blocked by operators by
+  **Warning:** `sha1` should be considered a compromised algorithm and used only
+  for legacy applications. Signing using SHA-1 can be blocked by operators by
   assigning the following policy corresponding to a named key:
 
-:::
+  :::
 
   ```hcl
   path "/transit/sign/:name/sha1" {
@@ -1460,14 +1454,14 @@ supports signing.
   }
   ```
 
-:::warning
+  :::warning
 
- **Note**: using `hash_algorithm=none` requires setting `prehashed=true`
-     and `signature_algorithm=pkcs1v15`. This generates a `PKCSv1_5_NoOID`
-     signature rather than the `PKCSv1_5_DERnull` signature type usually
-     created. See [RFC 3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
+  **Note**: using `hash_algorithm=none` requires setting `prehashed=true` and
+  `signature_algorithm=pkcs1v15`. This generates a `PKCSv1_5_NoOID` signature
+  rather than the `PKCSv1_5_DERnull` signature type usually created. See [RFC
+  3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
 
-:::
+  :::
 
 - `input` `(string: "")` – Specifies the **base64 encoded** input data. One of
   `input` or `batch_input` must be supplied.
@@ -1631,22 +1625,21 @@ data.
   - `sha3-512`
   - `none`
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and
-     `sha3-512`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512`.
 
-:::
+  :::
+  
+  :::warning
 
-:::warning
-
- ** Warning:** `sha1` should be considered a compromised algorithm. Signatures
+  **Warning:** `sha1` should be considered a compromised algorithm. Signatures
   verified using the algorithm could be forgeries. Verification using SHA-1 can
   be blocked by operators by assigning the following policy corresponding to a
   named key:
 
-:::
+  :::
 
   ```hcl
   path "/transit/verify/:name/sha1" {
@@ -1654,14 +1647,14 @@ data.
   }
   ```
 
-:::warning
+  :::warning
 
- **Note**: using `hash_algorithm=none` requires setting `prehashed=true`
-     and `signature_algorithm=pkcs1v15`. This verifies a `PKCSv1_5_NoOID`
-     signature rather than the `PKCSv1_5_DERnull` signature type usually
-     verified. See [RFC 3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
+  **Note**: using `hash_algorithm=none` requires setting `prehashed=true` and
+  `signature_algorithm=pkcs1v15`. This verifies a `PKCSv1_5_NoOID` signature
+  rather than the `PKCSv1_5_DERnull` signature type usually verified. See [RFC
+  3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
 
-:::
+  :::
 
 - `input` `(string: "")` – Specifies the **base64 encoded** input data. One of
   `input` or `batch_input` must be supplied.

--- a/website/content/api-docs/system/auth.mdx
+++ b/website/content/api-docs/system/auth.mdx
@@ -99,11 +99,11 @@ For example, enable the "foo" auth method will make it accessible at
 - `path` `(string: <required>)` – Specifies the path in which to enable the auth
   method. This is part of the request URL.
 
-:::danger
+  :::danger
 
- **NOTE:** Use ASCII printable characters to specify the desired path.
+  **NOTE:** Use ASCII printable characters to specify the desired path.
 
-:::
+  :::
 
 - `description` `(string: "")` – Specifies a human-friendly description of the
   auth method.

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -128,11 +128,11 @@ This endpoint enables a new secrets engine at the given path.
 - `path` `(string: <required>)` – Specifies the path where the secrets engine
   will be mounted. This is specified as part of the URL.
 
-:::danger
+  :::danger
 
- **NOTE:** Use ASCII printable characters to specify the desired path.
+  **NOTE:** Use ASCII printable characters to specify the desired path.
 
-:::
+  :::
 
 - `type` `(string: <required>)` – Specifies the type of the backend, such as
   "kv".

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -57,13 +57,14 @@ leader node.
   stream. This can be used to add read scalability to a cluster in cases where a
   high volume of reads to servers are needed. The default is false.
 
-:::warning
+  :::warning
 
-Adding a large number of non-voters to a cluster will impact application
-latency. Make sure to tune the [Raft settings](/docs/configuration/storage/raft/#raft-parameters)
-for your intended use case.
+  Adding a large number of non-voters to a cluster will impact application
+  latency. Make sure to tune the [Raft
+  settings](/docs/configuration/storage/raft/#raft-parameters) for your intended
+  use case.
 
-:::
+  :::
 
 ### Sample payload
 

--- a/website/content/api-docs/system/tools.mdx
+++ b/website/content/api-docs/system/tools.mdx
@@ -78,13 +78,12 @@ algorithm.
   - `sha3-384`
   - `sha3-512`
 
-:::warning
+  :::warning
 
- **Note**: In FIPS 140-2 mode, the following algorithms are not certified
-     and thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and
-     `sha3-512`.
+  **Note**: In FIPS 140-2 mode, the following algorithms are not certified and
+  thus should not be used: `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512`.
 
-:::
+  :::
 
 - `input` `(string: <required>)` – Specifies the **base64 encoded** input data.
 

--- a/website/content/docs/agent-and-proxy/agent/index.mdx
+++ b/website/content/docs/agent-and-proxy/agent/index.mdx
@@ -120,12 +120,14 @@ These are the currently-available general configuration options:
 
 - `listener` <code>([listener][listener]: \<optional>)</code> - Specifies the addresses and ports on which the Agent will respond to requests.
 
-:::warning
+  :::warning
 
- **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Agent will attempt to reload listener TLS configuration.
-  This method can be used to refresh certificates used by OpenBao Agent without having to restart its process.
+  **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Agent will
+  attempt to reload listener TLS configuration. This method can be used to
+  refresh certificates used by OpenBao Agent without having to restart its
+  process.
 
-:::
+  :::
 
 - `pid_file` `(string: "")` - Path to the file in which the agent's Process ID
   (PID) should be stored
@@ -161,12 +163,13 @@ These are the currently-available general configuration options:
 
 - `log_level` - Equivalent to the [`-log-level` command-line flag](#_log_level).
 
-:::warning
+  :::warning
 
- **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Agent will update the log level to the value
-  specified by configuration file (including overriding values set using CLI or environment variable parameters).
+  **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Agent will update
+  the log level to the value specified by configuration file (including
+  overriding values set using CLI or environment variable parameters).
 
-:::
+  :::
 
 - `log_format` - Equivalent to the [`-log-format` command-line flag](#_log_format).
 

--- a/website/content/docs/agent-and-proxy/proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/proxy/index.mdx
@@ -112,12 +112,14 @@ These are the currently-available general configuration options:
 
 - `listener` <code>([listener][listener]: \<optional>)</code> - Specifies the addresses and ports on which the Proxy will respond to requests.
 
-:::warning
+  :::warning
 
-**Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Proxy will attempt to reload listener TLS configuration.
-This method can be used to refresh certificates used by OpenBao Proxy without having to restart its process.
+  **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Proxy will
+  attempt to reload listener TLS configuration. This method can be used to
+  refresh certificates used by OpenBao Proxy without having to restart its
+  process.
 
-:::
+  :::
 
 - `pid_file` `(string: "")` - Path to the file in which the Proxy's Process ID
 (PID) should be stored
@@ -144,12 +146,13 @@ for a list of metrics specific to Proxy.
 
 - `log_level` - Equivalent to the [`-log-level` command-line flag](#_log_level).
 
-:::warning
+  :::warning
 
-**Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Proxy will update the log level to the value
-specified by configuration file (including overriding values set using CLI or environment variable parameters).
+  **Note:** On `SIGHUP` (`kill -SIGHUP $(pidof bao)`), OpenBao Proxy will update
+  the log level to the value specified by configuration file (including
+  overriding values set using CLI or environment variable parameters).
 
-:::
+  :::
 
 - `log_format` - Equivalent to the [`-log-format` command-line flag](#_log_format).
 

--- a/website/content/docs/audit/file.mdx
+++ b/website/content/docs/audit/file.mdx
@@ -57,15 +57,15 @@ these device-specific options:
   the bit pattern for the file mode, similar to `chmod`. Set to `"0000"` to
   prevent OpenBao from modifying the file mode.
 
-:::warning
+  :::warning
 
-Note: Starting with OpenBao v2.4.0, any executable bits set in `mode` are zeroed
-automatically, for security purposes. For example, `mode = 777` will convert to
-`mode = 666`. Furthermore, `mode` values that are
-[irregular](https://pkg.go.dev/io/fs#FileMode.IsRegular) are rejected with an
-error.
+  Note: Starting with OpenBao v2.4.0, any executable bits set in `mode` are
+  zeroed automatically, for security purposes. For example, `mode = 777` will
+  convert to `mode = 666`. Furthermore, `mode` values that are
+  [irregular](https://pkg.go.dev/io/fs#FileMode.IsRegular) are rejected with an
+  error.
 
-:::
+  :::
 
 ## Log file rotation
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -171,14 +171,14 @@ docs](/api-docs/system/audit) for more details.
 - `prefix` `(string: "")` - A customizable string prefix to write before the
   actual log line.
 
-:::warning
+  :::warning
 
-Note: The `prefix` option lets operators write semi-arbitrary content to the
-audit log. Starting with OpenBao v2.3.2, enabling new audit devices with this
-option is only supported if `allow_audit_log_prefixing = true` is set in the
-[server configuration](/docs/configuration).
+  Note: The `prefix` option lets operators write semi-arbitrary content to the
+  audit log. Starting with OpenBao v2.3.2, enabling new audit devices with this
+  option is only supported if `allow_audit_log_prefixing = true` is set in the
+  [server configuration](/docs/configuration).
 
-:::
+  :::
 
 ## Eliding list response bodies
 

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -103,11 +103,12 @@ management tool.
        secret_id_num_uses=40
    ```
 
-:::warning
+   :::warning
 
-**Note:** If the token issued by your approle needs the ability to create child tokens, you will need to set token_num_uses to 0.
+   **Note:** If the token issued by your approle needs the ability to create
+   child tokens, you will need to set token_num_uses to 0.
 
-:::
+   :::
 
 For the complete list of configuration options, please see the API
 documentation.

--- a/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
@@ -64,13 +64,13 @@ Configuration steps:
 
   1. Alternatively, if OpenBao is _not_ running in Kubernetes:
 
-:::info
+     :::info
 
-**Note:** When OpenBao is outside the cluster, the `$ISSUER` endpoint below may
-     or may not be reachable. If not, you can configure JWT auth using
+     **Note:** When OpenBao is outside the cluster, the `$ISSUER` endpoint below
+     may or may not be reachable. If not, you can configure JWT auth using
      [`jwt_validation_pubkeys`](#using-jwt-validation-public-keys) instead.
 
-:::
+     :::
 
      ```bash
      bao auth enable jwt

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -89,43 +89,43 @@ management tool.
 
 1. Enable the Kubernetes auth method:
 
-  ```bash
-  bao auth enable kubernetes
-  ```
+   ```bash
+   bao auth enable kubernetes
+   ```
 
 1. Use the `/config` endpoint to configure OpenBao to talk to Kubernetes. Use
-  `kubectl cluster-info` to validate the Kubernetes host address and TCP port.
-  For the list of available configuration options, please see the
-  [API documentation](/api-docs/auth/kubernetes).
+   `kubectl cluster-info` to validate the Kubernetes host address and TCP port.
+   For the list of available configuration options, please see the [API
+   documentation](/api-docs/auth/kubernetes).
 
-  ```bash
-  bao write auth/kubernetes/config \
-      token_reviewer_jwt="<your reviewer service account JWT>" \
-      kubernetes_host=https://192.168.99.100:<your TCP port or blank for 443> \
-      kubernetes_ca_cert=@ca.crt
-  ```
+   ```bash
+   bao write auth/kubernetes/config \
+       token_reviewer_jwt="<your reviewer service account JWT>" \
+       kubernetes_host=https://192.168.99.100:<your TCP port or blank for 443> \
+       kubernetes_ca_cert=@ca.crt
+   ```
 
-:::danger
+   :::danger
 
- **Note:** The pattern OpenBao uses to authenticate Pods depends on sharing
-  the JWT token over the network. Given the [security model of
-  OpenBao](/docs/internals/security), this is allowable because OpenBao is
-  part of the trusted compute base. In general, Kubernetes applications should
-  **not** share this JWT with other applications, as it allows API calls to be
-  made on behalf of the Pod and can result in unintended access being granted
-  to 3rd parties.
+   **Note:** The pattern OpenBao uses to authenticate Pods depends on sharing
+   the JWT token over the network. Given the [security model of
+   OpenBao](/docs/internals/security), this is allowable because OpenBao is part
+   of the trusted compute base. In general, Kubernetes applications should
+   **not** share this JWT with other applications, as it allows API calls to be
+   made on behalf of the Pod and can result in unintended access being granted
+   to 3rd parties.
 
-:::
+   :::
 
 1. Create a named role:
 
-  ```text
-  bao write auth/kubernetes/role/demo \
-      bound_service_account_names=myapp \
-      bound_service_account_namespaces=default \
-      policies=default \
-      ttl=1h
-  ```
+   ```bash
+   bao write auth/kubernetes/role/demo \
+       bound_service_account_names=myapp \
+       bound_service_account_namespaces=default \
+       policies=default \
+       ttl=1h
+   ```
 
   This role authorizes the "myapp" service account in the default
   namespace and it gives it the default policy.

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -127,14 +127,15 @@ There are two alternate methods of resolving the user object used to authenticat
 - `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
 - `userfilter` (string, optional) - Go template used to construct a ldap user search filter. The template can access the following context variables: \[`UserAttr`, `Username`\]. The default userfilter is `({{.UserAttr}}={{.Username}})` or `(userPrincipalName={{.Username}}@UPNDomain)` if the `upndomain` parameter is set. The user search filter can be used to restrict what user can attempt to log in. For example, to limit login to users that are not contractors, you could write `(&(objectClass=user)({{.UserAttr}}={{.Username}})(!(employeeType=Contractor)))`.
 
-:::warning
+  :::warning
 
-When specifying a `userfilter`, either the templated value `{{.UserAttr}}` or
-the literal value that matches `userattr` should be present in the filter to
-ensure that the search returns a unique result that takes `userattr` into
-consideration for entity alias mapping purposes and avoid possible collisions on login.
+  When specifying a `userfilter`, either the templated value `{{.UserAttr}}` or
+  the literal value that matches `userattr` should be present in the filter to
+  ensure that the search returns a unique result that takes `userattr` into
+  consideration for entity alias mapping purposes and avoid possible collisions
+  on login.
 
-:::
+  :::
 
 #### Binding - anonymous search
 
@@ -142,17 +143,19 @@ consideration for entity alias mapping purposes and avoid possible collisions on
 - `userdn` (string, optional) - Base DN under which to perform user search. Example: `ou=Users,dc=example,dc=com`
 - `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
 - `userfilter` (string, optional) - Go template used to construct a ldap user search filter. The template can access the following context variables: \[`UserAttr`, `Username`\]. The default userfilter is `({{.UserAttr}}={{.Username}})` or `(userPrincipalName={{.Username}}@UPNDomain)` if the `upndomain` parameter is set. The user search filter can be used to restrict what user can attempt to log in. For example, to limit login to users that are not contractors, you could write `(&(objectClass=user)({{.UserAttr}}={{.Username}})(!(employeeType=Contractor)))`.
+
+  :::warning
+  
+  When specifying a `userfilter`, either the templated value `{{.UserAttr}}` or
+  the literal value that matches `userattr` should be present in the filter to
+  ensure that the search returns a unique result that takes `userattr` into
+  consideration for entity alias mapping purposes and avoid possible collisions
+  on login.
+  
+  :::
+
 - `deny_null_bind` (bool, optional) - This option prevents users from bypassing authentication when providing an empty password. The default is `true`.
 - `anonymous_group_search` (bool, optional) - Use anonymous binds when performing LDAP group searches. Defaults to `false`.
-
-:::warning
-
-When specifying a `userfilter`, either the templated value `{{.UserAttr}}` or
-the literal value that matches `userattr` should be present in the filter to
-ensure that the search returns a unique result that takes `userattr` into
-consideration for entity alias mapping purposes and avoid possible collisions on login.
-
-:::
 
 #### Alias dereferencing
 

--- a/website/content/docs/auth/login-mfa/faq.mdx
+++ b/website/content/docs/auth/login-mfa/faq.mdx
@@ -23,12 +23,16 @@ This FAQ section contains frequently asked questions about the Login MFA feature
 
 - **Single-Phase MFA:** This is a single request mechanism where the required MFA information, such as MFA method ID, is provided via the X-Vault-MFA header in a single MFA request that is used to authenticate into OpenBao.
 
-:::warning
+  :::warning
 
-**Note**: If the configured MFA methods need a passcode, it needs to be provided in the request, such as in the case of TOTP or Duo.
-If the configured MFA methods, such as PingID, Okta, or Duo, do not require a passcode and have out of band mechanisms for verifying the extra factor, OpenBao will send an inquiry to the other service's APIs to determine whether the MFA request has yet been verified.
+  **Note**: If the configured MFA methods need a passcode, it needs to be
+  provided in the request, such as in the case of TOTP or Duo. If the configured
+  MFA methods, such as PingID, Okta, or Duo, do not require a passcode and have
+  out of band mechanisms for verifying the extra factor, OpenBao will send an
+  inquiry to the other service's APIs to determine whether the MFA request has
+  yet been verified.
 
-:::
+  :::
 
 - **Two-Phase MFA:** This is a two-request MFA method that is more conventionally used.
   - The MFA passcode required for the configured MFA method is not provided in a header of the login request that is MFA-restricted. Instead, the user first authenticates to the auth method, and on successful authentication to the auth method, an MFA requirement is returned to the user. The MFA requirement contains the MFA RequestID and constraints applicable to the MFA as configured by the operator.

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -81,13 +81,14 @@ The following flags are available for the `operator raft join` command.
   See [`retry_join_as_non_voter`](/docs/configuration/storage/raft#retry_join_as_non_voter)
   for the equivalent config option when using `retry_join` stanzas instead.
 
-:::warning
+  :::warning
 
-Adding a large number of non-voters to a cluster will impact application
-latency. Make sure to tune the [Raft settings](/docs/configuration/storage/raft/#raft-parameters)
-for your intended use case.
+  Adding a large number of non-voters to a cluster will impact application
+  latency. Make sure to tune the [Raft
+  settings](/docs/configuration/storage/raft/#raft-parameters) for your intended
+  use case.
 
-:::
+  :::
 
 - `-retry` `(bool: false)` - Continuously retry joining the Raft cluster upon
   failures. The default is false.
@@ -345,11 +346,12 @@ Flags applicable to this command are the following:
   a server can go without leader contact before being considered failed.
   This takes effect only when `cleanup_dead_servers` is set as `true`. Defaults to `24h`.
   
-:::note
+  :::note
 
-A failed server that autopilot has removed from the raft configuration cannot rejoin the cluster without being reinitialized.  
+  A failed server that autopilot has removed from the raft configuration cannot
+  rejoin the cluster without being reinitialized.
 
-:::
+  :::
 
 - `max-trailing-logs` `(int)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy. Defaults to `1000`.

--- a/website/content/docs/commands/pki/reissue.mdx
+++ b/website/content/docs/commands/pki/reissue.mdx
@@ -24,14 +24,14 @@ Usage: `bao pki reissue [flags] <parent> <template> <child_mount> [options]`
 - `<template>` is the fully qualified path of an intermediate certificate in OpenBao
   which will be used to populate certificate fields not overridden by `[options]`.
 
-:::warning
+  :::warning
 
-**Note**: not all possible certificate fields are supported by OpenBao, and
-  this template reader covers only those OpenBao generates as a best effort.  If
+  **Note**: not all possible certificate fields are supported by OpenBao, and
+  this template reader covers only those OpenBao generates as a best effort. If
   unknown fields are set, such as when an external CA was imported into OpenBao,
   there may not be a warning that those are missing from the new issuer.
 
-:::
+  :::
 
 - `<child_mount>` is the path of the mount in OpenBao where the new issuer is saved.
 
@@ -49,15 +49,15 @@ issuer entry.
    generate a new key for this certificate - or `"kms"` - to link to an external
    key.  Exported keys are not available through this API.
 
-:::warning
+  :::warning
 
-**Note**: It is only possible to generate a new certificate with an existing
-   key that exists in the same mount where that key-material exists.  This
-   command is expected to fail should the template exist on a different mount,
-   `existing` is the selected type, and no `key_ref` for a key in the new issuer
-   mount is provided.
+  **Note**: It is only possible to generate a new certificate with an existing
+  key that exists in the same mount where that key-material exists. This command
+  is expected to fail should the template exist on a different mount, `existing`
+  is the selected type, and no `key_ref` for a key in the new issuer mount is
+  provided.
 
-:::
+  :::
 
 - `-issuer_name` `(string: "")` - If present, the newly created issuer will be
    given this name.

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -90,13 +90,13 @@ flags](/docs/commands) included on all commands.
   must be unique cross all secrets engines. This defaults to the "type" of the
   secrets engine.
   
-:::danger
+  :::danger
 
- **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
-  example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
-  distinct instances of KV secrets engine.
+  **Case-sensitive:** The path where you enable secrets engines is
+  case-sensitive. For example, the KV secrets engine enabled at `kv/` and `KV/`
+  are treated as two distinct instances of KV secrets engine.
 
-:::
+  :::
 
 - `-passthrough-request-headers` `(string: "")` - request header values that will
   be sent to the secrets engine. Note that multiple keys may be

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -215,8 +215,9 @@ _lower_ priority.
 
 :::danger
 
-**Informational:**The glob character referred to in this documentation is the asterisk (`*`).
-It _is not a regular expression_ and is only supported **as the last character of the path**!
+**Informational:** The glob character referred to in this documentation is the
+asterisk (`*`). It _is not a regular expression_ and is only supported **as the
+last character of the path**!
 
 :::
 

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -205,19 +205,21 @@ can have a negative effect on performance due to the tracking of each lock attem
   Supported values (in order of descending detail) are `trace`, `debug`, `info`, `warn`, and `error`.
   This can also be specified via the `BAO_LOG_LEVEL` environment variable.
 
-:::warning
+  :::warning
 
- Note: On SIGHUP (`sudo kill -s HUP` _pid of bao_), if a valid value is specified, OpenBao will update the existing log level,
-  overriding (even if specified) both the CLI flag and environment variable.
+  Note: On SIGHUP (`sudo kill -s HUP` _pid of bao_), if a valid value is
+  specified, OpenBao will update the existing log level, overriding (even if
+  specified) both the CLI flag and environment variable.
 
-:::
+  :::
 
-:::warning
+  :::warning
 
- Note: Not all parts of OpenBao's logging can have its log level be changed dynamically this way; in particular,
-  secrets/auth plugins are currently not updated dynamically.
+  Note: Not all parts of OpenBao's logging can have its log level be changed
+  dynamically this way; in particular, secrets/auth plugins are currently not
+  updated dynamically.
 
-:::
+  :::
 
 - `log_format` - Equivalent to the [`-log-format` command-line flag](/docs/commands/server#_log_format).
 

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -119,12 +119,12 @@ default value in the `"/sys/config/ui"` [API endpoint](/api-docs/system/config-u
   `/sys/rekey-recovery-key/*`). These are a security risk to leave exposed on
   public listeners.
 
-:::warning
+  :::warning
 
-**In OpenBao v2.4.0, this parameter will default to true, forbidding any calls
-to the unauthenticated rekey endpoints. This will be a breaking change.
+  In OpenBao v2.4.0, this parameter will default to true, forbidding any calls
+  to the unauthenticated rekey endpoints. This will be a breaking change.
 
-:::
+  :::
 
 - `tls_disable` `(string: "false")` – Specifies if TLS will be disabled. OpenBao
   assumes TLS by default, so you must explicitly disable TLS to opt-in to
@@ -149,50 +149,49 @@ to the unauthenticated rekey endpoints. This will be a breaking change.
 - `tls_min_version` `(string: "tls12")` – Specifies the minimum supported
   version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13".
 
-:::warning
+  :::warning
 
- **Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
+  **Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
   `tls_min_version` and `tls_max_version` parameters) are widely considered
   insecure.
 
-:::
+  :::
 
 - `tls_max_version` `(string: "tls13")` – Specifies the maximum supported
   version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13".
 
-:::warning
+  :::warning
 
-**Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
+  **Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
   `tls_min_version` and `tls_max_version` parameters) are widely considered
   insecure.
 
-:::
+  :::
 
 - `tls_cipher_suites` `(string: "")` – Specifies the list of supported
   ciphersuites as a comma-separated-list. The list of all available ciphersuites
   is available in the [Golang TLS documentation][golang-tls].
 
-:::warning
+  :::warning
 
- **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
+  **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
   earlier; the order of ciphers is not important. For this parameter to be
   effective, the `tls_max_version` property must be set to `tls12` to prevent
   negotiation of TLSv1.3, which is not recommended. For more information about
   this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
 
-:::
+  :::
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.
 
-:::warning
+  :::warning
 
- **Warning**: The `tls_prefer_server_cipher_suites` parameter is
-  deprecated. Setting it has no effect. See the above
-  [Go blog post][go-tls-blog] for more information about
-  this change.
+  **Warning**: The `tls_prefer_server_cipher_suites` parameter is deprecated.
+  Setting it has no effect. See the above [Go blog post][go-tls-blog] for more
+  information about this change.
 
-:::
+  :::
 
 - `tls_require_and_verify_client_cert` `(string: "false")` – Turns on client
   authentication for this listener; the listener will require a presented
@@ -205,11 +204,15 @@ to the unauthenticated rekey endpoints. This will be a breaking change.
   authentication for this listener. The default behavior (when this is false)
   is for OpenBao to request client certificates when available.
 
-:::warning
+  :::warning
 
- **Warning**: The `tls_disable_client_certs` and `tls_require_and_verify_client_cert` fields in the listener stanza of the OpenBao server configuration are mutually exclusive fields. Please ensure they are not both set to true. TLS client verification remains optional with default settings and is not enforced.
+  **Warning**: The `tls_disable_client_certs` and
+  `tls_require_and_verify_client_cert` fields in the listener stanza of the
+  OpenBao server configuration are mutually exclusive fields. Please ensure they
+  are not both set to true. TLS client verification remains optional with
+  default settings and is not enforced.
 
-:::
+  :::
 
 - `x_forwarded_for_authorized_addrs` `(string: <required-to-enable>)` –
   Specifies the list of source IP CIDRs for which an X-Forwarded-For header
@@ -273,18 +276,18 @@ in the root of the TCP listener configuration.
 - `tls_acme_domains` `([]string: nil)` - An optional but strongly recommended
   allow-list of domains to allow acquiring certificates for.
 
-:::warning
+  :::warning
 
-Failing to specify `tls_acme_domains` on a publicly listening server issuing
-against a publicly trusted CA will allow anyone (including an attacker) to
-point arbitrary DNS names at your server. This will allow them to force you
-to request additional certificates from your CA, thereby counting against
-your quotas and potentially incurring cost on a paid CA offering.
+  Failing to specify `tls_acme_domains` on a publicly listening server issuing
+  against a publicly trusted CA will allow anyone (including an attacker) to
+  point arbitrary DNS names at your server. This will allow them to force you to
+  request additional certificates from your CA, thereby counting against your
+  quotas and potentially incurring cost on a paid CA offering.
 
-It is thus strongly recommended you specify `tls_acme_domains` if ACME is
-enabled.
+  It is thus strongly recommended you specify `tls_acme_domains` if ACME is
+  enabled.
 
-:::
+  :::
 
 - `tls_acme_disable_http_challenge` `(bool: false)` - An optional but strongly
   recommended option to allow disabling HTTP challenges. Use of this method

--- a/website/content/docs/configuration/listener/unix.mdx
+++ b/website/content/docs/configuration/listener/unix.mdx
@@ -43,12 +43,12 @@ multiple sockets.
 - `metrics_only` `(bool: false)` - Specifies if the listener should *only* serve the `/v1/sys/metrics` endpoint, blocking all other API requests. 
   This is useful for creating a dedicated, secure listener for monitoring systems.
 
-:::warning
+  :::warning
 
-**In OpenBao v2.4.0, this parameter will default to true, forbidding any calls
-to the unauthenticated rekey endpoints. This will be a breaking change.
+  In OpenBao v2.4.0, this parameter will default to true, forbidding any calls
+  to the unauthenticated rekey endpoints. This will be a breaking change.
 
-:::
+  :::
 
 ## `unix` listener examples
 

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -72,28 +72,28 @@ These parameters apply to the `seal` stanza in the OpenBao configuration file:
 - `lib` `(string: <required>)`: The path to the PKCS#11 library shared object
   file. May also be specified by the `BAO_HSM_LIB` environment variable.
 
-:::info
+  :::info
 
-Depending on your HSM, the value of the `lib` parameter may be
-either a binary or a dynamic library, and its use may require other libraries
-depending on which system the OpenBao binary is currently running on (e.g.: a
-Linux system may require other libraries to interpret Windows .dll files).
+  Depending on your HSM, the value of the `lib` parameter may be either a binary
+  or a dynamic library, and its use may require other libraries depending on
+  which system the OpenBao binary is currently running on (e.g.: a Linux system
+  may require other libraries to interpret Windows .dll files).
 
-:::
+  :::
 
 - `slot` `(string: <slot or token label required>)`: The slot number to use,
   specified as a string (e.g. `"2305843009213693953"`). May also be specified by
   the `BAO_HSM_SLOT` environment variable.
 
-:::info
+  :::info
 
-Slots are typically listed as hex-decimal values in the OS setup
-utility but this configuration uses their decimal equivalent. For example, using the
-HSM command-line `pkcs11-tool`, a slot listed as `0x2000000000000001`in hex is equal
-to `2305843009213693953` in decimal; these values may be listed shorter or
-differently as determined by the HSM in use.
+  Slots are typically listed as hex-decimal values in the OS setup utility but
+  this configuration uses their decimal equivalent. For example, using the HSM
+  command-line `pkcs11-tool`, a slot listed as `0x2000000000000001`in hex is
+  equal to `2305843009213693953` in decimal; these values may be listed shorter
+  or differently as determined by the HSM in use.
 
-:::
+  :::
 
 - `token_label` `(string: <slot or token label required>)`: The slot token label to
   use. May also be specified by the `BAO_HSM_TOKEN_LABEL` environment variable.
@@ -117,20 +117,20 @@ differently as determined by the HSM in use.
   - Names: `AES_GCM`, `CKM_AES_GCM`, Hexadecimal: `0x1087`
   - Names: `RSA_PKCS_OAEP`, `CKM_RSA_PKCS_OAEP`, Hexadecimal: `0x0009`
 
+  :::warning
+
+  Unlike Vault Enterprise, OpenBao only supports AEAD-enabled algorithms and
+  will not support Encrypt-Then-MAC constructs (like `CKM_AES_CBC_PAD` with
+  explicit HMACing).
+
+  :::
+
 - `disable_software_encryption` `(bool: false)`: For RSA-based mechanisms,
   OpenBao performs the encryption operation locally in memory by exporting the
   public key from the HSM. Set this option to `true` to force calling out to the
   HSM for all encryption operations. This option is available starting with
   OpenBao v2.4.0. All prior versions always call out to the HSM for encryption
   and never perform encryption in software.
-
-:::warning
-
-Unlike Vault Enterprise, OpenBao only supports AEAD-enabled algorithms and
-will not support Encrypt-Then-MAC constructs (like `CKM_AES_CBC_PAD` with
-explicit HMACing).
-
-:::
 
 - `disabled` `(string: "")`: Set this to `true` if OpenBao is migrating from an auto seal configuration. Otherwise, set to `false`.
 

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -188,12 +188,12 @@ them, optional commands to run, etc.
   spec. Also available as a command-line option (`-run-as-same-user`) or
   environment variable (`AGENT_INJECT_RUN_AS_SAME_USER`). Defaults to `false`.
 
-:::warning
+  :::warning
 
- **Note**: If the first application container in the pod is running as root
+  **Note**: If the first application container in the pod is running as root
   (uid 0), the `run-as-same-user` annotation will fail injection with an error.
 
-:::
+  :::
 
 - `openbao.openbao.org/agent-share-process-namespace` - sets
   [shareProcessNamespace] in the Pod spec where OpenBao Agent is injected.

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -110,14 +110,13 @@ management tool.
    $ bao write -force database/rotate-root/my-database
    ```
 
-:::danger
+   :::danger
 
- When this is done, the password for the user specified in the previous step
+   When this is done, the password for the user specified in the previous step
    is no longer accessible. Because of this, it is highly recommended that a
-   user is created specifically for OpenBao to use to manage database
-   users.
+   user is created specifically for OpenBao to use to manage database users.
 
-:::
+   :::
 
 1. Configure a role that maps a name in OpenBao to a set of creation statements to
    create the database credential:

--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -30,14 +30,14 @@ API.
   a given path. With a few exceptions, secrets engines can be enabled at multiple
   paths. Each secrets engine is isolated to its path. By default, they are
   enabled at their "type" (e.g. "kv" enables at `kv/`).
+  
+  :::danger
 
-:::danger
+  **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
+    example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
+    distinct instances of KV secrets engine.
 
- **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
-  example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
-  distinct instances of KV secrets engine.
-
-:::
+  :::
 
 - [Disable](/docs/commands/secrets/disable) - This disables an existing
   secrets engine. When a secrets engine is disabled, all of its secrets are

--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -110,21 +110,21 @@ management tool.
      verbs: ["bind", "escalate", "create", "update", "delete"]
    ```
 
-:::warning
+   :::warning
 
- **Note:** Getting the right permissions for OpenBao will require some trial and error most
-      likely since Kubernetes has strict protections against privilege escalation. You can read more
-      in the
-      [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).
+   **Note:** Getting the right permissions for OpenBao will require some trial
+   and error most likely since Kubernetes has strict protections against
+   privilege escalation. You can read more in the [Kubernetes RBAC
+   documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).
 
-:::
+   :::
 
-:::warning
+   :::warning
 
- **Note:** Protect the OpenBao service account, especially if you use broader permissions for it,
-      as it is essentially a cluster administrator account.
+   **Note:** Protect the OpenBao service account, especially if you use broader
+   permissions for it, as it is essentially a cluster administrator account.
 
-:::
+   :::
 
 1. Create a role binding to bind the role to OpenBao's service account and grant OpenBao permission
    to manage tokens.

--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -185,14 +185,14 @@ the proper permission, it can use this secrets engine.
     for storing the encrypted ciphertext. When the caller wants the plaintext,
     it must provide the ciphertext back to OpenBao to decrypt the value.
 
-     :::danger
+    :::danger
 
-     OpenBao HTTP API imposes a maximum request size of 32MB to prevent a denial
-     of service attack. This can be tuned per [`listener`
-     block](/docs/configuration/listener/tcp) in the OpenBao server
-     configuration.
+    OpenBao HTTP API imposes a maximum request size of 32MB to prevent a denial
+    of service attack. This can be tuned per [`listener`
+    block](/docs/configuration/listener/tcp) in the OpenBao server
+    configuration.
 
-     :::
+    :::
 
 1.  Decrypt a piece of data using the `/decrypt` endpoint with a named key:
 

--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -86,15 +86,15 @@ types also generate separate HMAC keys):
   signature verification
 - `hmac`: HMAC; supporting HMAC generation and verification.
 
-:::warning
+  :::warning
 
-**Note**: All key types support HMAC operations through the use of a second randomly
-generated key created key creation time or rotation. The HMAC key type only
-supports HMAC, and behaves identically to other algorithms with
-respect to the HMAC operations but supports key import. By default,
-the HMAC key type uses a 256-bit key.
+  **Note**: All key types support HMAC operations through the use of a second
+  randomly generated key created key creation time or rotation. The HMAC key
+  type only supports HMAC, and behaves identically to other algorithms with
+  respect to the HMAC operations but supports key import. By default, the HMAC
+  key type uses a 256-bit key.
 
-:::
+  :::
 
 RSA operations use one of the following methods:
 
@@ -185,14 +185,14 @@ the proper permission, it can use this secrets engine.
     for storing the encrypted ciphertext. When the caller wants the plaintext,
     it must provide the ciphertext back to OpenBao to decrypt the value.
 
-:::danger
+     :::danger
 
- OpenBao HTTP API imposes a maximum request size of 32MB to prevent a denial
-    of service attack. This can be tuned per [`listener`
-    block](/docs/configuration/listener/tcp) in the OpenBao server
-    configuration.
+     OpenBao HTTP API imposes a maximum request size of 32MB to prevent a denial
+     of service attack. This can be tuned per [`listener`
+     block](/docs/configuration/listener/tcp) in the OpenBao server
+     configuration.
 
-:::
+     :::
 
 1.  Decrypt a piece of data using the `/decrypt` endpoint with a named key:
 
@@ -299,17 +299,18 @@ the ciphertext for the input of the `import` endpoint:
 
 - Wrap the target key using the ephemeral AES key with AES-KWP.
 
-:::warning
+  :::warning
 
-Note: When wrapping a symmetric key (such as an AES or ChaCha20 key), wrap
-   the raw bytes of the key. For instance, with an AES 128-bit key, this'll be
-   a byte array 16 characters in length that will directly be wrapped without
-   base64 or other encodings.<br /><br />When wrapping an asymmetric key
-   (such as a RSA or ECDSA key), wrap the **PKCS8** encoded format of this
-   key, in raw DER/binary form. Do not apply PEM encoding to this blob prior
-   to encryption and do not base64 encode it.
+  Note: When wrapping a symmetric key (such as an AES or ChaCha20 key), wrap the
+  raw bytes of the key. For instance, with an AES 128-bit key, this'll be a byte
+  array 16 characters in length that will directly be wrapped without base64 or
+  other encodings.
 
-:::
+  When wrapping an asymmetric key (such as a RSA or ECDSA key), wrap the
+  **PKCS8** encoded format of this key, in raw DER/binary form. Do not apply PEM
+  encoding to this blob prior to encryption and do not base64 encode it.
+
+  :::
 
 - Wrap the AES key under the OpenBao wrapping key using RSAES-OAEP with MGF1 and
   either SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512.

--- a/website/content/docs/upgrading/ha-upgrade.mdx
+++ b/website/content/docs/upgrading/ha-upgrade.mdx
@@ -38,16 +38,15 @@ To complete the cluster upgrade:
 
 1. Properly shut down the remaining (active) node
 
-:::note
+   :::note
 
-It is important that you shut the node down properly.
-This will perform a step-down and release the HA lock, allowing a standby
-node to take over with a very short delay.
-If you kill OpenBao without letting it release the lock, a standby node will
-not be able to take over until the lock's timeout period has expired. This
-is backend-specific but could be ten seconds or more.
+   It is important that you shut the node down properly. This will perform a
+   step-down and release the HA lock, allowing a standby node to take over with
+   a very short delay. If you kill OpenBao without letting it release the lock,
+   a standby node will not be able to take over until the lock's timeout period
+   has expired. This is backend-specific but could be ten seconds or more.
 
-:::
+   :::
 
 2. Replace the OpenBao binary with the new version
 3. Start the node


### PR DESCRIPTION
Fix indentation of `:::warning`, `:::info` and `:::danger` blocks in lists.

We have many places on our website were we do something like this:

```mdx
- `parameter_a` ...
- `parameter_b` ...

:::warning

`parameter_b` has the limitation ...

:::

- `parameter_c` ...
```

In the generated HTML this will be two unordered lists (`parameter_a`, `parameter_b`) (`parameter_c`) interrupted by a block for the warning.

If we instead indent the warning block


```mdx
- `parameter_a` ...
- `parameter_b` ...

  :::warning

  `parameter_b` has the limitation ...

  :::

- `parameter_c` ...
```

We will get one list and the warning block will be part of the second list item, which in most cases is semantically correct.

Screenshots:

Old:
<img width="958" height="709" alt="image" src="https://github.com/user-attachments/assets/5a14fe86-dd01-4558-9bc7-6fecd3be194a" />

New:

<img width="953" height="722" alt="image" src="https://github.com/user-attachments/assets/dcce9bd1-c04a-4bff-abde-4ebaa4eff0b5" />

Source Page: https://openbao.org/docs/secrets/transit/

This has several advantages:

- It looks better (IMHO)
- It is better for accessibility as the HTML is semantically more correct. 
- For ordered lists (as seen in the screenshot) the numbering of the points will be reset to `1.` if the list is interrupted.

This PR fixes a few places with a similar problem with code blocks <code>```</code>