### PR TITLE
Delay updates for dependencies to counter supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
-      default-days: 3
+      default-days: 5
       semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
 
   - package-ecosystem: "github-actions"
     directories:
@@ -18,23 +17,21 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
-      default-days: 3
+      default-days: 5
       semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
-      default-days: 3
+      default-days: 5
       semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
 
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -44,12 +41,11 @@ updates:
       - dependencies
       - javascript
       - ui
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
-      default-days: 3
+      default-days: 5
       semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
 
   - package-ecosystem: "npm"
     directory: "/website"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,37 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+    cooldown:
+      default-days: 3
+      semver-patch-days: 7
+
   - package-ecosystem: "github-actions"
     directories:
       - "/"
       - "/.github/actions/*"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+    cooldown:
+      default-days: 3
+      semver-patch-days: 7
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+    cooldown:
+      default-days: 3
+      semver-patch-days: 7
+
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
@@ -23,6 +44,13 @@ updates:
       - dependencies
       - javascript
       - ui
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+    cooldown:
+      default-days: 3
+      semver-patch-days: 7
+
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
@@ -35,3 +63,8 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+    cooldown:
+      default-days: 5
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30


### PR DESCRIPTION
I propose to follow the rule: **don’t touch it if it works**.

Minor and major updates often include refactors, API changes, and new features. We rely on our dependencies for stable functions, so we prefer only bug fixes and critical security updates.

This PR updates Dependabot to block minor and major updates and allow only patch updates that are at least 7 days old. Per the docs, critical security updates will still come through.

Since the website is not a critical part of our app, I configured rules to allow minor and major updates there, but only after a set minimum age.