### PR TITLE
Fix audit log configuration on active node

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2424,7 +2424,7 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, logger log.Logge
 	// Adding new audit devices only occurs on the active node. Standby nodes
 	// will consume audit devices from storage only, but we want to run this
 	// from startup anyways to report any discrepancies.
-	if err := c.handleAuditLogSetup(ctx); err != nil {
+	if err := c.handleAuditLogSetup(ctx, standby); err != nil {
 		return err
 	}
 	if err := c.loadIdentityStoreArtifacts(ctx); err != nil {


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

On active nodes, standby=false during unseal and is only set to true once the active has fully finished initialization. This still makes some sense, as we don't really want to accept requests or handle background jobs until after unseal is finished.

However, in the course of HA, standby status needs to be passed through on the active core to allow audit devices to be configured during startup. This was already handled correctly for OCI plugins.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2168

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
