### PR TITLE
Namespace rotation CLI commands

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -85,7 +85,7 @@ func testVaultServerWithNamespace(tb testing.TB, name string, sealed bool) (*api
 			CustomMetadata: nil,
 			Seals: []map[string]interface{}{{
 				"type":             "shamir",
-				"secret_shares":    3,
+				"secret_shares":    2,
 				"secret_threshold": 2,
 			}},
 		})

--- a/command/commands.go
+++ b/command/commands.go
@@ -354,6 +354,21 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace key-status": func() (cli.Command, error) {
+			return &NamespaceKeyStatusCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"namespace rotate": func() (cli.Command, error) {
+			return &NamespaceRotateCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"namespace rotate-keys": func() (cli.Command, error) {
+			return &NamespaceRotateKeysCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"namespace generate-root": func() (cli.Command, error) {
 			return &NamespaceGenerateRootCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace.go
+++ b/command/namespace.go
@@ -67,6 +67,18 @@ Usage: bao namespace <subcommand> [options] [args]
 
       $ bao namespace unseal
 
+  Check the active encryption key status of the namespace:
+
+      $ bao namespace key-status
+
+  Rotate the underlying namespace encryption key:
+
+      $ bao namespace rotate
+
+  Rotate unseal keys for a namespace:
+
+      $ bao namespace rotate-keys
+
   Generate the root token for a sealable namespace:
 
       $ bao namespace generate-root

--- a/command/namespace_key_status.go
+++ b/command/namespace_key_status.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceKeyStatusCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceKeyStatusCommand)(nil)
+)
+
+type NamespaceKeyStatusCommand struct {
+	*BaseCommand
+}
+
+func (c *NamespaceKeyStatusCommand) Synopsis() string {
+	return "Provides information about the active encryption key of a namespace"
+}
+
+func (c *NamespaceKeyStatusCommand) Help() string {
+	helpText := `
+Usage: bao namespace key-status [options] PATH
+
+  Provides information about the namespace active encryption key.
+  Specifically, the current key term and the key installation time.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceKeyStatusCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+}
+
+func (c *NamespaceKeyStatusCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *NamespaceKeyStatusCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceKeyStatusCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) < 1 {
+		c.UI.Error("Not enough arguments (expected 1, got 0)")
+		return 1
+	}
+	if len(args) > 1 {
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	status, err := client.Sys().NamespaceKeyStatus(args[0])
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading key status: %s", err))
+		return 2
+	}
+
+	switch Format(c.UI) {
+	case "table":
+		c.UI.Output(printKeyStatus(status))
+		return 0
+	default:
+		return OutputData(c.UI, status)
+	}
+}

--- a/command/namespace_key_status_test.go
+++ b/command/namespace_key_status_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func testNamespaceKeyStatusCommand(tb testing.TB) (*cli.MockUi, *NamespaceKeyStatusCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceKeyStatusCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceKeyStatusCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"no_namespace_existing",
+			[]string{"unknown"},
+			"doesn't exist",
+			2,
+		},
+		{
+			"happy path",
+			[]string{nsName},
+			"Key Term",
+			0,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+				defer closer()
+
+				ui, cmd := testNamespaceKeyStatusCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+			})
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceKeyStatusCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_rotate.go
+++ b/command/namespace_rotate.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceRotateCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceRotateCommand)(nil)
+)
+
+type NamespaceRotateCommand struct {
+	*BaseCommand
+}
+
+func (c *NamespaceRotateCommand) Synopsis() string {
+	return "Rotates the underlying namespace encryption key"
+}
+
+func (c *NamespaceRotateCommand) Help() string {
+	helpText := `
+Usage: bao namespace rotate [options] PATH
+
+  Rotates the underlying namespace encryption key which is used to secure data
+  written to the storage backend. This installs a new key in the keyring. This
+  new key is used to encrypted new data, while older keys in the keyring are
+  used to decrypt older data.
+
+  Rotate namespace encryption key:
+
+      $ bao namespace rotate PATH
+
+  For a full list of examples, please see the documentation.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceRotateCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+}
+
+func (c *NamespaceRotateCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *NamespaceRotateCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceRotateCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) < 1 {
+		c.UI.Error("Not enough arguments (expected 1, got 0)")
+		return 1
+	}
+	if len(args) > 1 {
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	err = client.Sys().NamespaceRotateKeyring(args[0])
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error rotating keyring: %s", err))
+		return 2
+	}
+
+	status, err := client.Sys().NamespaceKeyStatus(args[0])
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading key status: %s", err))
+		return 2
+	}
+
+	switch Format(c.UI) {
+	case "table":
+		c.UI.Output("Success! Rotated encryption key")
+		c.UI.Output("")
+		c.UI.Output(printKeyStatus(status))
+		return 0
+	default:
+		return OutputData(c.UI, status)
+	}
+}

--- a/command/namespace_rotate_keys.go
+++ b/command/namespace_rotate_keys.go
@@ -1,0 +1,686 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/fatih/structs"
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/go-secure-stdlib/password"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/helper/pgpkeys"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceRotateKeysCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceRotateKeysCommand)(nil)
+)
+
+type NamespaceRotateKeysCommand struct {
+	*BaseCommand
+
+	flagCancel       bool
+	flagInit         bool
+	flagKeyShares    int
+	flagKeyThreshold int
+	flagNonce        string
+	flagPGPKeys      []string
+	flagStatus       bool
+	flagVerify       bool
+
+	// Backup options
+	flagBackup         bool
+	flagBackupDelete   bool
+	flagBackupRetrieve bool
+
+	testStdin io.Reader // for tests
+}
+
+func (c *NamespaceRotateKeysCommand) Synopsis() string {
+	return "Generates new unseal keys for a namespace"
+}
+
+func (c *NamespaceRotateKeysCommand) Help() string {
+	helpText := `
+Usage: bao namespace rotate-keys [options] PATH [KEY]
+
+  Generates a new set of unseal keys for a namespace. This can optionally
+  change the total number of key shares or the required threshold of those 
+  key shares to reconstruct the namespace root key. This operation is zero
+  downtime, but it requires that the OpenBao instance and the namespace is
+  unsealed and a quorum of existing unseal keys are provided.
+
+  An unseal key may be provided directly on the command line as an argument to
+  the command. If key is specified as "-", the command will read from stdin. If
+  a TTY is available, the command will prompt for text.
+
+  Initialize a rotation:
+
+      $ bao namespace rotate-keys \
+          -init \
+          -key-shares=15 \
+          -key-threshold=9
+
+  Rotate and encrypt the resulting unseal keys with PGP:
+
+      $ bao namespace rotate-keys \
+          -init \
+          -key-shares=3 \
+          -key-threshold=2 \
+          -pgp-keys="keybase:hashicorp,keybase:jefferai,keybase:sethvargo"
+
+  Store encrypted PGP keys in OpenBao's core:
+
+      $ bao namespace rotate-keys \
+          -init \
+          -pgp-keys="..." \
+          -backup
+
+  Retrieve backed-up unseal keys:
+
+      $ bao namespace rotate-keys -backup-retrieve
+
+  Delete backed-up unseal keys:
+
+      $ bao namespace rotate-keys -backup-delete
+
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceRotateKeysCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+	f := set.NewFlagSet("Common Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "init",
+		Target:  &c.flagInit,
+		Default: false,
+		Usage: "Initialize the rotation. This can only be done if there's not " +
+			"one in progress. Customize the new number of key shares and threshold " +
+			"using the -key-shares and -key-threshold flags respectively.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "cancel",
+		Target:  &c.flagCancel,
+		Default: false,
+		Usage: "Reset the rotation progress. This will discard any submitted " +
+			"unseal keys, recovery keys, or configuration.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "status",
+		Target:  &c.flagStatus,
+		Default: false,
+		Usage: "Print the status of the current attempt without providing an " +
+			"unseal or recovery key.",
+	})
+
+	f.IntVar(&IntVar{
+		Name:       "key-shares",
+		Aliases:    []string{"n"},
+		Target:     &c.flagKeyShares,
+		Default:    5,
+		Completion: complete.PredictAnything,
+		Usage: "Number of key shares to split the generated root key into. " +
+			"This is the number of \"unseal keys\" or \"recovery keys\" to generate.",
+	})
+
+	f.IntVar(&IntVar{
+		Name:       "key-threshold",
+		Aliases:    []string{"t"},
+		Target:     &c.flagKeyThreshold,
+		Default:    3,
+		Completion: complete.PredictAnything,
+		Usage: "Number of key shares required to reconstruct the root key. " +
+			"This must be less than or equal to -key-shares.",
+	})
+
+	f.StringVar(&StringVar{
+		Name:       "nonce",
+		Target:     &c.flagNonce,
+		Default:    "",
+		EnvVar:     "",
+		Completion: complete.PredictAnything,
+		Usage: "Nonce value provided at initialization. The same nonce value " +
+			"must be provided with each unseal or recovery key.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "verify",
+		Target:  &c.flagVerify,
+		Default: false,
+		Usage: "Indicates that the action (-status, -cancel, or providing a key " +
+			"share) will be affecting verification for the current rotation " +
+			"attempt.",
+	})
+
+	f.VarFlag(&VarFlag{
+		Name:       "pgp-keys",
+		Value:      (*pgpkeys.PubKeyFilesFlag)(&c.flagPGPKeys),
+		Completion: complete.PredictAnything,
+		Usage: "Comma-separated list of paths to files on disk containing " +
+			"public PGP keys OR a comma-separated list of Keybase usernames using " +
+			"the format \"keybase:<username>\". When supplied, the generated " +
+			"unseal or recovery keys will be encrypted and base64-encoded in the order " +
+			"specified in this list.",
+	})
+
+	f = set.NewFlagSet("Backup Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "backup",
+		Target:  &c.flagBackup,
+		Default: false,
+		Usage: "Store a backup of the current PGP encrypted unseal or recovery keys in " +
+			"OpenBao's core. The encrypted values can be recovered in the event of " +
+			"failure or discarded after success. See the -backup-delete and " +
+			"-backup-retrieve options for more information. This option only " +
+			"applies when the existing unseal or recovery keys were PGP encrypted.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "backup-delete",
+		Target:  &c.flagBackupDelete,
+		Default: false,
+		Usage:   "Delete any stored backup unseal or recovery keys.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "backup-retrieve",
+		Target:  &c.flagBackupRetrieve,
+		Default: false,
+		Usage: "Retrieve the backed-up unseal or recovery keys. This option is only available " +
+			"if the PGP keys were provided and the backup has not been deleted.",
+	})
+
+	return set
+}
+
+func (c *NamespaceRotateKeysCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *NamespaceRotateKeysCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceRotateKeysCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) < 1 {
+		c.UI.Error("Not enough arguments (expected 1-2, got 0)")
+		return 1
+	}
+	if len(args) > 2 {
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1-2, got %d)", len(args)))
+		return 1
+	}
+	namespaceName := args[0]
+
+	// Create the client
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	switch {
+	case c.flagBackupDelete:
+		return c.backupDelete(client, namespaceName)
+	case c.flagBackupRetrieve:
+		return c.backupRetrieve(client, namespaceName)
+	case c.flagCancel:
+		return c.cancel(client, namespaceName)
+	case c.flagInit:
+		return c.init(client, namespaceName)
+	case c.flagStatus:
+		return c.status(client, namespaceName)
+	default:
+		// If there are no other flags, prompt for an unseal key.
+		key := ""
+		if len(args) > 1 {
+			key = strings.TrimSpace(args[1])
+		}
+		return c.provide(client, namespaceName, key)
+	}
+}
+
+// init starts the rotation process.
+func (c *NamespaceRotateKeysCommand) init(client *api.Client, name string) int {
+	resp, err := client.Sys().NamespaceRotateRootInit(name, &api.RotateInitRequest{
+		SecretShares:        c.flagKeyShares,
+		SecretThreshold:     c.flagKeyThreshold,
+		PGPKeys:             c.flagPGPKeys,
+		Backup:              c.flagBackup,
+		RequireVerification: c.flagVerify,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error initializing rotation: %s", err))
+		return 2
+	}
+
+	if resp.Complete {
+		// if the rotation is complete, meaning we've immediately
+		// returned the unseal keys, print them out
+		if len(c.flagPGPKeys) == 0 {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength(
+					"WARNING! If you lose the keys, there " +
+						"is no recovery. Consider rerunning this operation and " +
+						"re-initializing with the -pgp-keys flag to protect the " +
+						"returned unseal keys along with -backup to allow recovery " +
+						"of the encrypted keys in case of emergency. You can " +
+						"delete the stored keys later using the -delete flag.",
+				))
+				c.UI.Output("")
+			}
+		}
+		if len(c.flagPGPKeys) > 0 && !c.flagBackup {
+			if Format(c.UI) == "table" {
+				c.UI.Warn(wrapAtLength("WARNING! You've used PGP keys for " +
+					"encryption of the resulting %s keys, but you did not " +
+					"enable the option to backup the keys to OpenBao's core. " +
+					"If you lose the encrypted keys you will not be able to " +
+					"recover them. Consider rerunning this operation and " +
+					"re-initializing with -backup to allow recovery of the " +
+					"encrypted unseal keys in case of emergency. You can " +
+					"delete the stored keys later using the -delete flag.",
+				))
+				c.UI.Output("")
+			}
+		}
+
+		return c.printUnsealKeys(client, name, resp, &api.RotateUpdateResponse{
+			Complete:        resp.Complete,
+			Keys:            resp.Keys,
+			KeysB64:         resp.KeysB64,
+			Backup:          resp.Backup,
+			PGPFingerprints: resp.PGPFingerprints,
+		})
+	}
+
+	// Print warnings about recovery, etc.
+	if len(c.flagPGPKeys) == 0 {
+		if Format(c.UI) == "table" {
+			c.UI.Warn(wrapAtLength("WARNING! If you lose the keys after they are " +
+				"returned, there is no recovery. Consider canceling this " +
+				"operation and re-initializing with the -pgp-keys flag to protect " +
+				"the returned %s keys along with -backup to allow recovery of the " +
+				"encrypted keys in case of emergency. You can delete the stored " +
+				"keys later using the -delete flag.",
+			))
+			c.UI.Output("")
+		}
+	}
+	if len(c.flagPGPKeys) > 0 && !c.flagBackup {
+		if Format(c.UI) == "table" {
+			c.UI.Warn(wrapAtLength("WARNING! You are using PGP keys for encryption " +
+				"of resulting %s keys, but you did not enable the option to backup " +
+				"the keys to OpenBao's core. If you lose the encrypted keys after " +
+				"they are returned, you will not be able to recover them. Consider " +
+				"canceling this operation and re-running with -backup to allow " +
+				"recovery of the encrypted unseal keys in case of emergency. You " +
+				"can delete the stored keys later using the -delete flag.",
+			))
+			c.UI.Output("")
+		}
+	}
+
+	return c.printStatus(resp)
+}
+
+// cancel is used to abort the rotation process.
+func (c *NamespaceRotateKeysCommand) cancel(client *api.Client, name string) int {
+	if err := client.Sys().NamespaceRotateRootCancel(name); err != nil {
+		c.UI.Error(fmt.Sprintf("Error canceling rotation: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Success! Canceled rotation (if it was started)")
+	return 0
+}
+
+// provide prompts the user for the seal key and posts it to the update root
+// endpoint. If this is the last unseal, this function outputs it.
+func (c *NamespaceRotateKeysCommand) provide(client *api.Client, namespaceName, key string) int {
+	var statusFn func(string) (interface{}, error)
+	var updateFn func(string, string, string) (interface{}, error)
+	if c.flagVerify {
+		statusFn = func(name string) (interface{}, error) {
+			return client.Sys().NamespaceRotateRootVerificationStatus(name)
+		}
+		updateFn = func(name, shard, nonce string) (interface{}, error) {
+			return client.Sys().NamespaceRotateRootVerificationUpdate(name, shard, nonce)
+		}
+	} else {
+		statusFn = func(name string) (interface{}, error) {
+			return client.Sys().NamespaceRotateRootStatus(name)
+		}
+		updateFn = func(name, shard, nonce string) (interface{}, error) {
+			return client.Sys().NamespaceRotateRootUpdate(name, shard, nonce)
+		}
+	}
+
+	status, err := statusFn(namespaceName)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error getting rotation status: %s", err))
+		return 2
+	}
+
+	var started bool
+	var nonce string
+
+	switch status := status.(type) {
+	case *api.RotateStatusResponse:
+		stat := status
+		started = stat.Started
+		nonce = stat.Nonce
+	case *api.RotateVerificationStatusResponse:
+		stat := status
+		started = stat.Started
+		nonce = stat.Nonce
+	default:
+		c.UI.Error("Unknown status type")
+		return 1
+	}
+
+	// Verify a root token generation is in progress. If there is not one in
+	// progress, return an error instructing the user to start one.
+	if !started {
+		c.UI.Error(wrapAtLength(
+			"No rotation is in progress. Start a rotation process by running " +
+				"\"bao namespace rotate-keys -init\"."))
+		return 1
+	}
+
+	switch key {
+	case "-": // Read from stdin
+		nonce = c.flagNonce
+
+		// Pull our fake stdin if needed
+		stdin := (io.Reader)(os.Stdin)
+		if c.testStdin != nil {
+			stdin = c.testStdin
+		}
+		if c.flagNonInteractive {
+			stdin = bytes.NewReader(nil)
+		}
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, stdin); err != nil {
+			c.UI.Error(fmt.Sprintf("Failed to read from stdin: %s", err))
+			return 1
+		}
+
+		key = buf.String()
+	case "": // Prompt using the tty
+		// Nonce value is not required if we are prompting via the terminal
+		if c.flagNonInteractive {
+			c.UI.Error(wrapAtLength("Refusing to read from stdin with -non-interactive specified; specify nonce via the -nonce flag"))
+			return 1
+		}
+
+		w := getWriterFromUI(c.UI)
+		_, err := fmt.Fprintf(w, "rotation nonce: %s\n", nonce)
+		if err != nil {
+			c.UI.Error("failed to output rotation nonce")
+		}
+
+		_, err = fmt.Fprint(w, "Unseal Key (will be hidden): \n")
+		if err != nil {
+			c.UI.Error("failed to output key type")
+		}
+
+		key, err = password.Read(os.Stdin)
+		if err != nil {
+			if err == password.ErrInterrupted {
+				c.UI.Error("user canceled")
+				return 1
+			}
+
+			c.UI.Error(wrapAtLength(fmt.Sprintf("An error occurred attempting to "+
+				"ask for the unseal key. The raw error message is shown below, but "+
+				"usually this is because you attempted to pipe a value into the "+
+				"command or you are executing outside of a terminal (tty). If you "+
+				"want to pipe the value, pass \"-\" as the argument to read from "+
+				"stdin. The raw error was: %s", err)))
+			return 1
+		}
+	default: // Supplied directly as an arg
+		nonce = c.flagNonce
+	}
+
+	// Trim any whitespace from they key, especially since we might have
+	// prompted the user for it.
+	key = strings.TrimSpace(key)
+
+	// Verify we have a nonce value
+	if nonce == "" {
+		c.UI.Error("Missing nonce value: specify it via the -nonce flag")
+		return 1
+	}
+
+	// Provide the key, this may potentially complete the update
+	resp, err := updateFn(namespaceName, key, nonce)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error posting unseal key: %s", err))
+		return 2
+	}
+
+	var complete bool
+	var mightContainUnsealKeys bool
+
+	switch resp := resp.(type) {
+	case *api.RotateUpdateResponse:
+		complete = resp.Complete
+		mightContainUnsealKeys = true
+	case *api.RotateVerificationUpdateResponse:
+		complete = resp.Complete
+	default:
+		c.UI.Error("Unknown update response type")
+		return 1
+	}
+
+	if !complete {
+		return c.status(client, namespaceName)
+	}
+
+	if mightContainUnsealKeys {
+		return c.printUnsealKeys(client, namespaceName, status.(*api.RotateStatusResponse),
+			resp.(*api.RotateUpdateResponse))
+	}
+
+	c.UI.Output(wrapAtLength("Rotation verification successful. The rotation is complete and the new keys are now active."))
+	return 0
+}
+
+// status is used just to fetch and dump the status.
+func (c *NamespaceRotateKeysCommand) status(client *api.Client, name string) int {
+	status, err := client.Sys().NamespaceRotateRootStatus(name)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading rotate status: %s", err))
+		return 2
+	}
+
+	return c.printStatus(status)
+}
+
+// backupRetrieve retrieves the stored backup keys.
+func (c *NamespaceRotateKeysCommand) backupRetrieve(client *api.Client, name string) int {
+	storedKeys, err := client.Sys().NamespaceRotateRootRetrieveBackup(name)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error retrieving rotation stored keys: %s", err))
+		return 2
+	}
+
+	secret := &api.Secret{
+		Data: structs.New(storedKeys).Map(),
+	}
+
+	return OutputSecret(c.UI, secret)
+}
+
+// backupDelete deletes the stored backup keys.
+func (c *NamespaceRotateKeysCommand) backupDelete(client *api.Client, name string) int {
+	if err := client.Sys().NamespaceRotateRootDeleteBackup(name); err != nil {
+		c.UI.Error(fmt.Sprintf("Error deleting rotation stored keys: %s", err))
+		return 2
+	}
+
+	c.UI.Output("Success! Deleted stored keys (if they existed)")
+	return 0
+}
+
+// printStatus dumps the status to output
+func (c *NamespaceRotateKeysCommand) printStatus(in interface{}) int {
+	out := []string{}
+	out = append(out, "Key | Value")
+
+	switch in := in.(type) {
+	case *api.RotateStatusResponse:
+		status := in
+		out = append(out, fmt.Sprintf("Nonce | %s", status.Nonce))
+		out = append(out, fmt.Sprintf("Started | %t", status.Started))
+		if status.Started {
+			if status.Progress == status.Required {
+				out = append(out, fmt.Sprintf("Rotation Progress | %d/%d (verification in progress)", status.Progress, status.Required))
+			} else {
+				out = append(out, fmt.Sprintf("Rotation Progress | %d/%d", status.Progress, status.Required))
+			}
+			out = append(out, fmt.Sprintf("New Shares | %d", status.N))
+			out = append(out, fmt.Sprintf("New Threshold | %d", status.T))
+			out = append(out, fmt.Sprintf("Verification Required | %t", status.VerificationRequired))
+			if status.VerificationNonce != "" {
+				out = append(out, fmt.Sprintf("Verification Nonce | %s", status.VerificationNonce))
+			}
+		}
+		if len(status.PGPFingerprints) > 0 {
+			out = append(out, fmt.Sprintf("PGP Fingerprints | %s", status.PGPFingerprints))
+			out = append(out, fmt.Sprintf("Backup | %t", status.Backup))
+		}
+	case *api.RotateVerificationStatusResponse:
+		status := in
+		out = append(out, fmt.Sprintf("Started | %t", status.Started))
+		out = append(out, fmt.Sprintf("New Shares | %d", status.N))
+		out = append(out, fmt.Sprintf("New Threshold | %d", status.T))
+		out = append(out, fmt.Sprintf("Verification Nonce | %s", status.Nonce))
+		out = append(out, fmt.Sprintf("Verification Progress | %d/%d", status.Progress, status.T))
+	default:
+		c.UI.Error("Unknown status type")
+		return 1
+	}
+
+	switch Format(c.UI) {
+	case "table":
+		c.UI.Output(tableOutput(out, nil))
+		return 0
+	default:
+		return OutputData(c.UI, in)
+	}
+}
+
+func (c *NamespaceRotateKeysCommand) printUnsealKeys(client *api.Client, name string, status *api.RotateStatusResponse, resp *api.RotateUpdateResponse) int {
+	switch Format(c.UI) {
+	case "table":
+	default:
+		return OutputData(c.UI, resp)
+	}
+
+	// Space between the key prompt, if any, and the output
+	c.UI.Output("")
+
+	// Provide the keys
+	var haveB64 bool
+	if resp.KeysB64 != nil && len(resp.KeysB64) == len(resp.Keys) {
+		haveB64 = true
+	}
+	for i, key := range resp.Keys {
+		if len(resp.PGPFingerprints) > 0 {
+			if haveB64 {
+				c.UI.Output(fmt.Sprintf("Key %d fingerprint: %s; value: %s", i+1, resp.PGPFingerprints[i], resp.KeysB64[i]))
+			} else {
+				c.UI.Output(fmt.Sprintf("Key %d fingerprint: %s; value: %s", i+1, resp.PGPFingerprints[i], key))
+			}
+		} else {
+			if haveB64 {
+				c.UI.Output(fmt.Sprintf("Key %d: %s", i+1, resp.KeysB64[i]))
+			} else {
+				c.UI.Output(fmt.Sprintf("Key %d: %s", i+1, key))
+			}
+		}
+	}
+
+	if resp.Nonce != "" {
+		c.UI.Output("")
+		c.UI.Output(fmt.Sprintf("Operation nonce: %s", resp.Nonce))
+	}
+
+	if len(resp.PGPFingerprints) > 0 && resp.Backup {
+		c.UI.Output("")
+		c.UI.Output(wrapAtLength(fmt.Sprintf(
+			"The encrypted unseal keys are backed up to \"core/unseal-keys-backup\" " +
+				"in the storage backend. Remove these keys at any time using " +
+				"\"bao namespace rotate-keys -backup-delete\". OpenBao does not automatically " +
+				"remove these keys.",
+		)))
+	}
+
+	switch status.VerificationRequired {
+	case false:
+		c.UI.Output("")
+		c.UI.Output(wrapAtLength(fmt.Sprintf(
+			"Namespace unseal keys rotated to %d key shares and a key threshold of %d. Please "+
+				"securely distribute the key shares printed above. When namespace is "+
+				"re-sealed, restarted, or stopped, you must supply at least %d of "+
+				"these keys to unseal it before it can start servicing requests.",
+			status.N,
+			status.T,
+			status.T)))
+
+	default:
+		c.UI.Output("")
+
+		c.UI.Output(wrapAtLength(fmt.Sprintf(
+			"OpenBao has created a new unseal key, split into %d key shares and a key threshold "+
+				"of %d. These will not be active until after verification is complete. "+
+				"Please securely distribute the key shares printed above. When namespace "+
+				"is re-sealed, restarted, or stopped, you must supply at least %d of "+
+				"these keys to unseal it before it can start servicing requests.",
+			status.N,
+			status.T,
+			status.T)))
+
+		c.UI.Output("")
+		c.UI.Warn(wrapAtLength(
+			"Again, these key shares are _not_ valid until verification is performed. " +
+				"Do not lose or discard your current key shares until after verification " +
+				"is complete or you will be unable to unseal namespace. If you cancel the " +
+				"rotation process or seal namespace before verification is complete the new " +
+				"shares will be discarded and the current shares will remain valid."))
+		c.UI.Output("")
+		c.UI.Warn(wrapAtLength(
+			"The current verification status, including initial nonce, is shown below.",
+		))
+		c.UI.Output("")
+
+		c.flagVerify = true
+		return c.status(client, name)
+	}
+
+	return 0
+}

--- a/command/namespace_rotate_keys_test.go
+++ b/command/namespace_rotate_keys_test.go
@@ -1,0 +1,460 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !race
+
+package command
+
+import (
+	"io"
+	"regexp"
+	"testing"
+
+	"github.com/openbao/openbao/api/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceRotateKeysCommand(tb testing.TB) (*cli.MockUi, *NamespaceRotateKeysCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceRotateKeysCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceRotateKeysCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"too_many_args",
+			[]string{"foo", "bar", "baz"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"no_namespace_existing",
+			[]string{"unknown"},
+			"doesn't exist",
+			2,
+		},
+		{
+			"pgp_keys_multi",
+			[]string{
+				"-init",
+				"-pgp-keys", "keybase:hashicorp",
+				"-pgp-keys", "keybase:jefferai",
+				nsName,
+			},
+			"can only be specified once",
+			1,
+		},
+		{
+			"key_shares_pgp_less",
+			[]string{
+				"-init",
+				"-key-shares", "10",
+				"-pgp-keys", "keybase:jefferai,keybase:sethvargo",
+				nsName,
+			},
+			"count mismatch",
+			2,
+		},
+		{
+			"key_shares_pgp_more",
+			[]string{
+				"-init",
+				"-key-shares", "1",
+				"-key-threshold", "1",
+				"-pgp-keys", "keybase:jefferai,keybase:sethvargo",
+				nsName,
+			},
+			"count mismatch",
+			2,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+				defer closer()
+
+				ui, cmd := testNamespaceRotateKeysCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+			})
+		}
+	})
+
+	t.Run("status", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		// Verify the non-init response
+		code := cmd.Run([]string{
+			"-status",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		combined := ui.OutputWriter.String()
+		require.Contains(t, combined, "Nonce")
+
+		// Now init to verify the init response
+		_, err := client.Sys().NamespaceRotateRootInit(nsName,
+			&api.RotateInitRequest{
+				SecretShares:    1,
+				SecretThreshold: 1,
+			})
+		require.NoError(t, err)
+
+		// Verify the init response
+		ui, cmd = testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+		code = cmd.Run([]string{
+			"-status",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		combined = ui.OutputWriter.String()
+		require.Contains(t, combined, "Progress")
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		// Initialize rotation
+		_, err := client.Sys().NamespaceRotateRootInit(nsName,
+			&api.RotateInitRequest{
+				SecretShares:    1,
+				SecretThreshold: 1,
+			})
+		require.NoError(t, err)
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-cancel",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		require.Contains(t, combined, "Success! Canceled rotation")
+
+		status, err := client.Sys().NamespaceGenerateRootStatus(nsName)
+		require.NoError(t, err)
+		require.False(t, status.Started)
+	})
+
+	t.Run("init", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-init",
+			"-key-shares", "1",
+			"-key-threshold", "1",
+			nsName,
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d: %s", code, exp, ui.ErrorWriter.String())
+		}
+
+		combined := ui.OutputWriter.String()
+		require.Contains(t, combined, "Nonce")
+
+		status, err := client.Sys().NamespaceRotateRootStatus(nsName)
+		require.NoError(t, err)
+		require.True(t, status.Started)
+	})
+
+	t.Run("init_pgp", func(t *testing.T) {
+		t.Parallel()
+
+		pgpKey := "keybase:hashicorp"
+		pgpFingerprints := []string{"c874011f0ab405110d02105534365d9472d7468f"}
+
+		client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-init",
+			"-key-shares", "1",
+			"-key-threshold", "1",
+			"-pgp-keys", pgpKey,
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		combined := ui.OutputWriter.String()
+		require.Contains(t, combined, "Nonce")
+
+		status, err := client.Sys().NamespaceRotateRootStatus(nsName)
+		require.NoError(t, err)
+		require.True(t, status.Started)
+		require.ElementsMatch(t, status.PGPFingerprints, pgpFingerprints)
+	})
+
+	t.Run("provide_arg", func(t *testing.T) {
+		t.Parallel()
+
+		client, keys, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		// Initialize rotation
+		status, err := client.Sys().NamespaceRotateRootInit(nsName,
+			&api.RotateInitRequest{
+				SecretShares:    1,
+				SecretThreshold: 1,
+			})
+		require.NoError(t, err)
+		nonce := status.Nonce
+
+		// Supply the first n-1 unseal keys
+		for _, key := range keys[:len(keys)-1] {
+			ui, cmd := testNamespaceRotateKeysCommand(t)
+			cmd.client = client
+			code := cmd.Run([]string{
+				"-nonce", nonce,
+				nsName,
+				key,
+			})
+			require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+		}
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-nonce", nonce,
+			nsName,
+			keys[len(keys)-1], // the last unseal key
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		re := regexp.MustCompile(`Key 1: (.+)`)
+		output := ui.OutputWriter.String()
+		match := re.FindAllStringSubmatch(output, -1)
+		require.False(t, len(match) < 1 || len(match[0]) < 2)
+
+		// Grab the unseal key and try to unseal
+		unsealKey := match[0][1]
+		err = client.Sys().SealNamespace(nsName)
+		require.NoError(t, err)
+
+		sealStatus, err := client.Sys().UnsealNamespace(
+			&api.UnsealNamespaceRequest{
+				Name: nsName,
+				Key:  unsealKey,
+			})
+		require.NoError(t, err)
+		require.False(t, sealStatus.Sealed)
+	})
+
+	t.Run("provide_stdin", func(t *testing.T) {
+		t.Parallel()
+
+		client, keys, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		// Initialize rotation
+		status, err := client.Sys().NamespaceRotateRootInit(nsName,
+			&api.RotateInitRequest{
+				SecretShares:    1,
+				SecretThreshold: 1,
+			})
+		require.NoError(t, err)
+		nonce := status.Nonce
+
+		// Supply the first n-1 unseal keys
+		for _, key := range keys[:len(keys)-1] {
+			stdinR, stdinW := io.Pipe()
+			go func() {
+				_, err := stdinW.Write([]byte(key))
+				require.NoError(t, err)
+
+				err = stdinW.Close()
+				require.NoError(t, err)
+			}()
+
+			ui, cmd := testNamespaceRotateKeysCommand(t)
+			cmd.client = client
+			cmd.testStdin = stdinR
+
+			code := cmd.Run([]string{
+				"-nonce", nonce,
+				nsName,
+				"-",
+			})
+			require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+		}
+
+		stdinR, stdinW := io.Pipe()
+		go func() {
+			_, err := stdinW.Write([]byte(keys[len(keys)-1])) // the last unseal key
+			require.NoError(t, err)
+
+			err = stdinW.Close()
+			require.NoError(t, err)
+		}()
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+		cmd.testStdin = stdinR
+
+		code := cmd.Run([]string{
+			"-nonce", nonce,
+			nsName,
+			"-",
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		re := regexp.MustCompile(`Key 1: (.+)`)
+		output := ui.OutputWriter.String()
+		match := re.FindAllStringSubmatch(output, -1)
+		require.False(t, len(match) < 1 || len(match[0]) < 2)
+
+		// Grab the unseal key and try to unseal
+		unsealKey := match[0][1]
+		err = client.Sys().SealNamespace(nsName)
+		require.NoError(t, err)
+
+		sealStatus, err := client.Sys().UnsealNamespace(
+			&api.UnsealNamespaceRequest{
+				Name: nsName,
+				Key:  unsealKey,
+			})
+		require.NoError(t, err)
+		require.False(t, sealStatus.Sealed)
+	})
+
+	t.Run("backup", func(t *testing.T) {
+		t.Parallel()
+
+		pgpKey := "keybase:hashicorp"
+		client, keys, closer := testVaultServerWithNamespace(t, nsName, false)
+		defer closer()
+
+		ui, cmd := testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-init",
+			"-key-shares", "1",
+			"-key-threshold", "1",
+			"-pgp-keys", pgpKey,
+			"-backup",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		// Get the status for the nonce
+		status, err := client.Sys().NamespaceRotateRootStatus(nsName)
+		require.NoError(t, err)
+		nonce := status.Nonce
+
+		var combined string
+		// Supply the unseal keys
+		for _, key := range keys {
+			ui, cmd := testNamespaceRotateKeysCommand(t)
+			cmd.client = client
+
+			code := cmd.Run([]string{
+				"-nonce", nonce,
+				nsName,
+				key,
+			})
+			require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+			// Append to our output string
+			combined += ui.OutputWriter.String()
+		}
+
+		re := regexp.MustCompile(`Key 1 fingerprint: (.+); value: (.+)`)
+		match := re.FindAllStringSubmatch(combined, -1)
+		require.False(t, len(match) < 1 || len(match[0]) < 3)
+
+		// Grab the output fingerprint and encrypted key
+		fingerprint, encryptedKey := match[0][1], match[0][2]
+
+		// Get the backup
+		ui, cmd = testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code = cmd.Run([]string{
+			"-backup-retrieve",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		output := ui.OutputWriter.String()
+		require.Contains(t, output, fingerprint)
+		require.Contains(t, output, encryptedKey)
+
+		// Delete the backup
+		ui, cmd = testNamespaceRotateKeysCommand(t)
+		cmd.client = client
+
+		code = cmd.Run([]string{
+			"-backup-delete",
+			nsName,
+		})
+		require.Equalf(t, 0, code, "expected %d to be %d: %s", code, 0, ui.ErrorWriter.String())
+
+		_, err = client.Sys().NamespaceRotateRootRetrieveBackup(nsName)
+		require.Error(t, err)
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceRotateKeysCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_rotate_test.go
+++ b/command/namespace_rotate_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func testNamespaceRotateCommand(tb testing.TB) (*cli.MockUi, *NamespaceRotateCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceRotateCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceRotateCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"no_namespace_existing",
+			[]string{"unknown"},
+			"doesn't exist",
+			2,
+		},
+		{
+			"happy path",
+			[]string{"ns"},
+			"Success! Rotated encryption key",
+			0,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, false)
+				defer closer()
+
+				ui, cmd := testNamespaceRotateCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+
+				if code == 0 {
+					status, err := client.Sys().NamespaceKeyStatus(nsName)
+					require.NoError(t, err)
+					require.Greater(t, status.Term, 1)
+				}
+			})
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceRotateCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}


### PR DESCRIPTION
This PR introduces the `bao namespace key-status`, `bao namespace rotate-key <ns>` and `bao namespace rotate <ns>` CLI commands

Changes:
- Added CLI commands in files `namespace_key_status.go`, `namespace_rotate.go` and `namespace_rotate_keys.go` with their appropriate test files
- Added api operations in `api/sys_namespaces` used with the commands


Notice: This PR targets the [namespaces-seal](https://github.com/openbao/openbao/tree/namespaces-seal) feature branch