### PR TITLE
Drop github.com/openbao/go-kms-wrapping/entropy/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -319,7 +319,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
-	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0 // indirect
 	github.com/openbao/openbao/api/auth/kubernetes/v2 v2.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0 h1:f+OX5kI8KLPYhzRhqhQTQPashOx5SxPaWtd24hoT5vo=
-github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0/go.mod h1:2ZTItykGc/yQcdNfyK2TPBYKlOibfwSPr7ugFyqGXlI=
 github.com/openbao/go-kms-wrapping/v2 v2.6.0 h1:W8QuKJc6mMo+HNrs9PfkiI/vh8a6LdVLEX5JqXSRFE0=
 github.com/openbao/go-kms-wrapping/v2 v2.6.0/go.mod h1:xoUdq1btm4MNgwBpMkVLvXxuvnH4gGzODozWGFpft8w=
 github.com/openbao/go-kms-wrapping/wrappers/aead/v2 v2.3.0 h1:4nrE306wqZAKP/EUkrwA8LcnqpJbPDir+EZBxeOQBSM=

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openbao/go-kms-wrapping/entropy/v2"
-
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
@@ -401,14 +399,8 @@ func (b *Backend) Setup(ctx context.Context, config *logical.BackendConfig) erro
 	return nil
 }
 
-// GetRandomReader returns an io.Reader to use for generating key material in
-// backends. If the backend has access to an external entropy source it will
-// return that, otherwise it returns crypto/rand.Reader.
+// GetRandomReader returns crypto/rand.Reader.
 func (b *Backend) GetRandomReader() io.Reader {
-	if sourcer, ok := b.System().(entropy.Sourcer); ok {
-		return entropy.NewReader(sourcer)
-	}
-
 	return rand.Reader
 }
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/moby/go-archive v0.1.0
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.2.1
-	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0
 	github.com/openbao/go-kms-wrapping/v2 v2.6.0
 	github.com/openbao/openbao/api/v2 v2.5.0
 	github.com/ryanuber/go-glob v1.0.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -235,8 +235,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0 h1:f+OX5kI8KLPYhzRhqhQTQPashOx5SxPaWtd24hoT5vo=
-github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0/go.mod h1:2ZTItykGc/yQcdNfyK2TPBYKlOibfwSPr7ugFyqGXlI=
 github.com/openbao/go-kms-wrapping/v2 v2.6.0 h1:W8QuKJc6mMo+HNrs9PfkiI/vh8a6LdVLEX5JqXSRFE0=
 github.com/openbao/go-kms-wrapping/v2 v2.6.0/go.mod h1:xoUdq1btm4MNgwBpMkVLvXxuvnH4gGzODozWGFpft8w=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
## Description

Drop github.com/openbao/go-kms-wrapping/entropy/v2 from the SDK.

## Rationale

This was used by Vault Enterprise to augment entropy used for key generation by sourcing additional entropy from KMSes (As far as I understand).

- We do not break SDK compatibility by removing it, as this could never be used by plugins that are not built-in.
- We have not received a single request for this feature
- If we wanted to implement this feature in the future, we would likely revise the mechanism regardless, as we have been with other KMS-related functionality.

This will also let us drop the entire entropy module from go-kms-wrapping and clean that repository up some more.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
