### PR TITLE
Add endpoint parameter to set a reason for database credential generation

### DIFF
--- a/sdk/database/dbplugin/v5/database.go
+++ b/sdk/database/dbplugin/v5/database.go
@@ -135,6 +135,7 @@ type NewUserRequest struct {
 type UsernameMetadata struct {
 	DisplayName string
 	RoleName    string
+	Reason      string
 }
 
 // NewUserResponse returns any information Vault needs to know after creating a new user.

--- a/sdk/database/dbplugin/v5/grpc_client.go
+++ b/sdk/database/dbplugin/v5/grpc_client.go
@@ -121,6 +121,7 @@ func newUserReqToProto(req NewUserRequest) (*proto.NewUserRequest, error) {
 		UsernameConfig: &proto.UsernameConfig{
 			DisplayName: req.UsernameConfig.DisplayName,
 			RoleName:    req.UsernameConfig.RoleName,
+			Reason:      req.UsernameConfig.Reason,
 		},
 		CredentialType: int32(req.CredentialType),
 		Password:       req.Password,

--- a/sdk/database/dbplugin/v5/grpc_server.go
+++ b/sdk/database/dbplugin/v5/grpc_server.go
@@ -146,6 +146,7 @@ func (g *gRPCServer) NewUser(ctx context.Context, req *proto.NewUserRequest) (*p
 		UsernameConfig: UsernameMetadata{
 			DisplayName: req.GetUsernameConfig().GetDisplayName(),
 			RoleName:    req.GetUsernameConfig().GetRoleName(),
+			Reason:      req.GetUsernameConfig().GetReason(),
 		},
 		CredentialType:     CredentialType(req.GetCredentialType()),
 		Password:           req.GetPassword(),

--- a/sdk/database/dbplugin/v5/proto/database.pb.go
+++ b/sdk/database/dbplugin/v5/proto/database.pb.go
@@ -229,6 +229,7 @@ type UsernameConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DisplayName   string                 `protobuf:"bytes,1,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
 	RoleName      string                 `protobuf:"bytes,2,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
+	Reason        string                 `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -273,6 +274,13 @@ func (x *UsernameConfig) GetDisplayName() string {
 func (x *UsernameConfig) GetRoleName() string {
 	if x != nil {
 		return x.RoleName
+	}
+	return ""
+}
+
+func (x *UsernameConfig) GetReason() string {
+	if x != nil {
+		return x.Reason
 	}
 	return ""
 }
@@ -838,10 +846,11 @@ const file_sdk_database_dbplugin_v5_proto_database_proto_rawDesc = "" +
 	"\x0fcredential_type\x18\x06 \x01(\x05R\x0ecredentialType\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\a \x01(\fR\tpublicKey\x12\x18\n" +
-	"\asubject\x18\b \x01(\tR\asubject\"P\n" +
+	"\asubject\x18\b \x01(\tR\asubject\"h\n" +
 	"\x0eUsernameConfig\x12!\n" +
 	"\fdisplay_name\x18\x01 \x01(\tR\vdisplayName\x12\x1b\n" +
-	"\trole_name\x18\x02 \x01(\tR\broleName\"-\n" +
+	"\trole_name\x18\x02 \x01(\tR\broleName\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\"-\n" +
 	"\x0fNewUserResponse\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\"\x8d\x02\n" +
 	"\x11UpdateUserRequest\x12\x1a\n" +

--- a/sdk/database/dbplugin/v5/proto/database.proto
+++ b/sdk/database/dbplugin/v5/proto/database.proto
@@ -38,6 +38,7 @@ message NewUserRequest {
 message UsernameConfig {
     string display_name = 1;
     string role_name = 2;
+    string reason = 3;
 }
 
 message NewUserResponse {


### PR DESCRIPTION
## Description

Extend credential requests to accept optional metadata (e.g. ticket ID or reason) that is injected into the generated temporary database username. This allows production DB access issued via ADFS → Vault; to be correlated with an approved change request using existing DB audit logs.

This provides a clear, auditable link between the accessing developer, the change performed, and the associated business approval.

## Rationale

Resolves: #2227

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
