### PR TITLE
docs: remove old info about UI being disabled

### DIFF
--- a/website/content/docs/contributing/code-organization.mdx
+++ b/website/content/docs/contributing/code-organization.mdx
@@ -12,7 +12,7 @@ OpenBao repository is organized into five main modules:
    for interacting with OpenBao instances,
  - A collection of useful helper modules
    ([in `sdk/`](https://github.com/openbao/openbao/tree/main/sdk/)),
- - The Web UI, built with Ember and [temporarily disabled](https://github.com/openbao/openbao/issues/189)
+ - The Web UI, built with Ember
    ([in `ui/`](https://github.com/openbao/openbao/tree/main/ui/)),
  - The API and documentation website ([in `website/`](https://github.com/openbao/openbao/tree/main/website/)), and
  - The cli and server code, [everywhere else](https://github.com/openbao/openbao/tree/main/).


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->
Removed the `[temporarily disabled](https://github.com/openbao/openbao/issues/189)` part regarding the website, as this is not the case anymore.

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
