### PR TITLE
Grant `openbao-core-committers` write access to the UI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,7 @@ physical/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
 sdk/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
 vault/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
 website/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+ui/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
 
 # Kubernetes team ownership
 api/auth/kubernetes @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
@@ -30,8 +31,8 @@ command/agentproxyshared/auth/kubernetes/ @openbao/openbao-org-maintainers @open
 builtin/credential/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
 builtin/logical/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
 serviceregistration/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-ui/**/*kubernetes* @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-ui/**/*kubernetes*/** @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+ui/**/*kubernetes* @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
+ui/**/*kubernetes*/** @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
 website/content/docs/platform/k8s/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
 website/content/partials/helm/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
 


### PR DESCRIPTION
Currently every UI change requires an `openbao-org-maintainers`
approval. Given my plans to make the UI more maintainable again
(see #2386) I think it is a good idea to also grant
`openbao-core-committers` write access to it.

Signed-off-by: Jan Martens <jan@martens.eu.org>

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.