### PR TITLE
Add minimal, distroless container image variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,7 @@ FROM registry.access.redhat.com/ubi10-minimal:10.1 AS ubi
 COPY LICENSE /licenses/mozilla.txt
 
 # Set up ca-certificates & base tooling.
-RUN set -eux; \
-    microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux
+RUN microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux
 
 # Create a non-root user to run the software.
 RUN groupadd --gid 1000 openbao && \
@@ -109,4 +108,24 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.
+CMD ["server", "-dev", "-dev-no-store-token"]
+
+
+# This is {docker.io,quay.io,ghcr.io}/openbao/openbao-distroless.
+FROM gcr.io/distroless/static:nonroot@sha256:f512d819b8f109f2375e8b51d8cfd8aafe81034bc3e319740128b7d7f70d5036 AS distroless
+
+COPY LICENSE /licenses/mozilla.txt
+
+# The OpenBao binary is built externally in CI and copied into the container
+# build.
+ARG BIN_NAME
+COPY ${BIN_NAME} /bin/
+
+# 8200/tcp is the primary interface that applications use to interact with
+# OpenBao.
+EXPOSE 8200
+
+# By default you'll get a single-node development server that stores everything
+# in RAM and bootstraps itself. Don't use this configuration for production.
+ENTRYPOINT ["/bin/bao"]
 CMD ["server", "-dev", "-dev-no-store-token"]

--- a/changelog/2592.txt
+++ b/changelog/2592.txt
@@ -1,3 +1,6 @@
 ```release-note:feature
-packaging/container: Add new "openbao-distroless" container image variant based on [distroless/static](https://github.com/GoogleContainerTools/distroless). The only executable contained in these images is OpenBao itself.
+Add a **Distroless container image**:
+  - Based on Google's [distroless/static](https://github.com/GoogleContainerTools/distroless).
+  - Available as `openbao/openbao-distroless` on docker.io, ghcr.io and quay.io.
+  - The only executable in the image is OpenBao itself, limiting attack surface & dependencies.
 ```

--- a/changelog/2592.txt
+++ b/changelog/2592.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+packaging/container: Add new "openbao-distroless" container image variant based on [distroless/static](https://github.com/GoogleContainerTools/distroless). The only executable contained in these images is OpenBao itself.
+```

--- a/changelog/2592.txt
+++ b/changelog/2592.txt
@@ -1,6 +1,4 @@
 ```release-note:feature
-Add a **Distroless container image**:
-  - Based on Google's [distroless/static](https://github.com/GoogleContainerTools/distroless).
-  - Available as `openbao/openbao-distroless` on docker.io, ghcr.io and quay.io.
-  - The only executable in the image is OpenBao itself, limiting attack surface & dependencies.
+Add new **openbao-distroless** container image variant based on [distroless/static](https://github.com/GoogleContainerTools/distroless).
+  - The only executable contained in these images is OpenBao itself.
 ```

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -424,6 +424,192 @@ dockers:
       - ./LICENSE
       - ./.release/docker/ubi-docker-entrypoint.sh
       - ./CHANGELOG.md
+  - id: distroless-amd64
+    use: buildx
+    goos: linux
+    goarch: amd64
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--platform=linux/amd64"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
+  - id: distroless-arm
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "6"
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/arm"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
+  - id: distroless-arm64
+    use: buildx
+    goos: linux
+    goarch: arm64
+    goarm: "8"
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--build-arg=REVISION={{ .FullCommit }}"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--platform=linux/arm64"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
+  - id: distroless-ppc64le
+    use: buildx
+    goos: linux
+    goarch: ppc64le
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--platform=linux/ppc64le"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
+  - id: distroless-riscv64
+    use: buildx
+    goos: linux
+    goarch: riscv64
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--platform=linux/riscv64"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
+  - id: distroless-s390x
+    use: buildx
+    goos: linux
+    goarch: s390x
+    skip_push: false
+    ids:
+      - builds-linux
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=BIN_NAME={{ .ProjectName }}"
+      - "--platform=linux/s390x"
+      - '--label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}'
+      - "--label=org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>"
+      - "--label=org.opencontainers.image.url=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md"
+      - "--label=org.opencontainers.image.source=https://github.com/openbao/openbao"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.vendor=OpenBao"
+      - "--label=org.opencontainers.image.licenses=MPL-2.0"
+      - "--label=org.opencontainers.image.title=OpenBao"
+      - "--label=org.opencontainers.image.description=OpenBao is a tool for securely accessing secrets"
+      - "--target=distroless"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x"
+      - "quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x"
+      - "docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x"
+    extra_files:
+      - ./LICENSE
+      - ./CHANGELOG.md
 
 docker_manifests:
   - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
@@ -490,6 +676,42 @@ docker_manifests:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}.{{ .Minor }}
+    skip_push: auto
+    image_templates:
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}
+    skip_push: auto
+    image_templates:
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:latest
+    skip_push: auto
+    image_templates:
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
   - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
     skip_push: false
     image_templates:
@@ -554,6 +776,42 @@ docker_manifests:
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
       - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}.{{ .Minor }}
+    skip_push: auto
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}
+    skip_push: auto
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:latest
+    skip_push: auto
+    image_templates:
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - docker.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
   - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
     skip_push: false
     image_templates:
@@ -618,6 +876,42 @@ docker_manifests:
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
       - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-ubi{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}
+    skip_push: false
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}.{{ .Minor }}
+    skip_push: auto
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Major }}
+    skip_push: auto
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
+  - name_template: quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:latest
+    skip_push: auto
+    image_templates:
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-amd64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-arm64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-ppc64le
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-riscv64
+      - quay.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/openbao-distroless{{ .Env.NIGHTLY_RELEASE }}:{{ .Version }}-s390x
 
 archives:
   - format: tar.gz

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -299,7 +299,7 @@ const PackageRepo = ({ type }) => {
 const DockerList = ({ version, registry }) => {
   const dockerVersion = version.slice(1);
 
-  // For example: v2.6.0, v2.5.0-beta20251125.
+  // For example: 2.6.0, 2.5.0-beta20251125.
   // Consider replacing with a more complete semver parser once required.
   const [major, minor, _patch] = dockerVersion
     .match(/^(\d+)\.(\d+)\.(\d+)/).slice(1).map(v => parseInt(v));

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -297,12 +297,19 @@ const PackageRepo = ({ type }) => {
   );
 };
 const DockerList = ({ version, registry }) => {
-  const dockerVersion = version.slice(1);
+  // For example: v2.6.0, v2.5.0-beta20251125.
+  // Consider replacing with a more complete semver parser once required.
+  const [major, minor, _patch] = version
+    .match(/^v(\d+)\.(\d+)\.(\d+)/).slice(1).map(v => parseInt(v));
+
   const dockerDistros = {
     "Alpine Image Distribution": "openbao/openbao",
     "Alpine Image Distribution with HSM Support": "openbao/openbao-hsm",
     "Red Hat Universal Base Image (UBI) Distribution": "openbao/openbao-ubi",
     "Red Hat Universal Base Image (UBI) Distribution with HSM support": "openbao/openbao-hsm-ubi",
+    ...(major >= 2 && minor >= 6 ? {
+      "Distroless Distribution": "openbao/openbao-distroless",
+    } : {}),
   }
   return (
       <>

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -297,10 +297,12 @@ const PackageRepo = ({ type }) => {
   );
 };
 const DockerList = ({ version, registry }) => {
+  const dockerVersion = version.slice(1);
+
   // For example: v2.6.0, v2.5.0-beta20251125.
   // Consider replacing with a more complete semver parser once required.
-  const [major, minor, _patch] = version
-    .match(/^v(\d+)\.(\d+)\.(\d+)/).slice(1).map(v => parseInt(v));
+  const [major, minor, _patch] = dockerVersion
+    .match(/^(\d+)\.(\d+)\.(\d+)/).slice(1).map(v => parseInt(v));
 
   const dockerDistros = {
     "Alpine Image Distribution": "openbao/openbao",
@@ -317,7 +319,7 @@ const DockerList = ({ version, registry }) => {
           <div key={label}>
             <p>{label}</p>
             <CodeBlock language="shell">
-              {`docker pull ${registry}/${image}:${version}`}
+              {`docker pull ${registry}/${image}:${dockerVersion}`}
             </CodeBlock>
           </div>
         ))}


### PR DESCRIPTION
## Description

Add a new container image variant, "openbao-distroless" to the existing Alpine-based and UBI-based container images officially maintained by OpenBao. openbao-distroless is based on Google's `distroless/static:nonroot` container images.

This is currently based on #2589.

## Rationale

OpenBao, being a Go application that compiles to a static binary on Linux, is perfectly capable of running in an extremely minimal environment with no conventional OS utilities available. However, container images currently released by the OpenBao project do not make any use of this property and require downstream users to accept that official images come with a full rootfs based on Alpine Linux or UBI at their option.

There are advantages to both "distroful" and "distroless" container packaging:

- distroful: Easy to add extra OS dependencies via package managers, easy to debug via the included shell and tools, helpful entrypoint scripts to take over some automatable confguration steps
- distroless: Reduced size, reduced dependencies, reduced attack surface, near-zero scanner noise caused by unrelated OS dependencies. Updating the base image is rarely required (really just to update ca-certificates) and can safely coincide with regular releases of the main software.

OpenBao is deployed across a variety of different container-based setups with different modifications such as plugin installation, PKCS#11 libraries, additional scripts &c. As a result, I believe it is best to make both distroful and distroless containers available.

Notably, there is no "distroless-hsm" variant. The reasoning behind its omission is two-fold:

1. I seek to entirely remove the HSM distribution of OpenBao in the future, moving CGO-based PKCS#11 functionality into plugin binaries via https://github.com/openbao/openbao/pull/2459.
2. I expect advanced users that set up PKCS#11 libraries with a distroless image to understand how to manually add the required runtime libraries to a distroless image, including some version of libc.

As a security-focused project, I believe it is a disservice to users not to offer a container image distribution that is optimized to have the lowest possible attack surface (There are further improvements we can make here, such as reproducible builds, but that is an undertaking for another day).

I also imagine https://github.com/openbao/openbao/security/advisories/GHSA-xp75-r577-cvhp would have been much more difficult to exploit on a system that does not have additional utilities available.

If we'd prefer an RFC on the topic, I can do that, however I believe this is fairly non-controversial and follows a pattern common in server-type open source software.

#### Why use Google's distroless images?

They're free, widely adopted & have dependency scanning metadata for the little included packages that they do have (by proxy of being based on Debian). Additionally, unlike distroful images, it is much easier to switch to a separate source of distroless base images (or to build our own) without breaking users.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
