### PR TITLE
Add blanket TSC exception for large contributions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -135,6 +135,9 @@ The following groups of people are eligible to be committers:
 1. Active moderators who have held the position for 90 days, and
 2. Former committers and organization-level maintainers, and
 3. Past HashiCorp employees who contributed during their tenure at the company.
+4. Members of an organization who has made a substantial code donation which
+   they intend to help maintain, such as a new client library, KMS
+   integration, or a new plugin. See [TSC decision](https://docs.google.com/document/d/1oNqm4GXCsIZbcNHsIqft4kgciRcuwS9rrIRGXlMz1yg/edit?tab=t.0#heading=h.52zbex718qh5).
 
 Repository committers should demonstrate expertise in the requested project
 and show a committment to making meaningful changes and maintaining security.


### PR DESCRIPTION
This documents the TSC blanket exception in October 2025 for organizations wishing to make larger contributions to OpenBao (such as client libraries, KMS integrations, or new plugins).

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
