### PR TITLE
remove @phil9909 from "Organization-Level Moderators"

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -42,7 +42,6 @@ See the information about community membership roles to learn about the role of 
 | Fatima Patel    | [@fatima2003](https://github.com/fatima2003)             |
 | Gabriel Santos  | [@Gabrielopesantos](https://github.com/Gabrielopesantos) |
 | Michael Hofer   | [@karras](https://github.com/karras)                     |
-| Philipp Stehle  | [@phil9909](https://github.com/phil9909)                 |
 | Klaus Kiefer    | [@klaus-sap](https://klaus-sap)                          |
 
 # OpenBao Community Roles


### PR DESCRIPTION
## Description

Remove myself from the "Organization-Level Moderators" table in the `MAINTAINERS.md` file.

## Rationale

I recently got "Repository-Level Committer" permissions for `vault/` and `openbao-plugins` and therefore are listed in the respective table. This makes me the only person being listed in multiple roles (generally only their "highest" role seems to be the one people are listed at, implying they are also in the "lower" roles).  

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
