### PR TITLE
grab state lock before closing standbyStop channel

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2224,6 +2224,10 @@ func (c *Core) sealInternalWithOptions(grabStateLock, keepHALock, performCleanup
 		if keepHALock {
 			atomic.StoreUint32(c.keepHALockOnStepDown, 1)
 		}
+		if grabStateLock {
+			cancelCtxAndLock()
+			defer c.stateLock.Unlock()
+		}
 
 		// If we are trying to acquire the lock, force it to return with nil so
 		// runStandby will exit

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -384,6 +384,9 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 }
 
 func (c *Core) stopStandby() {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+
 	select {
 	case c.standbyStopCh.Load().(chan struct{}) <- struct{}{}:
 	default:


### PR DESCRIPTION
in `sealInternalWithOptions` this was removed here: https://github.com/openbao/openbao/pull/1847/commits/cef50884967e184e2e9a6ca6322dbba29c79f8db#diff-a0a40b411f03b3c927d6a2eafaf8a17693cc05a44e81bfe1362045a9372b9cfeL2217-L2220 by @cipherboy

Was this an oversight? I think it would probably fix the same issue as adding the lock grab timeout in `runStandby` (but causes a race in `TestSysMonitorStreamingLogs`). So probably we don't need both changes.


See #1550
See #1528 

Notice: This PR targets the [read-replication](https://github.com/openbao/openbao/tree/read-replication) feature branch