### PR TITLE
Return an error on well-known component presence in OIDCDiscoveryURL value

### DIFF
--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -48,7 +48,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"oidc_discovery_url": {
 				Type:        framework.TypeString,
-				Description: `Either the base URL of the OIDC Discovery endpoint or the full URL with ".well-known/openid-configuration" path suffix. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".`,
+				Description: `The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".`,
 			},
 			"oidc_discovery_ca_pem": {
 				Type:        framework.TypeString,
@@ -384,16 +384,8 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("both 'oidc_client_id' and 'oidc_client_secret' must be set for OIDC"), nil
 
 	case config.OIDCDiscoveryURL != "":
-		// due to `go-oidc` issuer matching logic, we cannot handle base urls
-		// not ending with a trailing slash, but that's been always the case
-
-		// trim '.well-known/openid-configuration', due to jwt.NewOIDCDiscoveryKeySet()
-		// not accounting for its presence.
-		// config is saved to the storage without '.well-known' component
-		trimmedDiscoveryURL, _, _ := strings.Cut(config.OIDCDiscoveryURL, ".well-known/openid-configuration")
-		if trimmedDiscoveryURL != config.OIDCDiscoveryURL {
-			config.OIDCDiscoveryURL = trimmedDiscoveryURL
-			resp.AddWarning(fmt.Sprintf("modifying provided `OIDCDiscoveryURL` to %q", trimmedDiscoveryURL))
+		if strings.Contains(config.OIDCDiscoveryURL, ".well-known/openid-configuration") {
+			return logical.ErrorResponse("'oidc_discovery_url' contains '.well-known' component"), nil
 		}
 
 		var err error

--- a/changelog/2066.txt
+++ b/changelog/2066.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-auth/jwt: Allow OIDCDiscoveryURL to optionally include '.well-known/openid-configuration' path suffix.
+```release-note:change
+auth/jwt: Return error msg on OIDCDiscoveryURL including '.well-known/openid-configuration' component.
 ```

--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -14,7 +14,7 @@ export default AuthConfig.extend({
   oidcDiscoveryUrl: attr('string', {
     label: 'OIDC discovery URL',
     helpText:
-      'Either the base URL of the OIDC Discovery endpoint or the full URL with ".well-known/openid-configuration" path suffix. Cannot be used with jwt_validation_pubkeys',
+      'The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with jwt_validation_pubkeys',
   }),
 
   oidcClientId: attr('string', {

--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -37,7 +37,7 @@ set.
 
 ### Parameters
 
-- `oidc_discovery_url` `(string: <optional>)` - Either the base URL of the OIDC Discovery endpoint or the full URL with ".well-known/openid-configuration" path suffix. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".
+- `oidc_discovery_url` `(string: <optional>)` - The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".
 - `oidc_discovery_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used.
 - `oidc_client_id` `(string: <optional>)` - The OAuth Client ID from the provider for OIDC roles.
 - `oidc_client_secret` `(string: <optional>)` - The OAuth Client Secret from the provider for OIDC roles.


### PR DESCRIPTION
Resolves: #2035

This PR introduces a change to the `jwtAuthBackend`, which now returns an error on encountering a `.well-known/` component passed with `OIDCDiscoveryURL`.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
