### PR TITLE
docs: reference centralized duration format in API docs

### DIFF
--- a/website/content/api-docs/auth/token.mdx
+++ b/website/content/api-docs/auth/token.mdx
@@ -85,10 +85,10 @@ during this call.
   to be renewed past its initial TTL. Setting the value to `true` will allow
   the token to be renewable up to the system/mount maximum TTL.
 - `lease` `(string: "")` - DEPRECATED; use `ttl` instead
-- `ttl` `(string: "")` - The TTL period of the token, provided as "1h", where
-  hour is the largest suffix. If not provided, the token is valid for the
-  [default lease TTL](/docs/configuration), or indefinitely if the
-  root policy is used.
+- `ttl` `(string: "")` - The TTL period of the token, provided as a
+  [duration string](/docs/concepts/duration-format). If not provided, the
+  token is valid for the [default lease TTL](/docs/configuration), or
+  indefinitely if the root policy is used.
 - `type` `(string: "")` - The token type. Can be "batch" or "service". Defaults
   to the type specified by the role configuration named by `role_name`.
 - `explicit_max_ttl` `(string: "")` - If set, the token will have an explicit

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -3696,15 +3696,15 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
   :::
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
-  validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
-  used for future validity. If not set, uses the system default value or the
-  value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
-  for setting an absolute end date (rather than a relative one).
+  validity period of the requested certificate, provided as a
+  [duration string](/docs/concepts/duration-format). The value specified is
+  strictly used for future validity. If not set, uses the system default value
+  or the value of `max_ttl`, whichever is shorter. See `not_after` as an
+  alternative for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
-  defaults to the system maximum lease TTL.
+  [duration string](/docs/concepts/duration-format). If not set, defaults to
+  the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request
   certificates for `localhost` as one of the requested common names. This is

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -233,13 +233,13 @@ This endpoint creates or updates a named role.
   specified using identity template policies. Non-templated domains are also
   permitted.
 
-- `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+- `ttl` `(string: "")` – Specifies the Time To Live value provided as a
+  [duration string](/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
-  defaults to the system maximum lease TTL.
+  [duration string](/docs/concepts/duration-format). If not set, defaults to
+  the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list
   of critical options that certificates can have when signed. To allow any


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This PR fixes incorrect and inconsistent duration format documentation across the Token, PKI, and SSH API documentation pages. The previous documentation incorrectly stated "hour is the largest suffix" when the actual implementation supports days (`d`) as the largest time unit.

## Problem

The API documentation for TTL parameters contained inline explanations that:
1. **Were incorrect** - Claimed "hour is the largest suffix" when days (`d`) are actually supported
2. **Were inconsistent** - Repeated the same explanation across multiple pages
3. **Increased maintenance burden** - Required updating in multiple places if the format changed

User testing confirmed that `"ttl": "1d"` works correctly, contradicting the documentation.

## Solution

Replace all inline duration format explanations with references to the centralized [duration format documentation](/docs/concepts/duration-format), which accurately documents all supported time units:
- `ns` - Nanoseconds
- `us` (or `µs`) - Microseconds
- `ms` - Milliseconds
- `s` - Seconds
- `m` - Minutes
- `h` - Hours
- `d` - Days (largest unit)

## Changes

Updated three API documentation files:

### 1. Token API (`website/content/api-docs/auth/token.mdx`)
- **Before:** "provided as "1h", where hour is the largest suffix"
- **After:** "provided as a [duration string](/docs/concepts/duration-format)"

### 2. PKI API (`website/content/api-docs/secret/pki.mdx`)
- **Before:** "Hour is the largest suffix" (in `ttl` and `max_ttl` descriptions)
- **After:** Links to centralized duration format documentation

### 3. SSH API (`website/content/api-docs/secret/ssh.mdx`)
- **Before:** "Hour is the largest suffix" (in `ttl` and `max_ttl` descriptions)
- **After:** Links to centralized duration format documentation

## Verification

### Code Analysis
Verified that all three APIs use the same duration parser:
- **Token API:** `vault/token_store.go:3159` - calls `parseutil.ParseDurationSecond(ttl)`
- **PKI API:** `sdk/framework/field_data.go:257` - uses `framework.TypeDurationSecond` which calls `parseutil.ParseDurationSecond`
- **SSH API:** `builtin/logical/ssh/path_issue_sign.go:387,396` - calls `parseutil.ParseDurationSecond`

### Implementation Details
The `parseutil.ParseDurationSecond` function (from `github.com/hashicorp/go-secure-stdlib/parseutil` v0.2.0):
```go
// Special handling for days suffix
if strings.HasSuffix(inp, "d") {
    v, err := strconv.ParseInt(inp[:len(inp)-1], 10, 64)
    if err != nil {
        return dur, err
    }
    return overflowMul(time.Duration(v), 24*time.Hour)
}
// Falls back to Go's time.ParseDuration for other units
```

### Testing
- [x] Verified `curl` request with `"ttl": "1d"` works correctly
- [x] All modified files pass `markdownlint-cli2` with 0 errors
- [x] Confirmed all APIs reference the same centralized duration format documentation

## Benefits

1. **Accuracy** - Documentation now correctly reflects implementation
2. **Maintainability** - Single source of truth for duration format
3. **Consistency** - All API docs reference the same documentation
4. **Completeness** - Users can see all supported time units in one place
5. **DRY Principle** - Eliminates duplicate documentation

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #2032
