### PR TITLE
Remove keyring canary & poison pill

### DIFF
--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -31,15 +31,8 @@ const (
 // These paths don't need to be cached by the LRU cache. This should
 // particularly help memory pressure when unsealing.
 var cacheExceptionsPaths = []string{
-	"wal/logs/",
-	"index/pages/",
-	"index-dr/pages/",
 	"sys/expire/",
-	"core/poison-pill",
 	"core/raft/tls",
-
-	// Add barrierSealConfigPath and recoverySealConfigPlaintextPath to the cache
-	// exceptions to avoid unseal errors. See VAULT-17227
 	"core/seal-config",
 	"core/recovery-config",
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -72,18 +72,9 @@ const (
 	// for a highly-available deployment which is undergoing initialization.
 	CoreInitLockPath = "core/initialize-lock"
 
-	// The poison pill is used as a check during certain scenarios to indicate
-	// to standby nodes that they should seal
-	poisonPillPath = "core/poison-pill"
-
 	// coreLeaderPrefix is the prefix used for the UUID that contains
 	// the currently elected leader.
 	coreLeaderPrefix = "core/leader/"
-
-	// coreKeyringCanaryPath is used as a canary to indicate to replicated
-	// clusters that they need to perform a rotation synchronously;
-	// this isn't keyring-canary to avoid ignoring it when ignoring core/keyring
-	coreKeyringCanaryPath = "core/canary-keyring"
 
 	// coreGroupPolicyApplicationPath is used to store the behaviour for
 	// how policies should be applied

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -240,7 +240,6 @@ func isTransactionalMountPath(key string) bool {
 
 func isKeyringPath(key string) bool {
 	return key == barrierSealConfigPath ||
-		key == coreKeyringCanaryPath ||
 		key == barrier.KeyringPath ||
 		key == barrier.LegacyRootKeyPath ||
 		key == recoverySealConfigPath ||

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -1026,20 +1026,6 @@ func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{
 					return
 				}
 
-				// Check for a poison pill. If we can read it, it means we have stale
-				// keys (e.g. from replication being activated) and we need to seal to
-				// be unsealed again.
-				entry, _ := c.barrier.Get(ctx, poisonPillPath)
-				if entry != nil && len(entry.Value) > 0 {
-					c.logger.Warn("encryption keys have changed out from underneath us (possibly due to replication enabling), must be unsealed again")
-					// If we are using raft storage we do not want to shut down
-					// raft during replication secondary enablement. This will
-					// allow us to keep making progress on the raft log.
-					go c.sealInternalWithOptions(true, false, !isRaft)
-					opCount.Add(-1)
-					return
-				}
-
 				if err := c.checkKeyUpgrades(ctx); err != nil {
 					c.logger.Error("key rotation periodic upgrade check failed", "error", err)
 				}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4490,16 +4490,6 @@ func (b *SystemBackend) rotateBarrierKey(ctx context.Context) error {
 		})
 	}
 
-	// Write to the canary path, which will force a synchronous truing during
-	// replication
-	if err := b.Core.barrier.Put(ctx, &logical.StorageEntry{
-		Key:   coreKeyringCanaryPath,
-		Value: fmt.Appendf(nil, "new-rotation-term-%d", newTerm),
-	}); err != nil {
-		b.Core.logger.Error("error saving keyring canary", "error", err)
-		return fmt.Errorf("failed to save keyring canary: %w", err)
-	}
-
 	return nil
 }
 

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -561,16 +561,6 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 		return logical.CodedError(http.StatusInternalServerError, "failed to save rekey seal configuration: %v", err)
 	}
 
-	// Write to the canary path, which will force a synchronous truing during
-	// replication
-	if err := c.barrier.Put(ctx, &logical.StorageEntry{
-		Key:   coreKeyringCanaryPath,
-		Value: []byte(c.rootRotationConfig.Nonce),
-	}); err != nil {
-		c.logger.Error("error saving keyring canary", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, "failed to save keyring canary: %v", err)
-	}
-
 	c.rootRotationConfig.RotationProgress = nil
 
 	return nil
@@ -761,16 +751,6 @@ func (c *Core) performRecoveryRekey(ctx context.Context, newRootKey []byte) logi
 	if err := c.seal.SetRecoveryConfig(ctx, c.recoveryRotationConfig); err != nil {
 		c.logger.Error("error saving rekey seal configuration", "error", err)
 		return logical.CodedError(http.StatusInternalServerError, "failed to save rekey seal configuration: %v", err)
-	}
-
-	// Write to the canary path, which will force a synchronous truing during
-	// replication
-	if err := c.barrier.Put(ctx, &logical.StorageEntry{
-		Key:   coreKeyringCanaryPath,
-		Value: []byte(c.recoveryRotationConfig.Nonce),
-	}); err != nil {
-		c.logger.Error("error saving keyring canary", "error", err)
-		return logical.CodedError(http.StatusInternalServerError, "failed to save keyring canary: %v", err)
 	}
 
 	c.recoveryRotationConfig.RotationProgress = nil


### PR DESCRIPTION
## Description

Removes writing to `core/canary-keyring` and reading from `core/poison-pill`.

## Rationale

These paths are either written and never read or read but never written. I'm confused each time I re-read HA key rotation code.

I do see that @cipherboy kept `core/poison-pill` around in https://github.com/openbao/openbao/pull/197, perhaps we still have a good reason to keep it there but for now I will naively suggest we just remove it :D

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
