### PR TITLE
Bump container base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 #### DOCKERHUB DOCKERFILE ####
-FROM alpine:3.22 as default
+FROM alpine:3.23 AS default
 
 ARG BIN_NAME
 # NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
@@ -74,7 +74,7 @@ CMD ["server", "-dev", "-dev-no-store-token"]
 
 
 #### UBI DOCKERFILE ####
-FROM registry.access.redhat.com/ubi9-minimal:9.7 as ubi
+FROM registry.access.redhat.com/ubi10-minimal:10.1 AS ubi
 
 ARG BIN_NAME
 # PRODUCT_VERSION is the version built dist/$TARGETOS/$TARGETARCH/$BIN_NAME,


### PR DESCRIPTION
## Description

Bump Alpine and UBI base images to the latest major + minor version. I've built these locally (linux/arm64) and checked basic functionality. I don't think we have a reason to assume any breakage.

## Rationale

Dependabot has been silently quitting on these once more: https://github.com/openbao/openbao/actions/runs/20701827439

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
