### PR TITLE
docs: remove https://openbao.org from links

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -5163,7 +5163,7 @@ This endpoint creates or updates the CEL role definition.
 - `name` `(string: <required>)` - Specifies the name of the CEL role to create. This
   is part of the request URL.
 - `cel_program` `(CelProgram: <required>)` - Specifies the CEL Variable list and main 
-  CEL expression. Refer to https://openbao.org/docs/secrets/pki/cel for more 
+  CEL expression. Refer to [Quick Start - CEL in PKI](/docs/secrets/pki/cel) for more 
   information about how to contruct the CEL program correctly.
 
 #### Sample payload

--- a/website/content/blog/2024-07-25-release-v2-0-0.md
+++ b/website/content/blog/2024-07-25-release-v2-0-0.md
@@ -9,7 +9,7 @@ image: https://lfedge.org/wp-content/uploads/sites/24/2024/07/Screenshot-2024-07
 
 ![openbao-logo](https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-text-color.svg)
 
-We are thrilled to announce the availability of [OpenBao v2.0.0](https://openbao.org/docs/release-notes/2-0-0/), its initial GA release!
+We are thrilled to announce the availability of [OpenBao v2.0.0](/docs/release-notes/2-0-0/), its initial GA release!
 
 It was fabulous to see contributors and member companies from a wide range of backgrounds come together to support OpenBao over the past several months and build an initial GA release in the open. This release focuses mostly on stabilizing the fork, reducing the binary size, and giving the community room to make the decisions it needs to ensure a healthy start to the ecosystem.
 

--- a/website/content/blog/2024-09-23-kickoff.md
+++ b/website/content/blog/2024-09-23-kickoff.md
@@ -13,15 +13,15 @@ We asked one of our Gen Z community members to describe OpenBao recently. They w
 
 > <p align="center"><img src="https://raw.githubusercontent.com/openbao/artwork/main/color/openbao-color.svg" alt="OpenBao Logo" height="30%" width="30%" /></p>
 >
-> See the three bao representing different [auth](https://openbao.org/docs/auth/) and [secret](https://openbao.org/docs/secrets/) [engines](https://openbao.org/docs/plugins/) or nodes in a [cluster](https://openbao.org/docs/concepts/ha/)? Very _cutesy_.
+> See the three bao representing different [auth](/docs/auth/) and [secret](/docs/secrets/) [engines](/docs/plugins/) or nodes in a [cluster](/docs/concepts/ha/)? Very _cutesy_.
 >
-> See how secrets can be [dynamically](https://openbao.org/docs/use-cases/#dynamic-secrets) [rotated](https://openbao.org/docs/secrets/databases/)? Very _considerate_.
+> See how secrets can be [dynamically](/docs/use-cases/#dynamic-secrets) [rotated](/docs/secrets/databases/)? Very _considerate_.
 >
 > See our project running under [open governance](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md#technical-steering-committee-tsc-members) and with [OSI licenses](https://github.com/openbao/openbao/blob/main/LICENSE)? Very _mindful_.
 >
-> See us promise [API compatibility](https://openbao.org/docs/policies/migration/#proposal) with drop-in compatibility for Raft users? Very _respectful_.
+> See us promise [API compatibility](/docs/policies/migration/#proposal) with drop-in compatibility for Raft users? Very _respectful_.
 >
-> See all of the nicely packaged [release binaries](https://openbao.org/downloads/) ready for [installation](https://openbao.org/docs/install/)? [Very _demure_](https://www.nytimes.com/2024/08/14/style/demure-tiktok-mindful-cutesy.html).
+> See all of the nicely packaged [release binaries](/downloads/) ready for [installation](/docs/install/)? [Very _demure_](https://www.nytimes.com/2024/08/14/style/demure-tiktok-mindful-cutesy.html).
 
 ---
 

--- a/website/content/blog/2024-09-27-profiles.md
+++ b/website/content/blog/2024-09-27-profiles.md
@@ -4,7 +4,7 @@ description: A server-side request framework might alleviate some need for a new
 slug: profiles
 authors: cipherboy
 tags: [technical, plugins, core]
-image: https://openbao.org/img/how-openbao-works.png
+image: /img/how-openbao-works.png
 ---
 
 OpenBao and upstream [lack server-side cross-pluign communication](https://github.com/hashicorp/vault/issues/21023#issuecomment-1579232437).

--- a/website/content/blog/2024-10-16-transactions.md
+++ b/website/content/blog/2024-10-16-transactions.md
@@ -7,13 +7,13 @@ tags: [technical, storage, core]
 image: https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-text-color.svg
 ---
 
-Recently we merged the last of the [transactional storage](https://openbao.org/docs/rfcs/transactions/) [pull requests](https://github.com/openbao/openbao/pull/262), including [PostgreSQL support](https://github.com/openbao/openbao/pull/608)!
+Recently we merged the last of the [transactional storage](/docs/rfcs/transactions/) [pull requests](https://github.com/openbao/openbao/pull/262), including [PostgreSQL support](https://github.com/openbao/openbao/pull/608)!
 
 <!-- truncate -->
 
-Previously, upstream's storage model was built on [four basic operations](https://github.com/openbao/openbao/blob/2cb5d444b26cfdc79d814f9696c7f68f9c43606f/sdk/logical/storage.go#L31-L38): `Get(...)`, `Put(...)`, `List(...)`, and `Delete(...)`. Ahead of [OpenBao's initial v2.0.0 GA release](https://openbao.org/docs/release-notes/2-0-0/), we added support for a fifth operation, [paginated list's](https://openbao.org/docs/rfcs/paginated-lists/) `ListPage(...)`. Each of these operations were individually atomic, in that they either succeeded or erred with no change for a partial change.
+Previously, upstream's storage model was built on [four basic operations](https://github.com/openbao/openbao/blob/2cb5d444b26cfdc79d814f9696c7f68f9c43606f/sdk/logical/storage.go#L31-L38): `Get(...)`, `Put(...)`, `List(...)`, and `Delete(...)`. Ahead of [OpenBao's initial v2.0.0 GA release](/docs/release-notes/2-0-0/), we added support for a fifth operation, [paginated list's](/docs/rfcs/paginated-lists/) `ListPage(...)`. Each of these operations were individually atomic, in that they either succeeded or erred with no change for a partial change.
 
-However, there were no consistency guarantees across storage operations: two parallel requests coming into the same plugin could result in silently conflicting storage operations. For example, [in the PKI engine](https://openbao.org/docs/secrets/pki/), fetching the default issuer (certificate authority) required at least the following reads:
+However, there were no consistency guarantees across storage operations: two parallel requests coming into the same plugin could result in silently conflicting storage operations. For example, [in the PKI engine](/docs/secrets/pki/), fetching the default issuer (certificate authority) required at least the following reads:
 
  - [`/config/issuers`](https://github.com/openbao/openbao/blob/2cb5d444b26cfdc79d814f9696c7f68f9c43606f/builtin/logical/pki/storage.go#L1099-L1114) to resolve the value of `default`, and
  - [`/config/issuer/:id`](https://github.com/openbao/openbao/blob/2cb5d444b26cfdc79d814f9696c7f68f9c43606f/builtin/logical/pki/storage.go#L658-L678) to read the actual default issuer.
@@ -24,7 +24,7 @@ Transactions fix this and allow a plugin to have a consistent view of storage an
 
 Transactions also let us make several incremental design improvements: previously only single entries had consistency guarantees so the mount table had to fit within a single storage entry. Now, we can [split the mount table](https://github.com/openbao/openbao/issues/432) into separate entries and use transactions to have durable, safe modifications to these entries.
 
-Implementing transactions had several design challenges: The HashiCorp Raft implementation had no native support for transactions, so we needed to figure out how to reconcile this with the underlying operation log. We opted to put all commits (with write operations) on the log, regardless of if they'd conflict, allowing all nodes to verify the consistency of the transaction. Further, PostgreSQL's internal locking [means that two transactions cannot be executed from the same thread](https://stackoverflow.com/questions/32255557/postgresql-hang-forever-on-serializable-transaction). This forced us to loosen up some of our transaction semantic testing, to ensure we remain compatible with both implementations. If you're interested in the exact details [be sure to check out the RFC](https://openbao.org/docs/rfcs/transactions/).
+Implementing transactions had several design challenges: The HashiCorp Raft implementation had no native support for transactions, so we needed to figure out how to reconcile this with the underlying operation log. We opted to put all commits (with write operations) on the log, regardless of if they'd conflict, allowing all nodes to verify the consistency of the transaction. Further, PostgreSQL's internal locking [means that two transactions cannot be executed from the same thread](https://stackoverflow.com/questions/32255557/postgresql-hang-forever-on-serializable-transaction). This forced us to loosen up some of our transaction semantic testing, to ensure we remain compatible with both implementations. If you're interested in the exact details [be sure to check out the RFC](/docs/rfcs/transactions/).
 
 Most importantly, we're excited about the possibilities that safer, more durable storage semantics bring!
 

--- a/website/content/blog/2024-10-24-mentees-first-week.md
+++ b/website/content/blog/2024-10-24-mentees-first-week.md
@@ -6,7 +6,7 @@ authors: FattiesPatties
 tags:  [mentee]
 ---
 
-![openbao-mentee-doodle](https://openbao.org/img/mentee-blog.png)
+![openbao-mentee-doodle](/img/mentee-blog.png)
 
 ## My Journey Begins
 Hey everyone! I’m Fatima and I’m excited to share how my OpenBao journey started! I had been working on app development but was eager to break into the cybersecurity world. So I browsed through various open-source projects and stumbled upon OpenBao. The project’s purpose caught my interest and, of course, the little bao mascot sealed the deal so I decided to dive in and set it up.

--- a/website/content/blog/2024-10-27-transaction-details.md
+++ b/website/content/blog/2024-10-27-transaction-details.md
@@ -9,14 +9,14 @@ image: https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/o
 
 ## Overview
 
-OpenBao, like its upstream, favors the [`raft` internal storage engine](https://openbao.org/docs/configuration/storage/raft).
+OpenBao, like its upstream, favors the [`raft` internal storage engine](/docs/configuration/storage/raft).
 While more complex than relying on a database for replication, this storage
 engine allows us to have lower latency on read operations, because it uses
 a [local K/V implementation](https://github.com/etcd/bbolt) based on [B+-trees](https://en.wikipedia.org/wiki/B%2B_tree). For workloads
 with low writes but high reads (typical of most uses of K/V secrets), this
 trade off allows for the best performance.
 
-An earlier [blog post](https://openbao.org/blog/transactions) talked about the availability of
+An earlier [blog post](/blog/transactions) talked about the availability of
 transactions in the [`main` branch](https://github.com/openbao/openbao/tree/main), this post will focus on
 the technical details of implementing transactions.
 
@@ -156,7 +156,7 @@ performance discrepancies via [GitHub issue][file-issue].
 [raft-fsm]: https://github.com/openbao/openbao/blob/c9201295ed833b431249f4592f32b1946b69f263/physical/raft/fsm.go
 [storage-write]: https://github.com/openbao/openbao/blob/c9201295ed833b431249f4592f32b1946b69f263/physical/raft/raft.go#L1523-L1553
 [storage-read]: https://github.com/openbao/openbao/blob/c9201295ed833b431249f4592f32b1946b69f263/physical/raft/raft.go#L1493-L1521
-[transaction-rfc]: https://openbao.org/docs/rfcs/transactions/
+[transaction-rfc]: /docs/rfcs/transactions/
 [bbolt-txn]: https://pkg.go.dev/go.etcd.io/bbolt#Tx
 [bbolt-txn-limits]: https://pkg.go.dev/go.etcd.io/bbolt#pkg-overview
 [txn-commit]: https://github.com/openbao/openbao/blob/c9201295ed833b431249f4592f32b1946b69f263/physical/raft/transaction.go#L610-L722

--- a/website/content/blog/2024-11-29-release-v2-1-0.md
+++ b/website/content/blog/2024-11-29-release-v2-1-0.md
@@ -8,7 +8,7 @@ tags: [release, announcement, release]
 
 ![openbao-logo](https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-text-color.svg)
 
-We are thrilled to announce [the availability](https://openbao.org/downloads/?version=v2.1.0) of [OpenBao v2.1.0](https://openbao.org/docs/release-notes/2-1-0/), focused on safety and scalability improvements!
+We are thrilled to announce [the availability](/downloads/?version=v2.1.0) of [OpenBao v2.1.0](/docs/release-notes/2-1-0/), focused on safety and scalability improvements!
 
 This release spent some time laying the groundwork for safety and scalability improvements for releases to come. With the help of the community, OpenBao will now take advantage of transactional storage semantics from its underlying data store, giving operators and plugin developers confidence in the consistency of storage writes. This storage safety allows us to focus on alternative storage layouts for improving scalability, for instance, increasing the maximum number of mount table entries past the single-entry limit.
 

--- a/website/content/blog/2024-12-11-rfcs-dec-2024.md
+++ b/website/content/blog/2024-12-11-rfcs-dec-2024.md
@@ -32,7 +32,7 @@ The second half of 2024 saw several fabulous RFCs from different contributors to
 
 ### [openbao#549 / vault#5275 - Recursively List Keys](https://github.com/openbao/openbao/issues/549)
 
-**Description**: The [most widely requested Vault feature](https://github.com/hashicorp/vault/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) with no solution [is adding the ability to recursively list keys](https://github.com/hashicorp/vault/issues/5275). Prior to [transactions](https://openbao.org/docs/rfcs/transactions/) (for consistency) and [pagination](https://openbao.org/docs/rfcs/paginated-lists/) (for resource constraining expensive calls), this was hard to do safely. This RFC proposes introducing a new operation, with HTTP verb `SCAN` or via `GET` with `?scan=true`, and ACL capability (`scan`) to allow plugin authors to introduce recursive list endpoints and operators to secure access to them.
+**Description**: The [most widely requested Vault feature](https://github.com/hashicorp/vault/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) with no solution [is adding the ability to recursively list keys](https://github.com/hashicorp/vault/issues/5275). Prior to [transactions](/docs/rfcs/transactions/) (for consistency) and [pagination](/docs/rfcs/paginated-lists/) (for resource constraining expensive calls), this was hard to do safely. This RFC proposes introducing a new operation, with HTTP verb `SCAN` or via `GET` with `?scan=true`, and ACL capability (`scan`) to allow plugin authors to introduce recursive list endpoints and operators to secure access to them.
 
 **How you can help**: After the initial implementation is merged, it would be great to have feedback or PRs on additional endpoints to use this new operation.
 
@@ -46,7 +46,7 @@ The second half of 2024 saw several fabulous RFCs from different contributors to
 
 ### [openbao#296 - Transactional Storage](https://github.com/openbao/openbao/issues/432)
 
-**Description**: Recently merged and released in [v2.1.0](https://openbao.org/docs/release-notes/2-1-0/) was support for transactional storage across the entire OpenBao stack (from underlying physical storage backend to plugins). This allowed us to [improve the scalability](https://github.com/openbao/openbao/issues/432) and fault-tolerance of OpenBao above and beyond what HashiCorp Vault had.
+**Description**: Recently merged and released in [v2.1.0](/docs/release-notes/2-1-0/) was support for transactional storage across the entire OpenBao stack (from underlying physical storage backend to plugins). This allowed us to [improve the scalability](https://github.com/openbao/openbao/issues/432) and fault-tolerance of OpenBao above and beyond what HashiCorp Vault had.
 
 **How you can help**: A follow-up [tracking issue](https://github.com/openbao/openbao/issues/607) invites contributions of places where transactions should be used. As always, we welcome testing of this feature.
 

--- a/website/content/blog/2025-01-16-fosdem.md
+++ b/website/content/blog/2025-01-16-fosdem.md
@@ -4,7 +4,7 @@ description: "OpenBao will be at FOSDEM '25 and SOOC '25 next month"
 slug: fosdem-25
 authors: cipherboy
 tags: [community, conferences, stickers]
-image: https://openbao.org/img/bao-mascot.jpg
+image: /img/bao-mascot.jpg
 ---
 
 ![openbao-mascot](/img/bao-mascot.jpg)

--- a/website/content/blog/2025-01-31-bao-at-fosdem.md
+++ b/website/content/blog/2025-01-31-bao-at-fosdem.md
@@ -4,7 +4,7 @@ description: "OpenBao's travels to FOSDEM '25"
 slug: bao-at-fosdem-25
 authors: cipherboy
 tags: [community, conferences, stickers]
-image: https://openbao.org/img/baobao-fosdem-25-airplane.jpg
+image: /img/baobao-fosdem-25-airplane.jpg
 ---
 
 Follow along with OpenBao's travels this week as we attend FOSDEM '25 and
@@ -22,7 +22,7 @@ If you can't attend in person, it will also be [live streamed](https://live.fosd
 
 ![BaoBao-Departs-via-Airplane](/img/baobao-fosdem-25-airplane.jpg)
 
-From snowy Minnesota, [BaoBao](https://openbao.org/blog/fosdem-25/) took its
+From snowy Minnesota, [BaoBao](/blog/fosdem-25/) took its
 first ride to London Heathrow to begin its voyage to FOSDEM '25. With a brief
 layover, it explored King's Cross and the Coal Drops Yard. Rich with history,
 this area has long been used as a rail hub for the UK and now is connected to

--- a/website/content/blog/2025-02-07-bao-back-home.md
+++ b/website/content/blog/2025-02-07-bao-back-home.md
@@ -4,7 +4,7 @@ description: "OpenBao's travels back home"
 slug: bao-back-home
 authors: cipherboy
 tags: [community, conferences, stickers]
-image: https://openbao.org/img/alex-fosdem-25-speaking.jpg
+image: /img/alex-fosdem-25-speaking.jpg
 ---
 
 OpenBao returns from FOSDEM '25 and OpenUK's State of Open Con this week,

--- a/website/content/blog/2025-05-30-namespaces-announcement.md
+++ b/website/content/blog/2025-05-30-namespaces-announcement.md
@@ -24,7 +24,7 @@ Namespaces enable secure multi-tenancy. Each tenant (e.g., team, organisation, o
 
 Furthermore, namespaces enable the delegation of administration and promote self-service. Namespace admins can manage their own policies, secret engines, auth modes, or even quotas, without impacting other tenants, reducing the burden on cluster-level operators.
 
-Finally, namespaces are one of a few planned stepping stones towards OpenBao's [horizontal scalability](https://openbao.org/blog/vision-for-namespaces/) journey. OpenBao aims to allow support for large deployments with many infrequently accessed mounts, without overloading cluster nodes, while keeping a simpler cluster topology.
+Finally, namespaces are one of a few planned stepping stones towards OpenBao's [horizontal scalability](/blog/vision-for-namespaces/) journey. OpenBao aims to allow support for large deployments with many infrequently accessed mounts, without overloading cluster nodes, while keeping a simpler cluster topology.
 
 ## How to use Namespaces
 
@@ -149,7 +149,7 @@ While we have many plans on extending namespace capabilities in the future to ma
 
 Namespaces will give organisations the possibility to better structure and isolate secret information. However, the introduction of namespaces is just the first step. Our vision includes supporting _lazy loading_ of namespaces and mounts, allowing OpenBao clusters to efficiently serve workloads with many infrequently accessed resources. This will enable even greater scalability and resilience, as nodes will no longer need to load the entire system state at once. 
 
-[Here](https://openbao.org/blog/vision-for-namespaces/) is another article that you can read more about OpenBaos' scalability efforts. Sounds interesting? Reach out to the project via [Github](https://github.com/orgs/openbao/discussions), [Zulip](https://github.com/openbao#contact), or [Mailinglist](https://lists.openssf.org/g/openbao) if you want to support our work in the areas of namespaces or scalability.
+[Here](/blog/vision-for-namespaces/) is another article that you can read more about OpenBaos' scalability efforts. Sounds interesting? Reach out to the project via [Github](https://github.com/orgs/openbao/discussions), [Zulip](https://github.com/openbao#contact), or [Mailinglist](https://lists.openssf.org/g/openbao) if you want to support our work in the areas of namespaces or scalability.
 
 ## Get Started
 

--- a/website/content/blog/2025-08-28-openbao-oss-europe-2025-wrap.md
+++ b/website/content/blog/2025-08-28-openbao-oss-europe-2025-wrap.md
@@ -21,4 +21,4 @@ Throughout the conference, we shared how OpenBao is able to help organizations t
 
 Furthermore, the conference was also a wonderful opportunity for OpenBao maintainers to meet in person, exchange ideas, and align on next steps. A big thank you goes to [**Adfinis**](https://adfinis.com/), [**Paymenttools**](https://www.paymenttools.com/) and [**Reply**](https://www.reply.com/), who supported the project by sending maintainers to represent OpenBao on-site.
 
-And finally, a heartfelt thanks to everyone who stopped by, joined discussions, or offered feedback. Your energy and curiosity keep the project moving forward. To everyone who was not able to join the conference, feel free to learn more at [**openbao.org**](https://openbao.org/docs/contributing/) or join the conversation on [**GitHub**](https://github.com/openbao).
+And finally, a heartfelt thanks to everyone who stopped by, joined discussions, or offered feedback. Your energy and curiosity keep the project moving forward. To everyone who was not able to join the conference, feel free to learn more at [**openbao.org**](/docs/contributing/) or join the conversation on [**GitHub**](https://github.com/openbao).

--- a/website/content/docs/rfcs/cel-jwt.mdx
+++ b/website/content/docs/rfcs/cel-jwt.mdx
@@ -111,9 +111,9 @@ The CEL expression itself may return one of the following:
 
 ## Rationale and alternatives
 
-Dynamic policy assignment can be implemented using templating for [ACLs](https://openbao.org/api-docs/auth/jwt/#acl-policy-templating-examples), but the expressiveness of CEL is much greater.
+Dynamic policy assignment can be implemented using templating for [ACLs](/api-docs/auth/jwt/#acl-policy-templating-examples), but the expressiveness of CEL is much greater.
 
-Some form CEL or regex evaluation could be added to existing role instead of creating a new type, as with [glob matching](https://openbao.org/api-docs/auth/jwt/#createupdate-role) for `bound_claims`. 
+Some form CEL or regex evaluation could be added to existing role instead of creating a new type, as with [glob matching](/api-docs/auth/jwt/#createupdate-role) for `bound_claims`. 
 
 Alternatively, a web hook approach like [Vault's CIEPS](https://developer.hashicorp.com/vault/docs/secrets/pki/cieps) could be used to achieve similar flexibility. However, the performance implications and system brittleness make this an unattractive alternative.
 

--- a/website/content/docs/rfcs/cel-pki.mdx
+++ b/website/content/docs/rfcs/cel-pki.mdx
@@ -238,13 +238,13 @@ the others.
 
 **Generate Certificate and Key**
 * This endpoint generates a new set of credentials (private key and certificate) based on the policy named in the endpoint. 
-It takes in a set of parameters  like `common_name`, `alt_names`, &c similar to [pki/issue/:name](https://openbao.org/api-docs/secret/pki/#generate-certificate-and-key).
+It takes in a set of parameters  like `common_name`, `alt_names`, &c similar to [pki/issue/:name](/api-docs/secret/pki/#generate-certificate-and-key).
 The issuing CA certificate and full CA chain is returned as well, so that only the root CA need be in a client's trust store. 
 Choice of issuing CA is determined by the policy.
 
 **Sign Certificate**
 * This endpoint signs a new certificate based upon the provided `CSR` and the supplied parameters (like `common_name`, 
-`alt_names`, &c similar to [pki/sign/:name](https://openbao.org/api-docs/secret/pki/#sign-certificate)), subject to the 
+`alt_names`, &c similar to [pki/sign/:name](/api-docs/secret/pki/#sign-certificate)), subject to the 
 restrictions contained in the policy named in the endpoint. The issuing CA certificate and the full CA chain is returned 
 as well, so that only the root CA need be in a client's trust store.
 
@@ -254,7 +254,7 @@ _Access to these endpoints should be managed via ACLs. For instance, admin roles
 
 ## Rationale and alternatives
 
-Certain policies can be implemented using [roles](https://openbao.org/api-docs/secret/pki/#createupdate-role), 
+Certain policies can be implemented using [roles](/api-docs/secret/pki/#createupdate-role), 
 for instance, `allow_localhost` but for more flexible scenarios, such as validating specific request 
 metadata, or generating custom certificate templates based on runtime parameters, CEL policies would 
 provide the necessary adaptability and control. For example, a CEL policy could enforce a rule that 

--- a/website/content/docs/rfcs/inline-auth.mdx
+++ b/website/content/docs/rfcs/inline-auth.mdx
@@ -21,15 +21,15 @@ login requests.
 
 Authentication is one of the few non-scalable requests in OpenBao; while
 [theoretical work to allow per-namespace storage and active leader
-designation](https://openbao.org/blog/vision-for-namespaces/) would allow
-scaling, this still requires all login requests be processed by the active
-leader. Certain access patterns, such as listing or reading from K/V or
-issuing certificates without storing, are otherwise broadly horizontally
-scalable. Furthermore, sometimes this authentication is discarded; such as
-when fetching secrets from a CI/CD pipeline, each pipeline run will start
-with a fresh token as usually authentication is tied to some parent JWT and
-no authentication information or secrets are persisted across runs, usually
-due to lack of persistent, secure storage and reproducibility.
+designation](/blog/vision-for-namespaces/) would allow scaling, this still
+requires all login requests be processed by the active leader. Certain access
+patterns, such as listing or reading from K/V or issuing certificates without
+storing, are otherwise broadly horizontally scalable. Furthermore, sometimes
+this authentication is discarded; such as when fetching secrets from a CI/CD
+pipeline, each pipeline run will start with a fresh token as usually
+authentication is tied to some parent JWT and no authentication information or
+secrets are persisted across runs, usually due to lack of persistent, secure
+storage and reproducibility.
 
 Scaling login requests thus becomes important depending on the workload
 patterns.

--- a/website/content/docs/rfcs/postgresql.mdx
+++ b/website/content/docs/rfcs/postgresql.mdx
@@ -35,7 +35,7 @@ an understanding of the different environments OpenBao might run in:
     not granted _migration_ rights?
  5. How does OpenBao interact with a replicated PostgreSQL cluster or database
     proxies such as PgBouncer, especially in a future with [horizontal
-    scalability](https://openbao.org/blog/vision-for-namespaces/)?
+    scalability](/blog/vision-for-namespaces/)?
 
 Some of these are dependent on understanding the environment OpenBao is
 running in and the expected workloads attached to it. For this, we seek to
@@ -225,7 +225,7 @@ enforce a new minimum. Whether this will have `ha_enabled=true` by
 default will be up for discussion then.
 
 We should document that we do not intend to add the PostgreSQL
-equivalent of the [`sys/storage/raft/snapshot`](https://openbao.org/api-docs/system/storage/raft/#take-a-snapshot-of-the-raft-cluster)
+equivalent of the [`sys/storage/raft/snapshot`](/api-docs/system/storage/raft/#take-a-snapshot-of-the-raft-cluster)
 endpoint, and instead should rely on native, database-level [backup andd
 restore procedures](https://www.postgresql.org/docs/current/backup.html).
 This will be possible and durable especially after the remaining work

--- a/website/content/docs/rfcs/ssh-ca-multi-issuer.mdx
+++ b/website/content/docs/rfcs/ssh-ca-multi-issuer.mdx
@@ -12,7 +12,7 @@ OpenBao’s SSH engine is limited to one Certificate Authority (CA) issuer per m
 
 ### Problem Statement
 
-OpenBao’s current SSH engine design imposes limitations by allowing only one Certificate Authority (CA) issuer per mount. This restriction complicates the key rotation process, an important feature for security and operational continuity. To perform key rotation, new SSH mounts must be created, which necessitates duplicating all existing configurations (roles, ACLs, etc.) and updating all references to the new mounts or swapping the old and the new mount points via [two move operations](https://openbao.org/api-docs/system/remount/). This is not only time-consuming but prone to misconfigurations and errors.
+OpenBao’s current SSH engine design imposes limitations by allowing only one Certificate Authority (CA) issuer per mount. This restriction complicates the key rotation process, an important feature for security and operational continuity. To perform key rotation, new SSH mounts must be created, which necessitates duplicating all existing configurations (roles, ACLs, etc.) and updating all references to the new mounts or swapping the old and the new mount points via [two move operations](/api-docs/system/remount/). This is not only time-consuming but prone to misconfigurations and errors.
 
 While an alternative approach–deleting and recreating the CA issuer within an existing mount–can be used, it introduces significant risks. During the gap between deleting the old key and creating a new one, any requests for issuing access certificates fail. If the import or generation of a new CA issuer fails, this leads to service disruption. Even if the new key is created quickly, it lacks trust, as it is a fresh random key that cannot be cross-signed like in PKI. The key distribution process to all hosts is not instantaneous, leaving a window where authentication requests will fail.
 
@@ -42,11 +42,11 @@ To allow a pre-submitted CA to be used once this feature is released, the values
 **Endpoints**
 
 With this new "system", the existing endpoints to configure a CA cannot exist anymore in their current form so have to be updated. The following details which endpoints will be updated and how:
-- [Create/Update Role](https://openbao.org/api-docs/secret/ssh/#createupdate-role) (`POST ssh/roles/:name`): A new parameter `issuer_ref` added so operations performed through the role use the selected CA’s key material. If not set, `default` will be assumed. The CA can be referenced by name or ID.
-- [Delete CA Information](https://openbao.org/api-docs/secret/ssh/#delete-ca-information) (`DELETE ssh/config/ca`): Removes all pre-submitted/generated issuers, including the one referenced as `default`.
-- [Submit CA Information](https://openbao.org/api-docs/secret/ssh/#submit-ca-information) (`POST ssh/config/ca`): Creates a new CA’s configuration and set it as ‘default’. If another key is selected as ‘default’, it will be replaced.
-- [Read public key (Authenticated)](https://openbao.org/api-docs/secret/ssh/#read-public-key-authenticated) (`GET /ssh/config/ca`): Returns the `default` issuer's unique identifier, public_key and optional name. If a default isn't configured, a `400` response is returned.
-- [Read public key (Unauthenticated)](https://openbao.org/api-docs/secret/ssh/#read-public-key-unauthenticated) (`GET /ssh/public_key`) - Returns the `default` issuer's configured/generated public key in plain text.
+- [Create/Update Role](/api-docs/secret/ssh/#createupdate-role) (`POST ssh/roles/:name`): A new parameter `issuer_ref` added so operations performed through the role use the selected CA’s key material. If not set, `default` will be assumed. The CA can be referenced by name or ID.
+- [Delete CA Information](/api-docs/secret/ssh/#delete-ca-information) (`DELETE ssh/config/ca`): Removes all pre-submitted/generated issuers, including the one referenced as `default`.
+- [Submit CA Information](/api-docs/secret/ssh/#submit-ca-information) (`POST ssh/config/ca`): Creates a new CA’s configuration and set it as ‘default’. If another key is selected as ‘default’, it will be replaced.
+- [Read public key (Authenticated)](/api-docs/secret/ssh/#read-public-key-authenticated) (`GET /ssh/config/ca`): Returns the `default` issuer's unique identifier, public_key and optional name. If a default isn't configured, a `400` response is returned.
+- [Read public key (Unauthenticated)](/api-docs/secret/ssh/#read-public-key-unauthenticated) (`GET /ssh/public_key`) - Returns the `default` issuer's configured/generated public key in plain text.
 
 The following added:
 
@@ -54,8 +54,8 @@ The following added:
 - Read Default CA Configuration (`GET /ssh/config/issuers`): Returns the 'default' issuer, if configured.
 - List CA (`LIST /ssh/issuers`): This endpoint returns a list of all issuers in the mount, including their name and UUID.
 - Update CA (`POST /ssh/issuer/:issuer_ref`): This endpoint accepts an additional `issuer_ref` parameter to modify the CA name reference.
-- Read CA (`GET /ssh/issuer/:issuer_ref`): This is an extension of the existing ‘[Read Public Key (Authenticated)](https://openbao.org/api-docs/secret/ssh/#read-public-key-authenticated)’ endpoint but accepts the name of the CA from which the name, identifier and public key will be returned. If no `issuer_ref` is provided, the default CA is returned.
-- Read CA public key (`GET /ssh/issuer/:issuer_ref/public_key`): This is an extension of the existing ‘[Read public key (Unauthenticated)](https://openbao.org/api-docs/secret/ssh/#read-public-key-unauthenticated)’ endpoint but expects a reference of the CA from which public key, in plain text, will be returned.
+- Read CA (`GET /ssh/issuer/:issuer_ref`): This is an extension of the existing ‘[Read Public Key (Authenticated)](/api-docs/secret/ssh/#read-public-key-authenticated)’ endpoint but accepts the name of the CA from which the name, identifier and public key will be returned. If no `issuer_ref` is provided, the default CA is returned.
+- Read CA public key (`GET /ssh/issuer/:issuer_ref/public_key`): This is an extension of the existing ‘[Read public key (Unauthenticated)](/api-docs/secret/ssh/#read-public-key-unauthenticated)’ endpoint but expects a reference of the CA from which public key, in plain text, will be returned.
 - Delete CA (`DELETE ssh/issuer/:issuer_ref`): Given an `issuer_ref`, either CA’s name or ID, deletes a CA’s configuration. A warning will be issued if it’s set as default and referenced by a role.
 - Submit CA with Name (`POST /ssh/issuers/import/:issuer_name`): This is an extension of the ‘Submit CA Information’ endpoint but accepts an optional `issuer_name` parameter so the CA information has a name reference.
 

--- a/website/content/docs/rfcs/standby-nodes-handle-read-requests.mdx
+++ b/website/content/docs/rfcs/standby-nodes-handle-read-requests.mdx
@@ -191,11 +191,10 @@ Without horizontal read scaling, large organizations will continue hitting singl
 
 ### Related Issues
 
-- https://github.com/openbao/openbao/issues/1462
-- https://github.com/openbao/openbao/issues/38
-- https://github.com/openbao/openbao/issues/569
-
-- https://openbao.org/blog/vision-for-namespaces/
+- [Add Performance Replication to the stack #1462](https://github.com/openbao/openbao/issues/1462)
+- [Feature request: disaster recovery replication #38](https://github.com/openbao/openbao/issues/38)
+- [2024-2025 Project Direction & Roadmap #569](https://github.com/openbao/openbao/issues/569)
+- [Blog "Vision for Namespaces, Horizontal Scalability"](/blog/vision-for-namespaces/)
 
 ### Proof of Concept / Related PRs
 


### PR DESCRIPTION

## Description

remove the `https://openbao.org` prefix from internal links

## Rationale

1. Docusaurus will open "external" links in a new tab and will consider all "fully qualified" links to be external.
1. When you make changes locally, links and images don't load from the production website, but your local dev server.
1. Most places already use this format -> make it consistent


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
