### PR TITLE
fix: add missing lang attribute to UI

### DIFF
--- a/changelog/2580.txt
+++ b/changelog/2580.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: add lang="en" attribute to html tag
+```

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html lang="en">
+<!DOCTYPE html>
 <!--
  Copyright (c) HashiCorp, Inc.
  SPDX-License-Identifier: MPL-2.0
 -->
 
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-store" />


### PR DESCRIPTION
## Description

Add missing lang attribute to UI

## Rationale

While checking the accesibility score I encountered an error about the missing lang attribute and created this simple fix.

Resolves: #2579

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
