### PR TITLE
Forward secret mount disable request

### DIFF
--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1045,7 +1045,7 @@ func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, upda
 		// Update the mount table
 		if err := c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to taint entry in mounts table", "error", err)
-			return logical.CodedError(500, "failed to taint entry in mounts table")
+			return logical.CodedError(500, "failed to taint entry in mounts table: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Description
In a horizontal scalability setup, `logical.ShouldForward(err)` checks whether passed error contains any of following errors:
- `ErrPerfStandbyPleaseForward`
- `ErrReadOnly`
- `ErrStandby`
- "node is not the leader"

the secrets unmount function failed on persisting the taint of the mount entry with `ErrReadOnly` error (on the standby), which did not result in forwarding of the request because of the error not "bubbling up" in the error chain, this PR adds proper error wrap.

## Rationale
In multi-node (standy) nodes responding to read request setup
```
bao secrets enable kv-v2 (on any node)
bao secrets disable kv-v2 (on standby node)

Error disabling secrets engine at kv-v2/: Error making API request.

URL: DELETE http://127.0.0.1:8300/v1/sys/mounts/kv-v2
Code: 400. Errors:

* failed to taint entry in mounts table
```
after the update it properly gets forwarded to the active node

Resolves: [discussion on zulip](https://linuxfoundation.zulipchat.com/#narrow/channel/530381-openssf-openbao-support/topic/Read.20Replica.202.2E5.2E0.20prerelease/with/570551618)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
