### PR TITLE
Enable transactional namespace creation (#1990)

### DIFF
--- a/changelog/1990.txt
+++ b/changelog/1990.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/namespaces: ensure interrupted namespace creation fails gracefully; prevents identity store panic and partial memory-only namespaces
+```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -247,7 +247,7 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 	// Verify exact match of the route
 	match := c.router.MatchingMount(ctx, path)
 	if match == "" || ns.Path+path != match {
-		return errors.New("no matching mount")
+		return errNoMatchingMount
 	}
 
 	// Get the view for this backend


### PR DESCRIPTION
Backport of #1990

---

* Enable transactional namespace creation

Before this, when namespace creation was interrupted, restarting OpenBao would fail with a panic in identity store. This was caused by the namespace entry existing (causing it to show up in ListNamespaces(...)), but the sys/ mount table entry for this namespace not existing. This meant that IdentityStore.AddNamespaceView(...) was never called on restart, so entityPacker(partialNs) would fail, causing unseal to fail.

The only remediation procedure would be to use recovery mode to manually remove the namespace or to create new mount tables manually.

This transactional namespace creation ensures that if namespace creation fails, we do not have any remnants lying around and lets us rollback any in-memory items as well.

This was tested by running something like:

> $ dist/linux/amd64/benchmark-openbao run \
>     -config=docs/examples/sys/namespaces.hcl -duration=1s

and hitting ctrl+C randomly. Comparing:

> $ bao namespace list | wc -l

before and after restarting the instance will tell you if any in-progress namespaces were not properly deleted.



* Add changelog entry



* Consistently apply errNoMatchingMount

In ed3b3fb9482, the fix was mostly focused on secret mounts, though the same could likely be experienced by namespaces with lots of auth mounts. Thus, the same logic has been applied consistently to both.



---------

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #
