### PR TITLE
Remove testonly CI job group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,25 +67,6 @@ jobs:
       checkout-ref: ${{ needs.setup.outputs.checkout-ref }}
     secrets: inherit
 
-  test-go-testonly:
-    name: Run Go tests tagged with testonly
-    needs:
-      - setup
-      - verify-changes
-    # Don't run this job for docs/ui only PRs
-    if: |
-      needs.verify-changes.outputs.is_docs_change == 'false' &&
-      needs.verify-changes.outputs.is_ui_change == 'false'
-    uses: ./.github/workflows/test-go.yml
-    with:
-      testonly: true
-      total-runners: 2 # test runners cannot be less than 2
-      go-arch: amd64
-      go-tags: "${{ needs.setup.outputs.go-tags }},deadlock,testonly"
-      runs-on: ubuntu-latest
-      name: "testonly"
-    secrets: inherit
-
   test-go-race:
     name: Run Go tests with data race detection
     needs:
@@ -99,10 +80,6 @@ jobs:
     uses: ./.github/workflows/test-go.yml
     with:
       total-runners: 16
-      env-vars: |
-        {
-          "VAULT_CI_GO_TEST_RACE": 1
-        }
       extra-flags: "-race"
       go-arch: amd64
       go-tags: ${{ needs.setup.outputs.go-tags }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -48,11 +48,6 @@ on:
         required: false
         default: 60
         type: number
-      testonly:
-        description: Whether to run the tests tagged with testonly.
-        required: false
-        default: false
-        type: boolean
       checkout-ref:
         description: The ref to use for checkout.
         required: false
@@ -72,38 +67,16 @@ jobs:
       - uses: ./.github/actions/set-up-go
         name: Setup Git configuration (public)
       - run: mkdir -p test-results/go-test
-      - name: Build matrix excluding binary, integration, and testonly tests
+      - name: Build matrix excluding binary & integration tests
         id: build-non-binary
         env:
           INPUTS_TOTAL_RUNNERS: ${{ inputs.total-runners }}
-        if: ${{ !inputs.testonly }}
         run: |
-          # testonly tests need additional build tag though let's exclude them anyway for clarity
-          (
-            go list ./... github.com/openbao/openbao/api/v2/... github.com/openbao/openbao/sdk/v2/... \
-              | grep -v "_binary" | grep -v "vault/integ" | grep -v "testonly" \
-              | go run gotest.tools/gotestsum@latest tool ci-matrix --debug \
-                --partitions "$INPUTS_TOTAL_RUNNERS" \
-                --timing-files 'test-results/go-test/*.json' > matrix.json
-          )
-      - name: Build matrix for tests tagged with testonly
-        env:
-          INPUTS_TOTAL_RUNNERS: ${{ inputs.total-runners }}
-        if: ${{ inputs.testonly }}
-        run: |
-          set -exo pipefail
-          # enable glob expansion
-          shopt -s nullglob
-          # testonly tagged tests need an additional tag to be included
-          # also running some extra tests for sanity checking with the testonly build tag
-          (
-            go list -tags=testonly ./vault/external_tests/{kv,token,*replication-perf*,*testonly*} ./vault/ \
-              | go run gotest.tools/gotestsum@latest tool ci-matrix --debug \
-                --partitions "$INPUTS_TOTAL_RUNNERS" \
-                --timing-files 'test-results/go-test/*.json' > matrix.json
-          )
-          # disable glob expansion
-          shopt -u nullglob
+          go list ./... github.com/openbao/openbao/api/v2/... github.com/openbao/openbao/sdk/v2/... \
+            | grep -v "_binary" \
+            | go run gotest.tools/gotestsum@latest tool ci-matrix --debug \
+              --partitions "$INPUTS_TOTAL_RUNNERS" \
+              --timing-files 'test-results/go-test/*.json' > matrix.json
       - name: Capture list of binary tests
         if: inputs.binary-tests
         id: list-binary-tests

--- a/website/content/docs/contributing/packaging.mdx
+++ b/website/content/docs/contributing/packaging.mdx
@@ -94,7 +94,6 @@ The following flags **SHOULD NOT** be used in a release version:
 | `deadlock`    | Includes deadlock detection during testing.                                   |
 | `memprofiler` | Includes a memory profiler in the release binary for debugging purposes only. |
 | `race`        | Enabled for race testing.                                                     |
-| `testonly`    | Includes insecure custom hooks only for testing purposes.                     |
 | `tlsdebug`    | Enables TLS session key dumping, e.g. for debugging with Wireshark.           |
 
 :::


### PR DESCRIPTION
## Description

It's been unused for over a year and wastes CPU cycles in CI every day. The only reason it has been running all this time is that some additional not-test-only tests were statically injected into the test-only group.

## Rationale

I've found this CI group very confusing as a new contributor as nothing in the actual code base backed it up.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
