### PR TITLE
Fix title hierarchy in x509 rotation doc

### DIFF
--- a/website/content/docs/secrets/pki/rotation-primitives.mdx
+++ b/website/content/docs/secrets/pki/rotation-primitives.mdx
@@ -182,7 +182,7 @@ certificate has been used to directly issue leaf certificates.
 So, the rest of this process flow assumes an intermediate is being
 cross-signed as this is more common.
 
-##### Process flow
+#### Process flow
 
 ```
         -------------------
@@ -210,7 +210,7 @@ there's no limit on the number of cross-signed "duplicate" (used loosely--with
 the same subject and key material) certificates: this could be cross-signed
 by many different root certificates if necessary and desired.
 
-##### Certificate hierarchy
+#### Certificate hierarchy
 
 ```
  --------                                            --------


### PR DESCRIPTION

## Description

This MR fix the title hierarchy in the x509 rotation doc

## Rationale

Currently the [Process flow](https://openbao.org/docs/secrets/pki/rotation-primitives/#process-flow) and [Certificate hierarchy](https://openbao.org/docs/secrets/pki/rotation-primitives/#certificate-hierarchy) are subsection of [A note on Cross-Signed roots](https://openbao.org/docs/secrets/pki/rotation-primitives/#a-note-on-cross-signed-roots) but I believe that's not what we want.


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
