### PR TITLE
Correctly lowercase policies in identity groups

### DIFF
--- a/changelog/2143.txt
+++ b/changelog/2143.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/identity: Correctly lowercase policy names on identity groups to prevent root policy assignment. CVE-2025-64761 / GHSA-7ff4-jw48-3436. Second part of upstream's HCSEC-2025-13 / CVE-2025-5999.
+```

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -254,7 +254,7 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 	// Update the policies if supplied
 	policiesRaw, ok := d.GetOk("policies")
 	if ok {
-		group.Policies = strutil.RemoveDuplicatesStable(policiesRaw.([]string), true)
+		group.Policies = strutil.RemoveDuplicates(policiesRaw.([]string), true /* lowercase */)
 	}
 
 	if slices.Contains(group.Policies, "root") {


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Confusingly, while strutil.RemoveDuplicates and
strutil.RemoveDuplicatesStable both take a second parameter to perform case-insensitive comparison, the latter (as originally used by the group subsystem) returned the original input strings (performing comparisons that were case-insensitive) while the former returns normalized (lowercase) forms. This oversight meant that initial analysis of the vulnerability meant the identity group subsystem was incorrectly deemed not affected, so only the identity entity system was patched.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

In HCSEC-2025-13 / CVE-2025-5999 as fixed upstream, the fix was correctly applied to both the identity entity and identity group subsystems.

Resolves: GHSA-7ff4-jw48-3436

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
