### PR TITLE
Fix broken Randomize

### DIFF
--- a/website/content/ecosystem/lib/Randomize.tsx
+++ b/website/content/ecosystem/lib/Randomize.tsx
@@ -1,5 +1,7 @@
 import shuffle from "lodash/shuffle";
+import { Children } from "react";
 
-export default function Randomize(children) {
-  return shuffle(children);
+export default function Randomize({children}) {
+  const items = Children.toArray(children);
+  return shuffle(items);
 }


### PR DESCRIPTION
## Description

The "fix" in 1ed7b7365fc1bde7ce86205e568e54482b89a1c2 (https://github.com/openbao/openbao/pull/2298) to prevent crashes when there is a single child results in no randomization happening when there are multiple children.

So revert the "fix". ~~And comment out Randomize on the integrators page. But keep it around, so that future integrators add it.~~
EDIT: After sleeping over it, I changed this to instead explicitly handle the single-Object case. That seems better, since it allows applying `<Randomize>` to single items, which seems like the better UX for writers.

Sorry for missing this earlier 🙈 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
