### PR TITLE
refactor: Stop using reopenClass

### DIFF
--- a/changelog/2732.txt
+++ b/changelog/2732.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Remove deprecated uses of reopenClass
+```

--- a/ui/app/components/auth-config-form/config.js
+++ b/ui/app/components/auth-config-form/config.js
@@ -22,32 +22,29 @@ import { waitFor } from '@ember/test-waiters';
  *
  */
 
-const AuthConfigBase = Component.extend({
-  tagName: '',
-  model: null,
+export default class AuthConfigBase extends Component {
+  tagName = '';
+  model = null;
 
-  flashMessages: service(),
-  router: service(),
-  saveModel: task(
-    waitFor(function* () {
-      try {
-        yield this.model.save();
-      } catch (err) {
-        // AdapterErrors are handled by the error-message component
-        // in the form
-        if (err instanceof AdapterError === false) {
-          throw err;
-        }
-        return;
+  @service flashMessages;
+  @service router;
+
+  @task
+  @waitFor
+  *saveModel() {
+    try {
+      yield this.model.save();
+    } catch (err) {
+      // AdapterErrors are handled by the error-message component
+      // in the form
+      if (err instanceof AdapterError === false) {
+        throw err;
       }
-      this.router.transitionTo('vault.cluster.access.methods').followRedirects();
-      this.flashMessages.success('The configuration was saved successfully.');
-    })
-  ),
-});
+      return;
+    }
+    this.router.transitionTo('vault.cluster.access.methods').followRedirects();
+    this.flashMessages.success('The configuration was saved successfully.');
+  }
 
-AuthConfigBase.reopenClass({
-  positionalParams: ['model'],
-});
-
-export default AuthConfigBase;
+  static positionalParams = ['model'];
+}

--- a/ui/app/components/section-tabs.js
+++ b/ui/app/components/section-tabs.js
@@ -5,14 +5,10 @@
 
 import Component from '@ember/component';
 
-const SectionTabs = Component.extend({
-  tagName: '',
-  model: null,
-  tabType: 'authSettings',
-});
+export default class SectionTabs extends Component {
+  tagName = '';
+  model = null;
+  tabType = 'authSettings';
 
-SectionTabs.reopenClass({
-  positionalParams: ['model', 'tabType', 'paths'],
-});
-
-export default SectionTabs;
+  static positionalParams = ['model', 'tabType', 'paths'];
+}

--- a/ui/app/deprecation-workflow.js
+++ b/ui/app/deprecation-workflow.js
@@ -8,7 +8,10 @@ import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 export const deprecationWorkflowConfig = {
   // current output from deprecationWorkflow.flushDeprecations();
   // deprecations that will not be removed until 5.0.0 are filtered by deprecation-filter initializer rather than silencing below
-  workflow: [{ handler: 'log', matchId: 'ember-data:deprecate-array-like' }],
+  workflow: [
+    { handler: 'log', matchId: 'ember-data:deprecate-array-like' },
+    { handler: 'log', matchId: 'ember-data:deprecate-model-reopenclass' },
+  ],
 };
 
 setupDeprecationWorkflow(deprecationWorkflowConfig);

--- a/ui/app/lib/attach-capabilities.js
+++ b/ui/app/lib/attach-capabilities.js
@@ -41,47 +41,45 @@ export default function attachCapabilities(modelClass, capabilities) {
   //TODO: move this to the application serializer and do it JIT instead of on app boot
   debug(`adding new relationships: ${capabilityKeys.join(', ')} to ${modelClass.toString()}`);
   modelClass.reopen(newRelationships);
-  modelClass.reopenClass({
-    // relatedCapabilities is called in the application serializer's
-    // normalizeResponse hook to add the capabilities relationships to the
-    // JSON-API document used by Ember Data
-    relatedCapabilities(jsonAPIDoc) {
-      let { data, included } = jsonAPIDoc;
-      if (!data) {
-        data = jsonAPIDoc;
-      }
-      if (isArray(data)) {
-        const newData = data.map(this.relatedCapabilities);
-        return {
-          data: newData,
-          included,
-        };
-      }
-      const context = {
-        id: data.id,
-        ...data.attributes,
+  // relatedCapabilities is called in the application serializer's
+  // normalizeResponse hook to add the capabilities relationships to the
+  // JSON-API document used by Ember Data
+  modelClass.relatedCapabilities = function (jsonAPIDoc) {
+    let { data, included } = jsonAPIDoc;
+    if (!data) {
+      data = jsonAPIDoc;
+    }
+    if (isArray(data)) {
+      const newData = data.map(this.relatedCapabilities);
+      return {
+        data: newData,
+        included,
       };
-      for (const newCapability of capabilityKeys) {
-        const templateFn = capabilities[newCapability];
-        const type = typeOf(templateFn);
-        assert(`expected value of ${newCapability} to be a function but found ${type}.`, type === 'function');
-        data.relationships[newCapability] = {
-          data: {
-            type: 'capabilities',
-            id: templateFn(context),
-          },
-        };
-      }
+    }
+    const context = {
+      id: data.id,
+      ...data.attributes,
+    };
+    for (const newCapability of capabilityKeys) {
+      const templateFn = capabilities[newCapability];
+      const type = typeOf(templateFn);
+      assert(`expected value of ${newCapability} to be a function but found ${type}.`, type === 'function');
+      data.relationships[newCapability] = {
+        data: {
+          type: 'capabilities',
+          id: templateFn(context),
+        },
+      };
+    }
 
-      if (included) {
-        return {
-          data,
-          included,
-        };
-      } else {
-        return data;
-      }
-    },
-  });
+    if (included) {
+      return {
+        data,
+        included,
+      };
+    } else {
+      return data;
+    }
+  };
   return modelClass;
 }

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -345,7 +345,7 @@ export default Service.extend({
           },
         }),
       });
-      newModel.reopenClass({ merged: true });
+      newModel.merged = true;
       owner.unregister(modelName);
       owner.register(modelName, newModel);
     });


### PR DESCRIPTION
Remove deprecated uses of reopenClass in ember code.

This is fixes part of #2729


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
