### PR TITLE
Website: Fix typo in bao cli examples

### DIFF
--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -77,8 +77,8 @@ has a number of parameters to further configure a connection.
 
 If using the OpenBao CLI, it's probably easiest to write the JSON to a file and then reference the file:
 
-```shell
-openbao write database/config/cassandra-example <...other fields> pem_json=@/path/to/file.json
+```shell-session
+$ bao write database/config/cassandra-example <...other fields> pem_json=@/path/to/file.json
 ```
 
 </details>

--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -125,7 +125,7 @@ $ curl \
 ### Sample CLI request
 
 ```shell-session
-$ openbao write database/config/mysql \
+$ bao write database/config/mysql \
     plugin_name="mysql-database-plugin" \
     allowed_roles="readonly" \
     connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
@@ -136,7 +136,7 @@ $ openbao write database/config/mysql \
 ### Sample CLI request with ADO-style connection string
 
 ```shell-session
-$ openbao write database/config/mysql \
+$ bao write database/config/mysql \
     plugin_name="mysql-database-plugin" \
     connection_url='server=localhost;port=3306;user id={{username}};password={{password}};database=mysql;' \
     username="openbaouser" \

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -303,7 +303,7 @@ Creates, updates, or deletes a dynamic role.
 
 The `POST` endpoint allows for partial updates of existing roles. If a role exists and a `POST` request is made
 against it, only the keys specified in the request will be updated. To delete a value, specify the key with an
-empty string as the value. Example: `openbao write ldap/role/myrole default_ttl=""`
+empty string as the value. Example: `bao write ldap/role/myrole default_ttl=""`
 
 #### Parameters
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -198,8 +198,8 @@ an authenticated OpenBao client will need to [fetch a new EAB
 token](#get-acme-eab-binding-token). This returns two values: a key identifier
 and an HMAC key used by the ACME client to authenticate with EAB. For example:
 
-```
-$ openbao write -f /pki/acme/new-eab
+```shell-session
+$ bao write -f /pki/acme/new-eab
 $ certbot certonly --server https://localhost:8200/v1/pki/acme/directory \
                    --eab-kid <id> --eab-hmac-key <hmac-key>
 ```
@@ -231,8 +231,8 @@ to be specified by [mount tuning](../system/mounts.mdx#tune-mount-configuration)
 
 On an existing mount, these can be specified by running the following command:
 
-```
-$ openbao secrets tune -allowed-response-headers=Location -allowed-response-headers=Replay-Nonce \
+```shell-session
+$ bao secrets tune -allowed-response-headers=Location -allowed-response-headers=Replay-Nonce \
                      -allowed-response-headers=Link \
                      pki/
 ```
@@ -3866,7 +3866,7 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
 
 - `generate_lease` `(bool: false)` - Specifies if certificates issued/signed
   against this role will have OpenBao leases attached to them. Certificates can be
-  added to the CRL by `openbao revoke <lease_id>` when certificates are associated
+  added to the CRL by `bao revoke <lease_id>` when certificates are associated
   with leases. It can also be done using the `pki/revoke` endpoint. However,
   when lease generation is disabled, invoking `pki/revoke` would be the only way
   to add the certificates to the CRL. When large number of certificates are

--- a/website/content/api-docs/secret/rabbitmq.mdx
+++ b/website/content/api-docs/secret/rabbitmq.mdx
@@ -68,7 +68,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-$ openbao write rabbitmq/config/connection \
+$ bao write rabbitmq/config/connection \
     connection_uri="http://localhost:8080" \
     username="user" \
     password="password" \
@@ -118,7 +118,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-$ openbao write rabbitmq/config/lease \
+$ bao write rabbitmq/config/lease \
     ttl=1800 \
     max_ttl=3600
 ```
@@ -199,7 +199,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-$ openbao write rabbitmq/roles/my-role \
+$ bao write rabbitmq/roles/my-role \
     tags="tag1,tag2" \
     vhosts="..." \
     vhost_topics="..."
@@ -236,7 +236,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-$ openbao read rabbitmq/roles/my-role
+$ bao read rabbitmq/roles/my-role
 ```
 
 </TabItem>
@@ -283,7 +283,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-openbao delete rabbitmq/roles/my-role
+$ bao delete rabbitmq/roles/my-role
 ```
 
 </TabItem>
@@ -318,7 +318,7 @@ $ curl \
 <TabItem value="CLI" heading="CLI">
 
 ```shell-session
-$ openbao read rabbitmq/creds/my-role
+$ bao read rabbitmq/creds/my-role
 ```
 
 </TabItem>

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -1003,7 +1003,7 @@ This endpoints returns a specific issuer's public key. This in an unauthenticate
 :::warning
 
 Note: this is a raw response endpoint without JSON encoding; use
-   `openbao read -format=raw` or an external tool (e.g., `curl`) to fetch this
+   `bao read -format=raw` or an external tool (e.g., `curl`) to fetch this
    value.
 
 :::
@@ -1072,7 +1072,7 @@ This is an unauthenticated endpoint.
 :::warning
 
 Note: this is a raw response endpoint without JSON encoding; use
-   `openbao read -format=raw` or an external tool (e.g., `curl`) to fetch this
+   `bao read -format=raw` or an external tool (e.g., `curl`) to fetch this
    value.
 
 :::

--- a/website/content/api-docs/system/policies-password.mdx
+++ b/website/content/api-docs/system/policies-password.mdx
@@ -48,7 +48,7 @@ generation times.
 
 **cURL:**
 
-```shell
+```shell-session
 $ cat payload.json
 {
   "policy": "length = 20\nrule \"charset\" {\n  charset = \"abcde\"\n}\n"
@@ -63,14 +63,14 @@ $ curl \
 
 **OpenBao CLI:**
 
-```shell
+```shell-session
 $ cat my-policy.hcl
 length = 20
 rule "charset" {
     charset = "abcde"
 }
 
-$ openbao write sys/policies/password/my-policy policy=@my-policy.hcl
+$ bao write sys/policies/password/my-policy policy=@my-policy.hcl
 ```
 
 ## List password policies
@@ -84,7 +84,7 @@ This endpoints list the password policies.
 
 ### Sample request
 
-```shell
+```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
     --request LIST \
@@ -125,7 +125,7 @@ This endpoint retrieves information about the named password policy.
 
 ### Sample request
 
-```shell
+```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
     http://127.0.0.1:8200/v1/sys/policies/password/my-policy
@@ -157,7 +157,7 @@ default behavior).
 
 ### Sample request
 
-```shell
+```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE
@@ -179,7 +179,7 @@ This endpoint generates a password from the specified existing password policy.
 
 ### Sample request
 
-```shell
+```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
     http://127.0.0.1:8200/v1/sys/policies/password/my-policy/generate

--- a/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
@@ -21,12 +21,12 @@ Exec into the OpenBao pod:
 kubectl exec -it openbao-0 -- /bin/sh
 ```
 
-If you didn't set `server.dev.enabled=true`, you'll need to log in to OpenBao first using `openbao login`.
+If you didn't set `server.dev.enabled=true`, you'll need to log in to OpenBao first using `bao login`.
 Then run the following commands to configure the Kubernetes Auth Method:
 
 ```bash
-openbao auth enable kubernetes
-openbao write auth/kubernetes/config \
+bao auth enable kubernetes
+bao write auth/kubernetes/config \
     kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 ```
 

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -189,7 +189,7 @@ plugins for the credential types they support and usage examples.
 Passwords are generated via [Password Policies](../../concepts/password-policies.mdx).
 Databases can optionally set a password policy for use across all roles or at the
 individual role level for that database. For example, each time you call
-`openbao write database/config/my-database` you can specify a password policy for all
+`bao write database/config/my-database` you can specify a password policy for all
 roles using `my-database`. Each database has a default password policy defined as:
 20 characters with at least 1 uppercase character, at least 1 lowercase character,
 at least 1 number, and at least 1 dash character.


### PR DESCRIPTION
## Description

By reading the documentation I saw typos at some examples of the bao cli. This PR changes the snippets by using openbao instead of bao. 

There are no breaking changes only simple typos on the documentation.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
