### PR TITLE
Fix extraneous grpclogfaker logging

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2986,53 +2986,101 @@ type grpclogFaker struct {
 }
 
 func (g *grpclogFaker) Info(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Info(fmt.Sprint(args...))
 }
 
 func (g *grpclogFaker) Infof(format string, args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Info(fmt.Sprintf(format, args...))
 }
 
 func (g *grpclogFaker) Infoln(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Info(fmt.Sprintln(args...))
 }
 
 func (g *grpclogFaker) Warning(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Warn(fmt.Sprint(args...))
 }
 
 func (g *grpclogFaker) Warningf(format string, args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Warn(fmt.Sprintf(format, args...))
 }
 
 func (g *grpclogFaker) Warningln(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Warn(fmt.Sprintln(args...))
 }
 
 func (g *grpclogFaker) Error(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Error(fmt.Sprint(args...))
 }
 
 func (g *grpclogFaker) Errorf(format string, args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Error(fmt.Sprintf(format, args...))
 }
 
 func (g *grpclogFaker) Errorln(args ...any) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Error(fmt.Sprintln(args...))
 }
 
 func (g *grpclogFaker) Fatal(args ...interface{}) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Error(fmt.Sprint(args...))
 	os.Exit(1)
 }
 
 func (g *grpclogFaker) Fatalf(format string, args ...interface{}) {
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
 	g.logger.Error(fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
 
 func (g *grpclogFaker) Fatalln(args ...interface{}) {
-	g.logger.Error(fmt.Sprintln(args...))
+	if !g.log || !g.logger.IsDebug() {
+		return
+	}
+
+	g.logger.Error(fmt.Sprintln(args...) + "\n")
 	os.Exit(1)
 }
 


### PR DESCRIPTION
This spams server logs due to a refactor in the interfaces from b9ff7c9bfcf5d01958481e101e9f12c708b19698.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This restores guards that were removed in an earlier version. GRPC logging isn't necessarily intended to be this verbose. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
