### PR TITLE
Untangle tencentcloud dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -343,7 +343,8 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 // indirect
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 // indirect
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 // indirect
 	github.com/tilinna/clock v1.0.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -866,8 +866,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 h1:Dwnfdrk3KXpYRH9Kwrk9sHpZSOmrE7P9LBoNsYUJKR4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 h1:YEDZmv2ABU8QvwXEVTOQgVEQzDOByhz73vdjL6sERkE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480/go.mod h1:zaBIuDDs+rC74X8Aog+LSu91GFtHYRYDC196RGTm2jk=
 github.com/tilinna/clock v1.0.2 h1:6BO2tyAC9JbPExKH/z9zl44FLu1lImh3nDNKA0kgrkI=
 github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/tink-crypto/tink-go/v2 v2.5.0 h1:B8KLF6AofxdBIE4UJIaFbmoj5/1ehEtt7/MmzfI4Zpw=


### PR DESCRIPTION
## Description

`github.com/tencentcloud/tencentcloud-sdk-go` used to have packages `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/{common,cvm}` that were converted to separate modules (while remaining at the same import path). We currently use the old, converged module, even though all of our direct dependencies that cause the transitive dependency on Tencent's SDK already use the new module:

https://github.com/hashicorp/go-discover/blob/df7d739e0275027834e693da8b7e0a26f411e21f/go.mod#L22-L23

(Technically there's also https://github.com/openbao/go-kms-wrapping/blob/357d2d2b079f345659ec108a6f7231773230c1f8/wrappers/tencentcloudkms/go.mod#L9-L10, but we don't use the tencent wrapper in the main repo?)

## Rationale

I've only come across this problem because this causes a hard error once you add the main module to a Go workspace:

```
$ go work init && go work use ./openbao
$ cd openbao && go build -o bin/bao
../../../.go/pkg/mod/github.com/hashicorp/go-discover@v1.1.0/provider/tencentcloud/tencentcloud_discover.go:9:2: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common in multiple modules:
        github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/common)
        github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common@v1.0.480)
../../../.go/pkg/mod/github.com/hashicorp/go-discover@v1.1.0/provider/tencentcloud/tencentcloud_discover.go:10:2: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile in multiple modules:
        github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/common/profile)
        github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common@v1.0.480/profile)
../../../.go/pkg/mod/github.com/hashicorp/go-discover@v1.1.0/provider/tencentcloud/tencentcloud_discover.go:11:2: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312 in multiple modules:
        github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/cvm/v20170312)
        github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 (/home/satoqz/.go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm@v1.0.480/v20170312)
```

I suppose Go doesn't allow this kind of sloppy package resolution in a workspace context, I'm really not sure, but also very surprised that the current setup works at all.

This fixes that inconvenience, and ensures that that we can update this dependency in the future without running into problems (tbf, I'm not sure if it's dead code anyways, I'd need to look closer at go-discover).

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
