### PR TITLE
Add tlsdebug build tag to log TLS session keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ dev-ui-mem: assetcheck dev-ui
 dev-dynamic-mem: BUILD_TAGS+=memprofiler
 dev-dynamic-mem: dev-dynamic
 
+dev-tlsdebug: BUILD_TAGS+=tlsdebug
+dev-tlsdebug: dev
+
 # Creates a Docker image by adding the compiled linux/amd64 binary found in ./bin.
 # The resulting image is tagged "openbao:dev".
 docker-dev: BUILD_TAGS+=testonly

--- a/helper/tlsdebug/dummy_inject.go
+++ b/helper/tlsdebug/dummy_inject.go
@@ -1,0 +1,13 @@
+//go:build !tlsdebug
+
+package tlsdebug
+
+import (
+	"crypto/tls"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func Inject(_ hclog.Logger, config *tls.Config) *tls.Config {
+	return config
+}

--- a/helper/tlsdebug/inject.go
+++ b/helper/tlsdebug/inject.go
@@ -1,0 +1,31 @@
+//go:build tlsdebug
+
+package tlsdebug
+
+import (
+	"crypto/tls"
+	"os"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+var openKeyLogFile = sync.OnceValues(func() (*os.File, error) {
+	return os.CreateTemp("", "openbao_tls_session_key_log_")
+})
+
+func Inject(logger hclog.Logger, config *tls.Config) *tls.Config {
+	if config == nil {
+		return nil
+	}
+
+	file, err := openKeyLogFile()
+	if err != nil {
+		logger.Error("could not open TLS key log file", "error", err)
+	}
+
+	logger.Warn("injecting session key logger into TLS config", "log_file", file.Name())
+	config.KeyLogWriter = file
+
+	return config
+}

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/helper/tlsdebug"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 
 	log "github.com/hashicorp/go-hclog"
@@ -259,14 +260,14 @@ func (cl *Listener) TLSConfig(ctx context.Context) (*tls.Config, error) {
 		return nil, errors.New("unsupported protocol")
 	}
 
-	return &tls.Config{
+	return tlsdebug.Inject(cl.logger, &tls.Config{
 		ClientAuth:           tls.RequireAndVerifyClientCert,
 		GetCertificate:       serverLookup,
 		GetClientCertificate: clientLookup,
 		GetConfigForClient:   serverConfigLookup,
 		MinVersion:           tls.VersionTLS12,
 		CipherSuites:         cl.cipherSuites,
-	}, nil
+	}), nil
 }
 
 // Run starts the tcp listeners and will accept connections until stop is

--- a/website/content/docs/contributing/packaging.mdx
+++ b/website/content/docs/contributing/packaging.mdx
@@ -91,10 +91,11 @@ The following flags **SHOULD NOT** be used in a release version:
 
 | Tag | Effect |
 | :-- | :----- |
-| `memprofiler` | Includes a memory profiler in the release binary for debugging purposes only. |
-| `testonly`    | Includes insecure custom hooks only for testing purposes.                     |
 | `deadlock`    | Includes deadlock detection during testing.                                   |
+| `memprofiler` | Includes a memory profiler in the release binary for debugging purposes only. |
 | `race`        | Enabled for race testing.                                                     |
+| `testonly`    | Includes insecure custom hooks only for testing purposes.                     |
+| `tlsdebug`    | Enables TLS session key dumping, e.g. for debugging with Wireshark.           |
 
 :::
 


### PR DESCRIPTION
This enables decrypting TLS traffic e.g. with Wireshark (see https://wiki.wireshark.org/TLS#using-the-pre-master-secret), which can be useful for debugging.

It can be enabled with `dev-tlsdebug` or by setting the `tlsdebug` build tag using another method.

The path of the tls session key log file will be printed to the log.

It tested it for request forwarding and raft internal communication. Any connection that wants to make use of this has to call `tlsdebug.Inject` passing its `tls.Config` as a parameter (which is a no-op when tlsdebug is disabled). I didn't do this for other tls contexts like the ACME plugin as I have no experience on how to test this.