### PR TITLE
pki: fix "context canceled" issue when processing cache invalidation

### DIFF
--- a/changelog/2472.txt
+++ b/changelog/2472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: fix "context canceled" issue when processing cache invalidation (leading to pki returing 500 until reload)
+```


### PR DESCRIPTION

## Description

This lead to pki returning 500 until reload.

## Rationale

The context is cancelled as soon as the invalidation returns, but the PKI engine processes the invalidation asynchronously. 

This causes newly created pki mount to be unusable on standbys (because the primary used storage version 1 and the standbys use storage version 0, causing issues like "could not fetch the CA certificate (was one set?): no legacy cert bundle exists").

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
