### PR TITLE
Remove references to wrapping.WrapperTypeShamir

### DIFF
--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -19,7 +19,6 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	uuid "github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	bApi "github.com/openbao/openbao/api/v2"
 	cserver "github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/configutil"
@@ -31,6 +30,7 @@ import (
 	sr "github.com/openbao/openbao/serviceregistration"
 	"github.com/openbao/openbao/vault"
 	"github.com/openbao/openbao/vault/diagnose"
+	"github.com/openbao/openbao/vault/seal"
 	"github.com/openbao/openbao/version"
 	"github.com/posener/complete"
 	"golang.org/x/term"
@@ -600,7 +600,7 @@ SEALFAIL:
 			//nolint:staticcheck // user-facing error
 			return errors.New("Diagnose could not create a barrier seal object.")
 		}
-		if barrierSeal.BarrierType() == wrapping.WrapperTypeShamir {
+		if barrierSeal.BarrierType() == seal.WrapperTypeShamir {
 			diagnose.Skipped(ctx, "Skipping barrier encryption test. Only supported for auto-unseal.")
 			return nil
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -455,7 +455,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	infoKeys = append(infoKeys, "log level")
 
 	if len(config.Seals) == 0 {
-		config.Seals = append(config.Seals, &configutil.KMS{Type: wrapping.WrapperTypeShamir.String()})
+		config.Seals = append(config.Seals, &configutil.KMS{Type: vaultseal.WrapperTypeShamir.String()})
 	}
 
 	if len(config.Seals) > 1 {
@@ -472,7 +472,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 
 	var seal vault.Seal
 	switch configSeal.Type {
-	case string(wrapping.WrapperTypeShamir):
+	case string(vaultseal.WrapperTypeShamir):
 		seal = vault.NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 	default:
 		wrapper, config, err := kms.ConfigureWrapper(
@@ -2430,12 +2430,12 @@ func setSeal(c *ServerCommand, config *server.Config, kms *kmsplugin.Catalog, in
 	// Handle the case where no seal is provided
 	switch len(config.Seals) {
 	case 0:
-		config.Seals = append(config.Seals, &configutil.KMS{Type: wrapping.WrapperTypeShamir.String()})
+		config.Seals = append(config.Seals, &configutil.KMS{Type: vaultseal.WrapperTypeShamir.String()})
 	case 1:
 		// If there's only one seal and it's disabled assume they want to
 		// migrate to a shamir seal and simply didn't provide it
 		if config.Seals[0].Disabled {
-			config.Seals = append(config.Seals, &configutil.KMS{Type: wrapping.WrapperTypeShamir.String()})
+			config.Seals = append(config.Seals, &configutil.KMS{Type: vaultseal.WrapperTypeShamir.String()})
 		}
 	}
 	createdSeals := make([]vault.Seal, len(config.Seals))
@@ -2448,7 +2448,7 @@ func setSeal(c *ServerCommand, config *server.Config, kms *kmsplugin.Catalog, in
 
 		var seal vault.Seal
 		switch configSeal.Type {
-		case string(wrapping.WrapperTypeShamir):
+		case string(vaultseal.WrapperTypeShamir):
 			seal = vault.NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 		default:
 			wrapper, config, err := kms.ConfigureWrapper(

--- a/vault/core.go
+++ b/vault/core.go
@@ -1539,7 +1539,7 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 func (c *Core) unsealWithRaft(combinedKey []byte) error {
 	ctx := context.Background()
 
-	if c.seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if c.seal.BarrierType() == vaultseal.WrapperTypeShamir {
 		shamirWrapper, err := c.seal.GetShamirWrapper()
 		if err == nil {
 			if err = shamirWrapper.SetAesGcmKeyBytes(combinedKey); err != nil {
@@ -2636,7 +2636,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 	// In older versions of vault the default seal would not store a type. This
 	// is here to offer backwards compatibility for older seal configs.
 	if barrierConf.Type == "" {
-		barrierConf.Type = wrapping.WrapperTypeShamir.String()
+		barrierConf.Type = vaultseal.WrapperTypeShamir.String()
 	}
 
 	var recoveryConf *SealConfig
@@ -2656,7 +2656,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 		// In older versions of vault the default seal would not store a type. This
 		// is here to offer backwards compatibility for older seal configs.
 		if recoveryConf.Type == "" {
-			recoveryConf.Type = wrapping.WrapperTypeShamir.String()
+			recoveryConf.Type = vaultseal.WrapperTypeShamir.String()
 		}
 	}
 
@@ -2704,13 +2704,13 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 			// We have the same barrier type and the unwrap seal is nil so we're not
 			// migrating from same to same, IOW we assume it's not a migration.
 			return nil
-		case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
+		case c.seal.BarrierType() == vaultseal.WrapperTypeShamir:
 			// The stored barrier config is not shamir, there is no disabled seal
 			// in config, and either no configured seal (which equates to Shamir)
 			// or an explicitly configured Shamir seal.
 			return fmt.Errorf("cannot seal migrate from %q to Shamir, no disabled seal in configuration",
 				existBarrierSealConfig.Type)
-		case existBarrierSealConfig.Type == wrapping.WrapperTypeShamir.String():
+		case existBarrierSealConfig.Type == vaultseal.WrapperTypeShamir.String():
 			// The configured seal is not Shamir, the stored seal config is Shamir.
 			// This is a migration away from Shamir.
 			unwrapSeal = NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
@@ -2725,7 +2725,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 		// If we're not coming from Shamir we expect the previous seal to be
 		// in the config and disabled.
 
-		if unwrapSeal.BarrierType() == wrapping.WrapperTypeShamir {
+		if unwrapSeal.BarrierType() == vaultseal.WrapperTypeShamir {
 			//nolint:staticcheck // Shamir is a proper noun
 			return errors.New("Shamir seals cannot be set disabled (they should simply not be set)")
 		}
@@ -2735,7 +2735,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 	// c.migrationInfo.seal (old seal) and c.seal (new seal) populated.
 	unwrapSeal.SetCore(c)
 
-	if existBarrierSealConfig.Type != wrapping.WrapperTypeShamir.String() && existRecoverySealConfig == nil {
+	if existBarrierSealConfig.Type != vaultseal.WrapperTypeShamir.String() && existRecoverySealConfig == nil {
 		return errors.New("recovery seal configuration not found for existing seal")
 	}
 

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/vault"
+	"github.com/openbao/openbao/vault/seal"
 )
 
 const (
@@ -269,7 +270,7 @@ func migrateFromTransitToShamir_Pre14(t *testing.T, logger hclog.Logger, storage
 	if err != nil {
 		t.Fatal(err)
 	}
-	verifyBarrierConfig(t, b, wrapping.WrapperTypeShamir.String(), keyShares, keyThreshold, 1)
+	verifyBarrierConfig(t, b, seal.WrapperTypeShamir.String(), keyShares, keyThreshold, 1)
 	if r != nil {
 		t.Fatalf("expected nil recovery config, got: %#v", r)
 	}
@@ -540,7 +541,7 @@ func verifySealConfigShamir(t *testing.T, core *vault.TestClusterCore) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	verifyBarrierConfig(t, b, wrapping.WrapperTypeShamir.String(), keyShares, keyThreshold, 1)
+	verifyBarrierConfig(t, b, seal.WrapperTypeShamir.String(), keyShares, keyThreshold, 1)
 	if r != nil {
 		t.Fatal("should not have recovery config for shamir")
 	}
@@ -552,7 +553,7 @@ func verifySealConfigTransit(t *testing.T, core *vault.TestClusterCore) {
 		t.Fatal(err)
 	}
 	verifyBarrierConfig(t, b, wrapping.WrapperTypeTransit.String(), 1, 1, 1)
-	verifyBarrierConfig(t, r, wrapping.WrapperTypeShamir.String(), keyShares, keyThreshold, 0)
+	verifyBarrierConfig(t, r, seal.WrapperTypeShamir.String(), keyShares, keyThreshold, 0)
 }
 
 // verifyBarrierConfig verifies that a barrier configuration is correct.

--- a/vault/init.go
+++ b/vault/init.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	uuid "github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/vault/seal"
 
@@ -327,7 +326,7 @@ func (c *Core) initializeInternal(ctx context.Context, initParams *InitParams) (
 	var sealKey []byte
 	var sealKeyShares [][]byte
 
-	if barrierConfig.StoredShares == 1 && c.seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if barrierConfig.StoredShares == 1 && c.seal.BarrierType() == seal.WrapperTypeShamir {
 		sealKey, sealKeyShares, err = c.generateShares(barrierConfig)
 		if err != nil {
 			c.logger.Error("error generating shares", "error", err)
@@ -487,7 +486,7 @@ func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
 	c.unsealWithStoredKeysLock.Lock()
 	defer c.unsealWithStoredKeysLock.Unlock()
 
-	if c.seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if c.seal.BarrierType() == seal.WrapperTypeShamir {
 		return nil
 	}
 

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -51,8 +50,8 @@ func testCoreNewTestCore(t *testing.T, seal Seal) (*Core, *CoreConfig) {
 	return c, conf
 }
 
-func testCoreInitCommon(t *testing.T, seal Seal, barrierConf, recoveryConf *SealConfig) {
-	c, conf := testCoreNewTestCore(t, seal)
+func testCoreInitCommon(t *testing.T, s Seal, barrierConf, recoveryConf *SealConfig) {
+	c, conf := testCoreNewTestCore(t, s)
 	ctx := namespace.RootContext(t.Context())
 	init, err := c.Initialized(ctx)
 	require.NoError(t, err)
@@ -76,7 +75,7 @@ func testCoreInitCommon(t *testing.T, seal Seal, barrierConf, recoveryConf *Seal
 	require.NoError(t, err)
 
 	require.Falsef(t,
-		c.seal.BarrierType() == wrapping.WrapperTypeShamir && len(res.SecretShares) != barrierConf.SecretShares,
+		c.seal.BarrierType() == seal.WrapperTypeShamir && len(res.SecretShares) != barrierConf.SecretShares,
 		"Bad: got\n%#v\nexpected conf matching\n%#v\n", *res, *barrierConf,
 	)
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/openbao/openbao/vault/seal"
 	"golang.org/x/crypto/hkdf"
 	"google.golang.org/protobuf/proto"
 )
@@ -664,7 +664,7 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool) framework.Ope
 		case err == nil:
 		case strings.Contains(err.Error(), "failed to open the sealed hashes"):
 			switch b.Core.seal.BarrierType() {
-			case wrapping.WrapperTypeShamir:
+			case seal.WrapperTypeShamir:
 				return logical.ErrorResponse("could not verify hash file, possibly the snapshot is using a different set of unseal keys; use the snapshot-force API to bypass this check"), logical.ErrInvalidRequest
 			default:
 				return logical.ErrorResponse("could not verify hash file, possibly the snapshot is using a different autoseal key; use the snapshot-force API to bypass this check"), logical.ErrInvalidRequest

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -672,7 +672,7 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 			// The snapshot contained a root key or keyring we couldn't
 			// recover
 			switch c.seal.BarrierType() {
-			case wrapping.WrapperTypeShamir:
+			case seal.WrapperTypeShamir:
 				// If we are a shamir seal we can't do anything. Just
 				// seal all nodes.
 
@@ -925,7 +925,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 		// If we're using Shamir and using raft for both physical and HA, we
 		// need to block until the node is unsealed, unless retry is set to
 		// false.
-		if c.seal.BarrierType() == wrapping.WrapperTypeShamir && !c.isRaftHAOnly() {
+		if c.seal.BarrierType() == seal.WrapperTypeShamir && !c.isRaftHAOnly() {
 			c.raftInfo.Store(raftInfo)
 			if err := c.seal.SetBarrierConfig(ctx, raftInfo.leaderBarrierConfig); err != nil {
 				return err
@@ -948,7 +948,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 			return fmt.Errorf("failed to send answer to raft leader node: %w", err)
 		}
 
-		if c.seal.BarrierType() == wrapping.WrapperTypeShamir && !isRaftHAOnly {
+		if c.seal.BarrierType() == seal.WrapperTypeShamir && !isRaftHAOnly {
 			// Reset the state
 			c.raftInfo.Store(nil)
 

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -167,7 +166,7 @@ func (c *Core) RekeyInit(config *SealConfig, recovery bool) logical.HTTPCodedErr
 // BarrierRekeyInit is used to initialize the rekey settings for the barrier key
 func (c *Core) BarrierRekeyInit(config *SealConfig) logical.HTTPCodedError {
 	switch c.seal.BarrierType() {
-	case wrapping.WrapperTypeShamir:
+	case seal.WrapperTypeShamir:
 		// As of Vault 1.3 all seals use StoredShares==1.
 		if config.StoredShares != 1 {
 			c.logger.Warn("shamir stored keys supported, forcing rekey shares/threshold to 1")
@@ -393,7 +392,7 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 			c.logger.Error("rekey recovery key verification failed", "error", err)
 			return nil, logical.CodedError(http.StatusBadRequest, "recovery key verification failed: %v", err)
 		}
-	case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
+	case c.seal.BarrierType() == seal.WrapperTypeShamir:
 		if c.seal.StoredKeysSupported() == seal.StoredKeysSupportedShamirRoot {
 			shamirWrapper := seal.NewShamirWrapper()
 			if err = shamirWrapper.SetAesGcmKeyBytes(recoveredKey); err != nil {

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	uuid "github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
@@ -201,7 +200,7 @@ func (c *Core) initBarrierRotation(config *SealConfig, nonce string) logical.HTT
 		config.StoredShares = 1
 	}
 
-	if c.seal.BarrierType() != wrapping.WrapperTypeShamir {
+	if c.seal.BarrierType() != seal.WrapperTypeShamir {
 		config.SecretShares = 1
 		config.SecretThreshold = 1
 
@@ -351,7 +350,7 @@ func (c *Core) updateBarrierRotation(ctx context.Context, config *SealConfig, ke
 			c.logger.Error("recovery key verification failed", "error", err)
 			return nil, logical.CodedError(http.StatusBadRequest, "recovery key verification failed: %v", err)
 		}
-	case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
+	case c.seal.BarrierType() == seal.WrapperTypeShamir:
 		if c.seal.StoredKeysSupported() == seal.StoredKeysSupportedShamirRoot {
 			shamirWrapper := seal.NewShamirWrapper()
 			if err := shamirWrapper.SetAesGcmKeyBytes(recoveredKey); err != nil {

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -130,7 +130,7 @@ func (d *defaultSeal) Finalize(ctx context.Context) error {
 }
 
 func (d *defaultSeal) BarrierType() wrapping.WrapperType {
-	return wrapping.WrapperTypeShamir
+	return seal.WrapperTypeShamir
 }
 
 func (d *defaultSeal) StoredKeysSupported() seal.StoredKeysSupport {

--- a/vault/seal/shamirwrapper.go
+++ b/vault/seal/shamirwrapper.go
@@ -10,8 +10,6 @@ import (
 	"github.com/openbao/go-kms-wrapping/v2/aead"
 )
 
-// TODO(satoqz): Remove ShamirWrapper from go-kms-wrapping & replace remaining
-// references to wrapping.WrapperTypeShamir with vaultseal.WrapperTypeShamir.
 const WrapperTypeShamir wrapping.WrapperType = "shamir"
 
 // ShamirWrapper is here for backwards compatibility for Vault; it reports a

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/armon/go-radix"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 	"github.com/openbao/openbao/vault/barrier"
@@ -562,7 +561,7 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 	var sealKey []byte
 	var sealKeyShares [][]byte
 
-	if sealConfig.StoredShares == 1 && seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if sealConfig.StoredShares == 1 && seal.BarrierType() == vaultseal.WrapperTypeShamir {
 		sealKey, sealKeyShares, err = sm.core.generateShares(sealConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate namespace seal key: %w", err)


### PR DESCRIPTION
## Description

Replaces `wrapping.WrapperTypeShamir` with `seal.WrapperTypeShamir` across the entire codebase.

## Rationale

- https://github.com/openbao/openbao/pull/2547
- https://github.com/openbao/go-kms-wrapping/pull/75

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
