### PR TITLE
Mention openbao-hsm image on downloads page 

### DIFF
--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -180,7 +180,7 @@ const Asset = ({ urls }) => {
     <div className="card download-card">
       <div className="card__header">
         <h3 className="download-card__header-title">
-          {AssetArchitecture(asset).toUpperCase()}
+          {AssetArchitecture(asset)}
         </h3>
       </div>
       <div className="card__body">


### PR DESCRIPTION
## Description

As title states; also keep architecture names lowercased.

## Rationale

[#openssf-openbao-support > HSM support @ 💬](https://linuxfoundation.zulipchat.com/#narrow/channel/530381-openssf-openbao-support/topic/HSM.20support/near/577691642)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
