### PR TITLE
Fix Docusaurus deprecation warning

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -22,7 +22,6 @@ const config: Config = {
   projectName: "openbao", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
   // ignore broken anchors as most of them are false positives
   onBrokenAnchors: "ignore",
 


### PR DESCRIPTION
I noticed this warning while testing https://github.com/openbao/openbao/pull/2039:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

our current choice of `"warn"` is already the default for the new option[^1], so I've opted to simply remove the old one.

[^1]: https://docusaurus.io/docs/api/docusaurus-config#markdown