### PR TITLE
Add note for direct install using the Arch Linux package manager

### DIFF
--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -35,11 +35,11 @@ $ pkg install openbao
 
 ### Linux
 
-OpenBao manages packages for Ubuntu, Debian, Fedora, RHEL, Amazon Linux, and
+OpenBao manages packages for Amazon Linux, Debian, Fedora, RHEL, Ubuntu and
 other distributions. The packages are available for both direct download
 and native package managers on the [downloads](/downloads) page.
 
-In addition, OpenBao packages are available more directly in Arch Linux, RHEL and Fedora.
+In addition, OpenBao packages are available more directly in Arch Linux, Fedora and RHEL.
 
 For Arch Linux they can be installed by
 
@@ -59,7 +59,7 @@ For RHEL (and derivatives) they are in EPEL which can be enabled by
 $ dnf install -y epel-release
 ```
 
-and then installed on RHEL or Fedora by
+and then installed on Fedora or RHEL by
 
 ```shell-session
 $ dnf install -y openbao


### PR DESCRIPTION
## Description

Adds Arch Linux as a direct-install option similar to RHEL and Fedora.

## Rationale

Resolves: #2717

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
