### PR TITLE
Ensure identity groups, entities deleted on actives (#2531)

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2427,7 +2427,7 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, logger log.Logge
 	if err := c.handleAuditLogSetup(ctx, standby); err != nil {
 		return err
 	}
-	if err := c.loadIdentityStoreArtifacts(ctx); err != nil {
+	if err := c.loadIdentityStoreArtifacts(ctx, standby); err != nil {
 		return err
 	}
 	c.setupCachedMFAResponseAuth()

--- a/vault/identity_store_groups_test.go
+++ b/vault/identity_store_groups_test.go
@@ -255,7 +255,7 @@ func TestIdentityStore_PurgeCorruptedGroups(t *testing.T) {
 	require.NotNil(t, item)
 
 	// loadGroups should purge corrupt entries
-	require.NoError(t, c.identityStore.loadGroups(ctx))
+	require.NoError(t, c.identityStore.loadGroups(ctx, false /* readOnly */))
 
 	// enure it was removed
 	item, err = packer.GetItem(group.ID)


### PR DESCRIPTION
This ensures corrupt groups are only removed on active nodes; otherwise standby nodes would fail to start up.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Backport of #2531. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
