### PR TITLE
Add process on backport PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,8 @@ quickly merge or address your contributions.
 ## Pull requests
 
 When submitting a PR you should reference an existing issue. If no issue already exists,
-please create one. This can be skipped for trivial PRs like fixing typos.
+please create one. This can be skipped for trivial PRs like fixing typos or
+for backports.
 
 Creating an issue in advance of working on the PR can help to avoid duplication of effort,
 e.g. maybe we know of existing related work. Or it may be that we can provide guidance
@@ -166,7 +167,29 @@ Someone will do a first pass review on your PR making sure it follows the guidel
 in this document. If it doesn't we'll mark the PR incomplete and ask you to follow
 up on the missing requirements.
 
+### Backports
+
+For original PRs slated for backport, ask or apply for the following labels:
+
+- `backport-<version>` targeting the desired backport branch; and
+- `needs-backport`, to indicate the backport has not yet been performed.
+
+In the backport PR, please link the original pull request in the commit
+title, which will in turn let us find the original issue. When possible,
+backport the merged (squashed) commit rather than the source PR's
+commits. This will automatically link it to the original pull request.
+When all backport PRs are opened, remove the `needs-backport` label from
+the original PR. Do not open backports before the original PR is merged.
+The backport PRs should have all the other non-backport-related labels of
+the original PR.
+
+The milestone on the original PR should target the current `main` branch
+milestone. The milestone on the backport PR should target the backport
+branch's next milestone. The milestone on the issue (if applicable) should
+target the oldest series's milestone.
+
 ### Changelog Entries
+
 Please include a file within your PR named `changelog/#.txt`, where `#` is your
 pull request ID.  There are many examples under [changelog](changelog/), but
 the general format is


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This documents our process around backport PRs

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See https://github.com/openbao/openbao/pull/2336#discussion_r2769477275; asked by @DrDaveD.

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
