### PR TITLE
Allow cache-less OCSP handling (#2079)

### DIFF
--- a/changelog/2079.txt
+++ b/changelog/2079.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+auth/cert: allow use of always-fresh OCSP servers which elide NextUpdate
+```
+```release-note:bug
+sdk/helper/ocsp: allow use of always-fresh OCSP servers which elide NextUpdate
+```

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -162,9 +162,9 @@ func (c *Client) getHashAlgorithmFromOID(target pkix.AlgorithmIdentifier) crypto
 	return crypto.SHA1
 }
 
-// isInValidityRange checks the validity
+// isInValidityRange checks the validity.
 func isInValidityRange(currTime, nextUpdate time.Time) bool {
-	return !nextUpdate.IsZero() && !currTime.After(nextUpdate)
+	return nextUpdate.IsZero() || !currTime.After(nextUpdate)
 }
 
 func extractCertIDKeyFromRequest(ocspReq []byte) (*certIDKey, *ocspStatus) {
@@ -238,7 +238,7 @@ func validateOCSP(ocspRes *ocsp.Response) (*ocspStatus, error) {
 	if ocspRes == nil {
 		return nil, errors.New("OCSP Response is nil")
 	}
-	if !isInValidityRange(curTime, ocspRes.NextUpdate) {
+	if ocspRes.ProducedAt.IsZero() || !isInValidityRange(curTime, ocspRes.NextUpdate) {
 		return &ocspStatus{
 			code: ocspInvalidValidity,
 			err:  fmt.Errorf("invalid validity: producedAt: %v, thisUpdate: %v, nextUpdate: %v", ocspRes.ProducedAt, ocspRes.ThisUpdate, ocspRes.NextUpdate),
@@ -580,6 +580,14 @@ LOOP:
 	if !isValidOCSPStatus(ret.code) {
 		return ret, nil
 	}
+
+	// If the next update is zero, do not bother caching the result; there is
+	// always fresher OCSP info available and we should re-validate the
+	// request.
+	if ocspRes.NextUpdate.IsZero() {
+		return ret, nil
+	}
+
 	v := ocspCachedResponse{
 		status:     ret.code,
 		time:       float64(time.Now().UTC().Unix()),


### PR DESCRIPTION
* Allow cache-less OCSP handling

When the OCSP server does not indicate that it caches responses, we should not cache responses either to always ensure up-to-date information. This fixes a bug where certificate authentication would fail, yielding an error like:

> invalid validity:
>   producedAt: 2025-11-05 16:04:33 +0000 UTC,
>   thisUpdate: 2025-11-05 16:04:33 +0000 UTC,
>   nextUpdate: 0001-01-01 00:00:00 +0000 UTC

Resolves: #2068



* Add changelog entry



* Fix OCSP tests for zero-time nextUpdate

RFC 6960 seems to imply that producedAt is always present on responses. This means that we can use it to check for a non-empty or invalid response and reject it equivalently to if we had previously, for a response with a missing nextUpdate.

See also: https://datatracker.ietf.org/doc/html/rfc6960



---------

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Backport of https://github.com/openbao/openbao/pull/2079. 

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
