### PR TITLE
Find SSH keys with ssh subcommand

### DIFF
--- a/changelog/2419.txt
+++ b/changelog/2419.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ssh: Search for public and private key files if -public-key-path and -private-key-path flags aren't given, respectively.
+```


### PR DESCRIPTION
This patch will search for ed25519, ecdsa and rsa keys in order if the -public-key-path or -private-key-path flags are not specified

This should make using the CLI slightly more convenient and more similar to how ordinary SSH works

Resolves: #2418

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
