### PR TITLE
Remove UI section from dependabot config, increase Go PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,26 +30,12 @@ updates:
       # armon/go-metrics was moved to hashicorp/go-metrics, but we cannot
       # migrate to the new location without introducing other workarounds just
       # yet: https://github.com/openbao/openbao/pull/1929
-      # This causes hard errors in dependabot's update job, discarding all
-      # other pull requests that dependabot planned to open. These ignores
-      # can be removed once armon/go-metrics has been replaced entirely by
-      # hashicorp/go-metrics.
+      # This causes errors in dependabot's update job, making other issues
+      # related to dependabot harder to debug. These ignores can be removed once
+      # armon/go-metrics has been replaced entirely by hashicorp/go-metrics.
       - dependency-name: github.com/armon/go-metrics
       - dependency-name: github.com/hashicorp/go-metrics
-
-  - package-ecosystem: "npm"
-    directory: "/ui"
-    schedule:
-      interval: "weekly"
-    labels:
-      - dependencies
-      - javascript
-      - ui
-    cooldown:
-      default-days: 5
-      semver-patch-days: 7
-      semver-minor-days: 14
-      semver-major-days: 30
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/website"


### PR DESCRIPTION
This PR:

1. Stops dependabot from creating new PRs for the UI by removing the relevant configuration section. The majority of UI dependencies are extremely outdated and we do not have the capacity or expertise to migrate to newer versions. Furthermore, the legacy UI will eventually be replaced by the work-in-progress rewrite at https://github.com/openbao/dough. I would close all outstanding UI bump PRs, too (if dependabot doesn't do this automatically).

2. Increases the limit of open dependabot PRs for Go dependencies to 10 (The default is 5, which is easily eaten up by long-standing PRs: https://github.com/openbao/openbao/issues?q=is%3Apr%20is%3Aopen%20author%3Aapp%2Fdependabot%20label%3Ago)

---

@cipherboy the pull request limit is per group and not global, so stale UI PRs don't block Go PRs, but I still see no real reason to keep the UI ones around. @driif wdyt?