### PR TITLE
Skip OCI plugin test on hosts that are not linux/amd64

### DIFF
--- a/vault/plugin_catalog_oci_test.go
+++ b/vault/plugin_catalog_oci_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -152,6 +153,12 @@ func TestReconcileOCIPlugins(t *testing.T) {
 	// Skip this test in short mode as it requires network access
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
+	}
+
+	// Skip if we're not on linux/amd64, this just avoids maintaining additional
+	// hashes for plugin binaries down below.
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("system is not linux/amd64")
 	}
 
 	// Create a temporary directory for plugins


### PR DESCRIPTION
## Description

Skip `TestReconcileOCIPlugins` if the host system is not linux/amd64.

## Rationale

The test expects static hashes for linux/amd64 binaries and fails if executed on any other type of host. We could add additional hashes for other platforms or dynamically prefetch the expected hashes, though I find that unnecessarily complex, so I suggest we just skip it on other systems. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
