### PR TITLE
docs: fix rendering of namespaces page

### DIFF
--- a/website/content/docs/concepts/namespaces/index.mdx
+++ b/website/content/docs/concepts/namespaces/index.mdx
@@ -123,4 +123,6 @@ endpoints. But, for security reasons, OpenBao restricts access to some of the
 system backend endpoints to calls from the root namespace or calls that use a
 token in the root namespace with elevated permissions.
 
-@include 'api/restricted-endpoints.mdx'
+import RestrictedEndpoints from "@site/content/partials/api/restricted-endpoints.mdx";
+
+<RestrictedEndpoints />

--- a/website/content/partials/api/restricted-endpoints.mdx
+++ b/website/content/partials/api/restricted-endpoints.mdx
@@ -1,6 +1,6 @@
 <a id="privileged-endpoints" />
 
-::info
+:::info
 
 The CLI commands associated with restricted API paths are also restricted.
 


### PR DESCRIPTION

## Description

Fix this rendering issue:

<img width="582" height="214" alt="image" src="https://github.com/user-attachments/assets/242b3932-4171-4e05-a92b-baddfe0698e2" />

on https://openbao.org/docs/concepts/namespaces/


## Rationale

There are two problems:

-  A missing colon to get a proper info box
- The `@include` syntax is a [ReMark plugin from HashiCorp](https://github.com/hashicorp/remark-plugins/tree/main/plugins/include-markdown), which seems to include files verbatim instead of rendering it to HTML. I replaced this with the more verbose Docusaurus way of doing things as documented here: https://docusaurus.io/docs/markdown-features/react#importing-markdown

I can create another PR to replace all uses of  `@include` with the `import` syntax.

BTW: should we just drop that info box? It seems rather obvious information to me.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
