### PR TITLE
Update or remove deprecated code

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1254,9 +1254,9 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
 //
-// Deprecated: RawRequest exists for historical compatibility and should not be
-// used directly. Use client.Logical().ReadRaw(...) or higher level methods
-// instead.
+// RawRequest exists for historical compatibility and should not be used
+// directly. Use client.Logical().ReadRaw(...) or higher level methods instead
+// if possible.
 func (c *Client) RawRequest(r *Request) (*Response, error) {
 	return c.RawRequestWithContext(context.Background(), r)
 }
@@ -1265,9 +1265,9 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
 //
-// Deprecated: RawRequestWithContext exists for historical compatibility and
-// should not be used directly. Use client.Logical().ReadRawWithContext(...)
-// or higher level methods instead.
+// RawRequestWithContext exists for historical compatibility and should not be
+// used directly. Use client.Logical().ReadRawWithContext(...) or higher level
+// methods instead if possible.
 func (c *Client) RawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
 	// Note: we purposefully do not call cancel manually. The reason is
 	// when canceled, the request.Body will EOF when reading due to the way

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -336,8 +336,6 @@ type MountConfigOutput struct {
 	TokenType                 string                   `json:"token_type,omitempty" mapstructure:"token_type"`
 	AllowedManagedKeys        []string                 `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 	UserLockoutConfig         *UserLockoutConfigOutput `json:"user_lockout_config,omitempty"`
-	// Deprecated: This field will always be blank for newer server responses.
-	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }
 
 type UserLockoutConfigInput struct {

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -504,6 +504,7 @@ func (c *Sys) RotateRecoveryVerificationCancelWithContext(ctx context.Context) e
 
 // Deprecated: use RotateKeyring instead.
 func (c *Sys) Rotate() error {
+	//nolint:staticcheck // method already marked as deprecated
 	return c.RotateWithContext(context.Background())
 }
 

--- a/builtin/credential/jwt/path_cel_role.go
+++ b/builtin/credential/jwt/path_cel_role.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/types"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	celhelper "github.com/openbao/openbao/sdk/v2/helper/cel"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -439,7 +440,7 @@ func (b *jwtAuthBackend) celEnv(program celhelper.CelProgram) (*cel.Env, error) 
 
 	// Add all variable declarations to the CEL environment.
 	for _, variable := range program.Variables {
-		envOptions = append(envOptions, cel.Declarations(decls.NewVar(variable.Name, decls.Dyn)))
+		envOptions = append(envOptions, cel.VariableDecls(decls.NewVariable(variable.Name, types.DynType)))
 	}
 
 	// Add "pb.Auth" return type to environment

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1002,7 +1002,7 @@ func TestAutoRebuild(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	defaultCrlPath := "/v1/pki/crl"
+	defaultCrlPath := "pki/crl"
 	crl := getParsedCrlAtPath(t, client, defaultCrlPath)
 	lastCRLNumber := getCRLNumber(t, crl)
 	lastCRLExpiry := crl.NextUpdate
@@ -1143,7 +1143,7 @@ func TestAutoRebuild(t *testing.T) {
 			haveUpdatedDeltaCRL = true
 
 			// Ensure it has what we want.
-			deltaCrl := getParsedCrlAtPath(t, client, "/v1/pki/crl/delta")
+			deltaCrl := getParsedCrlAtPath(t, client, "pki/crl/delta")
 			if !requireSerialNumberInCRL(nil, deltaCrl, newLeafSerial) {
 				// Check if it is on the main CRL because its already regenerated.
 				mainCRL := getParsedCrlAtPath(t, client, defaultCrlPath)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -17,7 +17,8 @@ import (
 	"time"
 
 	celgo "github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	celhelper "github.com/openbao/openbao/sdk/v2/helper/cel"
@@ -787,9 +788,9 @@ func (b *backend) pathCelIssueSignCert(ctx context.Context, req *logical.Request
 	// Declare a map variable named "request" to represent the incoming data.
 	envOptions := []celgo.EnvOption{
 		celgo.Container("openbao.pki"),
-		celgo.Declarations(
-			decls.NewVar("request", decls.NewMapType(decls.String, decls.Dyn)),
-			decls.NewVar("now", decls.Timestamp),
+		celgo.VariableDecls(
+			decls.NewVariable("request", types.NewMapType(types.StringType, types.DynType)),
+			decls.NewVariable("now", types.TimestampType),
 		),
 		celgo.Types(
 			&CertTemplate{},
@@ -798,12 +799,12 @@ func (b *backend) pathCelIssueSignCert(ctx context.Context, req *logical.Request
 	}
 
 	if useCSR {
-		envOptions = append(envOptions, celgo.Declarations(decls.NewVar("parsed_csr", decls.NewMapType(decls.String, decls.Dyn))))
+		envOptions = append(envOptions, celgo.VariableDecls(decls.NewVariable("parsed_csr", types.NewMapType(types.StringType, types.DynType))))
 	}
 
 	// Add all variable declarations to the CEL environment.
 	for _, variable := range celRole.CelProgram.Variables {
-		envOptions = append(envOptions, celgo.Declarations(decls.NewVar(variable.Name, decls.Dyn)))
+		envOptions = append(envOptions, celgo.VariableDecls(decls.NewVariable(variable.Name, types.DynType)))
 	}
 
 	// Add identity information into the environment

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -114,7 +114,7 @@ func getSelfSigned(t *testing.T, subject, issuer *x509.Certificate, key *rsa.Pri
 func getCrlCertificateList(t *testing.T, client *api.Client, mountPoint string) *x509.RevocationList {
 	t.Helper()
 
-	path := fmt.Sprintf("/v1/%s/crl", mountPoint)
+	path := fmt.Sprintf("%s/crl", mountPoint)
 	return getParsedCrlAtPath(t, client, path)
 }
 
@@ -155,15 +155,14 @@ func requireSerialNumberInCRL(t *testing.T, revokeList *x509.RevocationList, ser
 func getParsedCrl(t *testing.T, client *api.Client, mountPoint string) *x509.RevocationList {
 	t.Helper()
 
-	path := fmt.Sprintf("/v1/%s/crl", mountPoint)
+	path := fmt.Sprintf("%s/crl", mountPoint)
 	return getParsedCrlAtPath(t, client, path)
 }
 
 func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *x509.RevocationList {
 	t.Helper()
 
-	req := client.NewRequest("GET", path)
-	resp, err := client.RawRequest(req)
+	resp, err := client.Logical().ReadRaw(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/changelog/2036.txt
+++ b/changelog/2036.txt
@@ -1,0 +1,3 @@
+```release-note:change
+api: The deprecated api.MountConfigOutput.PluginName field was removed. This was already always empty.
+```

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -423,8 +423,7 @@ listener "tcp" {
 	// Test against a listener configuration that sets 'require_request_header'
 	// to 'true', with the header missing from the request.
 	agentClient = newApiClient("http://"+listenAddr3, false)
-	req = agentClient.NewRequest("GET", "/v1/sys/health")
-	resp, err := agentClient.RawRequest(req)
+	resp, err := agentClient.Logical().ReadRaw("sys/health")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -438,8 +437,7 @@ listener "tcp" {
 	h := agentClient.Headers()
 	h[consts.RequestHeaderName] = []string{"bogus"}
 	agentClient.SetHeaders(h)
-	req = agentClient.NewRequest("GET", "/v1/sys/health")
-	resp, err = agentClient.RawRequest(req)
+	resp, err = agentClient.Logical().ReadRaw("sys/health")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/command/agentproxyshared/cache/api_proxy.go
+++ b/command/agentproxyshared/cache/api_proxy.go
@@ -88,6 +88,7 @@ func (ap *APIProxy) Send(ctx context.Context, req *SendRequest) (*SendResponse, 
 	// Make the request to Vault and get the response
 	ap.logger.Info("forwarding request to OpenBao", "method", req.Request.Method, "path", req.Request.URL.Path)
 
+	//nolint:staticcheck // currently there is no other way to perform this specific request
 	resp, err := client.RawRequestWithContext(ctx, fwReq)
 	if resp == nil && err != nil {
 		// We don't want to cache nil responses, so we simply return the error

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -857,11 +857,8 @@ func TestCache_NonCacheable(t *testing.T) {
 	}
 
 	// Query a non-existing mount, expect an error from api.Response
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	r := testClient.NewRequest("GET", "/v1/kv-invalid")
-
-	apiResp, err := testClient.RawRequestWithContext(ctx, r)
+	ctx := t.Context()
+	apiResp, err := testClient.Logical().ReadRawWithContext(ctx, "kv-invalid")
 	if apiResp != nil {
 		defer apiResp.Body.Close()
 	}
@@ -1098,8 +1095,7 @@ func testCachingCacheClearCommon(t *testing.T, clearType string) {
 		t.Fatal(err)
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
+	ctx := t.Context()
 	apiResp, err := testClient.RawRequestWithContext(ctx, r)
 	if apiResp != nil {
 		defer apiResp.Body.Close()

--- a/command/auth_list.go
+++ b/command/auth_list.go
@@ -161,9 +161,6 @@ func (c *AuthListCommand) detailedMounts(auths map[string]*api.AuthMount) []stri
 		}
 
 		pluginName := mount.Type
-		if pluginName == "plugin" {
-			pluginName = mount.Config.PluginName
-		}
 
 		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %s | %s | %t | %v | %s | %s | %s | %s | %s | %s | %s",
 			path,

--- a/command/debug.go
+++ b/command/debug.go
@@ -670,8 +670,7 @@ func (c *DebugCommand) collectHostInfo(ctx context.Context) {
 		c.logger.Info("capturing host information", "count", idxCount)
 		idxCount++
 
-		r := c.cachedClient.NewRequest("GET", "/v1/sys/host-info")
-		resp, err := c.cachedClient.RawRequestWithContext(ctx, r)
+		resp, err := c.cachedClient.Logical().ReadRawWithContext(ctx, "sys/host-info")
 		if err != nil {
 			c.captureError("host", err)
 			return
@@ -709,8 +708,7 @@ func (c *DebugCommand) collectMetrics(ctx context.Context) {
 		idxCount++
 
 		// Perform metrics request
-		r := c.cachedClient.NewRequest("GET", "/v1/sys/metrics")
-		resp, err := c.cachedClient.RawRequestWithContext(ctx, r)
+		resp, err := c.cachedClient.Logical().ReadRawWithContext(ctx, "sys/metrics")
 		if err != nil {
 			c.captureError("metrics", err)
 			continue
@@ -851,8 +849,7 @@ func (c *DebugCommand) collectReplicationStatus(ctx context.Context) {
 		c.logger.Info("capturing replication status", "count", idxCount)
 		idxCount++
 
-		r := c.cachedClient.NewRequest("GET", "/v1/sys/replication/status")
-		resp, err := c.cachedClient.RawRequestWithContext(ctx, r)
+		resp, err := c.cachedClient.Logical().ReadRawWithContext(ctx, "sys/replication/status")
 		if err != nil {
 			c.captureError("replication-status", err)
 			return
@@ -924,8 +921,7 @@ func (c *DebugCommand) collectInFlightRequestStatus(ctx context.Context) {
 		c.logger.Info("capturing in-flight request status", "count", idxCount)
 		idxCount++
 
-		req := c.cachedClient.NewRequest("GET", "/v1/sys/in-flight-req")
-		resp, err := c.cachedClient.RawRequestWithContext(ctx, req)
+		resp, err := c.cachedClient.Logical().ReadRawWithContext(ctx, "sys/in-flight-req")
 		if err != nil {
 			c.captureError("requests", err)
 			return
@@ -1054,11 +1050,7 @@ func (c *DebugCommand) compress(dst string) error {
 }
 
 func pprofTarget(ctx context.Context, client *api.Client, target string, params url.Values) ([]byte, error) {
-	req := client.NewRequest("GET", "/v1/sys/pprof/"+target)
-	if params != nil {
-		req.Params = params
-	}
-	resp, err := client.RawRequestWithContext(ctx, req)
+	resp, err := client.Logical().ReadRawWithDataWithContext(ctx, "sys/pprof/"+target, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,9 +1068,8 @@ func pprofProfile(ctx context.Context, client *api.Client, duration time.Duratio
 	seconds := int(duration.Seconds())
 	secStr := strconv.Itoa(seconds)
 
-	req := client.NewRequest("GET", "/v1/sys/pprof/profile")
-	req.Params.Add("seconds", secStr)
-	resp, err := client.RawRequestWithContext(ctx, req)
+	params := url.Values{"seconds": []string{secStr}}
+	resp, err := client.Logical().ReadRawWithDataWithContext(ctx, "sys/pprof/profile", params)
 	if err != nil {
 		return nil, err
 	}
@@ -1096,9 +1087,8 @@ func pprofTrace(ctx context.Context, client *api.Client, duration time.Duration)
 	seconds := int(duration.Seconds())
 	secStr := strconv.Itoa(seconds)
 
-	req := client.NewRequest("GET", "/v1/sys/pprof/trace")
-	req.Params.Add("seconds", secStr)
-	resp, err := client.RawRequestWithContext(ctx, req)
+	params := url.Values{"seconds": []string{secStr}}
+	resp, err := client.Logical().ReadRawWithDataWithContext(ctx, "sys/pprof/trace", params)
 	if err != nil {
 		return nil, err
 	}

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	paths "path"
 	"sort"
 	"strings"
@@ -18,11 +19,11 @@ import (
 )
 
 func kvReadRequest(client *api.Client, path string, params map[string]string) (*api.Secret, error) {
-	r := client.NewRequest("GET", "/v1/"+path)
+	readParams := make(url.Values, len(params))
 	for k, v := range params {
-		r.Params.Set(k, v)
+		readParams.Set(k, v)
 	}
-	resp, err := client.RawRequest(r)
+	resp, err := client.Logical().ReadRawWithData(path, readParams)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -60,8 +61,7 @@ func kvPreflightVersionRequest(client *api.Client, path string) (string, int, er
 	client.SetOutputPolicy(false)
 	defer client.SetOutputPolicy(currentOutputPolicy)
 
-	r := client.NewRequest("GET", "/v1/sys/internal/ui/mounts/"+path)
-	resp, err := client.RawRequest(r)
+	resp, err := client.Logical().ReadRaw("sys/internal/ui/mounts/" + path)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -282,9 +282,11 @@ func (c *OperatorRekeyCommand) init(client *api.Client) int {
 	keyTypeRequired := keyTypeUnseal
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyInit
 	case "recovery", "hsm":
 		keyTypeRequired = keyTypeRecovery
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyRecoveryKeyInit
 	default:
 		c.UI.Error(fmt.Sprintf("Unknown target: %s", c.flagTarget))
@@ -341,13 +343,17 @@ func (c *OperatorRekeyCommand) cancel(client *api.Client) int {
 	var fn func() error
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyCancel
 		if c.flagVerify {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			fn = client.Sys().RekeyVerificationCancel
 		}
 	case "recovery", "hsm":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyRecoveryKeyCancel
 		if c.flagVerify {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			fn = client.Sys().RekeyRecoveryKeyVerificationCancel
 		}
 
@@ -375,32 +381,40 @@ func (c *OperatorRekeyCommand) provide(client *api.Client, key string) int {
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
 		statusFn = func() (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyStatus()
 		}
 		updateFn = func(s1 string, s2 string) (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyUpdate(s1, s2)
 		}
 		if c.flagVerify {
 			statusFn = func() (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyVerificationStatus()
 			}
 			updateFn = func(s1 string, s2 string) (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyVerificationUpdate(s1, s2)
 			}
 		}
 	case "recovery", "hsm":
 		keyTypeRequired = keyTypeRecovery
 		statusFn = func() (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyRecoveryKeyStatus()
 		}
 		updateFn = func(s1 string, s2 string) (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyRecoveryKeyUpdate(s1, s2)
 		}
 		if c.flagVerify {
 			statusFn = func() (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyRecoveryKeyVerificationStatus()
 			}
 			updateFn = func(s1 string, s2 string) (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyRecoveryKeyVerificationUpdate(s1, s2)
 			}
 		}
@@ -542,19 +556,23 @@ func (c *OperatorRekeyCommand) status(client *api.Client) int {
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
 		fn = func() (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyStatus()
 		}
 		if c.flagVerify {
 			fn = func() (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyVerificationStatus()
 			}
 		}
 	case "recovery", "hsm":
 		fn = func() (interface{}, error) {
+			//nolint:staticcheck // endpoint already marked as deprecated
 			return client.Sys().RekeyRecoveryKeyStatus()
 		}
 		if c.flagVerify {
 			fn = func() (interface{}, error) {
+				//nolint:staticcheck // endpoint already marked as deprecated
 				return client.Sys().RekeyRecoveryKeyVerificationStatus()
 			}
 		}
@@ -579,8 +597,10 @@ func (c *OperatorRekeyCommand) backupRetrieve(client *api.Client) int {
 	var fn func() (*api.RotateRetrieveResponse, error)
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyRetrieveBackup
 	case "recovery", "hsm":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyRetrieveRecoveryBackup
 	default:
 		c.UI.Error(fmt.Sprintf("Unknown target: %s", c.flagTarget))
@@ -607,8 +627,10 @@ func (c *OperatorRekeyCommand) backupDelete(client *api.Client) int {
 	var fn func() error
 	switch strings.ToLower(strings.TrimSpace(c.flagTarget)) {
 	case "barrier":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyDeleteBackup
 	case "recovery", "hsm":
+		//nolint:staticcheck // endpoint already marked as deprecated
 		fn = client.Sys().RekeyDeleteRecoveryBackup
 	default:
 		c.UI.Error(fmt.Sprintf("Unknown target: %s", c.flagTarget))

--- a/command/operator_rekey_test.go
+++ b/command/operator_rekey_test.go
@@ -212,6 +212,7 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 			t.Errorf("expected %q to contain %q", combined, expected)
 		}
 
+		//nolint:staticcheck // endpoint already marked as deprecated
 		status, err := client.Sys().RekeyStatus()
 		if err != nil {
 			t.Fatal(err)
@@ -249,6 +250,7 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 			t.Errorf("expected %q to contain %q", combined, expected)
 		}
 
+		//nolint:staticcheck // endpoint already marked as deprecated
 		status, err := client.Sys().RekeyStatus()
 		if err != nil {
 			t.Fatal(err)
@@ -592,6 +594,7 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 		}
 
 		// Get the status for the nonce
+		//nolint:staticcheck // endpoint already marked as deprecated
 		status, err := client.Sys().RekeyStatus()
 		if err != nil {
 			t.Fatal(err)
@@ -655,6 +658,7 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", code, exp, ui.ErrorWriter.String())
 		}
 
+		//nolint:staticcheck // endpoint already marked as deprecated
 		secret, err := client.Sys().RekeyRetrieveBackup()
 		if err == nil {
 			t.Errorf("expected error: %#v", secret)

--- a/command/secrets_list.go
+++ b/command/secrets_list.go
@@ -161,9 +161,6 @@ func (c *SecretsListCommand) detailedMounts(mounts map[string]*api.MountOutput) 
 		}
 
 		pluginName := mount.Type
-		if pluginName == "plugin" {
-			pluginName = mount.Config.PluginName
-		}
 
 		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s | %t | %v | %s | %s | %s | %s | %s | %s | %s",
 			path,

--- a/command/server.go
+++ b/command/server.go
@@ -435,7 +435,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
-	grpclog.SetLogger(&grpclogFaker{
+	grpclog.SetLoggerV2(&grpclogFaker{
 		logger: namedGRPCLogFaker,
 		log:    api.ReadBaoVariable("BAO_GRPC_LOGGING") != "",
 	})
@@ -1059,7 +1059,7 @@ func (c *ServerCommand) Run(args []string) int {
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
 	c.allLoggers = append(c.allLoggers, namedGRPCLogFaker)
-	grpclog.SetLogger(&grpclogFaker{
+	grpclog.SetLoggerV2(&grpclogFaker{
 		logger: namedGRPCLogFaker,
 		log:    api.ReadBaoVariable("BAO_GRPC_LOGGING") != "",
 	})
@@ -3027,6 +3027,42 @@ type grpclogFaker struct {
 	log    bool
 }
 
+func (g *grpclogFaker) Info(args ...any) {
+	g.logger.Info(fmt.Sprint(args...))
+}
+
+func (g *grpclogFaker) Infof(format string, args ...any) {
+	g.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (g *grpclogFaker) Infoln(args ...any) {
+	g.logger.Info(fmt.Sprintln(args...))
+}
+
+func (g *grpclogFaker) Warning(args ...any) {
+	g.logger.Warn(fmt.Sprint(args...))
+}
+
+func (g *grpclogFaker) Warningf(format string, args ...any) {
+	g.logger.Warn(fmt.Sprintf(format, args...))
+}
+
+func (g *grpclogFaker) Warningln(args ...any) {
+	g.logger.Warn(fmt.Sprintln(args...))
+}
+
+func (g *grpclogFaker) Error(args ...any) {
+	g.logger.Error(fmt.Sprint(args...))
+}
+
+func (g *grpclogFaker) Errorf(format string, args ...any) {
+	g.logger.Error(fmt.Sprintf(format, args...))
+}
+
+func (g *grpclogFaker) Errorln(args ...any) {
+	g.logger.Error(fmt.Sprintln(args...))
+}
+
 func (g *grpclogFaker) Fatal(args ...interface{}) {
 	g.logger.Error(fmt.Sprint(args...))
 	os.Exit(1)
@@ -3042,20 +3078,7 @@ func (g *grpclogFaker) Fatalln(args ...interface{}) {
 	os.Exit(1)
 }
 
-func (g *grpclogFaker) Print(args ...interface{}) {
-	if g.log && g.logger.IsDebug() {
-		g.logger.Debug(fmt.Sprint(args...))
-	}
-}
-
-func (g *grpclogFaker) Printf(format string, args ...interface{}) {
-	if g.log && g.logger.IsDebug() {
-		g.logger.Debug(fmt.Sprintf(format, args...))
-	}
-}
-
-func (g *grpclogFaker) Println(args ...interface{}) {
-	if g.log && g.logger.IsDebug() {
-		g.logger.Debug(fmt.Sprintln(args...))
-	}
+func (g *grpclogFaker) V(l int) bool {
+	currentLevel := int(g.logger.GetLevel())
+	return l >= currentLevel
 }

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -516,7 +516,7 @@ func (p *HardcodedServerAddressProvider) ServerAddr(id raftlib.ServerID) (raftli
 func NewHardcodedServerAddressProvider(numCores, baseClusterPort int) raftlib.ServerAddressProvider {
 	entries := make(map[raftlib.ServerID]raftlib.ServerAddress)
 
-	for i := 0; i < numCores; i++ {
+	for i := range numCores {
 		id := fmt.Sprintf("core-%d", i)
 		addr := fmt.Sprintf("127.0.0.1:%d", baseClusterPort+i)
 		entries[raftlib.ServerID(id)] = raftlib.ServerAddress(addr)
@@ -568,7 +568,7 @@ func WaitForRaftApply(t testing.T, core *vault.TestClusterCore, index uint64) {
 	t.Helper()
 
 	backend := core.UnderlyingRawStorage.(*raft.RaftBackend)
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		if backend.AppliedIndex() >= index {
 			return
 		}
@@ -692,7 +692,7 @@ func SysMetricsReq(client *api.Client, cluster *vault.TestCluster, unauth bool) 
 		r.Headers.Set("X-Vault-Token", cluster.RootToken)
 	}
 	var data SysMetricsJSON
-	resp, err := client.RawRequestWithContext(context.Background(), r)
+	resp, err := client.RawRequest(r)
 	if err != nil {
 		return nil, err
 	}

--- a/http/plugin_test.go
+++ b/http/plugin_test.go
@@ -6,6 +6,7 @@ package http
 import (
 	"encoding/json"
 	"io"
+	"net/url"
 	"os"
 	"reflect"
 	"sync"
@@ -140,7 +141,7 @@ func TestPlugin_MockRawResponse(t *testing.T) {
 	cluster, core := getPluginClusterAndCore(t, logger)
 	defer cluster.Cleanup()
 
-	resp, err := core.Client.RawRequest(core.Client.NewRequest("GET", "/v1/mock/raw"))
+	resp, err := core.Client.Logical().ReadRaw("mock/raw")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,9 +173,8 @@ func TestPlugin_GetParams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := core.Client.NewRequest("GET", "/v1/mock/kv/foo")
-	r.Params.Add("version", "12")
-	resp, err := core.Client.RawRequest(r)
+	params := url.Values{"version": []string{"12"}}
+	resp, err := core.Client.Logical().ReadRawWithData("mock/kv/foo", params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/sys_monitor_test.go
+++ b/http/sys_monitor_test.go
@@ -6,6 +6,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -23,9 +24,8 @@ func TestSysMonitorUnknownLogLevel(t *testing.T) {
 	defer cluster.Cleanup()
 
 	client := cluster.Cores[0].Client
-	request := client.NewRequest("GET", "/v1/sys/monitor")
-	request.Params.Add("log_level", "haha")
-	_, err := client.RawRequest(request)
+	params := url.Values{"log_level": []string{"haha"}}
+	_, err := client.Logical().ReadRawWithData("sys/monitor", params)
 
 	if err == nil {
 		t.Fatal("expected to get an error, but didn't")
@@ -49,9 +49,8 @@ func TestSysMonitorUnknownLogFormat(t *testing.T) {
 	defer cluster.Cleanup()
 
 	client := cluster.Cores[0].Client
-	request := client.NewRequest("GET", "/v1/sys/monitor")
-	request.Params.Add("log_format", "haha")
-	_, err := client.RawRequest(request)
+	params := url.Values{"log_format": []string{"haha"}}
+	_, err := client.Logical().ReadRawWithData("sys/monitor", params)
 
 	if err == nil {
 		t.Fatal("expected to get an error, but didn't")

--- a/physical/raft/streamlayer.go
+++ b/physical/raft/streamlayer.go
@@ -377,6 +377,8 @@ func (l *raftLayer) Addr() net.Addr {
 
 // Dial is used to create a new outgoing connection
 func (l *raftLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
-	dialFunc := l.clusterListener.GetDialerFunc(context.Background(), consts.RaftStorageALPN)
-	return dialFunc(string(address), timeout)
+	dialFunc := l.clusterListener.GetContextDialerFunc(context.Background(), consts.RaftStorageALPN)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return dialFunc(ctx, string(address))
 }

--- a/physical/raft/streamlayer_test.go
+++ b/physical/raft/streamlayer_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/openbao/openbao/vault/cluster"
 )
@@ -24,8 +23,8 @@ func (*mockClusterHook) AddHandler(alpn string, handler cluster.Handler)    {}
 func (*mockClusterHook) StopHandler(alpn string)                            {}
 func (*mockClusterHook) TLSConfig(ctx context.Context) (*tls.Config, error) { return nil, nil }
 func (m *mockClusterHook) Addr() net.Addr                                   { return m.address }
-func (*mockClusterHook) GetDialerFunc(ctx context.Context, alpnProto string) func(string, time.Duration) (net.Conn, error) {
-	return func(string, time.Duration) (net.Conn, error) {
+func (*mockClusterHook) GetContextDialerFunc(ctx context.Context, alpnProto string) func(context.Context, string) (net.Conn, error) {
+	return func(context.Context, string) (net.Conn, error) {
 		return nil, nil
 	}
 }

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -869,7 +869,6 @@ func testPath(t *testing.T, path *Path, sp *logical.Paths, expectedJSON string) 
 	if err := documentPath(path, sp, "kv", logical.TypeLogical, doc); err != nil {
 		t.Fatal(err)
 	}
-	doc.CreateOperationIDs("")
 
 	docJSON, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/armon/go-metrics v0.4.1
 	github.com/armon/go-radix v1.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/evanphx/json-patch/v5 v5.6.0
@@ -42,6 +43,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
+	github.com/moby/go-archive v0.1.0
 	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0
 	github.com/openbao/go-kms-wrapping/v2 v2.5.0
 	github.com/openbao/openbao/api/v2 v2.4.0
@@ -67,7 +69,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -91,7 +92,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/sdk/helper/cel/helpers.go
+++ b/sdk/helper/cel/helpers.go
@@ -5,7 +5,7 @@ import (
 	"net/mail"
 
 	celgo "github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
@@ -67,11 +67,11 @@ func RegisterAllCelFunctions(env *celgo.Env) (*celgo.Env, error) {
 // and is useful for secret engines.
 func IdentityDeclarations() []celgo.EnvOption {
 	return []celgo.EnvOption{
-		celgo.Declarations(
-			decls.NewVar("client_token", decls.String),
-			decls.NewVar("entity_id", decls.String),
-			decls.NewVar("entity_groups", decls.NewListType(decls.Dyn)),
-			decls.NewVar("entity_info", decls.NewMapType(decls.String, decls.Dyn)),
+		celgo.VariableDecls(
+			decls.NewVariable("client_token", types.StringType),
+			decls.NewVariable("entity_id", types.StringType),
+			decls.NewVariable("entity_groups", types.NewListType(types.DynType)),
+			decls.NewVariable("entity_info", types.NewMapType(types.StringType, types.DynType)),
 		),
 	}
 }

--- a/sdk/helper/cel/program.go
+++ b/sdk/helper/cel/program.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/openbao/openbao/sdk/v2/framework"
 )
@@ -102,7 +103,7 @@ func ValidateProgram(celProgram CelProgram) (bool, error) {
 	var envOptions []cel.EnvOption
 	// Add variables to the CEL environment
 	for _, variable := range celProgram.Variables {
-		envOptions = append(envOptions, cel.Declarations(decls.NewVar(variable.Name, decls.Dyn)))
+		envOptions = append(envOptions, cel.VariableDecls(decls.NewVariable(variable.Name, types.DynType)))
 	}
 
 	env, err := cel.NewEnv(envOptions...)

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -160,6 +160,12 @@ func GetSubjectKeyID(pub interface{}) ([]byte, error) {
 			return nil, errutil.InternalError{Err: fmt.Sprintf("error marshalling public key: %s", err)}
 		}
 	case *ecdsa.PublicKey:
+		// TODO: Replace usage of elliptic.Marshal by below code once we compile with Go 1.25
+		// var err error
+		// publicKeyBytes, err = pub.Bytes()
+		// if err != nil {
+		// 	return nil, errutil.InternalError{Err: fmt.Sprintf("error marshalling public key: %s", err)}
+		// }
 		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
 	case ed25519.PublicKey:
 		publicKeyBytes = pub

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -21,7 +21,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/docker/docker/api/types"
+	"github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -29,10 +30,10 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-uuid"
+	"github.com/moby/go-archive"
 )
 
 const DockerAPIVersion = "1.40"
@@ -285,9 +286,9 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 	}
 
 	cleanup := func() {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			err := d.DockerAPI.ContainerRemove(ctx, result.Container.ID, container.RemoveOptions{Force: true})
-			if err == nil || client.IsErrNotFound(err) {
+			if err == nil || errdefs.IsNotFound(err) {
 				return
 			}
 			time.Sleep(1 * time.Second)
@@ -339,12 +340,12 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 type Service struct {
 	Config      ServiceConfig
 	Cleanup     func()
-	Container   *types.ContainerJSON
+	Container   *container.InspectResponse
 	StartResult *StartResult
 }
 
 type StartResult struct {
-	Container *types.ContainerJSON
+	Container *container.InspectResponse
 	Addrs     []string
 	RealIP    string
 }
@@ -770,14 +771,14 @@ func (bCtx *BuildContext) ToTarball() (io.Reader, error) {
 }
 
 type BuildOpt interface {
-	Apply(cfg *types.ImageBuildOptions) error
+	Apply(cfg *build.ImageBuildOptions) error
 }
 
 type BuildRemove bool
 
 var _ BuildOpt = (*BuildRemove)(nil)
 
-func (u BuildRemove) Apply(cfg *types.ImageBuildOptions) error {
+func (u BuildRemove) Apply(cfg *build.ImageBuildOptions) error {
 	cfg.Remove = bool(u)
 	return nil
 }
@@ -786,7 +787,7 @@ type BuildForceRemove bool
 
 var _ BuildOpt = (*BuildForceRemove)(nil)
 
-func (u BuildForceRemove) Apply(cfg *types.ImageBuildOptions) error {
+func (u BuildForceRemove) Apply(cfg *build.ImageBuildOptions) error {
 	cfg.ForceRemove = bool(u)
 	return nil
 }
@@ -795,7 +796,7 @@ type BuildPullParent bool
 
 var _ BuildOpt = (*BuildPullParent)(nil)
 
-func (u BuildPullParent) Apply(cfg *types.ImageBuildOptions) error {
+func (u BuildPullParent) Apply(cfg *build.ImageBuildOptions) error {
 	cfg.PullParent = bool(u)
 	return nil
 }
@@ -804,7 +805,7 @@ type BuildArgs map[string]*string
 
 var _ BuildOpt = (*BuildArgs)(nil)
 
-func (u BuildArgs) Apply(cfg *types.ImageBuildOptions) error {
+func (u BuildArgs) Apply(cfg *build.ImageBuildOptions) error {
 	cfg.BuildArgs = u
 	return nil
 }
@@ -813,7 +814,7 @@ type BuildTags []string
 
 var _ BuildOpt = (*BuildTags)(nil)
 
-func (u BuildTags) Apply(cfg *types.ImageBuildOptions) error {
+func (u BuildTags) Apply(cfg *build.ImageBuildOptions) error {
 	cfg.Tags = u
 	return nil
 }
@@ -825,7 +826,7 @@ func (d *Runner) BuildImage(ctx context.Context, containerfile string, container
 }
 
 func BuildImage(ctx context.Context, api *client.Client, containerfile string, containerContext BuildContext, opts ...BuildOpt) ([]byte, error) {
-	var cfg types.ImageBuildOptions
+	var cfg build.ImageBuildOptions
 
 	// Build container context tarball, provisioning containerfile in.
 	containerContext[containerfilePath] = PathContentsFromBytes([]byte(containerfile))

--- a/sdk/helper/stepwise/environments/docker/environment.go
+++ b/sdk/helper/stepwise/environments/docker/environment.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
@@ -485,7 +484,7 @@ type dockerClusterNode struct {
 	TLSConfig         *tls.Config
 	WorkDir           string
 	Cluster           *DockerCluster
-	container         *types.ContainerJSON
+	container         *container.InspectResponse
 	dockerAPI         *docker.Client
 }
 

--- a/sdk/helper/stepwise/environments/docker/runner.go
+++ b/sdk/helper/stepwise/environments/docker/runner.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	docker "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/moby/go-archive"
 )
 
 // Runner manages the lifecycle of the Docker container
@@ -28,7 +27,7 @@ type Runner struct {
 // pulling the specified Vault image, creating the container, and copies the
 // plugin binary into the container file system before starting the container
 // itself.
-func (d *Runner) Start(ctx context.Context) (*types.ContainerJSON, error) {
+func (d *Runner) Start(ctx context.Context) (*container.InspectResponse, error) {
 	hostConfig := &container.HostConfig{
 		PublishAllPorts: true,
 		AutoRemove:      true,

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/volume"
 	docker "github.com/docker/docker/client"
 	"github.com/hashicorp/go-cleanhttp"
@@ -460,7 +460,7 @@ type DockerClusterNode struct {
 	tlsConfig            *tls.Config
 	WorkDir              string
 	Cluster              *DockerCluster
-	Container            *types.ContainerJSON
+	Container            *container.InspectResponse
 	DockerAPI            *docker.Client
 	Service              *dockhelper.Service
 	Runner               *dockhelper.Runner

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -4,6 +4,7 @@
 package cluster
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -116,8 +117,8 @@ func (l *InmemLayer) Listeners() []NetworkListener {
 	return []NetworkListener{l.listener}
 }
 
-// Dial implements NetworkLayer.
-func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Config) (*tls.Conn, error) {
+// DialContext implements NetworkLayer.
+func (l *InmemLayer) DialContext(ctx context.Context, addr string, tlsConfig *tls.Config) (*tls.Conn, error) {
 	l.l.Lock()
 	connectionCh := l.connectionCh
 
@@ -143,10 +144,6 @@ func (l *InmemLayer) Dial(addr string, timeout time.Duration, tlsConfig *tls.Con
 	l.l.Unlock()
 	if !ok {
 		return nil, errors.New("inmemlayer: no address found")
-	}
-
-	if timeout < 0 {
-		return nil, fmt.Errorf("inmemlayer: timeout given is less than 0: %d", timeout)
 	}
 
 	alpn := ""

--- a/vault/cluster/inmem_layer_test.go
+++ b/vault/cluster/inmem_layer_test.go
@@ -51,7 +51,7 @@ func TestInmemCluster_Connect(t *testing.T) {
 	}()
 
 	// Make sure two nodes can connect in
-	conn, err := cluster.layers[1].Dial(server.addr, 0, nil)
+	conn, err := cluster.layers[1].DialContext(t.Context(), server.addr, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestInmemCluster_Connect(t *testing.T) {
 		t.Fatal("nil conn")
 	}
 
-	conn, err = cluster.layers[2].Dial(server.addr, 0, nil)
+	conn, err = cluster.layers[2].DialContext(t.Context(), server.addr, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestInmemCluster_Disconnect(t *testing.T) {
 	}()
 
 	// Make sure node1 cannot connect in
-	conn, err := cluster.layers[1].Dial(server.addr, 0, nil)
+	conn, err := cluster.layers[1].DialContext(t.Context(), server.addr, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -127,7 +127,7 @@ func TestInmemCluster_Disconnect(t *testing.T) {
 	}
 
 	// Node2 should be able to connect
-	conn, err = cluster.layers[2].Dial(server.addr, 0, nil)
+	conn, err = cluster.layers[2].DialContext(t.Context(), server.addr, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestInmemCluster_DisconnectAll(t *testing.T) {
 	server.DisconnectAll()
 
 	// Make sure nodes cannot connect in
-	conn, err := cluster.layers[1].Dial(server.addr, 0, nil)
+	conn, err := cluster.layers[1].DialContext(t.Context(), server.addr, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -167,7 +167,7 @@ func TestInmemCluster_DisconnectAll(t *testing.T) {
 		t.Fatal("expected nil conn")
 	}
 
-	conn, err = cluster.layers[2].Dial(server.addr, 0, nil)
+	conn, err = cluster.layers[2].DialContext(t.Context(), server.addr, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -235,7 +235,7 @@ func TestInmemCluster_ConnectCluster(t *testing.T) {
 	// Make sure each node can connect to each other
 	for _, node1 := range cluster.layers {
 		for _, node2 := range cluster2.layers {
-			conn, err := node1.Dial(node2.addr, 0, nil)
+			conn, err := node1.DialContext(t.Context(), node2.addr, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -244,7 +244,7 @@ func TestInmemCluster_ConnectCluster(t *testing.T) {
 				t.Fatal("nil conn")
 			}
 
-			conn, err = node2.Dial(node1.addr, 0, nil)
+			conn, err = node2.DialContext(t.Context(), node1.addr, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/vault/external_tests/api/sudo_paths_test.go
+++ b/vault/external_tests/api/sudo_paths_test.go
@@ -87,8 +87,7 @@ func TestSudoPaths(t *testing.T) {
 }
 
 func getSudoPathsFromSpec(client *api.Client) (map[string]struct{}, error) {
-	r := client.NewRequest("GET", "/v1/sys/internal/specs/openapi")
-	resp, err := client.RawRequest(r)
+	resp, err := client.Logical().ReadRaw("sys/internal/specs/openapi")
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve sudo endpoints: %v", err)
 	}

--- a/vault/external_tests/api/sys_rotate_ext_test.go
+++ b/vault/external_tests/api/sys_rotate_ext_test.go
@@ -69,16 +69,26 @@ func testSysRekey_VerificationDeprecated(t *testing.T, recovery bool) {
 	client := cluster.Cores[0].Client
 	client.SetMaxRetries(0)
 
+	//nolint:staticcheck // endpoint already marked as deprecated
 	initFunc := client.Sys().RekeyInit
+	//nolint:staticcheck // endpoint already marked as deprecated
 	updateFunc := client.Sys().RekeyUpdate
+	//nolint:staticcheck // endpoint already marked as deprecated
 	verificationUpdateFunc := client.Sys().RekeyVerificationUpdate
+	//nolint:staticcheck // endpoint already marked as deprecated
 	verificationStatusFunc := client.Sys().RekeyVerificationStatus
+	//nolint:staticcheck // endpoint already marked as deprecated
 	verificationCancelFunc := client.Sys().RekeyVerificationCancel
 	if recovery {
+		//nolint:staticcheck // endpoint already marked as deprecated
 		initFunc = client.Sys().RekeyRecoveryKeyInit
+		//nolint:staticcheck // endpoint already marked as deprecated
 		updateFunc = client.Sys().RekeyRecoveryKeyUpdate
+		//nolint:staticcheck // endpoint already marked as deprecated
 		verificationUpdateFunc = client.Sys().RekeyRecoveryKeyVerificationUpdate
+		//nolint:staticcheck // endpoint already marked as deprecated
 		verificationStatusFunc = client.Sys().RekeyRecoveryKeyVerificationStatus
+		//nolint:staticcheck // endpoint already marked as deprecated
 		verificationCancelFunc = client.Sys().RekeyRecoveryKeyVerificationCancel
 	}
 
@@ -105,7 +115,7 @@ func testSysRekey_VerificationDeprecated(t *testing.T, recovery bool) {
 			keys = cluster.RecoveryKeys
 		}
 		var resp *api.RotateUpdateResponse
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			resp, err = updateFunc(base64.StdEncoding.EncodeToString(keys[i]), status.Nonce)
 			if err != nil {
 				t.Fatal(err)

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -127,15 +126,8 @@ path "secret/foo" {
 	defer client.SetToken(originalToken)
 	client.SetToken(userpassToken)
 
-	// Create a GET request and set the MFA header containing the generated
-	// TOTP passcode
-	secretRequest := client.NewRequest("GET", "/v1/secret/foo")
-	secretRequest.Headers = make(http.Header)
-	// mfaHeaderValue := "my_duo:" + totpPasscode
-	// secretRequest.Headers.Add("X-Vault-MFA", mfaHeaderValue)
-
 	// Make the request
-	resp, err := client.RawRequest(secretRequest)
+	resp, err := client.Logical().ReadRaw("secret/foo")
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -79,7 +79,7 @@ func TestKV_Patch_BadContentTypeHeader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		return c.RawRequestWithContext(context.Background(), req)
+		return c.RawRequestWithContext(t.Context(), req)
 	})
 
 	apiResp, ok := apiRespRaw.(*api.Response)

--- a/vault/external_tests/kv/kv_subkeys_test.go
+++ b/vault/external_tests/kv/kv_subkeys_test.go
@@ -47,8 +47,7 @@ func TestKV_Subkeys_NotFound(t *testing.T) {
 	}
 
 	apiRespRaw, err := kvRequestWithRetry(t, func() (interface{}, error) {
-		req := c.NewRequest("GET", "/v1/kv/subkeys/foo")
-		return c.RawRequestWithContext(context.Background(), req)
+		return c.Logical().ReadRaw("kv/subkeys/foo")
 	})
 
 	apiResp, ok := apiRespRaw.(*api.Response)
@@ -118,8 +117,7 @@ func TestKV_Subkeys_Deleted(t *testing.T) {
 	}
 
 	apiRespRaw, err := kvRequestWithRetry(t, func() (interface{}, error) {
-		req := c.NewRequest("GET", "/v1/kv/subkeys/foo")
-		return c.RawRequestWithContext(context.Background(), req)
+		return c.Logical().ReadRaw("kv/subkeys/foo")
 	})
 
 	apiResp, ok := apiRespRaw.(*api.Response)
@@ -226,8 +224,7 @@ func TestKV_Subkeys_Destroyed(t *testing.T) {
 	}
 
 	apiRespRaw, err := kvRequestWithRetry(t, func() (interface{}, error) {
-		req := c.NewRequest("GET", "/v1/kv/subkeys/foo")
-		return c.RawRequestWithContext(context.Background(), req)
+		return c.Logical().ReadRaw("kv/subkeys/foo")
 	})
 
 	apiResp, ok := apiRespRaw.(*api.Response)
@@ -336,8 +333,7 @@ func TestKV_Subkeys_CurrentVersion(t *testing.T) {
 	}
 
 	apiRespRaw, err := kvRequestWithRetry(t, func() (interface{}, error) {
-		req := c.NewRequest("GET", "/v1/kv/subkeys/foo")
-		return c.RawRequestWithContext(context.Background(), req)
+		return c.Logical().ReadRaw("kv/subkeys/foo")
 	})
 
 	apiResp, ok := apiRespRaw.(*api.Response)

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -4,7 +4,6 @@
 package metrics
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -140,10 +139,8 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 	standbyClient := cores[1].Client
 
 	r := client.NewRequest("GET", "/v1/sys/metrics")
-	r2 := standbyClient.NewRequest("GET", "/v1/sys/metrics")
 	r.Headers.Set("X-Vault-Token", cluster.RootToken)
-	r2.Headers.Set("X-Vault-Token", cluster.RootToken)
-	respo, err := client.RawRequestWithContext(context.Background(), r)
+	respo, err := client.RawRequest(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +184,7 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 
 	r = standbyClient.NewRequest("GET", "/v1/sys/metrics")
 	r.Headers.Set("X-Vault-Token", cluster.RootToken)
-	respo, err = standbyClient.RawRequestWithContext(context.Background(), r)
+	respo, err = standbyClient.RawRequest(r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/external_tests/pprof/pprof.go
+++ b/vault/external_tests/pprof/pprof.go
@@ -4,7 +4,6 @@
 package pprof
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -117,8 +116,7 @@ func SysPprof_Test(t *testing.T, cluster testcluster.VaultCluster) {
 
 func SysPprof_Standby_Test(t *testing.T, cluster testcluster.VaultCluster) {
 	pprof := func(client *api.Client) (string, error) {
-		req := client.NewRequest("GET", "/v1/sys/pprof/cmdline")
-		resp, err := client.RawRequestWithContext(context.Background(), req)
+		resp, err := client.Logical().ReadRaw("sys/pprof/cmdline")
 		if err != nil {
 			return "", err
 		}

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -402,8 +402,7 @@ func TestRaft_NodeIDHeader(t *testing.T) {
 				}
 
 				client := c.Client
-				req := client.NewRequest("GET", "/v1/sys/seal-status")
-				resp, err := client.RawRequest(req)
+				resp, err := client.Logical().ReadRaw("sys/seal-status")
 				if err != nil {
 					t.Fatalf("err: %s", err)
 				}

--- a/vault/external_tests/response/allowed_response_headers_test.go
+++ b/vault/external_tests/response/allowed_response_headers_test.go
@@ -84,8 +84,7 @@ func TestIdentityStore_EntityDisabled(t *testing.T) {
 
 	// Here, should succeed but we should not see the header since it's
 	// not in the allowed list
-	req := client.NewRequest("GET", "/v1/auth/headtest/loginnoerror")
-	resp, err := client.RawRequest(req)
+	resp, err := client.Logical().ReadRaw("auth/headtest/loginnoerror")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,8 +97,7 @@ func TestIdentityStore_EntityDisabled(t *testing.T) {
 
 	// Should fail but we should not see the header since it's
 	// not in the allowed list
-	req = client.NewRequest("GET", "/v1/auth/headtest/login")
-	resp, err = client.RawRequest(req)
+	resp, err = client.Logical().ReadRaw("auth/headtest/login")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -118,8 +116,7 @@ func TestIdentityStore_EntityDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req = client.NewRequest("GET", "/v1/auth/headtest/loginnoerror")
-	resp, err = client.RawRequest(req)
+	resp, err = client.Logical().ReadRaw("auth/headtest/loginnoerror")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,8 +127,7 @@ func TestIdentityStore_EntityDisabled(t *testing.T) {
 		t.Fatalf("expected negotiate header; headers:\n%s", pretty.Sprint(resp.Header))
 	}
 
-	req = client.NewRequest("GET", "/v1/auth/headtest/login")
-	resp, err = client.RawRequest(req)
+	resp, err = client.Logical().ReadRaw("auth/headtest/login")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"maps"
 	"math/rand"
 	"net/http"
 	"path"
@@ -4507,9 +4508,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			}
 
 			// Merge backend schema components
-			for e, schema := range backendDoc.Components.Schemas {
-				doc.Components.Schemas[e] = schema
-			}
+			maps.Copy(doc.Components.Schemas, backendDoc.Components.Schemas)
 		}
 		return nil
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4385,8 +4385,6 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
-	context := d.Get("context").(string)
-
 	// Set up target document
 	doc := framework.NewOASDocument(version.Version)
 
@@ -4519,8 +4517,6 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	if err := procMountGroup("auth", "auth/"); err != nil {
 		return nil, err
 	}
-
-	doc.CreateOperationIDs(context)
 
 	buf, err := json.Marshal(doc)
 	if err != nil {

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"net/url"
@@ -23,6 +24,7 @@ import (
 	"github.com/openbao/openbao/vault/cluster"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -267,9 +269,11 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 	// ALPN header right. It's just "insecure" because GRPC isn't managing
 	// the TLS state.
 	dctx, cancelFunc := context.WithCancel(ctx)
-	c.rpcClientConn, err = grpc.DialContext(dctx, clusterURL.Host,
-		grpc.WithDialer(clusterListener.GetDialerFunc(ctx, consts.RequestForwardingALPN)),
-		grpc.WithInsecure(), // it's not, we handle it in the dialer
+	c.rpcClientConn, err = grpc.NewClient(fmt.Sprintf("passthrough:///%s", clusterURL.Host),
+		grpc.WithContextDialer(clusterListener.GetContextDialerFunc(ctx, consts.RequestForwardingALPN)),
+		grpc.WithTransportCredentials(
+			insecure.NewCredentials(), // it's not, we handle it in the dialer
+		),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time: 2 * c.clusterHeartbeatInterval,
 		}),


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

This is part of #1580.

~There are several changes that I expect to prompt some discussion:~
- ~Removal of CRLv1 support for the TLS auth method~
  - ~CRLv1 is no longer supported by the non-deprecated Go std functions~
  - ~CRLv2 MUST be generated by CAs conforming to RFC3280 (2003) and its successor RFC5280 (2008)~
  - ~OpenBao itself only generates CRLv2~
  - ~Counterpoint: OpenSSL CLI by default (without adding at least one extension to the CRL) will still produce a CRLv1, see discussion [here](https://github.com/openssl/openssl/issues/23109)~
- ~Removal of DSA signatures for cert signing in the SSH secrets engine~
  - ~The `crypto/dsa` Go package is deprecated~
  - ~DSA support was removed from OpenSSH in version 1.10, being disabled by default since 2015~
  - ~Counterpoint: There may still be legacy systems around that need DSA for SSH~

~We might want to not merge these two changes right away, but deprecate them first?~

Some other notable parts of this PR:
- We'll still be using a bunch of our own deprecated functions, especially `client.RawRequest`. I replaced it with `client.Logical().ReadRaw` where possible, but we are lacking corresponding methods for Delete, Post, ..., as well as options to set headers for the requests.
- `elliptic.Marshal` can't be replaced easily at the moment. Go 1.25 introduced `ecdsa.PublicKey.Bytes()`, which can be used as a direct replacement, but we are still bound to 1.24 at the moment (especially the EL8 runner). Converting to `ecdh.PublicKey` (as recommended by the Go docs) also does not work, as it does not support the curve P224, which we support. I opted to add a comment with the code we can replace it with in 1.25 and leave it as is otherwise.
- I removed the usage of `OASDocument.CreateOperationIDs` and could not detect any change in behavior in the automated tests or my manual tests. It is documented as being there for legacy plugins, but it was not clear to me if the legacy plugins would call this, or if we need to call it for the legacy plugins.
- After this PR, there are two deprecation warnings left: one for the mentioned `elliptic.Marshal`, the other one for usage of `cloud.google.com/go/monitoring/apiv3`, which is tied to #1929.

I recommend to review commit by commit.