### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 5
-      semver-patch-days: 7
-      semver-minor-days: 14
-      semver-major-days: 30
 
   - package-ecosystem: "github-actions"
     directories:
@@ -19,9 +16,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 5
-      semver-patch-days: 7
-      semver-minor-days: 14
-      semver-major-days: 30
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
https://github.com/openbao/openbao/pull/1861 introduced a delay in updates, but
this is not supported by all package ecosystems, which causes Dependabot PRs to
fail right now.