### PR TITLE
Bump github.com/cloudflare/circl to v1.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible // indirect
 	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
-	github.com/cloudflare/circl v1.6.2 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
-github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=


### PR DESCRIPTION
## Description

Bump github.com/cloudflare/circl from v1.6.2 to v1.6.3 to silence vulncheck's complaints about [GO-2026-4550](https://pkg.go.dev/vuln/GO-2026-4550). 

## Rationale

Notably, we're not affected by this one, but vulncheck hits a false-positive symbol result:

<details>
<summary>
Full report
</summary>

```
Vulnerability #1: GO-2026-4550
    CIRCL has an incorrect calculation in secp384r1 CombinedMult in
    github.com/cloudflare/circl
  More info: https://pkg.go.dev/vuln/GO-2026-4550
  Module: github.com/cloudflare/circl
    Found in: github.com/cloudflare/circl@v1.6.2
    Fixed in: github.com/cloudflare/circl@v1.6.3
    Example traces found:
      #1: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls conv.BytesLe2BigInt
      #2: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls conv.init
      #3: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed25519.NewKeyFromSeed
      #4: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed25519.PrivateKey.Seed
      #5: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls ed25519.Sign
      #6: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed25519.Verify
      #7: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls ed25519.init
      #8: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed448.NewKeyFromSeed
      #9: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed448.PrivateKey.Seed
      #10: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls ed448.Sign
      #11: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls ed448.Verify
      #12: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls ed448.init
      #13: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.Add
      #14: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.AddSub
      #15: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.Cmov
      #16: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls fp25519.Cswap
      #17: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.Inv
      #18: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.InvSqrt
      #19: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.IsZero
      #20: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.Modp
      #21: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.Mul
      #22: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.Neg
      #23: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.P
      #24: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.SetOne
      #25: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.Sqr
      #26: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp25519.Sub
      #27: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp25519.ToBytes
      #28: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls fp25519.init
      #29: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.Add
      #30: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.AddSub
      #31: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.Cmov
      #32: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls fp448.Cswap
      #33: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.Inv
      #34: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.InvSqrt
      #35: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.IsZero
      #36: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.Modp
      #37: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.Mul
      #38: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.Neg
      #39: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.One
      #40: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.P
      #41: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.SetOne
      #42: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.Sqr
      #43: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls fp448.Sub
      #44: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls fp448.ToBytes
      #45: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls fp448.init
      #46: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls goldilocks.Curve.CombinedMult
      #47: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls goldilocks.Curve.Order
      #48: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls goldilocks.Curve.ScalarBaseMult
      #49: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls goldilocks.FromBytes
      #50: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls goldilocks.Point.Neg
      #51: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls goldilocks.Point.ToBytes
      #52: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls goldilocks.Scalar.Add
      #53: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls goldilocks.Scalar.FromBytes
      #54: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls goldilocks.Scalar.Mul
      #55: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls goldilocks.init
      #56: helper/pgpkeys/encrypt_decrypt.go:105:35: pgpkeys.DecryptBytes calls openpgp.ReadEntity, which eventually calls math.OmegaNAF
      #57: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls math.init
      #58: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls mlsbset.Encoder.Encode
      #59: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls mlsbset.Encoder.IsExtended
      #60: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls mlsbset.New
      #61: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls mlsbset.Power.Exp
      #62: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls mlsbset.init
      #63: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls sha3.NewShake256
      #64: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls sha3.State.Read
      #65: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls sha3.State.Reset
      #66: helper/pgpkeys/encrypt_decrypt.go:41:11: pgpkeys.EncryptShares calls openpgp.signatureWriter.Close, which eventually calls sha3.State.Write
      #67: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls sha3.init
      #68: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls sign.init
      #69: helper/pgpkeys/encrypt_decrypt.go:33:29: pgpkeys.EncryptShares calls openpgp.Encrypt, which eventually calls x25519.KeyGen
      #70: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls x25519.Shared
      #71: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls x25519.init
      #72: helper/pgpkeys/encrypt_decrypt.go:33:29: pgpkeys.EncryptShares calls openpgp.Encrypt, which eventually calls x448.KeyGen
      #73: helper/pgpkeys/encrypt_decrypt.go:111:32: pgpkeys.DecryptBytes calls openpgp.ReadMessage, which eventually calls x448.Shared
      #74: vault/seal.go:23:2: vault.init calls packet.init, which eventually calls x448.init
```

</details>

...likely because of [missing symbol information in the database entry](https://github.com/golang/vulndb/blob/master/data/reports/GO-2026-4550.yaml)? Not sure.

Either way, based on [the upstream fix](https://github.com/cloudflare/circl/pull/583/changes), it is clear that the affected package is indeed `github.com/cloudflare/circl/ecc/p384`, which OpenBao doesn't use:

```
$ go mod why github.com/cloudflare/circl/ecc/p384
# github.com/cloudflare/circl/ecc/p384
(main module does not need package github.com/cloudflare/circl/ecc/p384)
```

instead, OpenBao uses `github.com/cloudflare/circl/ecc/goldilocks`, which is false-flagged by vulncheck:

```
$ go mod why github.com/cloudflare/circl/ecc/goldilocks
# github.com/cloudflare/circl/ecc/goldilocks
github.com/openbao/openbao/helper/pgpkeys
github.com/ProtonMail/go-crypto/openpgp
github.com/ProtonMail/go-crypto/openpgp/ed448
github.com/cloudflare/circl/sign/ed448
github.com/cloudflare/circl/ecc/goldilocks
```

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
