### PR TITLE
feat: add loading and error indicator to downloads page

### DIFF
--- a/changelog/2365.txt
+++ b/changelog/2365.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+website: Add loading and error indicators to downloads page
+```


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This PR improves the user experience when trying to download OpenBao from the official website.

When navigating to the `/downloads` page from the home page, the GitHub API takes a few seconds to return the available releases and leaves the impression to the user that the actual downloads page is located somewhere else.


Loading:

<img width="1008" height="950" alt="image" src="https://github.com/user-attachments/assets/6d3a65b7-4298-4938-9719-8fee5241085a" />


Error:

<img width="960" height="630" alt="image" src="https://github.com/user-attachments/assets/dbba39ef-c0dd-4e7a-b8a5-cc5249f9b213" />



<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2364

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
