### PR TITLE
Add Sigstore to the "Integrator" ecosystem

### DIFF
--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -35,6 +35,10 @@ import Member from './lib/Member.tsx';
       [Warden](https://github.com/stephnangue/warden) an open-source identity-aware egress gateway that intercepts outbound cloud API calls and forwards them using short-lived credentials minted via OpenBao, so that credentials never reach client applications.
   </Member>
 
+  <Member title="Sigstore" logoName="sigstore">
+      [Sigstore](https://www.sigstore.dev/) is an OpenSSF project that secures the software supply chain. It integrates with OpenBao by leveraging it as a KMS for signing artifacts.
+  </Member>
+
 </Randomize>
 </div>
 </div>

--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -32,7 +32,7 @@ import Member from './lib/Member.tsx';
   </Member>
 
   <Member title="Warden">
-      [Warden](https://github.com/stephnangue/warden) an open-source identity-aware egress gateway that intercepts outbound cloud API calls and forwards them using short-lived credentials minted via OpenBao, so that credentials never reach client applications.
+      [Warden](https://github.com/stephnangue/warden) is an open-source identity-aware egress gateway that intercepts outbound cloud API calls and forwards them using short-lived credentials minted via OpenBao, so that credentials never reach client applications.
   </Member>
 
   <Member title="Sigstore" logoName="sigstore">

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
     "@hashicorp/remark-plugins": "^4.1.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
-    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#168d91e8df1332fb283c1a17059ea9d79f6a155b",
+    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#180e1b63272b551ed67b77f1201f442a5a140a7b",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"


### PR DESCRIPTION
## Description

Thanks to @Nerkho and @Hayden-IO we now have "native" support for Sigstore:

* https://github.com/sigstore/sigstore/issues/2287

As agreed with Hayden on Slack, both projects are happy to showcase Sigstore in the OpenBao ecosystem.

See https://github.com/openbao/openbao-ecosystem-logos/pull/23 for the logo.

## Rationale

Raise awareness for both Sigstore and OpenBao.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
