### PR TITLE
Remove Entropy Augmentation hooks from core

### DIFF
--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -137,11 +136,7 @@ func caKey(ctx context.Context, storage logical.Storage, keyType string) (*keySt
 	return &keyEntry, nil
 }
 
-func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (string, string, error) {
-	if randomSource == nil {
-		randomSource = rand.Reader
-	}
-
+func generateSSHKeyPair(keyType string, keyBits int) (string, string, error) {
 	var publicKey crypto.PublicKey
 	var privateBlock *pem.Block
 
@@ -155,7 +150,7 @@ func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (st
 			return "", "", fmt.Errorf("refusing to generate weak %v key: %v bits < 2048 bits", keyType, keyBits)
 		}
 
-		privateSeed, err := rsa.GenerateKey(randomSource, keyBits)
+		privateSeed, err := rsa.GenerateKey(rand.Reader, keyBits)
 		if err != nil {
 			return "", "", err
 		}
@@ -189,7 +184,7 @@ func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (st
 			}
 		}
 
-		privateSeed, err := ecdsa.GenerateKey(curve, randomSource)
+		privateSeed, err := ecdsa.GenerateKey(curve, rand.Reader)
 		if err != nil {
 			return "", "", err
 		}
@@ -207,7 +202,7 @@ func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (st
 
 		publicKey = privateSeed.Public()
 	case ssh.KeyAlgoED25519, "ed25519":
-		_, privateSeed, err := ed25519.GenerateKey(randomSource)
+		_, privateSeed, err := ed25519.GenerateKey(rand.Reader)
 		if err != nil {
 			return "", "", err
 		}

--- a/builtin/logical/ssh/path_issue.go
+++ b/builtin/logical/ssh/path_issue.go
@@ -5,7 +5,6 @@ package ssh
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -125,7 +124,7 @@ func (b *backend) pathIssue(ctx context.Context, req *logical.Request, data *fra
 func (b *backend) pathIssueCertificate(ctx context.Context, req *logical.Request, data *framework.FieldData, role *sshRole, keySpecs *keySpecs) (*logical.Response, error) {
 	sc := b.makeStorageContext(ctx, req.Storage)
 
-	publicKey, privateKey, err := generateSSHKeyPair(rand.Reader, keySpecs.Type, keySpecs.Bits)
+	publicKey, privateKey, err := generateSSHKeyPair(keySpecs.Type, keySpecs.Bits)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/ssh/util.go
+++ b/builtin/logical/ssh/util.go
@@ -169,7 +169,7 @@ func (b *backend) handleKeyGeneration(data *framework.FieldData) (publicKey stri
 		keyType := data.Get("key_type").(string)
 		keyBits := data.Get("key_bits").(int)
 
-		publicKey, privateKey, err = generateSSHKeyPair(b.GetRandomReader(), keyType, keyBits)
+		publicKey, privateKey, err = generateSSHKeyPair(keyType, keyBits)
 		if err != nil {
 			err = errutil.InternalError{Err: err.Error()}
 			return publicKey, privateKey, generateSigningKey, err

--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -58,7 +58,7 @@ func (b *backend) pathRandom() *framework.Path {
 }
 
 func (b *backend) pathRandomWrite(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	return random.HandleRandomAPI(d, b.GetRandomReader())
+	return random.HandleRandomAPI(d)
 }
 
 const pathRandomHelpSyn = `Generate random bytes`

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -480,7 +479,7 @@ SEALFAIL:
 		return nil
 	})
 
-	coreConfig := createCoreConfig(server, config, *backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink, rand.Reader)
+	coreConfig := createCoreConfig(server, config, *backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
 
 	var disableClustering bool
 	_ = diagnose.Test(ctx, "HA Storage", func(ctx context.Context) error {

--- a/command/server.go
+++ b/command/server.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -1112,7 +1111,7 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink, rand.Reader)
+	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
 	if c.flagDevThreeNode {
 		return c.enableThreeNodeDevCluster(&coreConfig, info, infoKeys, c.flagDevListenAddr, api.ReadBaoVariable("BAO_DEV_TEMP_DIR"))
 	}
@@ -2674,7 +2673,7 @@ func runUnseal(c *ServerCommand, core *vault.Core, ctx context.Context) {
 }
 
 func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.Backend, configSR sr.ServiceRegistration, barrierSeal, unwrapSeal vault.Seal,
-	metricsHelper *metricsutil.MetricsHelper, metricSink *metricsutil.ClusterMetricSink, secureRandomReader io.Reader,
+	metricsHelper *metricsutil.MetricsHelper, metricSink *metricsutil.ClusterMetricSink,
 ) vault.CoreConfig {
 	coreConfig := &vault.CoreConfig{
 		RawConfig:                      config,
@@ -2712,7 +2711,6 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		DisableKeyEncodingChecks:       config.DisablePrintableCheck,
 		MetricsHelper:                  metricsHelper,
 		MetricSink:                     metricSink,
-		SecureRandomReader:             secureRandomReader,
 		EnableResponseHeaderHostname:   config.EnableResponseHeaderHostname,
 		EnableResponseHeaderRaftNodeID: config.EnableResponseHeaderRaftNodeID,
 		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity,

--- a/helper/random/random_api.go
+++ b/helper/random/random_api.go
@@ -4,21 +4,18 @@
 package random
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
-	"io"
 	"strconv"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/framework"
-	"github.com/openbao/openbao/sdk/v2/helper/xor"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
 const APIMaxBytes = 128 * 1024
 
-func HandleRandomAPI(d *framework.FieldData, additionalSource io.Reader) (*logical.Response, error) {
+func HandleRandomAPI(d *framework.FieldData) (*logical.Response, error) {
 	bytes := 0
 	// Parsing is convoluted here, but allows operators to ACL both source and byte count
 	maybeUrlBytes := d.Raw["urlbytes"]
@@ -68,19 +65,10 @@ func HandleRandomAPI(d *framework.FieldData, additionalSource io.Reader) (*logic
 			return nil, err
 		}
 	case "seal":
-		if rand.Reader == additionalSource {
-			warning = "no seal/entropy augmentation available, using platform entropy source"
-		}
-		randBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
+		warning = "no seal/entropy augmentation available, using platform entropy source"
+		fallthrough
 	case "all":
 		randBytes, err = uuid.GenerateRandomBytes(bytes)
-		if err == nil && rand.Reader != additionalSource {
-			var sealBytes []byte
-			sealBytes, err = uuid.GenerateRandomBytesWithReader(bytes, additionalSource)
-			if err == nil {
-				randBytes, err = xor.XORBytes(sealBytes, randBytes)
-			}
-		}
 	default:
 		return logical.ErrorResponse("unsupported entropy source %q; must be \"platform\" or \"seal\", or \"all\"", source), nil
 	}

--- a/physical/raft/streamlayer.go
+++ b/physical/raft/streamlayer.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	fmt "fmt"
-	"io"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -90,8 +89,8 @@ func (k *TLSKeyring) GetActive() *TLSKey {
 	return nil
 }
 
-func GenerateTLSKey(reader io.Reader) (*TLSKey, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P521(), reader)
+func GenerateTLSKey() (*TLSKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/physical/raft/streamlayer_test.go
+++ b/physical/raft/streamlayer_test.go
@@ -5,7 +5,6 @@ package raft
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/tls"
 	"net"
 	"testing"
@@ -37,7 +36,7 @@ func TestStreamLayer_UnspecifiedIP(t *testing.T) {
 		},
 	}
 
-	raftTLSKey, err := GenerateTLSKey(rand.Reader)
+	raftTLSKey, err := GenerateTLSKey()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/barrier/aes_gcm.go
+++ b/vault/barrier/aes_gcm.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -170,7 +169,7 @@ func (b *AESGCMBarrier) Initialized(ctx context.Context) (bool, error) {
 
 // Initialize works only if the barrier has not been initialized
 // and makes use of the given root key.
-func (b *AESGCMBarrier) Initialize(ctx context.Context, key, sealKey []byte, reader io.Reader) error {
+func (b *AESGCMBarrier) Initialize(ctx context.Context, key, sealKey []byte) error {
 	// Verify the key size
 	min, max := b.KeyLength()
 	if len(key) < min || len(key) > max {
@@ -185,7 +184,7 @@ func (b *AESGCMBarrier) Initialize(ctx context.Context, key, sealKey []byte, rea
 	}
 
 	// Generate encryption key
-	encrypt, err := b.GenerateKey(reader)
+	encrypt, err := b.GenerateKey()
 	if err != nil {
 		return fmt.Errorf("failed to generate encryption key: %w", err)
 	}
@@ -322,10 +321,10 @@ func (b *AESGCMBarrier) persistKeyringInternal(ctx context.Context, keyring *Key
 }
 
 // GenerateKey is used to generate a new key
-func (b *AESGCMBarrier) GenerateKey(reader io.Reader) ([]byte, error) {
+func (b *AESGCMBarrier) GenerateKey() ([]byte, error) {
 	// Generate a 256bit key
 	buf := make([]byte, 2*aes.BlockSize)
-	_, err := reader.Read(buf)
+	_, err := rand.Read(buf)
 
 	return buf, err
 }
@@ -554,7 +553,7 @@ func (b *AESGCMBarrier) Seal() error {
 
 // Rotate is used to create a new encryption key. All future writes
 // should use the new key, while old values should still be decryptable.
-func (b *AESGCMBarrier) Rotate(ctx context.Context, randomSource io.Reader) (uint32, error) {
+func (b *AESGCMBarrier) Rotate(ctx context.Context) (uint32, error) {
 	b.l.Lock()
 	defer b.l.Unlock()
 	if b.sealed {
@@ -562,7 +561,7 @@ func (b *AESGCMBarrier) Rotate(ctx context.Context, randomSource io.Reader) (uin
 	}
 
 	// Generate a new key
-	encrypt, err := b.GenerateKey(randomSource)
+	encrypt, err := b.GenerateKey()
 	if err != nil {
 		return 0, fmt.Errorf("failed to generate encryption key: %w", err)
 	}

--- a/vault/barrier/aes_gcm_test.go
+++ b/vault/barrier/aes_gcm_test.go
@@ -6,7 +6,6 @@ package barrier
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"testing"
 	"time"
 
@@ -22,101 +21,88 @@ var logger = logging.NewVaultLogger(log.Trace)
 
 func TestAESGCMBarrier_Basic(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	testBarrier(t, b)
 }
 
 func TestAESGCMBarrier_Rotate(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	testBarrier_Rotate(t, b)
 }
 
 func TestAESGCMBarrier_MissingRotateConfig(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Write a keyring which lacks rotation config settings
 	oldKeyring := b.keyring.Clone()
 	oldKeyring.rotationConfig = KeyRotationConfig{}
-	b.persistKeyring(context.Background(), oldKeyring)
+	require.NoError(t, b.persistKeyring(ctx, oldKeyring))
+	require.NoError(t, b.ReloadKeyring(ctx))
 
-	b.ReloadKeyring(context.Background())
-
-	// At this point, the rotation config should match the default
-	if !defaultRotationConfig.Equals(b.keyring.rotationConfig) {
-		t.Fatal("expected empty rotation config to recover as default config")
-	}
+	require.True(t, defaultRotationConfig.Equals(b.keyring.rotationConfig),
+		"expected empty rotation config to recover as default config")
 }
 
 func TestAESGCMBarrier_Upgrade(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade(t, b1, b2)
 }
 
 func TestAESGCMBarrier_Upgrade_RotateRootKey(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade_RotateRootKey(t, b1, b2)
 
 	// Test migration from legacy to new root key path. Move the existing
 	// root key over to the legacy path.
-	entry, err := b1.Get(context.Background(), RootKeyPath)
+	entry, err := b1.Get(ctx, RootKeyPath)
 	require.NoError(t, err)
 	require.NotNil(t, entry)
 	require.Equal(t, entry.Key, RootKeyPath)
 
 	entry.Key = LegacyRootKeyPath
-	err = b1.Put(context.Background(), entry)
-	require.NoError(t, err)
-	err = b1.Delete(context.Background(), RootKeyPath)
-	require.NoError(t, err)
+	require.NoError(t, b1.Put(ctx, entry))
+	require.NoError(t, b1.Delete(ctx, RootKeyPath))
 
 	// Now reload b1; this should succeed but not migrate the key.
-	err = b1.ReloadRootKey(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, b1.ReloadRootKey(ctx))
 
-	oldEntry, err := b1.Get(context.Background(), LegacyRootKeyPath)
+	oldEntry, err := b1.Get(ctx, LegacyRootKeyPath)
 	require.NoError(t, err)
 	require.NotNil(t, oldEntry)
 	require.Equal(t, entry.Value, oldEntry.Value)
 
-	newEntry, err := b1.Get(context.Background(), RootKeyPath)
+	newEntry, err := b1.Get(ctx, RootKeyPath)
 	require.NoError(t, err)
 	require.Nil(t, newEntry)
 
 	// Now persist b1; this should remove the legacy key path.
-	err = b1.persistKeyring(context.Background(), b1.keyring)
-	require.NoError(t, err)
+	require.NoError(t, b1.persistKeyring(ctx, b1.keyring))
 
-	oldEntry, err = b1.Get(context.Background(), LegacyRootKeyPath)
+	oldEntry, err = b1.Get(ctx, LegacyRootKeyPath)
 	require.NoError(t, err)
 	require.Nil(t, oldEntry)
 
-	newEntry, err = b1.Get(context.Background(), RootKeyPath)
+	newEntry, err = b1.Get(ctx, RootKeyPath)
 	require.NoError(t, err)
 	require.NotNil(t, newEntry)
 	require.Equal(t, entry.Value, newEntry.Value)
@@ -124,443 +110,303 @@ func TestAESGCMBarrier_Upgrade_RotateRootKey(t *testing.T) {
 
 func TestAESGCMBarrier_RotateRootKey(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	testBarrier_RotateRootKey(t, b)
 }
 
 // Verify data sent through is encrypted
 func TestAESGCMBarrier_Confidential(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Put a logical entry
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	err = b.Put(context.Background(), entry)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, entry))
 
 	// Check the physical entry
-	pe, err := inm.Get(context.Background(), "test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if pe == nil {
-		t.Fatal("missing physical entry")
-	}
-
-	if pe.Key != "test" {
-		t.Fatalf("bad: %#v", pe)
-	}
-	if bytes.Equal(pe.Value, entry.Value) {
-		t.Fatalf("bad: %#v", pe)
-	}
+	pe, err := inm.Get(ctx, "test")
+	require.NoError(t, err)
+	require.NotNil(t, pe)
+	require.Equal(t, "test", pe.Key)
+	require.False(t, bytes.Equal(pe.Value, entry.Value))
 }
 
 // Verify data sent through cannot be tampered with
 func TestAESGCMBarrier_Integrity(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Put a logical entry
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	err = b.Put(context.Background(), entry)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, entry))
 
 	// Change a byte in the underlying physical entry
-	pe, _ := inm.Get(context.Background(), "test")
+	pe, _ := inm.Get(ctx, "test")
 	pe.Value[15]++
-	err = inm.Put(context.Background(), pe)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, inm.Put(ctx, pe))
 
 	// Read from the barrier
-	_, err = b.Get(context.Background(), "test")
-	if err == nil {
-		t.Fatal("should fail!")
-	}
+	_, err = b.Get(ctx, "test")
+	require.Error(t, err, "should fail!")
 }
 
 // Verify data sent through cannot be moved
 func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion1
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	err = b.Initialize(context.Background(), key, nil, rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Put a logical entry
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	err = b.Put(context.Background(), entry)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, entry))
 
 	// Change the location of the underlying physical entry
-	pe, _ := inm.Get(context.Background(), "test")
+	pe, _ := inm.Get(ctx, "test")
 	pe.Key = "moved"
-	err = inm.Put(context.Background(), pe)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, inm.Put(ctx, pe))
 
 	// Read from the barrier
-	_, err = b.Get(context.Background(), "moved")
-	if err != nil {
-		t.Fatal("should succeed with version 1!")
-	}
+	_, err = b.Get(ctx, "moved")
+	require.NoError(t, err, "should succeed with version 1!")
 }
 
 func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion2
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	err = b.Initialize(context.Background(), key, nil, rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Put a logical entry
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	err = b.Put(context.Background(), entry)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, entry))
 
 	// Change the location of the underlying physical entry
-	pe, _ := inm.Get(context.Background(), "test")
+	pe, _ := inm.Get(ctx, "test")
 	pe.Key = "moved"
-	err = inm.Put(context.Background(), pe)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, inm.Put(ctx, pe))
 
 	// Read from the barrier
-	_, err = b.Get(context.Background(), "moved")
-	if err == nil {
-		t.Fatal("should fail with version 2!")
-	}
+	_, err = b.Get(ctx, "moved")
+	require.Error(t, err, "should fail with version 2!")
 }
 
 func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion1
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	err = b.Initialize(context.Background(), key, nil, rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Put a logical entry
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	err = b.Put(context.Background(), entry)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, entry))
 
 	// Seal
-	err = b.Seal()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
 
 	// Open again as version 2
 	b = NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion2
 
 	// Unseal
-	err = b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Check successful decryption
-	_, err = b.Get(context.Background(), "test")
-	if err != nil {
-		t.Fatal("Upgrade unsuccessful")
-	}
+	_, err = b.Get(ctx, "test")
+	require.NoError(t, err)
 }
 
 func TestEncrypt_Unique(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
-	if b.keyring == nil {
-		t.Fatal("barrier is sealed")
-	}
+	require.NotNil(t, b.keyring, "barrier is sealed")
 
 	entry := &logical.StorageEntry{Key: "test", Value: []byte("test")}
 	term := b.keyring.ActiveTerm()
 	primary, _ := b.aeadForTerm(term)
 
 	first, err := b.encrypt("test", term, primary, entry.Value)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	second, err := b.encrypt("test", term, primary, entry.Value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Equal(first, second) {
-		t.Fatal("improper random seeding detected")
-	}
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(first, second), "improper random seeding detected")
 }
 
 func TestInitialize_KeyLength(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
 	long := []byte("ThisKeyDoesNotHaveTheRightLength!")
 	middle := []byte("ThisIsASecretKeyAndMore")
 	short := []byte("Key")
 
-	err = b.Initialize(context.Background(), long, nil, rand.Reader)
-
-	if err == nil {
-		t.Fatal("key length protection failed")
-	}
-
-	err = b.Initialize(context.Background(), middle, nil, rand.Reader)
-
-	if err == nil {
-		t.Fatal("key length protection failed")
-	}
-
-	err = b.Initialize(context.Background(), short, nil, rand.Reader)
-
-	if err == nil {
-		t.Fatal("key length protection failed")
-	}
+	require.Error(t, b.Initialize(ctx, long, nil))
+	require.Error(t, b.Initialize(ctx, middle, nil))
+	require.Error(t, b.Initialize(ctx, short, nil))
 }
 
 func TestEncrypt_BarrierEncryptor(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 	// Initialize and unseal
-	key, err := b.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("err generating key: %v", err)
-	}
-	ctx := context.Background()
-	b.Initialize(ctx, key, nil, rand.Reader)
-	b.Unseal(ctx, key)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	cipher, err := b.Encrypt(ctx, "foo", []byte("quick brown fox"))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
+	require.NoError(t, err)
 	plain, err := b.Decrypt(ctx, "foo", cipher)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if string(plain) != "quick brown fox" {
-		t.Fatalf("bad: %s", plain)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "quick brown fox", string(plain))
 }
 
 // Ensure Decrypt returns an error (rather than panic) when given a ciphertext
 // that is nil or too short
 func TestDecrypt_InvalidCipherLength(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
-	key, err := b.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("err generating key: %v", err)
-	}
-	ctx := context.Background()
-	b.Initialize(ctx, key, nil, rand.Reader)
-	b.Unseal(ctx, key)
+	key, err := b.GenerateKey()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	var nilCipher []byte
-	if _, err = b.Decrypt(ctx, "", nilCipher); err == nil {
-		t.Fatal("expected error when given nil cipher")
-	}
+	_, err = b.Decrypt(ctx, "", nilCipher)
+	require.Error(t, err, "expected error when given nil cipher")
+
 	emptyCipher := []byte{}
-	if _, err = b.Decrypt(ctx, "", emptyCipher); err == nil {
-		t.Fatal("expected error when given empty cipher")
-	}
+	_, err = b.Decrypt(ctx, "", emptyCipher)
+	require.Error(t, err, "expected error when given empty cipher")
 
 	badTermLengthCipher := make([]byte, 3)
-	if _, err = b.Decrypt(ctx, "", badTermLengthCipher); err == nil {
-		t.Fatal("expected error when given cipher with too short term")
-	}
+	_, err = b.Decrypt(ctx, "", badTermLengthCipher)
+	require.Error(t, err, "expected error when given cipher with too short term")
 }
 
 func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
+	key, _ := b.GenerateKey()
 
-	keyringRaw, err := inm.Get(context.Background(), KeyringPath)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	ctx := t.Context()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
+
+	keyringRaw, err := inm.Get(ctx, KeyringPath)
+	require.NoError(t, err)
 
 	// Encrypt something to test cache invalidation
-	_, err = b.Encrypt(context.Background(), "foo", []byte("quick brown fox"))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	_, err = b.Encrypt(ctx, "foo", []byte("quick brown fox"))
+	require.NoError(t, err)
 
 	{
 		// Create a second barrier and rotate the keyring
 		b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
-		b2.Unseal(context.Background(), key)
-		_, err = b2.Rotate(context.Background(), rand.Reader)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		require.NoError(t, b2.Unseal(ctx, key))
+		_, err = b2.Rotate(ctx)
+		require.NoError(t, err)
 	}
 
 	// Reload the keyring on the first
-	err = b.ReloadKeyring(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if b.keyring.ActiveTerm() != 2 {
-		t.Fatal("failed to reload keyring")
-	}
-	if len(b.cache) != 0 {
-		t.Fatal("failed to clear cache")
-	}
+	require.NoError(t, b.ReloadKeyring(ctx))
+	require.EqualValues(t, 2, b.keyring.ActiveTerm(), "failed to reload keyring")
+	require.Empty(t, b.cache, "failed to clear cache")
 
 	// Encrypt something to test cache invalidation
-	_, err = b.Encrypt(context.Background(), "foo", []byte("quick brown fox"))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	_, err = b.Encrypt(ctx, "foo", []byte("quick brown fox"))
+	require.NoError(t, err)
 
 	// Restore old keyring to test rolling back
-	err = inm.Put(context.Background(), keyringRaw)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, inm.Put(ctx, keyringRaw))
 
 	// Reload the keyring on the first
-	err = b.ReloadKeyring(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if b.keyring.ActiveTerm() != 1 {
-		t.Fatal("failed to reload keyring")
-	}
-	if len(b.cache) != 0 {
-		t.Fatal("failed to clear cache")
-	}
+	require.NoError(t, b.ReloadKeyring(ctx))
+	require.EqualValues(t, 1, b.keyring.ActiveTerm(), "failed to reload keyring")
+	require.Empty(t, b.cache, "failed to clear cache")
 }
 
 func TestBarrier_LegacyRotate(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
-	key, _ := b1.GenerateKey(rand.Reader)
-	b1.Initialize(context.Background(), key, nil, rand.Reader)
-	err = b1.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+
+	key, _ := b1.GenerateKey()
+
+	ctx := t.Context()
+	require.NoError(t, b1.Initialize(ctx, key, nil))
+	require.NoError(t, b1.Unseal(ctx, key))
 
 	k1 := b1.keyring.TermKey(1)
 	k1.Encryptions = 0
 	k1.InstallTime = time.Now().Add(-24 * 366 * time.Hour)
-	b1.persistKeyring(context.Background(), b1.keyring)
-	b1.Seal()
 
-	err = b1.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b1.persistKeyring(ctx, b1.keyring))
+	require.NoError(t, b1.Seal())
+	require.NoError(t, b1.Unseal(ctx, key))
 
-	reason, err := b1.CheckBarrierAutoRotate(context.Background())
-	if err != nil || reason != legacyRotateReason {
-		t.Fail()
-	}
+	reason, err := b1.CheckBarrierAutoRotate(ctx)
+	require.NoError(t, err)
+	require.Equal(t, legacyRotateReason, reason)
 }
 
 // TestBarrier_persistKeyring_Context checks that we get the right errors if
@@ -595,23 +441,21 @@ func TestBarrier_persistKeyring_Context(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			ctx := t.Context()
 
 			// Set up barrier
 			backend, err := inmem.NewInmem(nil, corehelpers.NewTestLogger(t))
 			require.NoError(t, err)
 			barrier := NewAESGCMBarrier(backend, "").(*TransactionalAESGCMBarrier)
-			key, err := barrier.GenerateKey(rand.Reader)
-			require.NoError(t, err)
-			err = barrier.Initialize(context.Background(), key, nil, rand.Reader)
-			require.NoError(t, err)
-			err = barrier.Unseal(context.Background(), key)
-			require.NoError(t, err)
+			key, _ := barrier.GenerateKey()
+			require.NoError(t, barrier.Initialize(ctx, key, nil))
+			require.NoError(t, barrier.Unseal(ctx, key))
 			k := barrier.keyring.TermKey(1)
 			k.Encryptions = 0
 			k.InstallTime = time.Now().Add(-24 * 366 * time.Hour)
 
 			// Persist the keyring
-			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
+			ctx, cancel := context.WithTimeout(ctx, tc.contextTimeout)
 			persistChan := make(chan error)
 			go func() {
 				if tc.shouldCancel {
@@ -651,29 +495,25 @@ func TestAESGCMBarrier_Prefix_Rotate(t *testing.T) {
 }
 
 func TestAESGCMBarrier_Prefix_MissingRotateConfig(t *testing.T) {
+	ctx := t.Context()
+
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
 	b := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	err = b.Initialize(context.Background(), key, nil, rand.Reader)
-	require.NoError(t, err)
-	err = b.Unseal(context.Background(), key)
-	require.NoError(t, err)
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Write a keyring which lacks rotation config settings
 	oldKeyring := b.keyring.Clone()
 	oldKeyring.rotationConfig = KeyRotationConfig{}
-	err = b.persistKeyring(context.Background(), oldKeyring)
-	require.NoError(t, err)
-	err = b.ReloadKeyring(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, b.persistKeyring(ctx, oldKeyring))
+	require.NoError(t, b.ReloadKeyring(ctx))
 
-	// At this point, the rotation config should match the default
-	if !defaultRotationConfig.Equals(b.keyring.rotationConfig) {
-		t.Fatal("expected empty rotation config to recover as default config")
-	}
+	require.True(t, defaultRotationConfig.Equals(b.keyring.rotationConfig),
+		"expected empty rotation config to recover as default config")
 }
 
 func TestAESGCMBarrier_Prefix_Upgrade(t *testing.T) {

--- a/vault/barrier/barrier.go
+++ b/vault/barrier/barrier.go
@@ -6,7 +6,6 @@ package barrier
 import (
 	"context"
 	"errors"
-	"io"
 	"time"
 
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -93,10 +92,10 @@ type SecurityBarrierCore interface {
 	// and makes use of the given root key.  When sealKey is provided
 	// it's because we're using a new-style Shamir seal, and rootKey
 	// is to be stored using sealKey to encrypt it.
-	Initialize(ctx context.Context, rootKey []byte, sealKey []byte, random io.Reader) error
+	Initialize(ctx context.Context, rootKey []byte, sealKey []byte) error
 
 	// GenerateKey is used to generate a new key
-	GenerateKey(io.Reader) ([]byte, error)
+	GenerateKey() ([]byte, error)
 
 	// KeyLength is used to sanity check a key
 	KeyLength() (int, int)
@@ -133,7 +132,7 @@ type SecurityBarrierCore interface {
 
 	// Rotate is used to create a new encryption key. All future writes
 	// should use the new key, while old values should still be decryptable.
-	Rotate(ctx context.Context, reader io.Reader) (uint32, error)
+	Rotate(ctx context.Context) (uint32, error)
 
 	// CreateUpgrade creates an upgrade path key to the given term from the previous term
 	CreateUpgrade(ctx context.Context, term uint32) error

--- a/vault/barrier/barrier_test.go
+++ b/vault/barrier/barrier_test.go
@@ -4,9 +4,6 @@
 package barrier
 
 import (
-	"context"
-	"crypto/rand"
-	"reflect"
 	"testing"
 	"time"
 
@@ -15,6 +12,8 @@ import (
 )
 
 func testBarrier(t *testing.T, b SecurityBarrier) {
+	ctx := t.Context()
+
 	var prefix string
 	switch cb := b.(type) {
 	case *AESGCMBarrier:
@@ -23,135 +22,81 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 		prefix = cb.metaPrefix
 	}
 
-	e, key, err := testInitAndUnseal(t, b)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	e, key := testInitAndUnseal(t, b)
 
 	// Operations should work
-	out, err := b.Get(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out != nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err := b.Get(ctx, prefix+"test")
+	require.NoError(t, err)
+	require.Nil(t, out)
 
 	// List should have only "core/"
-	keys, err := b.List(context.Background(), prefix)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if len(keys) != 1 || keys[0] != "core/" {
-		t.Fatalf("bad: %v", keys)
-	}
+	keys, err := b.List(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, []string{"core/"}, keys)
 
 	// Try to write
-	if err := b.Put(context.Background(), e); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, e))
 
 	// Should be equal
-	out, err = b.Get(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !reflect.DeepEqual(out, e) {
-		t.Fatalf("bad: %v exp: %v", out, e)
-	}
+	out, err = b.Get(ctx, prefix+"test")
+	require.NoError(t, err)
+	require.Equal(t, e, out)
 
 	// List should show the items
-	keys, err = b.List(context.Background(), prefix)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if len(keys) != 2 {
-		t.Fatalf("bad: %v", keys)
-	}
-	if keys[0] != "core/" || keys[1] != "test" {
-		t.Fatalf("bad: %v", keys)
-	}
+	keys, err = b.List(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, []string{"core/", "test"}, keys)
 
 	// Delete should clear
-	err = b.Delete(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Delete(ctx, prefix+"test"))
 
 	// Double Delete is fine
-	err = b.Delete(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Delete(ctx, prefix+"test"))
 
 	// Should be nil
-	out, err = b.Get(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out != nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err = b.Get(ctx, prefix+"test")
+	require.NoError(t, err)
+	require.Nil(t, out)
 
 	// List should have nothing
-	keys, err = b.List(context.Background(), prefix)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if len(keys) != 1 || keys[0] != "core/" {
-		t.Fatalf("bad: %v", keys)
-	}
+	keys, err = b.List(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, []string{"core/"}, keys)
 
 	// Add the item back
-	if err := b.Put(context.Background(), e); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, e))
 
 	// Reseal should prevent any updates
-	if err := b.Seal(); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
 
 	// No access allowed
-	if _, err := b.Get(context.Background(), prefix+"test"); err != ErrBarrierSealed {
-		t.Fatalf("err: %v", err)
-	}
+	_, err = b.Get(ctx, prefix+"test")
+	require.ErrorIs(t, err, ErrBarrierSealed)
 
 	// Unseal should work
-	if err := b.Unseal(context.Background(), key); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Should be equal
-	out, err = b.Get(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !reflect.DeepEqual(out, e) {
-		t.Fatalf("bad: %v exp: %v", out, e)
-	}
+	out, err = b.Get(ctx, prefix+"test")
+	require.NoError(t, err)
+	require.Equal(t, e, out)
 
 	// Final cleanup
-	err = b.Delete(context.Background(), prefix+"test")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Delete(ctx, prefix+"test"))
 
 	// Reseal should prevent any updates
-	if err := b.Seal(); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
 
 	// Modify the key
 	key[0]++
 
 	// Unseal should fail
-	if err := b.Unseal(context.Background(), key); err != ErrBarrierInvalidKey {
-		t.Fatalf("err: %v", err)
-	}
+	require.ErrorIs(t, b.Unseal(ctx, key), ErrBarrierInvalidKey)
 }
 
-func testInitAndUnseal(t *testing.T, b SecurityBarrier) (*logical.StorageEntry, []byte, error) {
+func testInitAndUnseal(t *testing.T, b SecurityBarrier) (*logical.StorageEntry, []byte) {
+	ctx := t.Context()
+
 	var prefix string
 	switch cb := b.(type) {
 	case *AESGCMBarrier:
@@ -161,393 +106,232 @@ func testInitAndUnseal(t *testing.T, b SecurityBarrier) (*logical.StorageEntry, 
 	}
 
 	// Should not be initialized
-	init, err := b.Initialized(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if init {
-		t.Fatal("should not be initialized")
-	}
+	init, err := b.Initialized(ctx)
+	require.NoError(t, err)
+	require.False(t, init, "should not be initialized")
 
 	// Should start sealed
-	if !b.Sealed() {
-		t.Fatal("should be sealed")
-	}
+	require.True(t, b.Sealed(), "should be sealed")
 
 	// Sealing should be a no-op
-	if err := b.Seal(); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
 
 	// All operations should fail
 	e := &logical.StorageEntry{Key: prefix + "test", Value: []byte("test")}
-	if err := b.Put(context.Background(), e); err != ErrBarrierSealed {
-		t.Fatalf("err: %v", err)
-	}
-	if _, err := b.Get(context.Background(), prefix+"test"); err != ErrBarrierSealed {
-		t.Fatalf("err: %v", err)
-	}
-	if err := b.Delete(context.Background(), prefix+"test"); err != ErrBarrierSealed {
-		t.Fatalf("err: %v", err)
-	}
-	if _, err := b.List(context.Background(), prefix); err != ErrBarrierSealed {
-		t.Fatalf("err: %v", err)
-	}
+	require.ErrorIs(t, b.Put(ctx, e), ErrBarrierSealed)
+	_, err = b.Get(ctx, prefix+"test")
+	require.ErrorIs(t, err, ErrBarrierSealed)
+	require.ErrorIs(t, b.Delete(ctx, prefix+"test"), ErrBarrierSealed)
+	_, err = b.List(ctx, prefix)
+	require.ErrorIs(t, err, ErrBarrierSealed)
 
 	// Get a new key
-	key, err := b.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, err := b.GenerateKey()
+	require.NoError(t, err)
 
 	// Validate minimum key length
 	min, max := b.KeyLength()
-	if min < 16 {
-		t.Fatalf("minimum key size too small: %d", min)
-	}
-	if max < min {
-		t.Fatal("maximum key size smaller than min")
-	}
+	require.GreaterOrEqual(t, min, 16, "minimum key size too small")
+	require.GreaterOrEqual(t, max, min, "maximum key size smaller than min")
 
 	// Unseal should not work
-	if err := b.Unseal(context.Background(), key); err != ErrBarrierNotInit {
-		t.Fatalf("err: %v", err)
-	}
+	require.ErrorIs(t, b.Unseal(ctx, key), ErrBarrierNotInit)
 
 	// Initialize the vault
-	if err := b.Initialize(context.Background(), key, nil, rand.Reader); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Initialize(ctx, key, nil))
 
 	// Double Initialize should fail
-	if err := b.Initialize(context.Background(), key, nil, rand.Reader); err != ErrBarrierAlreadyInit {
-		t.Fatalf("err: %v", err)
-	}
+	require.ErrorIs(t, b.Initialize(ctx, key, nil), ErrBarrierAlreadyInit)
 
 	// Should be initialized
-	init, err = b.Initialized(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !init {
-		t.Fatal("should be initialized")
-	}
+	init, err = b.Initialized(ctx)
+	require.NoError(t, err)
+	require.True(t, init)
 
 	// Should still be sealed
-	if !b.Sealed() {
-		t.Fatal("should sealed")
-	}
+	require.True(t, b.Sealed())
 
 	// Unseal should work
-	if err := b.Unseal(context.Background(), key); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Unseal should no-op when done twice
-	if err := b.Unseal(context.Background(), key); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Should no longer be sealed
-	if b.Sealed() {
-		t.Fatal("should be unsealed")
-	}
+	require.False(t, b.Sealed())
 
 	// Verify the root key
-	if err := b.VerifyRoot(key); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return e, key, err
+	require.NoError(t, b.VerifyRoot(key))
+
+	return e, key
 }
 
 func testBarrier_Rotate(t *testing.T, b SecurityBarrier) {
+	ctx := t.Context()
+
 	// Initialize the barrier
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	err := b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Check the key info
 	info, err := b.ActiveKeyInfo()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if info.Term != 1 {
-		t.Fatalf("Bad term: %d", info.Term)
-	}
-	if time.Since(info.InstallTime) > time.Second {
-		t.Fatalf("Bad install: %v", info.InstallTime)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 1, info.Term)
+	require.False(t, time.Since(info.InstallTime) > time.Second)
 	first := info.InstallTime
 
 	// Write a key
 	e1 := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	if err := b.Put(context.Background(), e1); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, e1))
 
 	// Rotate the encryption key
-	newTerm, err := b.Rotate(context.Background(), rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if newTerm != 2 {
-		t.Fatalf("bad: %v", newTerm)
-	}
+	newTerm, err := b.Rotate(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, newTerm)
 
 	// Check the key info
 	info, err = b.ActiveKeyInfo()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if info.Term != 2 {
-		t.Fatalf("Bad term: %d", info.Term)
-	}
-	if !info.InstallTime.After(first) {
-		t.Fatalf("Bad install: %v", info.InstallTime)
-	}
+	require.NoError(t, err)
+	require.True(t, info.InstallTime.After(first))
 
 	// Write another key
 	e2 := &logical.StorageEntry{Key: "foo", Value: []byte("test")}
-	if err := b.Put(context.Background(), e2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, e2))
 
 	// Reading both should work
-	out, err := b.Get(context.Background(), e1.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err := b.Get(ctx, e1.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
-	out, err = b.Get(context.Background(), e2.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err = b.Get(ctx, e2.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
 	// Seal and unseal
-	err = b.Seal()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Reading both should work
-	out, err = b.Get(context.Background(), e1.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err = b.Get(ctx, e1.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
-	out, err = b.Get(context.Background(), e2.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err = b.Get(ctx, e2.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
 	// Should be fine to reload keyring
-	err = b.ReloadKeyring(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.ReloadKeyring(ctx))
 }
 
 func testBarrier_RotateRootKey(t *testing.T, b SecurityBarrier) {
+	ctx := t.Context()
+
 	// Initialize the barrier
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	err := b.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b.GenerateKey()
+	require.NoError(t, b.Initialize(ctx, key, nil))
+	require.NoError(t, b.Unseal(ctx, key))
 
 	// Write a key
 	e1 := &logical.StorageEntry{Key: "test", Value: []byte("test")}
-	if err := b.Put(context.Background(), e1); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Put(ctx, e1))
 
 	// Verify the root key
-	if err := b.VerifyRoot(key); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.VerifyRoot(key))
 
 	// Rotate to a new root key
-	newKey, _ := b.GenerateKey(rand.Reader)
-	err = b.RotateRootKey(context.Background(), newKey)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	newKey, _ := b.GenerateKey()
+	require.NoError(t, b.RotateRootKey(ctx, newKey))
 
 	// Verify the old root key
-	if err := b.VerifyRoot(key); err != ErrBarrierInvalidKey {
-		t.Fatalf("err: %v", err)
-	}
+	require.ErrorIs(t, b.VerifyRoot(key), ErrBarrierInvalidKey)
 
 	// Verify the new root key
-	if err := b.VerifyRoot(newKey); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.VerifyRoot(newKey))
 
 	// Reading should work
-	out, err := b.Get(context.Background(), e1.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err := b.Get(ctx, e1.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
 	// Seal
-	err = b.Seal()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Seal())
 
 	// Unseal with old key should fail
-	err = b.Unseal(context.Background(), key)
-	if err == nil {
-		t.Fatal("unseal should fail")
-	}
+	require.Error(t, b.Unseal(ctx, key))
 
 	// Unseal with new keys should work
-	err = b.Unseal(context.Background(), newKey)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.Unseal(ctx, newKey))
 
 	// Reading should work
-	out, err = b.Get(context.Background(), e1.Key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("bad: %v", out)
-	}
+	out, err = b.Get(ctx, e1.Key)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 
 	// Should be fine to reload keyring
-	err = b.ReloadKeyring(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b.ReloadKeyring(ctx))
 }
 
 func testBarrier_Upgrade(t *testing.T, b1, b2 SecurityBarrier) {
+	ctx := t.Context()
+
 	// Initialize the barrier
-	key, _ := b1.GenerateKey(rand.Reader)
-	b1.Initialize(context.Background(), key, nil, rand.Reader)
-	err := b1.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b2.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b1.GenerateKey()
+	require.NoError(t, b1.Initialize(ctx, key, nil))
+	require.NoError(t, b1.Unseal(ctx, key))
+	require.NoError(t, b2.Unseal(ctx, key))
 
 	// Rotate the encryption key
-	newTerm, err := b1.Rotate(context.Background(), rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
+	newTerm, err := b1.Rotate(ctx)
+	require.NoError(t, err)
 	// Create upgrade path
-	err = b1.CreateUpgrade(context.Background(), newTerm)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b1.CreateUpgrade(ctx, newTerm))
 
 	// Check for an upgrade
-	did, updated, err := b2.CheckUpgrade(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !did || updated != newTerm {
-		t.Fatal("failed to upgrade")
-	}
+	did, updated, err := b2.CheckUpgrade(ctx)
+	require.NoError(t, err)
+	require.True(t, did, "failed to upgrade")
+	require.True(t, updated == newTerm, "failed to upgrade")
 
 	// Should have no upgrades pending
-	did, updated, err = b2.CheckUpgrade(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if did {
-		t.Fatal("should not have upgrade")
-	}
+	did, updated, err = b2.CheckUpgrade(ctx)
+	require.NoError(t, err)
+	require.False(t, did, "should not have upgrade")
 	require.EqualValues(t, 0, updated)
 
 	// Rotate the encryption key
-	newTerm, err = b1.Rotate(context.Background(), rand.Reader)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	newTerm, err = b1.Rotate(ctx)
+	require.NoError(t, err)
 
 	// Create upgrade path
-	err = b1.CreateUpgrade(context.Background(), newTerm)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
+	require.NoError(t, b1.CreateUpgrade(ctx, newTerm))
 	// Destroy upgrade path
-	err = b1.DestroyUpgrade(context.Background(), newTerm)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b1.DestroyUpgrade(ctx, newTerm))
 
 	// Should have no upgrades pending
-	did, updated, err = b2.CheckUpgrade(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if did {
-		t.Fatal("should not have upgrade")
-	}
+	did, updated, err = b2.CheckUpgrade(ctx)
+	require.NoError(t, err)
+	require.False(t, did, "should not have upgrade")
 	require.EqualValues(t, 0, updated)
 }
 
 func testBarrier_Upgrade_RotateRootKey(t *testing.T, b1, b2 SecurityBarrier) {
+	ctx := t.Context()
+
 	// Initialize the barrier
-	key, _ := b1.GenerateKey(rand.Reader)
-	b1.Initialize(context.Background(), key, nil, rand.Reader)
-	err := b1.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	err = b2.Unseal(context.Background(), key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	key, _ := b1.GenerateKey()
+	require.NoError(t, b1.Initialize(ctx, key, nil))
+	require.NoError(t, b1.Unseal(ctx, key))
+	require.NoError(t, b2.Unseal(ctx, key))
 
 	// Rotate to a new root key
-	newKey, _ := b1.GenerateKey(rand.Reader)
-	err = b1.RotateRootKey(context.Background(), newKey)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	newKey, _ := b1.GenerateKey()
+	require.NoError(t, b1.RotateRootKey(ctx, newKey))
 
 	// Reload the root key
-	err = b2.ReloadRootKey(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b2.ReloadRootKey(ctx))
 
 	// Reload the keyring
-	err = b2.ReloadKeyring(context.Background())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, b2.ReloadKeyring(ctx))
 }

--- a/vault/barrier/testing.go
+++ b/vault/barrier/testing.go
@@ -1,7 +1,6 @@
 package barrier
 
 import (
-	"crypto/rand"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -18,8 +17,8 @@ func MockBarrier(t testing.TB, logger hclog.Logger) (physical.Backend, SecurityB
 	b := NewAESGCMBarrier(inm, "")
 
 	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	err = b.Initialize(t.Context(), key, nil, rand.Reader)
+	key, _ := b.GenerateKey()
+	err = b.Initialize(t.Context(), key, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -210,7 +210,7 @@ func (c *Core) setupCluster(ctx context.Context) error {
 		// Create a private key
 		if c.localClusterPrivateKey.Load() == nil {
 			c.logger.Debug("generating cluster private key")
-			key, err := ecdsa.GenerateKey(elliptic.P521(), c.secureRandomReader)
+			key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 			if err != nil {
 				c.logger.Error("failed to generate local cluster key", "error", err)
 				return err

--- a/vault/core.go
+++ b/vault/core.go
@@ -550,9 +550,6 @@ type Core struct {
 
 	coreNumber int
 
-	// secureRandomReader is the reader used for CSP operations
-	secureRandomReader io.Reader
-
 	recoveryMode bool
 
 	clusterNetworkLayer cluster.NetworkLayer
@@ -679,8 +676,6 @@ type CoreConfig struct {
 	// Unwrap seal is the optional seal marked "disabled"; this is the old
 	// seal in migration scenarios.
 	UnwrapSeal Seal
-
-	SecureRandomReader io.Reader
 
 	LogLevel string
 
@@ -848,11 +843,6 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		conf.RawConfig = new(server.Config)
 	}
 
-	// secureRandomReader cannot be nil
-	if conf.SecureRandomReader == nil {
-		conf.SecureRandomReader = rand.Reader
-	}
-
 	clusterHeartbeatInterval := conf.ClusterHeartbeatInterval
 	if clusterHeartbeatInterval == 0 {
 		clusterHeartbeatInterval = 5 * time.Second
@@ -921,7 +911,6 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		builtinRegistry:                conf.BuiltinRegistry,
 		metricsHelper:                  conf.MetricsHelper,
 		metricSink:                     conf.MetricSink,
-		secureRandomReader:             conf.SecureRandomReader,
 		recoveryMode:                   conf.RecoveryMode,
 		raftJoinDoneCh:                 make(chan struct{}),
 		pendingRaftPeerChallengeKey:    make([]byte, 32),
@@ -1815,7 +1804,7 @@ func (c *Core) migrateSeal(ctx context.Context) error {
 		}
 
 		// Generate a new root key
-		newRootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+		newRootKey, err := c.barrier.GenerateKey()
 		if err != nil {
 			return fmt.Errorf("error generating new root key: %w", err)
 		}

--- a/vault/external_tests/storage/crosstest/cross_test.go
+++ b/vault/external_tests/storage/crosstest/cross_test.go
@@ -4,7 +4,6 @@ package crosstest
 
 import (
 	"context"
-	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -186,11 +185,11 @@ func allLogical(t *testing.T) (map[string]logical.Storage, func()) {
 
 func newAESBarrier(t *testing.T, parent physical.Backend) barrier.SecurityBarrier {
 	b := barrier.NewAESGCMBarrier(parent, "")
-	key, err := b.GenerateKey(crand.Reader)
+	key, err := b.GenerateKey()
 	require.NoError(t, err, "failed generating random key")
 
-	b.Initialize(context.Background(), key, nil, crand.Reader)
-	b.Unseal(context.Background(), key)
+	require.NoError(t, b.Initialize(context.Background(), key, nil))
+	require.NoError(t, b.Unseal(context.Background(), key))
 
 	return b
 }

--- a/vault/init.go
+++ b/vault/init.go
@@ -121,7 +121,7 @@ func (c *Core) InitializedLocally(ctx context.Context) (bool, error) {
 
 func (c *Core) generateShares(sc *SealConfig) ([]byte, [][]byte, error) {
 	// Generate a root key
-	rootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	rootKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		return nil, nil, fmt.Errorf("key generation failed: %w", err)
 	}
@@ -318,7 +318,7 @@ func (c *Core) initializeInternal(ctx context.Context, initParams *InitParams) (
 		return nil, fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	barrierKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	barrierKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		c.logger.Error("error generating barrier root key", "error", err)
 		return nil, err
@@ -336,7 +336,7 @@ func (c *Core) initializeInternal(ctx context.Context, initParams *InitParams) (
 	}
 
 	// Initialize the barrier
-	if err := c.barrier.Initialize(ctx, barrierKey, sealKey, c.secureRandomReader); err != nil {
+	if err := c.barrier.Initialize(ctx, barrierKey, sealKey); err != nil {
 		c.logger.Error("failed to initialize barrier", "error", err)
 		return nil, fmt.Errorf("failed to initialize barrier: %w", err)
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3692,7 +3692,7 @@ func (b *SystemBackend) pathHashWrite(ctx context.Context, req *logical.Request,
 }
 
 func (b *SystemBackend) pathRandomWrite(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	return random.HandleRandomAPI(d, b.Core.secureRandomReader)
+	return random.HandleRandomAPI(d)
 }
 
 func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
@@ -4479,7 +4479,7 @@ func (b *SystemBackend) handleLeaderStatus(ctx context.Context, req *logical.Req
 
 func (b *SystemBackend) rotateBarrierKey(ctx context.Context) error {
 	// Rotate to the new term
-	newTerm, err := b.Core.barrier.Rotate(ctx, b.Core.secureRandomReader)
+	newTerm, err := b.Core.barrier.Rotate(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create new encryption key: %w", err)
 	}

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -541,7 +541,6 @@ func (b *MFABackend) HandleMFAGenerateTOTP(ctx context.Context, mConfig *mfa.Con
 		Digits:      otplib.Digits(totpConfig.Digits),
 		Algorithm:   otplib.Algorithm(totpConfig.Algorithm),
 		SecretSize:  uint(totpConfig.KeySize),
-		Rand:        b.Core.secureRandomReader,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate TOTP key for method name %q: %w", mConfig.Name, err)

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -104,7 +104,7 @@ func (c *Core) startRaftBackend(ctx context.Context) (retErr error) {
 			// this state the unseal will fail and a cluster recovery will need to
 			// be done.
 			creating = true
-			raftTLSKey, err := raft.GenerateTLSKey(c.secureRandomReader)
+			raftTLSKey, err := raft.GenerateTLSKey()
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ func (c *Core) raftTLSRotateDirect(ctx context.Context, logger hclog.Logger, sto
 
 	rotateKeyring := func() (time.Time, error) {
 		// Create a new key
-		raftTLSKey, err := raft.GenerateTLSKey(c.secureRandomReader)
+		raftTLSKey, err := raft.GenerateTLSKey()
 		if err != nil {
 			return time.Time{}, fmt.Errorf("failed to generate new raft TLS key: %w", err)
 		}
@@ -405,7 +405,7 @@ func (c *Core) raftTLSRotatePhased(ctx context.Context, logger hclog.Logger, raf
 		logger.Info("creating new raft TLS config")
 
 		// Create a new key
-		raftTLSKey, err := raft.GenerateTLSKey(c.secureRandomReader)
+		raftTLSKey, err := raft.GenerateTLSKey()
 		if err != nil {
 			return time.Time{}, fmt.Errorf("failed to generate new raft TLS key: %w", err)
 		}
@@ -578,7 +578,7 @@ func (c *Core) raftCreateTLSKeyring(ctx context.Context) (*raft.TLSKeyring, erro
 		return nil, errors.New("TLS keyring already present")
 	}
 
-	raftTLS, err := raft.GenerateTLSKey(c.secureRandomReader)
+	raftTLS, err := raft.GenerateTLSKey()
 	if err != nil {
 		return nil, err
 	}

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -423,7 +423,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 	// Generate a new key: for AutoUnseal, this is a new root key; for Shamir,
 	// this is a new unseal key, and performBarrierRekey will also generate a
 	// new root key.
-	newKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	newKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		c.logger.Error("failed to generate root key", "error", err)
 		return nil, logical.CodedError(http.StatusInternalServerError, "root key generation failed: %v", err)
@@ -525,7 +525,7 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 		}
 	}
 
-	newRootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	newRootKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		return logical.CodedError(http.StatusInternalServerError, "failed to perform rekey: %v", err)
 	}
@@ -652,7 +652,7 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 	}
 
 	// Generate a new root key
-	newRecoveryKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	newRecoveryKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		c.logger.Error("failed to generate recovery key", "error", err)
 		return nil, logical.CodedError(http.StatusInternalServerError, "recovery key generation failed: %v", err)

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -457,7 +457,7 @@ func (c *Core) progressRotation(rotationConfig, existingConfig *SealConfig, key 
 // generateKey generates a new root/recovery key dividing it into desired number of key shares.
 func (c *Core) generateKey(rotationConfig *SealConfig, recovery bool) ([]byte, *RekeyResult, logical.HTTPCodedError) {
 	// Generate a new root/recovery key
-	newKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	newKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		c.logger.Error("failed to generate key", "error", err)
 		return nil, nil, logical.CodedError(http.StatusInternalServerError, "key generation failed: %v", err)
@@ -561,7 +561,7 @@ func (c *Core) RotateBarrierRootKey(ctx context.Context) error {
 	c.rotationLock.Lock()
 	defer c.rotationLock.Unlock()
 
-	newRootKey, err := c.barrier.GenerateKey(c.secureRandomReader)
+	newRootKey, err := c.barrier.GenerateKey()
 	if err != nil {
 		return fmt.Errorf("failed to generate new root key: %v", err)
 	}

--- a/vault/rotate_test.go
+++ b/vault/rotate_test.go
@@ -4,9 +4,7 @@
 package vault
 
 import (
-	"crypto/rand"
 	"fmt"
-	"io"
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
@@ -442,16 +440,6 @@ func testRotateBarrierRootKey(t *testing.T, c *Core, unsealShares [][]byte) {
 	storedRootKeyAfter, err := c.seal.GetStoredKeys(t.Context())
 	require.NoError(t, err)
 	require.NotEqual(t, storedRootKeyBefore, storedRootKeyAfter, "should rotate stored root key")
-
-	// simulate root key generation failure
-	c.secureRandomReader = io.LimitReader(c.secureRandomReader, 0)
-	require.Error(t, c.RotateBarrierRootKey(t.Context()))
-	storedRootKey, err := c.seal.GetStoredKeys(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, storedRootKeyAfter, storedRootKey, "should not rotate stored root key")
-
-	// go back to original reader
-	c.secureRandomReader = rand.Reader
 
 	// seal
 	require.NoError(t, c.sealInternal())

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -569,13 +569,12 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 		}
 	}
 
-	// TODO(wslabosz): should we declare separate random readers per namespace?
-	barrierKey, err := b.GenerateKey(sm.core.secureRandomReader)
+	barrierKey, err := b.GenerateKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate namespace barrier key: %w", err)
 	}
 
-	if err := b.Initialize(ctx, barrierKey, sealKey, sm.core.secureRandomReader); err != nil {
+	if err := b.Initialize(ctx, barrierKey, sealKey); err != nil {
 		return nil, fmt.Errorf("failed to initialize namespace barrier: %w", err)
 	}
 
@@ -615,7 +614,7 @@ func (sm *SealManager) RotateBarrierKey(ctx context.Context, ns *namespace.Names
 		return ErrNotSealable
 	}
 
-	newTerm, err := b.Rotate(ctx, sm.core.secureRandomReader)
+	newTerm, err := b.Rotate(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create new encryption key: %w", err)
 	}

--- a/vault/seal_manager_test.go
+++ b/vault/seal_manager_test.go
@@ -4,10 +4,8 @@
 package vault
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"testing"
 
@@ -171,14 +169,6 @@ func TestSealManager_InitializeBarrier(t *testing.T) {
 	ns := &namespace.Namespace{UUID: "ns1", Path: "test/"}
 	err = c.sealManager.SetSeal(ctx, sealConfig, ns, true)
 	require.NoError(t, err)
-
-	// make secure random reader artificially fail
-	c.secureRandomReader = io.LimitReader(c.secureRandomReader, 0)
-	_, err = c.sealManager.InitializeBarrier(ctx, ns)
-	require.ErrorContains(t, err, "failed to generate namespace seal key")
-
-	// return to default reader
-	c.secureRandomReader = rand.Reader
 
 	keyShares, err := c.sealManager.InitializeBarrier(ctx, ns)
 	require.NoError(t, err)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1503,7 +1503,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.DisablePerformanceStandby = base.DisablePerformanceStandby
 		coreConfig.MetricsHelper = base.MetricsHelper
 		coreConfig.MetricSink = base.MetricSink
-		coreConfig.SecureRandomReader = base.SecureRandomReader
 		coreConfig.DisableSentinelTrace = base.DisableSentinelTrace
 		coreConfig.ClusterName = base.ClusterName
 		coreConfig.DisableAutopilot = base.DisableAutopilot

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1267,9 +1267,7 @@ func (ts *TokenStore) create(ctx context.Context, entry *logical.TokenEntry, per
 	}
 
 	entry.Policies = policyutil.SanitizePolicies(entry.Policies, policyutil.DoNotAddDefaultPolicy)
-	var createRootTokenFlag bool
 	if len(entry.Policies) == 1 && entry.Policies[0] == "root" {
-		createRootTokenFlag = true
 		metrics.IncrCounter([]string{"token", "create_root"}, 1)
 	}
 
@@ -1290,11 +1288,7 @@ func (ts *TokenStore) create(ctx context.Context, entry *logical.TokenEntry, per
 		if entry.ID == "" {
 			userSelectedID = false
 			var err error
-			if createRootTokenFlag {
-				entry.ID, err = base62.RandomWithReader(TokenLength, ts.core.secureRandomReader)
-			} else {
-				entry.ID, err = base62.Random(TokenLength)
-			}
+			entry.ID, err = base62.Random(TokenLength)
 			if err != nil {
 				return err
 			}

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,7 +38,7 @@ func (c *Core) ensureWrappingKey(ctx context.Context) error {
 	var keyParams certutil.ClusterKeyParams
 
 	if entry == nil {
-		key, err := ecdsa.GenerateKey(elliptic.P521(), c.secureRandomReader)
+		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 		if err != nil {
 			return fmt.Errorf("failed to generate wrapping key: %w", err)
 		}


### PR DESCRIPTION
## Description

Removes `secureRandomReader` from core.

80% of the diff is going down the errcheck rabbit hole and not directly related, so this is not as big of a change as the +/- makes it appear.

## Rationale

This covers most of #2665, though `GetRandomReader` remains in the SDK on `framework.Backend`.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
