### PR TITLE
Fix mount cleanup again...

### DIFF
--- a/vault/mount.go
+++ b/vault/mount.go
@@ -666,7 +666,7 @@ func (c *Core) mount(ctx context.Context, entry *MountEntry) error {
 	return nil
 }
 
-func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) (err error) {
+func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStorage bool) error {
 	c.mountsLock.Lock()
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
@@ -744,8 +744,8 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *MountEntry, upd
 	defer view.SetReadOnlyErr(origReadOnlyErr)
 
 	var backend logical.Backend
+	// Create the new backend
 	sysView := c.mountEntrySysView(entry)
-
 	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
@@ -754,8 +754,10 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *MountEntry, upd
 		return fmt.Errorf("nil backend of type %q returned from creation function", entry.Type)
 	}
 
+	// Discard the backend if any remaining steps below fail.
+	var success bool
 	defer func() {
-		if err != nil {
+		if !success {
 			backend.Cleanup(ctx)
 		}
 	}()
@@ -806,9 +808,11 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *MountEntry, upd
 		return err
 	}
 
+	success = true
 	if c.logger.IsInfo() {
 		c.logger.Info("successful mount", "namespace", entry.Namespace().Path, "path", entry.Path, "type", entry.Type, "version", entry.Version)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

#2371 and #2226 did not merge well, thanks to Go's elegant language design.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
