### PR TITLE
Fix missing `emitMetricsActiveNode` metrics (#2672)

### DIFF
--- a/changelog/2672.txt
+++ b/changelog/2672.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: fix count of leases/tokens/kv-secrets/entities metric not being emitted.
+```

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -168,7 +168,7 @@ func (c *Core) tokenGaugeTtlCollector(ctx context.Context) ([]metricsutil.GaugeL
 }
 
 // emitMetricsActiveNode is used to start all the periodic metrics; all of them should
-// be shut down when stopCh is closed.  This code runs on the active node only.
+// be shut down when stopCh is closed. This code runs on the active node only.
 func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 	// The gauge collection processes are started and stopped here
 	// because there's more than one TokenManager created during startup,
@@ -232,7 +232,7 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 	// Disable collection if configured.
 	if c.MetricSink().GaugeInterval == time.Duration(0) {
 		c.logger.Info("usage gauge collection is disabled")
-	} else if standby := c.Standby(); !standby {
+	} else {
 		for _, init := range metricsInit {
 			if init.DisableEnvVar != "" {
 				if api.ReadBaoVariable(init.DisableEnvVar) != "" {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -48,7 +48,9 @@ const (
 	leaderPrefixCleanDelay = 200 * time.Millisecond
 )
 
-// Standby checks if the Vault is in standby mode
+// Standby checks if the Vault is in standby mode.
+// Usage of this function at core initialization/setup stage is not advised
+// as it always evaluates to true until after postUnseal() method.
 func (c *Core) Standby() bool {
 	return c.standby.Load()
 }


### PR DESCRIPTION
## Description

Backport of #2672.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
