### PR TITLE
Ensure raft voter operations are handled locally

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -204,6 +204,8 @@ func handler(props *vault.HandlerProperties) http.Handler {
 
 		mux.Handle("/v1/sys/storage/raft/bootstrap", handleSysRaftBootstrap(core))
 		mux.Handle("/v1/sys/storage/raft/join", handleSysRaftJoin(core))
+		mux.Handle("/v1/sys/storage/raft/promote", handleLogicalNoForward(core))
+		mux.Handle("/v1/sys/storage/raft/demote", handleLogicalNoForward(core))
 		mux.Handle("/v1/sys/internal/ui/feature-flags", handleSysInternalFeatureFlags(core))
 
 		for _, path := range injectDataIntoTopRoutes {

--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -145,6 +145,10 @@ This endpoint removes a node from the raft cluster.
 | :----- | :------------------------------ |
 | `POST` | `/sys/storage/raft/remove-peer` |
 
+### Parameters
+
+- `server_id` `(string: <required>)`: id of the server to promote or demote
+
 ### Sample payload
 
 ```json
@@ -172,6 +176,10 @@ may be provided if the node is in a DR secondary cluster.
 |:-------|:----------------------------|
 | `POST` | `/sys/storage/raft/promote` |
 
+### Parameters
+
+- `server_id` `(string: <required>)`: id of the server to promote or demote
+
 ### Sample payload
 
 ```json
@@ -198,6 +206,10 @@ may be provided if the node is in a DR secondary cluster.
 | Method | Path                       |
 |:-------|:---------------------------|
 | `POST` | `/sys/storage/raft/demote` |
+
+### Parameters
+
+- `server_id` `(string: <required>)`: id of the server to promote or demote
 
 ### Sample payload
 


### PR DESCRIPTION
On standby nodes, calls to change voter status are forwarded to the primary, which doesn't help when only non-voters remain. This makes leadership elections unwinnable without modifying `peers.json` directly. This adjust the handler to support being called on standby nodes, to allow directly interacting with the current standby's state.

See also: https://github.com/openbao/openbao/pull/996#issuecomment-3382139174

---

@pree @eyenx Let me know if this helps. I'm not entirely convinced if this will work on standby nodes (do you know off the top of your head @JanMa?), but if it does, it might solve some things. You might need to call this multiple times on each non-voter node:

```
BAO_ADDR=standby1 bao write sys/storage/raft/promote server_id=standby1
BAO_ADDR=standby2 bao write sys/storage/raft/promote server_id=standby1
BAO_ADDR=standby3 bao write sys/storage/raft/promote server_id=standby1

BAO_ADDR=standby1 bao write sys/storage/raft/promote server_id=standby2
BAO_ADDR=standby2 bao write sys/storage/raft/promote server_id=standby2
BAO_ADDR=standby3 bao write sys/storage/raft/promote server_id=standby2

&c
```

to get elections to fully work. 