### PR TITLE
Add Secretz Enterprise as part of the Adfinis vendor description

### DIFF
--- a/website/content/ecosystem/vendors.mdx
+++ b/website/content/ecosystem/vendors.mdx
@@ -12,8 +12,8 @@ import Member from './lib/Member.tsx';
   <div className="row">
     <Randomize>
       <Member title="Adfinis">
-        [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
-        plans, builds, and runs OpenBao 24x7, and provides enterprise support.
+        Adfinis provides expert-led [professional and 24/7 managed services](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website),
+        and the [Secretz Enterprise](https://www.secretz.io/en/?mtm_campaign=secretz&mtm_kwd=global&mtm_source=openbao&mtm_medium=website) subscription for vendor-grade enterprise support and software assurance.
       </Member>
 
       <Member title="Helvethink">


### PR DESCRIPTION
## Description

A small update to Adfinis's vendor description in the ecosystem to highlight [Secretz Enterprise](https://www.secretz.io/en/), which is a subscription for OpenBao covering 24/7 enterprise support and software assurance. Length should be similar/same than other entries.

## Rationale

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
