### PR TITLE
Fix docker test cert injection race condition

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -694,16 +694,21 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 	wg.Add(1)
 	var seenLogs atomic.Bool
 	logConsumer := func(s string) {
+		n.Logger.Trace(s)
+	}
+	logStdout := &LogConsumerWriter{func(s string) {
+		// HACK: The first message printed to stdout implies that listeners are
+		// ready, or that startup failed. We use this to time the rotation of
+		// the initial certificate, such that:
+		// 1. SIGHUP is not sent too early.
+		// 2. We don't cause a race condition on the file system where OpenBao
+		//    will see either no cert or a mismatched cert/key.
 		if seenLogs.CompareAndSwap(false, true) {
 			wg.Done()
 		}
 		n.Logger.Trace(s)
-	}
-	logStdout := &LogConsumerWriter{logConsumer}
+	}}
 	logStderr := &LogConsumerWriter{func(s string) {
-		if seenLogs.CompareAndSwap(false, true) {
-			wg.Done()
-		}
 		testcluster.JSONLogNoTimestamp(n.Logger, s)
 	}}
 


### PR DESCRIPTION
## Description

This fixes a frequent test flake I introduced with https://github.com/openbao/openbao/pull/2620 that affected all tests using `NewTestDockerCluster`.

Some background first:

`NewTestDockerCluster` initially starts nodes with listeners configured against a dummy cert that is generated pre-startup. Once the container is up, we learn its real IP and write a new certificate that has the correct SAN into the container and send SIGHUP.

To do this, we must wait for the listener to read the initial dummy cert such that we don't swap the cert out in a racy way, e.g., by sending SIGHUP before the signal listener is registered or modifying files while they're still being loaded.

Previously, waiting for the listener to be ready was achieved by waiting for _any_ kind of log output from the node. This worked because the log gate would buffer structured logs (stderr) emitted pre listener startup and emit the first stdout line (UI messages) only once either listeners are ready or startup failed.

With https://github.com/openbao/openbao/pull/2620, stderr log lines can now appear _before_ listeners are ready. To fix this, we simply wait for the first stdout line only instead of both channels. (At least I think, CI will tell me...)

## Rationale

I've tried refactoring the readiness detection to be network-based but that was a rabbit hole that led me nowhere.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
