### PR TITLE
Add Adfinis to the vendor ecosystem page

### DIFF
--- a/website/content/ecosystem/supporters.mdx
+++ b/website/content/ecosystem/supporters.mdx
@@ -12,7 +12,7 @@ import Member from './lib/Member.tsx';
 <Randomize>
   <Member title="Adfinis">
     Several developers employed by
-    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao) work
+    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website) work
     full time on OpenBao.
   </Member>
   <Member title="GitLab">

--- a/website/content/ecosystem/vendors.mdx
+++ b/website/content/ecosystem/vendors.mdx
@@ -5,7 +5,13 @@ sidebar_position: 5
 
 # Vendors
 
-Currently, there is no vendor, which has given the OpenBao project permission to
-use their name and logo. If you are in the position to change that, please
-[suggest the
-addition](https://github.com/openbao/openbao/issues/new?template=docs_ecosystem.yaml).
+import Member from './lib/Member.tsx';
+
+<div className="container">
+<div className="row">
+  <Member title="Adfinis">
+    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
+    plans, builds, and runs OpenBao 24x7, and provides enterprise support.
+  </Member>
+</div>
+</div>


### PR DESCRIPTION
## Description

Simple PR to add Adfinis to the vendor page of the ecosystem section. We'll have to add the randomization once other entries are added, as it breaks the page otherwise.

## Rationale

Grow the OpenBao ecosystem.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
