### PR TITLE
pki: fix "context canceled" issue when processing cache invalidation (#2472)

### DIFF
--- a/changelog/2472.txt
+++ b/changelog/2472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: fix "context canceled" issue when processing cache invalidation (leading to pki returing 500 until reload)
+```


### PR DESCRIPTION
This lead to pki returing 500 until reload.

Backport of https://github.com/openbao/openbao/pull/2472 (with conflicts)

Conflicts:
- builtin/logical/pki/backend.go

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
