### PR TITLE
docs: add warning to mount and auth move

### DIFF
--- a/website/content/api-docs/system/remount.mdx
+++ b/website/content/api-docs/system/remount.mdx
@@ -6,12 +6,13 @@ description: >-
 
 # Remount ( API )
 
-The Remount documentation details the endpoints required to trigger and monitor the status of a remount operation.
+The Remount documentation details the endpoints required to trigger and monitor
+the status of a remount operation.
 
 ## Move backend
 
-The `/sys/remount` endpoint moves an already-mounted backend to a new mount point. Remounting works for both secret
-engines and auth methods.
+The `/sys/remount` endpoint moves an already-mounted backend to a new mount
+point. Remounting works for both secret engines and auth methods.
 
 OpenBao returns a migration ID when the remount operation completes. You
 can use the migration ID to look up the status of the mount migration.
@@ -20,17 +21,26 @@ More details about the remount operation are described in
 
 :::warning
 
-Note: This endpoint requires a policy with both `sudo` and `update` capabilities to `sys/remount`
+Note: This endpoint requires a policy with both `sudo` and `update` capabilities
+to `sys/remount`
 
 :::
 
 :::warning
 
-Note: A mount migration will revoke all leases for the secrets of a secrets backend or tokens of an auth backend,
-depending on which type of backend is being moved.
+Note: A mount migration will revoke all leases for the secrets of a secrets
+backend or tokens of an auth backend, depending on which type of backend is
+being moved.
 
 :::
 
+:::warning
+
+Before migrating a mount to a new path, one should ensure it is currently not
+actively used. Using a mount while it's being moved will lead to inconsistent
+reads on standby nodes.
+
+:::
 
 | Method | Path           |
 | :----- | :------------- |
@@ -90,9 +100,10 @@ $ curl \
 ## Monitor migration status
 
 
-This endpoint is used to monitor the status of a mount migration operation, using the ID returned in the response
-of the `sys/remount` call. The response contains the passed-in ID, the source and target mounts, and a status field
-that displays `in-progress`, `success` or `failure`.
+This endpoint is used to monitor the status of a mount migration operation,
+using the ID returned in the response of the `sys/remount` call. The response
+contains the passed-in ID, the source and target mounts, and a status field that
+displays `in-progress`, `success` or `failure`.
 
 | Method | Path           |
 | :----- | :------------- |

--- a/website/content/docs/commands/auth/move.mdx
+++ b/website/content/docs/commands/auth/move.mdx
@@ -8,16 +8,28 @@ description: |-
 
 # auth move
 
-The `auth move` command moves an existing auth method to a new path. Any
-leases from the old auth method are revoked, but all configuration associated
-with the engine is preserved. The command can be issued for a move within or across
+The `auth move` command moves an existing auth method to a new path. Any leases
+from the old auth method are revoked, but all configuration associated with the
+engine is preserved. The command can be issued for a move within or across
 namespaces, using namespace prefixes in the arguments.
 
-The command will trigger a remount operation and uses the returned migration ID to poll the 
-status of the operation until a terminal state of `success` or `failure` is reached.
+The command will trigger a remount operation and uses the returned migration ID
+to poll the status of the operation until a terminal state of `success` or
+`failure` is reached.
 
-**Moving an existing auth method will revoke any leases from the old
-method.**
+:::warning
+
+Moving an existing auth method will revoke any leases from the old method.
+
+:::
+
+:::warning
+
+Before moving an auth method to a new path, one should ensure it is currently
+not actively used. Using an auth method while it's being moved will lead to
+inconsistent reads on standby nodes.
+
+:::
 
 ## Examples
 

--- a/website/content/docs/commands/secrets/move.mdx
+++ b/website/content/docs/commands/secrets/move.mdx
@@ -10,14 +10,26 @@ description: |-
 
 The `secrets move` command moves an existing secrets engine to a new path. Any
 leases from the old secrets engine are revoked, but all configuration associated
-with the engine is preserved. The command can be issued for a move within or across
-namespaces, using namespace prefixes in the arguments.
+with the engine is preserved. The command can be issued for a move within or
+across namespaces, using namespace prefixes in the arguments.
 
-The command will trigger a remount operation and uses the returned migration ID to poll the 
-status of the operation until a terminal state of `success` or `failure` is reached.
+The command will trigger a remount operation and uses the returned migration ID
+to poll the status of the operation until a terminal state of `success` or
+`failure` is reached.
 
-**Moving an existing secrets engine will revoke any leases from the old
-engine.**
+:::warning
+
+Moving an existing secrets engine will revoke any leases from the old engine.
+
+:::
+
+:::warning
+
+Before moving an engine to a new path, one should ensure it is currently not
+actively used. Using an engine while it's being moved will lead to inconsistent
+reads on standby nodes.
+
+:::
 
 ## Examples
 


### PR DESCRIPTION
add warning to not migrate mounts that are actively used.

See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch