### PR TITLE
add consul plugin team to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,19 +13,26 @@ See the information about community membership roles to learn about the role of 
 
 ## Repository-Level Committers
 
-| Name             | GitHub                                  | Projects                                                                                          |
-| ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Andrii Fedorchuk | [@driif](https://github.com/driif) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault), and [openbao-plugins `secrets/consul/`](https://github.com/openbao/openbao-plugins/tree/main/secrets/consul) |
-| Christoph Voigt  | [@voigt](https://github.com/voigt) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault) |
-| Dave Dykstra     | [@DrDaveD](https://github.com/DrDaveD) | [`auth/jwt` and `auth/oidc`](https://github.com/openbao/openbao/tree/main/builtin/credential/jwt) |
-| Geoffrey Wilson  | [@suprjinx](https://github.com/suprjinx) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault) |
-| Jonas Köhnen     | [@satoqz](https://github.com/satoqz) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault) |
-| Pascal Reeb      | [@pree](https://github.com/pree) | [helm](https://github.com/openbao/openbao-helm), [csi-provider](https://github.com/openbao/openbao-csi-provider), [k8s](https://github.com/openbao/openbao-k8s), [secrets-operator](https://github.com/openbao/openbao-secrets-operator), and [openbao-plugins `secrets/consul/`](https://github.com/openbao/openbao-plugins/tree/main/secrets/consul)|
-| Philipp Stehle  | [@phil9909](https://github.com/phil9909) | [openbao-plugins `secrets/consul/`](https://github.com/openbao/openbao-plugins/tree/main/secrets/consul) |
-| Tom Gehrke       | [@phyrog](https://github.com/phyrog) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault) |
-| Toni Tauro       | [@eyenx](https://github.com/eyenx) | [helm](https://github.com/openbao/openbao-helm), [csi-provider](https://github.com/openbao/openbao-csi-provider), [k8s](https://github.com/openbao/openbao-k8s), [secrets-operator](https://github.com/openbao/openbao-secrets-operator), and [openbao-plugins `secrets/consul/`](https://github.com/openbao/openbao-plugins/tree/main/secrets/consul) |
-| Wojciech Slabosz | [@wslabosz-reply](https://github.com/wslabosz-reply) | [`vault/`](https://github.com/openbao/openbao/tree/main/vault) |
-| Yannis           | [@Nerkho](https://github.com/Nerkho) | [helm](https://github.com/openbao/openbao-helm), [csi-provider](https://github.com/openbao/openbao-csi-provider), [k8s](https://github.com/openbao/openbao-k8s), [secrets-operator](https://github.com/openbao/openbao-secrets-operator), and [openbao-plugins `secrets/consul/`](https://github.com/openbao/openbao-plugins/tree/main/secrets/consul) |
+| Name             | GitHub                                               | Projects                                                                                          |
+| ---------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Andrii Fedorchuk | [@driif](https://github.com/driif)                   | [`vault/`], and [openbao-plugins `secrets/consul/`]                                               |
+| Christoph Voigt  | [@voigt](https://github.com/voigt)                   | [`vault/`]                                                                                        |
+| Dave Dykstra     | [@DrDaveD](https://github.com/DrDaveD)               | [`auth/jwt` and `auth/oidc`](https://github.com/openbao/openbao/tree/main/builtin/credential/jwt) |
+| Geoffrey Wilson  | [@suprjinx](https://github.com/suprjinx)             | [`vault/`]                                                                                        |
+| Jonas Köhnen     | [@satoqz](https://github.com/satoqz)                 | [`vault/`]                                                                                        |
+| Pascal Reeb      | [@pree](https://github.com/pree)                     | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
+| Philipp Stehle   | [@phil9909](https://github.com/phil9909)             | [openbao-plugins `secrets/consul/`]                                                               |
+| Tom Gehrke       | [@phyrog](https://github.com/phyrog)                 | [`vault/`]                                                                                        |
+| Toni Tauro       | [@eyenx](https://github.com/eyenx)                   | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
+| Wojciech Slabosz | [@wslabosz-reply](https://github.com/wslabosz-reply) | [`vault/`]                                                                                        |
+| Yannis           | [@Nerkho](https://github.com/Nerkho)                 | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
+
+[`vault/`]: https://github.com/openbao/openbao/tree/main/vault
+[openbao-plugins `secrets/consul/`]: https://github.com/openbao/openbao-plugins/tree/main/secrets/consul
+[helm]: https://github.com/openbao/openbao-helm
+[csi-provider]: https://github.com/openbao/openbao-csi-provider
+[k8s]: https://github.com/openbao/openbao-k8s
+[secrets-operator]: https://github.com/openbao/openbao-secrets-operator
 
 ## Organization-Level Moderators
 


### PR DESCRIPTION
This PR adds the @openbao/plugins-secrets-consul-committers team to the "Repository-Level Committers" table in `MAINTAINERS.md`

I also:
- Made sure all tables are sorted alphabetically<sup>1</sup>
- Refactored the table to use [shortcut reference links](https://github.github.com/gfm/#shortcut-reference-link) for better readability

This happened in three individual commits for ease of review.

---
<sup>1</sup> they were almost sorted, probably a regression as people were added to the end of the table. I'm fine with unsorted lists, but almost-sorted bugs me :laughing: 