### PR TITLE
docs(readme): Remove legacy certification exams heading from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The key features of OpenBao are:
   Revocation assists in key rolling as well as locking down systems in the
   case of an intrusion.
 
-Documentation, Getting Started, and Certification Exams
+Documentation and Getting Started
 -------------------------------
 
 Documentation is available on the [OpenBao website](https://www.openbao.org/docs/).


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This is a tiny update to remove the obsolete "Certification Exams" section from the main [README.md](https://github.com/openbao/openbao/tree/main?tab=readme-ov-file#documentation-getting-started-and-certification-exams) The page used to have such information in the past 723e4c5b06f3f05d0d2a2e289982d81b2c3beee1 but not anymore.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2683

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
