### PR TITLE
Add StackHPC as an OpenBao integrator

### DIFF
--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -22,6 +22,10 @@ import Member from './lib/Member.tsx';
       [Crypto4A's](https://crypto4a.com/) QxVault™ is a fully integrated Secrets Management Vault with a built-in HSM
       for robust management of secrets, credentials, and API keys.
   </Member>
+
+  <Member title="StackHPC">
+    [StackHPC](https://www.stackhpc.com/) integrates OpenBao with OpenStack deployments, to provide TLS encryption for internal communication and to act as a secret store for users of the cloud.
+  </Member>
 </Randomize>
 </div>
 </div>


### PR DESCRIPTION
## Description

Add StackHPC to the list of integrators on OpenBao's website.

## Rationale

To show support for the OpenBao ecosystem.

Resolves: #

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
