### PR TITLE
Document core and openbao-plugins committer permissions of Philipp

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,13 +21,14 @@ See the information about community membership roles to learn about the role of 
 | Geoffrey Wilson  | [@suprjinx](https://github.com/suprjinx)             | [`vault/`]                                                                                        |
 | Jonas Köhnen     | [@satoqz](https://github.com/satoqz)                 | [`vault/`]                                                                                        |
 | Pascal Reeb      | [@pree](https://github.com/pree)                     | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
-| Philipp Stehle   | [@phil9909](https://github.com/phil9909)             | [openbao-plugins `secrets/consul/`]                                                               |
+| Philipp Stehle   | [@phil9909](https://github.com/phil9909)             | [`vault/`], and [openbao-plugins]                                                                 |
 | Tom Gehrke       | [@phyrog](https://github.com/phyrog)                 | [`vault/`]                                                                                        |
 | Toni Tauro       | [@eyenx](https://github.com/eyenx)                   | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
 | Wojciech Slabosz | [@wslabosz-reply](https://github.com/wslabosz-reply) | [`vault/`]                                                                                        |
 | Yannis           | [@Nerkho](https://github.com/Nerkho)                 | [helm], [csi-provider], [k8s], [secrets-operator], and [openbao-plugins `secrets/consul/`]        |
 
 [`vault/`]: https://github.com/openbao/openbao/tree/main/vault
+[openbao-plugins]: https://github.com/openbao/openbao-plugins
 [openbao-plugins `secrets/consul/`]: https://github.com/openbao/openbao-plugins/tree/main/secrets/consul
 [helm]: https://github.com/openbao/openbao-helm
 [csi-provider]: https://github.com/openbao/openbao-csi-provider


### PR DESCRIPTION
## Description

The project members recently accepted @phil9909's application to become a repository-level committer for the core and openbao-plugins repository.

## Rationale

Maintain maintainer information accordingly.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
