### PR TITLE
Fix cross namespace identity corrupts data (#2321)

### DIFF
--- a/changelog/2321.txt
+++ b/changelog/2321.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: fix corrupt data being stored when referencing `member_group_ids` across namespaces (requires `unsafe_cross_namespace_identity=true`)
+```

--- a/vault/external_tests/identity/cross_namespace_test.go
+++ b/vault/external_tests/identity/cross_namespace_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"testing"
+
+	vaulthttp "github.com/openbao/openbao/http"
+	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnsafeCrossNamespaceIdentity(t *testing.T) {
+	cases := []struct {
+		parentNamespaced, childNamespaced bool
+	}{
+		{
+			parentNamespaced: true,
+			childNamespaced:  true,
+		}, {
+			parentNamespaced: true,
+			childNamespaced:  false,
+		}, {
+			parentNamespaced: false,
+			childNamespaced:  true,
+		}, {
+			parentNamespaced: false,
+			childNamespaced:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		name := ""
+		if tc.parentNamespaced {
+			name += "parent_namespaced"
+		} else {
+			name += "parent_root"
+		}
+		if tc.childNamespaced {
+			name += "_child_namespaced"
+		} else {
+			name += "_child_root"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			coreConfig := &vault.CoreConfig{
+				UnsafeCrossNamespaceIdentity: true,
+				LogLevel:                     "debug",
+			}
+			cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+				HandlerFunc: vaulthttp.Handler,
+				NumCores:    2,
+			})
+			cluster.Start()
+			defer cluster.Cleanup()
+
+			core := cluster.Cores[0].Core
+			vault.TestWaitActive(t, core)
+			client := cluster.Cores[0].Client
+			client.SetCheckRedirect(nil)
+
+			// create data
+
+			t.Log("creating namespace")
+			_, err := client.Logical().Write("sys/namespaces/test", map[string]any{})
+			require.NoError(t, err)
+
+			client.SetCloneToken(true)
+
+			parentClient, err := client.Clone()
+			require.NoError(t, err)
+			if tc.parentNamespaced {
+				parentClient.SetNamespace("test")
+			}
+
+			childClient, err := client.Clone()
+			require.NoError(t, err)
+			if tc.childNamespaced {
+				childClient.SetNamespace("test")
+			}
+
+			t.Log("creating child")
+			resp, err := childClient.Logical().Write("identity/group", map[string]any{
+				"name": "child",
+				"type": "external",
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			childId := resp.Data["id"]
+			t.Logf("childId: %q", childId)
+
+			t.Log("creating parent")
+			resp, err = parentClient.Logical().Write("identity/group", map[string]any{
+				"name":             "parent",
+				"type":             "internal",
+				"member_group_ids": childId,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			parentId := resp.Data["id"]
+			t.Logf("parentId: %q", parentId)
+
+			// verify
+
+			verify := func() {
+				resp, err = childClient.Logical().Read("identity/group/name/child")
+
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.NotNil(t, resp.Data)
+
+				parentGroupIDs := resp.Data["parent_group_ids"]
+				require.NotNil(t, parentGroupIDs)
+
+				require.ElementsMatch(t, parentGroupIDs, []any{parentId})
+
+				resp, err = parentClient.Logical().Read("identity/group/name/parent")
+
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.NotNil(t, resp.Data)
+
+				memberGroupIDs := resp.Data["member_group_ids"]
+				require.NotNil(t, memberGroupIDs)
+
+				require.ElementsMatch(t, memberGroupIDs, []any{childId})
+			}
+
+			t.Log("verify")
+			verify()
+
+			// transfer leadership
+
+			require.NoError(t, client.Sys().StepDown())
+			t.Log("wait active again")
+			vault.TestWaitActive(t, cluster.Cores[1].Core)
+
+			// verify again
+
+			t.Log("verify after leadership transfer")
+			verify()
+		})
+	}
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1593,6 +1593,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.RollbackPeriod = base.RollbackPeriod
 		coreConfig.PendingRemovalMountsAllowed = base.PendingRemovalMountsAllowed
 		coreConfig.ExpirationRevokeRetryBase = base.ExpirationRevokeRetryBase
+		coreConfig.UnsafeCrossNamespaceIdentity = base.UnsafeCrossNamespaceIdentity
 		testApplyEntBaseConfig(coreConfig, base)
 	}
 	if coreConfig.ClusterName == "" {


### PR DESCRIPTION
Backport of #2321, mostly a clean cherry-pick, with a trivial merge conflict in `vault/testing.go` 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
