### PR TITLE
KV engine returns timestamp strings in RFC3339Nano format (#1872)

### DIFF
--- a/builtin/logical/kv/backend.go
+++ b/builtin/logical/kv/backend.go
@@ -439,7 +439,7 @@ func ptypesTimestampToString(t *timestamppb.Timestamp) string {
 		return ""
 	}
 
-	return t.AsTime().Format(time.RFC3339)
+	return t.AsTime().Format(time.RFC3339Nano)
 }
 
 var backendHelp string = `

--- a/changelog/1872.txt
+++ b/changelog/1872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/kv: KV entries timestamps are now correctly formatted in `RFC3339Nano`, as previously done so.
+```


### PR DESCRIPTION
Backport of #1872 by @wslabosz-reply 

Clean cherry-pick