### PR TITLE
fix test-go workflow: download-artifact downloads artifacts from all workflows

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Archive test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: test-results-${{ matrix.id }}${{ inputs.name != '' && '-' || '' }}${{ inputs.name }}
+          name: test-results-${{ matrix.id }}-${{ inputs.name == '' && 'default' || inputs.name }}
           path: test-results/go-test
         if: success() || failure()
       # GitHub Actions doesn't expose the job ID or the URL to the job execution,
@@ -308,7 +308,7 @@ jobs:
       - uses: actions/download-artifact@de96f4613b77ec03b5cf633e7c350c32bd3c5660 # v4.3.0
         with:
           path: test-results/go-test
-          pattern: test-results-*
+          pattern: test-results-*-${{ inputs.name == '' && 'default' || inputs.name }}
           merge-multiple: true
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4


### PR DESCRIPTION
Investigating this CI failure: https://github.com/openbao/openbao/actions/runs/18653935437/job/53179925629?pr=1973 Test Summary failed with:

>Error: Unquoted attribute value
> Line: 378
> Column: 118
> 0s

The error "Unquoted attribute value" can be found in the nodejs XML parser library the action is using. Somehow an invalid XML must have gotten into the results.

It looks like the `test-collect-reports` is downloading all test results (e.g. `test-results-0`, `test-results-0-race` and `test-results-0-testonly`), which is probably not what we want, because `test-collect-reports` runs 3 times (once for normal tests, once for race and once for testonly).

I fear that because the files will be always called `results-0.xml`, `results-1.xml`, etc. even for race tests and we merge them into a single folder, some race can occur. My assumption in now, that the action failed because two XMLs with the same name got written at the same time, resulting in a broken XML.

The [download artifact action](https://github.com/actions/download-artifact) seems to have no option to limit the download to the current workflow. So we need to make sure the name of the artifact used in `upload-artifact` and the glob in `download-artifact` are sufficiently specific. 