### PR TITLE
docs: fix wording, encoded → encrypted for encrypt plaintext

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -793,7 +793,7 @@ Note: If upsert is disallowed by global keys configuration, `create`
   encrypt against. This is specified as part of the URL.
 
 - `plaintext` `(string: <required>)` – Specifies **base64 encoded** plaintext to
-  be encoded.
+  be encrypted.
 
 - `associated_data` `(string: "")` - Specifies **base64 encoded** associated
   data (also known as additional data or AAD) to also be authenticated with


### PR DESCRIPTION
### Summary
This PR updates the documentation for the `plaintext` parameter to correctly state that
the base64-encoded plaintext is **encrypted**, not **encoded**.

## Rationale
The transit encrypt operation takes a plaintext parameter that is base64-encoded and **encrypts** it.
Encrypt accepts a base64-encoded plaintext value.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
