### PR TITLE
Fix some staticcheck findings (nil pointer deref)

### DIFF
--- a/api/ssh_agent_test.go
+++ b/api/ssh_agent_test.go
@@ -14,12 +14,12 @@ func TestSSH_CreateTLSClient(t *testing.T) {
 	// load the default configuration
 	config, err := LoadSSHHelperConfig("./test-fixtures/agent_config.hcl")
 	if err != nil {
-		panic(fmt.Sprintf("error loading agent's config file: %s", err))
+		t.Fatalf("error loading agent's config file: %s", err)
 	}
 
 	client, err := config.NewClient()
 	if err != nil {
-		panic(fmt.Sprintf("error creating the client: %s", err))
+		t.Errorf("error creating the client: %s", err)
 	}
 
 	// Provide a certificate and enforce setting of transport
@@ -27,10 +27,10 @@ func TestSSH_CreateTLSClient(t *testing.T) {
 
 	client, err = config.NewClient()
 	if err != nil {
-		panic(fmt.Sprintf("error creating the client: %s", err))
+		t.Fatalf("error creating the client: %s", err)
 	}
 	if client.config.HttpClient.Transport == nil {
-		panic("error creating client with TLS transport")
+		t.Fatal("error creating client with TLS transport")
 	}
 }
 
@@ -43,17 +43,17 @@ vault_addr = "1.2.3.4"
 tls_server_name = "%s"
 `, tlsServerName))
 	if err != nil {
-		panic(fmt.Sprintf("error loading config: %s", err))
+		t.Fatalf("error loading config: %s", err)
 	}
 
 	client, err := config.NewClient()
 	if err != nil {
-		panic(fmt.Sprintf("error creating the client: %s", err))
+		t.Fatalf("error creating the client: %s", err)
 	}
 
 	actualTLSServerName := client.config.HttpClient.Transport.(*http.Transport).TLSClientConfig.ServerName
 	if actualTLSServerName != tlsServerName {
-		panic(fmt.Sprintf("incorrect TLS server name. expected: %s actual: %s", tlsServerName, actualTLSServerName))
+		t.Fatalf("incorrect TLS server name. expected: %s actual: %s", tlsServerName, actualTLSServerName)
 	}
 }
 

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -10,12 +10,10 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/go-hclog"
 	_ "github.com/jackc/pgx/v5"
@@ -33,6 +31,7 @@ import (
 	postgreshelper "github.com/openbao/openbao/sdk/v2/helper/testhelpers/postgresql"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
@@ -65,9 +64,7 @@ func TestBackend_PluginMain_Postgres(t *testing.T) {
 	}
 
 	dbType, err := postgresql.New()
-	if err != nil {
-		t.Fatalf("Failed to initialize postgres: %s", err)
-	}
+	require.NoErrorf(t, err, "Failed to initialize postgres: %s", err)
 
 	v5.Serve(dbType.(v5.Database))
 }
@@ -91,13 +88,9 @@ func TestBackend_config_connection(t *testing.T) {
 	config.StorageView = &logical.InmemStorage{}
 	config.System = sys
 	lb, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	b, ok := lb.(*databaseBackend)
-	if !ok {
-		t.Fatal("could not convert to database backend")
-	}
+	require.Truef(t, ok, "could not convert to database backend")
 	defer b.Cleanup(context.Background())
 
 	// Test creation
@@ -122,17 +115,12 @@ func TestBackend_config_connection(t *testing.T) {
 			Raw:    configData,
 			Schema: pathConfigurePluginConnection(b).Fields,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if exists {
-			t.Fatal("expected not exists")
-		}
+		require.NoError(t, err)
+		require.Falsef(t, exists, "expected not exists")
 
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%v resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%v resp:%#v\n", err, resp)
 
 		expected := map[string]interface{}{
 			"plugin_name": "postgresql-database-plugin",
@@ -146,15 +134,12 @@ func TestBackend_config_connection(t *testing.T) {
 			"plugin_version":                     "",
 		}
 		configReq.Operation = logical.ReadOperation
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		delete(resp.Data["connection_details"].(map[string]interface{}), "name")
-		if !reflect.DeepEqual(expected, resp.Data) {
-			t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
-		}
+		require.Equalf(t, expected, resp.Data, "bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
 	}
 
 	// Test existence check and an update to a single connection detail parameter
@@ -176,17 +161,12 @@ func TestBackend_config_connection(t *testing.T) {
 			Raw:    configData,
 			Schema: pathConfigurePluginConnection(b).Fields,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !exists {
-			t.Fatal("expected exists")
-		}
+		require.NoError(t, err)
+		require.Truef(t, exists, "expected exists")
 
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%v resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%v resp:%#v\n", err, resp)
 
 		expected := map[string]interface{}{
 			"plugin_name": "postgresql-database-plugin",
@@ -200,15 +180,12 @@ func TestBackend_config_connection(t *testing.T) {
 			"plugin_version":                     "",
 		}
 		configReq.Operation = logical.ReadOperation
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		delete(resp.Data["connection_details"].(map[string]interface{}), "name")
-		if !reflect.DeepEqual(expected, resp.Data) {
-			t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
-		}
+		require.Equalf(t, expected, resp.Data, "bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
 	}
 
 	// Test an update to a non-details value
@@ -226,10 +203,9 @@ func TestBackend_config_connection(t *testing.T) {
 			Data:      configData,
 		}
 
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%v resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%v resp:%#v\n", err, resp)
 
 		expected := map[string]interface{}{
 			"plugin_name": "postgresql-database-plugin",
@@ -243,15 +219,12 @@ func TestBackend_config_connection(t *testing.T) {
 			"plugin_version":                     "",
 		}
 		configReq.Operation = logical.ReadOperation
-		resp, err = b.HandleRequest(namespace.RootContext(nil), configReq)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), configReq)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		delete(resp.Data["connection_details"].(map[string]interface{}), "name")
-		if !reflect.DeepEqual(expected, resp.Data) {
-			t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
-		}
+		require.Equal(t, expected, resp.Data, "bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
 	}
 
 	req := &logical.Request{
@@ -259,15 +232,11 @@ func TestBackend_config_connection(t *testing.T) {
 		Storage:   config.StorageView,
 		Path:      "config/",
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoError(t, err)
 	keys := resp.Data["keys"].([]string)
 	key := keys[0]
-	if key != "plugin-test" {
-		t.Fatalf("bad key: %q", key)
-	}
+	require.Equalf(t, key, "plugin-test", "bad key: %q", key)
 }
 
 func TestBackend_BadConnectionString(t *testing.T) {
@@ -279,9 +248,7 @@ func TestBackend_BadConnectionString(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	cleanup, _ := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -289,17 +256,12 @@ func TestBackend_BadConnectionString(t *testing.T) {
 
 	respCheck := func(req *logical.Request) {
 		t.Helper()
-		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if resp == nil || !resp.IsError() {
-			t.Fatalf("expected error, resp:%#v", resp)
-		}
+		resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.IsError(), "expected error, resp:%#v", resp)
 		err = resp.Error()
-		if strings.Contains(err.Error(), "localhost") {
-			t.Fatal("error should not contain connection info")
-		}
+		require.NotContainsf(t, err.Error(), "localhost", "error should not contain connection info")
 	}
 
 	// Configure a connection
@@ -328,9 +290,7 @@ func TestBackend_basic(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -348,10 +308,9 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Create a role
 	data = map[string]interface{}{
@@ -365,10 +324,9 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 	// Get creds
 	data = map[string]interface{}{}
 	req = &logical.Request{
@@ -377,10 +335,9 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 	// Update the role with no max ttl
 	data = map[string]interface{}{
 		"db_name":             "plugin-test",
@@ -394,10 +351,9 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 	// Get creds
 	data = map[string]interface{}{}
 	req = &logical.Request{
@@ -406,14 +362,11 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 	// Test for #3812
-	if credsResp.Secret.TTL != 5*time.Minute {
-		t.Fatalf("unexpected TTL of %d", credsResp.Secret.TTL)
-	}
+	require.Equalf(t, credsResp.Secret.TTL, 5*time.Minute, "unexpected TTL of %d", credsResp.Secret.TTL)
 	// Update the role with a max ttl
 	data = map[string]interface{}{
 		"db_name":             "plugin-test",
@@ -427,10 +380,9 @@ func TestBackend_basic(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds and revoke when the role stays in existence
 	{
@@ -441,17 +393,12 @@ func TestBackend_basic(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (credsResp != nil && credsResp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-		}
+		credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+		require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 		// Test for #3812
-		if credsResp.Secret.TTL != 5*time.Minute {
-			t.Fatalf("unexpected TTL of %d", credsResp.Secret.TTL)
-		}
-		if !testCredsExist(t, credsResp, connURL) {
-			t.Fatal("Creds should exist")
-		}
+		require.Equalf(t, credsResp.Secret.TTL, 5*time.Minute, "unexpected TTL of %d", credsResp.Secret.TTL)
+		require.Truef(t, testCredsExist(t, credsResp, connURL), "Creds should exist")
 
 		// Revoke creds
 		resp, err = b.HandleRequest(namespace.RootContext(nil), &logical.Request{
@@ -465,13 +412,10 @@ func TestBackend_basic(t *testing.T) {
 				},
 			},
 		})
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
-		if testCredsExist(t, credsResp, connURL) {
-			t.Fatal("Creds should not exist")
-		}
+		require.Falsef(t, testCredsExist(t, credsResp, connURL), "Creds should not exist")
 	}
 
 	// Get creds and revoke using embedded revocation data
@@ -483,13 +427,10 @@ func TestBackend_basic(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (credsResp != nil && credsResp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-		}
-		if !testCredsExist(t, credsResp, connURL) {
-			t.Fatal("Creds should exist")
-		}
+		credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+		require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
+		require.Truef(t, testCredsExist(t, credsResp, connURL), "Creds should exist")
 
 		// Delete role, forcing us to rely on embedded data
 		req = &logical.Request{
@@ -497,10 +438,9 @@ func TestBackend_basic(t *testing.T) {
 			Path:      "roles/plugin-role-test",
 			Storage:   config.StorageView,
 		}
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		// Revoke creds
 		resp, err = b.HandleRequest(namespace.RootContext(nil), &logical.Request{
@@ -516,13 +456,10 @@ func TestBackend_basic(t *testing.T) {
 				},
 			},
 		})
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
-		if testCredsExist(t, credsResp, connURL) {
-			t.Fatal("Creds should not exist")
-		}
+		require.Falsef(t, testCredsExist(t, credsResp, connURL), "Creds should not exist")
 	}
 }
 
@@ -535,9 +472,7 @@ func TestBackend_connectionCrud(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -555,10 +490,9 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Create a role
 	data = map[string]interface{}{
@@ -574,10 +508,9 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Update the connection
 	data = map[string]interface{}{
@@ -594,39 +527,28 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-	if len(resp.Warnings) == 0 {
-		t.Fatalf("expected warning about password in url %s, resp:%#v\n", connURL, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
+	require.NotEqualf(t, len(resp.Warnings), 0, "expected warning about password in url %s, resp:%#v\n", connURL, resp)
 
 	req.Operation = logical.ReadOperation
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 	returnedConnectionDetails := resp.Data["connection_details"].(map[string]interface{})
-	if strings.Contains(returnedConnectionDetails["connection_url"].(string), "secret") {
-		t.Fatal("password should not be found in the connection url")
-	}
+	require.NotContainsf(t, returnedConnectionDetails["connection_url"].(string), "secret", "password should not be found in the connection url")
 	// Covered by the filled out `expected` value below, but be explicit about this requirement.
-	if _, exists := returnedConnectionDetails["password"]; exists {
-		t.Fatal("password should NOT be found in the returned config")
-	}
-	if _, exists := returnedConnectionDetails["private_key"]; exists {
-		t.Fatal("private_key should NOT be found in the returned config")
-	}
+	require.NotContainsf(t, returnedConnectionDetails, "password", "password should NOT be found in the returned config")
+	require.NotContainsf(t, returnedConnectionDetails, "private_key", "private_key should NOT be found in the returned config")
 
 	// Replace connection url with templated version
 	req.Operation = logical.UpdateOperation
 	connURL = strings.ReplaceAll(connURL, "postgres:secret", "{{username}}:{{password}}")
 	data["connection_url"] = connURL
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Read connection
 	expected := map[string]interface{}{
@@ -641,15 +563,12 @@ func TestBackend_connectionCrud(t *testing.T) {
 		"plugin_version":                     "",
 	}
 	req.Operation = logical.ReadOperation
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	delete(resp.Data["connection_details"].(map[string]interface{}), "name")
-	if diff := deep.Equal(resp.Data, expected); diff != nil {
-		t.Fatal(diff)
-	}
+	require.Equal(t, resp.Data, expected)
 
 	// Reset Connection
 	data = map[string]interface{}{}
@@ -659,10 +578,9 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds
 	data = map[string]interface{}{}
@@ -672,18 +590,15 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 
 	credCheckURL := dbutil.QueryHelper(connURL, map[string]string{
 		"username": "postgres",
 		"password": "secret",
 	})
-	if !testCredsExist(t, credsResp, credCheckURL) {
-		t.Fatal("Creds should exist")
-	}
+	require.Truef(t, testCredsExist(t, credsResp, credCheckURL), "Creds should exist")
 
 	// Delete Connection
 	data = map[string]interface{}{}
@@ -693,22 +608,18 @@ func TestBackend_connectionCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Read connection
 	req.Operation = logical.ReadOperation
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Should be empty
-	if resp != nil {
-		t.Fatal("Expected response to be nil")
-	}
+	require.Nilf(t, resp, "Expected response to be nil")
 }
 
 func TestBackend_roleCrud(t *testing.T) {
@@ -720,13 +631,9 @@ func TestBackend_roleCrud(t *testing.T) {
 	config.System = sys
 
 	lb, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	b, ok := lb.(*databaseBackend)
-	if !ok {
-		t.Fatal("could not convert to db backend")
-	}
+	require.Truef(t, ok, "could not convert to db backend")
 	defer b.Cleanup(context.Background())
 
 	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -743,10 +650,9 @@ func TestBackend_roleCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Test role creation
 	{
@@ -763,10 +669,9 @@ func TestBackend_roleCrud(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		// Read the role
 		data = map[string]interface{}{}
@@ -776,10 +681,9 @@ func TestBackend_roleCrud(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		expected := v4.Statements{
 			Creation:   []string{strings.TrimSpace(testRole)},
@@ -795,19 +699,10 @@ func TestBackend_roleCrud(t *testing.T) {
 			Renewal:    resp.Data["renew_statements"].([]string),
 		}
 
-		if diff := deep.Equal(&expected, &actual); diff != nil {
-			t.Fatal(diff)
-		}
-
-		if diff := deep.Equal(resp.Data["db_name"], "plugin-test"); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["default_ttl"], float64(300)); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["max_ttl"], float64(600)); diff != nil {
-			t.Fatal(diff)
-		}
+		require.Equal(t, &expected, &actual)
+		require.Equal(t, resp.Data["db_name"], "plugin-test")
+		require.Equal(t, resp.Data["default_ttl"], float64(300))
+		require.Equal(t, resp.Data["max_ttl"], float64(600))
 	}
 
 	// Test role modification of TTL
@@ -822,10 +717,9 @@ func TestBackend_roleCrud(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%v resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%v resp:%#v\n", err, resp)
 
 		// Read the role
 		data = map[string]interface{}{}
@@ -835,10 +729,9 @@ func TestBackend_roleCrud(t *testing.T) {
 			Storage:   config.StorageView,
 			Data:      data,
 		}
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		expected := v4.Statements{
 			Creation:   []string{strings.TrimSpace(testRole)},
@@ -854,20 +747,10 @@ func TestBackend_roleCrud(t *testing.T) {
 			Renewal:    resp.Data["renew_statements"].([]string),
 		}
 
-		if !reflect.DeepEqual(&expected, &actual) {
-			t.Fatalf("Statements did not match, expected %#v, got %#v", &expected, &actual)
-		}
-
-		if diff := deep.Equal(resp.Data["db_name"], "plugin-test"); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["default_ttl"], float64(300)); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["max_ttl"], float64(420)); diff != nil {
-			t.Fatal(diff)
-		}
-
+		require.Equalf(t, &expected, &actual, "Statements did not match, expected %#v, got %#v", &expected, &actual)
+		require.Equal(t, resp.Data["db_name"], "plugin-test")
+		require.Equal(t, resp.Data["default_ttl"], float64(300))
+		require.Equal(t, resp.Data["max_ttl"], float64(420))
 	}
 
 	// Test role modification of statements
@@ -886,9 +769,8 @@ func TestBackend_roleCrud(t *testing.T) {
 			Data:      data,
 		}
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%v resp:%#v\n", err, resp)
-		}
+		require.NoErrorf(t, err, "err:%v resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%v resp:%#v\n", err, resp)
 
 		// Read the role
 		data = map[string]interface{}{}
@@ -899,9 +781,8 @@ func TestBackend_roleCrud(t *testing.T) {
 			Data:      data,
 		}
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+		require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 		expected := v4.Statements{
 			Creation:   []string{strings.TrimSpace(testRole), strings.TrimSpace(testRole)},
@@ -917,19 +798,9 @@ func TestBackend_roleCrud(t *testing.T) {
 			Renewal:    resp.Data["renew_statements"].([]string),
 		}
 
-		if diff := deep.Equal(&expected, &actual); diff != nil {
-			t.Fatal(diff)
-		}
-
-		if diff := deep.Equal(resp.Data["db_name"], "plugin-test"); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["default_ttl"], float64(300)); diff != nil {
-			t.Fatal(diff)
-		}
-		if diff := deep.Equal(resp.Data["max_ttl"], float64(420)); diff != nil {
-			t.Fatal(diff)
-		}
+		require.Equal(t, &expected, &actual)
+		require.Equal(t, resp.Data["db_name"], "plugin-test")
+		require.Equal(t, resp.Data["max_ttl"], float64(420))
 	}
 
 	// Delete the role
@@ -940,10 +811,9 @@ func TestBackend_roleCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Read the role
 	data = map[string]interface{}{}
@@ -953,15 +823,12 @@ func TestBackend_roleCrud(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Should be empty
-	if resp != nil {
-		t.Fatal("Expected response to be nil")
-	}
+	require.Nilf(t, resp, "Expected response to be nil")
 }
 
 func TestBackend_allowedRoles(t *testing.T) {
@@ -973,9 +840,7 @@ func TestBackend_allowedRoles(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -992,10 +857,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Create a denied and an allowed role
 	data = map[string]interface{}{
@@ -1010,10 +874,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	data = map[string]interface{}{
 		"db_name":             "plugin-test",
@@ -1027,10 +890,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds from denied role, should fail
 	data = map[string]interface{}{}
@@ -1040,10 +902,8 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err == nil {
-		t.Fatal("expected error because role is denied")
-	}
+	_, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.Errorf(t, err, "expected error because role is denied")
 
 	// update connection with glob allowed roles connection
 	data = map[string]interface{}{
@@ -1057,10 +917,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds, should work.
 	data = map[string]interface{}{}
@@ -1070,14 +929,11 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 
-	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatal("Creds should exist")
-	}
+	require.Truef(t, testCredsExist(t, credsResp, connURL), "Creds should exist")
 
 	// update connection with * allowed roles connection
 	data = map[string]interface{}{
@@ -1091,10 +947,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds, should work.
 	data = map[string]interface{}{}
@@ -1104,14 +959,11 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 
-	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatal("Creds should exist")
-	}
+	require.Truef(t, testCredsExist(t, credsResp, connURL), "Creds should exist")
 
 	// update connection with allowed roles
 	data = map[string]interface{}{
@@ -1125,10 +977,9 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Get creds from denied role, should fail
 	data = map[string]interface{}{}
@@ -1138,10 +989,8 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err == nil {
-		t.Fatal("expected error because role is denied")
-	}
+	_, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.Errorf(t, err, "expected error because role is denied")
 
 	// Get creds from allowed role, should work.
 	data = map[string]interface{}{}
@@ -1151,14 +1000,11 @@ func TestBackend_allowedRoles(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 
-	if !testCredsExist(t, credsResp, connURL) {
-		t.Fatal("Creds should exist")
-	}
+	require.Truef(t, testCredsExist(t, credsResp, connURL), "Creds should exist")
 }
 
 func TestBackend_RotateRootCredentials(t *testing.T) {
@@ -1170,9 +1016,7 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "13.4-buster")
@@ -1194,10 +1038,9 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	// Create a role
 	data = map[string]interface{}{
@@ -1211,10 +1054,9 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 	// Get creds
 	data = map[string]interface{}{}
 	req = &logical.Request{
@@ -1223,10 +1065,9 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 
 	data = map[string]interface{}{}
 	req = &logical.Request{
@@ -1235,18 +1076,13 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	resp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "err:%s resp:%#v\n", err, resp)
 
 	dbConfig, err := b.(*databaseBackend).DatabaseConfig(context.Background(), config.StorageView, "plugin-test")
-	if err != nil {
-		t.Fatalf("err: %#v", err)
-	}
-	if dbConfig.ConnectionDetails["password"].(string) == "secret" {
-		t.Fatal("root credentials not rotated")
-	}
+	require.NoErrorf(t, err, "err: %#v", err)
+	require.NotEqualf(t, dbConfig.ConnectionDetails["password"].(string), "secret", "root credentials not rotated")
 
 	// Get creds to make sure it still works
 	data = map[string]interface{}{}
@@ -1256,10 +1092,9 @@ func TestBackend_RotateRootCredentials(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	credsResp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (credsResp != nil && credsResp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, credsResp)
-	}
+	credsResp, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoErrorf(t, err, "err:%s resp:%#v\n", err, credsResp)
+	require.Falsef(t, credsResp != nil && credsResp.IsError(), "err:%s resp:%#v\n", err, credsResp)
 }
 
 func TestBackend_ConnectionURL_redacted(t *testing.T) {
@@ -1271,9 +1106,7 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer b.Cleanup(context.Background())
 
 	tests := []struct {
@@ -1292,17 +1125,10 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 
 	respCheck := func(req *logical.Request) *logical.Response {
 		t.Helper()
-		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if resp == nil {
-			t.Fatalf("expected a response, resp: %#v", resp)
-		}
-
-		if resp.Error() != nil {
-			t.Fatalf("unexpected error in response, err: %#v", resp.Error())
-		}
+		resp, err := b.HandleRequest(namespace.RootContext(context.TODO()), req)
+		require.NoError(t, err)
+		require.NotNil(t, resp, "expected a response, resp: %#v", resp)
+		require.Nil(t, resp.Error(), "unexpected error in response, err: %#v", resp.Error())
 
 		return resp
 	}
@@ -1312,14 +1138,10 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 			t.Cleanup(cleanup)
 
 			p, err := url.Parse(u)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			actualPassword, _ := p.User.Password()
-			if tt.password != actualPassword {
-				t.Fatalf("expected computed URL password %#v, actual %#v", tt.password, actualPassword)
-			}
+			require.Equalf(t, tt.password, actualPassword, "expected computed URL password %#v, actual %#v", tt.password, actualPassword)
 
 			// Configure a connection
 			data := map[string]interface{}{
@@ -1348,25 +1170,18 @@ func TestBackend_ConnectionURL_redacted(t *testing.T) {
 				connDetails = v.(map[string]interface{})
 			}
 
-			if connDetails == nil {
-				t.Fatalf("response data missing connection_details, resp: %#v", resp)
-			}
+			require.NotNilf(t, connDetails, "response data missing connection_details, resp: %#v", resp)
 
 			actual := connDetails["connection_url"].(string)
 			expected := p.Redacted()
-			if expected != actual {
-				t.Fatalf("expected redacted URL %q, actual %q", expected, actual)
-			}
+			require.Equalf(t, expected, actual, "expected redacted URL %q, actual %q", expected, actual)
 
 			if tt.password != "" {
 				// extra test to ensure that URL.Redacted() is working as expected.
 				p, err = url.Parse(actual)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if pp, _ := p.User.Password(); pp == tt.password {
-					t.Fatal("password was not redacted by URL.Redacted()")
-				}
+				require.NoError(t, err)
+				pp, _ := p.User.Password()
+				require.NotEqual(t, pp, tt.password, "password was not redacted by URL.Redacted()")
 			}
 		})
 	}
@@ -1422,9 +1237,7 @@ func TestBackend_AsyncClose(t *testing.T) {
 	config.System = sys
 
 	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Configure a connection
 	data := map[string]interface{}{
@@ -1438,10 +1251,8 @@ func TestBackend_AsyncClose(t *testing.T) {
 		Storage:   config.StorageView,
 		Data:      data,
 	}
-	_, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	_, err = b.HandleRequest(namespace.RootContext(context.TODO()), req)
+	require.NoError(t, err)
 	timeout := time.NewTimer(750 * time.Millisecond)
 	done := make(chan bool)
 	go func() {
@@ -1461,9 +1272,7 @@ func TestNewDatabaseWrapper_IgnoresBuiltinVersion(t *testing.T) {
 	cluster, sys := getCluster(t)
 	t.Cleanup(cluster.Cleanup)
 	_, err := newDatabaseWrapper(context.Background(), "mysql-database-plugin", "v1.0.0+builtin", sys, hclog.Default())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func testCredsExist(t *testing.T, resp *logical.Response, connURL string) bool {
@@ -1472,15 +1281,13 @@ func testCredsExist(t *testing.T, resp *logical.Response, connURL string) bool {
 		Username string `mapstructure:"username"`
 		Password string `mapstructure:"password"`
 	}
-	if err := mapstructure.Decode(resp.Data, &d); err != nil {
-		t.Fatal(err)
-	}
+	err := mapstructure.Decode(resp.Data, &d)
+	require.NoError(t, err)
+
 	log.Printf("[TRACE] Generated credentials: %v", d)
 
 	db, err := sql.Open("pgx", connURL+"&timezone=utc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	returnedRows := func() int {
 		stmt, err := db.Prepare("SELECT DISTINCT schemaname FROM pg_tables WHERE has_table_privilege($1, 'information_schema.role_column_grants', 'select');")

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,9 +76,7 @@ func TestTidyConfigs(t *testing.T) {
 		if len(resp.Warnings) > 0 {
 			t.Logf("got warnings while starting manual tidy: %v", resp.Warnings)
 			for _, warning := range resp.Warnings {
-				if strings.Contains(warning, "Manual tidy requested but no tidy operations were set.") {
-					t.Fatalf("expected to be able to enable tidy operation with just %v but got warning: %v / (resp=%v)", operation, warning, resp)
-				}
+				require.NotContainsf(t, warning, "Manual tidy requested but no tidy operations were set.", "expected to be able to enable tidy operation with just %v but got warning: %v / (resp=%v)", operation, warning, resp)
 			}
 		}
 
@@ -123,7 +122,7 @@ func TestTidyConfigs(t *testing.T) {
 
 		resp, err := CBRead(b, s, "config/auto-tidy")
 		requireSuccessNonNilResponse(t, resp, err, "expected to be able to read auto-tidy operation for flag "+flag.Config)
-		require.Equal(t, resp.Data[flag.Config].(int), flag.DefaultValue, "expected initial auto-tidy config to match default value for "+flag.Config)
+		require.Equal(t, flag.DefaultValue, resp.Data[flag.Config].(int), "expected initial auto-tidy config to match default value for "+flag.Config)
 
 		resp, err = CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
 			"enabled":         true,
@@ -134,7 +133,7 @@ func TestTidyConfigs(t *testing.T) {
 
 		resp, err = CBRead(b, s, "config/auto-tidy")
 		requireSuccessNonNilResponse(t, resp, err, "expected to be able to read auto-tidy operation for config "+flag.Config)
-		require.Equal(t, resp.Data[flag.Config].(int), flag.FirstValue, "expected value to be set after reading auto-tidy config "+flag.Config)
+		require.Equal(t, flag.FirstValue, resp.Data[flag.Config].(int), "expected value to be set after reading auto-tidy config "+flag.Config)
 
 		resp, err = CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
 			"enabled":         true,
@@ -145,7 +144,7 @@ func TestTidyConfigs(t *testing.T) {
 
 		resp, err = CBRead(b, s, "config/auto-tidy")
 		requireSuccessNonNilResponse(t, resp, err, "expected to be able to read auto-tidy operation for config "+flag.Config)
-		require.Equal(t, resp.Data[flag.Config].(int), flag.SecondValue, "expected value to be set after reading auto-tidy config "+flag.Config)
+		require.Equal(t, flag.SecondValue, resp.Data[flag.Config].(int), "expected value to be set after reading auto-tidy config "+flag.Config)
 
 		resp, err = CBWrite(b, s, "tidy", map[string]interface{}{
 			"tidy_cert_store": true,
@@ -155,8 +154,8 @@ func TestTidyConfigs(t *testing.T) {
 		requireSuccessNonNilResponse(t, resp, err, "expected to be able to start tidy operation with "+flag.Config)
 		if len(resp.Warnings) > 0 {
 			for _, warning := range resp.Warnings {
-				if strings.Contains(warning, "unrecognized parameter") && strings.Contains(warning, flag.Config) {
-					t.Fatalf("warning '%v' claims parameter '%v' is unknown", warning, flag.Config)
+				if strings.Contains(warning, flag.Config) {
+					require.NotContainsf(t, warning, "unrecognized parameter", "warning '%v' claims parameter '%v' is unknown", warning, flag.Config)
 				}
 			}
 		}
@@ -166,7 +165,7 @@ func TestTidyConfigs(t *testing.T) {
 		resp, err = CBRead(b, s, "tidy-status")
 		requireSuccessNonNilResponse(t, resp, err, "expected to be able to start tidy operation with "+flag.Config)
 		t.Logf("got response: %v for config: %v", resp, flag.Config)
-		require.Equal(t, resp.Data[flag.Config].(int), flag.FirstValue, "expected flag to be set in tidy-status for config "+flag.Config)
+		require.Equal(t, flag.FirstValue, resp.Data[flag.Config].(int), "expected flag to be set in tidy-status for config "+flag.Config)
 	}
 }
 
@@ -287,9 +286,9 @@ func TestAutoTidy(t *testing.T) {
 	require.NoError(t, err, "failed converting %s to int", resp.Data["revocation_time"])
 	revTime := time.Unix(revocationTime, 0)
 	now := time.Now()
-	if !now.After(revTime) || !now.Add(-10*time.Minute).Before(revTime) {
-		t.Fatalf("parsed revocation time not within the last 10 minutes current time: %s, revocation time: %s", now, revTime)
-	}
+	require.Conditionf(t, func() bool {
+		return now.After(revTime) && now.Add(-10*time.Minute).Before(revTime)
+	}, "parsed revocation time not within the last 10 minutes current time: %s, revocation time: %s", now, revTime)
 	utcLoc, err := time.LoadLocation("UTC")
 	require.NoError(t, err, "failed to parse UTC location?")
 
@@ -348,9 +347,7 @@ func TestTidyCancellation(t *testing.T) {
 		"safety_buffer":   "1s",
 		"pause_duration":  "1s",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("tidy"), logical.UpdateOperation), resp, true)
 
@@ -363,7 +360,7 @@ func TestTidyCancellation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Data)
-	require.Equal(t, resp.Data["state"], "Running")
+	require.Equal(t, "Running", resp.Data["state"])
 
 	// If we now cancel the operation, the response should say Cancelling.
 	cancelResp, err := CBWrite(b, s, "tidy-cancel", map[string]interface{}{})
@@ -380,7 +377,7 @@ func TestTidyCancellation(t *testing.T) {
 		return
 	}
 
-	require.Equal(t, state, "Cancelling")
+	require.Equal(t, "Cancelling", state)
 
 	// Wait a little longer, and ensure we only processed at most 2 more certs
 	// after the cancellation respon.
@@ -391,11 +388,9 @@ func TestTidyCancellation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, statusResp)
 	require.NotNil(t, statusResp.Data)
-	require.Equal(t, statusResp.Data["state"], "Cancelled")
+	require.Equal(t, "Cancelled", statusResp.Data["state"])
 	nowMany := statusResp.Data["cert_store_deleted_count"].(uint)
-	if howMany+3 <= nowMany {
-		t.Fatalf("expected to only process at most 3 more certificates, but processed (%v >>> %v) certs", nowMany, howMany)
-	}
+	require.LessOrEqualf(t, howMany+3, nowMany, "expected to only process at most 3 more certificates, but processed (%v >>> %v) certs", nowMany, howMany)
 }
 
 func TestTidyIssuers(t *testing.T) {
@@ -501,8 +496,8 @@ func TestTidyIssuers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, statusResp)
 	require.NotNil(t, statusResp.Data)
-	require.Equal(t, statusResp.Data["issuer_safety_buffer"], 1)
-	require.Equal(t, statusResp.Data["tidy_expired_issuers"], true)
+	require.Equal(t, 1, statusResp.Data["issuer_safety_buffer"])
+	require.True(t, statusResp.Data["tidy_expired_issuers"].(bool))
 }
 
 func TestTidyIssuerConfig(t *testing.T) {
@@ -540,7 +535,7 @@ func TestTidyIssuerConfig(t *testing.T) {
 	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("config/auto-tidy"), logical.UpdateOperation), resp, true)
 
 	requireSuccessNonNilResponse(t, resp, err)
-	require.Equal(t, true, resp.Data["tidy_expired_issuers"])
+	require.True(t, resp.Data["tidy_expired_issuers"].(bool))
 	require.Equal(t, 5, resp.Data["issuer_safety_buffer"])
 }
 
@@ -563,9 +558,7 @@ func TestCertStorageMetrics(t *testing.T) {
 	metricsConf.EnableTypePrefix = false
 
 	_, err := metrics.NewGlobal(metricsConf, inmemSink)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// This test requires the periodicFunc to trigger, which requires we stand
 	// up a full test cluster.
@@ -623,32 +616,25 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	// Since certificate counts are off by default, we shouldn't see counts in the tidy status
 	tidyStatus, err := client.Logical().Read("pki/tidy-status")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// backendUUID should exist, we need this for metrics
 	backendUUID := tidyStatus.Data["internal_backend_uuid"].(string)
 	// "current_cert_store_count", "current_revoked_cert_count"
 	countData, ok := tidyStatus.Data["current_cert_store_count"]
-	if ok && countData != nil {
-		t.Fatalf("Certificate counting should be off by default, but current cert store count %v appeared in tidy status in unconfigured mount", countData)
-	}
+	require.True(t, ok)
+	require.NotNilf(t, countData, "Certificate counting should be off by default, but current cert store count %v appeared in tidy status in unconfigured mount", countData)
 	revokedCountData, ok := tidyStatus.Data["current_revoked_cert_count"]
-	if ok && revokedCountData != nil {
-		t.Fatalf("Certificate counting should be off by default, but revoked cert count %v appeared in tidy status in unconfigured mount", revokedCountData)
-	}
+	require.True(t, ok)
+	require.NotNilf(t, revokedCountData, "Certificate counting should be off by default, but revoked cert count %v appeared in tidy status in unconfigured mount", revokedCountData)
 
 	// Since certificate counts are off by default, those metrics should not exist yet
 	stableMetric := inmemSink.Data()
 	mostRecentInterval := stableMetric[len(stableMetric)-1]
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_revoked_certificates_stored"]
-	if ok {
-		t.Fatal("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
-	}
+	require.False(t, ok, "Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
+
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_certificates_stored"]
-	if ok {
-		t.Fatal("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
-	}
+	require.False(t, ok, "Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
 
 	// Write the auto-tidy config.
 	_, err = client.Logical().Write("pki/config/auto-tidy", map[string]interface{}{
@@ -683,13 +669,9 @@ func TestCertStorageMetrics(t *testing.T) {
 	stableMetric = inmemSink.Data()
 	mostRecentInterval = stableMetric[len(stableMetric)-1]
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_revoked_certificates_stored"]
-	if ok {
-		t.Fatal("Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
-	}
+	require.False(t, ok, "Certificate counting should be off by default, but revoked cert count was emitted as a metric in an unconfigured mount")
 	_, ok = mostRecentInterval.Gauges["secrets.pki."+backendUUID+".total_certificates_stored"]
-	if ok {
-		t.Fatal("Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
-	}
+	require.False(t, ok, "Certificate counting should be off by default, but total certificate count was emitted as a metric in an unconfigured mount")
 
 	// But since certificate counting is on, the metrics should exist on tidyStatus endpoint:
 	tidyStatus, err = client.Logical().Read("pki/tidy-status")
@@ -699,19 +681,11 @@ func TestCertStorageMetrics(t *testing.T) {
 	backendUUID = tidyStatus.Data["internal_backend_uuid"].(string)
 	// "current_cert_store_count", "current_revoked_cert_count"
 	certStoreCount, ok := tidyStatus.Data["current_cert_store_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
-	}
-	if certStoreCount != json.Number("1") {
-		t.Fatalf("Only created one certificate, but a got a certificate count of %v", certStoreCount)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("1"), certStoreCount, "Only created one certificate, but a got a certificate count of %v", certStoreCount)
 	revokedCertCount, ok := tidyStatus.Data["current_revoked_cert_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
-	}
-	if revokedCertCount != json.Number("0") {
-		t.Fatalf("Have not yet revoked a certificate, but got a revoked cert store count of %v", revokedCertCount)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("0"), revokedCertCount, "Have not yet revoked a certificate, but got a revoked cert store count of %v", revokedCertCount)
 
 	// Write the auto-tidy config, again, this time turning on metrics
 	_, err = client.Logical().Write("pki/config/auto-tidy", map[string]interface{}{
@@ -770,24 +744,15 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	backendUUID = tidyStatus.Data["internal_backend_uuid"].(string)
 	certStoreCount, ok = tidyStatus.Data["current_cert_store_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
-	}
-	if certStoreCount != json.Number("2") {
-		t.Fatalf("Created root and leaf certificate, but a got a certificate count of %v", certStoreCount)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("2"), certStoreCount, "Created root and leaf certificate, but a got a certificate count of %v", certStoreCount)
 	revokedCertCount, ok = tidyStatus.Data["current_revoked_cert_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
-	}
-	if revokedCertCount != json.Number("1") {
-		t.Fatalf("Revoked one certificate, but got a revoked cert store count of %v\n:%v", revokedCertCount, tidyStatus)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("1"), revokedCertCount, "Revoked one certificate, but got a revoked cert store count of %v\n:%v", revokedCertCount, tidyStatus)
 	// This should now be initialized
 	certCountError, ok := tidyStatus.Data["certificate_counting_error"]
-	if ok && certCountError.(string) != "" {
-		t.Fatalf("Expected certificate count error to disappear after initialization, but got error %v", certCountError)
-	}
+	assert.False(t, ok)
+	require.Nil(t, certCountError, "Expected certificate count error to disappear after initialization, but got error %v", certCountError)
 
 	testhelpers.RetryUntil(t, newPeriod*5, func() error {
 		stableMetric = inmemSink.Data()
@@ -820,25 +785,15 @@ func TestCertStorageMetrics(t *testing.T) {
 	// After Tidy, Cert Store Count Should Still Be Available, and Be Updated:
 	// Check Metrics After Cert Has Be Created and Revoked
 	tidyStatus, err = client.Logical().Read("pki/tidy-status")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	backendUUID = tidyStatus.Data["internal_backend_uuid"].(string)
 	// "current_cert_store_count", "current_revoked_cert_count"
 	certStoreCount, ok = tidyStatus.Data["current_cert_store_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but current cert store count does not appear in tidy status")
-	}
-	if certStoreCount != json.Number("1") {
-		t.Fatalf("Created root and leaf certificate, deleted leaf, but a got a certificate count of %v", certStoreCount)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but current cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("1"), certStoreCount, "Created root and leaf certificate, deleted leaf, but a got a certificate count of %v", certStoreCount)
 	revokedCertCount, ok = tidyStatus.Data["current_revoked_cert_count"]
-	if !ok {
-		t.Fatal("Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
-	}
-	if revokedCertCount != json.Number("0") {
-		t.Fatalf("Revoked certificate has been tidied, but got a revoked cert store count of %v", revokedCertCount)
-	}
+	require.True(t, ok, "Certificate counting has been turned on, but revoked cert store count does not appear in tidy status")
+	require.Equalf(t, json.Number("0"), revokedCertCount, "Revoked certificate has been tidied, but got a revoked cert store count of %v", revokedCertCount)
 
 	testhelpers.RetryUntil(t, newPeriod*5, func() error {
 		stableMetric = inmemSink.Data()
@@ -931,7 +886,7 @@ func TestTidyAcmeWithBackdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, listResp)
 	thumbprintEntries := listResp.Data["keys"].([]interface{})
-	require.Equal(t, len(thumbprintEntries), 1)
+	require.Equal(t, 1, len(thumbprintEntries))
 	thumbprint := thumbprintEntries[0].(string)
 
 	// Let "Time Pass"; this is a HACK, this function sys-writes to overwrite the date on objects in storage
@@ -949,11 +904,11 @@ func TestTidyAcmeWithBackdate(t *testing.T) {
 	// Wait for tidy to finish.
 	tidyResp := waitForTidyToFinish(t, client, "pki")
 
-	require.Equal(t, tidyResp.Data["acme_orders_deleted_count"], json.Number("1"),
+	require.Equal(t, json.Number("1"), tidyResp.Data["acme_orders_deleted_count"],
 		"expected to revoke a single ACME order: %v", tidyResp)
-	require.Equal(t, tidyResp.Data["acme_account_revoked_count"], json.Number("0"),
+	require.Equal(t, json.Number("0"), tidyResp.Data["acme_account_revoked_count"],
 		"no ACME account should have been revoked: %v", tidyResp)
-	require.Equal(t, tidyResp.Data["acme_account_deleted_count"], json.Number("0"),
+	require.Equal(t, json.Number("0"), tidyResp.Data["acme_account_deleted_count"],
 		"no ACME account should have been revoked: %v", tidyResp)
 
 	// Make sure our order is indeed deleted.
@@ -976,11 +931,11 @@ func TestTidyAcmeWithBackdate(t *testing.T) {
 
 	// Wait for tidy to finish.
 	tidyResp = waitForTidyToFinish(t, client, "pki")
-	require.Equal(t, tidyResp.Data["acme_orders_deleted_count"], json.Number("0"),
+	require.Equal(t, json.Number("0"), tidyResp.Data["acme_orders_deleted_count"],
 		"no ACME orders should have been deleted: %v", tidyResp)
-	require.Equal(t, tidyResp.Data["acme_account_revoked_count"], json.Number("1"),
+	require.Equal(t, json.Number("1"), tidyResp.Data["acme_account_revoked_count"],
 		"expected to revoke a single ACME account: %v", tidyResp)
-	require.Equal(t, tidyResp.Data["acme_account_deleted_count"], json.Number("0"),
+	require.Equal(t, json.Number("0"), tidyResp.Data["acme_account_deleted_count"],
 		"no ACME account should have been revoked: %v", tidyResp)
 
 	// Lookup our account to make sure we get the appropriate revoked status
@@ -1049,7 +1004,7 @@ func TestTidyAcmeWithSafetyBuffer(t *testing.T) {
 	require.NoError(t, err, "failed listing ACME thumbprints")
 	require.NotEmpty(t, listResp.Data["keys"], "expected non-empty list response")
 	thumbprintEntries := listResp.Data["keys"].([]interface{})
-	require.Equal(t, len(thumbprintEntries), 1)
+	require.Equal(t, 1, len(thumbprintEntries))
 
 	// Wait for the account to expire.
 	time.Sleep(2 * time.Second)
@@ -1063,7 +1018,7 @@ func TestTidyAcmeWithSafetyBuffer(t *testing.T) {
 
 	// Wait for tidy to finish.
 	statusResp := waitForTidyToFinish(t, client, "pki")
-	require.Equal(t, statusResp.Data["acme_account_revoked_count"], json.Number("1"), "expected to revoke a single ACME account")
+	require.Equal(t, json.Number("1"), statusResp.Data["acme_account_revoked_count"], "expected to revoke a single ACME account")
 
 	// Wait for the account to expire.
 	time.Sleep(2 * time.Second)
@@ -1099,27 +1054,19 @@ func TestTidyAcmeWithSafetyBuffer(t *testing.T) {
 func backDateAcmeAccountSys(t *testing.T, testContext context.Context, client *api.Client, thumbprintString string, backdateAmount time.Duration, mount string) {
 	rawThumbprintPath := path.Join("sys/raw/logical/", mount, acmeThumbprintPrefix+thumbprintString)
 	thumbprintResp, err := client.Logical().ReadWithContext(testContext, rawThumbprintPath)
-	if err != nil {
-		t.Fatalf("unable to fetch thumbprint response at %v: %v", rawThumbprintPath, err)
-	}
+	require.NoErrorf(t, err, "unable to fetch thumbprint response at %v", rawThumbprintPath)
 
 	var thumbprint acmeThumbprint
 	err = jsonutil.DecodeJSON([]byte(thumbprintResp.Data["value"].(string)), &thumbprint)
-	if err != nil {
-		t.Fatalf("unable to decode thumbprint response %v to find account entry: %v", thumbprintResp.Data, err)
-	}
+	require.NoErrorf(t, err, "unable to decode thumbprint response %v to find account entry", thumbprintResp.Data)
 
 	accountPath := path.Join("sys/raw/logical", mount, acmeAccountPrefix+thumbprint.Kid)
 	accountResp, err := client.Logical().ReadWithContext(testContext, accountPath)
-	if err != nil {
-		t.Fatalf("unable to fetch account entry %v: %v", thumbprint.Kid, err)
-	}
+	require.NoErrorf(t, err, "unable to fetch account entry %v", thumbprint.Kid)
 
 	var account acmeAccount
 	err = jsonutil.DecodeJSON([]byte(accountResp.Data["value"].(string)), &account)
-	if err != nil {
-		t.Fatalf("unable to decode acme account %v: %v", accountResp, err)
-	}
+	require.NoErrorf(t, err, "unable to decode acme account %v", accountResp)
 
 	t.Logf("got account before update: %v", account)
 
@@ -1130,17 +1077,13 @@ func backDateAcmeAccountSys(t *testing.T, testContext context.Context, client *a
 	t.Logf("got account after update: %v", account)
 
 	encodeJSON, err := jsonutil.EncodeJSON(account)
-	if err != nil {
-		t.Fatalf("json encoding failed: %v", err)
-	}
+	require.NoErrorf(t, err, "json encoding failed")
 
 	_, err = client.Logical().WriteWithContext(context.Background(), accountPath, map[string]interface{}{
 		"value":    base64.StdEncoding.EncodeToString(encodeJSON),
 		"encoding": "base64",
 	})
-	if err != nil {
-		t.Fatalf("error saving backdated account entry at %v: %v", accountPath, err)
-	}
+	require.NoErrorf(t, err, "error saving backdated account entry at %v", accountPath)
 
 	ordersPath := path.Join("sys/raw/logical", mount, acmeAccountPrefix, thumbprint.Kid, "/orders/")
 	ordersRaw, err := client.Logical().ListWithContext(context.Background(), ordersPath)
@@ -1166,31 +1109,23 @@ func backDateAcmeAccountSys(t *testing.T, testContext context.Context, client *a
 func backDateAcmeOrderSys(t *testing.T, testContext context.Context, client *api.Client, accountKid string, orderId string, backdateAmount time.Duration, mount string) {
 	rawOrderPath := path.Join("sys/raw/logical/", mount, acmeAccountPrefix, accountKid, "orders", orderId)
 	orderResp, err := client.Logical().ReadWithContext(testContext, rawOrderPath)
-	if err != nil {
-		t.Fatalf("unable to fetch order entry %v on account %v at %v", orderId, accountKid, rawOrderPath)
-	}
+	require.NoErrorf(t, err, "unable to fetch order entry %v on account %v at %v", orderId, accountKid, rawOrderPath)
 
 	var order *acmeOrder
 	err = jsonutil.DecodeJSON([]byte(orderResp.Data["value"].(string)), &order)
-	if err != nil {
-		t.Fatalf("error decoding order entry %v on account %v, %v produced: %v", orderId, accountKid, orderResp, err)
-	}
+	require.NoErrorf(t, err, "error decoding order entry %v on account %v with response %v", orderId, accountKid, orderResp)
 
 	order.Expires = backDate(order.Expires, backdateAmount)
 	order.CertificateExpiry = backDate(order.CertificateExpiry, backdateAmount)
 
 	encodeJSON, err := jsonutil.EncodeJSON(order)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = client.Logical().WriteWithContext(context.Background(), rawOrderPath, map[string]interface{}{
 		"value":    base64.StdEncoding.EncodeToString(encodeJSON),
 		"encoding": "base64",
 	})
-	if err != nil {
-		t.Fatalf("error saving backdated order entry %v on account %v : %v", orderId, accountKid, err)
-	}
+	require.NoErrorf(t, err, "error saving backdated order entry %v on account %v", orderId, accountKid)
 
 	for _, authId := range order.AuthorizationIds {
 		backDateAcmeAuthorizationSys(t, testContext, client, accountKid, authId, backdateAmount, mount)
@@ -1201,35 +1136,25 @@ func backDateAcmeAuthorizationSys(t *testing.T, testContext context.Context, cli
 	rawAuthPath := path.Join("sys/raw/logical/", mount, acmeAccountPrefix, accountKid, "/authorizations/", authId)
 
 	authResp, err := client.Logical().ReadWithContext(testContext, rawAuthPath)
-	if err != nil {
-		t.Fatalf("unable to fetch authorization %v : %v", rawAuthPath, err)
-	}
+	require.NoErrorf(t, err, "unable to fetch authorization %v", rawAuthPath)
 
 	var auth *ACMEAuthorization
 	err = jsonutil.DecodeJSON([]byte(authResp.Data["value"].(string)), &auth)
-	if err != nil {
-		t.Fatalf("error decoding auth %v, auth entry %v produced %v", rawAuthPath, authResp, err)
-	}
+	require.NoErrorf(t, err, "error decoding auth %v, auth entry with response %v", rawAuthPath, authResp)
 
 	expiry, err := auth.GetExpires()
-	if err != nil {
-		t.Fatalf("could not get expiry on %v: %v", rawAuthPath, err)
-	}
+	require.NoErrorf(t, err, "could not get expiry on %v", rawAuthPath)
 	newExpiry := backDate(expiry, backdateAmount)
 	auth.Expires = time.Time.Format(newExpiry, time.RFC3339)
 
 	encodeJSON, err := jsonutil.EncodeJSON(auth)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = client.Logical().WriteWithContext(context.Background(), rawAuthPath, map[string]interface{}{
 		"value":    base64.StdEncoding.EncodeToString(encodeJSON),
 		"encoding": "base64",
 	})
-	if err != nil {
-		t.Fatalf("error updating authorization date on %v: %v", rawAuthPath, err)
-	}
+	require.NoErrorf(t, err, "error updating authorization date on %v", rawAuthPath)
 }
 
 func backDate(original time.Time, change time.Duration) time.Time {
@@ -1279,7 +1204,7 @@ func waitForAutoTidyToFinish(t *testing.T, client *api.Client) {
 	for foundTidyRunning == "" || !foundTidyFinished {
 		select {
 		case <-timeoutChan:
-			t.Fatalf("expected auto-tidy to run (%v) and finish (%v) before timeout", foundTidyRunning, foundTidyFinished)
+			require.FailNowf(t, "expected auto-tidy to run (%v) and finish (%v) before timeout", foundTidyRunning, foundTidyFinished)
 		default:
 			time.Sleep(250 * time.Millisecond)
 
@@ -1320,7 +1245,7 @@ func waitForManualTidy(t *testing.T, client *api.Client, tidyConfig map[string]i
 	for {
 		select {
 		case <-timeoutChan:
-			t.Fatal("expected manual tidy to run before timeout")
+			require.FailNow(t, "expected manual tidy to run before timeout")
 		default:
 			time.Sleep(50 * time.Millisecond)
 

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -1300,16 +1300,16 @@ func testPolicyFuzzingCommon(t *testing.T, be *backend) {
 					if resp.Data["error"].(string) == keysutil.ErrTooOld {
 						continue
 					}
-					t.Errorf("got an error: %v, resp is %#v, ciphertext was %s, chosenKey is %s, id is %d", err, *resp, ct, chosenKey, id)
+					assert.Fail(t, "got an error", "error: %v, resp is %#v, ciphertext was %s, chosenKey is %s, id is %d", err, *resp, ct, chosenKey, id)
 				}
 				ptb64, ok := resp.Data["plaintext"].(string)
 				if !ok {
-					t.Errorf("no plaintext found, response was %#v", *resp)
+					assert.Fail(t, "no plaintext found", "response was %#v", *resp)
 					return
 				}
 				pt, err := base64.StdEncoding.DecodeString(ptb64)
 				if err != nil {
-					t.Errorf("got an error decoding base64 plaintext: %v", err)
+					assert.Fail(t, "decoding base64 plaintext failed", "error: %v", err)
 					return
 				}
 				assert.Equalf(t, string(pt), testPlaintext, "got bad plaintext back: %s", pt)

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -17,7 +17,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +36,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	uuid "github.com/hashicorp/go-uuid"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,13 +49,9 @@ func createBackendWithStorage(t testing.TB) (*backend, logical.Storage) {
 	config.StorageView = &logical.InmemStorage{}
 
 	b, _ := Backend(context.Background(), config)
-	if b == nil {
-		t.Fatal("failed to create backend")
-	}
-	err := b.Backend.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NotNilf(t, b, "failed to create backend")
+	err := b.Setup(context.Background(), config)
+	require.NoError(t, err)
 	return b, config.StorageView
 }
 
@@ -69,14 +65,10 @@ func createBackendWithSysView(t testing.TB) (*backend, logical.Storage) {
 	}
 
 	b, _ := Backend(context.Background(), conf)
-	if b == nil {
-		t.Fatal("failed to create backend")
-	}
+	require.NotNilf(t, b, "failed to create backend")
 
-	err := b.Backend.Setup(context.Background(), conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := b.Setup(context.Background(), conf)
+	require.NoError(t, err)
 
 	return b, storage
 }
@@ -90,14 +82,10 @@ func createBackendWithSysViewWithStorage(t testing.TB, s logical.Storage) *backe
 	}
 
 	b, _ := Backend(context.Background(), conf)
-	if b == nil {
-		t.Fatal("failed to create backend")
-	}
+	require.NotNilf(t, b, "failed to create backend")
 
-	err := b.Backend.Setup(context.Background(), conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := b.Setup(context.Background(), conf)
+	require.NoError(t, err)
 
 	return b
 }
@@ -112,14 +100,10 @@ func createBackendWithForceNoCacheWithSysViewWithStorage(t testing.TB, s logical
 	}
 
 	b, _ := Backend(context.Background(), conf)
-	if b == nil {
-		t.Fatal("failed to create backend")
-	}
+	require.NotNilf(t, b, "failed to create backend")
 
-	err := b.Backend.Setup(context.Background(), conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := b.Setup(context.Background(), conf)
+	require.NoError(t, err)
 
 	return b
 }
@@ -145,9 +129,8 @@ func testTransit_RSA(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), keyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"
 
@@ -161,9 +144,8 @@ func testTransit_RSA(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), encryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	ciphertext1 := resp.Data["ciphertext"].(string)
 
@@ -177,15 +159,12 @@ func testTransit_RSA(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	decryptedPlaintext := resp.Data["plaintext"]
 
-	if plaintext != decryptedPlaintext {
-		t.Fatalf("bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
-	}
+	require.Equalf(t, plaintext, decryptedPlaintext, "bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
 
 	// Rotate the key
 	rotateReq := &logical.Request{
@@ -194,41 +173,31 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		Storage:   storage,
 	}
 	resp, err = b.HandleRequest(context.Background(), rotateReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	// Encrypt again
 	resp, err = b.HandleRequest(context.Background(), encryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 	ciphertext2 := resp.Data["ciphertext"].(string)
 
-	if ciphertext1 == ciphertext2 {
-		t.Fatal("expected different ciphertexts")
-	}
+	require.NotEqualf(t, ciphertext1, ciphertext2, "expected different ciphertexts")
 
 	// See if the older ciphertext can still be decrypted
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if resp.Data["plaintext"].(string) != plaintext {
-		t.Fatal("failed to decrypt old ciphertext after rotating the key")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Equalf(t, resp.Data["plaintext"].(string), plaintext, "failed to decrypt old ciphertext after rotating the key")
 
 	// Decrypt the new ciphertext
 	decryptReq.Data = map[string]interface{}{
 		"ciphertext": ciphertext2,
 	}
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if resp.Data["plaintext"].(string) != plaintext {
-		t.Fatal("failed to decrypt ciphertext after rotating the key")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Equalf(t, resp.Data["plaintext"].(string), plaintext, "failed to decrypt ciphertext after rotating the key")
 
 	signReq := &logical.Request{
 		Path:      "sign/rsa",
@@ -239,9 +208,8 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		},
 	}
 	resp, err = b.HandleRequest(context.Background(), signReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 	signature := resp.Data["signature"].(string)
 
 	verifyReq := &logical.Request{
@@ -255,30 +223,24 @@ func testTransit_RSA(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), verifyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if !resp.Data["valid"].(bool) {
-		t.Fatal("failed to verify the RSA signature")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Truef(t, resp.Data["valid"].(bool), "failed to verify the RSA signature")
 
 	signReq.Data = map[string]interface{}{
 		"input":          plaintext,
 		"hash_algorithm": "invalid",
 	}
-	resp, err = b.HandleRequest(context.Background(), signReq)
-	if err == nil {
-		t.Fatal(err)
-	}
+	_, err = b.HandleRequest(context.Background(), signReq)
+	require.Error(t, err)
 
 	signReq.Data = map[string]interface{}{
 		"input":          plaintext,
 		"hash_algorithm": "sha2-512",
 	}
 	resp, err = b.HandleRequest(context.Background(), signReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 	signature = resp.Data["signature"].(string)
 
 	verifyReq.Data = map[string]interface{}{
@@ -286,12 +248,9 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		"signature": signature,
 	}
 	resp, err = b.HandleRequest(context.Background(), verifyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if resp.Data["valid"].(bool) {
-		t.Fatal("expected validation to fail")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp.Data["valid"].(bool), "expected validation to fail")
 
 	verifyReq.Data = map[string]interface{}{
 		"input":          plaintext,
@@ -299,12 +258,9 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		"hash_algorithm": "sha2-512",
 	}
 	resp, err = b.HandleRequest(context.Background(), verifyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if !resp.Data["valid"].(bool) {
-		t.Fatal("failed to verify the RSA signature")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Truef(t, resp.Data["valid"].(bool), "failed to verify the RSA signature")
 
 	// Take a random hash and sign it using PKCSv1_5_NoOID.
 	hash := "P8m2iUWdc4+MiKOkiqnjNUIBa3pAUuABqqU2/KdIE8s="
@@ -315,9 +271,8 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		"prehashed":           true,
 	}
 	resp, err = b.HandleRequest(context.Background(), signReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 	signature = resp.Data["signature"].(string)
 
 	verifyReq.Data = map[string]interface{}{
@@ -328,12 +283,9 @@ func testTransit_RSA(t *testing.T, keyType string) {
 		"prehashed":           true,
 	}
 	resp, err = b.HandleRequest(context.Background(), verifyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
-	if !resp.Data["valid"].(bool) {
-		t.Fatal("failed to verify the RSA signature")
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
+	require.Truef(t, resp.Data["valid"].(bool), "failed to verify the RSA signature")
 }
 
 func TestBackend_basic(t *testing.T) {
@@ -955,12 +907,11 @@ func TestKeyUpgrade(t *testing.T) {
 
 	p.MigrateKeyToKeysMap()
 
-	if p.Key != nil ||
-		p.Keys == nil ||
-		len(p.Keys) != 1 ||
-		!reflect.DeepEqual(p.Keys[strconv.Itoa(1)].Key, key) {
-		t.Errorf("bad key migration, result is %#v", p.Keys)
-	}
+	errMsg := fmt.Sprintf("bad key migration, result is %#v", p.Keys)
+	require.Nilf(t, p.Key, errMsg)
+	require.NotNilf(t, p.Keys, errMsg)
+	require.Lenf(t, p.Keys, 1, errMsg)
+	require.Equalf(t, p.Keys[strconv.Itoa(1)].Key, key, errMsg)
 }
 
 func TestDerivedKeyUpgrade(t *testing.T) {
@@ -984,46 +935,28 @@ func testDerivedKeyUpgrade(t *testing.T, keyType keysutil.KeyType) {
 	p.MigrateKeyToKeysMap()
 	p.Upgrade(context.Background(), storage, cryptoRand.Reader) // Need to run the upgrade code to make the migration stick
 
-	if p.KDF != keysutil.Kdf_hmac_sha256_counter {
-		t.Fatalf("bad KDF value by default; counter val is %d, KDF val is %d, policy is %#v", keysutil.Kdf_hmac_sha256_counter, p.KDF, p)
-	}
+	require.Equalf(t, p.KDF, keysutil.Kdf_hmac_sha256_counter, "bad KDF value by default; counter val is %d, KDF val is %d, policy is %#v", keysutil.Kdf_hmac_sha256_counter, p.KDF, p)
 
 	derBytesOld, err := p.GetKey(keyContext, 1, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	derBytesOld2, err := p.GetKey(keyContext, 1, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if !reflect.DeepEqual(derBytesOld, derBytesOld2) {
-		t.Fatal("mismatch of same context alg")
-	}
+	require.Equalf(t, derBytesOld, derBytesOld2, "mismatch of same context alg")
 
 	p.KDF = keysutil.Kdf_hkdf_sha256
-	if p.NeedsUpgrade() {
-		t.Fatal("expected no upgrade needed")
-	}
+	require.Falsef(t, p.NeedsUpgrade(), "expected no upgrade needed")
 
 	derBytesNew, err := p.GetKey(keyContext, 1, 64)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	derBytesNew2, err := p.GetKey(keyContext, 1, 64)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if !reflect.DeepEqual(derBytesNew, derBytesNew2) {
-		t.Fatal("mismatch of same context alg")
-	}
+	require.Equal(t, derBytesNew, derBytesNew2, "mismatch of same context alg")
 
-	if reflect.DeepEqual(derBytesOld, derBytesNew) {
-		t.Fatal("match of different context alg")
-	}
+	require.NotEqual(t, derBytesOld, derBytesNew, "match of different context alg")
 }
 
 func TestConvergentEncryption(t *testing.T) {
@@ -1047,15 +980,9 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		},
 	}
 	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if !resp.IsError() {
-		t.Fatalf("bad: expected error response, got %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Truef(t, resp.IsError(), "bad: expected error response, got %#v", *resp)
 
 	req = &logical.Request{
 		Storage:   storage,
@@ -1068,18 +995,12 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		},
 	}
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.NotNil(t, resp, "expected populated request")
 
 	p, err := keysutil.LoadPolicy(context.Background(), storage, path.Join("policy", "testkey"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if p == nil {
-		t.Fatal("got nil policy")
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, p, "got nil policy")
 
 	if ver > 2 {
 		p.ConvergentVersion = -1
@@ -1087,9 +1008,7 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		p.ConvergentVersion = ver
 	}
 	err = p.Persist(context.Background(), storage)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	b.invalidate(context.Background(), "policy/testkey")
 
 	if ver < 3 {
@@ -1098,26 +1017,16 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		key.ConvergentVersion = 0
 		p.Keys[strconv.Itoa(p.LatestVersion)] = key
 		err = p.Persist(context.Background(), storage)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		b.invalidate(context.Background(), "policy/testkey")
 
 		// Verify it
 		p, err = keysutil.LoadPolicy(context.Background(), storage, path.Join(p.StoragePrefix, "policy", "testkey"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if p == nil {
-			t.Fatal("got nil policy")
-		}
-		if p.ConvergentVersion != ver {
-			t.Fatalf("bad convergent version %d", p.ConvergentVersion)
-		}
+		require.NoError(t, err)
+		require.NotNilf(t, p, "got nil policy")
+		require.Equalf(t, p.ConvergentVersion, ver, "bad convergent version %d", p.ConvergentVersion)
 		key = p.Keys[strconv.Itoa(p.LatestVersion)]
-		if key.ConvergentVersion != 0 {
-			t.Fatalf("bad convergent key version %d", key.ConvergentVersion)
-		}
+		require.Equalf(t, key.ConvergentVersion, 0, "bad convergent key version %d", key.ConvergentVersion)
 	}
 
 	// First, test using an invalid length of nonce -- this is only used for v1 convergent
@@ -1129,15 +1038,9 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 			"context":   "pWZ6t/im3AORd0lVYE0zBdKpX6Bl3/SvFtoVTPWbdkzjG788XmMAnOlxandSdd7S",
 		}
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err == nil {
-			t.Fatalf("expected error, got nil, version is %d", ver)
-		}
-		if resp == nil {
-			t.Fatal("expected non-nil response")
-		}
-		if !resp.IsError() {
-			t.Fatalf("expected error response, got %#v", *resp)
-		}
+		require.Errorf(t, err, "expected error, got nil, version is %d", ver)
+		require.NotNilf(t, resp, "expected non-nil response")
+		require.Truef(t, resp.IsError(), "expected error response, got %#v", *resp)
 
 		// Ensure we fail if we do not provide a nonce
 		req.Data = map[string]interface{}{
@@ -1145,9 +1048,8 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 			"context":   "pWZ6t/im3AORd0lVYE0zBdKpX6Bl3/SvFtoVTPWbdkzjG788XmMAnOlxandSdd7S",
 		}
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err == nil && (resp == nil || !resp.IsError()) {
-			t.Fatal("expected error response")
-		}
+		require.Errorf(t, err, "expected error response")
+		require.Falsef(t, resp == nil || !resp.IsError(), "expected error response")
 	}
 
 	// Now test encrypting the same value twice
@@ -1159,32 +1061,18 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		req.Data["nonce"] = "b25ldHdvdGhyZWVl" // "onetwothreee"
 	}
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext1 := resp.Data["ciphertext"].(string)
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext2 := resp.Data["ciphertext"].(string)
 
-	if ciphertext1 != ciphertext2 {
-		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext1, ciphertext2)
-	}
+	require.Equalf(t, ciphertext1, ciphertext2, "expected the same ciphertext but got %s and %s", ciphertext1, ciphertext2)
 
 	// For sanity, also check a different nonce value...
 	req.Data = map[string]interface{}{
@@ -1198,35 +1086,19 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 	}
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext3 := resp.Data["ciphertext"].(string)
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext4 := resp.Data["ciphertext"].(string)
 
-	if ciphertext3 != ciphertext4 {
-		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext3, ciphertext4)
-	}
-	if ciphertext1 == ciphertext3 {
-		t.Fatal("expected different ciphertexts")
-	}
+	require.Equalf(t, ciphertext3, ciphertext4, "expected the same ciphertext but got %s and %s", ciphertext3, ciphertext4)
+	require.NotEqualf(t, ciphertext1, ciphertext3, "expected different ciphertexts")
 
 	// ...and a different context value
 	req.Data = map[string]interface{}{
@@ -1237,111 +1109,61 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		req.Data["nonce"] = "dHdvdGhyZWVmb3Vy" // "twothreefour"
 	}
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext5 := resp.Data["ciphertext"].(string)
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext6 := resp.Data["ciphertext"].(string)
 
-	if ciphertext5 != ciphertext6 {
-		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext5, ciphertext6)
-	}
-	if ciphertext1 == ciphertext5 {
-		t.Fatal("expected different ciphertexts")
-	}
-	if ciphertext3 == ciphertext5 {
-		t.Fatal("expected different ciphertexts")
-	}
+	require.Equalf(t, ciphertext5, ciphertext6, "expected the same ciphertext but got %s and %s", ciphertext5, ciphertext6)
+	require.NotEqualf(t, ciphertext1, ciphertext5, "expected different ciphertexts")
+	require.NotEqualf(t, ciphertext3, ciphertext5, "expected different ciphertexts")
 
 	// If running version 2, check upgrade handling
 	if ver == 2 {
 		curr, err := keysutil.LoadPolicy(context.Background(), storage, path.Join(p.StoragePrefix, "policy", "testkey"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if curr == nil {
-			t.Fatal("got nil policy")
-		}
-		if curr.ConvergentVersion != 2 {
-			t.Fatalf("bad convergent version %d", curr.ConvergentVersion)
-		}
+		require.NoError(t, err)
+		require.NotNilf(t, curr, "got nil policy")
+		require.Equalf(t, curr.ConvergentVersion, 2, "bad convergent version %d", curr.ConvergentVersion)
 		key := curr.Keys[strconv.Itoa(curr.LatestVersion)]
-		if key.ConvergentVersion != 0 {
-			t.Fatalf("bad convergent key version %d", key.ConvergentVersion)
-		}
+		require.Equalf(t, key.ConvergentVersion, 0, "bad convergent key version %d", key.ConvergentVersion)
 
 		curr.ConvergentVersion = 3
 		err = curr.Persist(context.Background(), storage)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		b.invalidate(context.Background(), "policy/testkey")
 
 		// Different algorithm, should be different value
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp == nil {
-			t.Fatal("expected non-nil response")
-		}
-		if resp.IsError() {
-			t.Fatalf("got error response: %#v", *resp)
-		}
+		require.NoError(t, err)
+		require.NotNilf(t, resp, "expected non-nil response")
+		require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 		ciphertext7 := resp.Data["ciphertext"].(string)
 
 		// Now do it via key-specified version
-		if len(curr.Keys) != 1 {
-			t.Fatalf("unexpected length of keys %d", len(curr.Keys))
-		}
+		require.Lenf(t, curr.Keys, 1, "unexpected length of keys %d", len(curr.Keys))
 		key = curr.Keys[strconv.Itoa(curr.LatestVersion)]
 		key.ConvergentVersion = 3
 		curr.Keys[strconv.Itoa(curr.LatestVersion)] = key
 		curr.ConvergentVersion = 2
 		err = curr.Persist(context.Background(), storage)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		b.invalidate(context.Background(), "policy/testkey")
 
 		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp == nil {
-			t.Fatal("expected non-nil response")
-		}
-		if resp.IsError() {
-			t.Fatalf("got error response: %#v", *resp)
-		}
+		require.NoError(t, err)
+		require.NotNilf(t, resp, "expected non-nil response")
+		require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 		ciphertext8 := resp.Data["ciphertext"].(string)
 
-		if ciphertext7 != ciphertext8 {
-			t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext7, ciphertext8)
-		}
-		if ciphertext6 == ciphertext7 {
-			t.Fatal("expected different ciphertexts")
-		}
-		if ciphertext3 == ciphertext7 {
-			t.Fatal("expected different ciphertexts")
-		}
+		require.Equalf(t, ciphertext7, ciphertext8, "expected the same ciphertext but got %s and %s", ciphertext7, ciphertext8)
+		require.NotEqualf(t, ciphertext6, ciphertext7, "expected different ciphertexts")
+		require.NotEqualf(t, ciphertext3, ciphertext7, "expected different ciphertexts")
 	}
 
 	// Finally, check operations on empty values
@@ -1353,15 +1175,9 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		req.Data["nonce"] = "dHdvdGhyZWVmb3Vy" // "twothreefour"
 	}
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if !resp.IsError() {
-		t.Fatalf("expected error response, got: %#v", *resp)
-	}
+	require.Errorf(t, err, "expected error, got nil")
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Truef(t, resp.IsError(), "expected error response, got: %#v", *resp)
 
 	// Now set plaintext to empty
 	req.Data = map[string]interface{}{
@@ -1372,32 +1188,18 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 		req.Data["nonce"] = "dHdvdGhyZWVmb3Vy" // "twothreefour"
 	}
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext7 := resp.Data["ciphertext"].(string)
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non-nil response")
-	}
-	if resp.IsError() {
-		t.Fatalf("got error response: %#v", *resp)
-	}
+	require.NoError(t, err)
+	require.NotNilf(t, resp, "expected non-nil response")
+	require.Falsef(t, resp.IsError(), "got error response: %#v", *resp)
 	ciphertext8 := resp.Data["ciphertext"].(string)
 
-	if ciphertext7 != ciphertext8 {
-		t.Fatalf("expected the same ciphertext but got %s and %s", ciphertext7, ciphertext8)
-	}
+	require.Equalf(t, ciphertext7, ciphertext8, "expected the same ciphertext but got %s and %s", ciphertext7, ciphertext8)
 }
 
 func TestPolicyFuzzing(t *testing.T) {
@@ -1463,9 +1265,7 @@ func testPolicyFuzzingCommon(t *testing.T, be *backend) {
 
 			// Try to write the key to make sure it exists
 			_, err := be.pathPolicyWrite(context.Background(), req, fd)
-			if err != nil {
-				t.Errorf("got an error: %v", err)
-			}
+			assert.NoErrorf(t, err, "got an error: %v", err)
 
 			switch chosenFunc {
 			// Encrypt our plaintext and store the result
@@ -1474,9 +1274,7 @@ func testPolicyFuzzingCommon(t *testing.T, be *backend) {
 				fd.Raw["plaintext"] = base64.StdEncoding.EncodeToString([]byte(testPlaintext))
 				fd.Schema = be.pathEncrypt().Fields
 				resp, err := be.pathEncryptWrite(context.Background(), req, fd)
-				if err != nil {
-					t.Errorf("got an error: %v, resp is %#v", err, *resp)
-				}
+				assert.NoErrorf(t, err, "got an error: %v, resp is %#v", err, *resp)
 				latestEncryptedText[chosenKey] = resp.Data["ciphertext"].(string)
 
 			// Rotate to a new key version
@@ -1484,9 +1282,7 @@ func testPolicyFuzzingCommon(t *testing.T, be *backend) {
 				// t.Errorf("%s, %s, %d", chosenFunc, chosenKey, id)
 				fd.Schema = be.pathRotate().Fields
 				resp, err := be.pathRotateWrite(context.Background(), req, fd)
-				if err != nil {
-					t.Errorf("got an error: %v, resp is %#v, chosenKey is %s", err, *resp, chosenKey)
-				}
+				assert.NoErrorf(t, err, "got an error: %v, resp is %#v, chosenKey is %s", err, *resp, chosenKey)
 
 			// Decrypt the ciphertext and compare the result
 			case "decrypt":
@@ -1516,33 +1312,27 @@ func testPolicyFuzzingCommon(t *testing.T, be *backend) {
 					t.Errorf("got an error decoding base64 plaintext: %v", err)
 					return
 				}
-				if string(pt) != testPlaintext {
-					t.Errorf("got bad plaintext back: %s", pt)
-				}
+				assert.Equalf(t, string(pt), testPlaintext, "got bad plaintext back: %s", pt)
 
 			// Change the min version, which also tests the archive functionality
 			case "change_min_version":
 				// t.Errorf("%s, %s, %d", chosenFunc, chosenKey, id)
 				resp, err := be.pathPolicyRead(context.Background(), req, fd)
-				if err != nil {
-					t.Errorf("got an error reading policy %s: %v", chosenKey, err)
-				}
+				assert.NoErrorf(t, err, "got an error reading policy %s: %v", chosenKey, err)
 				latestVersion := resp.Data["latest_version"].(int)
 
 				// keys start at version 1 so we want [1, latestVersion] not [0, latestVersion)
 				setVersion := (rand.Int() % latestVersion) + 1
 				fd.Raw["min_decryption_version"] = setVersion
 				fd.Schema = be.pathKeysConfig().Fields
-				resp, err = be.pathKeysConfigWrite(context.Background(), req, fd)
-				if err != nil {
-					t.Errorf("got an error setting min decryption version: %v", err)
-				}
+				_, err = be.pathKeysConfigWrite(context.Background(), req, fd)
+				assert.NoErrorf(t, err, "got an error setting min decryption version: %v", err)
 			}
 		}
 	}
 
 	// Spawn 1000 of these workers for 10 seconds
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		wg.Add(1)
 		go doFuzzy(i)
 	}
@@ -1561,9 +1351,7 @@ func TestBadInput(t *testing.T) {
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.NotNil(t, resp, "expected populated request")
 
 	req.Path = "decrypt/test"
@@ -1572,9 +1360,7 @@ func TestBadInput(t *testing.T) {
 	}
 
 	_, err = b.HandleRequest(context.Background(), req)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Errorf(t, err, "expected error")
 }
 
 func TestTransit_AutoRotateKeys(t *testing.T) {
@@ -1634,14 +1420,10 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 				}
 
 				b, _ := Backend(context.Background(), conf)
-				if b == nil {
-					t.Fatal("failed to create backend")
-				}
+				require.NotNilf(t, b, "failed to create backend")
 
 				err := b.Setup(context.Background(), conf)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 
 				// Write a key with the default auto rotate value (0/disabled)
 				req := &logical.Request{
@@ -1650,9 +1432,7 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 					Path:      "keys/test1",
 				}
 				resp, err := b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				require.NotNil(t, resp, "expected populated request")
 
 				// Write a key with an auto rotate value one day in the future
@@ -1665,96 +1445,62 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 					},
 				}
 				resp, err = b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				require.NotNil(t, resp, "expected populated request")
 
 				// Run the rotation check and ensure none of the keys have rotated
 				b.checkAutoRotateAfter = time.Now()
-				if err = b.autoRotateKeys(context.Background(), &logical.Request{Storage: storage}); err != nil {
-					t.Fatal(err)
-				}
+				err = b.autoRotateKeys(context.Background(), &logical.Request{Storage: storage})
+				require.NoError(t, err)
 				req = &logical.Request{
 					Storage:   storage,
 					Operation: logical.ReadOperation,
 					Path:      "keys/test1",
 				}
 				resp, err = b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if resp == nil {
-					t.Fatal("expected non-nil response")
-				}
-				if resp.Data["latest_version"] != 1 {
-					t.Fatalf("incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
-				}
+				require.NoError(t, err)
+				require.NotNilf(t, resp, "expected non-nil response")
+				require.Equalf(t, resp.Data["latest_version"], 1, "incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
 
 				req.Path = "keys/test2"
 				resp, err = b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if resp == nil {
-					t.Fatal("expected non-nil response")
-				}
-				if resp.Data["latest_version"] != 1 {
-					t.Fatalf("incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
-				}
+				require.NoError(t, err)
+				require.NotNilf(t, resp, "expected non-nil response")
+				require.Equalf(t, resp.Data["latest_version"], 1, "incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
 
 				// Update auto rotate period on one key to be one nanosecond
 				p, _, err := b.GetPolicy(context.Background(), keysutil.PolicyRequest{
 					Storage: storage,
 					Name:    "test2",
 				}, b.GetRandomReader())
-				if err != nil {
-					t.Fatal(err)
-				}
-				if p == nil {
-					t.Fatal("expected non-nil policy")
-				}
+				require.NoError(t, err)
+				require.NotNilf(t, p, "expected non-nil policy")
 				p.AutoRotatePeriod = time.Nanosecond
 				err = p.Persist(context.Background(), storage)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 
 				// Run the rotation check and validate the state of key rotations
 				b.checkAutoRotateAfter = time.Now()
-				if err = b.autoRotateKeys(context.Background(), &logical.Request{Storage: storage}); err != nil {
-					t.Fatal(err)
-				}
+				err = b.autoRotateKeys(context.Background(), &logical.Request{Storage: storage})
+				require.NoError(t, err)
 				req = &logical.Request{
 					Storage:   storage,
 					Operation: logical.ReadOperation,
 					Path:      "keys/test1",
 				}
 				resp, err = b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if resp == nil {
-					t.Fatal("expected non-nil response")
-				}
-				if resp.Data["latest_version"] != 1 {
-					t.Fatalf("incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
-				}
+				require.NoError(t, err)
+				require.NotNilf(t, resp, "expected non-nil response")
+				require.Equalf(t, resp.Data["latest_version"], 1, "incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
 				req.Path = "keys/test2"
 				resp, err = b.HandleRequest(context.Background(), req)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if resp == nil {
-					t.Fatal("expected non-nil response")
-				}
+				require.NoError(t, err)
+				require.NotNilf(t, resp, "expected non-nil response")
 				expectedVersion := 1
 				if test.shouldRotate {
 					expectedVersion = 2
 				}
-				if resp.Data["latest_version"] != expectedVersion {
-					t.Fatalf("incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], expectedVersion)
-				}
+				require.Equalf(t, resp.Data["latest_version"], expectedVersion, "incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], expectedVersion)
 			},
 		)
 	}
@@ -1782,9 +1528,8 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), keyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="                          // "the quick brown fox"
 	associated := "U3BoaW54IG9mIGJsYWNrIHF1YXJ0eiwganVkZ2UgbXkgdm93Lgo=" // "Sphinx of black quartz, judge my vow."
@@ -1800,9 +1545,8 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), encryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	ciphertext1 := resp.Data["ciphertext"].(string)
 
@@ -1816,61 +1560,51 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	decryptedPlaintext := resp.Data["plaintext"]
 
-	if plaintext != decryptedPlaintext {
-		t.Fatalf("bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
-	}
+	require.Equalf(t, decryptedPlaintext, plaintext, "bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
 
 	// Using associated as ciphertext should fail.
 	decryptReq.Data["ciphertext"] = associated
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 
 	// Redoing the above with additional data should work.
 	encryptReq.Data["associated_data"] = associated
 	resp, err = b.HandleRequest(context.Background(), encryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	ciphertext2 := resp.Data["ciphertext"].(string)
 	decryptReq.Data["ciphertext"] = ciphertext2
 	decryptReq.Data["associated_data"] = associated
 
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	decryptedPlaintext = resp.Data["plaintext"]
-	if plaintext != decryptedPlaintext {
-		t.Fatalf("bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
-	}
+	require.Equalf(t, decryptedPlaintext, plaintext, "bad: plaintext; expected: %q\nactual: %q", plaintext, decryptedPlaintext)
 
 	// Removing the associated_data should break the decryption.
 	decryptReq.Data = map[string]interface{}{
 		"ciphertext": ciphertext2,
 	}
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 
 	// Using a valid ciphertext with associated_data should also break the
 	// decryption.
 	decryptReq.Data["ciphertext"] = ciphertext1
 	decryptReq.Data["associated_data"] = associated
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 
 	// Basic generate data key/decrypt should work.
 	generateDataKeyReq := &logical.Request{
@@ -1881,9 +1615,8 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), generateDataKeyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	plaintext1 := resp.Data["plaintext"].(string)
 	ciphertext1 = resp.Data["ciphertext"].(string)
@@ -1893,29 +1626,24 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	decryptedPlaintext = resp.Data["plaintext"]
 
-	if plaintext1 != decryptedPlaintext {
-		t.Fatalf("bad: plaintext; expected: %q\nactual: %q", plaintext1, decryptedPlaintext)
-	}
+	require.Equalf(t, plaintext1, decryptedPlaintext, "bad: plaintext; expected: %q\nactual: %q", plaintext1, decryptedPlaintext)
 
 	// Using associated as ciphertext should fail.
 	decryptReq.Data["ciphertext"] = associated
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 
 	// Redoing the above with additional data should work.
 	generateDataKeyReq.Data["associated_data"] = associated
 	resp, err = b.HandleRequest(context.Background(), generateDataKeyReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	plaintext2 := resp.Data["plaintext"].(string)
 	ciphertext2 = resp.Data["ciphertext"].(string)
@@ -1923,32 +1651,27 @@ func testTransit_AEAD(t *testing.T, keyType string) {
 	decryptReq.Data["associated_data"] = associated
 
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
-	}
+	require.NoErrorf(t, err, "bad: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && resp.IsError(), "bad: err: %v\nresp: %#v", err, resp)
 
 	decryptedPlaintext = resp.Data["plaintext"]
-	if plaintext2 != decryptedPlaintext {
-		t.Fatalf("bad: plaintext; expected: %q\nactual: %q", plaintext2, decryptedPlaintext)
-	}
+	require.Equalf(t, plaintext2, decryptedPlaintext, "bad: plaintext; expected: %q\nactual: %q", plaintext1, decryptedPlaintext)
 
 	// Removing the associated_data should break the decryption.
 	decryptReq.Data = map[string]interface{}{
 		"ciphertext": ciphertext2,
 	}
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 
 	// Using a valid ciphertext with associated_data should also break the
 	// decryption.
 	decryptReq.Data["ciphertext"] = ciphertext1
 	decryptReq.Data["associated_data"] = associated
 	resp, err = b.HandleRequest(context.Background(), decryptReq)
-	if err == nil || (resp != nil && !resp.IsError()) {
-		t.Fatalf("bad expected error: err: %v\nresp: %#v", err, resp)
-	}
+	require.Errorf(t, err, "bad expected error: err: %v\nresp: %#v", err, resp)
+	require.Falsef(t, resp != nil && !resp.IsError(), "bad expected error: err: %v\nresp: %#v", err, resp)
 }
 
 // Hack: use Transit as a signer.
@@ -2111,16 +1834,12 @@ func testTransit_ReadPublicKeyImported(t *testing.T, keyType string) {
 	generateKeys(t)
 	b, s := createBackendWithStorage(t)
 	keyID, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatalf("failed to generate key ID: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to generate key ID: %s", err)
 
 	// Get key
 	privateKey := getKey(t, keyType)
 	publicKeyBytes, err := getPublicKey(privateKey, keyType)
-	if err != nil {
-		t.Fatalf("failed to extract the public key: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to extract the public key: %s", err)
 
 	// Import key
 	importReq := &logical.Request{
@@ -2133,9 +1852,8 @@ func testTransit_ReadPublicKeyImported(t *testing.T, keyType string) {
 		},
 	}
 	importResp, err := b.HandleRequest(context.Background(), importReq)
-	if err != nil || (importResp != nil && importResp.IsError()) {
-		t.Fatalf("failed to import public key. err: %s\nresp: %#v", err, importResp)
-	}
+	require.NoErrorf(t, err, "failed to import public key. err: %s\nresp: %#v", err, importResp)
+	require.Falsef(t, importResp != nil && importResp.IsError(), "failed to import public key. err: %s\nresp: %#v", err, importResp)
 
 	// Read key
 	readReq := &logical.Request{
@@ -2145,9 +1863,8 @@ func testTransit_ReadPublicKeyImported(t *testing.T, keyType string) {
 	}
 
 	readResp, err := b.HandleRequest(context.Background(), readReq)
-	if err != nil || (readResp != nil && readResp.IsError()) {
-		t.Fatalf("failed to read key. err: %s\nresp: %#v", err, readResp)
-	}
+	require.NoErrorf(t, err, "failed to read key. err: %s\nresp: %#v", err, readResp)
+	require.Falsef(t, readResp != nil && readResp.IsError(), "failed to read key. err: %s\nresp: %#v", err, readResp)
 }
 
 func TestTransit_SignWithImportedPublicKey(t *testing.T) {
@@ -2160,16 +1877,12 @@ func testTransit_SignWithImportedPublicKey(t *testing.T, keyType string) {
 	generateKeys(t)
 	b, s := createBackendWithStorage(t)
 	keyID, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatalf("failed to generate key ID: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to generate key ID: %s", err)
 
 	// Get key
 	privateKey := getKey(t, keyType)
 	publicKeyBytes, err := getPublicKey(privateKey, keyType)
-	if err != nil {
-		t.Fatalf("failed to extract the public key: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to extract the public key: %s", err)
 
 	// Import key
 	importReq := &logical.Request{
@@ -2182,9 +1895,8 @@ func testTransit_SignWithImportedPublicKey(t *testing.T, keyType string) {
 		},
 	}
 	importResp, err := b.HandleRequest(context.Background(), importReq)
-	if err != nil || (importResp != nil && importResp.IsError()) {
-		t.Fatalf("failed to import public key. err: %s\nresp: %#v", err, importResp)
-	}
+	require.NoErrorf(t, err, "failed to import public key. err: %s\nresp: %#v", err, importResp)
+	require.Falsef(t, importResp != nil && importResp.IsError(), "failed to import public key. err: %s\nresp: %#v", err, importResp)
 
 	// Sign text
 	signReq := &logical.Request{
@@ -2197,9 +1909,7 @@ func testTransit_SignWithImportedPublicKey(t *testing.T, keyType string) {
 	}
 
 	_, err = b.HandleRequest(context.Background(), signReq)
-	if err == nil {
-		t.Fatal("expected error, should have failed to sign input")
-	}
+	require.Errorf(t, err, "expected error, should have failed to sign input")
 }
 
 func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
@@ -2207,22 +1917,17 @@ func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
 	keyType := "rsa-2048"
 	b, s := createBackendWithStorage(t)
 	keyID, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatalf("failed to generate key ID: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to generate key ID: %s", err)
 
 	// Get key
 	privateKey := getKey(t, keyType)
 	publicKeyBytes, err := getPublicKey(privateKey, keyType)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Retrieve public wrapping key
 	wrappingKey, err := b.getWrappingKey(context.Background(), s)
-	if err != nil || wrappingKey == nil {
-		t.Fatalf("failed to retrieve public wrapping key: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to retrieve public wrapping key: %s", err)
+	require.NotNilf(t, wrappingKey, "retrieved public wrapping key is nil")
 
 	privWrappingKey := wrappingKey.Keys[strconv.Itoa(wrappingKey.LatestVersion)].RSAKey
 	pubWrappingKey := &privWrappingKey.PublicKey
@@ -2241,9 +1946,8 @@ func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
 		},
 	}
 	importResp, err := b.HandleRequest(context.Background(), importReq)
-	if err != nil || (importResp != nil && importResp.IsError()) {
-		t.Fatalf("failed to import key. err: %s\nresp: %#v", err, importResp)
-	}
+	require.NoErrorf(t, err, "failed to import key. err: %s\nresp: %#v", err, importResp)
+	require.Falsef(t, importResp != nil && importResp.IsError(), "failed to import key. err: %s\nresp: %#v", err, importResp)
 
 	// Sign text
 	signReq := &logical.Request{
@@ -2256,9 +1960,8 @@ func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
 	}
 
 	signResp, err := b.HandleRequest(context.Background(), signReq)
-	if err != nil || (signResp != nil && signResp.IsError()) {
-		t.Fatalf("failed to sign plaintext. err: %s\nresp: %#v", err, signResp)
-	}
+	require.NoErrorf(t, err, "failed to sign plaintext. err: %s\nresp: %#v", err, signResp)
+	require.Falsef(t, signResp != nil && signResp.IsError(), "failed to sign plaintext. err: %s\nresp: %#v", err, signResp)
 
 	// Get signature
 	signature := signResp.Data["signature"].(string)
@@ -2274,9 +1977,8 @@ func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
 		},
 	}
 	importPubResp, err := b.HandleRequest(context.Background(), importPubReq)
-	if err != nil || (importPubResp != nil && importPubResp.IsError()) {
-		t.Fatalf("failed to import public key. err: %s\nresp: %#v", err, importPubResp)
-	}
+	require.NoErrorf(t, err, "failed to import public key. err: %s\nresp: %#v", err, importPubResp)
+	require.Falsef(t, importPubResp != nil && importPubResp.IsError(), "failed to import public key. err: %s\nresp: %#v", err, importPubResp)
 
 	// Verify signed text
 	verifyReq := &logical.Request{
@@ -2290,9 +1992,8 @@ func TestTransit_VerifyWithImportedPublicKey(t *testing.T) {
 	}
 
 	verifyResp, err := b.HandleRequest(context.Background(), verifyReq)
-	if err != nil || (importResp != nil && verifyResp.IsError()) {
-		t.Fatalf("failed to verify signed data. err: %s\nresp: %#v", err, importResp)
-	}
+	require.NoErrorf(t, err, "failed to verify signed data. err: %s\nresp: %#v", err, importResp)
+	require.Falsef(t, verifyResp != nil && verifyResp.IsError(), "failed to verify signed data. err: %s\nresp: %#v", err, importResp)
 }
 
 func TestTransit_ExportPublicKeyImported(t *testing.T) {
@@ -2305,16 +2006,12 @@ func testTransit_ExportPublicKeyImported(t *testing.T, keyType string) {
 	generateKeys(t)
 	b, s := createBackendWithStorage(t)
 	keyID, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatalf("failed to generate key ID: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to generate key ID: %s", err)
 
 	// Get key
 	privateKey := getKey(t, keyType)
 	publicKeyBytes, err := getPublicKey(privateKey, keyType)
-	if err != nil {
-		t.Fatalf("failed to extract the public key: %s", err)
-	}
+	require.NoErrorf(t, err, "failed to extract the public key: %s", err)
 
 	t.Logf("generated key: %v", string(publicKeyBytes))
 
@@ -2330,9 +2027,8 @@ func testTransit_ExportPublicKeyImported(t *testing.T, keyType string) {
 		},
 	}
 	importResp, err := b.HandleRequest(context.Background(), importReq)
-	if err != nil || (importResp != nil && importResp.IsError()) {
-		t.Fatalf("failed to import public key. err: %s\nresp: %#v", err, importResp)
-	}
+	require.NoErrorf(t, err, "failed to import public key. err: %s\nresp: %#v", err, importResp)
+	require.Falsef(t, importResp != nil && importResp.IsError(), "failed to import public key. err: %s\nresp: %#v", err, importResp)
 
 	t.Logf("importing key: %v", importResp)
 
@@ -2344,40 +2040,28 @@ func testTransit_ExportPublicKeyImported(t *testing.T, keyType string) {
 	}
 
 	exportResp, err := b.HandleRequest(context.Background(), exportReq)
-	if err != nil || (exportResp != nil && exportResp.IsError()) {
-		t.Fatalf("failed to export key. err: %v\nresp: %#v", err, exportResp)
-	}
+	require.NoErrorf(t, err, "failed to export key. err: %v\nresp: %#v", err, exportResp)
+	require.Falsef(t, exportResp != nil && exportResp.IsError(), "failed to export key. err: %v\nresp: %#v", err, exportResp)
 
 	t.Logf("exporting key: %v", exportResp)
 
 	responseKeys, exist := exportResp.Data["keys"]
-	if !exist {
-		t.Fatal("expected response data to hold a 'keys' field")
-	}
+	require.Truef(t, exist, "expected response data to hold a 'keys' field")
 
 	exportedKeyBytes := responseKeys.(map[string]string)["1"]
 
 	if keyType != "ed25519" {
 		exportedKeyBlock, _ := pem.Decode([]byte(exportedKeyBytes))
 		publicKeyBlock, _ := pem.Decode(publicKeyBytes)
-
-		if !reflect.DeepEqual(publicKeyBlock.Bytes, exportedKeyBlock.Bytes) {
-			t.Fatalf("exported key bytes should have matched with imported key for key type: %v\nexported: %v\nimported: %v", keyType, exportedKeyBlock.Bytes, publicKeyBlock.Bytes)
-		}
+		require.Equalf(t, publicKeyBlock.Bytes, exportedKeyBlock.Bytes, "exported key bytes should have matched with imported key for key type: %v\nexported: %v\nimported: %v", keyType, exportedKeyBlock.Bytes, publicKeyBlock.Bytes)
 	} else {
 		exportedKey, err := base64.StdEncoding.DecodeString(exportedKeyBytes)
-		if err != nil {
-			t.Fatalf("error decoding exported key bytes (%v) to base64 for key type %v: %v", exportedKeyBytes, keyType, err)
-		}
+		require.NoErrorf(t, err, "error decoding exported key bytes (%v) to base64 for key type %v: %v", exportedKeyBytes, keyType, err)
 
 		publicKeyBlock, _ := pem.Decode(publicKeyBytes)
 		publicKeyParsed, err := x509.ParsePKIXPublicKey(publicKeyBlock.Bytes)
-		if err != nil {
-			t.Fatalf("error decoding source key bytes (%v) from PKIX marshaling for key type %v: %v", publicKeyBlock.Bytes, keyType, err)
-		}
+		require.NoErrorf(t, err, "error decoding source key bytes (%v) from PKIX marshaling for key type %v: %v", publicKeyBlock.Bytes, keyType, err)
 
-		if !reflect.DeepEqual([]byte(publicKeyParsed.(ed25519.PublicKey)), exportedKey) {
-			t.Fatalf("exported key bytes should have matched with imported key for key type: %v\nexported: %v\nimported: %v", keyType, exportedKey, publicKeyParsed)
-		}
+		require.Equalf(t, []byte(publicKeyParsed.(ed25519.PublicKey)), exportedKey, "exported key bytes should have matched with imported key for key type: %v\nexported: %v\nimported: %v", keyType, exportedKey, publicKeyParsed)
 	}
 }

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -553,11 +553,7 @@ func HandleOtherCSRSANs(in *x509.CertificateRequest, sans map[string][]string) e
 	if err := HandleOtherSANs(certTemplate, sans); err != nil {
 		return err
 	}
-	if len(certTemplate.ExtraExtensions) > 0 {
-		for _, v := range certTemplate.ExtraExtensions {
-			in.ExtraExtensions = append(in.ExtraExtensions, v)
-		}
-	}
+	in.ExtraExtensions = append(in.ExtraExtensions, certTemplate.ExtraExtensions...)
 	return nil
 }
 

--- a/sdk/helper/testcluster/exec.go
+++ b/sdk/helper/testcluster/exec.go
@@ -75,14 +75,14 @@ func NewTestExecDevCluster(t *testing.T, opts *ExecDevClusterOptions) *ExecDevCl
 }
 
 func NewExecDevCluster(ctx context.Context, opts *ExecDevClusterOptions) (*ExecDevCluster, error) {
+	if opts == nil {
+		opts = &ExecDevClusterOptions{}
+	}
 	dc := &ExecDevCluster{
 		ClusterName: opts.ClusterName,
 		stopCh:      make(chan struct{}),
 	}
 
-	if opts == nil {
-		opts = &ExecDevClusterOptions{}
-	}
 	if opts.NumCores == 0 {
 		opts.NumCores = 3
 	}


### PR DESCRIPTION
## Description

Fix false positive nil pointer dereference staticcheck findings by migrating some tests to testify.
Fix staticcheck warning about `t.Fatalf` being called in a sub goroutine

## Rationale

Resolves: #1580

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
