### PR TITLE
Fix incorrectly returned leader nodes from read replicas (#2331)

### DIFF
--- a/changelog/2331.txt
+++ b/changelog/2331.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: return correct raft leader id from read replica nodes when using `bao operator raft list-peers`
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1406,13 +1406,13 @@ func (b *RaftBackend) GetConfiguration(ctx context.Context) (*RaftConfigurationR
 		Index: future.Index(),
 	}
 
+	_, leader := b.raft.LeaderWithID()
+
 	for _, server := range future.Configuration().Servers {
 		entry := &RaftServer{
-			NodeID:  string(server.ID),
-			Address: string(server.Address),
-			// Since we only service this request on the active node our node ID
-			// denotes the raft leader.
-			Leader:          string(server.ID) == b.NodeID(),
+			NodeID:          string(server.ID),
+			Address:         string(server.Address),
+			Leader:          server.ID == leader,
 			Voter:           server.Suffrage == raft.Voter,
 			ProtocolVersion: strconv.Itoa(raft.ProtocolVersionMax),
 		}


### PR DESCRIPTION
Backport of: #2331

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
