### PR TITLE
Fix shadowing of the transaction with barrier retrieval in mounts

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -85,9 +85,6 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ns == nil {
-		return nil, namespace.ErrNoNamespace
-	}
 
 	// Inject each policy
 	for _, policy := range policies {

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -65,11 +65,7 @@ func (c *Core) enableCredential(ctx context.Context, entry *MountEntry) error {
 	}
 
 	// Enable credential internally
-	if err := c.enableCredentialInternal(ctx, entry, MountTableUpdateStorage); err != nil {
-		return err
-	}
-
-	return nil
+	return c.enableCredentialInternal(ctx, entry, MountTableUpdateStorage)
 }
 
 // enableCredential is used to enable a new credential backend
@@ -194,6 +190,7 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *Moun
 	newTable := c.auth.shallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
+		// barrier nil is fine here, as the namespace is embedded in the context
 		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to update auth table", "error", err)
 			return fmt.Errorf("failed to update auth table: %w", err)
@@ -350,6 +347,7 @@ func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateS
 
 	if updateStorage {
 		// Update the auth table
+		// barrier nil is fine here, as the namespace is embedded in the context
 		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
@@ -374,14 +372,13 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 		return fmt.Errorf("cannot remount auth mount to non-auth mount %q", dst.MountPath)
 	}
 
-	for _, auth := range protectedAuths {
-		if strings.HasPrefix(src.MountPath, auth) {
+	// Prevent protected paths from being remounted, or target mounts being in protected paths
+	for _, p := range protectedAuths {
+		if strings.HasPrefix(src.MountPath, p) {
 			return fmt.Errorf("cannot remount %q", src.MountPath)
 		}
-	}
 
-	for _, auth := range protectedAuths {
-		if strings.HasPrefix(dst.MountPath, auth) {
+		if strings.HasPrefix(dst.MountPath, p) {
 			return fmt.Errorf("cannot remount to %q", dst.MountPath)
 		}
 	}
@@ -397,11 +394,6 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 
 	if match := c.router.MountConflict(ctx, dstRelativePath); match != dst.Namespace.Path && match != "" {
 		return fmt.Errorf("path in use at %q", match)
-	}
-
-	srcBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
 	}
 
 	// Mark the entry as tainted
@@ -434,13 +426,8 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	srcPath := mountEntry.Path
 	mountEntry.Path = strings.TrimPrefix(dst.MountPath, credentialRoutePrefix)
 
-	dstBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Update the mount table
-	if err := c.persistAuth(ctx, nil, c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
+	if err := c.persistAuth(ctx, c.NamespaceView(mountEntry.namespace), c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
@@ -451,10 +438,16 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 
 	if src.Namespace.ID != dst.Namespace.ID {
 		// Handle storage entries
-		if err := c.moveAuthStorage(ctx, src, mountEntry, srcBarrierView, dstBarrierView); err != nil {
+		if err := c.moveAuthStorage(ctx, src, mountEntry); err != nil {
 			c.authLock.Unlock()
 			return err
 		}
+	}
+
+	dstBarrierView, err := c.mountEntryView(mountEntry)
+	if err != nil {
+		c.authLock.Unlock()
+		return err
 	}
 
 	// Remount the backend
@@ -470,11 +463,7 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	c.authLock.Unlock()
 
 	// Un-taint the new path in the router
-	if err := c.router.Untaint(ctx, dstRelativePath); err != nil {
-		return err
-	}
-
-	return nil
+	return c.router.Untaint(ctx, dstRelativePath)
 }
 
 // taintCredEntry is used to mark an entry in the auth table as tainted
@@ -485,7 +474,7 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 	// Taint the entry from the auth table
 	// We do this on the original since setting the taint operates
 	// on the entries which a shallow clone shares anyways
-	entry, err := c.auth.setTaint(nsID, strings.TrimPrefix(path, credentialRoutePrefix), true, mountStateUnmounting)
+	entry, err := c.auth.setTaint(nsID, strings.TrimPrefix(path, credentialRoutePrefix))
 	if err != nil {
 		return err
 	}
@@ -497,7 +486,7 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 
 	if updateStorage {
 		// Update the auth table
-		if err := c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace()), c.auth, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -587,7 +576,6 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		}
 
 		view := NamespaceView(barrier, ns)
-
 		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)
 		if err != nil {
 			c.logger.Error("failed to list transactional auth mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
@@ -604,7 +592,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	}
 
 	if len(globalEntries) == 0 {
-		// TODO(ascheel) Assertion: globalEntries is empty if there is only
+		// TODO(ascheel) Assertion: globalEntries is empty iff there is only
 		// one namespace (the root namespace).
 		c.logger.Info("no auth mounts in transactional auth mount table; adding default auth mount table")
 		c.auth, err = c.defaultAuthTable(ctx)
@@ -630,7 +618,6 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 				}
 			}
 		}
-
 	}
 
 	if len(localEntries) > 0 {
@@ -927,10 +914,16 @@ func (c *Core) runCredentialUpdates(ctx context.Context, barrier logical.Storage
 
 // persistAuth is used to persist the auth table after modification
 func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
+	// TODO: refactor barrier passing
+
 	// Sometimes we may not want to explicitly pass barrier; fetch it if
 	// necessary.
 	if barrier == nil {
-		barrier = c.barrier
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+		barrier = c.NamespaceView(ns)
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -996,8 +989,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 			Value: compressedBytes,
 		}
 
-		// Write to the physical backend
-		if err := c.barrier.Put(ctx, entry); err != nil {
+		// Write to the storage
+		if err := barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist auth mount table", "error", err)
 			return -1, err
 		}
@@ -1014,8 +1007,6 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				if mount != "" && mtEntry.UUID != mount {
 					continue
 				}
-
-				view := NamespaceView(barrier, mtEntry.Namespace())
 
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
@@ -1036,7 +1027,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				// Write to the backend.
-				if err := view.Put(ctx, sEntry); err != nil {
+				if err := barrier.Put(ctx, sEntry); err != nil {
 					c.logger.Error("failed to persist auth mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
 					return -1, err
 				}
@@ -1054,9 +1045,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
 					path := path.Join(prefix, mount)
-					if err := view.Delete(ctx, path); err != nil {
+					if err := barrier.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
 					}
 				}
@@ -1069,10 +1059,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
-
 					// List all entries and remove any deleted ones.
-					presentEntries, err := view.List(ctx, prefix+"/")
+					presentEntries, err := barrier.List(ctx, prefix+"/")
 					if err != nil {
 						return -1, fmt.Errorf("failed to list entries in namespace %v (%v) for removal: %w", ns.ID, nsIndex, err)
 					}
@@ -1082,7 +1070,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 							continue
 						}
 
-						if err := view.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
 							return -1, fmt.Errorf("failed to remove deleted mount %v (%d) in namespace %v (%v): %w", presentEntry, index, ns.ID, nsIndex, err)
 						}
 					}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -604,7 +604,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	}
 
 	if len(globalEntries) == 0 {
-		// TODO(ascheel) Assertion: globalEntries is empty iff there is only
+		// TODO(ascheel) Assertion: globalEntries is empty if there is only
 		// one namespace (the root namespace).
 		c.logger.Info("no auth mounts in transactional auth mount table; adding default auth mount table")
 		c.auth, err = c.defaultAuthTable(ctx)
@@ -618,7 +618,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		}
 
 		for nsIndex, ns := range allNamespaces {
-			view := c.NamespaceView(ns)
+			view := NamespaceView(barrier, ns)
 			for index, uuid := range globalEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreAuthConfigPath, uuid)
 				if err != nil {
@@ -635,8 +635,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 
 	if len(localEntries) > 0 {
 		for nsIndex, ns := range allNamespaces {
-			view := c.NamespaceView(ns)
-
+			view := NamespaceView(barrier, ns)
 			for index, uuid := range localEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
 				if err != nil {
@@ -1016,7 +1015,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 					continue
 				}
 
-				view := c.NamespaceView(mtEntry.Namespace())
+				view := NamespaceView(barrier, mtEntry.Namespace())
 
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
@@ -1055,7 +1054,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := c.NamespaceView(ns)
+					view := NamespaceView(barrier, ns)
 					path := path.Join(prefix, mount)
 					if err := view.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
@@ -1070,7 +1069,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := c.NamespaceView(ns)
+					view := NamespaceView(barrier, ns)
 
 					// List all entries and remove any deleted ones.
 					presentEntries, err := view.List(ctx, prefix+"/")

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -190,8 +190,7 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *Moun
 	newTable := c.auth.shallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		// barrier nil is fine here, as the namespace is embedded in the context
-		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(ns), newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to update auth table", "error", err)
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
@@ -346,9 +345,7 @@ func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateS
 	}
 
 	if updateStorage {
-		// Update the auth table
-		// barrier nil is fine here, as the namespace is embedded in the context
-		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace()), newTable, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -914,16 +911,8 @@ func (c *Core) runCredentialUpdates(ctx context.Context, barrier logical.Storage
 
 // persistAuth is used to persist the auth table after modification
 func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
-	// TODO: refactor barrier passing
-
-	// Sometimes we may not want to explicitly pass barrier; fetch it if
-	// necessary.
 	if barrier == nil {
-		ns, err := namespace.FromContext(ctx)
-		if err != nil {
-			return err
-		}
-		barrier = c.NamespaceView(ns)
+		return errors.New("nil barrier encountered while persisting auth mount changes")
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -989,8 +978,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 			Value: compressedBytes,
 		}
 
-		// Write to the storage
-		if err := barrier.Put(ctx, entry); err != nil {
+		// Write to the root namespace storage
+		if err := c.barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist auth mount table", "error", err)
 			return -1, err
 		}

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -367,7 +367,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 	}
 
 	c.auth.Entries[1].Local = true
-	if err := c.persistAuth(ctx, nil, c.auth, nil, ""); err != nil {
+	if err := c.persistAuth(ctx, c.barrier, c.auth, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -786,9 +786,7 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			// 3. Manipulate mount table in storage: delete entry from mount table
-			ns, err := namespace.FromContext(ctx)
-			require.NoError(t, err)
-			storageEntry, err := c.NamespaceView(ns).Get(ctx, coreMountConfigPath)
+			storageEntry, err := c.barrier.Get(ctx, coreMountConfigPath)
 			require.NoError(t, err)
 			require.NotNil(t, storageEntry, "expected mount table to be written at %s", coreMountConfigPath)
 
@@ -1062,10 +1060,7 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			// 3. Manipulate mount table in storage: delete entry from mount table
-			ns, err := namespace.FromContext(ctx)
-			require.NoError(t, err)
-
-			storageEntry, err := c.NamespaceView(ns).Get(ctx, coreAuthConfigPath)
+			storageEntry, err := c.barrier.Get(ctx, coreAuthConfigPath)
 			require.NoError(t, err)
 			require.NotNil(t, storageEntry, "expected mount table to be written at %s", coreAuthConfigPath)
 

--- a/vault/external_tests/identity/cross_namespace_test.go
+++ b/vault/external_tests/identity/cross_namespace_test.go
@@ -65,7 +65,7 @@ func TestUnsafeCrossNamespaceIdentity(t *testing.T) {
 			// create data
 
 			t.Log("creating namespace")
-			_, err := client.Logical().Write("sys/namespaces/test", map[string]any{})
+			_, err := client.Sys().CreateNamespace("test")
 			require.NoError(t, err)
 
 			client.SetCloneToken(true)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1858,11 +1858,15 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		}
 	}
 
-	var err error
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return handleError(err)
+	}
+
 	if isAuth {
-		err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
+		err = b.Core.persistAuth(ctx, b.Core.NamespaceView(ns), b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 	} else {
-		err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
+		err = b.Core.persistMounts(ctx, b.Core.NamespaceView(ns), b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 	}
 
 	if err != nil {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6254,16 +6254,15 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 			t.Fatal()
 		}
 		mountEntry.Version = nonExistentBuiltinVersion
+		barrier := core.NamespaceView(mountEntry.Namespace())
 		if tc.mountTable == "mounts" {
-			err = core.persistMounts(ctx, nil, core.mounts, &mountEntry.Local, mountEntry.UUID)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = core.persistMounts(ctx, barrier, core.mounts, &mountEntry.Local, mountEntry.UUID)
 		} else {
-			err = core.persistAuth(ctx, nil, core.auth, &mountEntry.Local, mountEntry.UUID)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = core.persistAuth(ctx, barrier, core.auth, &mountEntry.Local, mountEntry.UUID)
+		}
+
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		config = readMountConfig(tc.pluginName, tc.mountTable)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -776,7 +776,7 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *MountEntry, upd
 	newTable := c.mounts.shallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(ns), newTable, &entry.Local, entry.UUID); err != nil {
 			if logical.ShouldForward(err) {
 				return err
 			}
@@ -1013,7 +1013,7 @@ func (c *Core) removeMountEntryWithLock(ctx context.Context, path string, update
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace()), newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to remove entry from mounts table", "error", err)
 			return logical.CodedError(500, "failed to remove entry from mounts table")
 		}
@@ -1766,16 +1766,8 @@ func (c *Core) runMountUpdates(ctx context.Context, barrier logical.Storage, nee
 
 // persistMounts is used to persist the mount table after modification.
 func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
-	// TODO: refactor barrier passing
-
-	// Sometimes we may not want to explicitly pass barrier; fetch it if
-	// necessary.
 	if barrier == nil {
-		ns, err := namespace.FromContext(ctx)
-		if err != nil {
-			return err
-		}
-		barrier = c.NamespaceView(ns)
+		return errors.New("nil barrier encountered while persisting mount changes")
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -1841,8 +1833,8 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 			Value: compressedBytes,
 		}
 
-		// Write to the physical backend
-		if err := barrier.Put(ctx, entry); err != nil {
+		// Write to the root namespace storage
+		if err := c.barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist mount table", "error", err)
 			return -1, err
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -283,22 +283,20 @@ func (old *MountTable) delta(new *MountTable) (additions []*MountEntry, deletion
 	return additions, deletions
 }
 
-// setTaint is used to set the taint on given entry Accepts either the mount
+// setTaint is used to set the taint on given entry. Accepts either the mount
 // entry's path or namespace + path, i.e. <ns-path>/secret/ or <ns-path>/token/
-func (t *MountTable) setTaint(nsID, path string, tainted bool, mountState string) (*MountEntry, error) {
+func (t *MountTable) setTaint(nsID, path string) (*MountEntry, error) {
 	n := len(t.Entries)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if entry := t.Entries[i]; entry.Path == path && entry.Namespace().ID == nsID {
-			t.Entries[i].Tainted = tainted
-			t.Entries[i].MountState = mountState
+			t.Entries[i].Tainted = true
 			return t.Entries[i], nil
 		}
 	}
 	return nil, nil
 }
 
-// remove is used to remove a given path entry; returns the entry that was
-// removed
+// remove is used to remove a given path entry; returning removed entry
 func (t *MountTable) remove(ctx context.Context, path string) (*MountEntry, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
@@ -373,8 +371,6 @@ func (t *MountTable) sortEntriesByPathDepth() *MountTable {
 	})
 	return t
 }
-
-const mountStateUnmounting = "unmounting"
 
 // MountEntry is used to represent a mount table entry
 type MountEntry struct {
@@ -659,11 +655,7 @@ func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 	}
 
 	// Mount internally
-	if err := c.mountInternal(ctx, entry, MountTableUpdateStorage); err != nil {
-		return err
-	}
-
-	return nil
+	return c.mountInternal(ctx, entry, MountTableUpdateStorage)
 }
 
 func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
@@ -1036,14 +1028,9 @@ func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, upda
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
-	mountState := ""
-	if unmounting {
-		mountState = mountStateUnmounting
-	}
-
 	// As modifying the taint of an entry affects shallow clones,
 	// we simply use the original
-	entry, err := c.mounts.setTaint(nsID, mountPath, true, mountState)
+	entry, err := c.mounts.setTaint(nsID, mountPath)
 	if err != nil {
 		return err
 	}
@@ -1054,7 +1041,7 @@ func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, upda
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace()), c.mounts, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to taint entry in mounts table", "error", err)
 			return logical.CodedError(500, "failed to taint entry in mounts table: %v", err)
 		}
@@ -1150,11 +1137,6 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 		return fmt.Errorf("path in use at %q", match)
 	}
 
-	srcBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Mark the entry as tainted
 	if err := c.taintMountEntry(ctx, src.Namespace.ID, src.MountPath, updateStorage, false); err != nil {
 		return err
@@ -1195,13 +1177,8 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	srcPath := mountEntry.Path
 	mountEntry.Path = dst.MountPath
 
-	dstBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Update the mount table
-	if err := c.persistMounts(ctx, nil, c.mounts, &mountEntry.Local, mountEntry.UUID); err != nil {
+	if err := c.persistMounts(ctx, c.NamespaceView(mountEntry.Namespace()), c.mounts, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
@@ -1212,10 +1189,15 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 
 	if src.Namespace.ID != dst.Namespace.ID {
 		// Handle storage entries
-		if err := c.moveMountStorage(ctx, src, mountEntry, srcBarrierView, dstBarrierView); err != nil {
+		if err := c.moveMountStorage(ctx, src, mountEntry); err != nil {
 			c.mountsLock.Unlock()
 			return err
 		}
+	}
+
+	dstBarrierView, err := c.mountEntryView(mountEntry)
+	if err != nil {
+		return err
 	}
 
 	// Remount the backend
@@ -1231,41 +1213,36 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	c.mountsLock.Unlock()
 
 	// Un-taint the path
-	if err := c.router.Untaint(ctx, dstRelativePath); err != nil {
-		return err
-	}
-
-	return nil
+	return c.router.Untaint(ctx, dstRelativePath)
 }
 
 // moveMountStorage moves storage entries of a mount mountEntry to its new destination
-func (c *Core) moveMountStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry, srcBarrierView, dstBarrierView BarrierView) error {
-	return c.moveStorage(ctx, src, me, srcBarrierView, dstBarrierView)
+func (c *Core) moveMountStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry) error {
+	return c.moveStorage(ctx, src, me, backendBarrierPrefix)
 }
 
 // moveAuthStorage moves storage entries of an auth mountEntry to its new destination
-func (c *Core) moveAuthStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry, srcBarrierView, dstBarrierView BarrierView) error {
-	return c.moveStorage(ctx, src, me, srcBarrierView, dstBarrierView)
+func (c *Core) moveAuthStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry) error {
+	return c.moveStorage(ctx, src, me, credentialBarrierPrefix)
 }
 
 // moveStorage moves storage entries of a mountEntry to its new destination
 // It detects the mountEntry type
-func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry, srcBarrierView, dstBarrierView BarrierView) error {
-	srcPrefix := srcBarrierView.Prefix()
-	dstPrefix := dstBarrierView.Prefix()
-
-	barrier := c.barrier
+func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, me *MountEntry, prefix string) error {
+	srcBarrier := c.NamespaceView(src.Namespace)
+	dstBarrier := c.NamespaceView(me.Namespace())
 
 	var key string
-	keys, err := barrier.List(ctx, srcPrefix)
+	keys, err := srcBarrier.List(ctx, path.Join(prefix, me.UUID)+"/")
 	if err != nil {
 		return err
 	}
 
 	for len(keys) > 0 {
 		key, keys = keys[0], keys[1:]
+		entryKey := path.Join(prefix, me.UUID, key)
 		if strings.HasSuffix(key, "/") {
-			nestedKeys, err := barrier.List(ctx, srcPrefix+key)
+			nestedKeys, err := srcBarrier.List(ctx, entryKey)
 			if err != nil {
 				return err
 			}
@@ -1277,32 +1254,29 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 			continue
 		}
 
-		if err := logical.WithTransaction(ctx, barrier, func(s logical.Storage) error {
-			se, err := s.Get(ctx, srcPrefix+key)
-			if err != nil {
+		// Reading and deleting using root namespace barrier is fine, but writing using
+		// different barrier than the namespace we write to is probably wrong.
+		if err := logical.WithTransaction(ctx, srcBarrier, func(s logical.Storage) error {
+			se, err := srcBarrier.Get(ctx, entryKey)
+			if err != nil || se == nil {
 				return err
 			}
-			if se == nil {
-				return nil
-			}
-			se.Key = dstPrefix + key
-			err = s.Put(ctx, se)
-			if err != nil {
+
+			if err := logical.WithTransaction(ctx, dstBarrier, func(s logical.Storage) error {
+				se.Key = entryKey
+				return s.Put(ctx, se)
+			}); err != nil {
 				return err
 			}
-			err = s.Delete(ctx, srcPrefix+key)
-			if err != nil {
-				return err
-			}
-			return nil
+
+			return s.Delete(ctx, entryKey)
 		}); err != nil {
 			return err
 		}
 	}
 
-	srcEntryView := NamespaceView(srcBarrierView, src.Namespace)
+	// Delete the mount storage entry from the source location
 	var coreLocalPath, corePath string
-
 	switch me.Table {
 	case mountTableType:
 		coreLocalPath = coreLocalMountConfigPath
@@ -1315,16 +1289,10 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 	}
 
 	if me.Local {
-		srcEntryView = srcEntryView.SubView(coreLocalPath + "/")
-	} else {
-		srcEntryView = srcEntryView.SubView(corePath + "/")
-	}
-	err = srcEntryView.Delete(ctx, me.UUID)
-	if err != nil {
-		return err
+		return srcBarrier.Delete(ctx, path.Join(coreLocalPath, me.UUID))
 	}
 
-	return nil
+	return srcBarrier.Delete(ctx, path.Join(corePath, me.UUID))
 }
 
 // From an input path that has a relative namespace hierarchy followed by a mount point, return the full
@@ -1798,10 +1766,16 @@ func (c *Core) runMountUpdates(ctx context.Context, barrier logical.Storage, nee
 
 // persistMounts is used to persist the mount table after modification.
 func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table *MountTable, local *bool, mount string) error {
+	// TODO: refactor barrier passing
+
 	// Sometimes we may not want to explicitly pass barrier; fetch it if
 	// necessary.
 	if barrier == nil {
-		barrier = c.barrier
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+		barrier = c.NamespaceView(ns)
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -1886,8 +1860,6 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 					continue
 				}
 
-				view := NamespaceView(barrier, mtEntry.Namespace())
-
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
 
@@ -1907,7 +1879,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				// Write to the backend.
-				if err := view.Put(ctx, sEntry); err != nil {
+				if err := barrier.Put(ctx, sEntry); err != nil {
 					c.logger.Error("failed to persist mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
 					return -1, err
 				}
@@ -1925,9 +1897,8 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
 					path := path.Join(prefix, mount)
-					if err := view.Delete(ctx, path); err != nil {
+					if err := barrier.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
 					}
 				}
@@ -1940,10 +1911,8 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceView(barrier, ns)
-
 					// List all entries and remove any deleted ones.
-					presentEntries, err := view.List(ctx, prefix+"/")
+					presentEntries, err := barrier.List(ctx, prefix+"/")
 					if err != nil {
 						return -1, fmt.Errorf("failed to list entries in namespace %v (%v) for removal: %w", ns.ID, nsIndex, err)
 					}
@@ -1953,7 +1922,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 							continue
 						}
 
-						if err := view.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
 							return -1, fmt.Errorf("failed to remove deleted mount %v (%v) in namespace %v (%v): %w", presentEntry, index, ns.ID, nsIndex, err)
 						}
 					}
@@ -2311,7 +2280,6 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 	}
 
 	ctx = namespace.ContextWithNamespace(ctx, entry.namespace)
-	ctx = context.WithValue(ctx, "core_number", c.coreNumber)
 	b, err := f(ctx, config)
 	if err != nil {
 		return nil, "", err

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1300,7 +1300,7 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 		}
 	}
 
-	srcEntryView := c.NamespaceView(src.Namespace)
+	srcEntryView := NamespaceView(srcBarrierView, src.Namespace)
 	var coreLocalPath, corePath string
 
 	switch me.Table {
@@ -1450,7 +1450,7 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 		}
 
 		for nsIndex, ns := range allNamespaces {
-			view := c.NamespaceView(ns)
+			view := NamespaceView(barrier, ns)
 			for index, uuid := range globalEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreMountConfigPath, uuid)
 				if err != nil {
@@ -1466,7 +1466,7 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 
 	if len(localEntries) > 0 {
 		for nsIndex, ns := range allNamespaces {
-			view := c.NamespaceView(ns)
+			view := NamespaceView(barrier, ns)
 			for index, uuid := range localEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalMountConfigPath, uuid)
 				if err != nil {
@@ -1523,7 +1523,6 @@ func (c *Core) loadLegacyMountsForNamespace(ctx context.Context, ns *namespace.N
 	}
 
 	view := c.NamespaceView(ns)
-
 	raw, err := view.Get(ctx, coreMountConfigPath)
 	if err != nil {
 		c.logger.Error("failed to read legacy mount table", "error", err)
@@ -1887,7 +1886,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 					continue
 				}
 
-				view := c.NamespaceView(mtEntry.Namespace())
+				view := NamespaceView(barrier, mtEntry.Namespace())
 
 				found = true
 				currentEntries[mtEntry.UUID] = struct{}{}
@@ -1926,7 +1925,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := c.NamespaceView(ns)
+					view := NamespaceView(barrier, ns)
 					path := path.Join(prefix, mount)
 					if err := view.Delete(ctx, path); err != nil {
 						return -1, fmt.Errorf("requested removal of auth mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
@@ -1941,7 +1940,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := c.NamespaceView(ns)
+					view := NamespaceView(barrier, ns)
 
 					// List all entries and remove any deleted ones.
 					presentEntries, err := view.List(ctx, prefix+"/")

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -333,7 +333,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	c.mounts.Entries[1].Local = true
-	if err := c.persistMounts(ctx, nil, c.mounts, nil, ""); err != nil {
+	if err := c.persistMounts(ctx, c.barrier, c.mounts, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1091,19 +1091,19 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	// Now try saving invalid versions
 	origTableType := mt.Type
 	mt.Type = "foo"
-	if err := persistFunc(ctx, nil, mt, nil, ""); err == nil {
+	if err := persistFunc(ctx, c.barrier, mt, nil, ""); err == nil {
 		t.Fatal("expected error")
 	}
 
 	if len(mt.Entries) > 0 {
 		mt.Type = origTableType
 		mt.Entries[0].Table = "bar"
-		if err := persistFunc(ctx, nil, mt, nil, ""); err == nil {
+		if err := persistFunc(ctx, c.barrier, mt, nil, ""); err == nil {
 			t.Fatal("expected error")
 		}
 
 		mt.Entries[0].Table = mt.Type
-		if err := persistFunc(ctx, nil, mt, nil, ""); err != nil {
+		if err := persistFunc(ctx, c.barrier, mt, nil, ""); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -675,7 +675,7 @@ func BenchmarkClearNamespaceResources(b *testing.B) {
 
 	for b.Loop() {
 		ns := randomNamespace(s)
-		err := s.clearNamespaceResources(ctx, namespace.RootNamespace, ns)
+		err := s.clearNamespaceResources(ctx, ns)
 		require.NoError(b, err)
 	}
 }

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -118,8 +118,8 @@ func (c *Core) reloadMatchingPlugin(ctx context.Context, pluginName string) erro
 	return nil
 }
 
-// reloadBackendCommon is a generic method to reload a backend provided a
-// MountEntry.
+// reloadBackendCommon is a generic method to reload a backend
+// represented by a MountEntry.
 func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAuth bool) error {
 	// Make sure our cache is up-to-date. Since some singleton mounts can be
 	// tuned, we do this before the below check.
@@ -192,19 +192,18 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 		}
 	}
 
+	barrier := c.NamespaceView(entry.Namespace())
 	// update the mount table since we changed the runningSha
 	if oldSha != entry.RunningSha256 && MountTableUpdateStorage {
 		if isAuth {
-			err = c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID)
-			if err != nil {
-				return err
-			}
+			err = c.persistAuth(ctx, barrier, c.auth, &entry.Local, entry.UUID)
 		} else {
-			err = c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID)
-			if err != nil {
-				return err
-			}
+			err = c.persistMounts(ctx, barrier, c.mounts, &entry.Local, entry.UUID)
 		}
+	}
+
+	if err != nil {
+		return err
 	}
 
 	// Set the backend back

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -564,9 +564,6 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 	if err != nil {
 		return nil, err
 	}
-	if ns == nil {
-		return nil, namespace.ErrNoNamespace
-	}
 
 	// Get the appropriate view based on policy type and namespace
 	view := ps.getBarrierView(ns, policyType)

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -122,7 +122,7 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(ctx, nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(ctx, core.NamespaceView(mountEntry.Namespace()), newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 
@@ -206,7 +206,7 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(ctx, nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(ctx, core.NamespaceView(mountEntry.Namespace()), newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -90,6 +90,7 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 	ran := make(chan string)
 	release := make(chan struct{})
 	core, _, _ = testCoreUnsealed(t, core)
+	ctx := namespace.RootContext(t.Context())
 
 	// create 10 backends
 	// when a rollback happens, each backend will try to write to an unbuffered
@@ -121,11 +122,11 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(context.Background(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(ctx, nil, newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 
-	timeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	timeout, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	got := make(map[string]bool)
 	hasMore := true
@@ -173,6 +174,7 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 	ran := make(chan string)
 	release := make(chan struct{})
 	core, _, _ = testCoreUnsealed(t, core)
+	ctx := namespace.RootContext(t.Context())
 
 	// create 10 backends
 	// when a rollback happens, each backend will try to write to an unbuffered
@@ -204,11 +206,11 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(context.Background(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(ctx, nil, newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 
-	timeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	timeout, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	got := make(map[string]bool)
 	hasMore := true

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -166,11 +166,9 @@ func (sm *SealManager) RemoveNamespace(ns *namespace.Namespace) {
 	sm.barrierByNamespace.Delete(ns.Path)
 }
 
-// NamespaceView finds the correct barrier to use for the namespace
-// and returns BarrierView restricted to the logical.Storage space
-// of the given namespace. As this function retrieves the barrier
-// from the seal manager, remember to __not__ shadow the transaction
-// by retrieving the view using this method.
+// NamespaceView returns the BarrierView that applies to the given namespace.
+// Remember that this method does not take in an existing storage type and is
+// likely wrong to call within the context of a transaction.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
 	barrier := c.sealManager.NamespaceBarrierByLongestPrefix(ns.Path)
 	return NamespaceView(barrier, ns)

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -168,7 +168,9 @@ func (sm *SealManager) RemoveNamespace(ns *namespace.Namespace) {
 
 // NamespaceView finds the correct barrier to use for the namespace
 // and returns BarrierView restricted to the logical.Storage space
-// of the given namespace.
+// of the given namespace. As this function retrieves the barrier
+// from the seal manager, remember to __not__ shadow the transaction
+// by retrieving the view using this method.
 func (c *Core) NamespaceView(ns *namespace.Namespace) BarrierView {
 	barrier := c.sealManager.NamespaceBarrierByLongestPrefix(ns.Path)
 	return NamespaceView(barrier, ns)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -325,6 +325,10 @@ func TestCoreSeal(core *Core) error {
 	return core.sealInternal()
 }
 
+func TestNamespaceUnseal(core *Core, ns *namespace.Namespace, key []byte) (bool, error) {
+	return core.namespaceStore.unsealNamespace(namespace.ContextWithNamespace(context.Background(), ns), ns, TestKeyCopy(key))
+}
+
 func TestCoreCreateNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) {
 	t.Helper()
 	ctx := namespace.RootContext(context.Background())
@@ -369,7 +373,7 @@ func TestCoreCreateUnsealedNamespaces(t testing.T, core *Core, namespaces ...*na
 	for _, ns := range namespaces {
 		keys := TestCoreCreateSealedNamespaces(t, core, ns)
 		for _, key := range keys[ns.Path] {
-			unsealed, err := core.sealManager.UnsealNamespace(namespace.ContextWithNamespace(context.Background(), ns), ns, TestKeyCopy(key))
+			unsealed, err := TestNamespaceUnseal(core, ns, key)
 			require.NoError(t, err)
 			if unsealed {
 				break


### PR DESCRIPTION
Fixes the shadowing of the transaction storage by using a method that retrieves the barrier from the in-memory struct (SealManager).

Note: this PR targets [namespaces-seal](https://github.com/openbao/openbao/tree/namespaces-seal) branch

- adjusted barrier passing/retrieval in `mount.go` and `auth.go` 
- adjusted `(*Core).moveStorage()` method
- adjusted test cases related to (re)mounting in `mount_test.go` and `auth_test.go`
- adjusted tests cases in `vault/rollback_test.go` and `vault/core_cache_invalidate_test.go`
- (unrelated cleanup) removed `mountStateUnmounting` and `MountState` from `MountEntry`

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
