### PR TITLE
Read replication read only error detection

### DIFF
--- a/http/help.go
+++ b/http/help.go
@@ -17,10 +17,9 @@ func wrapHelpHandler(h http.Handler, core *vault.Core) http.Handler {
 		// If the help parameter is not blank, then show the help. We request
 		// forward because standby nodes do not have mounts and other state.
 		if v := req.URL.Query().Get("help"); v != "" || req.Method == "HELP" {
-			handleRequestForwarding(core,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					handleHelp(core, w, r)
-				})).ServeHTTP(writer, req)
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handleHelp(core, w, r)
+			}).ServeHTTP(writer, req)
 			return
 		}
 

--- a/sdk/logical/error.go
+++ b/sdk/logical/error.go
@@ -5,8 +5,8 @@ package logical
 
 import (
 	"errors"
+	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 )
 
@@ -135,9 +135,10 @@ func ShouldForward(err error) bool {
 		return false
 	}
 
-	if errwrap.Contains(err, ErrPerfStandbyPleaseForward.Error()) ||
-		errwrap.Contains(err, ErrReadOnly.Error()) ||
-		errwrap.Contains(err, consts.ErrStandby.Error()) {
+	errMsg := err.Error()
+	if strings.Contains(errMsg, ErrPerfStandbyPleaseForward.Error()) ||
+		strings.Contains(errMsg, ErrReadOnly.Error()) ||
+		strings.Contains(errMsg, consts.ErrStandby.Error()) {
 		return true
 	}
 


### PR DESCRIPTION
Change the requests forwarding logic to forward requests based on substring matching in error strings. We [noticed](https://github.com/openbao/openbao/pull/1849#discussion_r2391565992) that at least in one location the `ReadOnlyError` was not "wrapped" but embedded as a substring and therefore forwarding didn't work.

Thie PR also removes the `handleRequestForwarding` handler, because it was empty anyhow (since #1674).

See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch