### PR TITLE
fix race condition in jobmanager

### DIFF
--- a/changelog/2630.txt
+++ b/changelog/2630.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fix potential deadlock in JobManager, which can cause mount deletion timeouts
+```

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -108,7 +108,10 @@ func (j *JobManager) AddJob(job Job, queueID string) {
 		defer func() {
 			// newWork must be buffered to avoid deadlocks if work is added
 			// before the job manager is started
-			j.newWork <- struct{}{}
+			select {
+			case j.newWork <- struct{}{}:
+			default:
+			}
 		}()
 	}
 	defer j.l.Unlock()


### PR DESCRIPTION
## Description

Fixes a race in JobManager that made `AddJob` potentially blocking (and - together with other locks - led to a deadlock in the RollbackManager)

When this was originally implemented, I guess the assumption was that this can't block, because of the `if len(j.queues) == 0 {` meaning only the scheduled job would write to the channel and this happens under `j.l.Lock()` so it can't race.

BUT

The inner loop of `assignWork` works like this: https://github.com/openbao/openbao/blob/bae41858140bb28c2b28d3ed7cea07988f4c7ab3/helper/fairshare/jobmanager.go#L279-L299

1. We drain `newWork` (which is good)
2. We call `getNextJob()` 
3. We dispatch the job

`getNextJob` does proper locking and will remove empty queues.

What I think happens is: `AddJob` gets called between step 1 and 2 as well as between 2 and 3 (with and otherwise empty queue).

The first time `len(j.queues)` was zero and a message was sent to `newWork`, but it does not block, because it's a buffered channel.
The second time `len(j.queues)` is zero again (because `getNextJob` was called in between and popped the first job) and now sending to `newWork` blocks. 

To fix this, I wrapped this in a `select` block with a `default` arm.

## Rationale

Resolves: #2612

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
