### PR TITLE
Fix memory leak in raft (#1889)

### DIFF
--- a/changelog/1889.txt
+++ b/changelog/1889.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: fix memory leak on standby nodes
+```

--- a/physical/raft/transaction.go
+++ b/physical/raft/transaction.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"maps"
+	"math"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -18,6 +20,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/openbao/openbao/sdk/v2/helper/pointerutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	bolt "go.etcd.io/bbolt"
 )
@@ -624,6 +627,10 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 	defer func() {
 		if t.writable {
 			t.b.fsm.fastTxnTracker.completeTransaction(t.index)
+
+			// in "Rollback" we call fastTxnTracker.clearOldEntries(...) at this
+			// We don't do this in "Commit" because it will be called from the fsm.
+			// This ensures the cleanup also happens on standby nodes
 		}
 
 		t.b.fsm.l.RUnlock()
@@ -706,6 +713,8 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 		OpType: commitTxOp,
 	})
 
+	lowestActiveIndex := t.b.fsm.fastTxnTracker.lowestActiveIndexAfterCommit(t.index)
+
 	// Acquire a regular operation permit pool entry to let us access the
 	// underlying storage.
 	t.b.permitPool.Acquire()
@@ -715,6 +724,7 @@ func (t *RaftTransaction) Commit(ctx context.Context) error {
 	// the transaction application in Raft, applyLog will gather it for us
 	// and return it as a proper error.
 	t.b.l.RLock()
+	log.LowestActiveIndex = pointerutil.Ptr(min(lowestActiveIndex, t.b.raft.AppliedIndex()-1)) // we need to cap the lowest active index, otherwise we might miss transaction started later
 	err = t.b.applyLog(ctx, log)
 	t.b.l.RUnlock()
 
@@ -735,6 +745,12 @@ func (t *RaftTransaction) Rollback(ctx context.Context) error {
 	// Also unlock the read lock on the underlying fsm.
 	defer func() {
 		if t.writable {
+			lowestActiveIndex := t.b.fsm.fastTxnTracker.lowestActiveIndexAfterCommit(t.index)
+			t.b.l.RLock()
+			lowestActiveIndex = min(lowestActiveIndex, t.b.raft.AppliedIndex()-1) // we need to cap the lowest active index, otherwise we might miss transaction started later
+			t.b.l.RUnlock()
+
+			t.b.fsm.fastTxnTracker.clearOldEntries(lowestActiveIndex)
 			t.b.fsm.fastTxnTracker.completeTransaction(t.index)
 		}
 
@@ -790,6 +806,32 @@ func FsmTxnCommitIndexTracker() *fsmTxnCommitIndexTracker {
 	}
 }
 
+// lowestActiveIndexAfterCommit returns what will be the lowest starting index
+// of among active transactions after the given transaction has been committed
+// (or rolled-back).
+func (t *fsmTxnCommitIndexTracker) lowestActiveIndexAfterCommit(transactionStartIndex uint64) uint64 {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	lowestActiveIndex := uint64(math.MaxUint64)
+	for index, activeCount := range t.sourceIndexMap {
+		if index == transactionStartIndex && activeCount == 1 { // ignore given transaction, iff it is the only transaction at this index
+			continue
+		}
+		lowestActiveIndex = min(lowestActiveIndex, index)
+	}
+	return lowestActiveIndex
+}
+
+func (t *fsmTxnCommitIndexTracker) clearOldEntries(lowestActiveIndex uint64) {
+	t.l.Lock()
+	defer t.l.Unlock()
+
+	maps.DeleteFunc(t.indexModifiedMap, func(key uint64, _ map[string]struct{}) bool {
+		return key < lowestActiveIndex
+	})
+}
+
 func (t *fsmTxnCommitIndexTracker) trackTransaction(index uint64) {
 	t.l.Lock()
 	defer t.l.Unlock()
@@ -806,33 +848,6 @@ func (t *fsmTxnCommitIndexTracker) completeTransaction(index uint64) {
 		t.sourceIndexMap[index] -= 1
 	} else {
 		delete(t.sourceIndexMap, index)
-	}
-
-	if existing == 1 {
-		// See if we invalidated the smallest entry; if so, find the next
-		// smallest entry and invalidate all earlier indexModifiedMap
-		// entries as a result.
-		minIndex := index
-		for key := range t.sourceIndexMap {
-			if key < minIndex {
-				minIndex = key
-			}
-		}
-
-		if minIndex < index {
-			return
-		}
-
-		deletedIndices := make([]uint64, 0, physical.DefaultParallelTransactions/2)
-		for key := range t.indexModifiedMap {
-			if key <= minIndex {
-				deletedIndices = append(deletedIndices, key)
-			}
-		}
-
-		for _, index := range deletedIndices {
-			delete(t.indexModifiedMap, index)
-		}
 	}
 }
 

--- a/physical/raft/types.pb.go
+++ b/physical/raft/types.pb.go
@@ -97,10 +97,12 @@ func (x *LogOperation) GetValue() []byte {
 }
 
 type LogData struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Operations    []*LogOperation        `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Operations []*LogOperation        `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
+	// LowestActiveIndex is optional, the start index of the oldest (therefore lowest) active transaction
+	LowestActiveIndex *uint64 `protobuf:"varint,2,opt,name=lowest_active_index,json=lowestActiveIndex,proto3,oneof" json:"lowest_active_index,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *LogData) Reset() {
@@ -138,6 +140,13 @@ func (x *LogData) GetOperations() []*LogOperation {
 		return x.Operations
 	}
 	return nil
+}
+
+func (x *LogData) GetLowestActiveIndex() uint64 {
+	if x != nil && x.LowestActiveIndex != nil {
+		return *x.LowestActiveIndex
+	}
+	return 0
 }
 
 type IndexValue struct {
@@ -357,11 +366,13 @@ const file_physical_raft_types_proto_rawDesc = "" +
 	"\aop_type\x18\x01 \x01(\rR\x06opType\x12\x14\n" +
 	"\x05flags\x18\x02 \x01(\x04R\x05flags\x12\x10\n" +
 	"\x03key\x18\x03 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x04 \x01(\fR\x05value\"=\n" +
+	"\x05value\x18\x04 \x01(\fR\x05value\"\x8a\x01\n" +
 	"\aLogData\x122\n" +
 	"\n" +
 	"operations\x18\x01 \x03(\v2\x12.raft.LogOperationR\n" +
-	"operations\"6\n" +
+	"operations\x123\n" +
+	"\x13lowest_active_index\x18\x02 \x01(\x04H\x00R\x11lowestActiveIndex\x88\x01\x01B\x16\n" +
+	"\x14_lowest_active_index\"6\n" +
 	"\n" +
 	"IndexValue\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x04R\x04term\x12\x14\n" +
@@ -412,6 +423,7 @@ func file_physical_raft_types_proto_init() {
 	if File_physical_raft_types_proto != nil {
 		return
 	}
+	file_physical_raft_types_proto_msgTypes[1].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/physical/raft/types.proto
+++ b/physical/raft/types.proto
@@ -23,6 +23,9 @@ message LogOperation {
 
 message LogData {
 	repeated LogOperation operations = 1;
+
+	// LowestActiveIndex is optional, the start index of the oldest (therefore lowest) active transaction
+	optional uint64 lowest_active_index = 2;
 }
 
 message IndexValue {

--- a/sdk/helper/pointerutil/pointer.go
+++ b/sdk/helper/pointerutil/pointer.go
@@ -36,3 +36,7 @@ func FileModePtr(o os.FileMode) *os.FileMode {
 func Int64Ptr(i int64) *int64 {
 	return &i
 }
+
+func Ptr[T any](t T) *T {
+	return &t
+}


### PR DESCRIPTION
Backport of #1889

Clean cherry-pick / no conflicts:

```console
$ git cherry-pick 5b350923ae61f9b8155376985c9ab9d7c4a9bfa2
[fix-raft-memory-leak-backport a93d9de1ef] Fix memory leak in raft (#1889)
 Date: Wed Oct 8 09:46:24 2025 +0200
 6 files changed, 80 insertions(+), 33 deletions(-)
 create mode 100644 changelog/1889.txt
```