### PR TITLE
PKI health check returning proper mount path (#2061)

### DIFF
--- a/changelog/2061.txt
+++ b/changelog/2061.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command: pki health check error now contains actual mount path instead of a template placeholder.
+```

--- a/command/healthcheck/pki_allow_acme_headers.go
+++ b/command/healthcheck/pki_allow_acme_headers.go
@@ -138,17 +138,18 @@ func (h *AllowAcmeHeaders) Evaluate(e *Executor) ([]*Result, error) {
 }
 
 func craftInsufficientPermissionResult(e *Executor, path, errorMsg string) []*Result {
-	ret := Result{
-		Status:   ResultInsufficientPermissions,
-		Endpoint: path,
-		Message:  errorMsg,
-	}
-
+	var retMsg string
 	if e.Client.Token() == "" {
-		ret.Message = "No token available so unable read the tune endpoint for this mount. " + ret.Message
+		retMsg = fmt.Sprintf("No token available, unable to read the tune endpoint for this mount. %s", errorMsg)
 	} else {
-		ret.Message = "This token lacks permission to read the tune endpoint for this mount. " + ret.Message
+		retMsg = fmt.Sprintf("Token lacks permission to read the tune endpoint for this mount. %s", errorMsg)
 	}
 
-	return []*Result{&ret}
+	return []*Result{
+		{
+			Status:   ResultInsufficientPermissions,
+			Endpoint: path,
+			Message:  retMsg,
+		},
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/2061

Clean cherry-pick / no conflicts.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
