### PR TITLE
Update TSC members and entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,13 +79,14 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 
 ## Technical Steering Committee (TSC) Members
 
-| Member           | Email                     | GitHub                                     | Alternate                                       | Company/Organization | TSC Position |
-|------------------|---------------------------|--------------------------------------------|-------------------------------------------------|----------------------|--------------|
-| James Butcher    | james@iotechsys.com       |                                            | Brad Corrion (brad@iotechsys.com)               | IOTech Systems       | Member       |
-| Julian Cassignol | jcassignol@wallix.com     |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
-| Michael Hofer    | michael.hofer@adfinis.com | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Member       |
-| Maw Wildpaner    | maw@gitlab.com            |                                            | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
-| Klaus Kiefer     | klaus.kiefer@sap.com      | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
+| Member           | Email                        | GitHub                                     | Alternate                                       | Company/Organization | TSC Position |
+|------------------|------------------------------|--------------------------------------------|-------------------------------------------------|----------------------|--------------|
+| James Butcher    | james@iotechsys.com          |                                            | Brad Corrion (brad@iotechsys.com)               | IOTech Systems       | Member       |
+| Julian Cassignol | jcassignol@wallix.com        |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
+| Michael Hofer    | michael.hofer@adfinis.com    | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Chair        |
+| Maw Wildpaner    | maw@gitlab.com               |                                            | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
+| Klaus Kiefer     | klaus.kiefer@sap.com         | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
+| Alex Scheel      | alexander.m.scheel@gmail.com | [@cipherboy](https://github.com/cipherboy) |                                                 | Individual           | Member       |
 
 To view the process for joining the TSC, see [GOVERNANCE.md](GOVERNANCE.md) in
 the root of this repository. That document is considered part of this document.


### PR DESCRIPTION
## Description

Update the list of TSC members and entries, see Feb 12 TSC meeting minutes.

## Rationale

Ensure we keep the list of TSC members up to date.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
