### PR TITLE
Properly close HTTP servers

### DIFF
--- a/changelog/2703.txt
+++ b/changelog/2703.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/listeners: Close HTTP servers first before closing the underlying listener.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -83,8 +83,6 @@ type AgentCommand struct {
 	// Telemetry object
 	metricsHelper *metricsutil.MetricsHelper
 
-	cleanupGuard sync.Once
-
 	startedCh  chan struct{} // for tests
 	reloadedCh chan struct{} // for tests
 
@@ -386,7 +384,6 @@ func (c *AgentCommand) Run(args []string) int {
 				"from the 'cert' auto-auth method specified in the 'vault' stanza. Consider " +
 				"specifying certificate information in the 'cert' auto-auth's config stanza."))
 		}
-
 	}
 
 	// Output the header that the agent has started
@@ -460,8 +457,6 @@ func (c *AgentCommand) Run(args []string) int {
 		}
 	}
 
-	var listeners []net.Listener
-
 	// If there are templates, add an in-process listener
 	if len(config.Templates) > 0 || len(config.EnvTemplates) > 0 {
 		config.Listeners = append(config.Listeners, &configutil.Listener{Type: listenerutil.BufConnType})
@@ -469,6 +464,27 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// Ensure we've added all the reload funcs for TLS before anyone triggers a reload.
 	c.tlsReloadFuncsLock.Lock()
+
+	var (
+		listeners []net.Listener
+		servers   []*http.Server
+	)
+
+	// Ensure that listeners and HTTP servers are closed at all the exits.
+	defer func() {
+		var errs error
+		for _, srv := range servers {
+			errs = errors.Join(srv.Close())
+		}
+		// Closing an HTTP server will close the underlying listener, so avoid
+		// double-closing it.
+		for _, ln := range listeners[len(servers):] {
+			errs = errors.Join(errs, ln.Close())
+		}
+		if errs != nil {
+			c.UI.Error(fmt.Sprintf("Error closing listeners: %v", errs))
+		}
+	}()
 
 	for i, lnConfig := range config.Listeners {
 		var ln net.Listener
@@ -567,19 +583,11 @@ func (c *AgentCommand) Run(args []string) int {
 				c.UI.Error(fmt.Sprintf("HTTP server (listening on %s) exited with error: %v", ln.Addr().String(), err))
 			}
 		}(ln)
+
+		servers = append(servers, server)
 	}
 
 	c.tlsReloadFuncsLock.Unlock()
-
-	// Ensure that listeners are closed at all the exits
-	listenerCloseFunc := func() {
-		for _, ln := range listeners {
-			if err := ln.Close(); err != nil {
-				c.UI.Error(fmt.Sprintf("Could not close listener (listening on %s): %v", ln.Addr().String(), err))
-			}
-		}
-	}
-	defer c.cleanupGuard.Do(listenerCloseFunc)
 
 	// Inform any tests that the server is ready
 	if c.startedCh != nil {

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -439,10 +439,29 @@ func (c *ProxyCommand) Run(args []string) int {
 		}
 	}
 
-	var listeners []net.Listener
-
 	// Ensure we've added all the reload funcs for TLS before anyone triggers a reload.
 	c.tlsReloadFuncsLock.Lock()
+
+	var (
+		listeners []net.Listener
+		servers   []*http.Server
+	)
+
+	// Ensure that listeners and HTTP servers are closed at all the exits.
+	defer func() {
+		var errs error
+		for _, srv := range servers {
+			errs = errors.Join(srv.Close())
+		}
+		// Closing an HTTP server will close the underlying listener, so avoid
+		// double-closing it.
+		for _, ln := range listeners[len(servers):] {
+			errs = errors.Join(errs, ln.Close())
+		}
+		if errs != nil {
+			c.UI.Error(fmt.Sprintf("Error closing listeners: %v", errs))
+		}
+	}()
 
 	for i, lnConfig := range config.Listeners {
 		var ln net.Listener
@@ -541,19 +560,11 @@ func (c *ProxyCommand) Run(args []string) int {
 				c.UI.Error(fmt.Sprintf("HTTP server (listening on %s) exited with error: %v", ln.Addr().String(), err))
 			}
 		}(ln)
+
+		servers = append(servers, server)
 	}
 
 	c.tlsReloadFuncsLock.Unlock()
-
-	// Ensure that listeners are closed at all the exits
-	listenerCloseFunc := func() {
-		for _, ln := range listeners {
-			if err := ln.Close(); err != nil {
-				c.UI.Error(fmt.Sprintf("Could not close listener (listening on %s): %v", ln.Addr().String(), err))
-			}
-		}
-	}
-	defer c.cleanupGuard.Do(listenerCloseFunc)
 
 	// Inform any tests that the server is ready
 	if c.startedCh != nil {

--- a/command/server.go
+++ b/command/server.go
@@ -546,9 +546,16 @@ func (c *ServerCommand) runRecoveryMode() int {
 		})
 	}
 
+	// Make sure we close all HTTP servers and listeners from this point on.
+	var servers []*http.Server
 	listenerCloseFunc := func() {
 		var errs error
-		for _, ln := range lns {
+		for _, srv := range servers {
+			errs = errors.Join(srv.Close())
+		}
+		// Closing an HTTP server will close the underlying listener, so avoid
+		// double-closing it.
+		for _, ln := range lns[len(servers):] {
 			errs = errors.Join(errs, ln.Close())
 		}
 		if errs != nil {
@@ -620,6 +627,8 @@ func (c *ServerCommand) runRecoveryMode() int {
 				c.UI.Error(fmt.Sprintf("HTTP server (listening on %s) exited with error: %v", ln.Addr().String(), err))
 			}
 		}(ln.Listener)
+
+		servers = append(servers, server)
 	}
 
 	if newCoreError != nil {
@@ -1229,10 +1238,16 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Make sure we close all listeners from this point on
+	// Make sure we close all HTTP servers and listeners from this point on.
+	var servers []*http.Server
 	listenerCloseFunc := func() {
 		var errs error
-		for _, ln := range lns {
+		for _, srv := range servers {
+			errs = errors.Join(srv.Close())
+		}
+		// Closing an HTTP server will close the underlying listener, so avoid
+		// double-closing it.
+		for _, ln := range lns[len(servers):] {
 			errs = errors.Join(errs, ln.Close())
 		}
 		if errs != nil {
@@ -1335,7 +1350,7 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	// Initialize the HTTP servers
-	err = startHttpServers(c, core, config, lns)
+	servers, err = startHttpServers(c, core, config, lns)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1
@@ -2893,16 +2908,23 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 }
 
 // Initialize the HTTP servers
-func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config, lns []listenerutil.Listener) error {
+func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config, lns []listenerutil.Listener) ([]*http.Server, error) {
 	for _, ln := range lns {
 		if ln.Config == nil {
-			return errors.New("found nil listener config after parsing")
+			return nil, errors.New("found nil listener config after parsing")
 		}
-
 		if err := config2.IsValidListener(ln.Config); err != nil {
-			return err
+			return nil, err
 		}
+	}
 
+	// Server config tests can exit now.
+	if c.flagTestServerConfig {
+		return nil, nil
+	}
+
+	var servers []*http.Server
+	for _, ln := range lns {
 		handler := vaulthttp.Handler.Handler(&vault.HandlerProperties{
 			Core:                  core,
 			ListenerConfig:        ln.Config,
@@ -2938,18 +2960,16 @@ func startHttpServers(c *ServerCommand, core *vault.Core, config *server.Config,
 			server.IdleTimeout = ln.Config.HTTPIdleTimeout
 		}
 
-		// server config tests can exit now
-		if c.flagTestServerConfig {
-			continue
-		}
-
 		go func(ln net.Listener) {
 			if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				c.UI.Error(fmt.Sprintf("HTTP server (listening on %s) exited with error: %v", ln.Addr().String(), err))
 			}
 		}(ln.Listener)
+
+		servers = append(servers, server)
 	}
-	return nil
+
+	return servers, nil
 }
 
 // formatPropts returns a formatted info key/value such as:


### PR DESCRIPTION
## Description

If we've started an HTTP server on a listener, on shutdown, close the HTTP server instead of closing the listener directly to avoid the HTTP server logging an unexpected error.

There are two bugs here:

1. Closing listeners instead of HTTP servers, which has been the case for aeons.
2. The error message that started surfacing with #2229, which hasn't made it into a release yet.

So I don't think we should backport, but it's important to fix this before v2.6 which will have #2229.

Notably, I've chosen `.Close()` over `.Shutdown(ctx)` to avoid a larger behavioral change.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/2667

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
