### PR TITLE
raft: send lowestActiveIndex also for put and delete operations (#2067)

### DIFF
--- a/changelog/2067.txt
+++ b/changelog/2067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: fix memory leak when using only non-transactional operations. This was a regression introduced in release 2.4.2 with #1889.
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
+	"github.com/openbao/openbao/sdk/v2/helper/pointerutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/cluster"
@@ -1735,6 +1736,15 @@ func (b *RaftBackend) applyLog(ctx context.Context, command *LogData) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	var lowestActiveIndex uint64
+	if command.LowestActiveIndex != nil {
+		lowestActiveIndex = *command.LowestActiveIndex
+	} else {
+		lowestActiveIndex = b.fsm.fastTxnTracker.lowestActiveIndex()
+	}
+	lowestActiveIndex = min(b.raft.AppliedIndex(), lowestActiveIndex) // we need to cap the lowest active index, otherwise we might miss transaction started concurrently
+	command.LowestActiveIndex = pointerutil.Ptr(lowestActiveIndex)
 
 	isTx := len(command.Operations) > 0 && command.Operations[0].OpType == beginTxOp
 	commandBytes, err := proto.Marshal(command)


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/2067 by @phil9909 

Cherry-picked with minor conflicts (imports)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
