### PR TITLE
KV engine returns timestamp strings in RFC3339Nano format

### DIFF
--- a/builtin/logical/kv/backend.go
+++ b/builtin/logical/kv/backend.go
@@ -439,7 +439,7 @@ func ptypesTimestampToString(t *timestamppb.Timestamp) string {
 		return ""
 	}
 
-	return t.AsTime().Format(time.RFC3339)
+	return t.AsTime().Format(time.RFC3339Nano)
 }
 
 var backendHelp string = `

--- a/changelog/1872.txt
+++ b/changelog/1872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: KV entries timestamps are now correctly formatted in `RFC3339Nano`, as previously done so.
+```


### PR DESCRIPTION
Resolves #1841

`ptypesTimestampToString` now returns back the timestamp string in `RFC3339Nano` format, as it was done, (but wrongly indicated [here](https://github.com/golang/protobuf/blob/75de7c059e36b64f01d0dd234ff2fff404ec3374/ptypes/timestamp.go#L76-L86)) by the previous version of this code fragment.
