### PR TITLE
Clean up started external plugins when an error occurs later in the request

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -73,7 +73,7 @@ func (c *Core) enableCredential(ctx context.Context, entry *MountEntry) error {
 }
 
 // enableCredential is used to enable a new credential backend
-func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
+func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, updateStorage bool) (err error) {
 	// Ensure we end the path in a slash
 	if !strings.HasSuffix(entry.Path, "/") {
 		entry.Path += "/"
@@ -170,6 +170,11 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	if backend == nil {
 		return fmt.Errorf("nil backend returned from %q factory", entry.Type)
 	}
+	defer func() {
+		if err != nil {
+			backend.Cleanup(ctx)
+		}
+	}()
 
 	// Check for the correct backend type
 	backendType := backend.Type()

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -666,7 +666,7 @@ func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 	return nil
 }
 
-func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
+func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) (err error) {
 	c.mountsLock.Lock()
 	c.authLock.Lock()
 	locked := true
@@ -756,6 +756,12 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	if backend == nil {
 		return fmt.Errorf("nil backend of type %q returned from creation function", entry.Type)
 	}
+
+	defer func() {
+		if err != nil {
+			backend.Cleanup(ctx)
+		}
+	}()
 
 	// Check for the correct backend type
 	backendType := backend.Type()


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This calls `backend.Cleanup` if an error occurs during `enableCredentialInternal` or `mountInternal`. This will stop and clean up any external plugins that were created during this request.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Forwarding requests from read replicas works currently by trying to write to local storage first and then, if an error occurs, forward it to the leader. If a read replica receives a mount request, it will start the plugin, and if an error occurs, forwards the request. That leaves the plugin process still running, and can be observed in tests by running

```
gotestsum --format=testname ./vault/external_tests/plugin -run '^TestExternalPlugin_AuthMethod$'
```

After finishing (even successfully), you can still see the zombie processes running:

```
ps | grep vault-plugin
51410 ttys000    0:00.05 /private/var/folders/qt/k902my_s6y19_fkrzf_yd83r0000gn/T/633506120/vault-plugin-auth-approle
51411 ttys000    0:00.05 /private/var/folders/qt/k902my_s6y19_fkrzf_yd83r0000gn/T/633506120/vault-plugin-auth-approle
51412 ttys000    0:00.06 /private/var/folders/qt/k902my_s6y19_fkrzf_yd83r0000gn/T/633506120/vault-plugin-auth-approle
51413 ttys000    0:00.05 /private/var/folders/qt/k902my_s6y19_fkrzf_yd83r0000gn/T/633506120/vault-plugin-auth-approle
```

While it's easy to reproduce this using read replica request forwarding, I believe it is not restricted to that scenario.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
