### PR TITLE
Allow initalize blocks in dev mode

### DIFF
--- a/changelog/2463.txt
+++ b/changelog/2463.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/server: Allow self-initialization stanzas in development server mode.
+```

--- a/changelog/2571.txt
+++ b/changelog/2571.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-command: Allow initalization blocks in config for devlopment server.
-```


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Allows `initalize` blocks to be used `bao server -dev`.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2447

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
