### PR TITLE
purge corrupt groups during unseal

### DIFF
--- a/vault/identity_store_groups_test.go
+++ b/vault/identity_store_groups_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/go-test/deep"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/storagepacker"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestIdentityStore_Groups_AddByNameEntityUpdate(t *testing.T) {
@@ -219,6 +221,46 @@ func TestIdentityStore_UpsertGroupInTxn(t *testing.T) {
 	group.NamespaceID = "fake-namespace"
 	err = c.identityStore.UpsertGroupInTxn(ctx, txn, group, true)
 	require.ErrorContains(t, err, `group namespace id "fake-namespace" does not match context namespace "root"`)
+}
+
+func TestIdentityStore_PurgeCorruptedGroups(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(t.Context())
+
+	packer := c.identityStore.groupPacker(ctx)
+
+	// store a corrupt group (as https://github.com/openbao/openbao/issues/2319 would have)
+	// by directly calling the groupPacker, circumventing validation
+	group := &identity.Group{
+		ID:          "fake-id",
+		NamespaceID: "fake-namespace",
+		Name:        "fake-group",
+	}
+	group.BucketKey = packer.BucketKey(group.ID)
+	groupAsAny, err := anypb.New(group)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	item := &storagepacker.Item{
+		ID:      group.ID,
+		Message: groupAsAny,
+	}
+
+	require.NoError(t, packer.PutItem(ctx, item))
+
+	// ensure it was written
+	item, err = packer.GetItem(group.ID)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// loadGroups should purge corrupt entries
+	require.NoError(t, c.identityStore.loadGroups(ctx))
+
+	// enure it was removed
+	item, err = packer.GetItem(group.ID)
+	require.NoError(t, err)
+	require.Nil(t, item)
 }
 
 func TestIdentityStore_MemberGroupIDDelete(t *testing.T) {


### PR DESCRIPTION
## Description

This cleans-up corrupt data cause by https://github.com/openbao/openbao/issues/2319

The bug causing the data corruption was already fixed in https://github.com/openbao/openbao/pull/2321 (released in 2.5.0) this PR only adds clean-up logic, if corrupted data is found (after upgrade from 2.4.4 or older)

The data is simply dropped, no attempt to recover the information is made, see reasoning here: https://github.com/openbao/openbao/issues/2319#issuecomment-3773409586 (TL;DR it's not always possible to do "the right thing")

Also: This removes logic to clean up groups mapping to non-existing namespaces. This logic was inherited from Vault and can't happen in our implementation (as groups are stored within the namespace storage prefix and will only be loaded for all existing namespaces, so loading the group implies that the namespace exists, no need to check).


## Rationale

Resolves: https://github.com/openbao/openbao/issues/2319


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
