### PR TITLE
Enable auto light/dark on website

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -180,6 +180,7 @@ const config: Config = {
   ],
 
   themeConfig: {
+    colorMode: { respectPrefersColorScheme: true },
     navbar: {
       title: "OpenBao",
       logo: {


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Currently, the OpenBao website always defaults to light mode, though it can be toggled to dark mode. With this setting, it automatically follows the browser's chosen theme (which generally follows the system theme).

The selector now has three states: auto (selected in the screenshot below), light, and dark.

<img width="1624" height="974" alt="Screenshot 2026-03-23 at 19 59 11" src="https://github.com/user-attachments/assets/ddb5705d-9362-4797-88d3-8bfb48482ec5" />

## Rationale

Resolves: #2698 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
