### PR TITLE
Fix slice out of bounds panic in plugin registration

### DIFF
--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -930,7 +930,10 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 	}
 
 	// Format: <plugin_directory>/.oci-cache/<plugin_slug>/<sha256_prefix>
-	shaPrefix := hex.EncodeToString(sha256)[:8]
+	shaPrefix := hex.EncodeToString(sha256)
+	if len(shaPrefix) >= 8 {
+		shaPrefix = shaPrefix[:8]
+	}
 	ociCachePath := filepath.Join(c.directory, oci.PluginCacheDir, fmt.Sprintf("%s-%s", pluginType.String(), name), shaPrefix)
 	if symAbs != c.directory && symAbs != ociCachePath {
 		return nil, errors.New("cannot execute files outside of configured plugin directory")


### PR DESCRIPTION
Test cases don't always use a valid SHA256 sum when registering plugins
which causes a slice out of bounds panic.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.