### PR TITLE
database/mysql: Add multi-host connection failover support

### DIFF
--- a/changelog/2312.txt
+++ b/changelog/2312.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+database/mysql: Add multi-host connection failover support. Connection URLs can now specify multiple hosts (e.g., `tcp(host1:3306,host2:3306)`) for automatic failover when a host becomes unavailable.
+```

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -10,12 +10,16 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/database/helper/connutil"
@@ -38,6 +42,9 @@ type mySQLConnectionProducer struct {
 
 	// tlsConfigName is a globally unique name that references the TLS config for this instance in the mysql driver
 	tlsConfigName string
+
+	// hosts holds parsed host:port pairs for multi-host failover
+	hosts []string
 
 	RawConfig             map[string]interface{}
 	maxConnectionLifetime time.Duration
@@ -75,6 +82,11 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 		"username": url.PathEscape(c.Username),
 		"password": password,
 	})
+
+	// Parse multi-host DSN for failover support
+	if err := c.parseMultiHostDSN(); err != nil {
+		return nil, fmt.Errorf("error parsing multi-host DSN: %w", err)
+	}
 
 	if c.MaxOpenConnections == 0 {
 		c.MaxOpenConnections = 4
@@ -143,15 +155,29 @@ func (c *mySQLConnectionProducer) Connection(ctx context.Context) (interface{}, 
 		c.db.Close()
 	}
 
-	connURL, err := c.addTLStoDSN()
+	// Parse the DSN into a Config struct
+	config, err := mysql.ParseDSN(c.ConnectionURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to parse connectionURL: %w", err)
 	}
 
-	c.db, err = sql.Open("mysql", connURL)
-	if err != nil {
-		return nil, err
+	// Set TLS config if configured
+	if c.tlsConfigName != "" {
+		config.TLSConfig = c.tlsConfigName
 	}
+
+	// Enable multi-host failover if multiple hosts are configured
+	if len(c.hosts) > 1 {
+		config.DialFunc = c.dialWithFailover
+	}
+
+	// Create connector and open DB using the connector-based approach
+	connector, err := mysql.NewConnector(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create mysql connector: %w", err)
+	}
+
+	c.db = sql.OpenDB(connector)
 
 	// Set some connection pool settings. We don't need much of this,
 	// since the request rate shouldn't be high.
@@ -218,16 +244,71 @@ func (c *mySQLConnectionProducer) getTLSAuth() (tlsConfig *tls.Config, err error
 	return tlsConfig, nil
 }
 
-func (c *mySQLConnectionProducer) addTLStoDSN() (connURL string, err error) {
-	config, err := mysql.ParseDSN(c.ConnectionURL)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse connectionURL: %s", err)
+// parseMultiHostDSN extracts multiple hosts from connection URL for failover.
+func (c *mySQLConnectionProducer) parseMultiHostDSN() error {
+	// Match tcp(...) in the connection URL
+	re := regexp.MustCompile(`tcp\(([^)]+)\)`)
+	match := re.FindStringSubmatch(c.ConnectionURL)
+
+	if match == nil {
+		// No tcp() found - could be unix socket or other format
+		// Leave hosts empty, single-host behavior will be used
+		return nil
 	}
 
-	if len(c.tlsConfigName) > 0 {
-		config.TLSConfig = c.tlsConfigName
+	hostsPart := match[1]
+
+	// Check if there are multiple hosts (comma-separated)
+	if !strings.Contains(hostsPart, ",") {
+		// Single host - ensure it has a port, store it, and return
+		host := strings.TrimSpace(hostsPart)
+		if _, _, err := net.SplitHostPort(host); err != nil {
+			host += ":3306"
+		}
+		c.hosts = []string{host}
+		return nil
 	}
 
-	connURL = config.FormatDSN()
-	return connURL, nil
+	// Multiple hosts found - parse each one
+	hostList := strings.Split(hostsPart, ",")
+	c.hosts = make([]string, 0, len(hostList))
+
+	for _, h := range hostList {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+		// Ensure each host has a port
+		if _, _, err := net.SplitHostPort(h); err != nil {
+			h += ":3306"
+		}
+		c.hosts = append(c.hosts, h)
+	}
+
+	if len(c.hosts) == 0 {
+		return errors.New("no valid hosts found in connection URL")
+	}
+
+	// Normalize the ConnectionURL to use only the first host
+	// This is required because mysql.ParseDSN() doesn't support multiple hosts
+	c.ConnectionURL = re.ReplaceAllString(c.ConnectionURL, fmt.Sprintf("tcp(%s)", c.hosts[0]))
+
+	return nil
+}
+
+// dialWithFailover tries each host in sequence until one succeeds.
+func (c *mySQLConnectionProducer) dialWithFailover(ctx context.Context, network, _ string) (conn net.Conn, err error) {
+	var merr *multierror.Error
+
+	for _, host := range c.hosts {
+		var d net.Dialer
+
+		conn, err = d.DialContext(ctx, network, host)
+		if err == nil {
+			return conn, nil
+		}
+		merr = multierror.Append(merr, fmt.Errorf("failed to connect to %s: %w", host, err))
+	}
+
+	return nil, merr.ErrorOrNil()
 }

--- a/plugins/database/mysql/connection_producer_test.go
+++ b/plugins/database/mysql/connection_producer_test.go
@@ -19,59 +19,6 @@ import (
 	dockertest "github.com/ory/dockertest/v3"
 )
 
-func Test_addTLStoDSN(t *testing.T) {
-	type testCase struct {
-		rootUrl        string
-		tlsConfigName  string
-		expectedResult string
-	}
-
-	tests := map[string]testCase{
-		"no tls, no query string": {
-			rootUrl:        "user:password@tcp(localhost:3306)/test",
-			tlsConfigName:  "",
-			expectedResult: "user:password@tcp(localhost:3306)/test",
-		},
-		"tls, no query string": {
-			rootUrl:        "user:password@tcp(localhost:3306)/test",
-			tlsConfigName:  "tlsTest101",
-			expectedResult: "user:password@tcp(localhost:3306)/test?tls=tlsTest101",
-		},
-		"tls, query string": {
-			rootUrl:        "user:password@tcp(localhost:3306)/test?foo=bar",
-			tlsConfigName:  "tlsTest101",
-			expectedResult: "user:password@tcp(localhost:3306)/test?tls=tlsTest101&foo=bar",
-		},
-		"tls, query string, ? in password": {
-			rootUrl:        "user:pa?ssword?@tcp(localhost:3306)/test?foo=bar",
-			tlsConfigName:  "tlsTest101",
-			expectedResult: "user:pa?ssword?@tcp(localhost:3306)/test?tls=tlsTest101&foo=bar",
-		},
-		"tls, valid tls parameter in query string": {
-			rootUrl:        "user:password@tcp(localhost:3306)/test?tls=true",
-			tlsConfigName:  "",
-			expectedResult: "user:password@tcp(localhost:3306)/test?tls=true",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			tCase := mySQLConnectionProducer{
-				ConnectionURL: test.rootUrl,
-				tlsConfigName: test.tlsConfigName,
-			}
-
-			actual, err := tCase.addTLStoDSN()
-			if err != nil {
-				t.Fatalf("error occurred in test: %s", err)
-			}
-			if actual != test.expectedResult {
-				t.Fatalf("generated: %s, expected: %s", actual, test.expectedResult)
-			}
-		})
-	}
-}
-
 func TestInit_clientTLS(t *testing.T) {
 	t.Skip("Skipping this test because CircleCI can't mount the files we need without further investigation: " +
 		"https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-mount-volumes-to-docker-containers-")
@@ -309,5 +256,91 @@ func writeFile(t *testing.T, filename string, data []byte, perms os.FileMode) {
 	err := os.WriteFile(filename, data, perms)
 	if err != nil {
 		t.Fatalf("Unable to write to file [%s]: %s", filename, err)
+	}
+}
+
+func Test_parseMultiHostDSN(t *testing.T) {
+	type testCase struct {
+		connectionURL         string
+		expectedHosts         []string
+		expectedConnectionURL string
+	}
+
+	tests := map[string]testCase{
+		"single host": {
+			connectionURL:         "user:password@tcp(localhost:3306)/test",
+			expectedHosts:         []string{"localhost:3306"},
+			expectedConnectionURL: "user:password@tcp(localhost:3306)/test",
+		},
+		"multiple hosts": {
+			connectionURL:         "user:password@tcp(host1:3306,host2:3307)/test",
+			expectedHosts:         []string{"host1:3306", "host2:3307"},
+			expectedConnectionURL: "user:password@tcp(host1:3306)/test",
+		},
+		"multiple hosts without ports": {
+			connectionURL:         "user:password@tcp(host1,host2)/test",
+			expectedHosts:         []string{"host1:3306", "host2:3306"},
+			expectedConnectionURL: "user:password@tcp(host1:3306)/test",
+		},
+		"unix socket": {
+			connectionURL:         "user:password@unix(/var/run/mysqld/mysqld.sock)/test",
+			expectedHosts:         nil,
+			expectedConnectionURL: "user:password@unix(/var/run/mysqld/mysqld.sock)/test",
+		},
+		"multiple hosts with tls param": {
+			connectionURL:         "user:password@tcp(host1:3306,host2:3307)/test?tls=skip-verify",
+			expectedHosts:         []string{"host1:3306", "host2:3307"},
+			expectedConnectionURL: "user:password@tcp(host1:3306)/test?tls=skip-verify",
+		},
+		"ipv6 single host": {
+			connectionURL:         "user:password@tcp([::1]:3306)/test",
+			expectedHosts:         []string{"[::1]:3306"},
+			expectedConnectionURL: "user:password@tcp([::1]:3306)/test",
+		},
+		"ipv6 without port": {
+			connectionURL:         "user:password@tcp([::1])/test",
+			expectedHosts:         []string{"[::1]:3306"},
+			expectedConnectionURL: "user:password@tcp([::1])/test",
+		},
+		"ipv6 multiple hosts": {
+			connectionURL:         "user:password@tcp([::1]:3306,[::2]:3307)/test",
+			expectedHosts:         []string{"[::1]:3306", "[::2]:3307"},
+			expectedConnectionURL: "user:password@tcp([::1]:3306)/test",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			producer := &mySQLConnectionProducer{
+				ConnectionURL: test.connectionURL,
+			}
+
+			err := producer.parseMultiHostDSN()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !reflect.DeepEqual(producer.hosts, test.expectedHosts) {
+				t.Fatalf("hosts: got %v, expected %v", producer.hosts, test.expectedHosts)
+			}
+
+			if producer.ConnectionURL != test.expectedConnectionURL {
+				t.Fatalf("connectionURL: got %s, expected %s", producer.ConnectionURL, test.expectedConnectionURL)
+			}
+		})
+	}
+}
+
+func Test_dialWithFailover(t *testing.T) {
+	producer := &mySQLConnectionProducer{
+		hosts: []string{"invalid-host-1:3306", "invalid-host-2:3306"},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	_, err := producer.dialWithFailover(ctx, "tcp", "ignored")
+	if err == nil {
+		t.Fatal("expected error when connecting to invalid hosts")
 	}
 }

--- a/website/content/docs/secrets/databases/mysql-maria.mdx
+++ b/website/content/docs/secrets/databases/mysql-maria.mdx
@@ -96,6 +96,22 @@ the proper permission, it can generate credentials.
    username           v_openbaouser_my-role_crBWVqVh2Hc1
    ```
 
+## Multi-host connection failover
+
+You can specify multiple hosts in the `connection_url` for failover. Separate
+them with commas inside `tcp()` — if a host is unreachable, the next one is tried:
+
+```shell-session
+$ bao write database/config/my-mysql-database \
+    plugin_name=mysql-database-plugin \
+    connection_url="{{username}}:{{password}}@tcp(mysql1:3306,mysql2:3306,mysql3:3306)/mydb" \
+    allowed_roles="my-role" \
+    username="openbaouser" \
+    password="openbaopass"
+```
+
+Hosts without an explicit port default to `3306`.
+
 ## Client x509 certificate authentication
 
 This plugin supports using MySQL's [x509 Client-side Certificate Authentication](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html#using-encrypted-connections-client-side-configuration)


### PR DESCRIPTION
## Description

  Add support for multiple hosts in MySQL connection URL for automatic failover.

  Format: `tcp(host1:3306,host2:3306)/dbname`

## Rationale

  Resolves: #2311

## Acknowledgements

 - [ X ] By contributing this change, I certify I have not used generative AI (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [ X ] By contributing this change, I certify I have signed-off on the [DCO ownership](https://developercertificate.org/) statement and this change did not use post-BUSL-licensed code from HashiCorp. Existing MPL-licensed code is still allowed, subject to attribution. Code authored by yourself and submitted to HashiCorp for inclusion is also allowed.
