### PR TITLE
Add license checks to Syft on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,8 @@ jobs:
       - build-ui-dist
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+      SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES: "true"
+      SYFT_GOLANG_SEARCH_REMOTE_LICENSES: "true"
     strategy:
       matrix:
         release_os:


### PR DESCRIPTION
When using Syft in the release pipeline, we may need to tell it to check Go modules for license information. While this should be local, enabling remote checks should allow it succeed if not.

Not clear is if global environments are fine here or if we do need to add it to the goreleaser build process.

This works locally via something like:

> ```
> $ SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES=true \
>     SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true \
>     syft scan --output=json go.mod  | jq
> ```

Related: https://github.com/openbao/openbao/issues/1894
See also: https://github.com/anchore/syft/wiki/configuration
See also: https://goreleaser.com/customization/sbom/#usage

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

