### PR TITLE
Add go-metrics to dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,16 @@ updates:
       semver-patch-days: 7
       semver-minor-days: 14
       semver-major-days: 30
+    ignore:
+      # armon/go-metrics was moved to hashicorp/go-metrics, but we cannot
+      # migrate to the new location without introducing other workarounds just
+      # yet: https://github.com/openbao/openbao/pull/1929
+      # This causes hard errors in dependabot's update job, discarding all
+      # other pull requests that dependabot planned to open. These ignores
+      # can be removed once armon/go-metrics has been replaced entirely by
+      # hashicorp/go-metrics.
+      - dependency-name: github.com/armon/go-metrics
+      - dependency-name: github.com/hashicorp/go-metrics
 
   - package-ecosystem: "npm"
     directory: "/ui"


### PR DESCRIPTION
It seems as though we cannot merge https://github.com/openbao/openbao/pull/1929 in the near future, hence adding this as a workaround to (hopefully) get successful dependabot runs.

Failing workflow for context: https://github.com/openbao/openbao/actions/runs/18524597614/job/52792268572