### PR TITLE
fix:  False “existing mount” conflict when mounting a backend at a pa…

### DIFF
--- a/changelog/1958.txt
+++ b/changelog/1958.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/namespaces: Fix mount creation failing if mount name is equal to the name of the containing namespace
+```


### PR DESCRIPTION
Backport of #1958 to `release/2.4.x`.

---

…th equal to the current namespace name. (#1958)

* fix:  Ensure comparisons are done against absolute paths within the current NS context



* chore: Add changelog entry



* chore: Run formatter



* chore: Reword changelog based on PR comment suggestion



* fix: Use strings.CutSuffix to simplify logic



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
