### PR TITLE
Sys `/health`, `/leader` and `/ha-status` responses cleanup

### DIFF
--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -43,12 +43,13 @@ type HealthResponse struct {
 	Initialized                bool   `json:"initialized"`
 	Sealed                     bool   `json:"sealed"`
 	Standby                    bool   `json:"standby"`
-	PerformanceStandby         bool   `json:"performance_standby"`
 	ReplicationPerformanceMode string `json:"replication_performance_mode"`
 	ReplicationDRMode          string `json:"replication_dr_mode"`
 	ServerTimeUTC              int64  `json:"server_time_utc"`
 	Version                    string `json:"version"`
 	ClusterName                string `json:"cluster_name,omitempty"`
 	ClusterID                  string `json:"cluster_id,omitempty"`
-	LastWAL                    uint64 `json:"last_wal,omitempty"`
+	// not present in OpenBao, but left here for compatibility.
+	PerformanceStandby bool   `json:"performance_standby"`
+	LastWAL            uint64 `json:"last_wal,omitempty"`
 }

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -32,10 +32,10 @@ func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
 
 type LeaderResponse struct {
 	HAEnabled            bool      `json:"ha_enabled"`
-	IsSelf               bool      `json:"is_self"`
-	ActiveTime           time.Time `json:"active_time"`
-	LeaderAddress        string    `json:"leader_address"`
-	LeaderClusterAddress string    `json:"leader_cluster_address"`
+	IsSelf               bool      `json:"is_self,omitempty"`
+	ActiveTime           time.Time `json:"active_time,omitzero"`
+	LeaderAddress        string    `json:"leader_address,omitempty"`
+	LeaderClusterAddress string    `json:"leader_cluster_address,omitempty"`
 	RaftCommittedIndex   uint64    `json:"raft_committed_index,omitempty"`
 	RaftAppliedIndex     uint64    `json:"raft_applied_index,omitempty"`
 }

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -96,22 +96,23 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 }
 
 type SealStatusResponse struct {
-	Type             string   `json:"type"`
-	Initialized      bool     `json:"initialized"`
-	Sealed           bool     `json:"sealed"`
-	T                int      `json:"t"`
-	N                int      `json:"n"`
-	Progress         int      `json:"progress"`
-	Nonce            string   `json:"nonce"`
-	Version          string   `json:"version"`
-	BuildDate        string   `json:"build_date"`
-	Migration        bool     `json:"migration"`
-	ClusterName      string   `json:"cluster_name,omitempty"`
-	ClusterID        string   `json:"cluster_id,omitempty"`
-	RecoverySeal     bool     `json:"recovery_seal"`
-	RecoverySealType string   `json:"recovery_seal_type,omitempty"`
-	StorageType      string   `json:"storage_type,omitempty"`
-	Warnings         []string `json:"warnings,omitempty"`
+	Type             string `json:"type"`
+	Initialized      bool   `json:"initialized"`
+	Sealed           bool   `json:"sealed"`
+	T                int    `json:"t"`
+	N                int    `json:"n"`
+	Progress         int    `json:"progress"`
+	Nonce            string `json:"nonce"`
+	Version          string `json:"version"`
+	BuildDate        string `json:"build_date"`
+	Migration        bool   `json:"migration"`
+	ClusterName      string `json:"cluster_name,omitempty"`
+	ClusterID        string `json:"cluster_id,omitempty"`
+	RecoverySeal     bool   `json:"recovery_seal"`
+	RecoverySealType string `json:"recovery_seal_type,omitempty"`
+	StorageType      string `json:"storage_type,omitempty"`
+	// unused in OpenBao, but present for compatibility
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type UnsealOpts struct {

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -124,9 +124,7 @@ Cluster Name                  cluster name
 Cluster ID                    cluster id
 HA Enabled                    true
 Raft Committed Index          3
-Raft Applied Index            4
-Last WAL                      2
-Warnings                      [warning]`
+Raft Applied Index            4`
 
 	if expectedOutputString != output {
 		fmt.Printf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
@@ -152,7 +150,7 @@ Unseal Nonce                  nonce
 Seal Migration in Progress    true
 Version                       version
 Build Date                    build date
-Storage Type                  n/a
+Storage Type                  type
 HA Enabled                    false`
 
 	if expectedOutputString != output {
@@ -184,7 +182,6 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			ClusterID:        "cluster id",
 			RecoverySeal:     true,
 			StorageType:      "storage type",
-			Warnings:         []string{"warning"},
 		}
 
 		// must initialize this struct without explicit field names due to embedding
@@ -195,9 +192,6 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			time.Time{}.UTC(),        // ActiveTime
 			"leader address",         // LeaderAddress
 			"leader cluster address", // LeaderClusterAddress
-			true,                     // PerfStandby
-			1,                        // PerfStandbyLastRemoteWAL
-			2,                        // LastWAL
 			3,                        // RaftCommittedIndex
 			4,                        // RaftAppliedIndex
 		}
@@ -217,7 +211,7 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			ClusterName:      "",
 			ClusterID:        "",
 			RecoverySeal:     true,
-			StorageType:      "",
+			StorageType:      "type",
 		}
 
 		// must initialize this struct without explicit field names due to embedding
@@ -228,9 +222,6 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			time.Time{}.UTC(), // ActiveTime
 			"",                // LeaderAddress
 			"",                // LeaderClusterAddress
-			false,             // PerfStandby
-			0,                 // PerfStandbyLastRemoteWAL
-			0,                 // LastWAL
 			0,                 // RaftCommittedIndex
 			0,                 // RaftAppliedIndex
 		}

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -148,7 +148,7 @@ func TestReadCommand_Run(t *testing.T) {
 		}
 		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		expected := []string{
-			"cluster_id", "cluster_name", "initialized", "performance_standby", "replication_dr_mode", "replication_performance_mode", "sealed",
+			"cluster_id", "cluster_name", "initialized", "replication_dr_mode", "replication_performance_mode", "sealed",
 			"server_time_utc", "standby", "version",
 		}
 		for _, expectedField := range expected {

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -31,7 +31,6 @@ func TestSysHealth_get(t *testing.T) {
 		"initialized":                  false,
 		"sealed":                       true,
 		"standby":                      true,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 501)
 	testResponseBody(t, resp, &actual)
@@ -64,7 +63,6 @@ func TestSysHealth_get(t *testing.T) {
 		"initialized":                  true,
 		"sealed":                       true,
 		"standby":                      true,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 503)
 	testResponseBody(t, resp, &actual)
@@ -101,7 +99,6 @@ func TestSysHealth_get(t *testing.T) {
 		"initialized":                  true,
 		"sealed":                       false,
 		"standby":                      false,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
@@ -143,7 +140,6 @@ func TestSysHealth_customcodes(t *testing.T) {
 		"initialized":                  false,
 		"sealed":                       true,
 		"standby":                      true,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 581)
 	testResponseBody(t, resp, &actual)
@@ -177,7 +173,6 @@ func TestSysHealth_customcodes(t *testing.T) {
 		"initialized":                  true,
 		"sealed":                       true,
 		"standby":                      true,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 523)
 	testResponseBody(t, resp, &actual)
@@ -215,7 +210,6 @@ func TestSysHealth_customcodes(t *testing.T) {
 		"initialized":                  true,
 		"sealed":                       false,
 		"standby":                      false,
-		"performance_standby":          false,
 	}
 	testResponseStatus(t, resp, 202)
 	testResponseBody(t, resp, &actual)

--- a/http/sys_leader_test.go
+++ b/http/sys_leader_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/openbao/openbao/vault"
 )
@@ -24,11 +23,7 @@ func TestSysLeader_get(t *testing.T) {
 
 	var actual map[string]interface{}
 	expected := map[string]interface{}{
-		"ha_enabled":             false,
-		"is_self":                false,
-		"leader_address":         "",
-		"leader_cluster_address": "",
-		"active_time":            time.Time{}.UTC().Format(time.RFC3339),
+		"ha_enabled": false,
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -52,9 +52,8 @@ func (c *Core) Standby() bool {
 
 func (c *Core) ActiveTime() time.Time {
 	c.stateLock.RLock()
-	activeTime := c.activeTime
-	c.stateLock.RUnlock()
-	return activeTime
+	defer c.stateLock.RUnlock()
+	return c.activeTime
 }
 
 // getHAMembers retrieves cluster membership that doesn't depend on raft. This should only ever be called by the

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1278,41 +1278,22 @@ func (b *SystemBackend) statusPaths() []*framework.Path {
 									Required: true,
 								},
 								"is_self": {
-									Type:     framework.TypeBool,
-									Required: true,
+									Type: framework.TypeBool,
 								},
 								"active_time": {
 									Type: framework.TypeTime,
-									// active_time has 'omitempty' tag, but its not a pointer so never "empty"
-									Required: true,
 								},
 								"leader_address": {
-									Type:     framework.TypeString,
-									Required: true,
+									Type: framework.TypeString,
 								},
 								"leader_cluster_address": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-								"performance_standby": {
-									Type:     framework.TypeBool,
-									Required: true,
-								},
-								"performance_standby_last_remote_wal": {
-									Type:     framework.TypeInt64,
-									Required: true,
-								},
-								"last_wal": {
-									Type:     framework.TypeInt64,
-									Required: false,
+									Type: framework.TypeString,
 								},
 								"raft_committed_index": {
-									Type:     framework.TypeInt64,
-									Required: false,
+									Type: framework.TypeInt64,
 								},
 								"raft_applied_index": {
-									Type:     framework.TypeInt64,
-									Required: false,
+									Type: framework.TypeInt64,
 								},
 							},
 						}},
@@ -1351,20 +1332,35 @@ func (b *SystemBackend) statusPaths() []*framework.Path {
 									Required: true,
 								},
 								"t": {
-									Type:     framework.TypeInt,
-									Required: true,
+									Type: framework.TypeInt,
 								},
 								"n": {
-									Type:     framework.TypeInt,
-									Required: true,
+									Type: framework.TypeInt,
 								},
 								"progress": {
-									Type:     framework.TypeInt,
-									Required: true,
+									Type: framework.TypeInt,
 								},
 								"nonce": {
-									Type:     framework.TypeString,
+									Type: framework.TypeString,
+								},
+								"migration": {
+									Type: framework.TypeBool,
+								},
+								"cluster_name": {
+									Type: framework.TypeString,
+								},
+								"cluster_id": {
+									Type: framework.TypeString,
+								},
+								"recovery_seal": {
+									Type:     framework.TypeBool,
 									Required: true,
+								},
+								"recovery_seal_type": {
+									Type: framework.TypeString,
+								},
+								"storage_type": {
+									Type: framework.TypeString,
 								},
 								"version": {
 									Type:     framework.TypeString,
@@ -1373,26 +1369,6 @@ func (b *SystemBackend) statusPaths() []*framework.Path {
 								"build_date": {
 									Type:     framework.TypeString,
 									Required: true,
-								},
-								"migration": {
-									Type:     framework.TypeBool,
-									Required: true,
-								},
-								"cluster_name": {
-									Type:     framework.TypeString,
-									Required: false,
-								},
-								"cluster_id": {
-									Type:     framework.TypeString,
-									Required: false,
-								},
-								"recovery_seal": {
-									Type:     framework.TypeBool,
-									Required: true,
-								},
-								"storage_type": {
-									Type:     framework.TypeString,
-									Required: false,
 								},
 							},
 						}},

--- a/website/content/api-docs/system/ha-status.mdx
+++ b/website/content/api-docs/system/ha-status.mdx
@@ -5,7 +5,7 @@ description: The `/sys/ha-status` endpoint is used to check the HA status of an 
 # `/sys/ha-status`
 
 The `/sys/ha-status` endpoint is used to check the HA status of an OpenBao cluster.
-It lists the active node and the peers that it's heard from since it became active.
+It shows currently active node, along with peers that it's heard from since it became active.
 
 ## HA status
 

--- a/website/content/api-docs/system/health.mdx
+++ b/website/content/api-docs/system/health.mdx
@@ -26,21 +26,21 @@ The default status codes are:
 
 ### Parameters
 
-- `standbyok` `(bool: false)` – Specifies if being a standby should still return
+- `standbyok` `(bool: false)` - Specifies if being a standby should still return
   the active status code instead of the standby status code. This is useful when
   OpenBao is behind a non-configurable load balancer that just wants a 200-level
   response.
 
-- `activecode` `(int: 200)` – Specifies the status code that should be returned
+- `activecode` `(int: 200)` - Specifies the status code that should be returned
   for an active node.
 
-- `standbycode` `(int: 429)` – Specifies the status code that should be returned
+- `standbycode` `(int: 429)` - Specifies the status code that should be returned
   for a standby node.
 
-- `sealedcode` `(int: 503)` – Specifies the status code that should be returned
+- `sealedcode` `(int: 503)` - Specifies the status code that should be returned
   for a sealed node.
 
-- `uninitcode` `(int: 501)` – Specifies the status code that should be returned
+- `uninitcode` `(int: 501)` - Specifies the status code that should be returned
   for a uninitialized node.
 
 ### Sample request
@@ -59,7 +59,6 @@ This response is only returned for a `GET` request.
   "initialized": true,
   "sealed": false,
   "standby": false,
-  "performance_standby": false,
   "replication_performance_mode": "disabled",
   "replication_dr_mode": "disabled",
   "server_time_utc": 1516639589,
@@ -91,7 +90,6 @@ This response is only returned for a `GET` request.
   "initialized": true,
   "sealed": false,
   "standby": false,
-  "performance_standby": false,
   "replication_performance_mode": "disabled",
   "replication_dr_mode": "disabled",
   "server_time_utc": 1706217694,

--- a/website/content/api-docs/system/leader.mdx
+++ b/website/content/api-docs/system/leader.mdx
@@ -1,18 +1,15 @@
 ---
 description: |-
-  The `/sys/leader` endpoint is used to check the high availability status and
-  current leader of OpenBao.
+  The `/sys/leader` endpoint is used to check the HA status and
+  details of the current leader node of OpenBao.
 ---
 
 # `/sys/leader`
 
-The `/sys/leader` endpoint is used to check the High Availability status and
-current leader of OpenBao.
+The `/sys/leader` endpoint is used to check the high availability
+status and details of the current leader node of OpenBao.
 
 ## Read leader status
-
-This endpoint returns the High Availability status and current leader instance
-of OpenBao.
 
 | Method | Path          |
 | :----- | :------------ |
@@ -25,7 +22,9 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/leader
 ```
 
-### Sample response
+### Sample responses
+
+With HA enabled:
 
 ```json
 {
@@ -33,7 +32,27 @@ $ curl \
   "is_self": false,
   "leader_address": "https://127.0.0.1:8200/",
   "leader_cluster_address": "https://127.0.0.1:8201/",
-  "performance_standby": false,
-  "performance_standby_last_remote_wal": 0
+  "active_time": "2009-11-10 23:00:00 +0000 UTC",
+}
+```
+
+With HA enabled and running raft:
+```json
+{
+  "ha_enabled": true,
+  "is_self": false,
+  "leader_address": "https://127.0.0.1:8200/",
+  "leader_cluster_address": "https://127.0.0.1:8201/",
+  "active_time": "2009-11-10 23:00:00 +0000 UTC",
+  "raft_committed_index": 0,
+  "raft_applied_index": 0,
+}
+```
+
+With HA disabled:
+
+```json
+{
+  "ha_enabled": false
 }
 ```


### PR DESCRIPTION
## Description
- removed `PerfStandby`, `PerfStandbyLastRemoteWAL` and `LastWAL` from `SealStatusOutput`
- adjusted `/leader` and`/seal-status` openapi schema in `vault/logical_system_paths.go` 
- `ActiveTime`, `IsSelf`, `LeaderAddress` and `LeaderClusterAddress` properties will only appear when HA is enabled
- adjusted related documentation

## Rationale
Removed attributes were unused and contribute to the bloat in the documentation and code.

Relatively related to [per-ns sealing feature](https://github.com/openbao/openbao/tree/namespaces-seal), seal status command will have to be adjusted for ns attribution (separate call, will reuse the schema).

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
