### PR TITLE
Remove HashiCorp support note from Kubernetes Service Registration docs

### DIFF
--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -11,9 +11,6 @@ Kubernetes Service Registration tags OpenBao pods with their current status for
 use with selectors. Service registration is only available when OpenBao is running in
 [High Availability mode](../../concepts/ha.mdx).
 
-- **HashiCorp Supported** – Kubernetes Service Registration is officially supported
-  by HashiCorp.
-
 ## Configuration
 
 ```hcl


### PR DESCRIPTION
Removed mention of HashiCorp support for Kubernetes Service Registration.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
