### PR TITLE
feat(valkey): Support connection_url for configuration

### DIFF
--- a/changelog/1923.txt
+++ b/changelog/1923.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+database/valkey: Adds the ability to configure the Valkey database connection using a single connection_url parameter.
+```

--- a/plugins/database/valkey/valkey_test.go
+++ b/plugins/database/valkey/valkey_test.go
@@ -132,6 +132,7 @@ func TestDriver(t *testing.T) {
 
 	t.Run("Init", func(t *testing.T) { testValkeyDBInitialize_NoTLS(t, host, port) })
 	t.Run("Init", func(t *testing.T) { testValkeyDBInitialize_TLS(t, host, port) })
+	t.Run("Init", func(t *testing.T) { testValkeyDBInitialize_ConnectionURL(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testValkeyDBCreateUser(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testValkeyDBCreateUser_DefaultRule(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testValkeyDBCreateUser_plusRole(t, host, port) })
@@ -210,6 +211,23 @@ func testValkeyDBInitialize_TLS(t *testing.T, host string, port int) {
 	err = setupValkeyDBInitialize(t, connectionDetails)
 	if err != nil {
 		t.Fatalf("Testing TLS Init() failed: error: %s", err)
+	}
+}
+
+func testValkeyDBInitialize_ConnectionURL(t *testing.T, host string, port int) {
+	if valkeyTls {
+		t.Skip("skipping plain text Init() test in TLS mode")
+	}
+
+	t.Log("Testing Connection URL Init()")
+
+	connectionURL := fmt.Sprintf("valkey://%s:%s@%s:%d", adminUsername, adminPassword, host, port)
+	connectionDetails := map[string]interface{}{
+		"connection_url": connectionURL,
+	}
+	err := setupValkeyDBInitialize(t, connectionDetails)
+	if err != nil {
+		t.Fatalf("Testing Init() with connection_url failed: error: %s", err)
 	}
 }
 


### PR DESCRIPTION
Adds the ability to configure the Valkey database connection using a single `connection_url` parameter. This provides a unified and convenient alternative to specifying individual parameters like `host`, `port`, `username`, and `password`.

A new test case is added to validate the initialization via `connection_url`.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1812
