### PR TITLE
Free additional storage on release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,12 @@ jobs:
           - openbsd
           - windows
     steps:
-      - name: "Check free space on runner"
+      - name: Free additional storage on runner
+        if: inputs.dogorelease
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+
+      - name: Check free storage on runner
         if: inputs.dogorelease
         run: |
           df -h .

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -40,9 +40,6 @@ builds:
       - goos: windows
     mod_timestamp: "{{ .CommitTimestamp }}"
     skip: false
-    hooks:
-      post:
-        - go clean -cache
 report_sizes: true
 
 nfpms:


### PR DESCRIPTION
https://github.com/openbao/openbao-nightly/actions/runs/19676726648/job/56360758810 shows that our previous hack clearing the Go compiler cache (https://github.com/openbao/openbao/pull/2010) between steps is unreliable and may lead to failures. This approach (suggested by @pree, thanks!!) almost doubles initial free runner storage (19G -> 37G) and has no risk of interfering with Goreleaser's steps.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
