### PR TITLE
Fix error logging during auth when there are no trustedChains

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -310,7 +310,7 @@ func (b *backend) verifyCredentials(ctx context.Context, req *logical.Request, d
 	// If no trusted chain was found, client is not authenticated
 	// This check happens after checking for a matching configured non-CA certs
 	if len(trustedChains) == 0 {
-		if retErr == nil {
+		if retErr != nil {
 			return nil, logical.ErrorResponse("invalid certificate or no client certificate supplied; additionally got errors during verification: %v", retErr), nil
 		}
 		return nil, logical.ErrorResponse("invalid certificate or no client certificate supplied"), nil


### PR DESCRIPTION
## Description

Was setting up mTLS auth and wondered why I got this error:
```
invalid certificate or no client certificate supplied; additionally got errors during verification: <nil>
```

Checking the code it seems a `err != nil` was accidentally inverted. The bug didn't shadow any error I should have gotten (for some reason my trustedChains is just empty), but it will definitely ruin somebody else's day.

I hope the info I provided is enough for a small fix like this :-)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
