### PR TITLE
Add Kubernetes JWT provider that authenticates with pod Service Account token

### DIFF
--- a/builtin/credential/jwt/backend.go
+++ b/builtin/credential/jwt/backend.go
@@ -151,14 +151,19 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 	var err error
 	var keySet jwt.KeySet
 
+	pConfig, err := NewProviderConfig(b.providerCtx, config, ProviderMap())
+	if err != nil {
+		return nil, fmt.Errorf("error initializing provider_config: %w", err)
+	}
+
 	// Configure the key set for the validator
 	switch config.authType() {
 	case JWKS:
-		keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, config.JWKSURL, config.JWKSCAPEM)
+		keySet, err = jwt.NewJSONWebKeySet(injectProviderHTTPClient(pConfig, b.providerCtx), config.JWKSURL, config.JWKSCAPEM)
 	case StaticKeys:
 		keySet, err = jwt.NewStaticKeySet(config.ParsedJWTPubKeys)
 	case OIDCDiscovery, OIDCFlow:
-		keySet, err = jwt.NewOIDCDiscoveryKeySet(b.providerCtx, config.OIDCDiscoveryURL, config.OIDCDiscoveryCAPEM)
+		keySet, err = jwt.NewOIDCDiscoveryKeySet(injectProviderHTTPClient(pConfig, b.providerCtx), config.OIDCDiscoveryURL, config.OIDCDiscoveryCAPEM)
 	default:
 		return nil, errors.New("unsupported config type")
 	}

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -380,7 +380,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	resp := &logical.Response{}
 	switch {
 	case methodCount != 1:
-		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url' or 'oidc_discovery_url' must be set"), nil
+		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_pairs', 'oidc_discovery_url', or 'provider_config' must be set"), nil
 
 	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -366,6 +366,19 @@ func toAlg[T ~string](a []T) []jwt.Alg {
 	return alg
 }
 
+// injectProviderHTTPClient checks if the given provider provides a custom HTTP client.
+// If so, it injects it into the context and returns the new context.
+// Otherwise, it returns the original context.
+func injectProviderHTTPClient(pConfig CustomProvider, ctx context.Context) context.Context {
+	if httpClientProvider, ok := pConfig.(HTTPClient); ok {
+		httpClient := httpClientProvider.GetHTTPClient()
+		if httpClient != nil {
+			ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+		}
+	}
+	return ctx
+}
+
 const (
 	pathLoginHelpSyn = `
 	Authenticates to OpenBao using a JWT (or OIDC) token.

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -366,19 +366,6 @@ func toAlg[T ~string](a []T) []jwt.Alg {
 	return alg
 }
 
-// injectProviderHTTPClient checks if the given provider provides a custom HTTP client.
-// If so, it injects it into the context and returns the new context.
-// Otherwise, it returns the original context.
-func injectProviderHTTPClient(pConfig CustomProvider, ctx context.Context) context.Context {
-	if httpClientProvider, ok := pConfig.(HTTPClient); ok {
-		httpClient := httpClientProvider.GetHTTPClient()
-		if httpClient != nil {
-			ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-		}
-	}
-	return ctx
-}
-
 const (
 	pathLoginHelpSyn = `
 	Authenticates to OpenBao using a JWT (or OIDC) token.

--- a/builtin/credential/jwt/provider_config.go
+++ b/builtin/credential/jwt/provider_config.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
+	"github.com/hashicorp/cap/jwt"
 	"golang.org/x/oauth2"
 )
 
@@ -71,8 +71,8 @@ type GroupsFetcher interface {
 	FetchGroups(context.Context, *jwtAuthBackend, map[string]interface{}, *jwtRole, oauth2.TokenSource) (interface{}, error)
 }
 
-// HTTPClient- Optional support for custom HTTP client.
-type HTTPClient interface {
-	// GetHTTPClient returns an HTTP client to be used for requests.
-	GetHTTPClient() *http.Client
+// KeySetDiscovery - Optional support for custom provider-specific discovery mechanism
+type KeySetDiscovery interface {
+	// NewKeySet returns a new KeySet that will be used to verify JWTs
+	NewKeySet(context.Context) (jwt.KeySet, error)
 }

--- a/builtin/credential/jwt/provider_config.go
+++ b/builtin/credential/jwt/provider_config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"golang.org/x/oauth2"
 )
@@ -22,6 +23,7 @@ func ProviderMap() map[string]CustomProvider {
 		"gsuite":     &GSuiteProvider{},
 		"secureauth": &SecureAuthProvider{},
 		"ibmisam":    &IBMISAMProvider{},
+		"kubernetes": &KubernetesProvider{},
 	}
 }
 
@@ -67,4 +69,10 @@ type UserInfoFetcher interface {
 type GroupsFetcher interface {
 	// FetchGroups queries for groups claims during login
 	FetchGroups(context.Context, *jwtAuthBackend, map[string]interface{}, *jwtRole, oauth2.TokenSource) (interface{}, error)
+}
+
+// HTTPClient- Optional support for custom HTTP client.
+type HTTPClient interface {
+	// GetHTTPClient returns an HTTP client to be used for requests.
+	GetHTTPClient() *http.Client
 }

--- a/builtin/credential/jwt/provider_kubernetes.go
+++ b/builtin/credential/jwt/provider_kubernetes.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package jwtauth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// Global variables instead of const to allow test cases to overwrite paths.
+var (
+	// localJWTPath is the path to the Kubernetes Service Account JWT token file.
+	localJWTPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	// localCACertPath is the path to the Kubernetes API server CA certificate.
+	localCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
+type KubernetesProvider struct{}
+
+func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error {
+	// Ensure JWKSCAPEM and OIDCDiscoveryCAPEM are not set. These options conflict with
+	// the Kubernetes provider because they configure a custom HTTP client via github.com/hashicorp/cap
+	// when calling jwt.NewJSONWebKeySet() or jwt.NewOIDCDiscoveryKeySet(), preventing
+	// the Kubernetes provider from injecting its own HTTP client with proper CA certificate
+	// and Authorization header.
+	if jc.JWKSCAPEM != "" {
+		return errors.New("jwks_ca_pem must not be set when using the kubernetes provider")
+	}
+
+	if jc.OIDCDiscoveryCAPEM != "" {
+		return errors.New("oidc_discovery_ca_pem must not be set when using the kubernetes provider")
+	}
+
+	// Verify that the Service Account token and CA certificate files are accessible.
+	_, err := os.ReadFile(localJWTPath)
+	if err != nil {
+		return fmt.Errorf("error reading service account token file: %w", err)
+	}
+
+	_, err = os.ReadFile(localCACertPath)
+	if err != nil {
+		return fmt.Errorf("error reading CA certificate file: %w", err)
+	}
+
+	return nil
+}
+
+func (k *KubernetesProvider) SensitiveKeys() []string {
+	return []string{}
+}
+
+func (k *KubernetesProvider) GetHTTPClient() *http.Client {
+	// The HTTP client is created only once by JWT/OIDC authentication method.
+	// Note: CA certificate rotation is not supported without restarting or re-creating backend instance.
+	certPool := x509.NewCertPool()
+	caCert, err := os.ReadFile(localCACertPath)
+	if err != nil {
+		return cleanhttp.DefaultPooledClient()
+	}
+
+	certPool.AppendCertsFromPEM([]byte(caCert))
+
+	tlsConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	baseTransport := cleanhttp.DefaultPooledTransport()
+	baseTransport.TLSClientConfig = tlsConfig
+
+	saAuthTransport := &bearerAuthRoundTripper{
+		baseTransport:      baseTransport,
+		kubernetesProvider: k,
+	}
+
+	return &http.Client{
+		Transport: saAuthTransport,
+	}
+}
+
+// bearerAuthRoundTripper is an http.RoundTripper that adds an Authorization header
+// containing the Kubernetes Service Account token as a bearer token.
+type bearerAuthRoundTripper struct {
+	baseTransport      http.RoundTripper
+	kubernetesProvider *KubernetesProvider
+}
+
+func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return rt.baseTransport.RoundTrip(req)
+	}
+
+	// Clone the request to avoid modifying the original.
+	req = req.Clone(req.Context())
+
+	// Read the token from disk on each request.
+	// Since discovery and JWKS downloads are infrequent, caching in memory has minimal benefit.
+	token, err := os.ReadFile(localJWTPath)
+	if err == nil {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	return rt.baseTransport.RoundTrip(req)
+}

--- a/builtin/credential/jwt/provider_kubernetes.go
+++ b/builtin/credential/jwt/provider_kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -70,7 +71,7 @@ func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error 
 
 	// For security, the OIDC discovery URL is derived from Kubernetes-provided environment variables in the pod,
 	// rather than accepting a user-supplied URL.
-	k.oidcDiscoveryURL = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
+	k.oidcDiscoveryURL = "https://" + net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
 
 	return nil
 }
@@ -106,7 +107,7 @@ func (k *KubernetesProvider) NewKeySet(ctx context.Context) (jwt.KeySet, error) 
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
-	jwksURL, err := retrieveJWKSURL(k.oidcDiscoveryURL+"/.well-known/openid-configuration", ctx, httpClient)
+	jwksURL, err := retrieveJWKSURL(ctx, k.oidcDiscoveryURL+"/.well-known/openid-configuration", httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (k *KubernetesProvider) NewKeySet(ctx context.Context) (jwt.KeySet, error) 
 // This function is similar to jwt.NewOIDCDiscoveryKeySet(), but it skips validating the "issuer" field:
 // this provider relies on Service IP address from KUBERNETES_SERVICE_HOST environment variable on connecting
 // the API server, which does not match the issuer field in the discovery document.
-func retrieveJWKSURL(wellKnown string, ctx context.Context, client *http.Client) (string, error) {
+func retrieveJWKSURL(ctx context.Context, wellKnown string, client *http.Client) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
 	if err != nil {
 		return "", err
@@ -145,6 +146,10 @@ func retrieveJWKSURL(wellKnown string, ctx context.Context, client *http.Client)
 	}
 	if err := json.Unmarshal(body, &p); err != nil {
 		return "", err
+	}
+
+	if p.JWKSURL == "" {
+		return "", errors.New("jwks_uri not found in OIDC discovery document")
 	}
 
 	return p.JWKSURL, nil

--- a/builtin/credential/jwt/provider_kubernetes_test.go
+++ b/builtin/credential/jwt/provider_kubernetes_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package jwtauth
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesProviderWithOIDCDiscovery(t *testing.T) {
+	b, storage := getBackend(t)
+	server, token := mockKubernetesAPIServer(t)
+
+	// Configure the backend with OIDC discovery URL and Kubernetes provider.
+	// The provider uses the service account token for authentication and the pod CA cert for server validation.
+	data := map[string]interface{}{
+		"oidc_discovery_url": server.server.URL,
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	// Verify that the request to the API server includes Authorization header with the bearer token.
+	requests := server.getRequests()
+	require.Len(t, requests, 1)
+	require.Equal(t, "/.well-known/openid-configuration", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+
+	createRole(t, b, storage)
+
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:openbao-client"))
+
+	requests = server.getRequests()
+	require.Len(t, requests, 2)
+	require.Equal(t, "/.well-known/openid-configuration", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+	require.Equal(t, "/certs", requests[1].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[1].Header.Get("Authorization"))
+
+	// Re-attempt login to verify that JWKS caching works and no new request is made to JWKS endpoint.
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:openbao-client"))
+	requests = server.getRequests()
+	require.Len(t, requests, 0)
+}
+
+func TestKubernetesProviderWithJWKSURL(t *testing.T) {
+	b, storage := getBackend(t)
+	server, token := mockKubernetesAPIServer(t)
+
+	// Configure the backend with JWKS URL and Kubernetes provider.
+	// The provider uses the service account token for authentication and the pod CA cert for server validation.
+	data := map[string]interface{}{
+		"jwks_url": server.server.URL + "/certs",
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	createRole(t, b, storage)
+
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:openbao-client"))
+
+	// Verify that the request to the API server includes Authorization header with the bearer token.
+	requests := server.getRequests()
+	require.Len(t, requests, 2)
+	require.Equal(t, "/certs", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+	require.Equal(t, "/certs", requests[1].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[1].Header.Get("Authorization"))
+
+	// Re-attempt login to verify that JWKS caching works and no new request is made to JWKS endpoint.
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:openbao-client"))
+	requests = server.getRequests()
+	require.Len(t, requests, 0)
+}
+
+func TestKubernetesProviderWithInvalidConfig(t *testing.T) {
+	b, storage := getBackend(t)
+
+	tempDir := t.TempDir()
+	caCertPath := path.Join(tempDir, "ca.crt")
+	err := os.WriteFile(caCertPath, []byte("test-ca-cert-data"), 0o600)
+	require.NoError(t, err)
+
+	// Configure jwks_ca_pem with Kubernetes provider.
+	data := map[string]interface{}{
+		"jwks_url":    "https://example.com/",
+		"jwks_ca_pem": caCertPath,
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+
+	// Configure oidc_discovery_ca_pem with Kubernetes provider.
+	data = map[string]interface{}{
+		"oidc_discovery_url":    "https://example.com/",
+		"oidc_discovery_ca_pem": caCertPath,
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err = b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func TestKubernetesProviderWithInvalidTokenFile(t *testing.T) {
+	b, storage := getBackend(t)
+	server, _ := mockKubernetesAPIServer(t)
+
+	// Overwrite the global SA token path variable to point to a non-existing file.
+	localJWTPath = "/non/existing/token/file"
+
+	data := map[string]interface{}{
+		"jwks_url": server.server.URL + "/certs",
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func TestKubernetesProviderWithInvalidCACertFile(t *testing.T) {
+	b, storage := getBackend(t)
+	server, _ := mockKubernetesAPIServer(t)
+
+	// Overwrite the global CA cert path variable to point to a non-existing file.
+	localCACertPath = "/non/existing/ca/cert/file"
+
+	data := map[string]interface{}{
+		"jwks_url": server.server.URL + "/certs",
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func mockKubernetesAPIServer(t *testing.T) (*oidcProvider, string) {
+	t.Helper()
+
+	// Start the test OIDC provider.
+	server := newOIDCProvider(t)
+	server.clientID = "https://kubernetes.default.svc.cluster.local"
+	t.Cleanup(server.server.Close)
+	cert, err := server.getTLSCert()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+
+	// Write server cert to a file.
+	certFile := path.Join(tempDir, "ca.crt")
+	err = os.WriteFile(certFile, []byte(cert), 0o600)
+	require.NoError(t, err)
+
+	// Write token that will be used to authenticate towards Kubnetes API server.
+	tokenFile := path.Join(tempDir, "token")
+	token := "my-kubernetes-service-account-token"
+	err = os.WriteFile(tokenFile, []byte(token), 0o600)
+	require.NoError(t, err)
+
+	// Overwrite the global cert and token variables so that Kubernetes provider uses them instead of the pod paths.
+	localCACertPath = certFile
+	localJWTPath = tokenFile
+
+	return server, token
+}
+
+func createRole(t *testing.T, b logical.Backend, s logical.Storage) {
+	t.Helper()
+
+	data := map[string]interface{}{
+		"role_type":       "jwt",
+		"user_claim":      "sub",
+		"bound_subject":   "system:serviceaccount:default:openbao-client",
+		"bound_audiences": "https://kubernetes.default.svc.cluster.local",
+	}
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/my-role",
+		Storage:   s,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+}
+
+func login(t *testing.T, b logical.Backend, s logical.Storage, jwt string) {
+	t.Helper()
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"role": "my-role",
+			"jwt":  jwt,
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+}

--- a/builtin/credential/jwt/provider_kubernetes_test.go
+++ b/builtin/credential/jwt/provider_kubernetes_test.go
@@ -227,8 +227,8 @@ func mockKubernetesAPIServer(t *testing.T) (*oidcProvider, string) {
 	localJWTPath = tokenFile
 
 	parsedURL, _ := url.Parse(server.server.URL)
-	os.Setenv("KUBERNETES_SERVICE_HOST", parsedURL.Hostname()) //nolint:errcheck
-	os.Setenv("KUBERNETES_SERVICE_PORT", parsedURL.Port())     //nolint:errcheck
+	t.Setenv("KUBERNETES_SERVICE_HOST", parsedURL.Hostname())
+	t.Setenv("KUBERNETES_SERVICE_PORT", parsedURL.Port())
 
 	return server, token
 }

--- a/changelog/2114.txt
+++ b/changelog/2114.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+jwt/auth: Add new Kubernetes JWT provider that authenticates to the Kubernetes API using a pod's Service Account token.
+```

--- a/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
@@ -34,7 +34,47 @@ Kubernetes cluster requirements:
 * Must use short-lived service account tokens when logging in.
   * Tokens mounted into pods default to short-lived from 1.21.
 
-Configuration steps:
+#### Configuration steps when OpenBao is running in Kubernetes
+
+1. Find the issuer URL of the cluster.
+
+   ```bash
+   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
+   ```
+
+1. Enable and configure JWT auth in OpenBao.
+
+   ```bash
+   kubectl exec openbao-0 -- bao auth enable jwt
+   kubectl exec openbao-0 -- bao write auth/jwt/config -<<EOF
+   {
+      "oidc_discovery_url": "https://kubernetes.default.svc.cluster.local",
+      "provider_config": {
+          "provider": "kubernetes"
+      }
+   }
+   EOF
+   ```
+
+* `provider_config.provider` `(string: <required>)` - Name of the provider.
+   Must be set to "kubernetes".
+
+OpenBao automatically uses the service account token found at `/var/run/secrets/kubernetes.io/serviceaccount/token`
+for authentication with the Kubernetes API server, and the CA certificate at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+to verify the server's TLS certificate. It supports short-lived tokens.
+
+No special Kubernetes RBAC permissions are required for the service account token.
+The default service account token is sufficient.
+
+#### Configuration steps when OpenBao is _not_ running in Kubernetes:
+
+:::info
+
+**Note:** When OpenBao is outside the cluster, the `$ISSUER` endpoint below
+may or may not be reachable. If not, you can configure JWT auth using
+[`jwt_validation_pubkeys`](#using-jwt-validation-public-keys) instead.
+
+:::
 
 1. Ensure OIDC discovery URLs do not require authentication, as detailed
    [here][k8s-sa-issuer-discovery]:
@@ -45,39 +85,13 @@ Configuration steps:
       --group=system:unauthenticated
    ```
 
-1. Find the issuer URL of the cluster.
-
-   ```bash
-   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
-   ```
-
 1. Enable and configure JWT auth in OpenBao.
 
-  1. If OpenBao is running in Kubernetes:
+   ```bash
+   bao auth enable jwt
+   bao write auth/jwt/config oidc_discovery_url="${ISSUER}"
+   ```
 
-     ```bash
-     kubectl exec openbao-0 -- bao auth enable jwt
-     kubectl exec openbao-0 -- bao write auth/jwt/config \
-        oidc_discovery_url=https://kubernetes.default.svc.cluster.local \
-        oidc_discovery_ca_pem=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-     ```
-
-  1. Alternatively, if OpenBao is _not_ running in Kubernetes:
-
-     :::info
-
-     **Note:** When OpenBao is outside the cluster, the `$ISSUER` endpoint below
-     may or may not be reachable. If not, you can configure JWT auth using
-     [`jwt_validation_pubkeys`](#using-jwt-validation-public-keys) instead.
-
-     :::
-
-     ```bash
-     bao auth enable jwt
-     bao write auth/jwt/config oidc_discovery_url="${ISSUER}"
-     ```
-
-1. Configure a role and log in as detailed [below](#creating-a-role-and-logging-in).
 
 [k8s-sa-issuer-discovery]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 


### PR DESCRIPTION
## Description 

This change implements a Kubernetes-specific JWT provider that uses the pod's Service Account token and CA certificate for authenticating requests to the Kubernetes API server's OIDC endpoints.

This approach avoids requiring RBAC policy changes on Kubernetes, that would otherwise be needed to allow anonymous access to the OIDC discovery and JWKS endpoints.

The provider is configured in following way

```console
$ bao write auth/jwt/config - <<EOF
{
    "oidc_discovery_url": "https://kubernetes.default.svc.cluster.local",
    "provider_config": {
        "provider": "kubernetes"
    }
}
EOF
```

The provider uses the default mount paths `/var/run/secrets/kubernetes.io/serviceaccount/token` and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` which removes burden from user to configure anything further than setting the discovery URL and selecting the Kubernetes provider. The default automounted token is sufficient, no RBAC permissions need to be created.


## Rationale 

Resolves: #2113

## Detailed Description

The JWT/OIDC provider interface is extended to allow providers to supply a custom `http.Client` instance to be used for HTTP requests. Currently, this is used for the OIDC discovery document and JWKS endpoints, which are the only endpoints supported by the Kubernetes API server when acting as OIDC provider.

The interface is implemented by the new Kubernetes provider. It creates `http.Client` that uses a custom `http.RoundTripper` which automatically adds the pod’s Service Account token to the `Authorization` header for all requests. This idea is taken from Kubernetes client-go library, which uses the same mechanism to attach the token ([link](https://github.com/kubernetes/client-go/blob/45e0decafa9b847c983f55c84b4f6ce5617f8f69/transport/round_trippers.go#L310-L324)).

HTTP requests are handled in `github.com/hashicorp/cap`,  `github.com/coreos/go-oidc` and `golang.org/x/oauth2`. These libraries support injecting a custom `http.Client` using `context` with a variable with specific context key ([link](https://github.com/golang/oauth2/blob/f28b0b5467dda26d56f1240381158f7c334654d1/oauth2.go#L339-L341)). This PR uses that capability to supply the provider-specific client. This enables authentication without requiring explicit support from the dependency libraries.

Note that `github.com/hashicorp/cap` creates its own client if a CA certificate is provided to it . Fortunately, if no CA certificate is passed, it does not override the context, allowing the provider-created `http.Client` to remain in effect ([link](https://github.com/hashicorp/cap/blob/70a13e3d0b472b4d6c12aec92361724741e6a451/jwt/keyset.go#L206-L227)). For this reason, the Kubernetes provider introduced in this PR does not allow user to specify `oidc_discovery_ca_pem` or `jwks_ca_pem` in the authentication method parameters.

The provider reads the Service Account token and Kubernetes CA certificate directly from pod instead of asking user to provide the content of the files and storing that in the backend configuration. This avoids problems when the files are rotated.  When first JWT/OIDC login is  validated, the `http.Client` is brought to memory via keyset validator and then reused in next logins ([link](https://github.com/openbao/openbao/blob/05457927fb4a8edd7d2c8e527cb2c891f06e9459/builtin/credential/jwt/backend.go#L143-L178)). If the Kubernetes signing keys are rotated  `github.com/coreos/go-oidc` will automatically re-download JWKS with the same client.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
