### PR TITLE
Add PR Merge Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,9 @@ component-a/subcomponent-alpha  @alpha-team
 In a PR that only changes `component-a/subcomponent-alpha/`, you will need a
 review from the `alpha-team`, but not from the `a-team`.
 
+This rules should reflect the [documented bahaviour of
+GitHub][github-about-code-owners].
+
 ### OpenBao UI
 
 How you contribute to the UI depends on what you want to contribute. If that is
@@ -290,3 +293,4 @@ following steps listed in the README, under the section [Developing OpenBao][1].
 
 [1]: https://github.com/openbao/openbao#developing-openbao
 [2]: https://github.com/openbao/openbao/discussions
+[github-about-code-owners]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection


### PR DESCRIPTION
As discussed in the DEV WG meeting (Jan 22nd 2026)

Preview: https://github.com/adfinis-forks/openbao/blob/pr-merge-policy/CONTRIBUTING.md#merge-policy

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
