### PR TITLE
fix(website): add collapsible code blocks

### DIFF
--- a/website/src/components/CodeBlockWrap/index.tsx
+++ b/website/src/components/CodeBlockWrap/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import CodeBlock from "@theme/CodeBlock";
+import styles from "./styles.module.css";
+
+type CodeBlockWrapProps = {
+  children: React.ReactNode;
+  language?: string;
+  title?: string;
+  showLineNumbers?: boolean;
+};
+
+export default function CodeBlockWrap({
+  children,
+  language,
+  title,
+  showLineNumbers
+}: CodeBlockWrapProps) {
+  const checkboxId = React.useId();
+
+  return (
+    <div className={styles.codeBlockWrap}>
+      <input type="checkbox" id={checkboxId} className={styles.codeBlockCheck} />
+      <div className={styles.codeBlock}>
+        <CodeBlock language={language} title={title} showLineNumbers={showLineNumbers}>
+          {children}
+        </CodeBlock>
+      </div>
+      <label htmlFor={checkboxId} className={styles.codeBlockLabel} />
+    </div>
+  );
+}

--- a/website/src/components/CodeBlockWrap/styles.module.css
+++ b/website/src/components/CodeBlockWrap/styles.module.css
@@ -1,0 +1,51 @@
+.codeBlockWrap {
+  position: relative;
+  margin-bottom: var(--ifm-pre-padding);
+
+  & > .codeBlock {
+    max-height: 200px;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+    width: 100%;
+    border-radius: var(--ifm-code-border-radius);
+    position: relative;
+    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 80px), transparent 100%);
+    mask-image: linear-gradient(to bottom, black calc(100% - 80px), transparent 100%);
+  }
+}
+
+.codeBlockCheck {
+  display: none;
+
+  &:checked ~ .codeBlock {
+    max-height: none;
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+
+  &:checked ~ .codeBlockLabel {
+    display: none;
+  }
+}
+
+.codeBlockLabel {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  cursor: pointer;
+  padding: 0 0 10px;
+  z-index: 1;
+
+  &:after {
+    content: "show more ›";
+    display: inline-block;
+    padding: 4px 12px;
+    background: var(--ifm-code-background);
+    border-radius: var(--ifm-code-border-radius);
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.85rem;
+  }
+}

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -9,8 +9,9 @@ import {
   GetReleases,
   AssetArchitecture,
   OsPrettyPrint,
-  ArchPackageMapApply,
+  ArchPackageMapApply
 } from "@site/src/components/Releases";
+import CodeBlockWrap from "@site/src/components/CodeBlockWrap";
 
 // Create a context
 const OptionsContext = createContext(null);
@@ -229,7 +230,7 @@ const DebRepo = ({ gpgKeyName }) => {
       Simply add this repository configuration to your DEB-sources. APT then
       verifies that the packages have been created and signed by the official
       pipeline and have not been tampered with.
-      <CodeBlock
+      <CodeBlockWrap
         language="shell"
         title="/etc/apt/sources.list.d/openbao.sources"
         showLineNumbers
@@ -240,7 +241,7 @@ Suites: stable
 Components: main
 Signed-By:
 ` + gpgKey.replaceAll(/^(?!$)/gm, " ")}
-      </CodeBlock>
+      </CodeBlockWrap>
       <h6>Install OpenBao</h6>
       <CodeBlock language="shell">
         {`sudo apt update && sudo apt install openbao`}


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

By wrapping the original code block element, I was able to achieve a (mostly) CSS-only approach in order to prevent cluttering the downloads page with a large code block.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->



## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
