### PR TITLE
Fix race condition between retry_join and initialize stanza

### DIFF
--- a/changelog/2293.txt
+++ b/changelog/2293.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix race condition between retry_join and initialize stanza that could cause split-brain clusters.
+```

--- a/website/content/docs/configuration/self-init.mdx
+++ b/website/content/docs/configuration/self-init.mdx
@@ -101,6 +101,34 @@ The root token is not returned to the caller and is revoked after use.
 
 :::
 
+## HA Cluster Considerations
+
+When using the `initialize` stanza with [`retry_join`](storage/raft.mdx#retry_join-stanza)
+in a Raft HA cluster, OpenBao will automatically wait for the `retry_join` process
+to potentially succeed before attempting self-initialization. This coordination
+is necessary because `retry_join` runs asynchronously in the background - without
+waiting, a node might self-initialize and create a separate cluster instead of
+joining an existing one.
+
+By default, OpenBao waits up to 30 seconds for a potential cluster join. This can
+be configured using the `OPENBAO_SELF_INIT_RETRY_JOIN_WAIT` environment variable:
+
+```bash
+# Wait up to 60 seconds for retry_join
+export OPENBAO_SELF_INIT_RETRY_JOIN_WAIT=60s
+
+# Disable the wait (not recommended in HA deployments)
+export OPENBAO_SELF_INIT_RETRY_JOIN_WAIT=0s
+```
+
+:::warning
+
+In multi-node deployments, ensure that only the intended leader node runs the
+`initialize` stanza, or stagger the startup of nodes to allow the first node
+to complete initialization before other nodes start.
+
+:::
+
 Multiple `initialize` stanzas may exist and are executed in the order they
 are specified in the configuration file(s). Multiple `request` blocks may
 exist inside a single `initialize` stanza and are executed in the order they


### PR DESCRIPTION
## Description

This PR fixes a race condition between `retry_join` and the `initialize` stanza when deploying OpenBao in HA mode with Raft storage.

**The Problem:**
When `retry_join` is configured alongside an `initialize` stanza, the `InitiateRetryJoin()` function starts a background goroutine that retries joining every 2 seconds. However, the `Initialize()` function (which handles the `initialize` stanza) is called immediately after. If the join hasn't completed yet, the node self-initializes and creates a separate cluster instead of joining the existing one - causing a split-brain scenario.

**The Solution:**
Added coordination logic in `Initialize()` that waits for `retry_join` to potentially succeed before attempting self-initialization:
- Waits up to 30 seconds (configurable via `OPENBAO_SELF_INIT_RETRY_JOIN_WAIT`)
- Exits early if we become initialized by joining a cluster
- Exits early if no leader candidates are reachable (first node scenario)
- Continues waiting if leaders are reachable (they may initialize us)

**Changes:**
- `command/server.go`: Added `hasRetryJoinConfig()`, `waitForRetryJoin()`, and `anyLeaderCandidateReachable()` functions
- `command/server_test.go`: Added unit tests for the new functions
- `website/content/docs/configuration/self-init.mdx`: Documented the HA cluster considerations and environment variable

## Rationale

Resolves: #2274

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.