### PR TITLE
Fix regression in OIDC named key rotation (#2669)

### DIFF
--- a/changelog/2669.txt
+++ b/changelog/2669.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Fix OIDC named key rotation silently skipping in non-root namespaces due to double namespace prefix in storage path lookup.
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -2057,8 +2057,7 @@ func (i *IdentityStore) oidcPeriodicFunc(ctx context.Context) {
 	nextRun = now.Add(24 * time.Hour)
 	minJwksClientCacheDuration := time.Duration(math.MaxInt64)
 
-	nsPath := ns.Path
-	s := i.router.MatchingStorageByAPIPath(ctx, nsPath+"identity/oidc")
+	s := i.router.MatchingStorageByAPIPath(ctx, "identity/oidc")
 	if s == nil {
 		return
 	}

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1154,6 +1154,72 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 	}
 }
 
+// TestOIDC_PeriodicFunc_NonRootNamespace tests that oidcPeriodicFunc rotates
+// OIDC named keys in non-root namespaces. This is a test for a regression that happened
+// for non root namespaces.
+func TestOIDC_PeriodicFunc_NonRootNamespace(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	rootCtx := namespace.RootContext(t.Context())
+
+	ns := testCreateNamespace(t, rootCtx, c.systemBackend, "ns", nil)
+	nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
+
+	storage := c.router.MatchingStorageByAPIPath(nsCtx, "identity/oidc")
+
+	key := testNamedKey("test-key-ns")
+	if err := key.generateAndSetKey(nsCtx, hclog.NewNullLogger(), storage); err != nil {
+		t.Fatal("failed to set signing key")
+	}
+	if err := key.generateAndSetKey(nsCtx, hclog.NewNullLogger(), storage); err != nil {
+		t.Fatal("failed to set next signing key")
+	}
+
+	key.NextRotation = time.Now().Add(-time.Second) // past time
+
+	// Store namedKey
+	entry, _ := logical.StorageEntryJSON(namedKeyConfigPath+key.name, key)
+	if err := storage.Put(nsCtx, entry); err != nil {
+		t.Fatal("writing to in mem storage failed")
+	}
+
+	// run periodicFunc
+	c.identityStore.oidcPeriodicFunc(nsCtx)
+
+	// collect entries
+	namedKeyEntry, _ := storage.Get(nsCtx, namedKeyConfigPath+key.name)
+	publicKeysEntry, _ := storage.List(nsCtx, publicKeysConfigPath)
+
+	// verify the number of keys
+	var namedKey namedKey
+	if err := namedKeyEntry.DecodeJSON(&namedKey); err != nil {
+		t.Fatal("failed to decode named key entry")
+	}
+
+	expectedKeyCount := 3 // existing 2 + newly created on rotation
+	actualKeyRingLen := len(namedKey.KeyRing)
+
+	if actualKeyRingLen < expectedKeyCount {
+		t.Errorf(
+			"For key: %s expected namedKey's KeyRing to be at least of length %d but was: %d",
+			key.name,
+			expectedKeyCount,
+			actualKeyRingLen,
+		)
+	}
+
+	expectedPublicKeyCount := 3 // existing 2 + newly created on rotation
+	actualPubKeysLen := len(publicKeysEntry)
+
+	if actualPubKeysLen < expectedPublicKeyCount {
+		t.Errorf(
+			"For key: %s expected public keys to be at least of length %d but was: %d",
+			key.name,
+			expectedPublicKeyCount,
+			actualPubKeysLen,
+		)
+	}
+}
+
 // TestOIDC_Config tests CRUD operations for configuring the OIDC backend
 func TestOIDC_Config(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)


### PR DESCRIPTION
Co-authored-by: Jayakrishnan <jayakrishnanmk07@gmail.com>

Backport of https://github.com/openbao/openbao/pull/2669 (resolved logical merge conflict in `vault/identity_store_oidc_test.go` due to https://github.com/openbao/openbao/pull/2626)
