### PR TITLE
Add logical.Alias type support to CEL JWT authentication

### DIFF
--- a/builtin/credential/jwt/path_cel_login_test.go
+++ b/builtin/credential/jwt/path_cel_login_test.go
@@ -165,6 +165,51 @@ func Test_runCelProgram(t *testing.T) {
 				require.Contains(t, err.Error(), "no such field")
 			},
 		},
+		{
+			name: "pb.Auth with logical.Alias metadata from SPIFFE ID",
+			celRole: celRoleEntry{
+				Name: "spiffe-role",
+				Program: &celhelper.Program{
+					Variables: []celhelper.Variable{
+						{Name: "spiffe_path", Expression: "claims.sub.startsWith('spiffe://') ? claims.sub.substring(9) : claims.sub"},
+						{Name: "trust_domain", Expression: "spiffe_path.contains('/') ? spiffe_path.split('/')[0] : ''"},
+						{Name: "ns_parts", Expression: "spiffe_path.contains('/ns/') ? spiffe_path.split('/ns/') : []"},
+						{Name: "sa_parts", Expression: "size(ns_parts) > 1 && ns_parts[1].contains('/sa/') ? ns_parts[1].split('/sa/') : []"},
+						{Name: "workload_ns", Expression: "size(sa_parts) > 0 ? sa_parts[0] : ''"},
+						{Name: "workload_sa", Expression: "size(sa_parts) > 1 ? sa_parts[1] : ''"},
+					},
+					Expression: `trust_domain != '' && workload_ns != '' && workload_sa != ''
+					? pb.Auth{
+						policies: ['workload-policy'],
+						display_name: trust_domain + '.' + workload_ns + '.' + workload_sa,
+						alias: logical.Alias{
+							name: claims.sub,
+							metadata: {
+								'trust_domain': trust_domain,
+								'namespace': workload_ns,
+								'service_account': workload_sa
+							}
+						}
+					}
+					: false`,
+				},
+			},
+			claims: map[string]interface{}{
+				"sub": "spiffe://test-domain/ns/default/sa/my-service",
+			},
+			auth: logical.Auth{},
+			validateResult: func(t *testing.T, err error, rslt *pb.Auth) {
+				require.NoError(t, err)
+				require.NotNil(t, rslt)
+				require.Equal(t, []string{"workload-policy"}, rslt.Policies)
+				require.Equal(t, "test-domain.default.my-service", rslt.DisplayName)
+				require.NotNil(t, rslt.Alias)
+				require.Equal(t, "spiffe://test-domain/ns/default/sa/my-service", rslt.Alias.Name)
+				require.Equal(t, "test-domain", rslt.Alias.Metadata["trust_domain"])
+				require.Equal(t, "default", rslt.Alias.Metadata["namespace"])
+				require.Equal(t, "my-service", rslt.Alias.Metadata["service_account"])
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/builtin/credential/jwt/path_cel_role.go
+++ b/builtin/credential/jwt/path_cel_role.go
@@ -385,6 +385,7 @@ func (b *jwtAuthBackend) celEvalConfig() *celhelper.EvalConfig {
 			cel.Variable("operation", types.StringType),
 			cel.Types(
 				&pb.Auth{},
+				&logical.Alias{},
 			),
 		},
 	}


### PR DESCRIPTION
# Add logical.Alias Type Support to CEL JWT Authentication

**Related to**: #493 (Expand JWT claim matching capabilities)

## Problem

CEL JWT auth can set `Auth.Metadata` (for audit logs) but cannot set `Alias.Metadata` (required for policy templating). This prevents:
- Parsing SPIFFE IDs to extract workload identity components
- Using templated policies with dynamic identity-based paths
- Scaling beyond creating individual policies per workload

Example: Parse `spiffe://domain/ns/my-ns/sa/my-svc` to extract `namespace` and `service_account`, then use in policy template:
```
kv/data/{{identity.entity.aliases.<accessor>.metadata.namespace}}/{{identity.entity.aliases.<accessor>.metadata.service_account}}
```

## Solution

Add `&logical.Alias{}` to CEL type registration, enabling CEL programs to construct `logical.Alias` objects with metadata.

**Files changed:**
- `builtin/credential/jwt/path_cel_role.go`: Added type registration (1 line)
- `builtin/credential/jwt/path_cel_login_test.go`: Added test for SPIFFE ID parsing

## Example

CEL program parsing SPIFFE ID into alias metadata:
```cel
pb.Auth{
  policies: ['workload-policy'],
  alias: logical.Alias{
    name: claims.sub,
    metadata: {
      'namespace': workload_ns,
      'service_account': workload_sa
    }
  }
}
```

Policy template (works for all workloads):
```hcl
path "kv/data/{{identity.entity.aliases.<accessor>.metadata.namespace}}/{{identity.entity.aliases.<accessor>.metadata.service_account}}" {
  capabilities = ["read"]
}
```

## Impact

- **Fully backward compatible**: Existing CEL programs continue to work unchanged
- **Enables scalability**: One templated policy instead of thousands of individual policies
- **Aligns with Vault Enterprise 1.21**: Similar to HashiCorp's SPIFFE authentication support
