### PR TITLE
Remove superfluous & confusing FAQ section

### DIFF
--- a/website/content/docs/faq/index.mdx
+++ b/website/content/docs/faq/index.mdx
@@ -1,9 +1,0 @@
----
-sidebar_label: FAQ for product and features
-description: |-
-  An FAQ page for product and features.
----
-
-# Product features FAQ
-
-You can access a number of different FAQ pages to get answers to questions about our product and features. These FAQ pages are updated periodically so please check back for the latest updates and new FAQ questions.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -545,7 +545,6 @@ const sidebars: SidebarsConfig = {
                     ],
                 },
             ],
-            FAQ: ["faq/index", "deprecation/faq", "auth/login-mfa/faq"],
         },
         "glossary",
     ],


### PR DESCRIPTION
Remove this sidebar section from the documentation:

<img width="291" height="139" alt="image" src="https://github.com/user-attachments/assets/cf55d560-d839-4403-af4f-4523cbeeec11" />

https://openbao.org/docs/faq/

While we could fix the ill-formatted sidebar itself, both entries besides the empty index page are already present in other, more specific parts of the sidebar:

- https://openbao.org/docs/deprecation/faq/
- https://openbao.org/docs/auth/login-mfa/faq/

I see no reason to keep this section - I doubt the usefulness of this cross-topic collection, and it seems to cause confusion as people assume it to be a general-purpose FAQ: #1859.
