### PR TITLE
Fix duplicate headers in bao agent re-authentication

### DIFF
--- a/changelog/2373.txt
+++ b/changelog/2373.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/auth: Fix token reissue error with kerberos method
+```


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Bao agent adds the headers to the client on every authentication run, this causes the Kerberos authentication method to fail due to a duplicated authentication header. Headers are also added on indefinitely leading to increasing memory usage on each re-authentication run

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2372

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
