### PR TITLE
Add Shamir seal wrapper

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/mitchellh/go-testing-interface"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/audit"
 	config2 "github.com/openbao/openbao/command/config"
@@ -476,7 +475,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	info["Seal Type"] = sealType
 
 	var seal vault.Seal
-	defaultSeal := vault.NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+	defaultSeal := vault.NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 	sealLogger := c.logger.ResetNamed(fmt.Sprintf("seal.%s", sealType))
 	wrapper, sealConfigError = configutil.ConfigureWrapper(configSeal, &infoKeys, &info, sealLogger)
 	if sealConfigError != nil {
@@ -2474,7 +2473,7 @@ func setSeal(c *ServerCommand, config *server.Config, infoKeys *[]string, info m
 		var seal vault.Seal
 		sealLogger := c.logger.ResetNamed(fmt.Sprintf("seal.%s", sealType))
 		c.allLoggers = append(c.allLoggers, sealLogger)
-		defaultSeal := vault.NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+		defaultSeal := vault.NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 		var sealInfoKeys []string
 		sealInfoMap := map[string]string{}
 		wrapper, sealConfigError = configutil.ConfigureWrapper(configSeal, &sealInfoKeys, &sealInfoMap, sealLogger)

--- a/vault/core.go
+++ b/vault/core.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/go-uuid"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/go-kms-wrapping/wrappers/awskms/v2"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/audit"
@@ -1028,7 +1027,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	// Load seal information.
 	if c.seal == nil {
-		wrapper := aeadwrapper.NewShamirWrapper()
+		wrapper := vaultseal.NewShamirWrapper()
 		wrapper.SetConfig(context.Background(), awskms.WithLogger(c.logger.Named("shamir")))
 		c.seal = NewDefaultSeal(vaultseal.NewAccess(wrapper))
 	}
@@ -2720,7 +2719,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 		case existBarrierSealConfig.Type == wrapping.WrapperTypeShamir.String():
 			// The configured seal is not Shamir, the stored seal config is Shamir.
 			// This is a migration away from Shamir.
-			unwrapSeal = NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+			unwrapSeal = NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 		default:
 			// We know at this point that there is a configured non-Shamir seal,
 			// that it does not match the stored non-Shamir seal config, and that
@@ -2875,7 +2874,7 @@ func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []
 
 	case vaultseal.StoredKeysSupportedShamirRoot:
 		if useTestSeal {
-			testseal := NewDefaultSeal(vaultseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+			testseal := NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 			testseal.SetCore(c)
 			cfg, err := seal.BarrierConfig(ctx)
 			if err != nil {

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -15,7 +15,6 @@ import (
 
 	uuid "github.com/hashicorp/go-uuid"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
@@ -354,13 +353,13 @@ func (c *Core) updateBarrierRotation(ctx context.Context, config *SealConfig, ke
 		}
 	case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
 		if c.seal.StoredKeysSupported() == seal.StoredKeysSupportedShamirRoot {
-			shamirWrapper := aeadwrapper.NewShamirWrapper()
-			testseal := NewDefaultSeal(seal.NewAccess(shamirWrapper))
-			testseal.SetCore(c)
-			err := shamirWrapper.SetAesGcmKeyBytes(recoveredKey)
-			if err != nil {
+			shamirWrapper := seal.NewShamirWrapper()
+			if err := shamirWrapper.SetAesGcmKeyBytes(recoveredKey); err != nil {
 				return nil, logical.CodedError(http.StatusInternalServerError, "failed to setup unseal key: %v", err)
 			}
+
+			testseal := NewDefaultSeal(seal.NewAccess(shamirWrapper))
+			testseal.SetCore(c)
 
 			cfg, err := c.seal.BarrierConfig(ctx)
 			if err != nil {

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -72,7 +71,7 @@ type Seal interface {
 	SetRecoveryKey(context.Context, []byte) error
 	VerifyRecoveryKey(context.Context, []byte) error // SealAccess
 	GetAccess() seal.Access                          // SealAccess
-	GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error)
+	GetShamirWrapper() (*seal.ShamirWrapper, error)
 }
 
 type defaultSeal struct {
@@ -273,10 +272,10 @@ func (d *defaultSeal) SetRecoveryKey(ctx context.Context, key []byte) error {
 	return errors.New("recovery not supported")
 }
 
-func (d *defaultSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
+func (d *defaultSeal) GetShamirWrapper() (*seal.ShamirWrapper, error) {
 	// defaultSeal is meant to be for Shamir seals, so it should always have a ShamirWrapper.
 	// Nonetheless, NewDefaultSeal does not check, so let's play it safe.
-	w, ok := d.GetAccess().GetWrapper().(*aeadwrapper.ShamirWrapper)
+	w, ok := d.GetAccess().GetWrapper().(*seal.ShamirWrapper)
 	if !ok {
 		return nil, fmt.Errorf("expected defaultSeal to have a ShamirWrapper, but found a %T instead", d.GetAccess().GetWrapper())
 	}

--- a/vault/seal/shamirwrapper.go
+++ b/vault/seal/shamirwrapper.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package seal
+
+import (
+	"context"
+
+	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/go-kms-wrapping/v2/aead"
+)
+
+// TODO(satoqz): Remove ShamirWrapper from go-kms-wrapping & replace remaining
+// references to wrapping.WrapperTypeShamir with vaultseal.WrapperTypeShamir.
+const WrapperTypeShamir wrapping.WrapperType = "shamir"
+
+// ShamirWrapper is here for backwards compatibility for Vault; it reports a
+// type of "shamir" instead of "aead".
+type ShamirWrapper struct {
+	*aead.Wrapper
+}
+
+// NewShamirWrapper returns a type of "shamir" instead of "aead" and is for backwards
+// compatibility with old versions of Vault.
+func NewShamirWrapper() *ShamirWrapper {
+	return &ShamirWrapper{
+		Wrapper: aead.NewWrapper(),
+	}
+}
+
+func (s *ShamirWrapper) Type(context.Context) (wrapping.WrapperType, error) {
+	return WrapperTypeShamir, nil
+}

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -15,7 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"google.golang.org/protobuf/proto"
 
 	log "github.com/hashicorp/go-hclog"
@@ -117,7 +116,7 @@ func (d *autoSeal) BarrierType() wrapping.WrapperType {
 	return d.barrierType
 }
 
-func (d *autoSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
+func (d *autoSeal) GetShamirWrapper() (*seal.ShamirWrapper, error) {
 	return nil, errors.New("autoSeal does not use a ShamirWrapper")
 }
 

--- a/vault/seal_testing.go
+++ b/vault/seal_testing.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	testing "github.com/mitchellh/go-testing-interface"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/vault/seal"
@@ -25,7 +24,7 @@ func NewTestSeal(t testing.T, opts *seal.TestSealOpts) Seal {
 
 	switch opts.StoredKeys {
 	case seal.StoredKeysSupportedShamirRoot:
-		newSeal := NewDefaultSeal(seal.NewAccess(aeadwrapper.NewShamirWrapper()))
+		newSeal := NewDefaultSeal(seal.NewAccess(seal.NewShamirWrapper()))
 		// Need StoredShares set or this will look like a legacy shamir seal.
 		newSeal.SetCachedBarrierConfig(&SealConfig{
 			StoredShares:    1,


### PR DESCRIPTION
## Description
`ShamirWrapper` from gkw repository was deprecated long time ago, it didn't surface on the main repository due to additional layer of reassignment and variable export which was removed with https://github.com/openbao/openbao/pull/2473. This PR moves the (deprecated) `ShamirWraper` code from gkw repository and reintroduces (while also undeprecating) it to the main repo.

## Rationale
It's valuable to have `shamir` as a string in user-facing error messages, while also any other solution to deprecated code would require a lot more changes.

Resolves: 
Not a part of any issue but affects https://github.com/openbao/openbao/pull/2460 and externally plugnized auto unseal RFC implementation.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
