### PR TITLE
Add Workflow to check for absolute links in docs

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -10,6 +10,26 @@ on:
       - "website/**"
 
 jobs:
+  check-links:
+    name: Check Absolute Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Find absolute links
+        run: |
+          echo "Checking for absolute links in website/content/docs/..."
+          grep -rn -P "(\(|: |openbao.org)/docs/[^)]+" website/content/docs > grep_output.txt || true
+
+          echo "Checking for absolute links in website/content/api-docs/..."
+          grep -rn -P "(\(|: |openbao.org)/api-docs/[^)]+" website/content/api-docs >> grep_output.txt || true
+
+          # Check if any absolute links were found
+          if [ -s grep_output.txt ]; then
+            echo "::error::Found absolute links that should be relative. See annotations for details."
+            jq -rRs 'split("\n")[:-1][]| split(":") | "::error file=\(.[0]),line=\(.[1]),title=Absolute Link found::\(.[2:]| join(":"))"' grep_output.txt
+            exit 1
+          fi
   test-docs:
     name: Test Docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
To ensure we make use of relative links so versioned docs work properly.
If an absolute link is found, the relevant code will be annotated with an error
<img width="861" height="322" alt="image" src="https://github.com/user-attachments/assets/b5ec0a94-5257-463e-93ed-e0d8a353f85d" />


Part-Of: #1681

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.