### PR TITLE
Update nominated TSC representatives for GitLab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | James Butcher    | james@iotechsys.com       |                                            | Brad Corrion (brad@iotechsys.com)               | IOTech Systems       | Member       |
 | Julian Cassignol | jcassignol@wallix.com     |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
 | Michael Hofer    | michael.hofer@adfinis.com | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Member       |
-| Alexander Scheel | ascheel@gitlab.com        | [@cipherboy](https://github.com/cipherboy) | Ken McDonald (kmcdonald@gitlab.com)             | GitLab               | Chair        |
+| Maw Wildpaner    | maw@gitlab.com            |                                            | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
 | Klaus Kiefer     | klaus.kiefer@sap.com      | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
 
 To view the process for joining the TSC, see [GOVERNANCE.md](GOVERNANCE.md) in


### PR DESCRIPTION
## Description

The TSC representatives for GitLab has changed and need to be updated accordingly.

## Rationale

Ensure the relevant contacts and members are kept up to date.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
