### PR TITLE
website: document inheritable rate-limit quotas

### DIFF
--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -27,6 +27,9 @@ the mount to restrict more specific API paths.
 - `block_interval` `(string: "")` - If set, when a client reaches a rate limit
   threshold, the client will be prohibited from any further requests until after
   the 'block_interval' has elapsed.
+- `inheritable` `(bool: false)` - If set to `true`, child namespaces will use
+  this quota unless another more specific quota exists. This can only be set on
+  namespace quotas. A quota on the root namespace is inheritable by default.
 - `role` `(string: "")` - If set on a quota where `path` is set to an auth mount with a
   concept of roles (such as `/auth/approle/`), this will make the quota restrict login
   requests to that mount that are made with the specified role. The request will fail if
@@ -39,7 +42,8 @@ the mount to restrict more specific API paths.
   "path": "",
   "rate": 897.3,
   "interval": "2m",
-  "block_interval": "5m"
+  "block_interval": "5m",
+  "inheritable": true
 }
 ```
 
@@ -98,6 +102,7 @@ $ curl \
   "data": {
     "block_interval": 300,
     "interval": 2,
+    "inheritable": true,
     "name": "global-rate-limiter",
     "path": "",
     "rate": 897.3,


### PR DESCRIPTION
## Summary
- document the `inheritable` flag on the rate-limit quota API page
- add the field to the sample payload and sample response so the docs match the API schema

## Testing
- npm --prefix website run lint -- content/api-docs/system/rate-limit-quotas.mdx


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.