### PR TITLE
Fix swallowed error while setting key bytes on wrapper during raft unseal

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1550,9 +1550,9 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 	if c.seal.BarrierType() == wrapping.WrapperTypeShamir {
 		shamirWrapper, err := c.seal.GetShamirWrapper()
 		if err == nil {
-			err = shamirWrapper.SetAesGcmKeyBytes(combinedKey)
-		} else {
-			return err
+			if err = shamirWrapper.SetAesGcmKeyBytes(combinedKey); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
this [commit](https://github.com/openbao/openbao/commit/03c7bfe4b96fb191b0dc00fa6b19077ed1797112) introduced a bug where if the setting of aes gcm key bytes failed, we wouldn't return an error and rather proceed with raft unseal

## Rationale
Fixes a bug introduced with older commit.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
