### PR TITLE
fix(core/namespaces): only return namespaces which the provided token…

### DIFF
--- a/changelog/1982.txt
+++ b/changelog/1982.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/namespaces: only report namespaces which the provided token has access to from `sys/internal/ui/namespaces`
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4138,6 +4138,47 @@ func (b *SystemBackend) pathInternalUIMountRead(ctx context.Context, req *logica
 	return resp, nil
 }
 
+func (b *SystemBackend) pathInternalUINamespacesRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Short-circuit here if there's no client token provided
+	if req.ClientToken == "" {
+		return nil, errors.New("client token empty")
+	}
+
+	// Load the ACL policies so we can check for access and filter namespaces
+	acl, te, entity, _, err := b.Core.fetchACLTokenEntryAndEntity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if entity != nil && entity.Disabled {
+		b.logger.Warn("permission denied as the entity on the token is disabled")
+		return nil, logical.ErrPermissionDenied
+	}
+	if te != nil && te.EntityID != "" && entity == nil {
+		b.logger.Warn("permission denied as the entity on the token is invalid")
+		return nil, logical.ErrPermissionDenied
+	}
+
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := b.Core.namespaceStore.ListNamespaces(ctx, false, false)
+	if err != nil {
+		return nil, errors.New("failed to list namespaces")
+	}
+
+	var nsList []string
+	for _, entry := range list {
+		if acl != nil && hasMountAccess(ctx, acl, entry.Path) {
+			relativePath := parent.TrimmedPath(entry.Path)
+			nsList = append(nsList, relativePath)
+		}
+	}
+
+	return logical.ListResponse(nsList), nil
+}
+
 func (b *SystemBackend) pathInternalCountersRequests(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	resp := logical.ErrorResponse("The functionality has been removed on this path")
 

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -9,52 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/openbao/openbao/helper/namespace"
-	"github.com/openbao/openbao/sdk/v2/framework"
-	"github.com/openbao/openbao/sdk/v2/logical"
 )
-
-var pathInternalUINamespacesRead = func(b *SystemBackend) framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-		// Short-circuit here if there's no client token provided
-		if req.ClientToken == "" {
-			return nil, errors.New("client token empty")
-		}
-
-		// Load the ACL policies so we can check for access and filter namespaces
-		_, te, entity, _, err := b.Core.fetchACLTokenEntryAndEntity(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		if entity != nil && entity.Disabled {
-			b.logger.Warn("permission denied as the entity on the token is disabled")
-			return nil, logical.ErrPermissionDenied
-		}
-		if te != nil && te.EntityID != "" && entity == nil {
-			b.logger.Warn("permission denied as the entity on the token is invalid")
-			return nil, logical.ErrPermissionDenied
-		}
-
-		parent, err := namespace.FromContext(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		list, err := b.Core.namespaceStore.ListNamespaces(ctx, false, false)
-		if err != nil {
-			return nil, errors.New("failed to list namespaces")
-		}
-
-		var nsList []string
-		for _, entry := range list {
-			relativePath := parent.TrimmedPath(entry.Path)
-			nsList = append(nsList, relativePath)
-		}
-
-		return logical.ListResponse(nsList), nil
-	}
-}
 
 // tuneMount is used to set config on a mount point
 func (b *SystemBackend) tuneMountTTLs(ctx context.Context, path string, me *MountEntry, newDefault, newMax time.Duration) error {

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -2293,7 +2293,7 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: pathInternalUINamespacesRead(b),
+					Callback: b.pathInternalUINamespacesRead,
 					Summary:  "Backwards compatibility is not guaranteed for this API",
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -8,8 +8,8 @@ description: >-
 The `/sys/internal/ui/namespaces` endpoint is used to expose namespaces
 to the UI so that it can change its behavior in response, even before a user logs in.
 
-This is currently only being used internally for the UI and is
-an unauthenticated endpoint. Due to the nature of its intended usage, there is no
+This is currently only being used internally for the UI.
+Due to the nature of its intended usage, there is no
 guarantee on backwards compatibility for this endpoint.
 
 ## Get namespaces


### PR DESCRIPTION
Backport of #1982 to `release/2.4.x`.

---

… has access to (#1982)

* fix(core/namespaces): only return namespaces where the token has access



* chore: add feedback from Wojciech



* chore(logical_system): move pathInternalUINamespacesRead into it's own function within



* fix: check acl on absolute path



* Apply changelog suggestion from @cipherboy



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
