### PR TITLE
Add check that builds bao with the go on el8

### DIFF
--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -97,6 +97,8 @@ jobs:
 
   el8gobuild:
     # make sure that bao can still be built with the golang version on el8
+    # unless there is a `no-el8gobuild` label
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-el8gobuild')"
     name: EL8 Go build checks
     runs-on: ubuntu-latest
     container: ghcr.io/almalinux/8-base


### PR DESCRIPTION
This adds an optional linter check to verify that openbao will work with the golang version that is current on el8, even if go.mod has been set to a later go version. This is needed for EPEL packaging to be successful.

Replaces #1845.
