### PR TITLE
Enable sealable namespace creation

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5611,54 +5611,6 @@ This path responds to the following HTTP methods.
 		`,
 	},
 
-	"list-namespaces": {
-		"List namespaces.",
-		`
-This path responds to the following HTTP methods.
-
-	LIST /
-		List namespaces.
-
-	SCAN /
-		Scan (recursively list) namespaces.
-		`,
-	},
-	"namespaces": {
-		"Create, read, update and delete namespaces.",
-		`
-This path responds to the following HTTP methods.
-
-	GET /<path>
-		Retrieve a namespace.
-
-	PUT /<path>
-		Create or update a namespace.
-
-	PATCH /<path>
-		Update a namespace's custom metadata.
-
-	DELETE /<path>
-		Delete a namespace.
-		`,
-	},
-	"namespaces-lock": {
-		"Lock a namespace.",
-		`
-This path responds to the following HTTP methods.
-
-	PUT /<path>
-		Lock the API for a namespace.
-		`,
-	},
-	"namespaces-unlock": {
-		"Unlock a namespace.",
-		`
-This path responds to the following HTTP methods.
-
-	PUT /<path>
-		Unlock the API for a namespace.
-		`,
-	},
 	"list-workflows": {
 		"List workflows.",
 		`

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -5,16 +5,24 @@ package vault
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
+
+var namespacePathSchema = &framework.FieldSchema{
+	Type:        framework.TypeString,
+	Required:    false,
+	Description: "Path of the namespace.",
+}
 
 func (b *SystemBackend) namespacePaths() []*framework.Path {
 	namespaceListSchema := map[string]*framework.FieldSchema{
@@ -59,6 +67,11 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 			Required:    true,
 			Description: "User provided key-value pairs.",
 		},
+		"key_shares": {
+			Type:        framework.TypeMap,
+			Required:    false,
+			Description: "Key shares used to combine into unseal/recovery key of the namespace.",
+		},
 	}
 
 	return []*framework.Path{
@@ -86,8 +99,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["list-namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["list-namespaces"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesHelp["list-namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesHelp["list-namespaces"][1]),
 		},
 
 		{
@@ -103,11 +116,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 			},
 
 			Fields: map[string]*framework.FieldSchema{
-				"path": {
-					Type:        framework.TypeString,
-					Required:    false,
-					Description: "Path of the namespace.",
-				},
+				"path": namespacePathSchema,
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -126,8 +135,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-lock"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces-lock"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesHelp["namespaces-lock"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesHelp["namespaces-lock"][1]),
 		},
 
 		{
@@ -143,11 +152,7 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 			},
 
 			Fields: map[string]*framework.FieldSchema{
-				"path": {
-					Type:        framework.TypeString,
-					Required:    false,
-					Description: "Path of the namespace.",
-				},
+				"path": namespacePathSchema,
 				"unlock_key": {
 					Type:        framework.TypeString,
 					Required:    true,
@@ -165,8 +170,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces-unlock"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces-unlock"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesHelp["namespaces-unlock"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesHelp["namespaces-unlock"][1]),
 		},
 
 		{
@@ -177,14 +182,14 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 			},
 
 			Fields: map[string]*framework.FieldSchema{
-				"path": {
-					Type:        framework.TypeString,
-					Required:    true,
-					Description: "Path of the namespace.",
-				},
+				"path": namespacePathSchema,
 				"custom_metadata": {
 					Type:        framework.TypeMap,
 					Description: "User provided key-value pairs.",
+				},
+				"seal": {
+					Type:        framework.TypeMap,
+					Description: "User provided seal config.",
 				},
 			},
 
@@ -230,8 +235,8 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["namespaces"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["namespaces"][1]),
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesHelp["namespaces"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesHelp["namespaces"][1]),
 		},
 	}
 }
@@ -339,15 +344,40 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			}
 		}
 
-		entry, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
-			ns.CustomMetadata = metadata
-			return ns, nil
-		})
+		sealRaw, ok := data.GetOk("seal")
+		sealConfig := &SealConfig{}
+		if ok {
+			if err := mapstructure.Decode(sealRaw, &sealConfig); err != nil {
+				return logical.ErrorResponse("invalid seal config data"), logical.ErrInvalidRequest
+			}
+
+			if err := sealConfig.Validate(); err != nil {
+				return logical.ErrorResponse("invalid seal config: %v", err), err
+			}
+		} else {
+			// fallback to nil
+			sealConfig = nil
+		}
+
+		entry, keyShares, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, sealConfig,
+			func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+				ns.CustomMetadata = metadata
+				return ns, nil
+			})
 		if err != nil {
 			return handleError(err)
 		}
 
-		return &logical.Response{Data: createNamespaceDataResponse(entry)}, nil
+		resp := &logical.Response{Data: createNamespaceDataResponse(entry)}
+		if len(keyShares) != 0 {
+			encoded := make([]string, 0, len(keyShares))
+			for _, share := range keyShares {
+				encoded = append(encoded, hex.EncodeToString(share))
+			}
+			resp.Data["key_shares"] = encoded
+		}
+
+		return resp, nil
 	}
 }
 
@@ -376,7 +406,7 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
-		ns, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+		ns, _, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, nil, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			if ns.UUID == "" {
 				return nil, fmt.Errorf("requested namespace does not exist")
 			}
@@ -478,4 +508,47 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 			},
 		}, nil
 	}
+}
+
+var sysNamespacesHelp = map[string][2]string{
+	"list-namespaces": {
+		"List namespaces.",
+		`
+This path responds to the following HTTP methods.
+	LIST /
+		List namespaces.
+	SCAN /
+		Scan (recursively list) namespaces.
+		`,
+	},
+	"namespaces": {
+		"Create, read, update and delete namespaces.",
+		`
+This path responds to the following HTTP methods.
+	GET /<name>
+		Retrieve a namespace.
+	PUT /<name>
+		Create or update a namespace.
+	PATCH /<name>
+		Update a namespace's custom metadata.
+	DELETE /<name>
+		Delete a namespace.
+		`,
+	},
+	"namespaces-lock": {
+		"Lock a namespace.",
+		`
+This path responds to the following HTTP methods.
+	PUT /<name>
+		Lock the API for a namespace.
+		`,
+	},
+	"namespaces-unlock": {
+		"Unlock a namespace.",
+		`
+This path responds to the following HTTP methods.
+	PUT /<name>
+		Unlock the API for a namespace.
+		`,
+	},
 }

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -345,8 +345,9 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 		}
 
 		sealRaw, ok := data.GetOk("seal")
-		sealConfig := &SealConfig{}
+		var sealConfig *SealConfig
 		if ok {
+			sealConfig = &SealConfig{}
 			if err := mapstructure.Decode(sealRaw, &sealConfig); err != nil {
 				return logical.ErrorResponse("invalid seal config data"), logical.ErrInvalidRequest
 			}
@@ -354,9 +355,6 @@ func (b *SystemBackend) handleNamespacesSet() framework.OperationFunc {
 			if err := sealConfig.Validate(); err != nil {
 				return logical.ErrorResponse("invalid seal config: %v", err), err
 			}
-		} else {
-			// fallback to nil
-			sealConfig = nil
 		}
 
 		entry, keyShares, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, sealConfig,

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -42,8 +42,8 @@ func TestNamespaceBackend_Set(t *testing.T) {
 	rootCtx := namespace.RootContext(t.Context())
 
 	t.Run("create namespace", func(t *testing.T) {
-		customMetadata := map[string]string{"abc": "def"}
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/foo")
+		customMetadata := map[string]string{"abc": "def"}
 		req.Data["custom_metadata"] = customMetadata
 		res, err := b.HandleRequest(rootCtx, req)
 		require.NoError(t, err)
@@ -53,8 +53,29 @@ func TestNamespaceBackend_Set(t *testing.T) {
 		require.Equal(t, res.Data["path"].(string), "foo/")
 		require.Equal(t, res.Data["tainted"].(bool), false)
 		require.Equal(t, res.Data["locked"].(bool), false)
-		require.Equal(t, res.Data["custom_metadata"], customMetadata,
-			"read custom_metadata does not match original custom_metadata")
+		require.Equal(t, res.Data["custom_metadata"], customMetadata)
+	})
+
+	t.Run("create sealable namespace", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/sealable-foo")
+		customMetadata := map[string]string{"abc": "def"}
+		sealConfig := map[string]any{
+			"type":             "shamir",
+			"secret_shares":    3,
+			"secret_threshold": 2,
+		}
+		req.Data["custom_metadata"] = customMetadata
+		req.Data["seal"] = sealConfig
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, res.Data["uuid"].(string), "namespace has no UUID")
+		require.NotEmpty(t, res.Data["id"].(string), "namespace has no ID")
+		require.Equal(t, res.Data["path"].(string), "sealable-foo/")
+		require.Equal(t, res.Data["tainted"].(bool), false)
+		require.Equal(t, res.Data["locked"].(bool), false)
+		require.Equal(t, res.Data["custom_metadata"], customMetadata)
+		require.Len(t, res.Data["key_shares"], 3)
 	})
 
 	t.Run("create namespace name validation", func(t *testing.T) {
@@ -141,6 +162,25 @@ func TestNamespaceBackend_Set(t *testing.T) {
 		require.Equal(t, res.Data["locked"].(bool), false)
 		require.Equal(t, res.Data["custom_metadata"], newMetadata,
 			"read custom_metadata does not match original custom_metadata")
+	})
+
+	t.Run("create namespace with bad seal config should fail", func(t *testing.T) {
+		sealConfig := map[string]any{
+			"type":             "shamir",
+			"secret_shares":    0,
+			"secret_threshold": 0,
+		}
+
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/bad_seal_ns")
+		req.Data["seal"] = sealConfig
+		_, err := b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+
+		// namespace should not exist
+		req = logical.TestRequest(t, logical.ReadOperation, "namespaces/bad_seal_ns")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Empty(t, res)
 	})
 }
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1442,10 +1442,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Type:        "noop",
 		NamespaceID: namespace.RootNamespaceID,
 	}
-	err := c.mount(namespace.RootContext(t.Context()), me)
+	ctx := namespace.RootContext(t.Context())
+	err := c.mount(ctx, me)
 	require.NoError(t, err)
 
-	ns, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(t.Context()), "foo/", nil)
+	ns, _, err := c.namespaceStore.ModifyNamespaceByPath(ctx, "foo/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1453,7 +1454,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	// object lying around. This meant that list and subsequent create
 	// namespace operations returned this ghost structure and did not error
 	// properly. Retrying the create ensures no ghost object exists.
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(t.Context()), "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(ctx, "foo/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1464,19 +1465,19 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Type:        "noop",
 		NamespaceID: namespace.RootNamespaceID,
 	}
-	err = c.mount(namespace.RootContext(t.Context()), me)
+	err = c.mount(ctx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(t.Context()), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(ctx, "fud/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(t.Context()), "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(ctx, "fud/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
 	// Creating a new namespace should succeed.
-	nsBar, err := c.namespaceStore.ModifyNamespaceByPath(namespace.RootContext(t.Context()), "bar/", nil)
+	nsBar, _, err := c.namespaceStore.ModifyNamespaceByPath(ctx, "bar/", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, nsBar)
 
@@ -1492,11 +1493,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "foo/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1509,11 +1510,11 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 	err = c.mount(barCtx, me)
 	require.NoError(t, err)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
-	ns, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil)
+	ns, _, err = c.namespaceStore.ModifyNamespaceByPath(barCtx, "fud/", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ns)
 
@@ -1524,7 +1525,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Type:        "noop",
 		NamespaceID: namespace.RootNamespaceID,
 	}
-	err = c.mount(namespace.RootContext(t.Context()), me)
+	err = c.mount(ctx, me)
 	require.Error(t, err)
 
 	me = &routing.MountEntry{
@@ -1533,7 +1534,7 @@ func TestNamespaceMount_Exclusion(t *testing.T) {
 		Type:        "noop",
 		NamespaceID: namespace.RootNamespaceID,
 	}
-	err = c.mount(namespace.RootContext(t.Context()), me)
+	err = c.mount(ctx, me)
 	require.Error(t, err)
 
 	// Ensure creating sibling mounts still works.

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1462,6 +1462,7 @@ func (j *namespaceCreationFailureJob) Execute() error {
 			retErr = multierror.Append(retErr, err)
 		}
 
+		// TODO(wslabosz): think if sealmanager namespace removal should happen earlier.
 		j.store.core.sealManager.RemoveNamespace(j.target)
 	}
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -339,25 +339,34 @@ func (ns *NamespaceStore) invalidate(ctx context.Context, path string) {
 	ns.invalidated.Store(true)
 }
 
-// SetNamespace is used to create or update a given namespace
-func (ns *NamespaceStore) SetNamespace(ctx context.Context, namespace *namespace.Namespace) error {
+// SetNamespace is used to create or update a namespace.
+func (ns *NamespaceStore) SetNamespace(ctx context.Context, entry *namespace.Namespace) error {
 	defer metrics.MeasureSince([]string{"namespace", "set_namespace"}, time.Now())
 
 	if _, err := ns.lockWithInvalidation(ctx, true); err != nil {
 		return err
 	}
 
-	if err := ns.setNamespaceLocked(ctx, namespace); err != nil {
-		ns.logger.Error("set namespace failed", "error", err)
-		return err
+	_, err := ns.setNamespaceLocked(ctx, entry, nil)
+	return err
+}
+
+// SetNamespaceWithSeal is used to create namespace in sealed state.
+// It's not possible to update the Seal config of a namespace with this function;
+// only add a seal config to a net-new namespace.
+func (ns *NamespaceStore) SetNamespaceWithSeal(ctx context.Context, entry *namespace.Namespace, sealConfig *SealConfig) ([][]byte, error) {
+	defer metrics.MeasureSince([]string{"namespace", "set_namespace_with_seal"}, time.Now())
+
+	if _, err := ns.lockWithInvalidation(ctx, true); err != nil {
+		return nil, err
 	}
 
-	return nil
+	return ns.setNamespaceLocked(ctx, entry, sealConfig)
 }
 
 // setNamespaceLocked must be called while holding a write lock over the
 // NamespaceStore. This function unlocks the lock once finished.
-func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace) error {
+func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *namespace.Namespace, sealConfig *SealConfig) ([][]byte, error) {
 	// If we are creating a net-new namespace, we have to unlock before
 	// creating required mounts as the mount type will call
 	// GetNamespaceByAccessor. In that case, we will manually call
@@ -378,40 +387,45 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	// Copy the entry before validating and potentially mutating it.
 	entry := nsEntry.Clone(true /* preserve unlock */)
 	if err := entry.Validate(); err != nil {
-		return logical.CodedError(http.StatusBadRequest, err.Error())
+		return nil, logical.CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Validate that we have a parent namespace.
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("error loading parent namespace from context: %w", err)
+		return nil, fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
 	var exists bool
 	if entry.UUID == "" {
 		id, err := ns.assignIdentifier(entry.Path)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		entry.ID = id
 		entry.UUID, err = uuid.GenerateUUID()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		var existing *namespace.Namespace
 		existing, exists = ns.namespacesByUUID[entry.UUID]
 		if !exists {
-			return errors.New("trying to update a non-existent namespace")
+			return nil, errors.New("trying to update a non-existent namespace")
 		}
 
 		if existing.ID != entry.ID {
-			return errors.New("accessor ID does not match")
+			return nil, errors.New("accessor ID does not match")
 		}
 
 		if existing.Path != entry.Path {
-			return errors.New("unable to remount namespace at new path")
+			return nil, errors.New("unable to remount namespace at new path")
+		}
+
+		// reject update calls with seal config provided.
+		if sealConfig != nil {
+			return nil, errors.New("cannot modify existing namespace seal config")
 		}
 	}
 
@@ -425,15 +439,14 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		path := entry.Path
 		if parent.ID != namespace.RootNamespaceID {
 			if !entry.HasParent(parent) {
-				return errors.New("namespace path lacks parent as a prefix")
+				return nil, errors.New("namespace path lacks parent as a prefix")
 			}
 
 			path = namespace.Canonicalize(parent.TrimmedPath(entry.Path))
 		}
 
-		conflict := ns.core.router.MatchingPrefixInternal(ctx, path)
-		if conflict != "" {
-			return fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
+		if conflict := ns.core.router.MatchingPrefixInternal(ctx, path); conflict != "" {
+			return nil, fmt.Errorf("new namespace conflicts with existing mount: %v", conflict)
 		}
 	}
 
@@ -482,13 +495,12 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		// a lot of subsystems from using it if it is reloaded from storage.
 		entry.Tainted = true
 		if err := ns.writeNamespace(ctx, parentView, entry); err != nil {
-			return fmt.Errorf("failed to persist initial tainted namespace: %w", err)
+			return nil, fmt.Errorf("failed to persist initial tainted namespace: %w", err)
 		}
 
 		// But we don't mark our in-memory version as being tainted so that
 		// initial mounts can succeed.
 		entry.Tainted = false
-
 		ns.creationDeletionMap[entry.UUID] = true
 	}
 
@@ -496,14 +508,26 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	ns.namespacesByUUID[entry.UUID] = entry
 	ns.namespacesByAccessor[entry.ID] = entry
 
+	var sealKeyShares [][]byte
 	if !exists {
-		// unlock before initializeNamespace since that will re-acquire the lock
+		if sealConfig != nil {
+			if err := ns.core.sealManager.SetSeal(ctx, sealConfig, entry, true); err != nil {
+				return nil, fmt.Errorf("failed to set namespace seal: %w", err)
+			}
+
+			sealKeyShares, err = ns.core.sealManager.InitializeBarrier(ctx, entry)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize namespace barrier: %w", err)
+			}
+		}
+
+		// unlock before initializeNamespace since that will re-acquire the lock.
 		ns.lock.Unlock()
 		unlocked = true
 
 		// Create sys/, token/ mounts and policies for the new namespace.
 		if err := ns.initializeNamespace(ctx, entry); err != nil {
-			return fmt.Errorf("failed to initialize namespace: %w", err)
+			return nil, fmt.Errorf("failed to initialize namespace: %w", err)
 		}
 
 		// Reacquire the lock to undo tainting in storage. We need the lock
@@ -516,7 +540,14 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	// Finally, write the non-tainted namespace or perform our only write if
 	// we are modifying an existing entry.
 	if err := ns.writeNamespace(ctx, parentView, entry); err != nil {
-		return fmt.Errorf("failed to persist namespace: %w", err)
+		return nil, fmt.Errorf("failed to persist namespace: %w", err)
+	}
+
+	// Seal the namespace, as we've finished the setup.
+	if sealConfig != nil {
+		if err := ns.sealNamespaceLocked(ctx, entry); err != nil {
+			return nil, fmt.Errorf("failed to seal namespace: %w", err)
+		}
 	}
 
 	// Since the write succeeded, copy back any potentially changed values.
@@ -527,7 +558,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	failed = false
 
 	// Lastly, push the change to all mounts.
-	return ns.pushToMounts(ctx, entry)
+	return sealKeyShares, ns.pushToMounts(ctx, entry)
 }
 
 func (ns *NamespaceStore) writeNamespace(ctx context.Context, storage barrier.View, entry *namespace.Namespace) error {
@@ -819,33 +850,33 @@ func (ns *NamespaceStore) getNamespaceByPathLocked(
 // ModifyNamespace is used to perform modifications to a namespace while
 // holding a write lock to prevent other changes to namespaces from occurring
 // at the same time.
-func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, error) {
+func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string, sealConfig *SealConfig, callback func(context.Context, *namespace.Namespace) (*namespace.Namespace, error)) (*namespace.Namespace, [][]byte, error) {
 	defer metrics.MeasureSince([]string{"namespace", "modify_namespace"}, time.Now())
 
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	path = namespace.Canonicalize(parent.Path + path)
 	if path == "" {
-		return nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
+		return nil, nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
 	}
 
 	unlock, err := ns.lockWithInvalidation(ctx, true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	entry := ns.namespacesByPath.Get(path)
 	if entry != nil {
 		if entry.Tainted {
 			unlock()
-			return nil, errors.New("namespace with that name exists and is currently tainted")
+			return nil, nil, errors.New("namespace with that name exists and is currently tainted")
 		}
 		if value := ns.creationDeletionMap[entry.UUID]; value {
 			unlock()
-			return nil, errors.New("namespace with that name exists and is currently being created or deleted")
+			return nil, nil, errors.New("namespace with that name exists and is currently being created or deleted")
 		}
 
 		entry = entry.Clone(true /* preserve unlock key so we can copy it */)
@@ -863,20 +894,21 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 		entry, err = callback(ctx, entry)
 		if err != nil {
 			unlock()
-			return nil, err
+			return nil, nil, err
 		}
 
 		// ModifyNamespaceByPath can never modify lock status.
 		entry.UnlockKey = unlockKey
 	}
 
-	// setNamespaceLocked will unlock ns.lock
-	if err := ns.setNamespaceLocked(ctx, entry); err != nil {
+	// setNamespaceLocked will unlock ns.lock.
+	nsKeyShares, err := ns.setNamespaceLocked(ctx, entry, sealConfig)
+	if err != nil {
 		ns.logger.Error("set namespace failed", "error", err)
-		return nil, err
+		return nil, nil, err
 	}
 
-	return entry.Clone(false), nil
+	return entry.Clone(false), nsKeyShares, nil
 }
 
 // ListAllNamespaces lists all available namespaces. includeRoot and includeSealed
@@ -1231,7 +1263,10 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 
 	// setNamespaceLocked now handles unlocking.
 	unlock = nil
-	return ns.setNamespaceLocked(parentCtx, namespaceToUnlock)
+	if _, err = ns.setNamespaceLocked(parentCtx, namespaceToUnlock, nil); err != nil {
+		return fmt.Errorf("unable to save unlocked namespace %q", namespaceToUnlock.Path)
+	}
+	return nil
 }
 
 // LockNamespace attempts to lock the namespace with provided path.
@@ -1287,7 +1322,7 @@ func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (strin
 
 	// setNamespaceLocked now handles unlocking.
 	unlock = nil
-	if err := ns.setNamespaceLocked(parentCtx, namespaceToLock); err != nil {
+	if _, err = ns.setNamespaceLocked(parentCtx, namespaceToLock, nil); err != nil {
 		return "", fmt.Errorf("unable to save locked namespace %q", namespaceToLock.Path)
 	}
 

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openbao/openbao/helper/benchhelpers"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/vault/seal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -295,12 +296,10 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 
 	// verify that modifying a locked namespace does not affect lock
 	// status.
-	ret, err = c.namespaceStore.ModifyNamespaceByPath(ctx, testNamespace.Path, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
+	ret, _, err = c.namespaceStore.ModifyNamespaceByPath(ctx, testNamespace.Path, nil, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 		ns.CustomMetadata["testing"] = "pass"
-
 		// Ensure we do not see the unlock key during modification either.
 		require.Empty(t, ret.UnlockKey)
-
 		return ns, nil
 	})
 	require.NoError(t, err)
@@ -620,7 +619,7 @@ func BenchmarkNamespaceStore(b *testing.B) {
 	b.Run("ModifyNamespaceByPath", func(b *testing.B) {
 		for b.Loop() {
 			path := randomNamespace(s).Path
-			s.ModifyNamespaceByPath(ctx, path, testModifyNamespace)
+			_, _, _ = s.ModifyNamespaceByPath(ctx, path, nil, testModifyNamespace)
 		}
 	})
 
@@ -685,13 +684,14 @@ func BenchmarkNamespace_Set(b *testing.B) {
 	s := c.namespaceStore
 	ctx := namespace.RootContext(b.Context())
 
+	defaultSealConfig := &SealConfig{Type: seal.WrapperTypeShamir.String(), SecretShares: 5, SecretThreshold: 3}
 	item := &namespace.Namespace{}
 
 	b.Run("SetNamespace", func(b *testing.B) {
 		var i int
 		for b.Loop() {
 			item.Path = "ns" + strconv.Itoa(i)
-			s.SetNamespace(ctx, item)
+			_ = s.SetNamespace(ctx, item)
 			i += 1
 		}
 	})
@@ -701,7 +701,17 @@ func BenchmarkNamespace_Set(b *testing.B) {
 		for b.Loop() {
 			item.Path = "ns" + strconv.Itoa(i)
 			s.lock.Lock()
-			s.setNamespaceLocked(ctx, item)
+			_, _ = s.setNamespaceLocked(ctx, item, nil)
+			i += 1
+		}
+	})
+
+	b.Run("SetNamespaceLockedWithSealConfig", func(b *testing.B) {
+		var i int
+		for b.Loop() {
+			item.Path = "ns" + strconv.Itoa(i)
+			s.lock.Lock()
+			_, _ = s.setNamespaceLocked(ctx, item, defaultSealConfig)
 			i += 1
 		}
 	})


### PR DESCRIPTION
## Description
- Added `seal` optional parameter to namespace creation
- Adjusted namespace creation logic in `NamespaceStore` to allow for namespace seal creation within `SealManager`
- Adjusted affected tests

All logic changes are sourced from [namespaces-seal feature branch](https://github.com/openbao/openbao/tree/namespaces-seal)

## Rationale
Introduced changes allow for sealable namespace creation through API, currently without a way to unseal them after creation.

This change is non-breaking, as existing behavior is retained, with possible extension in next PRs. 

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
