### PR TITLE
vault: simplify resolveTokenPolicies default policy logic

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -4314,7 +4314,7 @@ func (ts *TokenStore) resolveTokenPolicies(ctx context.Context, req *logical.Req
 	// We are creating a token from a parent namespace. We should only use the input
 	// policies.
 	case ns.ID != parent.NamespaceID:
-		addDefault = !noDefaultPolicy
+		addDefault = true
 
 	// No policies specified, inherit parent
 	case len(policies) == 0:
@@ -4334,22 +4334,22 @@ func (ts *TokenStore) resolveTokenPolicies(ctx context.Context, req *logical.Req
 			return logical.ErrorResponse("child policies must be subset of parent"), nil, logical.ErrInvalidRequest
 		}
 
-		// If the parent has default, and they haven't requested not to get it,
-		// add it. Note that if they have explicitly put "default" in
-		// data.Policies it will still be added because NoDefaultPolicy
-		// controls *automatic* adding.
-		if !noDefaultPolicy && slices.Contains(parent.Policies, "default") {
+		// If the parent has default, add it automatically unless the client
+		// explicitly opted out via no_default_policy. Note that if they have
+		// explicitly put "default" in data.Policies it will still be stripped
+		// below because NoDefaultPolicy controls *automatic* adding.
+		if slices.Contains(parent.Policies, "default") {
 			addDefault = true
 		}
 
-	// Add default by default in this case unless requested not to
+	// Add default unless explicitly requested not to
 	case isSudo:
-		addDefault = !noDefaultPolicy
+		addDefault = true
 	}
 
-	finalPolicies := policyutil.SanitizePolicies(policies, addDefault)
-
-	// Yes, this is a little inefficient to do it like this, but meh
+	// Apply no_default_policy as a single gate: suppress automatic addition and
+	// strip any "default" that arrived via inheritance or explicit input.
+	finalPolicies := policyutil.SanitizePolicies(policies, addDefault && !noDefaultPolicy)
 	if noDefaultPolicy {
 		finalPolicies = strutil.StrListDelete(finalPolicies, "default")
 	}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Decouple addDefault from noDefaultPolicy in the switch cases so each branch purely expresses intent, then apply noDefaultPolicy as a single gate at the final SanitizePolicies call.

Previously, addDefault was set to !noDefaultPolicy in each branch and then a second pass with strutil.StrListDelete was needed to strip "default" that may have arrived via inheritance. Now the logic flows in one direction: branches set `addDefault=true` when appropriate, and noDefaultPolicy is applied once at the end via `addDefault && !noDefaultPolicy`, with `strutil.StrListDelete` still handling "default" that was already present in the policy list before SanitizePolicies runs.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Related: #2658

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
