### PR TITLE
use deploy key for dependency synchronization

### DIFF
--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.head_ref }}
+          ssh-key: ${{ secrets.DEPENDABOT_DEPLOY_KEY }}
       - name: Set up Go
         uses: ./.github/actions/set-up-go
       - name: Run sync-deps


### PR DESCRIPTION
In https://github.com/openbao/openbao/pull/1966 we added a workflow to run `make sync-deps` on Dependabot PRs to automatically keep dependencies in sync across all modules. As it turns out using the default `GITHUB_TOKEN` provided to a workflow run when committing changes will _not_ trigger any new workflow runs for the new commit. To do that, you need to use a PAT, a Deploy Key or a GitHub App to make the commit.

This PR introduces the use of a deploy key in the sync deps workflow to ensure the required workflows are triggered when `make sync-deps` commits any changes.

Signed-off-by: Jan Martens <jan@martens.eu.org>