### PR TITLE
Default to disable_unauthed_rekey_endpoints=true

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -187,7 +187,7 @@ func handler(props *vault.HandlerProperties) http.Handler {
 			handleAuditNonLogical(core, handleSysGenerateRootUpdate(core, vault.GenerateStandardRootTokenStrategy))))
 
 		// Register without unauthenticated rekey, if necessary.
-		if props.ListenerConfig == nil || !props.ListenerConfig.DisableUnauthedRekeyEndpoints {
+		if props.ListenerConfig == nil || (props.ListenerConfig.DisableUnauthedRekeyEndpoints != nil && !*props.ListenerConfig.DisableUnauthedRekeyEndpoints) {
 			mux.Handle("/v1/sys/rekey/init", handleRequestForwarding(core,
 				handleAuditNonLogical(core, handleSysRekeyInit(core, false))))
 			mux.Handle("/v1/sys/rekey/update", handleRequestForwarding(core,

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -150,7 +150,8 @@ type Listener struct {
 	// This defaults to false, i.e., respond to requests; in the future when
 	// an authenticated variant with new semantics is available on a new
 	// endpoint, this will be set to true (disabling request handling).
-	DisableUnauthedRekeyEndpoints bool `hcl:"disable_unauthed_rekey_endpoints"`
+	DisableUnauthedRekeyEndpoints    *bool       `hcl:"-"`
+	DisableUnauthedRekeyEndpointsRaw interface{} `hcl:"disable_unauthed_rekey_endpoints"`
 }
 
 // AgentAPI allows users to select which parts of the Agent API they want enabled.
@@ -510,6 +511,20 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 
 				l.TLSACMEDisableAlpnChallengeRaw = nil
 			}
+		}
+
+		// Unauthed Rekey
+		if l.DisableUnauthedRekeyEndpointsRaw != nil {
+			value, err := parseutil.ParseBool(l.DisableUnauthedRekeyEndpointsRaw)
+			if err != nil {
+				return multierror.Prefix(fmt.Errorf("invalid value for disable_unauthed_rekey_endpoints: %w", err), fmt.Sprintf("listeners.%d", i))
+			}
+
+			l.DisableUnauthedRekeyEndpoints = &value
+			l.DisableUnauthedRekeyEndpointsRaw = nil
+		} else {
+			disabled := true
+			l.DisableUnauthedRekeyEndpoints = &disabled
 		}
 
 		result.Listeners = append(result.Listeners, &l)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -121,8 +121,11 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"generate-root/update",
 				"decode-token",
 				"mfa/validate",
-				// these endpoint are unauthenticated only with
-				// "disable_unauthed_rekey_endpoints" listener property set to true
+
+				// These endpoint are unauthenticated only with
+				// "disable_unauthed_rekey_endpoints" listener property explicitly
+				// set to false. Note that they are not routable through the normal
+				// SystemBackend calls but are instead specially handled by http.
 				"rekey/init",
 				"rekey/update",
 				"rekey/verify",


### PR DESCRIPTION
As discussed with the new authenticated rotation endpoints available for a full release, now we can complete the deprecation and default to disabling the unsafe legacy rekey endpoints.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
