### PR TITLE
Bump qs to 6.14.x in /ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -209,7 +209,7 @@
     "minimatch": "^3.0.2",
     "node-notifier": "^8.0.1",
     "prismjs": "^1.21.0",
-    "qs": "^6.3.0",
+    "qs": "^6.14.1",
     "serialize-javascript": "^3.1.0",
     "underscore": "^1.12.1",
     "trim": "^0.0.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -24157,12 +24157,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.3.0":
-  version: 6.10.1
-  resolution: "qs@npm:6.10.1"
+"qs@npm:^6.14.1":
+  version: 6.14.1
+  resolution: "qs@npm:6.14.1"
   dependencies:
-    side-channel: ^1.0.4
-  checksum: 00e390dbf98eff4d8ff121b61ab2fe32106852290de99ecd0e40fc76651c4101f43fc6cc8313cb69423563876fc532951b11dda55d2917def05f292258263480
+    side-channel: ^1.1.0
+  checksum: 7fffab0344fd75bfb6b8c94b8ba17f3d3e823d25b615900f68b473c3a078e497de8eaa08f709eaaa170eedfcee50638a7159b98abef7d8c89c2ede79291522f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We're not affected by the server-side DoS in `qs < 6.14.x`, but let's upgrade to be safe and avoid complaining scanners. Dependabot repeatedly failed to generate this PR itself running into "`unknown_error: null`", so bumping this manually...

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
