### PR TITLE
Remove log gating

### DIFF
--- a/changelog/2620.txt
+++ b/changelog/2620.txt
@@ -1,0 +1,3 @@
+```release-note:change
+command: Remove buffering and delayed release of logs during startup phase of server, agent, proxy & debug subcommands. This includes the removal of the undocumented and hidden `-disable-gated-logs` flag.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/kr/pretty"
@@ -79,7 +78,6 @@ type AgentCommand struct {
 	tlsReloadFuncs     []reloadutil.ReloadFunc
 
 	logWriter io.Writer
-	logGate   *gatedwriter.Writer
 	logger    hclog.Logger
 
 	// Telemetry object
@@ -180,11 +178,7 @@ func (c *AgentCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Create a logger. We wrap it in a gated writer so that it doesn't
-	// start logging too early.
-	c.logGate = gatedwriter.NewWriter(os.Stderr)
-	c.logWriter = c.logGate
-
+	c.logWriter = os.Stderr
 	if c.logFlags.flagCombineLogs {
 		c.logWriter = os.Stdout
 	}
@@ -223,11 +217,6 @@ func (c *AgentCommand) Run(args []string) int {
 		InferLevels:              true,
 		InferLevelsWithTimestamp: true,
 	})
-
-	// release log gate if the disable-gated-logs flag is set
-	if c.logFlags.flagDisableGatedLogs {
-		c.logGate.Flush()
-	}
 
 	infoKeys := make([]string, 0, 10)
 	info := make(map[string]string)
@@ -402,7 +391,7 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// Output the header that the agent has started
 	if !c.logFlags.flagCombineLogs {
-		c.UI.Output("==> OpenBao Agent started! Log data will stream in below:\n")
+		c.UI.Output("==> OpenBao Agent started!")
 	}
 
 	var leaseCache *cache.LeaseCache
@@ -773,7 +762,7 @@ func (c *AgentCommand) Run(args []string) int {
 	padding := 24
 	sort.Strings(infoKeys)
 	caser := cases.Title(language.English, cases.NoLower)
-	c.UI.Output("==> OpenBao Agent configuration:\n")
+	c.UI.Output("\n==> OpenBao Agent configuration:\n")
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -782,9 +771,6 @@ func (c *AgentCommand) Run(args []string) int {
 			info[k]))
 	}
 	c.UI.Output("")
-
-	// Release the log gate.
-	c.logGate.Flush()
 
 	// Write out the PID to the file now that server has successfully started
 	if err := c.storePidFile(config.PidFile); err != nil {

--- a/command/commands.go
+++ b/command/commands.go
@@ -108,8 +108,6 @@ const (
 	flagNameDisableRedirects = "disable-redirects"
 	// flagNameCombineLogs is used to specify whether log output should be combined and sent to stdout
 	flagNameCombineLogs = "combine-logs"
-	// flagDisableGatedLogs is used to disable gated logs and immediately show the vault logs as they become available
-	flagDisableGatedLogs = "disable-gated-logs"
 	// flagNameLogFile is used to specify the path to the log file that Vault should use for logging
 	flagNameLogFile = "log-file"
 	// flagNameLogRotateBytes is the flag used to specify the number of bytes a log file should be before it is rotated.

--- a/command/debug.go
+++ b/command/debug.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/oklog/run"
 	"github.com/openbao/openbao/api/v2"
@@ -248,10 +247,8 @@ func (c *DebugCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize the logger for debug output
-	gatedWriter := gatedwriter.NewWriter(os.Stderr)
 	if c.logger == nil {
-		c.logger = logging.NewVaultLoggerWithWriter(gatedWriter, hclog.Trace)
+		c.logger = logging.NewVaultLoggerWithWriter(os.Stderr, hclog.Trace)
 	}
 
 	dstOutputFile, err := c.preflight(args)
@@ -270,29 +267,24 @@ func (c *DebugCommand) Run(args []string) int {
 	c.UI.Info(fmt.Sprintf("      Metrics Interval: %s", c.flagMetricsInterval))
 	c.UI.Info(fmt.Sprintf("               Targets: %s", strings.Join(c.flagTargets, ", ")))
 	c.UI.Info(fmt.Sprintf("                Output: %s", dstOutputFile))
-	c.UI.Output("")
-
-	// Release the log gate.
-	c.logger.(hclog.OutputResettable).ResetOutputWithFlush(&hclog.LoggerOptions{
-		Output: os.Stderr,
-	}, gatedWriter)
 
 	// Capture static information
+	c.UI.Output("")
 	c.UI.Info("==> Capturing static information...")
 	if err := c.captureStaticTargets(); err != nil {
 		c.UI.Error(fmt.Sprintf("Error capturing static information: %s", err))
 		return 2
 	}
 
-	c.UI.Output("")
-
 	// Capture polling information
+	c.UI.Output("")
 	c.UI.Info("==> Capturing dynamic information...")
 	if err := c.capturePollingTargets(); err != nil {
 		c.UI.Error(fmt.Sprintf("Error capturing dynamic information: %s", err))
 		return 2
 	}
 
+	c.UI.Output("")
 	c.UI.Output("Finished capturing information, bundling files...")
 
 	// Generate index file

--- a/command/log_flags.go
+++ b/command/log_flags.go
@@ -15,7 +15,6 @@ import (
 // logFlags are the 'log' related flags that can be shared across commands.
 type logFlags struct {
 	flagCombineLogs       bool
-	flagDisableGatedLogs  bool
 	flagLogLevel          string
 	flagLogFormat         string
 	flagLogFile           string
@@ -38,13 +37,6 @@ func (f *FlagSet) addLogFlags(l *logFlags) {
 	f.BoolVar(&BoolVar{
 		Name:    flagNameCombineLogs,
 		Target:  &l.flagCombineLogs,
-		Default: false,
-		Hidden:  true,
-	})
-
-	f.BoolVar(&BoolVar{
-		Name:    flagDisableGatedLogs,
-		Target:  &l.flagDisableGatedLogs,
 		Default: false,
 		Hidden:  true,
 	})

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/cli"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/kr/pretty"
@@ -76,7 +75,6 @@ type ProxyCommand struct {
 	tlsReloadFuncs     []reloadutil.ReloadFunc
 
 	logWriter io.Writer
-	logGate   *gatedwriter.Writer
 	logger    log.Logger
 
 	// Telemetry object
@@ -177,11 +175,7 @@ func (c *ProxyCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Create a logger. We wrap it in a gated writer so that it doesn't
-	// start logging too early.
-	c.logGate = gatedwriter.NewWriter(os.Stderr)
-	c.logWriter = c.logGate
-
+	c.logWriter = os.Stderr
 	if c.logFlags.flagCombineLogs {
 		c.logWriter = os.Stdout
 	}
@@ -211,11 +205,6 @@ func (c *ProxyCommand) Run(args []string) int {
 		return 1
 	}
 	c.logger = l
-
-	// release log gate if the disable-gated-logs flag is set
-	if c.logFlags.flagDisableGatedLogs {
-		c.logGate.Flush()
-	}
 
 	infoKeys := make([]string, 0, 10)
 	info := make(map[string]string)
@@ -375,7 +364,7 @@ func (c *ProxyCommand) Run(args []string) int {
 
 	// Output the header that the proxy has started
 	if !c.logFlags.flagCombineLogs {
-		c.UI.Output("==> OpenBao Proxy started! Log data will stream in below:\n")
+		c.UI.Output("==> OpenBao Proxy started!")
 	}
 
 	var leaseCache *cache.LeaseCache
@@ -694,7 +683,7 @@ func (c *ProxyCommand) Run(args []string) int {
 	padding := 24
 	sort.Strings(infoKeys)
 	caser := cases.Title(language.English, cases.NoLower)
-	c.UI.Output("==> OpenBao Proxy configuration:\n")
+	c.UI.Output("\n==> OpenBao Proxy configuration:\n")
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -703,9 +692,6 @@ func (c *ProxyCommand) Run(args []string) int {
 			info[k]))
 	}
 	c.UI.Output("")
-
-	// Release the log gate.
-	c.logGate.Flush()
 
 	// Write out the PID to the file now that server has successfully started
 	if err := c.storePidFile(config.PidFile); err != nil {

--- a/command/server.go
+++ b/command/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/mitchellh/go-testing-interface"
@@ -99,7 +98,6 @@ type ServerCommand struct {
 	WaitGroup *sync.WaitGroup
 
 	logWriter io.Writer
-	logGate   *gatedwriter.Writer
 	logger    hclog.InterceptLogger
 
 	cleanupGuard sync.Once
@@ -363,12 +361,6 @@ func (c *ServerCommand) AutocompleteFlags() complete.Flags {
 	return c.Flags().Completions()
 }
 
-func (c *ServerCommand) flushLog() {
-	c.logger.(hclog.OutputResettable).ResetOutputWithFlush(&hclog.LoggerOptions{
-		Output: c.logWriter,
-	}, c.logGate)
-}
-
 func (c *ServerCommand) runRecoveryMode() int {
 	config, configErrors, err := c.ParseServerConfig(c.flagConfigs)
 	if err != nil {
@@ -400,9 +392,6 @@ func (c *ServerCommand) runRecoveryMode() int {
 	for _, cErr := range configErrors {
 		c.logger.Warn(cErr.String())
 	}
-
-	// Ensure logging is flushed if initialization fails
-	defer c.flushLog()
 
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
@@ -538,7 +527,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	// Initialize the listeners
 	lns := make([]listenerutil.Listener, 0, len(config.Listeners))
 	for _, lnConfig := range config.Listeners {
-		ln, _, _, err := server.NewListener(lnConfig, c.logger, c.logGate, c.UI)
+		ln, _, _, err := server.NewListener(lnConfig, c.logger, c.UI)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error initializing listener of type %s: %s", lnConfig.Type, err))
 			return 1
@@ -581,7 +570,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	padding := 24
 
 	sort.Strings(infoKeys)
-	c.UI.Output("==> OpenBao server configuration:\n")
+	c.UI.Output("\n==> OpenBao server configuration:\n")
 
 	titleCaser := cases.Title(language.English, cases.NoLower)
 
@@ -646,10 +635,8 @@ func (c *ServerCommand) runRecoveryMode() int {
 	}
 
 	if !c.logFlags.flagCombineLogs {
-		c.UI.Output("==> OpenBao server started! Log data will stream in below:\n")
+		c.UI.Output("==> OpenBao server started!")
 	}
-
-	c.flushLog()
 
 	for {
 		select {
@@ -778,7 +765,7 @@ func (c *ServerCommand) InitListeners(logger hclog.Logger, config *server.Config
 
 	var errMsg error
 	for i, lnConfig := range config.Listeners {
-		ln, props, cg, err := server.NewListener(lnConfig, c.logger, c.logGate, c.UI)
+		ln, props, cg, err := server.NewListener(lnConfig, c.logger, c.UI)
 		if err != nil {
 			errMsg = fmt.Errorf("Error initializing listener of type %s: %s", lnConfig.Type, err)
 			return 1, nil, nil, errMsg
@@ -929,9 +916,7 @@ func (c *ServerCommand) Run(args []string) int {
 	// Don't exit just because we saw a potential deadlock.
 	deadlock.Opts.OnPotentialDeadlock = func() {}
 
-	c.logGate = gatedwriter.NewWriter(os.Stderr)
-	c.logWriter = c.logGate
-
+	c.logWriter = os.Stderr
 	if c.logFlags.flagCombineLogs {
 		c.logWriter = os.Stdout
 	}
@@ -1018,18 +1003,10 @@ func (c *ServerCommand) Run(args []string) int {
 	c.logger = l
 	c.allLoggers = append(c.allLoggers, l)
 
-	// flush logs right away if the server is started with the disable-gated-logs flag
-	if c.logFlags.flagDisableGatedLogs {
-		c.flushLog()
-	}
-
 	// reporting Errors found in the config
 	for _, cErr := range configErrors {
 		c.logger.Warn(cErr.String())
 	}
-
-	// Ensure logging is flushed if initialization fails
-	defer c.flushLog()
 
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
@@ -1294,7 +1271,7 @@ func (c *ServerCommand) Run(args []string) int {
 	info["go version"] = runtime.Version()
 
 	sort.Strings(infoKeys)
-	c.UI.Output("==> OpenBao server configuration:\n")
+	c.UI.Output("\n==> OpenBao server configuration:\n")
 
 	titleCaser := cases.Title(language.English, cases.NoLower)
 
@@ -1388,19 +1365,11 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 
-	// Output the header that the server has started
-	if !c.logFlags.flagCombineLogs {
-		c.UI.Output("==> OpenBao server started! Log data will stream in below:\n")
-	}
-
 	// Inform any tests that the server is ready
 	select {
 	case c.startedCh <- struct{}{}:
 	default:
 	}
-
-	// Release the log gate.
-	c.flushLog()
 
 	// Write out the PID to the file now that server has successfully started
 	if err := c.storePidFile(config.PidFile); err != nil {
@@ -1410,6 +1379,11 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// Notify systemd that the server is ready (if applicable)
 	c.notifySystemd(systemd.SdNotifyReady)
+
+	// Output the header that the server has started
+	if !c.logFlags.flagCombineLogs {
+		c.UI.Output("==> OpenBao server started!")
+	}
 
 	if c.flagDev {
 		protocol := "http://"
@@ -1795,7 +1769,7 @@ func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) erro
 // freshly initialized core to perform the component requests of the
 // self-initialization process.
 func (c *ServerCommand) doSelfInit(core *vault.Core, config *server.Config, rootToken string) error {
-	c.UI.Warn("Beginning post-unseal configuration")
+	c.logger.Info("beginning post-unseal configuration")
 	p, err := profiles.NewEngine(
 		// Set up the profile system with relevant parameter sources:
 		// - Environment variables
@@ -2030,7 +2004,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	padding := 24
 
 	sort.Strings(infoKeys)
-	c.UI.Output("==> OpenBao server configuration:\n")
+	c.UI.Output("\n==> OpenBao server configuration:\n")
 
 	titleCaser := cases.Title(language.English, cases.NoLower)
 
@@ -2161,16 +2135,13 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 	}
 
 	// Output the header that the server has started
-	c.UI.Output("==> OpenBao server started! Log data will stream in below:\n")
+	c.UI.Output("==> OpenBao server started!")
 
 	// Inform any tests that the server is ready
 	select {
 	case c.startedCh <- struct{}{}:
 	default:
 	}
-
-	// Release the log gate.
-	c.flushLog()
 
 	// Wait for shutdown
 	shutdownTriggered := false
@@ -2395,9 +2366,6 @@ func (c *ServerCommand) storageMigrationActive(backend physical.Backend) bool {
 		if first {
 			first = false
 			c.UI.Warn("\nWARNING! Unable to read storage migration status.")
-
-			// unexpected state, so stop buffering log messages
-			c.flushLog()
 		}
 		c.logger.Warn("storage migration check error", "error", err.Error())
 
@@ -2832,6 +2800,7 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 					c.logger.DeregisterSink(qw)
 
 					// Print the big dev mode warning!
+					c.UI.Warn("")
 					c.UI.Warn(wrapAtLength(
 						"WARNING! dev mode is enabled! In this mode, OpenBao runs entirely " +
 							"in-memory and starts unsealed with a single unseal key. The root " +

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -6,7 +6,6 @@ package server
 import (
 	_ "crypto/sha512"
 	"fmt"
-	"io"
 	"net"
 
 	// We must import sha512 so that it registers with the runtime so that
@@ -20,7 +19,7 @@ import (
 )
 
 // ListenerFactory is the factory function to create a listener.
-type ListenerFactory func(*configutil.Listener, hclog.Logger, io.Writer, cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error)
+type ListenerFactory func(*configutil.Listener, hclog.Logger, cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error)
 
 // BuiltinListeners is the list of built-in listener types.
 var BuiltinListeners = map[string]ListenerFactory{
@@ -30,13 +29,13 @@ var BuiltinListeners = map[string]ListenerFactory{
 
 // NewListener creates a new listener of the given type with the given
 // configuration. The type is looked up in the BuiltinListeners map.
-func NewListener(l *configutil.Listener, logger hclog.Logger, logGate io.Writer, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
+func NewListener(l *configutil.Listener, logger hclog.Logger, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
 	f, ok := BuiltinListeners[l.Type]
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("unknown listener type: %q", l.Type)
 	}
 
-	return f(l, logger, logGate, ui)
+	return f(l, logger, ui)
 }
 
 func listenerWrapProxy(ln net.Listener, l *configutil.Listener) (net.Listener, error) {

--- a/command/server/listener_tcp.go
+++ b/command/server/listener_tcp.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -19,7 +18,7 @@ import (
 	"github.com/openbao/openbao/helper/listenerutil"
 )
 
-func tcpListenerFactory(l *configutil.Listener, logger hclog.Logger, _ io.Writer, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
+func tcpListenerFactory(l *configutil.Listener, logger hclog.Logger, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
 	addr := l.Address
 	if addr == "" {
 		addr = "127.0.0.1:8200"

--- a/command/server/listener_tcp_test.go
+++ b/command/server/listener_tcp_test.go
@@ -20,7 +20,7 @@ func TestTCPListener(t *testing.T) {
 	ln, _, _, err := tcpListenerFactory(&configutil.Listener{
 		Address:    "127.0.0.1:0",
 		TLSDisable: true,
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -51,7 +51,7 @@ func TestTCPListener_tls(t *testing.T) {
 		TLSKeyFile:                    wd + "reload_foo.key",
 		TLSRequireAndVerifyClientCert: true,
 		TLSClientCAFile:               wd + "reload_ca.pem",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -89,7 +89,7 @@ func TestTCPListener_tls(t *testing.T) {
 		TLSRequireAndVerifyClientCert: true,
 		TLSDisableClientCerts:         true,
 		TLSClientCAFile:               wd + "reload_ca.pem",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err == nil {
 		t.Fatal("expected error due to mutually exclusive client cert options")
 	}
@@ -100,7 +100,7 @@ func TestTCPListener_tls(t *testing.T) {
 		TLSKeyFile:            wd + "reload_foo.key",
 		TLSDisableClientCerts: true,
 		TLSClientCAFile:       wd + "reload_ca.pem",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -127,7 +127,7 @@ func TestTCPListener_tls13(t *testing.T) {
 		TLSRequireAndVerifyClientCert: true,
 		TLSClientCAFile:               wd + "reload_ca.pem",
 		TLSMinVersion:                 "tls13",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -166,7 +166,7 @@ func TestTCPListener_tls13(t *testing.T) {
 		TLSDisableClientCerts:         true,
 		TLSClientCAFile:               wd + "reload_ca.pem",
 		TLSMinVersion:                 "tls13",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err == nil {
 		t.Fatal("expected error due to mutually exclusive client cert options")
 	}
@@ -178,7 +178,7 @@ func TestTCPListener_tls13(t *testing.T) {
 		TLSDisableClientCerts: true,
 		TLSClientCAFile:       wd + "reload_ca.pem",
 		TLSMinVersion:         "tls13",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -192,7 +192,7 @@ func TestTCPListener_tls13(t *testing.T) {
 		TLSDisableClientCerts: true,
 		TLSClientCAFile:       wd + "reload_ca.pem",
 		TLSMaxVersion:         "tls12",
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -427,7 +427,7 @@ func TestTCPListener_proxyProtocol(t *testing.T) {
 				TLSDisable:                   true,
 				ProxyProtocolBehavior:        tc.Behavior,
 				ProxyProtocolAuthorizedAddrs: proxyProtocolAuthorizedAddrs,
-			}, nil, nil, cli.NewMockUi())
+			}, nil, cli.NewMockUi())
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}

--- a/command/server/listener_unix.go
+++ b/command/server/listener_unix.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"io"
 	"net"
 
 	"github.com/hashicorp/cli"
@@ -13,7 +12,7 @@ import (
 	"github.com/openbao/openbao/helper/listenerutil"
 )
 
-func unixListenerFactory(l *configutil.Listener, _ hclog.Logger, _ io.Writer, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
+func unixListenerFactory(l *configutil.Listener, _ hclog.Logger, ui cli.Ui) (net.Listener, map[string]string, listenerutil.ReloadableCertGetter, error) {
 	addr := l.Address
 	if addr == "" {
 		addr = "/run/vault.sock"

--- a/command/server/listener_unix_test.go
+++ b/command/server/listener_unix_test.go
@@ -15,7 +15,7 @@ import (
 func TestUnixListener(t *testing.T) {
 	ln, _, _, err := unixListenerFactory(&configutil.Listener{
 		Address: filepath.Join(t.TempDir(), "/vault.sock"),
-	}, nil, nil, cli.NewMockUi())
+	}, nil, cli.NewMockUi())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
 	github.com/hashicorp/go-secure-stdlib/fileutil v0.1.0
-	github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1
 	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2
 	github.com/hashicorp/go-secure-stdlib/nonceutil v0.1.0
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,6 @@ github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/fileutil v0.1.0 h1:f2mwVgMJjXuX/+eWD6ZW30+oIRgCofL+XMWknFkB1WM=
 github.com/hashicorp/go-secure-stdlib/fileutil v0.1.0/go.mod h1:uwcr2oga9pN5+OkHZyTN5MDk3+1YHOuMukhpnPaQAoI=
-github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1 h1:9um9R8i0+HbRHS9d64kdvWR0/LJvo12sIonvR9zr1+U=
-github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1/go.mod h1:6RoRTSMDK2H/rKh3P/JIsk1tK8aatKTt3JyvIopi3GQ=
 github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2 h1:NS6BHieb/pDfx3M9jDdaPpGyyVp+aD4A3DjX3dgRmzs=
 github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2/go.mod h1:rf5JPE13wi+NwjgsmGkbg4b2CgHq8v7Htn/F0nDe/hg=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.3 h1:kH3Rhiht36xhAfhuHyWJDgdXXEx9IIZhDGRk24CDhzg=


### PR DESCRIPTION
## Description

This removes log gating during the startup phase of the server, agent, proxy & debug commands, including the associated undocumented `-disable-gated-logs` flag.

Log gating is a cosmetic feature that was introduced all the way back in 2015. During startup, any logs generated by the system are held back (buffered internally) and only flushed once we've printed:

```
==> OpenBao server started! Log data will stream in below:
```

This makes the server startup logs slightly less messy as output intended to be read by humans only is always pinned to the top of the log.

## Rationale

Log gating comes with the severe drawback that any logs produced during the gated phase will not be streamed to the output in real-time. This tradeoff is mostly acceptable as the initial gated phase during startup is typically very short and does not produce many logs anyway. Still, looking specifically at `command/server.go`, the gated phase covers setup code for several critical components, to name a few:

- Physical storage backend
- Auto Seals
- Service Discovery
- Metrics
- Listeners

Additionally, with https://github.com/openbao/openbao/pull/2586, this phase would include:

- Initial OCI plugin downloads
- Auto Seal / KMS plugin setup

Particularly OCI plugin downloads may lengthen the pre-core, gated setup phase significantly. A lack of logs makes this hard to debug; the logs generated by the OCI downloader are only visible once plugin downloads have finished and either failed or core has started.

We could come up with workarounds and expose only specific logs before releasing the gate, though I believe entirely removing log gating is the simplest & best solution that will cover all kinds of scenarios.

As a result, a small amount of logs may be displayed before the

```
==> OpenBao server configuration
```

header is reached, and the following

```
==> OpenBao server started!
```

header will appear once all logs that lead to successful startup have been displayed in real-time, not before them.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
