### PR TITLE
Ignore returned error for tx.Rollback and Body.Close

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -35,7 +35,7 @@ func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequ
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -57,7 +57,7 @@ func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCrea
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -79,7 +79,7 @@ func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCr
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -103,7 +103,7 @@ func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secre
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -127,7 +127,7 @@ func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor stri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -146,7 +146,7 @@ func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -171,7 +171,7 @@ func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor strin
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -196,7 +196,7 @@ func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, incremen
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -220,7 +220,7 @@ func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*S
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -248,7 +248,7 @@ func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token strin
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -275,7 +275,7 @@ func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor stri
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -302,7 +302,7 @@ func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) e
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -325,7 +325,7 @@ func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) err
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -353,7 +353,7 @@ func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) err
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }

--- a/api/help.go
+++ b/api/help.go
@@ -26,7 +26,7 @@ func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result Help
 	err = resp.DecodeJSON(&result)

--- a/api/logical.go
+++ b/api/logical.go
@@ -114,7 +114,7 @@ func (c *Logical) ReadRawWithDataWithContext(ctx context.Context, path string, d
 
 func (c *Logical) ParseRawResponseAndCloseBody(resp *Response, err error) (*Secret, error) {
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -173,7 +173,7 @@ func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, er
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -214,7 +214,7 @@ func (c *Logical) ListPageWithContext(ctx context.Context, path string, after st
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -253,7 +253,7 @@ func (c *Logical) ScanWithContext(ctx context.Context, path string) (*Secret, er
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -294,7 +294,7 @@ func (c *Logical) ScanPageWithContext(ctx context.Context, path string, after st
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -357,7 +357,7 @@ func (c *Logical) write(ctx context.Context, request *Request) (*Secret, error) 
 
 	resp, err := c.c.rawRequestWithContext(ctx, request)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -413,7 +413,7 @@ func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, da
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := ParseSecret(resp.Body)
@@ -462,7 +462,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp == nil || resp.StatusCode != 404 {
 		if err != nil {

--- a/api/response.go
+++ b/api/response.go
@@ -42,7 +42,7 @@ func (r *Response) Error() error {
 		return err
 	}
 
-	r.Body.Close()
+	r.Body.Close() //nolint:errcheck
 	r.Body = io.NopCloser(bodyBuf)
 	ns := r.Header.Get(NamespaceHeaderName)
 

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -47,7 +47,7 @@ func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[s
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -72,7 +72,7 @@ func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[stri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -276,7 +276,7 @@ func (c *SSHHelper) VerifyWithContext(ctx context.Context, otp string) (*SSHVeri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -33,7 +33,7 @@ func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input strin
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *Sys) ListAuditWithContext(ctx context.Context) (map[string]*Audit, erro
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -116,7 +116,7 @@ func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -134,7 +134,7 @@ func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -26,7 +26,7 @@ func (c *Sys) ListAuthWithContext(ctx context.Context) (map[string]*AuthMount, e
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -70,7 +70,7 @@ func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string,
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -87,7 +87,7 @@ func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -50,7 +50,7 @@ func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) (
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -25,7 +25,7 @@ func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -59,7 +59,7 @@ func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) er
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -76,7 +76,7 @@ func (c *Sys) DisableCORSWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -34,7 +34,7 @@ func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path stri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result GenerateRootStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -75,7 +75,7 @@ func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result GenerateRootStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -106,7 +106,7 @@ func (c *Sys) generateRootCancelCommonWithContext(ctx context.Context, path stri
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -145,7 +145,7 @@ func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, sha
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result GenerateRootStatusResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -23,7 +23,7 @@ func (c *Sys) HAStatusWithContext(ctx context.Context) (*HAStatusResponse, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result HAStatusResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -32,7 +32,7 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result HealthResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -22,7 +22,7 @@ func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result InitStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -46,7 +46,7 @@ func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResp
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result InitResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -23,7 +23,7 @@ func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result LeaderResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -31,7 +31,7 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -57,7 +57,7 @@ func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return ParseSecret(resp.Body)
 }
@@ -80,7 +80,7 @@ func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -97,7 +97,7 @@ func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -114,7 +114,7 @@ func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -153,7 +153,7 @@ func (c *Sys) RevokeWithOptionsWithContext(ctx context.Context, opts *RevokeOpti
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/api/sys_mfa.go
+++ b/api/sys_mfa.go
@@ -30,7 +30,7 @@ func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payl
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if err != nil {
 		return nil, err

--- a/api/sys_monitor.go
+++ b/api/sys_monitor.go
@@ -39,7 +39,7 @@ func (c *Sys) Monitor(ctx context.Context, logLevel string, logFormat string) (c
 		droppedCount := 0
 
 		defer close(logCh)
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 
 		for {
 			if ctx.Err() != nil {

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -27,7 +27,7 @@ func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutpu
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *Moun
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -80,7 +80,7 @@ func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -138,7 +138,7 @@ func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*Mo
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config Moun
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -224,7 +224,7 @@ func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountCo
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -257,7 +257,7 @@ func (c *Sys) MountInfoWithContext(ctx context.Context, path string) (*MountOutp
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -59,7 +59,7 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 	if resp == nil {
 		return nil, nil
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -170,7 +170,7 @@ func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*Get
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *GetPluginResponse
@@ -222,7 +222,7 @@ func (c *Sys) RegisterPluginWithContext(ctx context.Context, i *RegisterPluginIn
 
 	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -255,7 +255,7 @@ func (c *Sys) DeregisterPluginWithContext(ctx context.Context, i *DeregisterPlug
 	req.Params.Set("version", i.Version)
 	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -294,7 +294,7 @@ func (c *Sys) ReloadPluginWithContext(ctx context.Context, i *ReloadPluginInput)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if i.Scope == "global" {
 		// Get the reload id
@@ -345,7 +345,7 @@ func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInp
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if resp != nil {
 		secret, parseErr := ParseSecret(resp.Body)
 		if parseErr != nil {

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -345,8 +345,8 @@ func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInp
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
 	if resp != nil {
+		defer resp.Body.Close() //nolint:errcheck
 		secret, parseErr := ParseSecret(resp.Body)
 		if parseErr != nil {
 			return nil, err

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -30,7 +30,7 @@ func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, er
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		if resp.StatusCode == 404 {
 			return "", nil
 		}
@@ -106,7 +106,7 @@ func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) erro
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -123,7 +123,7 @@ func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -159,7 +159,7 @@ func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RaftJoinResponse
 	err = resp.DecodeJSON(&result)
@@ -181,7 +181,7 @@ func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// Make sure that the last file in the archive, SHA256SUMS.sealed, is present
 	// and non-empty.  This is to catch cases where the snapshot failed midstream,
@@ -260,7 +260,7 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -282,7 +282,7 @@ func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotStat
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		if resp.StatusCode == 404 {
 			return nil, nil
 		}
@@ -326,7 +326,7 @@ func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*Autop
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		if resp.StatusCode == 404 {
 			return nil, nil
 		}
@@ -380,7 +380,7 @@ func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -38,7 +38,7 @@ func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse,
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -61,7 +61,7 @@ func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStat
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -84,7 +84,7 @@ func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVer
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyVerificationStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -107,7 +107,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyVerificationStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -133,7 +133,7 @@ func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -159,7 +159,7 @@ func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *Rekey
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyStatusResponse
 	err = resp.DecodeJSON(&result)
@@ -180,7 +180,7 @@ func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -199,7 +199,7 @@ func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -218,7 +218,7 @@ func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -237,7 +237,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context)
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }
@@ -266,7 +266,7 @@ func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyUpdateResponse
 	err = resp.DecodeJSON(&result)
@@ -297,7 +297,7 @@ func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonc
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyUpdateResponse
 	err = resp.DecodeJSON(&result)
@@ -320,7 +320,7 @@ func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetriev
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -355,7 +355,7 @@ func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*Reke
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -388,7 +388,7 @@ func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 
 	return err
@@ -408,7 +408,7 @@ func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 
 	return err
@@ -438,7 +438,7 @@ func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, non
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyVerificationUpdateResponse
 	err = resp.DecodeJSON(&result)
@@ -469,7 +469,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdateWithContext(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result RekeyVerificationUpdateResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -87,7 +87,7 @@ func (c *Sys) RotateRootStatusWithContext(ctx context.Context) (*RotateStatusRes
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateStatusResponse
@@ -109,7 +109,7 @@ func (c *Sys) RotateRecoveryStatusWithContext(ctx context.Context) (*RotateStatu
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateStatusResponse
@@ -135,7 +135,7 @@ func (c *Sys) RotateRootInitWithContext(ctx context.Context, config *RotateInitR
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateStatusResponse
@@ -161,7 +161,7 @@ func (c *Sys) RotateRecoveryInitWithContext(ctx context.Context, config *RotateI
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateStatusResponse
@@ -183,7 +183,7 @@ func (c *Sys) RotateRootCancelWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRecoveryCancel() error {
@@ -199,7 +199,7 @@ func (c *Sys) RotateRecoveryCancelWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRootUpdate(shard, nonce string) (*RotateUpdateResponse, error) {
@@ -224,7 +224,7 @@ func (c *Sys) RotateRootUpdateWithContext(ctx context.Context, shard, nonce stri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateUpdateResponse
@@ -255,7 +255,7 @@ func (c *Sys) RotateRecoveryUpdateWithContext(ctx context.Context, shard, nonce 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateUpdateResponse
@@ -277,7 +277,7 @@ func (c *Sys) RotateRootRetrieveBackupWithContext(ctx context.Context) (*RotateR
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -309,7 +309,7 @@ func (c *Sys) RotateRecoveryRetrieveBackupWithContext(ctx context.Context) (*Rot
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
@@ -342,7 +342,7 @@ func (c *Sys) RotateRootDeleteBackupWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRecoveryDeleteBackup() error {
@@ -359,7 +359,7 @@ func (c *Sys) RotateRecoveryDeleteBackupWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRootVerificationStatus() (*RotateVerificationStatusResponse, error) {
@@ -375,7 +375,7 @@ func (c *Sys) RotateRootVerificationStatusWithContext(ctx context.Context) (*Rot
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateVerificationStatusResponse
@@ -397,7 +397,7 @@ func (c *Sys) RotateRecoveryVerificationStatusWithContext(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateVerificationStatusResponse
@@ -428,7 +428,7 @@ func (c *Sys) RotateRootVerificationUpdateWithContext(ctx context.Context, shard
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateVerificationUpdateResponse
@@ -459,7 +459,7 @@ func (c *Sys) RotateRecoveryVerificationUpdateWithContext(ctx context.Context, s
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *RotateVerificationUpdateResponse
@@ -482,7 +482,7 @@ func (c *Sys) RotateRootVerificationCancelWithContext(ctx context.Context) error
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRecoveryVerificationCancel() error {
@@ -499,7 +499,7 @@ func (c *Sys) RotateRecoveryVerificationCancelWithContext(ctx context.Context) e
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 // Deprecated: use RotateKeyring instead.
@@ -519,7 +519,7 @@ func (c *Sys) RotateWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateKeyring() error {
@@ -536,7 +536,7 @@ func (c *Sys) RotateKeyringWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) RotateRoot() error {
@@ -553,7 +553,7 @@ func (c *Sys) RotateRootWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return resp.Body.Close()
+	return resp.Body.Close() //nolint:errcheck
 }
 
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
@@ -570,7 +570,7 @@ func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -31,7 +31,7 @@ func (c *Sys) SealWithContext(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -88,7 +88,7 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	var result SealStatusResponse
 	err = resp.DecodeJSON(&result)

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -20,7 +20,7 @@ func (c *Sys) StepDownWithContext(ctx context.Context) error {
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 	}
 	return err
 }

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -203,7 +203,7 @@ func contactIssuer(ctx context.Context, uri string, data *url.Values, ignoreBad 
 	if err != nil {
 		return nil, nil
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/builtin/credential/jwt/path_login_test.go
+++ b/builtin/credential/jwt/path_login_test.go
@@ -198,7 +198,7 @@ func getTestOIDC(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	defer res.Body.Close()
+	defer res.Body.Close() //nolint:errcheck
 	body, _ := io.ReadAll(res.Body)
 
 	type a0r struct {

--- a/builtin/credential/jwt/provider_azure.go
+++ b/builtin/credential/jwt/provider_azure.go
@@ -164,7 +164,7 @@ func (a *AzureProvider) getAzureGroups(groupsURL string, tokenSource oauth2.Toke
 	if err != nil {
 		return nil, fmt.Errorf("unable to call Microsoft Graph API: %s", err)
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Microsoft Graph API response: %s", err)

--- a/builtin/credential/kerberos/cmd/login-kerb/main.go
+++ b/builtin/credential/kerberos/cmd/login-kerb/main.go
@@ -112,7 +112,7 @@ func main() {
 		fmt.Printf("request failed: %s\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {

--- a/builtin/credential/kubernetes/token_review.go
+++ b/builtin/credential/kubernetes/token_review.go
@@ -141,7 +141,7 @@ func parseResponse(resp *http.Response) (*authv1.TokenReview, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// If the request was not a success create a kuberenets error
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {

--- a/builtin/logical/kv/path_config.go
+++ b/builtin/logical/kv/path_config.go
@@ -96,7 +96,7 @@ func (b *versionedKVBackend) pathConfigWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/path_data.go
+++ b/builtin/logical/kv/path_data.go
@@ -101,7 +101,7 @@ func (b *versionedKVBackend) pathDataRead() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -302,7 +302,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -445,7 +445,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -624,7 +624,7 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/path_delete.go
+++ b/builtin/logical/kv/path_delete.go
@@ -91,7 +91,7 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -160,7 +160,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/path_destroy.go
+++ b/builtin/logical/kv/path_destroy.go
@@ -57,7 +57,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/path_metadata.go
+++ b/builtin/logical/kv/path_metadata.go
@@ -196,7 +196,7 @@ func (b *versionedKVBackend) pathMetadataList() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -341,7 +341,7 @@ func (b *versionedKVBackend) pathMetadataRead() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -523,7 +523,7 @@ func (b *versionedKVBackend) pathMetadataWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -675,7 +675,7 @@ func (b *versionedKVBackend) pathMetadataPatch() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 
@@ -778,7 +778,7 @@ func (b *versionedKVBackend) pathMetadataDelete() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/path_subkeys.go
+++ b/builtin/logical/kv/path_subkeys.go
@@ -100,7 +100,7 @@ func (b *versionedKVBackend) pathSubkeysRead() framework.OperationFunc {
 				return nil, err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			req.Storage = txn
 		}
 

--- a/builtin/logical/kv/upgrade.go
+++ b/builtin/logical/kv/upgrade.go
@@ -145,7 +145,7 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 				return err
 			}
 
-			defer txn.Rollback(ctx)
+			defer txn.Rollback(ctx) //nolint:errcheck
 			storage = txn
 		}
 

--- a/builtin/logical/pki/acme_challenges.go
+++ b/builtin/logical/pki/acme_challenges.go
@@ -176,7 +176,7 @@ func ValidateHTTP01Challenge(domain string, token string, thumbprint string, con
 	minExpected := len(token) + 1 + len(thumbprint)
 	maxExpected := 512
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// Attempt to read the body, but don't do so infinitely.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxExpected+1)))

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -333,7 +333,7 @@ func (b *backend) pathFetchCertListDetailed(ctx context.Context, req *logical.Re
 			return nil, fmt.Errorf("failed to start read-only transaction: %w", err)
 		}
 
-		defer readOnlyTxn.Rollback(ctx) // Ensure rollback after the operation
+		defer readOnlyTxn.Rollback(ctx) //nolint:errcheck // Ensure rollback after the operation
 		req.Storage = readOnlyTxn
 	}
 

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -290,7 +290,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 			return nil, err
 		}
 
-		defer txn.Rollback(ctx)
+		defer txn.Rollback(ctx) //nolint:errcheck
 		req.Storage = txn
 	}
 

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -255,7 +255,7 @@ func fetchDerEncodedRequest(request *logical.Request, data *framework.FieldData)
 		if rawBody == nil {
 			return nil, errors.New("no data in request body")
 		}
-		defer rawBody.Close()
+		defer rawBody.Close() //nolint:errcheck
 
 		requestBytes, err := io.ReadAll(io.LimitReader(rawBody, maximumRequestSize))
 		if err != nil {

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -140,7 +140,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 			return nil, err
 		}
 
-		defer txn.Rollback(ctx)
+		defer txn.Rollback(ctx) //nolint:errcheck
 		req.Storage = txn
 	}
 

--- a/builtin/logical/pki/test_helpers.go
+++ b/builtin/logical/pki/test_helpers.go
@@ -166,7 +166,7 @@ func getParsedCrlAtPath(t *testing.T, client *api.Client, path string) *x509.Rev
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	crlBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/builtin/logical/pkiext/nginx_test.go
+++ b/builtin/logical/pkiext/nginx_test.go
@@ -395,7 +395,7 @@ func CheckWithGo(t *testing.T, rootCert string, clientCert string, clientChain [
 		return
 	}
 
-	defer clientResp.Body.Close()
+	defer clientResp.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(clientResp.Body)
 	if err != nil {
 		t.Fatalf("failed to get read response body: %v", err)

--- a/command/agent/exec/exec_test.go
+++ b/command/agent/exec/exec_test.go
@@ -354,7 +354,7 @@ func TestExecServer_Run(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error making request to the test app: %s", err)
 			}
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			decoder := json.NewDecoder(resp.Body)
 			var response struct {

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -860,7 +860,7 @@ func TestCache_NonCacheable(t *testing.T) {
 	ctx := t.Context()
 	apiResp, err := testClient.Logical().ReadRawWithContext(ctx, "kv-invalid")
 	if apiResp != nil {
-		defer apiResp.Body.Close()
+		defer apiResp.Body.Close() //nolint:errcheck
 	}
 	if apiResp.Error() == nil || (apiResp != nil && apiResp.StatusCode != 404) {
 		t.Fatalf("expected an error response and a 404 from requesting an invalid path, got: %#v", apiResp)
@@ -1098,7 +1098,7 @@ func testCachingCacheClearCommon(t *testing.T, clearType string) {
 	ctx := t.Context()
 	apiResp, err := testClient.RawRequestWithContext(ctx, r)
 	if apiResp != nil {
-		defer apiResp.Body.Close()
+		defer apiResp.Body.Close() //nolint:errcheck
 	}
 	if apiResp != nil && apiResp.StatusCode == 404 {
 		_, parseErr := api.ParseSecret(apiResp.Body)

--- a/command/agentproxyshared/cache/handler.go
+++ b/command/agentproxyshared/cache/handler.go
@@ -45,7 +45,7 @@ func ProxyHandler(ctx context.Context, logger hclog.Logger, proxier Proxier, inm
 			return
 		}
 		if r.Body != nil {
-			r.Body.Close()
+			r.Body.Close() //nolint:errcheck
 		}
 		r.Body = io.NopCloser(bytes.NewReader(reqBody))
 		req := &SendRequest{
@@ -75,7 +75,7 @@ func ProxyHandler(ctx context.Context, logger hclog.Logger, proxier Proxier, inm
 			return
 		}
 
-		defer resp.Response.Body.Close()
+		defer resp.Response.Body.Close() //nolint:errcheck
 
 		metrics.IncrCounter([]string{"agent", "proxy", "success"}, 1)
 		if resp.CacheMeta != nil {
@@ -196,7 +196,7 @@ func sanitizeAutoAuthTokenResponse(ctx context.Context, logger hclog.Logger, inm
 		return err
 	}
 	if resp.Response.Body != nil {
-		resp.Response.Body.Close()
+		resp.Response.Body.Close() //nolint:errcheck
 	}
 	resp.Response.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	resp.Response.ContentLength = int64(len(bodyBytes))

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -414,7 +414,7 @@ func (c *LeaseCache) Send(ctx context.Context, req *SendRequest) (*SendResponse,
 
 	// Reset the response body for upper layers to read
 	if resp.Response.Body != nil {
-		resp.Response.Body.Close()
+		resp.Response.Body.Close() //nolint:errcheck
 	}
 	resp.Response.Body = io.NopCloser(bytes.NewReader(resp.ResponseBody))
 

--- a/command/agentproxyshared/cache/proxy.go
+++ b/command/agentproxyshared/cache/proxy.go
@@ -67,7 +67,7 @@ func NewSendResponse(apiResponse *api.Response, responseBody []byte) (*SendRespo
 			return nil, err
 		}
 		// Close the old body
-		apiResponse.Body.Close()
+		apiResponse.Body.Close() //nolint:errcheck
 
 		// Re-set the response body after reading from the Reader
 		apiResponse.Body = io.NopCloser(bytes.NewReader(respBody))

--- a/command/debug.go
+++ b/command/debug.go
@@ -676,7 +676,7 @@ func (c *DebugCommand) collectHostInfo(ctx context.Context) {
 			return
 		}
 		if resp != nil {
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			secret, err := api.ParseSecret(resp.Body)
 			if err != nil {
@@ -714,7 +714,7 @@ func (c *DebugCommand) collectMetrics(ctx context.Context) {
 			continue
 		}
 		if resp != nil {
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			metricsEntry := make(map[string]interface{})
 			err := json.NewDecoder(resp.Body).Decode(&metricsEntry)
@@ -855,7 +855,7 @@ func (c *DebugCommand) collectReplicationStatus(ctx context.Context) {
 			return
 		}
 		if resp != nil {
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			secret, err := api.ParseSecret(resp.Body)
 			if err != nil {
@@ -929,7 +929,7 @@ func (c *DebugCommand) collectInFlightRequestStatus(ctx context.Context) {
 
 		var data map[string]interface{}
 		if resp != nil {
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 			err = jsonutil.DecodeJSONFromReader(resp.Body, &data)
 			if err != nil {
 				c.captureError("requests", err)
@@ -1054,7 +1054,7 @@ func pprofTarget(ctx context.Context, client *api.Client, target string, params 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -1073,7 +1073,7 @@ func pprofProfile(ctx context.Context, client *api.Client, duration time.Duratio
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -1092,7 +1092,7 @@ func pprofTrace(ctx context.Context, client *api.Client, duration time.Duration)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -25,7 +25,7 @@ func kvReadRequest(client *api.Client, path string, params map[string]string) (*
 	}
 	resp, err := client.Logical().ReadRawWithData(path, readParams)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 404 {
 		secret, parseErr := api.ParseSecret(resp.Body)
@@ -63,7 +63,7 @@ func kvPreflightVersionRequest(client *api.Client, path string) (string, int, er
 
 	resp, err := client.Logical().ReadRaw("sys/internal/ui/mounts/" + path)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if err != nil {
 		// If we get a 404 we are using an older version of vault, default to

--- a/command/read.go
+++ b/command/read.go
@@ -130,7 +130,7 @@ func (c *ReadCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("No value found at %s", path))
 		return 2
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -51,7 +51,7 @@ func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	type PublicKeys struct {
 		Primary struct {

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -710,7 +710,7 @@ func SysMetricsReq(client *api.Client, cluster *vault.TestCluster, unauth bool) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if err := json.Unmarshal(bodyBytes, &data); err != nil {
 		return nil, errors.New("failed to unmarshal:" + err.Error())
 	}

--- a/http/forwarded_for_test.go
+++ b/http/forwarded_for_test.go
@@ -70,7 +70,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		buf := bytes.NewBuffer(nil)
 		buf.ReadFrom(resp.Body)
 		if !strings.HasPrefix(buf.String(), "1.2.3.4:") {
@@ -105,7 +105,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		buf := bytes.NewBuffer(nil)
 		buf.ReadFrom(resp.Body)
 		if !strings.HasPrefix(buf.String(), "127.0.0.1:") {
@@ -209,7 +209,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		buf := bytes.NewBuffer(nil)
 		buf.ReadFrom(resp.Body)
 		if !strings.HasPrefix(buf.String(), "4.5.6.7:") {
@@ -248,7 +248,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		buf := bytes.NewBuffer(nil)
 		buf.ReadFrom(resp.Body)
 		if !strings.HasPrefix(buf.String(), "4.5.6.7:") {

--- a/http/forwarding_test.go
+++ b/http/forwarding_test.go
@@ -251,7 +251,7 @@ func testHTTP_Forwarding_Stress_Common(t *testing.T, parallel bool, num uint32) 
 			if resp == nil {
 				return nil, errors.New("nil response")
 			}
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			// Make sure we weren't redirected
 			if resp.StatusCode > 300 && resp.StatusCode < 400 {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -121,7 +121,7 @@ func testResponseStatus(t *testing.T, resp *http.Response, code int) {
 	if resp.StatusCode != code {
 		body := new(bytes.Buffer)
 		io.Copy(body, resp.Body)
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 
 		t.Fatalf(
 			"Expected status %d, got %d. Body:\n\n%s",
@@ -140,7 +140,7 @@ func testResponseHeader(t *testing.T, resp *http.Response, expectedHeaders map[s
 }
 
 func testResponseBody(t *testing.T, resp *http.Response, out interface{}) {
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if err := jsonutil.DecodeJSONFromReader(resp.Body, out); err != nil {
 		t.Fatalf("err: %s", err)

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -1183,7 +1183,7 @@ func TestLogical_NamespaceRestrictedAPIs(t *testing.T) {
 				"Restricted API should return 400 Bad Request with namespace")
 
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				resp.Body.Close() //nolint:errcheck
 			}
 		})
 
@@ -1199,7 +1199,7 @@ func TestLogical_NamespaceRestrictedAPIs(t *testing.T) {
 			}
 
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				resp.Body.Close() //nolint:errcheck
 			}
 		})
 	}
@@ -1215,7 +1215,7 @@ func TestLogical_NamespaceRestrictedAPIs(t *testing.T) {
 			require.Equal(t, http.StatusOK, resp.StatusCode,
 				"Non-restricted API should return 200 OK with namespace and proper permissions")
 
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 		})
 	}
 
@@ -1232,7 +1232,7 @@ func TestLogical_NamespaceRestrictedAPIs(t *testing.T) {
 				"Restricted API should return 400 Bad Request with namespace and proper permissions")
 
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				resp.Body.Close() //nolint:errcheck
 			}
 		})
 	}

--- a/http/plugin_test.go
+++ b/http/plugin_test.go
@@ -145,7 +145,7 @@ func TestPlugin_MockRawResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +178,7 @@ func TestPlugin_GetParams(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	secret, err := api.ParseSecret(resp.Body)
 	if err != nil {

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -324,7 +324,7 @@ func (m *PostgreSQLBackend) createTables() error {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer txn.Rollback()
+	defer txn.Rollback() //nolint:errcheck
 
 	createTableQuery := "CREATE TABLE IF NOT EXISTS " + m.table + " (" +
 		`parent_path TEXT COLLATE "C" NOT NULL,` +

--- a/plugins/database/mysql/mysql.go
+++ b/plugins/database/mysql/mysql.go
@@ -159,7 +159,7 @@ func (m *MySQL) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) 
 	if err != nil {
 		return dbplugin.DeleteUserResponse{}, err
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	if len(req.Statements.Commands) == 0 {
 		return dbplugin.DeleteUserResponse{}, m.defaultDeleteUser(ctx, tx, req.Username)
@@ -263,9 +263,7 @@ func (m *MySQL) executePreparedStatementsWithMap(ctx context.Context, statements
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = tx.Rollback()
-	}()
+	defer tx.Rollback() //nolint:errcheck
 
 	// Execute each query
 	for _, stmt := range statements {

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -192,7 +192,7 @@ func (p *PostgreSQL) changeUserPassword(ctx context.Context, username string, ch
 	if err != nil {
 		return fmt.Errorf("unable to start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	for _, stmt := range stmts {
 		for _, query := range strutil.ParseArbitraryStringSlice(stmt, ";") {
@@ -246,9 +246,7 @@ func (p *PostgreSQL) changeUserExpiration(ctx context.Context, username string, 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	defer tx.Rollback() //nolint:errcheck
 
 	expirationStr := changeExp.NewExpiration.Format(expirationFormat)
 
@@ -297,7 +295,7 @@ func (p *PostgreSQL) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (
 	if err != nil {
 		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	m := map[string]string{
 		"name":       username,
@@ -366,9 +364,7 @@ func (p *PostgreSQL) customDeleteUser(ctx context.Context, username string, revo
 	if err != nil {
 		return err
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	defer tx.Rollback() //nolint:errcheck
 
 	for _, stmt := range revocationStmts {
 		if containsMultilineStatement(stmt) {

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -253,7 +253,7 @@ func (c *Client) retryOCSP(
 			retErr = multierror.Append(retErr, err)
 			continue
 		} else {
-			defer res.Body.Close()
+			defer res.Body.Close() //nolint:errcheck
 		}
 
 		if res.StatusCode != http.StatusOK {

--- a/sdk/helper/ocsp/ocsp_test.go
+++ b/sdk/helper/ocsp/ocsp_test.go
@@ -61,7 +61,7 @@ func TestOCSP(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to GET contents. err: %v", err)
 			}
-			defer res.Body.Close()
+			defer res.Body.Close() //nolint:errcheck
 			_, err = io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatalf("failed to read content body for %v", tgt)

--- a/sdk/logical/logical_storage.go
+++ b/sdk/logical/logical_storage.go
@@ -107,7 +107,7 @@ func WithTransaction(ctx context.Context, originalStorage Storage, callback func
 		if err != nil {
 			return err
 		}
-		defer txn.Rollback(ctx)
+		defer txn.Rollback(ctx) //nolint:errcheck
 		if err := callback(txnStorage); err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func StartTxStorage(ctx context.Context, req *Request) (func(), error) {
 		}
 		req.OriginalStorage = req.Storage
 		req.Storage = txn
-		return func() { txn.Rollback(ctx) }, nil
+		return func() { txn.Rollback(ctx) }, nil //nolint:errcheck
 	}
 	return func() {}, nil
 }

--- a/sdk/logical/storage.go
+++ b/sdk/logical/storage.go
@@ -99,7 +99,7 @@ func ScanViewPaginated(ctx context.Context, view ClearableView, logger hclog.Log
 		}
 
 		// This transaction is not used for any operations within the scan.
-		defer txn.Rollback(ctx)
+		defer txn.Rollback(ctx) //nolint:errcheck
 		view = txn.(ClearableView)
 	}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -535,7 +535,7 @@ func (c *Core) loadCredentials(ctx context.Context) error {
 	// Defer rolling back: we may commit the transaction anyways, but we
 	// need to ensure the transaction is cleaned up in the event of an
 	// error.
-	defer txn.Rollback(ctx)
+	defer txn.Rollback(ctx) //nolint:errcheck
 
 	legacy, err := c.loadLegacyCredentials(ctx, txn)
 	if err != nil {
@@ -823,7 +823,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 
 		// In the event of an unexpected error, rollback this transaction.
 		// A rollback of a committed transaction does not impact the commit.
-		defer barrier.(logical.Transaction).Rollback(ctx)
+		defer barrier.(logical.Transaction).Rollback(ctx) //nolint:errcheck
 	}
 
 	if table.Type != credentialTableType {

--- a/vault/external_tests/api/sudo_paths_test.go
+++ b/vault/external_tests/api/sudo_paths_test.go
@@ -92,7 +92,7 @@ func getSudoPathsFromSpec(client *api.Client) (map[string]struct{}, error) {
 		return nil, fmt.Errorf("unable to retrieve sudo endpoints: %v", err)
 	}
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 
 	oasInfo := make(map[string]interface{})

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -129,7 +129,7 @@ path "secret/foo" {
 	// Make the request
 	resp, err := client.Logical().ReadRaw("secret/foo")
 	if resp != nil {
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp != nil && resp.StatusCode == 403 {
 		return errors.New("failed to read the secret")

--- a/vault/external_tests/identity/oidc_provider_test.go
+++ b/vault/external_tests/identity/oidc_provider_test.go
@@ -981,7 +981,7 @@ func decodeRawRequest(t *testing.T, client *api.Client, method, path string, par
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.Equal(t, http.StatusOK, r.StatusCode)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 
 	// Decode the body into v
 	require.NoError(t, json.NewDecoder(r.Body).Decode(v))

--- a/vault/external_tests/kv/kv_subkeys_test.go
+++ b/vault/external_tests/kv/kv_subkeys_test.go
@@ -126,7 +126,7 @@ func TestKV_Subkeys_Deleted(t *testing.T) {
 	}
 
 	if apiResp != nil {
-		defer apiResp.Body.Close()
+		defer apiResp.Body.Close() //nolint:errcheck
 	}
 
 	if err == nil || apiResp == nil {
@@ -233,7 +233,7 @@ func TestKV_Subkeys_Destroyed(t *testing.T) {
 	}
 
 	if apiResp != nil {
-		defer apiResp.Body.Close()
+		defer apiResp.Body.Close() //nolint:errcheck
 	}
 
 	if err == nil || apiResp == nil {
@@ -342,7 +342,7 @@ func TestKV_Subkeys_CurrentVersion(t *testing.T) {
 	}
 
 	if apiResp != nil {
-		defer apiResp.Body.Close()
+		defer apiResp.Body.Close() //nolint:errcheck
 	}
 
 	if err != nil || apiResp == nil {

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -149,7 +149,7 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 	if respo != nil {
-		defer respo.Body.Close()
+		defer respo.Body.Close() //nolint:errcheck
 	}
 	var data testhelpers.SysMetricsJSON
 	coreLeaderMetric := false
@@ -216,6 +216,6 @@ func TestLeaderReElectionMetrics(t *testing.T) {
 		}
 	}
 	if respo != nil {
-		defer respo.Body.Close()
+		defer respo.Body.Close() //nolint:errcheck
 	}
 }

--- a/vault/external_tests/pprof/pprof.go
+++ b/vault/external_tests/pprof/pprof.go
@@ -84,7 +84,7 @@ func SysPprof_Test(t *testing.T, cluster testcluster.VaultCluster) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 
 		httpRespBody, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -120,7 +120,7 @@ func SysPprof_Standby_Test(t *testing.T, cluster testcluster.VaultCluster) {
 		if err != nil {
 			return "", err
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 
 		data, err := io.ReadAll(resp.Body)
 		return string(data), err

--- a/vault/external_tests/pprof/pprof_test.go
+++ b/vault/external_tests/pprof/pprof_test.go
@@ -63,7 +63,7 @@ func TestSysPprof_MaxRequestDuration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	httpRespBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -624,7 +624,7 @@ func TestRaft_SnapshotAPI_Rotate_Backward(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 
 			snap, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -793,7 +793,7 @@ func TestRaft_SnapshotAPI_Rotate_Forward(t *testing.T) {
 			}
 
 			snap, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -839,7 +839,7 @@ func TestRaft_SnapshotAPI_Rotate_Forward(t *testing.T) {
 			}
 
 			snap2, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -969,7 +969,7 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 	}
 
 	snap, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	resp.Body.Close() //nolint:errcheck
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2179,7 +2179,7 @@ func (c *Core) validatePingID(ctx context.Context, mConfig *mfa.Config, username
 		}
 		bodyBytes := bytes.NewBuffer(nil)
 		_, err = bodyBytes.ReadFrom(resp.Body)
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 		if err != nil {
 			return nil, fmt.Errorf("error reading pingid response: %w", err)
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1379,7 +1379,7 @@ func (c *Core) loadMounts(ctx context.Context) error {
 	// Defer rolling back: we may commit the transaction anyways, but we
 	// need to ensure the transaction is cleaned up in the event of an
 	// error.
-	defer txn.Rollback(ctx)
+	defer txn.Rollback(ctx) //nolint:errcheck
 
 	legacy, err := c.loadLegacyMounts(ctx, txn)
 	if err != nil {
@@ -1701,7 +1701,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 
 		// In the event of an unexpected error, rollback this transaction.
 		// A rollback of a committed transaction does not impact the commit.
-		defer barrier.(logical.Transaction).Rollback(ctx)
+		defer barrier.(logical.Transaction).Rollback(ctx) //nolint:errcheck
 	}
 
 	if table.Type != mountTableType {

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -441,10 +441,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		}
 
 		defer func() {
-			if err := txn.Rollback(ctx); err != nil {
-				ns.logger.Error("failed to rollback transaction", "error", err)
-			}
-
+			txn.Rollback(ctx) //nolint:errcheck
 			cleanupFailed()
 		}()
 

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1182,7 +1182,7 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 
 	answerRespJson, err := raftInfo.leaderClient.RawRequestWithContext(ctx, answerReq)
 	if answerRespJson != nil {
-		defer answerRespJson.Body.Close()
+		defer answerRespJson.Body.Close() //nolint:errcheck
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Disable lint rule `errcheck` for lines not handling return values of http.Response.Body.Close and tx.Rollback

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

- tx.Rollback returns an error if tx has already been committed, see previous discussion here: https://github.com/openbao/openbao/pull/1990#discussion_r2527711000
- Body.Close only returns an error in very rare cases, and even then, there is nothing actionable for us to do

Part of: #1574 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
