### PR TITLE
Fix RabbitMQ test flake

### DIFF
--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -44,7 +44,7 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "docker.mirror.hashicorp.services/library/rabbitmq",
-		ImageTag:      "3-management",
+		ImageTag:      "4-management",
 		ContainerName: "rabbitmq",
 		Ports:         []string{"15672/tcp"},
 	})
@@ -240,9 +240,9 @@ func testAccStepReadCreds(t *testing.T, b logical.Backend, uri, name string) log
 				t.Fatal(err)
 			}
 
-			_, err = client.ListVhosts()
+			_, err = client.ListQueues()
 			if err != nil {
-				t.Fatalf("unable to list vhosts with generated credentials: %s", err)
+				t.Fatalf("unable to list queues with generated credentials: %s", err)
 			}
 
 			resp, err = b.HandleRequest(context.Background(), &logical.Request{
@@ -268,9 +268,9 @@ func testAccStepReadCreds(t *testing.T, b logical.Backend, uri, name string) log
 				t.Fatal(err)
 			}
 
-			_, err = client.ListVhosts()
+			_, err = client.ListQueues()
 			if err == nil {
-				t.Fatalf("expected to fail listing vhosts: %s", err)
+				t.Fatalf("expected to fail listing queues: %s", err)
 			}
 
 			return nil


### PR DESCRIPTION
## Description

Fixes the RabbitMQ test flake we've seen recently, e.g. here:
https://github.com/openbao/openbao/actions/runs/21173874251/job/60897441391

## Rationale

Bit of a weird one. Every now and then, `/api/vhosts` will return a JSON structure like so:

```json
[
  {
    "cluster_info": []
  }
]
```

instead of the expected structure:

```json
[
  {
    "cluster_info": {
      "rabbitmq@rabbitmq": "running"
    }
  }
]
```

The Go client expects a `map[string]string`, and will fail to unmarshal if the empty array is encountered.

I'm assuming this occurs because of a startup race within the RabbitMQ instance, though it is not clear to me how to fix it as the API is clearly responsive, and that is all we need to run the test.

Two fixes I'm applying here:

1. Upgrade to RabbitMQ v4, which seems to work OOTB. I haven't been able to locally reproduce the flake with v4, though I couldn't find a changelog entry on this bug being fixed, and I'm having trouble traversing the Erlang source code, so not sure this is enough and doesn't just reduce the likelihood.
2. Switch to listing queues instead of vhosts, this is equivalent for purposes of the tests as they only check for authentication and ignore the return value of the operation itself.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
