### PR TITLE
Identity subsystem returns timestamp strings in RFC3339Nano format

### DIFF
--- a/changelog/1873.txt
+++ b/changelog/1873.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Entities timestamps are now correctly formatted in `RFC3339Nano`, as previously done so.
+```

--- a/helper/identity/sentinel.go
+++ b/helper/identity/sentinel.go
@@ -19,9 +19,9 @@ func (e *Entity) SentinelGet(key string) (interface{}, error) {
 	case "name":
 		return e.Name, nil
 	case "creation_time":
-		return e.CreationTime.AsTime().Format(time.RFC3339), nil
+		return e.CreationTime.AsTime().Format(time.RFC3339Nano), nil
 	case "last_update_time":
-		return e.LastUpdateTime.AsTime().Format(time.RFC3339), nil
+		return e.LastUpdateTime.AsTime().Format(time.RFC3339Nano), nil
 	case "merged_entity_ids":
 		return e.MergedEntityIDs, nil
 	case "policies":
@@ -63,9 +63,9 @@ func (p *Alias) SentinelGet(key string) (interface{}, error) {
 	case "name":
 		return p.Name, nil
 	case "creation_time":
-		return p.CreationTime.AsTime().Format(time.RFC3339), nil
+		return p.CreationTime.AsTime().Format(time.RFC3339Nano), nil
 	case "last_update_time":
-		return p.LastUpdateTime.AsTime().Format(time.RFC3339), nil
+		return p.LastUpdateTime.AsTime().Format(time.RFC3339Nano), nil
 	case "merged_from_entity_ids":
 		return p.MergedFromCanonicalIDs, nil
 	}
@@ -106,9 +106,9 @@ func (g *Group) SentinelGet(key string) (interface{}, error) {
 	case "meta", "metadata":
 		return g.Metadata, nil
 	case "creation_time":
-		return g.CreationTime.AsTime().Format(time.RFC3339), nil
+		return g.CreationTime.AsTime().Format(time.RFC3339Nano), nil
 	case "last_update_time":
-		return g.LastUpdateTime.AsTime().Format(time.RFC3339), nil
+		return g.LastUpdateTime.AsTime().Format(time.RFC3339Nano), nil
 	}
 
 	return nil, nil

--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -546,13 +546,11 @@ func (i *IdentityStore) handleAliasReadCommon(ctx context.Context, alias *identi
 		respData["mount_type"] = mountValidationResp.MountType
 	}
 
-	// Convert protobuf timestamp into RFC3339 format
-	respData["creation_time"] = alias.CreationTime.AsTime().Format(time.RFC3339)
-	respData["last_update_time"] = alias.LastUpdateTime.AsTime().Format(time.RFC3339)
+	// Convert protobuf timestamp into RFC3339Nano format
+	respData["creation_time"] = alias.CreationTime.AsTime().Format(time.RFC3339Nano)
+	respData["last_update_time"] = alias.LastUpdateTime.AsTime().Format(time.RFC3339Nano)
 
-	return &logical.Response{
-		Data: respData,
-	}, nil
+	return &logical.Response{Data: respData}, nil
 }
 
 // pathAliasIDDelete deletes the alias for a given alias ID

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -475,9 +475,9 @@ func (i *IdentityStore) handleEntityReadCommon(ctx context.Context, entity *iden
 	respData["disabled"] = entity.Disabled
 	respData["namespace_id"] = entity.NamespaceID
 
-	// Convert protobuf timestamp into RFC3339 format
-	respData["creation_time"] = entity.CreationTime.AsTime().Format(time.RFC3339)
-	respData["last_update_time"] = entity.LastUpdateTime.AsTime().Format(time.RFC3339)
+	// Convert protobuf timestamp into RFC3339Nano format
+	respData["creation_time"] = entity.CreationTime.AsTime().Format(time.RFC3339Nano)
+	respData["last_update_time"] = entity.LastUpdateTime.AsTime().Format(time.RFC3339Nano)
 
 	// Convert each alias into a map and replace the time format in each
 	aliasesToReturn := make([]interface{}, len(entity.Aliases))
@@ -489,8 +489,8 @@ func (i *IdentityStore) handleEntityReadCommon(ctx context.Context, entity *iden
 		aliasMap["metadata"] = alias.Metadata
 		aliasMap["name"] = alias.Name
 		aliasMap["merged_from_canonical_ids"] = alias.MergedFromCanonicalIDs
-		aliasMap["creation_time"] = alias.CreationTime.AsTime().Format(time.RFC3339)
-		aliasMap["last_update_time"] = alias.LastUpdateTime.AsTime().Format(time.RFC3339)
+		aliasMap["creation_time"] = alias.CreationTime.AsTime().Format(time.RFC3339Nano)
+		aliasMap["last_update_time"] = alias.LastUpdateTime.AsTime().Format(time.RFC3339Nano)
 		aliasMap["local"] = alias.Local
 		aliasMap["custom_metadata"] = alias.CustomMetadata
 
@@ -528,9 +528,7 @@ func (i *IdentityStore) handleEntityReadCommon(ctx context.Context, entity *iden
 
 	respData["group_ids"] = append(groupIDs, inheritedGroupIDs...)
 
-	return &logical.Response{
-		Data: respData,
-	}, nil
+	return &logical.Response{Data: respData}, nil
 }
 
 // pathEntityIDDelete deletes the entity for a given entity ID

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -406,8 +406,8 @@ func (i *IdentityStore) handleGroupReadCommon(ctx context.Context, group *identi
 	respData["member_entity_ids"] = group.MemberEntityIDs
 	respData["parent_group_ids"] = group.ParentGroupIDs
 	respData["metadata"] = group.Metadata
-	respData["creation_time"] = group.CreationTime.AsTime().Format(time.RFC3339)
-	respData["last_update_time"] = group.LastUpdateTime.AsTime().Format(time.RFC3339)
+	respData["creation_time"] = group.CreationTime.AsTime().Format(time.RFC3339Nano)
+	respData["last_update_time"] = group.LastUpdateTime.AsTime().Format(time.RFC3339Nano)
 	respData["modify_index"] = group.ModifyIndex
 	respData["type"] = group.Type
 	respData["namespace_id"] = group.NamespaceID
@@ -420,8 +420,8 @@ func (i *IdentityStore) handleGroupReadCommon(ctx context.Context, group *identi
 		aliasMap["metadata"] = group.Alias.Metadata
 		aliasMap["name"] = group.Alias.Name
 		aliasMap["merged_from_canonical_ids"] = group.Alias.MergedFromCanonicalIDs
-		aliasMap["creation_time"] = group.Alias.CreationTime.AsTime().Format(time.RFC3339)
-		aliasMap["last_update_time"] = group.Alias.LastUpdateTime.AsTime().Format(time.RFC3339)
+		aliasMap["creation_time"] = group.Alias.CreationTime.AsTime().Format(time.RFC3339Nano)
+		aliasMap["last_update_time"] = group.Alias.LastUpdateTime.AsTime().Format(time.RFC3339Nano)
 
 		if mountValidationResp := i.router.ValidateMountByAccessor(group.Alias.MountAccessor); mountValidationResp != nil {
 			aliasMap["mount_path"] = mountValidationResp.MountPath
@@ -442,9 +442,7 @@ func (i *IdentityStore) handleGroupReadCommon(ctx context.Context, group *identi
 
 	respData["member_group_ids"] = memberGroupIDs
 
-	return &logical.Response{
-		Data: respData,
-	}, nil
+	return &logical.Response{Data: respData}, nil
 }
 
 func (i *IdentityStore) pathGroupIDDelete() framework.OperationFunc {


### PR DESCRIPTION
Similar to https://github.com/openbao/openbao/pull/1872 this PR changes the format of the identity system timestamps (response types) to `RFC3339Nano`, as indicated by our [documentation](https://openbao.org/api-docs/secret/identity/entity/#create-an-entity) the correct format.
(sorry for not noticing it earlier and fixing in scope of https://github.com/openbao/openbao/pull/1872)

currently:
```
curl -X POST -H "X-Vault-Token: $(bao print token)" -d '{"metadata": {"organization": "openbao","team": "openbao"},"policies": ["eng-dev", "infra-dev"]}' "http://127.0.0.1:8200/v1/identity/entity" 
{(...),"data":{"aliases":null,"id":"77ba06c3-6949-04d4-e906-876acb1e9708", (...)}

curl -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/entity/id/77ba06c3-6949-04d4-e906-876acb1e9708"
{"(...), "creation_time":"2025-09-30T14:22:01Z","direct_group_ids":[],"disabled":false,"group_ids":[],"id":"77ba06c3-6949-04d4-e906-876acb1e9708","inherited_group_ids":[],"last_update_time":"2025-09-30T14:22:01Z", (...)}
```

after change:
```
curl -X POST -H "X-Vault-Token: $(bao print token)" -d '{"metadata": {"organization": "openbao","team": "openbao"},"policies": ["eng-dev", "infra-dev"]}' "http://127.0.0.1:8200/v1/identity/entity"
{(...), "data":{"aliases":null,"id":"9b1f4332-8992-0086-2a00-86d3e1ab1474", (...)}

curl -H "X-Vault-Token: $(bao print token)" "http://127.0.0.1:8200/v1/identity/entity/id/9b1f4332-8992-0086-2a00-86d3e1ab1474"
{(...), "creation_time":"2025-09-30T14:19:24.896021Z","direct_group_ids":[],"disabled":false,"group_ids":[],"id":"9b1f4332-8992-0086-2a00-86d3e1ab1474","inherited_group_ids":[],"last_update_time":"2025-09-30T14:19:24.896021Z", (...)}
```