### PR TITLE
Add option to allow credentials on cross-origin requests

### DIFF
--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -82,13 +82,15 @@ func (c *Sys) DisableCORSWithContext(ctx context.Context) error {
 }
 
 type CORSRequest struct {
-	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
-	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins   []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders   []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	AllowCredentials bool     `json:"allow_credentials" mapstructure:"allow_credentials"`
+	Enabled          bool     `json:"enabled" mapstructure:"enabled"`
 }
 
 type CORSResponse struct {
-	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
-	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins   []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders   []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	AllowCredentials bool     `json:"allow_credentials" mapstructure:"allow_credentials"`
+	Enabled          bool     `json:"enabled" mapstructure:"enabled"`
 }

--- a/changelog/2262.txt
+++ b/changelog/2262.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/listeners: Add a parameter to allow cross-origin requests to include credentials (`Access-Control-Allow-Credentials` header).
+```

--- a/http/cors.go
+++ b/http/cors.go
@@ -56,6 +56,10 @@ func wrapCORSHandler(h http.Handler, core *vault.Core) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Vary", "Origin")
 
+		if corsConf.AllowCredentials {
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
+
 		// apply headers for preflight requests
 		if req.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Allow-Methods", strings.Join(allowedMethods, ","))

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -126,7 +126,7 @@ func TestHandler_cors(t *testing.T) {
 
 	// Enable CORS and allow from any origin for testing.
 	corsConfig := core.CORSConfig()
-	err := corsConfig.Enable(context.Background(), []string{addr}, nil)
+	err := corsConfig.Enable(context.Background(), []string{addr}, nil, false)
 	if err != nil {
 		t.Fatalf("Error enabling CORS: %s", err)
 	}
@@ -187,6 +187,31 @@ func TestHandler_cors(t *testing.T) {
 		"Access-Control-Max-Age":       "300",
 		"Vary":                         "Origin",
 	}
+
+	for expHeader, expected := range expHeaders {
+		actual := resp.Header.Get(expHeader)
+		if actual == "" {
+			t.Fatalf("bad:\nHeader: %#v was not on response.", expHeader)
+		}
+
+		if actual != expected {
+			t.Fatalf("bad:\nExpected: %#v\nActual: %#v\n", expected, actual)
+		}
+	}
+
+	// Test that the Access-Control-Allow-Credentials is set correctly when configured
+	err = corsConfig.Enable(context.Background(), []string{addr}, nil, true)
+	if err != nil {
+		t.Fatalf("Error enabling CORS: %s", err)
+	}
+
+	client = cleanhttp.DefaultClient()
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expHeaders["Access-Control-Allow-Credentials"] = "true"
 
 	for expHeader, expected := range expHeaders {
 		actual := resp.Header.Get(expHeader)

--- a/http/sys_config_cors_test.go
+++ b/http/sys_config_cors_test.go
@@ -60,15 +60,38 @@ func TestSysConfigCors(t *testing.T) {
 		"warnings":       nil,
 		"auth":           nil,
 		"data": map[string]interface{}{
-			"enabled":         true,
-			"allowed_origins": []interface{}{addr},
-			"allowed_headers": expectedHeaders,
+			"enabled":           true,
+			"allowed_origins":   []interface{}{addr},
+			"allowed_headers":   expectedHeaders,
+			"allow_credentials": false,
 		},
-		"enabled":         true,
-		"allowed_origins": []interface{}{addr},
-		"allowed_headers": expectedHeaders,
+		"enabled":           true,
+		"allowed_origins":   []interface{}{addr},
+		"allowed_headers":   expectedHeaders,
+		"allow_credentials": false,
 	}
 
+	testResponseStatus(t, resp, 200)
+
+	testResponseBody(t, resp, &actual)
+	expected["request_id"] = actual["request_id"]
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
+	}
+
+	// Enable CORS, but with allow_credentials turned on
+	resp = testHttpPut(t, token, addr+"/v1/sys/config/cors", map[string]interface{}{
+		"allowed_origins":   addr,
+		"allowed_headers":   "X-Custom-Header",
+		"allow_credentials": "true",
+	})
+	testResponseStatus(t, resp, 204)
+
+	expected["allow_credentials"] = true
+	expected["data"].(map[string]interface{})["allow_credentials"] = true
+
+	resp = testHttpGet(t, token, addr+"/v1/sys/config/cors")
 	testResponseStatus(t, resp, 200)
 
 	testResponseBody(t, resp, &actual)

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -134,11 +134,13 @@ type Listener struct {
 	// RandomPort is used only for some testing purposes
 	RandomPort bool `hcl:"-"`
 
-	CorsEnabledRaw        interface{} `hcl:"cors_enabled"`
-	CorsEnabled           bool        `hcl:"-"`
-	CorsAllowedOrigins    []string    `hcl:"cors_allowed_origins"`
-	CorsAllowedHeaders    []string    `hcl:"-"`
-	CorsAllowedHeadersRaw []string    `hcl:"cors_allowed_headers,alias:cors_allowed_headers"`
+	CorsEnabledRaw          interface{} `hcl:"cors_enabled"`
+	CorsEnabled             bool        `hcl:"-"`
+	CorsAllowedOrigins      []string    `hcl:"cors_allowed_origins"`
+	CorsAllowedHeaders      []string    `hcl:"-"`
+	CorsAllowedHeadersRaw   []string    `hcl:"cors_allowed_headers,alias:cors_allowed_headers"`
+	CorsAllowCredentialsRaw interface{} `hcl:"cors_allow_credentials,alias:cors_allow_credentials"`
+	CorsAllowCredentials    bool        `hcl:"-"`
 
 	// Custom Http response headers
 	CustomResponseHeaders    map[string]map[string]string `hcl:"-"`
@@ -475,6 +477,14 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				for _, header := range l.CorsAllowedHeadersRaw {
 					l.CorsAllowedHeaders = append(l.CorsAllowedHeaders, textproto.CanonicalMIMEHeaderKey(header))
 				}
+			}
+
+			if l.CorsAllowCredentialsRaw != nil {
+				if l.CorsAllowCredentials, err = parseutil.ParseBool(l.CorsAllowCredentialsRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("invalid value for cors_allow_credentials: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.CorsAllowCredentialsRaw = nil
 			}
 		}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -231,6 +231,7 @@ func (b *SystemBackend) handleCORSRead(ctx context.Context, req *logical.Request
 		corsConf.RLock()
 		resp.Data["allowed_origins"] = corsConf.AllowedOrigins
 		resp.Data["allowed_headers"] = corsConf.AllowedHeaders
+		resp.Data["allow_credentials"] = corsConf.AllowCredentials
 		corsConf.RUnlock()
 	}
 
@@ -242,8 +243,9 @@ func (b *SystemBackend) handleCORSRead(ctx context.Context, req *logical.Request
 func (b *SystemBackend) handleCORSUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	origins := d.Get("allowed_origins").([]string)
 	headers := d.Get("allowed_headers").([]string)
+	allow_credentials := d.Get("allow_credentials").(bool)
 
-	return nil, b.Core.corsConfig.Enable(ctx, origins, headers)
+	return nil, b.Core.corsConfig.Enable(ctx, origins, headers, allow_credentials)
 }
 
 // handleCORSDelete sets the CORS enabled flag to false and clears the list of

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -33,6 +33,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 					Type:        framework.TypeCommaStringSlice,
 					Description: "A comma-separated string or array of strings indicating headers that are allowed on cross-origin requests.",
 				},
+				"allow_credentials": {
+					Type:        framework.TypeBool,
+					Description: "If true, the browser will be allowed to send credentials (e.g. kerberos authentication) with cross-origin requests.",
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -57,6 +61,10 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 								},
 								"allowed_headers": {
 									Type:     framework.TypeCommaStringSlice,
+									Required: false,
+								},
+								"allow_credentials": {
+									Type:     framework.TypeBool,
 									Required: false,
 								},
 							},

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -92,9 +92,10 @@ func TestSystemConfigCORS(t *testing.T) {
 
 	expected := &logical.Response{
 		Data: map[string]interface{}{
-			"enabled":         true,
-			"allowed_origins": []string{"http://www.example.com"},
-			"allowed_headers": append(StdAllowedHeaders, "X-Custom-Header"),
+			"enabled":           true,
+			"allow_credentials": false,
+			"allowed_origins":   []string{"http://www.example.com"},
+			"allowed_headers":   append(StdAllowedHeaders, "X-Custom-Header"),
 		},
 	}
 
@@ -144,6 +145,40 @@ func TestSystemConfigCORS(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
+
+	req = logical.TestRequest(t, logical.UpdateOperation, "config/cors")
+	req.Data["allowed_origins"] = "http://www.example.com"
+	req.Data["allowed_headers"] = "X-Custom-Header"
+	req.Data["allow_credentials"] = "true"
+	_, err = b.HandleRequest(namespace.RootContext(t.Context()), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected = &logical.Response{
+		Data: map[string]interface{}{
+			"enabled":           true,
+			"allowed_origins":   []string{"http://www.example.com"},
+			"allowed_headers":   append(StdAllowedHeaders, "X-Custom-Header"),
+			"allow_credentials": true,
+		},
+	}
+
+	req = logical.TestRequest(t, logical.ReadOperation, "config/cors")
+	actual, err = b.HandleRequest(namespace.RootContext(t.Context()), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+	schema.ValidateResponse(
+		t,
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		actual,
+		true,
+	)
 
 	req = logical.TestRequest(t, logical.DeleteOperation, "config/cors")
 	resp, err = b.HandleRequest(namespace.RootContext(nil), req)

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -41,7 +41,8 @@ $ curl \
     "Authorization",
     "X-Vault-Wrap-Format",
     "X-Vault-Wrap-TTL"
-  ]
+  ],
+  "allow_credentials": false
 }
 ```
 
@@ -60,12 +61,15 @@ cross-origin requests, as well as headers that are allowed on cross-origin reque
 
 - `allowed_headers` `(string or string array: "" or [])` – A comma-delimited string or array of strings specifying headers that are permitted to be on cross-origin requests. Headers set via this parameter will be appended to the list of headers that OpenBao allows by default.
 
+- `allow_credentials` `(boolean: false)` – A boolean, specifying whether credentials (e.g. kerberos negotiation) are permitted on cross-origin requests. This adds the "Access-Control-Allow-Credentials: true" header on responses.
+
 ### Sample payload
 
 ```json
 {
   "allowed_origins": "*",
-  "allowed_headers": "X-Custom-Header"
+  "allowed_headers": "X-Custom-Header",
+  "allow_credentials": true
 }
 ```
 


### PR DESCRIPTION
## Description

This adds an `allow_credentials` parameter when configuring CORS settings using `/sys/config/cors`. When set to true, it wil cause OpenBao to send back an `Access-Control-Allow-Credentials: true` header. This enables the client to use auth methods like kerberos on cross-origin requests.

## Rationale

In my testing, I wasn't able to get `custom_response_headers` to work on the CORS preflight request, and because of that, I couldn't perform cross-origin kerberos authentication. Adding this feature allows cross-origin credentials and fixes the issue. 

Resolves: #1903

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
