### PR TITLE
docs(docs): Add missing documentation on HTTP audit device

### DIFF
--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -172,10 +172,10 @@ docs](/api-docs/system/audit) for more details.
   actual log line.
 
 - `skip_test` `(string: "")` When set to `"true"`, OpenBao will not send an
-initial test probe request to the audit log destination when enabling the
-audit device. By default, OpenBao tests the connection to the destination server on
-mount, and if the destination is unreachable, the audit device fails to
-enable which can block unsealing.
+  initial test probe request to the audit log destination when enabling the
+  audit device. By default, OpenBao tests the connection to the destination
+  server on mount, and if the destination is unreachable, the audit device fails
+  to enable which can block unsealing.
 
   :::warning
 


### PR DESCRIPTION
## Description

- The [documentation for HTTP audit device configuration](https://openbao.org/docs/audit/http/#configuration) do not mention the skip_test option.

- The [skip_test option](https://github.com/openbao/openbao/blob/v2.5.1/vault/audit.go#L139) is implemented in the codebase such that if this configuration value is set as "true", Openbao does NOT do an initial test probe request to the destination of the HTTP to ensure that the audit log destination is healthy and accepting requests

- If `skip_test` value is NOT set as "true", Openbao makes a test probe request. If this fails, the mounting of the HTTP audit device fails and Openbao fails to unseal

- This PR adds this missing information to the HTTP audit device documentation

## Rationale

- This option is useful in specific cases like the one we faced where in our Kubernetes deployment setup where the Openbao pods were initialized and up and running before the HTTP audit device destination server was up and running causing the audit device mounting and unsealing in Openbao to fail. So we should document this existing useful feature to make docs consistent with the actual code implementation

Resolves: #2627

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
