### PR TITLE
Skip lease restoration on standby nodes (#2549)

### DIFF
--- a/changelog/2549.txt
+++ b/changelog/2549.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Skip re-scheduling lease expiration jobs that need to write to storage when a node unseals in read-only mode.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -2415,7 +2415,7 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, logger log.Logge
 	if err := c.startRollback(); err != nil {
 		return err
 	}
-	if err := c.setupExpiration(expireLeaseStrategyFairsharing); err != nil {
+	if err := c.setupExpiration(expireLeaseStrategyFairsharing, standby); err != nil {
 		return err
 	}
 	if err := c.setupAudits(ctx); err != nil {

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -324,34 +325,22 @@ func getNumExpirationWorkers(c *Core, l log.Logger) int {
 }
 
 // NewExpirationManager creates a new ExpirationManager that uses the provided router for revocation.
-func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, detectDeadlocks bool) *ExpirationManager {
-	managerLogger := logger.Named("job-manager")
-	jobManager := fairshare.NewJobManager("expire", getNumExpirationWorkers(c, logger), managerLogger, c.metricSink)
-	jobManager.Start()
-
-	c.AddLogger(managerLogger)
-
+func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, detectDeadlocks, shouldProcessExp bool) *ExpirationManager {
 	exp := &ExpirationManager{
 		core:        c,
 		router:      c.router,
 		tokenStore:  c.tokenStore,
 		logger:      logger,
-		pending:     sync.Map{},
 		pendingLock: &locking.SyncRWMutex{},
-		nonexpiring: sync.Map{},
-		leaseCount:  0,
 		tidyLock:    new(int32),
-
-		lockPerLease: sync.Map{},
 
 		uniquePolicies:      make(map[string][]string),
 		emptyUniquePolicies: time.NewTicker(7 * 24 * time.Hour),
 
 		// new instances of the expiration manager will go immediately into
 		// restore mode
-		restoreMode:  new(int32),
-		restoreLocks: locksutil.CreateLocks(),
-		quitCh:       make(chan struct{}),
+		restoreMode: new(int32),
+		quitCh:      make(chan struct{}),
 
 		coreStateLock:     c.stateLock,
 		quitContext:       c.activeContext,
@@ -359,14 +348,26 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 
 		logLeaseExpirations: api.ReadBaoVariable("BAO_SKIP_LOGGING_LEASE_EXPIRATIONS") == "",
 
-		jobManager:      jobManager,
 		revokeRetryBase: c.expirationRevokeRetryBase,
 	}
+
+	managerLogger := logger.Named("job-manager")
+	c.AddLogger(managerLogger)
+
+	exp.jobManager = fairshare.NewJobManager("expire", getNumExpirationWorkers(c, logger), managerLogger, c.metricSink)
+	exp.jobManager.Start()
+
+	// active node
+	if shouldProcessExp {
+		// active nodes start by running in restore mode by default
+		*exp.restoreMode = 1
+		exp.restoreLocks = locksutil.CreateLocks()
+	}
+
 	exp.expireFunc.Store(&e)
 	if exp.revokeRetryBase == 0 {
 		exp.revokeRetryBase = revokeRetryBase
 	}
-	*exp.restoreMode = 1
 
 	if exp.logger == nil {
 		opts := log.LoggerOptions{Name: "expiration_manager"}
@@ -384,27 +385,24 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 }
 
 // setupExpiration is invoked after we've loaded the mount table to
-// initialize the expiration manager
-func (c *Core) setupExpiration(e ExpireLeaseStrategy) error {
+// initialize the expiration manager.
+func (c *Core) setupExpiration(e ExpireLeaseStrategy, standby bool) error {
 	c.metricsMutex.Lock()
 	defer c.metricsMutex.Unlock()
 
-	// Create the manager
 	expLogger := c.baseLogger.Named("expiration")
 	c.AddLogger(expLogger)
 
-	detectDeadlocks := false
-	for _, v := range c.detectDeadlocks {
-		if v == "expiration" {
-			detectDeadlocks = true
-		}
+	// Create the manager
+	c.expiration = NewExpirationManager(c, e, expLogger, slices.Contains(c.detectDeadlocks, "expiration"), !standby)
+
+	// Link expiration mgr to token store
+	c.tokenStore.SetExpirationManager(c.expiration)
+
+	if standby {
+		c.logger.Info("skipping lease restoration - standby")
+		return nil
 	}
-
-	expMgr := NewExpirationManager(c, e, expLogger, detectDeadlocks)
-	c.expiration = expMgr
-
-	// Link the token store to this
-	c.tokenStore.SetExpirationManager(expMgr)
 
 	// Restore the existing state
 	c.logger.Info("restoring leases")
@@ -740,11 +738,8 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 	wg := &sync.WaitGroup{}
 
 	// Create 64 workers to distribute work to
-	for i := 0; i < consts.ExpirationRestoreWorkerCount; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+	for range consts.ExpirationRestoreWorkerCount {
+		wg.Go(func() {
 			for {
 				select {
 				case lease, ok := <-broker:
@@ -771,13 +766,11 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	// Distribute the collected keys to the workers in a go routine
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		i := 0
 		for ns := range existing {
 			for _, leaseID := range existing[ns] {
@@ -804,11 +797,11 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 
 		// Close the broker, causing worker routines to exit
 		close(broker)
-	}()
+	})
 
 	// Ensure all keys on the chan are processed
 LOOP:
-	for i := 0; i < leaseCount; i++ {
+	for range leaseCount {
 		select {
 		case err = <-errs:
 			// Close all go routines
@@ -2784,7 +2777,7 @@ func (le *leaseEntry) nonexpiringToken() bool {
 		le.namespace.ID == namespace.RootNamespaceID
 }
 
-// TODO maybe lock RevokeErr once this goes in: https://github.com/openbao/openbao/pull/11122
+// TODO: maybe lock RevokeErr once this goes in: https://github.com/hashicorp/vault/pull/11122
 func (le *leaseEntry) isIrrevocable() bool {
 	return le.RevokeErr != ""
 }

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -2431,7 +2431,7 @@ func TestExpiration_revokeEntry_rejected_fairsharing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = core.setupExpiration(expireLeaseStrategyFairsharing)
+	err = core.setupExpiration(expireLeaseStrategyFairsharing, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/2549 (with conflicts)

Some conflicts in `NewExpirationManager` had to be resolved (on main we now use typesafe atomic for restore-mode, here we still use a simple int pointer)

Co-authored-by: Wojciech Slabosz <wojciech.slabosz@sap.com>
Co-authored-by: Jonas Köhnen <jonas.koehnen@sap.com>