### PR TITLE
Fix race condition in `Core.reloadMountInternal`

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -328,6 +328,10 @@ func (c *Core) removeCredEntry(ctx context.Context, path string, updateStorage b
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
+	return c.removeCredEntryWithLock(ctx, path, updateStorage)
+}
+
+func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateStorage bool) error {
 	// Taint the entry from the auth table
 	newTable := c.auth.shallowClone()
 	entry, err := newTable.remove(ctx, path)

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -341,10 +341,14 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 					require.NoError(collect, err)
 				}, 20*time.Second, 10*time.Millisecond)
 
-				secret, err := client.Logical().Write("auth/"+pluginPath+"/role/role1/secret-id", nil)
-				if err != nil {
-					t.Fatal(err)
-				}
+				var (
+					secret *api.Secret
+					err    error
+				)
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+					secret, err = client.Logical().Write("auth/"+pluginPath+"/role/role1/secret-id", nil)
+					require.NoError(collect, err)
+				}, 20*time.Second, 10*time.Millisecond)
 				secretID := secret.Data["secret_id"].(string)
 
 				secret, err = client.Logical().Read("auth/" + pluginPath + "/role/role1/role-id")


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This fixes a race condition in `Core.reloadMountInternal`, which if called concurrently, can make decisions based on stale router data.

It happens due to no locking between
https://github.com/openbao/openbao/blob/251a8318219e009424757fd8e9263c81901d3f72/vault/mount.go#L2601
and e.g.
https://github.com/openbao/openbao/blob/251a8318219e009424757fd8e9263c81901d3f72/vault/mount.go#L2636

If the router data is changed in the meantime, the function will take the wrong branch, resulting in trying to create a mount entry twice and erroring.

## Rationale

Fixes the root cause of flaky test failures such as
- https://github.com/openbao/openbao/actions/runs/21404624126/job/61710614593
- https://github.com/openbao/openbao/actions/runs/21354580909/job/61459003167

~Note: this is currently based on top of #2226 due to the introduction of `Core.enableCredentialInternalWithLock` and `mountInternalWithLock` and will be rebased to main, once #2226 is merged.~

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
