### PR TITLE
Add Percona to OpenBao ecosystem as Integrator

### DIFF
--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -11,6 +11,9 @@ import Member from './lib/Member.tsx';
 <div className="container">
 <div className="row">
 <Randomize>
+  <Member title="Percona">
+    [Percona](https://percona.com/) provides OpenBao integration for managing encryption keys in Percona Server for MongoDB and PostgreSQL Transparent Data Encryption (pg_tde).
+  </Member>
   <Member title="Securosys">
     [Securosys](https://www.securosys.com/) Primus HSM provides hardware-backed sealing for OpenBao Vaults.
   </Member>


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Adding Percona (percona.com) as an integrator to the OpenBao ecosystem

## Rationale

Percona provides Data at Rest encryption in Percona Server for MongoDB and pg_tde extension to PostgreSQL - both projects integrate well with OpenBao for managing encryption keys.

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
