### PR TITLE
Implement cert auth CEL config for mapping group aliases

### DIFF
--- a/builtin/credential/cert/path_certs.go
+++ b/builtin/credential/cert/path_certs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-sockaddr"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
+	celhelper "github.com/openbao/openbao/sdk/v2/helper/cel"
 	"github.com/openbao/openbao/sdk/v2/helper/tokenutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -196,6 +197,13 @@ separated by a dash (-) instead of a dot (.) to allow usage in ACL templates.`,
 certificate.`,
 			},
 
+			"group_aliases_cel_program": {
+				Type: framework.TypeString,
+				Description: `CEL program for extracting group aliases from certificates at login.
+The authenticating certificate is mapped to the variable 'client_cert' and a direct serialization of an x509.Certificate struct.
+To e.g. map all OrganizationName values in the subject, use 'client_cert.Subject.Organization'`,
+			},
+
 			"policies": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: tokenutil.DeprecationText("token_policies"),
@@ -321,6 +329,7 @@ func (b *backend) pathCertRead(ctx context.Context, req *logical.Request, d *fra
 	data := map[string]interface{}{
 		"certificate":                  cert.Certificate,
 		"display_name":                 cert.DisplayName,
+		"group_aliases_cel_program":    cert.GroupAliasCelProgram,
 		"allowed_names":                cert.AllowedNames,
 		"allowed_common_names":         cert.AllowedCommonNames,
 		"allowed_dns_sans":             cert.AllowedDNSSANs,
@@ -393,6 +402,9 @@ func (b *backend) pathCertWrite(ctx context.Context, req *logical.Request, d *fr
 	}
 	if displayNameRaw, ok := d.GetOk("display_name"); ok {
 		cert.DisplayName = displayNameRaw.(string)
+	}
+	if groupAliasesCelProgramRaw, ok := d.GetOk("group_aliases_cel_program"); ok {
+		cert.GroupAliasCelProgram = groupAliasesCelProgramRaw.(string)
 	}
 	if allowedNamesRaw, ok := d.GetOk("allowed_names"); ok {
 		cert.AllowedNames = allowedNamesRaw.([]string)
@@ -481,6 +493,16 @@ func (b *backend) pathCertWrite(ctx context.Context, req *logical.Request, d *fr
 		cert.DisplayName = name
 	}
 
+	if cert.GroupAliasCelProgram != "" {
+		celProgram := celhelper.Program{
+			Expression: cert.GroupAliasCelProgram,
+		}
+		evalConfig := b.getGroupAliasesEvalConfig()
+		if err := celProgram.Validate(&evalConfig); err != nil {
+			return logical.ErrorResponse("failed to validate group aliases program: %w", err), nil
+		}
+	}
+
 	parsed := parsePEM([]byte(cert.Certificate))
 	if len(parsed) == 0 {
 		return logical.ErrorResponse("failed to parse certificate"), nil
@@ -522,6 +544,7 @@ type CertEntry struct {
 	Name                       string
 	Certificate                string
 	DisplayName                string
+	GroupAliasCelProgram       string
 	Policies                   []string
 	TTL                        time.Duration
 	MaxTTL                     time.Duration

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -13,9 +13,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
+	celgo "github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
 	"github.com/openbao/openbao/sdk/v2/framework"
+	celhelper "github.com/openbao/openbao/sdk/v2/helper/cel"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/cidrutil"
 	"github.com/openbao/openbao/sdk/v2/helper/ocsp"
@@ -179,6 +183,12 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, data *fra
 	if err := matched.Entry.PopulateTokenAuth(auth, req); err != nil {
 		return nil, fmt.Errorf("failed to populate auth information: %w", err)
 	}
+
+	groupAliases, err := b.getGroupAliases(ctx, clientCerts[0], matched)
+	if err != nil {
+		return nil, fmt.Errorf("error evaluating getGroupAliases: %w", err)
+	}
+	auth.GroupAliases = groupAliases
 
 	return &logical.Response{
 		Auth: auth,
@@ -566,6 +576,68 @@ func (b *backend) certificateExtensionsMetadata(clientCert *x509.Certificate, co
 	}
 
 	return metadata
+}
+
+func (b *backend) getGroupAliases(ctx context.Context, clientCert *x509.Certificate, config *ParsedCert) ([]*logical.Alias, error) {
+	groupAliases := []*logical.Alias{}
+
+	if config.Entry.GroupAliasCelProgram == "" {
+		return groupAliases, nil
+	}
+
+	evaluationData := map[string]any{
+		"client_cert": clientCert,
+	}
+
+	aliasesProgram := celhelper.Program{
+		Expression: config.Entry.GroupAliasCelProgram,
+	}
+
+	evalConfig := b.getGroupAliasesEvalConfig()
+	result, err := aliasesProgram.Evaluate(ctx, &evalConfig, evaluationData)
+	if err != nil {
+		return nil, err
+	}
+
+	switch value := result.Value().(type) {
+	case []string:
+		// The CEL program succeeded.
+		for _, name := range value {
+			if name == "" {
+				continue
+			}
+			groupAliases = append(groupAliases, &logical.Alias{
+				Name: name,
+			})
+		}
+		return groupAliases, nil
+
+	case string:
+		// The CEL program decided the request is invalid and returned a human-readable error string.
+		return nil, errors.New(value)
+
+	case bool:
+		// The CEL program decided the request is invalid and returned a bool.
+		return nil, errors.New("request denied")
+
+	default:
+		// Any other type is unexpected and indicates an error in MainProgram's policy.
+		return nil, fmt.Errorf("unexpected getGroupAliases result type %T", value)
+	}
+}
+
+func (b *backend) getGroupAliasesEvalConfig() celhelper.EvalConfig {
+	envOptions := []celgo.EnvOption{
+		ext.NativeTypes(reflect.TypeFor[*x509.Certificate]()),
+		celgo.Variable("client_cert", celgo.ObjectType("x509.Certificate")),
+	}
+	return celhelper.EvalConfig{
+		WithExtLib:    true,
+		WithEmail:     true,
+		WithIdentity:  true,
+		WithJSON:      true,
+		CustomOptions: envOptions,
+	}
 }
 
 // loadTrustedCerts is used to load all the trusted certificates from the backend


### PR DESCRIPTION
Fixes #2673

## Description

This feature leverages CEL to allow users to calculate external groups/group aliases in TLS client cert auth by making the authenticating peer certificate available as `client_cert`.

I'd love to make the entire chain available as `chain`, but I'm having trouble determining which root was matched. Something like:
```go
evaluationData := map[string]any{
	"chain":       append(chain, config.matchedRootCert),
	"client_cert": chain[0],
}
```

## Rationale

See #2673. Copypasta from there:
> The "TLS certificates auth method" has no way of assigning policies based on the client certificate properties.

Resolves: #2673

## TODO

- [ ] Making the CEL input field resizable and multi line for easier editing
- [ ] Documentation
- [ ] Testing

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
