### PR TITLE
Fix serializing in-memory fields in mount entry

### DIFF
--- a/vault/routing/mount_entry.go
+++ b/vault/routing/mount_entry.go
@@ -30,14 +30,14 @@ type MountEntry struct {
 	Tainted               bool              `json:"tainted,omitempty"`                 // Set as a Write-Ahead flag for unmount/remount
 	NamespaceID           string            `json:"namespace_id"`
 
-	// Namespace contains the populated Namespace
-	Namespace *namespace.Namespace
+	// Namespace contains the populated Namespace.
+	Namespace *namespace.Namespace `json:"-"`
 
 	// SynthesizedConfigCache is used to cache configuration values. These
 	// particular values are cached since we want to get them at a point-in-time
 	// without separately managing their locks individually. See SyncCache() for
 	// the specific values that are being cached.
-	SynthesizedConfigCache sync.Map
+	SynthesizedConfigCache sync.Map `json:"-"`
 
 	// version info
 	Version        string `json:"plugin_version,omitempty"`         // The semantic version of the mounted plugin, e.g. v1.2.3.


### PR DESCRIPTION
## Description

Fix an unreleased regression caused by https://github.com/openbao/openbao/pull/2551, which made fields public without telling `encoding/json` to ignore them.

Credits to @wslabosz-reply for spotting and questioning this. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
