### PR TITLE
Use absolute paths in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,39 +4,39 @@
 * @openbao/openbao-org-maintainers
 
 # Anyone can modify changelog entries
-changelog/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers @openbao/openbao-k8s-committers
+/changelog/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers @openbao/openbao-k8s-committers
 
 # Core team ownership
-api/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-audit/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-builtin/logical/kv/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-CHANGELOG.md @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-command/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-.go-version @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-go.mod @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-go.sum @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-helper/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-http/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-Makefile @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-physical/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-sdk/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-vault/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
-website/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/api/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/audit/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/builtin/logical/kv/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/CHANGELOG.md @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/command/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/.go-version @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/go.mod @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/go.sum @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/helper/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/http/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/Makefile @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/physical/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/sdk/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/vault/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
+/website/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers
 
 # Kubernetes team ownership
-api/auth/kubernetes @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
-command/agentproxyshared/auth/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-builtin/credential/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-builtin/logical/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-serviceregistration/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-ui/**/*kubernetes* @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-ui/**/*kubernetes*/** @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
-website/content/docs/platform/k8s/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
-website/content/partials/helm/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
+/api/auth/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
+/command/agentproxyshared/auth/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/builtin/credential/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/builtin/logical/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/serviceregistration/kubernetes/ @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/ui/**/*kubernetes* @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/ui/**/*kubernetes*/** @openbao/openbao-org-maintainers @openbao/openbao-k8s-committers
+/website/content/docs/platform/k8s/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
+/website/content/partials/helm/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-k8s-committers
 
 # JWT Auth Plugin
-builtin/credential/jwt @openbao/openbao-org-maintainers @openbao/openbao-auth-jwt-committers
-command/agentproxyshared/auth/jwt @openbao/openbao-org-maintainers @openbao/openbao-auth-jwt-committers
-website/content/docs/auth/jwt/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers
-website/content/api-docs/auth/jwt.mdx @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers
-website/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers
+/builtin/credential/jwt/ @openbao/openbao-org-maintainers @openbao/openbao-auth-jwt-committers
+/command/agentproxyshared/auth/jwt/ @openbao/openbao-org-maintainers @openbao/openbao-auth-jwt-committers
+/website/content/docs/auth/jwt/ @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers
+/website/content/api-docs/auth/jwt.mdx @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers
+/website/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx @openbao/openbao-org-maintainers @openbao/openbao-core-committers @openbao/openbao-auth-jwt-committers


### PR DESCRIPTION
## Description

Begin paths in CODEOWNERS with a `/` to declare absolute paths.

## Rationale

openbao-core-committers get tagged as reviewers on PRs that they shouldn't be. This can happen for example when files in any folder named `vault` are modified even if it isn't `/vault`, for example in https://github.com/openbao/openbao/pull/2465.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
