### PR TITLE
Clarify claim_mapping behavior

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -157,7 +157,9 @@ entities attempting to login. At least one of the bound values must be set.
   syntax for referencing claims.
 - `claim_mappings` `(map: <optional>)` - If set, a map of claims (keys) to be copied to
   specified metadata fields (values). Keys support [JSON pointer](/docs/auth/jwt#claim-specifications-and-json-pointer)
-  syntax for referencing claims.
+  syntax for referencing claims but may also be direct claim key names.
+  [See claim mapping documentation](/docs/auth/jwt#claims-as-metadata) for
+  more information.
 - `oauth2_metadata` `(list: <optional>` - If set, a list of token types
   that come from the OIDC provider to return in metadata.
   The types can be any of `access_token`, `id_token`, or `refresh_token`,

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -348,8 +348,24 @@ parameter is a map of items to copy. The map elements are of the form: `"<JWT cl
 ```
 
 This specifies that the value in the JWT claim "division" should be copied to the metadata key "organization". The JWT
-"department" claim value will also be copied into metadata but will retain the key name. If a claim is configured in `claim_mappings`,
-it must existing in the JWT or else the authentication will fail.
+"department" claim value will also be copied into metadata but will retain the key name.
+
+If a claim is configured in `claim_mappings`, it must exist in the JWT when
+using JSON pointer syntax (beginning with a `/`) or else the authentication
+will fail. Claim mappings which do not begin with a `/` are optional. For
+example, in the configuration:
+
+```json
+{
+    "optional_jwt_claim": "optional_metadata_key",
+    "/required_jwt_claim": "required_metadata_key",
+}
+```
+
+the claim `optional_jwt_claim` may or may not be present, and when elided,
+`optional_metadata_key` will be skipped as a metadata value. However, the
+claim `required_jwt_claim` must always be present on the JWT or authentication
+will fail otherwise.
 
 Note: the metadata key name "role" is reserved and may not be used for claim mappings.
 


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

In the JWT engine, `claim_mapping` allows mapping `claims->metadata` keys. The syntax optionally uses JSON pointer but may also be direct keys: this was not documented. Notably, while JSON pointer makes claims required, the direct key names (by virtue of being a simple map lookup) allow claims to be optionally used.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
