### PR TITLE
CI: add go test summary

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -310,6 +310,10 @@ jobs:
           path: test-results/go-test
           pattern: test-results-*
           merge-multiple: true
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test-results/go-test/results-*.xml"
       - env:
           EXPECTED_IDS: ${{ needs.test-matrix.outputs.matrix_ids }}
         run: |


### PR DESCRIPTION
Use the [Test Summary Action](https://github.com/marketplace/actions/test-summary-action) to render a summary of the test results. [Example](https://github.com/openbao/openbao/actions/runs/18156540525/attempts/1#summary-51679004842). The action uses the JUnit XMLs generated by `gotestsum`.

Sadly, there is no button in the GitHub PR UI to navigate to the summary directly (or I haven't found it). The fastest way I found was to click on "Details" for one of the "checks" e.g. "Run Go tests / test-go (12)" and then on "Summary" in the top left. The action also supports generating a markdown file, maybe we could use another action to post this summary as a comment to the PR (possibly only in failure cases).