### PR TITLE
Support BAO_CONFIG_PATH in plugin init (#2164)

### DIFF
--- a/changelog/2164.txt
+++ b/changelog/2164.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command: Support `BAO_CONFIG_PATH` in `plugin init`, just like `server` &c do.
+```

--- a/command/plugin_init.go
+++ b/command/plugin_init.go
@@ -71,6 +71,7 @@ func (c *PluginInitCommand) Flags() *FlagSets {
 
 	f.StringSliceVar(&StringSliceVar{
 		Name:   "config",
+		EnvVar: "BAO_CONFIG_PATH",
 		Target: &c.flagConfigs,
 		Completion: complete.PredictOr(
 			complete.PredictFiles("*.hcl"),

--- a/website/content/docs/commands/plugin/init.mdx
+++ b/website/content/docs/commands/plugin/init.mdx
@@ -36,7 +36,10 @@ The following flags are available in addition to the [standard set of flags](../
 
 ### Command options
 
-- `-config` `(string: required)` - Path to configuration file or directory. Can be specified multiple times.
+- `-config` `(string: required)` - Path to configuration file or directory. Can
+  be specified multiple times. The environment variable `BAO_CONFIG_PATH` may
+  also be used to specify multiple configuration paths using a comma (,) as a
+  separator.
 
 - `-directory` `(string: optional)` - Plugin directory override. Uses `plugin_directory` from config if not specified.
 


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/2164 (clean cherry-pick)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
