### PR TITLE
Add pr/no-changelog label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     labels:
       - dependencies
       - pr/no-changelog
-      - github_actions
+      - github-actions
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
Adding this manually is quite annoying :-)

Signed-off-by: Jan Martens <jan@martens.eu.org>