### PR TITLE
Namespace sealing mount storage refactor

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -184,7 +184,7 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	newTable := c.auth.ShallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(ns), newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to update auth table", "error", err)
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
@@ -340,7 +340,7 @@ func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateS
 
 	if updateStorage {
 		// Update the auth table
-		if err := c.persistAuth(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace), newTable, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -389,11 +389,6 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 		return fmt.Errorf("path in use at %q", match)
 	}
 
-	srcBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Mark the entry as tainted
 	if err := c.taintCredEntry(ctx, src.Namespace.ID, src.MountPath, updateStorage); err != nil {
 		return err
@@ -430,7 +425,7 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	}
 
 	// Update the mount table
-	if err := c.persistAuth(ctx, nil, c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
+	if err := c.persistAuth(ctx, c.NamespaceView(mountEntry.Namespace), c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.Namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
@@ -441,7 +436,7 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 
 	if src.Namespace.ID != dst.Namespace.ID {
 		// Handle storage entries
-		if err := c.moveAuthStorage(ctx, src, mountEntry, srcBarrierView, dstBarrierView); err != nil {
+		if err := c.moveAuthStorage(ctx, src, mountEntry); err != nil {
 			c.authLock.Unlock()
 			return err
 		}
@@ -484,7 +479,7 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 
 	if updateStorage {
 		// Update the auth table
-		if err := c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace), c.auth, &entry.Local, entry.UUID); err != nil {
 			return fmt.Errorf("failed to update auth table: %w", err)
 		}
 	}
@@ -574,8 +569,7 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		}
 
 		view := NamespaceScopedView(barrier, ns)
-
-		nsGlobal, nsLocal, err := c.listTransactionalCredentialsForNamespace(ctx, view)
+		nsGlobal, nsLocal, err := listTransactionalCredentialsForNamespace(ctx, view)
 		if err != nil {
 			c.logger.Error("failed to list transactional auth mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
 			return err
@@ -623,7 +617,6 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	if len(localEntries) > 0 {
 		for nsIndex, ns := range allNamespaces {
 			view := NamespaceScopedView(barrier, ns)
-
 			for index, uuid := range localEntries[ns.ID] {
 				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
 				if err != nil {
@@ -646,7 +639,21 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	return nil
 }
 
-func (c *Core) listTransactionalCredentialsForNamespace(ctx context.Context, barrier logical.Storage) ([]string, []string, error) {
+func getLegacyCredentialsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
+	globalEntry, err := barrier.Get(ctx, coreAuthConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy auth mounts: %w", err)
+	}
+
+	localEntry, err := barrier.Get(ctx, coreLocalAuthConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy local auth mounts: %w", err)
+	}
+
+	return globalEntry, localEntry, nil
+}
+
+func listTransactionalCredentialsForNamespace(ctx context.Context, barrier logical.Storage) ([]string, []string, error) {
 	globalEntries, err := barrier.List(ctx, coreAuthConfigPath+"/")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed listing core auth mounts: %w", err)
@@ -664,25 +671,44 @@ func (c *Core) listTransactionalCredentialsForNamespace(ctx context.Context, bar
 // returning true if it was used. This will let us know (if we're inside
 // a transaction) if we need to do an upgrade.
 func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storage, standby bool) (bool, error) {
-	// Load the existing auth mount table
-	raw, err := barrier.Get(ctx, coreAuthConfigPath)
+	// Load the existing mount table per namespace
+	allNamespaces, err := c.ListNamespaces(ctx)
 	if err != nil {
-		c.logger.Error("failed to read auth table", "error", err)
-		return false, errLoadAuthFailed
-	}
-	rawLocal, err := barrier.Get(ctx, coreLocalAuthConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read local auth table", "error", err)
-		return false, errLoadAuthFailed
+		return false, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	if raw != nil {
-		authTable, err := c.decodeMountTable(ctx, raw.Value)
+	globalEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
+	localEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
+	for index, ns := range allNamespaces {
+		if ns.Tainted {
+			c.logger.Info("skipping loading auth mounts for tainted namespace", "ns", ns.ID)
+			continue
+		}
+
+		view := NamespaceScopedView(barrier, ns)
+		entry, localEntry, err := getLegacyCredentialsForNamespace(ctx, view)
+		if err != nil {
+			c.logger.Error("failed to get legacy auth mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
+			return false, err
+		}
+
+		if entry != nil {
+			globalEntries[ns.ID] = entry
+		}
+
+		if localEntry != nil {
+			localEntries[ns.ID] = localEntry
+		}
+	}
+
+	if len(globalEntries) > 0 {
+		authTable, size, err := c.decodeMountTable(ctx, globalEntries)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the auth table", "error", err)
 			return false, err
 		}
 		c.auth = authTable
+		c.tableMetrics(routing.CredentialTableType, false, len(c.auth.Entries), size)
 	}
 
 	var needPersist bool
@@ -704,17 +730,17 @@ func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storag
 			c.logger.Info("migrating legacy mount table to transactional layout")
 			needPersist = true
 		}
-		c.tableMetrics(routing.CredentialTableType, false, len(c.auth.Entries), len(raw.Value))
 	}
-	if rawLocal != nil {
-		localAuthTable, err := c.decodeMountTable(ctx, rawLocal.Value)
+
+	if len(localEntries) > 0 {
+		localAuthTable, size, err := c.decodeMountTable(ctx, localEntries)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy local auth mount table", "error", err)
 			return false, err
 		}
 		if localAuthTable != nil && len(localAuthTable.Entries) > 0 {
 			c.auth.Entries = append(c.auth.Entries, localAuthTable.Entries...)
-			c.tableMetrics(routing.CredentialTableType, true, len(localAuthTable.Entries), len(rawLocal.Value))
+			c.tableMetrics(routing.CredentialTableType, true, len(localAuthTable.Entries), size)
 		}
 	}
 
@@ -725,8 +751,7 @@ func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storag
 	//    backend.
 	// 2. We may have had a legacy auth mount table and need to upgrade into the
 	//    new format. runCredentialUpdates will handle this for us.
-	err = c.runCredentialUpdates(ctx, barrier, needPersist, standby)
-	if err != nil {
+	if err = c.runCredentialUpdates(ctx, barrier, needPersist, standby); err != nil {
 		c.logger.Error("failed to run legacy auth mount table upgrades", "error", err)
 		return false, err
 	}
@@ -812,10 +837,8 @@ func (c *Core) runCredentialUpdates(ctx context.Context, barrier logical.Storage
 
 // persistAuth is used to persist the auth table after modification
 func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *routing.MountTable, local *bool, mount string) error {
-	// Sometimes we may not want to explicitly pass barrier; fetch it if
-	// necessary.
 	if barrier == nil {
-		barrier = c.barrier
+		return errors.New("nil barrier encountered while persisting auth mount changes")
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -868,8 +891,18 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 
 	// Handle writing the legacy auth mount table by default.
 	writeTable := func(mt *routing.MountTable, path string) (int, error) {
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return -1, err
+		}
+
+		mountCopy := mt.ShallowClone()
+		mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
+			return e.NamespaceID != ns.ID
+		})
+
 		// Encode the auth mount table into JSON and compress it (Gzip).
-		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mt, nil)
+		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
 		if err != nil {
 			c.logger.Error("failed to encode or compress auth mount table", "error", err)
 			return -1, err
@@ -881,8 +914,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 			Value: compressedBytes,
 		}
 
-		// Write to the physical backend
-		if err := c.barrier.Put(ctx, entry); err != nil {
+		// Write using passed barrier.
+		if err := barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist auth mount table", "error", err)
 			return -1, err
 		}
@@ -919,8 +952,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				// Write to the backend.
-				view := NamespaceScopedView(barrier, mtEntry.Namespace)
-				if err := view.Put(ctx, sEntry); err != nil {
+				if err := barrier.Put(ctx, sEntry); err != nil {
 					c.logger.Error("failed to persist auth mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
 					return -1, err
 				}
@@ -936,8 +968,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 					return -1, err
 				}
 
-				view := NamespaceScopedView(barrier, ns)
-				if err := view.Delete(ctx, path.Join(prefix, mount)); err != nil {
+				if err := barrier.Delete(ctx, path.Join(prefix, mount)); err != nil {
 					c.logger.Error("failed to persist removal of auth mount table entry", "namespace", ns.Path, "uuid", mount, "error", err)
 					return -1, fmt.Errorf("failed to remove auth mount from storage: %w", err)
 				}
@@ -950,10 +981,8 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceScopedView(barrier, ns)
-
 					// List all entries and remove any deleted ones.
-					presentEntries, err := view.List(ctx, prefix+"/")
+					presentEntries, err := barrier.List(ctx, prefix+"/")
 					if err != nil {
 						return -1, fmt.Errorf("failed to list entries in namespace %v (%v) for removal: %w", ns.ID, nsIndex, err)
 					}
@@ -963,7 +992,7 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 							continue
 						}
 
-						if err := view.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
 							return -1, fmt.Errorf("failed to remove deleted mount %v (%d) in namespace %v (%v): %w", presentEntry, index, ns.ID, nsIndex, err)
 						}
 					}

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -369,7 +369,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 	}
 
 	c.auth.Entries[1].Local = true
-	if err := c.persistAuth(t.Context(), nil, c.auth, nil, ""); err != nil {
+	if err := c.persistAuth(t.Context(), c.barrier, c.auth, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -837,11 +837,12 @@ func TestCore_RemountCredential_Cleanup(t *testing.T) {
 func TestCore_RemountCredential_Namespaces(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
 	rootCtx := namespace.RootContext(t.Context())
-	ns1 := testCreateNamespace(t, rootCtx, c.systemBackend, "ns1", nil)
+	ns1 := &namespace.Namespace{Path: "ns1/"}
+	ns2 := &namespace.Namespace{Path: "ns1/ns2/"}
+	ns3 := &namespace.Namespace{Path: "ns1/ns3/"}
+	TestCoreCreateNamespaces(t, c, ns1, ns2, ns3)
 	ns1Ctx := namespace.ContextWithNamespace(rootCtx, ns1)
-	ns2 := testCreateNamespace(t, ns1Ctx, c.systemBackend, "ns2", nil)
 	ns2Ctx := namespace.ContextWithNamespace(rootCtx, ns2)
-	ns3 := testCreateNamespace(t, ns1Ctx, c.systemBackend, "ns3", nil)
 	ns3Ctx := namespace.ContextWithNamespace(rootCtx, ns3)
 
 	me := &routing.MountEntry{

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -480,12 +480,11 @@ func (ij *invalidationJob) auditInvalidation(ctx context.Context) error {
 }
 
 func (ij *invalidationJob) legacyMountInvalidation(ctx context.Context) error {
-	if ij.nsUUID != namespace.RootNamespaceUUID {
-		ij.im.dispacherLogger.Warn("skipping invalidating legacy mount table in non-root namespace", "ns", ij.nsUUID, "key", ij.nsKey)
-		return nil
+	if err := ij.im.core.reloadLegacyMounts(ctx, ij.nsKey); err != nil {
+		return fmt.Errorf("unable to invalidate legacy mount for key %q in namespace %q: %w", ij.nsKey, ij.nsUUID, err)
 	}
 
-	return ij.im.core.reloadLegacyMounts(ctx, ij.nsKey)
+	return nil
 }
 
 func (ij *invalidationJob) transactionalMountInvalidation(ctx context.Context) error {

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -50,24 +50,32 @@ func testCore_Invalidate_TestCore(t *testing.T, config *CoreConfig) (*Core, stri
 	return c, root
 }
 
-func testCore_Invalidate_sneakValueAroundCache(t *testing.T, c *Core, entry *logical.StorageEntry) {
+func testCore_Invalidate_sneakValueAroundCache(t *testing.T, ctx context.Context, c *Core, entry *logical.StorageEntry) {
 	t.Helper()
 
 	// we briefly disable the physical cache, this will put the value into the backing storage, but not update the cache
 	c.physicalCache.SetEnabled(false)
 	defer c.physicalCache.SetEnabled(true)
 
-	require.NoError(t, c.barrier.Put(t.Context(), entry))
+	ns, err := namespace.FromContext(ctx)
+	require.NoError(t, err)
+
+	view := c.NamespaceView(ns)
+	require.NoError(t, view.Put(ctx, entry))
 }
 
-func testCore_Invalidate_sneakValueAroundCacheDelete(t *testing.T, c *Core, key string) {
+func testCore_Invalidate_sneakValueAroundCacheDelete(t *testing.T, ctx context.Context, c *Core, key string) {
 	t.Helper()
 
 	// we briefly disable the physical cache, this will put the value into the backing storage, but not update the cache
 	c.physicalCache.SetEnabled(false)
 	defer c.physicalCache.SetEnabled(true)
 
-	require.NoError(t, logical.ClearView(t.Context(), logical.NewStorageView(c.barrier, key)))
+	ns, err := namespace.FromContext(ctx)
+	require.NoError(t, err)
+
+	view := c.NamespaceView(ns)
+	require.NoError(t, logical.ClearView(ctx, view.SubView(key)))
 }
 
 func testCore_Invalidate_handleRequest(t require.TestingT, ctx context.Context, c *Core, req *logical.Request, expectedErrors ...string) *logical.Response {
@@ -91,7 +99,7 @@ func testCore_Invalidate_handleRequest(t require.TestingT, ctx context.Context, 
 func TestCore_Invalidate_Namespaces(t *testing.T) {
 	t.Parallel()
 	c, root := testCore_Invalidate_TestCore(t, nil)
-
+	rootCtx := namespace.RootContext(t.Context())
 	// 1. Create some namespace to populate cache
 	ns := &namespace.Namespace{
 		ID:   "ns",
@@ -112,7 +120,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	newEntry, err := logical.StorageEntryJSON(storagePath, clone)
 	require.NoError(t, err)
 
-	testCore_Invalidate_sneakValueAroundCache(t, c, newEntry)
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 
 	// 2.2 add mount to namespace
 	newEntry, err = logical.StorageEntryJSON("namespaces/"+ns.UUID+"/core/mounts/666666666-6666-6666-6666-6666666666666", routing.MountEntry{
@@ -124,7 +132,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 		NamespaceID: ns.ID,
 	})
 	require.NoError(t, err)
-	testCore_Invalidate_sneakValueAroundCache(t, c, newEntry)
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 	mountPath := "ns/my-path"
 
 	// 3. Invalidate Path
@@ -134,7 +142,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	// 4.1 Validate custom metadata
 	req := logical.TestRequest(t, logical.ReadOperation, "sys/namespaces/ns")
 	req.ClientToken = root
-	resp := testCore_Invalidate_handleRequest(t, namespace.RootContext(t.Context()), c, req)
+	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	if diff := deep.Equal(resp.Data["custom_metadata"], map[string]string{
 		"testkey": "updated value",
@@ -146,13 +154,13 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		req = logical.TestRequest(t, logical.ListOperation, mountPath)
 		req.ClientToken = root
-		resp = testCore_Invalidate_handleRequest(collect, namespace.RootContext(t.Context()), c, req)
+		resp = testCore_Invalidate_handleRequest(collect, rootCtx, c, req)
 		require.NotNil(collect, resp)
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// 5. Manipulate Storage: delete namespace
-	testCore_Invalidate_sneakValueAroundCacheDelete(t, c, storagePath)
-	testCore_Invalidate_sneakValueAroundCacheDelete(t, c, "namespaces/"+ns.UUID)
+	testCore_Invalidate_sneakValueAroundCacheDelete(t, rootCtx, c, storagePath)
+	testCore_Invalidate_sneakValueAroundCacheDelete(t, rootCtx, c, "namespaces/"+ns.UUID)
 
 	// 6. Invalidate Path
 	c.invalidateSynchronous(storagePath)
@@ -161,7 +169,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	// 7.1 namespace should be gone
 	req = logical.TestRequest(t, logical.ReadOperation, "sys/namespaces/ns")
 	req.ClientToken = root
-	resp = testCore_Invalidate_handleRequest(t, namespace.RootContext(t.Context()), c, req)
+	resp = testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	require.Nil(t, resp)
 
@@ -169,7 +177,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		req = logical.TestRequest(t, logical.ListOperation, mountPath)
 		req.ClientToken = root
-		resp = testCore_Invalidate_handleRequest(collect, namespace.RootContext(t.Context()), c, req, "unsupported path")
+		resp = testCore_Invalidate_handleRequest(collect, rootCtx, c, req, "unsupported path")
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
@@ -183,6 +191,7 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	c, root := testCore_Invalidate_TestCore(t, &CoreConfig{
 		Physical: physical,
 	})
+	rootCtx := namespace.RootContext(t.Context())
 
 	// 1. Create some namespace to populate cache
 	ns := &namespace.Namespace{
@@ -194,6 +203,7 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	}
 
 	TestCoreCreateNamespaces(t, c, ns)
+	nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
 
 	// 2. Manipulate Storage
 	// 2.1 Inject custom metadata into namespace
@@ -204,10 +214,11 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	newEntry, err := logical.StorageEntryJSON(storagePath, clone)
 	require.NoError(t, err)
 
-	testCore_Invalidate_sneakValueAroundCache(t, c, newEntry)
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 
 	// 2.2 add mount to namespace
-	storageEntry, err := c.barrier.Get(t.Context(), "core/mounts")
+	view := c.NamespaceView(ns)
+	storageEntry, err := view.Get(nsCtx, coreMountConfigPath)
 	require.NoError(t, err)
 	require.NotNil(t, storageEntry, "expected mount table to be written at %s", storagePath)
 
@@ -227,8 +238,8 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	updatedData, err := jsonutil.EncodeJSON(mountTable)
 	require.NoError(t, err)
 
-	testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-		Key:   "core/mounts",
+	testCore_Invalidate_sneakValueAroundCache(t, nsCtx, c, &logical.StorageEntry{
+		Key:   coreMountConfigPath,
 		Value: updatedData,
 	})
 
@@ -239,7 +250,7 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	// 4.1 Validate custom metadata
 	req := logical.TestRequest(t, logical.ReadOperation, "sys/namespaces/ns")
 	req.ClientToken = root
-	resp := testCore_Invalidate_handleRequest(t, namespace.RootContext(t.Context()), c, req)
+	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	if diff := deep.Equal(resp.Data["custom_metadata"], map[string]string{
 		"testkey": "updated value",
@@ -251,36 +262,37 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		req = logical.TestRequest(t, logical.ListOperation, mountPath)
 		req.ClientToken = root
-		resp = testCore_Invalidate_handleRequest(collect, namespace.RootContext(t.Context()), c, req)
+		resp = testCore_Invalidate_handleRequest(collect, rootCtx, c, req)
 		require.NotNil(collect, resp)
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func TestCore_Invalidate_Policy(t *testing.T) {
 	t.Parallel()
-	testCases := map[string]func(t *testing.T, c *Core) (storagePath string, ctx context.Context){
-		"global": func(t *testing.T, c *Core) (storagePath string, ctx context.Context) {
-			return "sys/policy/test-policy", namespace.RootContext(t.Context())
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"global": func(t *testing.T, c *Core) context.Context {
+			return namespace.RootContext(t.Context())
 		},
 
-		"local": func(t *testing.T, c *Core) (storagePath string, ctx context.Context) {
+		"local": func(t *testing.T, c *Core) context.Context {
 			ns := &namespace.Namespace{
 				ID:   "ns",
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
 
-			return fmt.Sprintf("namespaces/%s/sys/policy/test-policy", ns.UUID), namespace.ContextWithNamespace(t.Context(), ns)
+			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
 	}
 
 	for name, init := range testCases {
 		t.Run(name, func(t *testing.T) {
 			c, root := testCore_Invalidate_TestCore(t, nil)
-			storagePath, ctx := init(t, c)
+			ctx := init(t, c)
 
 			// 1. Create some policy to populate cache
-			req := logical.TestRequest(t, logical.CreateOperation, "sys/policy/test-policy")
+			storagePath := "sys/policy/test-policy"
+			req := logical.TestRequest(t, logical.CreateOperation, storagePath)
 			req.ClientToken = root
 			req.Data = map[string]interface{}{
 				"policy": `
@@ -301,7 +313,14 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			newEntry, err := logical.StorageEntryJSON(storagePath, clone)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, newEntry)
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, newEntry)
+
+			ns, err := namespace.FromContext(ctx)
+			require.NoError(t, err)
+
+			if ns.ID != namespace.RootNamespaceID {
+				storagePath = path.Join(namespaceBarrierPrefix, ns.UUID, storagePath)
+			}
 
 			// 3. Invalidate Path
 			c.invalidateSynchronous(storagePath)
@@ -318,7 +337,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 func TestCore_Invalidate_Quota(t *testing.T) {
 	t.Parallel()
 	c, root := testCore_Invalidate_TestCore(t, nil)
-
+	rootCtx := namespace.RootContext(t.Context())
 	// 1. Create some qutoa to populate cache
 	req := logical.TestRequest(t, logical.CreateOperation, "sys/quotas/rate-limit/test-quota")
 	req.ClientToken = root
@@ -326,7 +345,7 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 		"rate":     3.141,
 		"interval": "42s",
 	}
-	testCore_Invalidate_handleRequest(t, t.Context(), c, req)
+	testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	// 2. Manipulate Storage
 	quota, err := c.quotaManager.QuotaByName("rate-limit", "test-quota")
@@ -338,7 +357,7 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	newEntry, err := logical.StorageEntryJSON("sys/quotas/rate-limit/test-quota", clone)
 	require.NoError(t, err)
 
-	testCore_Invalidate_sneakValueAroundCache(t, c, newEntry)
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 
 	// 3. Invalidate Path
 	c.invalidateSynchronous("sys/quotas/rate-limit/test-quota")
@@ -347,7 +366,7 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	req = logical.TestRequest(t, logical.ReadOperation, "sys/quotas/rate-limit/test-quota")
 	req.ClientToken = root
 
-	resp := testCore_Invalidate_handleRequest(t, t.Context(), c, req)
+	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	require.Equal(t, 1, resp.Data["interval"])
 }
@@ -426,6 +445,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	c, root := testCore_Invalidate_TestCore(t, &CoreConfig{
 		RawConfig: &server.Config{UnsafeAllowAPIAuditCreation: true, AllowAuditLogPrefixing: true},
 	})
+	rootCtx := namespace.RootContext(t.Context())
 
 	// 1. Inject a dummy audit factory
 	var callCount atomic.Int32
@@ -451,13 +471,13 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 		},
 	}
 
-	testCore_Invalidate_handleRequest(t, t.Context(), c, registerReq)
+	testCore_Invalidate_handleRequest(t, rootCtx, c, registerReq)
 
 	require.EqualValues(t, 1, callCount.Load(), "expected audit factory to be called exactly once")
 
 	// 3. Trigger audit event
 	triggerAuditEvent := func() {
-		testCore_Invalidate_handleRequest(t, t.Context(), c, &logical.Request{
+		testCore_Invalidate_handleRequest(t, rootCtx, c, &logical.Request{
 			Operation:   logical.ReadOperation,
 			ClientToken: root,
 			Path:        "secret/kv/dummy",
@@ -468,7 +488,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	require.Len(t, currentBackend.Req, 1, "expected 1 audit request event")
 
 	// 4. Manipulate audit table in storage: delete audit
-	entry, err := c.barrier.Get(t.Context(), "core/audit")
+	entry, err := c.barrier.Get(rootCtx, "core/audit")
 	require.NoError(t, err)
 	require.NotNil(t, entry, "expected audit table to be written")
 
@@ -480,7 +500,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	data, err := jsonutil.EncodeJSON(auditTable)
 	require.NoError(t, err)
 
-	testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, &logical.StorageEntry{
 		Key:   "core/audit",
 		Value: data,
 	})
@@ -500,7 +520,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	require.Len(t, currentBackend.Req, 1, "expected still 1 audit request event")
 
 	// 7. Manipulate audit table in storage: restore audit
-	testCore_Invalidate_sneakValueAroundCache(t, c, entry)
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, entry)
 
 	// 8. call invalidate
 	c.invalidateSynchronous("core/audit")
@@ -520,19 +540,19 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 
 func TestCore_Invalidate_SecretMount(t *testing.T) {
 	t.Parallel()
-	testCases := map[string]func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context){
-		"global": func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context) {
-			return "", namespace.RootContext(t.Context())
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"global": func(t *testing.T, c *Core) context.Context {
+			return namespace.RootContext(t.Context())
 		},
 
-		"local": func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context) {
+		"local": func(t *testing.T, c *Core) context.Context {
 			ns := &namespace.Namespace{
 				ID:   "ns",
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
 
-			return fmt.Sprintf("namespaces/%s/", ns.UUID), namespace.ContextWithNamespace(t.Context(), ns)
+			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
 	}
 
@@ -540,7 +560,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, root := testCore_Invalidate_TestCore(t, nil)
-			nsPrefix, ctx := init(t, c)
+			ctx := init(t, c)
 
 			// 1. Inject a dummy factory
 			var factoryCallCount, cleanCallCount, readCallCount atomic.Int32
@@ -580,16 +600,15 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.mounts.Entries), "expected mount table to grew by one")
 
-			// 3. Get the UUID
+			// 3. Get mount UUID
 			readReq := &logical.Request{
 				Operation:   logical.ReadOperation,
 				ClientToken: root,
 				Path:        "sys/mounts/my-kv-mount",
 			}
 			resp := testCore_Invalidate_handleRequest(t, ctx, c, readReq)
-
 			uuid := resp.Data["uuid"].(string)
-			storagePath := path.Join(nsPrefix, "core/mounts", uuid)
+			entryPath := path.Join(coreMountConfigPath, uuid)
 
 			triggerReadCall := func(collect require.TestingT, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
@@ -601,15 +620,19 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			triggerReadCall(t)
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
-			// 4. Manipulate mount table in storage: delete storageEntry
-			storageEntry, err := c.barrier.Get(ctx, storagePath)
+			ns, err := namespace.FromContext(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", storagePath)
+			view := c.NamespaceView(ns)
 
-			testCore_Invalidate_sneakValueAroundCacheDelete(t, c, storagePath)
+			// 4. Manipulate mount table in storage: delete storageEntry
+			storageEntry, err := view.Get(ctx, entryPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", view.Prefix()+entryPath)
+
+			testCore_Invalidate_sneakValueAroundCacheDelete(t, ctx, c, entryPath)
 
 			// 5. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -624,10 +647,10 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			triggerReadCall(t, "unsupported path")
 
 			// 7. Manipulate mount table in storage: restore mount
-			testCore_Invalidate_sneakValueAroundCache(t, c, storageEntry)
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 8. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -646,13 +669,13 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			updatedData, err := jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   entryPath,
 				Value: updatedData,
 			})
 
 			// 10. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				triggerReadCall(collect, "unsupported path")
@@ -665,13 +688,13 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			updatedData, err = jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   entryPath,
 				Value: updatedData,
 			})
 
 			// 12. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				resp := testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
@@ -690,13 +713,13 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			updatedData, err = jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   entryPath,
 				Value: updatedData,
 			})
 
 			// 14. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				require.EqualValues(collect, 3, factoryCallCount.Load(), "expected factory to be called exactly thrice")
@@ -776,8 +799,6 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.mounts.Entries), "expected mount table to grew by one")
 
-			storagePath := "core/mounts"
-
 			triggerReadCall := func(collect require.TestingT, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
@@ -788,10 +809,14 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			triggerReadCall(t)
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
-			// 3. Manipulate mount table in storage: delete entry from mount table
-			storageEntry, err := c.barrier.Get(ctx, storagePath)
+			ns, err := namespace.FromContext(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, storageEntry, "expected mount table to be written at %s", storagePath)
+			view := c.NamespaceView(ns)
+
+			// 3. Manipulate mount table in storage: delete entry from mount table
+			storageEntry, err := view.Get(ctx, coreMountConfigPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount table to be written at %s", view.Prefix()+coreMountConfigPath)
 
 			mountTable := new(routing.MountTable)
 			require.NoError(t, jsonutil.DecodeJSON(storageEntry.Value, mountTable))
@@ -802,13 +827,13 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			updatedData, err := jsonutil.EncodeJSON(mountTable)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   coreMountConfigPath,
 				Value: updatedData,
 			})
 
 			// 4. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + coreMountConfigPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -823,10 +848,10 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			triggerReadCall(t, "unsupported path")
 
 			// 6. Manipulate mount table in storage: restore mount
-			testCore_Invalidate_sneakValueAroundCache(t, c, storageEntry)
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 7. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + coreMountConfigPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -842,19 +867,19 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 
 func TestCore_Invalidate_AuthMount(t *testing.T) {
 	t.Parallel()
-	testCases := map[string]func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context){
-		"global": func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context) {
-			return "", namespace.RootContext(t.Context())
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"global": func(t *testing.T, c *Core) context.Context {
+			return namespace.RootContext(t.Context())
 		},
 
-		"local": func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context) {
+		"local": func(t *testing.T, c *Core) context.Context {
 			ns := &namespace.Namespace{
 				ID:   "ns",
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
 
-			return fmt.Sprintf("namespaces/%s/", ns.UUID), namespace.ContextWithNamespace(t.Context(), ns)
+			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
 	}
 
@@ -862,7 +887,7 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, root := testCore_Invalidate_TestCore(t, nil)
-			nsPrefix, ctx := init(t, c)
+			ctx := init(t, c)
 
 			// 1. Inject a dummy factory
 			var factoryCallCount, cleanCallCount, readCallCount atomic.Int32
@@ -902,16 +927,15 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.auth.Entries), "expected mount table to grew by one")
 
-			// 3. Get the UUID
+			// 3. Get mount UUID
 			readReq := &logical.Request{
 				Operation:   logical.ReadOperation,
 				ClientToken: root,
 				Path:        "sys/auth/my-auth",
 			}
 			resp := testCore_Invalidate_handleRequest(t, ctx, c, readReq)
-
 			uuid := resp.Data["uuid"].(string)
-			storagePath := path.Join(nsPrefix, "core/auth", uuid)
+			entryPath := path.Join(coreAuthConfigPath, uuid)
 
 			callLogin := func(collect require.TestingT, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
@@ -923,15 +947,19 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			callLogin(t)
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
-			// 4. Manipulate mount table in storage: delete storageEntry
-			storageEntry, err := c.barrier.Get(ctx, storagePath)
+			ns, err := namespace.FromContext(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", storagePath)
+			view := c.NamespaceView(ns)
 
-			testCore_Invalidate_sneakValueAroundCacheDelete(t, c, storagePath)
+			// 4. Manipulate mount table in storage: delete storageEntry
+			storageEntry, err := view.Get(ctx, entryPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", view.Prefix()+entryPath)
+
+			testCore_Invalidate_sneakValueAroundCacheDelete(t, ctx, c, entryPath)
 
 			// 5. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -946,10 +974,10 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			callLogin(t, "unsupported path")
 
 			// 7. Manipulate mount table in storage: restore mount
-			testCore_Invalidate_sneakValueAroundCache(t, c, storageEntry)
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 8. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -968,13 +996,13 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			updatedData, err := jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   entryPath,
 				Value: updatedData,
 			})
 
 			// 10. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + entryPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				callLogin(collect, "unsupported path")
@@ -1052,8 +1080,6 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.auth.Entries), "expected mount table to grew by one")
 
-			storagePath := "core/auth"
-
 			callLogin := func(collect require.TestingT, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
@@ -1064,10 +1090,14 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			callLogin(t)
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
-			// 3. Manipulate mount table in storage: delete entry from mount table
-			storageEntry, err := c.barrier.Get(ctx, storagePath)
+			ns, err := namespace.FromContext(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, storageEntry, "expected mount table to be written at %s", storagePath)
+			view := c.NamespaceView(ns)
+
+			// 3. Manipulate mount table in storage: delete entry from mount table
+			storageEntry, err := view.Get(ctx, coreAuthConfigPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount table to be written at %s", view.Prefix()+coreAuthConfigPath)
 
 			mountTable := new(routing.MountTable)
 			require.NoError(t, jsonutil.DecodeJSON(storageEntry.Value, mountTable))
@@ -1078,13 +1108,13 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			updatedData, err := jsonutil.EncodeJSON(mountTable)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   coreAuthConfigPath,
 				Value: updatedData,
 			})
 
 			// 4. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1099,10 +1129,10 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			callLogin(t, "unsupported path")
 
 			// 6. Manipulate mount table in storage: restore mount
-			testCore_Invalidate_sneakValueAroundCache(t, c, storageEntry)
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 7. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1120,13 +1150,13 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			updatedData, err = jsonutil.EncodeJSON(mountTable)
 			require.NoError(t, err)
 
-			testCore_Invalidate_sneakValueAroundCache(t, c, &logical.StorageEntry{
-				Key:   storagePath,
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   coreAuthConfigPath,
 				Value: updatedData,
 			})
 
 			// 9. call invalidate
-			c.invalidateSynchronous(storagePath)
+			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				callLogin(collect, "unsupported path")

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1856,11 +1856,15 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		}
 	}
 
-	var err error
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return handleError(err)
+	}
+
 	if isAuth {
-		err = b.Core.persistAuth(ctx, nil, b.Core.auth, &mountEntry.Local, mountEntry.UUID)
+		err = b.Core.persistAuth(ctx, b.Core.NamespaceView(ns), b.Core.auth, &mountEntry.Local, mountEntry.UUID)
 	} else {
-		err = b.Core.persistMounts(ctx, nil, b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
+		err = b.Core.persistMounts(ctx, b.Core.NamespaceView(ns), b.Core.mounts, &mountEntry.Local, mountEntry.UUID)
 	}
 
 	if err != nil {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -6263,16 +6263,15 @@ func TestCanUnseal_WithNonExistentBuiltinPluginVersion_InMountStorage(t *testing
 			t.Fatal()
 		}
 		mountEntry.Version = nonExistentBuiltinVersion
-		if tc.mountTable == "mounts" {
-			err = core.persistMounts(ctx, nil, core.mounts, &mountEntry.Local, mountEntry.UUID)
-			if err != nil {
-				t.Fatal(err)
-			}
+		barrier := core.NamespaceView(mountEntry.Namespace)
+		if tc.mountTable == routing.MountTableType {
+			err = core.persistMounts(ctx, barrier, core.mounts, &mountEntry.Local, mountEntry.UUID)
 		} else {
-			err = core.persistAuth(ctx, nil, core.auth, &mountEntry.Local, mountEntry.UUID)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = core.persistAuth(ctx, barrier, core.auth, &mountEntry.Local, mountEntry.UUID)
+		}
+
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		config = readMountConfig(tc.pluginName, tc.mountTable)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -118,41 +118,49 @@ func (c *Core) generateMountAccessor(entryType string) (string, error) {
 	return accessor, nil
 }
 
-// DecodeMountTable is used for testing
-func (c *Core) DecodeMountTable(ctx context.Context, raw []byte) (*routing.MountTable, error) {
-	return c.decodeMountTable(ctx, raw)
-}
-
-func (c *Core) decodeMountTable(ctx context.Context, raw []byte) (*routing.MountTable, error) {
-	// Decode into mount table
-	mountTable := new(routing.MountTable)
-	if err := jsonutil.DecodeJSON(raw, mountTable); err != nil {
-		return nil, err
-	}
-
-	// Populate the namespace in memory
+func (c *Core) decodeMountTable(ctx context.Context, entries map[string]*logical.StorageEntry) (*routing.MountTable, int, error) {
 	var mountEntries []*routing.MountEntry
-	for _, entry := range mountTable.Entries {
-		if entry.NamespaceID == "" {
-			entry.NamespaceID = namespace.RootNamespaceID
+	var mountType string
+	var size int
+	for _, entry := range entries {
+		// Decode into single mount table
+		mountTable := new(routing.MountTable)
+		if err := jsonutil.DecodeJSON(entry.Value, mountTable); err != nil {
+			return nil, 0, err
 		}
-		ns, err := c.NamespaceByID(ctx, entry.NamespaceID)
-		if err != nil {
-			return nil, err
+		size += size + len(entry.Value)
+
+		// Verify mountTable type on every level stays the same.
+		if mountType != "" && mountType != mountTable.Type {
+			return nil, 0, errors.New("broken mount table encountered; mismatched table types between namespaces")
 		}
-		if ns == nil {
-			c.logger.Error("namespace on mount entry not found", "namespace_id", entry.NamespaceID, "mount_path", entry.Path, "mount_description", entry.Description)
-			continue
+		mountType = mountTable.Type
+
+		// Populate the namespace in memory
+		for _, entry := range mountTable.Entries {
+			if entry.NamespaceID == "" {
+				entry.NamespaceID = namespace.RootNamespaceID
+			}
+
+			ns, err := c.NamespaceByID(ctx, entry.NamespaceID)
+			if err != nil {
+				return nil, 0, err
+			}
+
+			if ns == nil {
+				c.logger.Error("namespace on mount entry not found", "namespace_id", entry.NamespaceID, "mount_path", entry.Path, "mount_description", entry.Description)
+				continue
+			}
+			entry.Namespace = ns
 		}
 
-		entry.Namespace = ns
-		mountEntries = append(mountEntries, entry)
+		mountEntries = append(mountEntries, mountTable.Entries...)
 	}
 
 	return &routing.MountTable{
-		Type:    mountTable.Type,
+		Type:    mountType,
 		Entries: mountEntries,
-	}, nil
+	}, size, nil
 }
 
 func (c *Core) fetchAndDecodeMountTableEntry(ctx context.Context, barrier logical.Storage, prefix string, uuid string) (*routing.MountEntry, error) {
@@ -340,7 +348,7 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	newTable := c.mounts.ShallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if updateStorage {
-		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(ns), newTable, &entry.Local, entry.UUID); err != nil {
 			if logical.ShouldForward(err) {
 				return err
 			}
@@ -557,7 +565,7 @@ func (c *Core) removeMountEntryWithLock(ctx context.Context, path string, update
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, nil, newTable, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace), newTable, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to remove entry from mounts table", "error", err)
 			return logical.CodedError(500, "failed to remove entry from mounts table")
 		}
@@ -582,7 +590,7 @@ func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, upda
 
 	if updateStorage {
 		// Update the mount table
-		if err := c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID); err != nil {
+		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace), c.mounts, &entry.Local, entry.UUID); err != nil {
 			c.logger.Error("failed to taint entry in mounts table", "error", err)
 			return logical.CodedError(500, "failed to taint entry in mounts table: %v", err)
 		}
@@ -678,11 +686,6 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 		return fmt.Errorf("path in use at %q", match)
 	}
 
-	srcBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Mark the entry as tainted
 	if err := c.taintMountEntry(ctx, src.Namespace.ID, src.MountPath, updateStorage, false); err != nil {
 		return err
@@ -729,7 +732,7 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	}
 
 	// Update the mount table
-	if err := c.persistMounts(ctx, nil, c.mounts, &mountEntry.Local, mountEntry.UUID); err != nil {
+	if err := c.persistMounts(ctx, c.NamespaceView(mountEntry.Namespace), c.mounts, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.Namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
@@ -740,7 +743,7 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 
 	if src.Namespace.ID != dst.Namespace.ID {
 		// Handle storage entries
-		if err := c.moveMountStorage(ctx, src, mountEntry, srcBarrierView, dstBarrierView); err != nil {
+		if err := c.moveMountStorage(ctx, src, mountEntry); err != nil {
 			c.mountsLock.Unlock()
 			return err
 		}
@@ -766,34 +769,33 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	return nil
 }
 
-// moveMountStorage moves storage entries of a mount mountEntry to its new destination
-func (c *Core) moveMountStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry, srcBarrierView, dstBarrierView barrier.View) error {
-	return c.moveStorage(ctx, src, me, srcBarrierView, dstBarrierView)
+// moveMountStorage moves storage entries of a mount mountEntry to its new destination.
+func (c *Core) moveMountStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry) error {
+	return c.moveStorage(ctx, src, me, backendBarrierPrefix)
 }
 
-// moveAuthStorage moves storage entries of an auth mountEntry to its new destination
-func (c *Core) moveAuthStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry, srcBarrierView, dstBarrierView barrier.View) error {
-	return c.moveStorage(ctx, src, me, srcBarrierView, dstBarrierView)
+// moveAuthStorage moves storage entries of an auth mountEntry to its new destination.
+func (c *Core) moveAuthStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry) error {
+	return c.moveStorage(ctx, src, me, routing.CredentialRoutePrefix)
 }
 
-// moveStorage moves storage entries of a mountEntry to its new destination
-// It detects the mountEntry type
-func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry, srcBarrierView, dstBarrierView barrier.View) error {
-	srcPrefix := srcBarrierView.Prefix()
-	dstPrefix := dstBarrierView.Prefix()
-
-	barrier := c.barrier
+// moveStorage moves storage entries of a mountEntry to its new destination.
+// It detects the mountEntry type.
+func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, me *routing.MountEntry, prefix string) error {
+	srcBarrier := c.NamespaceView(src.Namespace)
+	dstBarrier := c.NamespaceView(me.Namespace)
 
 	var key string
-	keys, err := barrier.List(ctx, srcPrefix)
+	keys, err := srcBarrier.List(ctx, path.Join(prefix, me.UUID)+"/")
 	if err != nil {
 		return err
 	}
 
 	for len(keys) > 0 {
 		key, keys = keys[0], keys[1:]
+		entryKey := path.Join(prefix, me.UUID, key)
 		if strings.HasSuffix(key, "/") {
-			nestedKeys, err := barrier.List(ctx, srcPrefix+key)
+			nestedKeys, err := srcBarrier.List(ctx, entryKey)
 			if err != nil {
 				return err
 			}
@@ -805,32 +807,24 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 			continue
 		}
 
-		if err := logical.WithTransaction(ctx, barrier, func(s logical.Storage) error {
-			se, err := s.Get(ctx, srcPrefix+key)
-			if err != nil {
+		if err := logical.WithTransaction(ctx, srcBarrier, func(s logical.Storage) error {
+			se, err := s.Get(ctx, entryKey)
+			if err != nil || se == nil {
 				return err
 			}
-			if se == nil {
-				return nil
-			}
-			se.Key = dstPrefix + key
-			err = s.Put(ctx, se)
-			if err != nil {
+
+			se.Key = entryKey
+			if err := dstBarrier.Put(ctx, se); err != nil {
 				return err
 			}
-			err = s.Delete(ctx, srcPrefix+key)
-			if err != nil {
-				return err
-			}
-			return nil
+
+			return s.Delete(ctx, entryKey)
 		}); err != nil {
 			return err
 		}
 	}
 
-	srcEntryView := NamespaceScopedView(barrier, src.Namespace)
 	var coreLocalPath, corePath string
-
 	switch me.Table {
 	case routing.MountTableType:
 		coreLocalPath = coreLocalMountConfigPath
@@ -843,16 +837,10 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 	}
 
 	if me.Local {
-		srcEntryView = srcEntryView.SubView(coreLocalPath + "/")
-	} else {
-		srcEntryView = srcEntryView.SubView(corePath + "/")
-	}
-	err = srcEntryView.Delete(ctx, me.UUID)
-	if err != nil {
-		return err
+		return srcBarrier.Delete(ctx, path.Join(coreLocalPath, me.UUID))
 	}
 
-	return nil
+	return srcBarrier.Delete(ctx, path.Join(corePath, me.UUID))
 }
 
 // From an input path that has a relative namespace hierarchy followed by a mount point, return the full
@@ -1017,6 +1005,20 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	return nil
 }
 
+func getLegacyMountsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
+	globalEntry, err := barrier.Get(ctx, coreMountConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy mount table: %w", err)
+	}
+
+	localEntry, err := barrier.Get(ctx, coreLocalMountConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy local mount table: %w", err)
+	}
+
+	return globalEntry, localEntry, nil
+}
+
 func listTransactionalMountsForNamespace(ctx context.Context, barrier logical.Storage) ([]string, []string, error) {
 	globalEntries, err := barrier.List(ctx, coreMountConfigPath+"/")
 	if err != nil {
@@ -1035,26 +1037,44 @@ func listTransactionalMountsForNamespace(ctx context.Context, barrier logical.St
 // returning true if it was used. This will let us know (if we're inside
 // a transaction) if we need to do an upgrade.
 func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, standby bool) (bool, error) {
-	// Load the existing mount table
-	raw, err := barrier.Get(ctx, coreMountConfigPath)
+	// Load the existing mount table per namespace
+	allNamespaces, err := c.ListNamespaces(ctx)
 	if err != nil {
-		c.logger.Error("failed to read legacy mount table", "error", err)
-		return false, errLoadMountsFailed
-	}
-	rawLocal, err := barrier.Get(ctx, coreLocalMountConfigPath)
-	if err != nil {
-		c.logger.Error("failed to read legacy local mount table", "error", err)
-		return false, errLoadMountsFailed
+		return false, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	if raw != nil {
-		mountTable, err := c.decodeMountTable(ctx, raw.Value)
+	globalEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
+	localEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
+	for index, ns := range allNamespaces {
+		if ns.Tainted {
+			c.logger.Info("skipping loading mounts for tainted namespace", "ns", ns.ID)
+			continue
+		}
+
+		view := NamespaceScopedView(barrier, ns)
+		entry, localEntry, err := getLegacyMountsForNamespace(ctx, view)
+		if err != nil {
+			c.logger.Error("failed to get legacy mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
+			return false, err
+		}
+
+		if entry != nil {
+			globalEntries[ns.ID] = entry
+		}
+
+		if localEntry != nil {
+			localEntries[ns.ID] = localEntry
+		}
+	}
+
+	if len(globalEntries) > 0 {
+		mountTable, size, err := c.decodeMountTable(ctx, globalEntries)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
 			return false, err
 		}
-		c.tableMetrics(routing.MountTableType, false, len(mountTable.Entries), len(raw.Value))
 		c.mounts = mountTable
+		c.tableMetrics(routing.MountTableType, false, len(mountTable.Entries), size)
 	}
 
 	var needPersist bool
@@ -1073,18 +1093,17 @@ func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, st
 			c.logger.Info("migrating legacy mount table to transactional layout")
 			needPersist = true
 		}
-		c.tableMetrics(routing.MountTableType, false, len(c.mounts.Entries), len(raw.Value))
 	}
 
-	if rawLocal != nil {
-		localMountTable, err := c.decodeMountTable(ctx, rawLocal.Value)
+	if len(localEntries) > 0 {
+		localMountTable, size, err := c.decodeMountTable(ctx, localEntries)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
 			return false, err
 		}
 		if localMountTable != nil && len(localMountTable.Entries) > 0 {
-			c.tableMetrics(routing.MountTableType, true, len(localMountTable.Entries), len(rawLocal.Value))
 			c.mounts.Entries = append(c.mounts.Entries, localMountTable.Entries...)
+			c.tableMetrics(routing.MountTableType, true, len(localMountTable.Entries), size)
 		}
 	}
 
@@ -1095,8 +1114,7 @@ func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, st
 	//    backend.
 	// 2. We may have had a legacy mount table and need to upgrade into the
 	//    new format. runMountUpdates will handle this for us.
-	err = c.runMountUpdates(ctx, barrier, needPersist, standby)
-	if err != nil {
+	if err = c.runMountUpdates(ctx, barrier, needPersist, standby); err != nil {
 		c.logger.Error("failed to run legacy mount table upgrades", "error", err)
 		return false, err
 	}
@@ -1223,10 +1241,8 @@ func (c *Core) runMountUpdates(ctx context.Context, barrier logical.Storage, nee
 
 // persistMounts is used to persist the mount table after modification.
 func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table *routing.MountTable, local *bool, mount string) error {
-	// Sometimes we may not want to explicitly pass barrier; fetch it if
-	// necessary.
 	if barrier == nil {
-		barrier = c.barrier
+		return errors.New("nil barrier encountered while persisting mount changes")
 	}
 
 	// Gracefully handle a transaction-aware backend, if a transaction
@@ -1279,8 +1295,18 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 
 	// Handle writing the legacy mount table by default.
 	writeTable := func(mt *routing.MountTable, path string) (int, error) {
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return -1, err
+		}
+
+		mountCopy := mt.ShallowClone()
+		mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
+			return e.NamespaceID != ns.ID
+		})
+
 		// Encode the mount table into JSON and compress it (Gzip).
-		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mt, nil)
+		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
 		if err != nil {
 			c.logger.Error("failed to encode or compress mount table", "error", err)
 			return -1, err
@@ -1292,7 +1318,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 			Value: compressedBytes,
 		}
 
-		// Write to the physical backend
+		// Write using passed barrier.
 		if err := barrier.Put(ctx, entry); err != nil {
 			c.logger.Error("failed to persist mount table", "error", err)
 			return -1, err
@@ -1330,8 +1356,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				// Write to the backend.
-				view := NamespaceScopedView(barrier, mtEntry.Namespace)
-				if err := view.Put(ctx, sEntry); err != nil {
+				if err := barrier.Put(ctx, sEntry); err != nil {
 					c.logger.Error("failed to persist mount table entry", "index", index, "uuid", mtEntry.UUID, "error", err)
 					return -1, err
 				}
@@ -1347,8 +1372,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 					return -1, err
 				}
 
-				view := NamespaceScopedView(barrier, ns)
-				if err := view.Delete(ctx, path.Join(prefix, mount)); err != nil {
+				if err := barrier.Delete(ctx, path.Join(prefix, mount)); err != nil {
 					c.logger.Error("failed to persist removal of secrets mount table entry", "namespace", ns.Path, "uuid", mount, "error", err)
 					return -1, fmt.Errorf("failed to remove mount from storage: %w", err)
 				}
@@ -1361,10 +1385,8 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 				}
 
 				for nsIndex, ns := range allNamespaces {
-					view := NamespaceScopedView(barrier, ns)
-
 					// List all entries and remove any deleted ones.
-					presentEntries, err := view.List(ctx, prefix+"/")
+					presentEntries, err := barrier.List(ctx, prefix+"/")
 					if err != nil {
 						return -1, fmt.Errorf("failed to list entries in namespace %v (%v) for removal: %w", ns.ID, nsIndex, err)
 					}
@@ -1374,7 +1396,7 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 							continue
 						}
 
-						if err := view.Delete(ctx, prefix+"/"+presentEntry); err != nil {
+						if err := barrier.Delete(ctx, prefix+"/"+presentEntry); err != nil {
 							return -1, fmt.Errorf("failed to remove deleted mount %v (%v) in namespace %v (%v): %w", presentEntry, index, ns.ID, nsIndex, err)
 						}
 					}
@@ -1898,7 +1920,7 @@ func (c *Core) reloadNamespaceMounts(childCtx context.Context, uuid string, dele
 			return fmt.Errorf("unable to invalidate mounts for namespace %q: %w", uuid, err)
 		}
 
-		authGlobal, authLocal, err := c.listTransactionalCredentialsForNamespace(childCtx, barrier)
+		authGlobal, authLocal, err := listTransactionalCredentialsForNamespace(childCtx, barrier)
 		if err != nil {
 			return fmt.Errorf("unable to invalidate auths for namespace %q: %w", uuid, err)
 		}
@@ -1960,13 +1982,14 @@ func (c *Core) reloadLegacyMounts(ctx context.Context, keys ...string) error {
 			table = routing.CredentialTableType
 		}
 
-		raw, err := c.barrier.Get(ctx, path)
+		view := c.NamespaceView(ns)
+		raw, err := view.Get(ctx, path)
 		if err != nil {
 			return fmt.Errorf("failed to read legacy mount table: %w", err)
 		}
 
 		if raw != nil {
-			mountTable, err := c.decodeMountTable(ctx, raw.Value)
+			mountTable, _, err := c.decodeMountTable(ctx, map[string]*logical.StorageEntry{ns.ID: raw})
 			if err != nil {
 				return fmt.Errorf("failed to decompress and/or decode the legacy mount table: %w", err)
 			}
@@ -2193,7 +2216,7 @@ func (c *Core) mountEntrySysView(entry *routing.MountEntry) extendedSystemView {
 	}
 }
 
-// mountEntryView returns the barrier view object with prefix depending on the mount entry type, table and namespace
+// mountEntryView returns the barrier view object with prefix depending on the mount entry type, table and namespace.
 func (c *Core) mountEntryView(me *routing.MountEntry) (barrier.View, error) {
 	if me.Namespace != nil && me.Namespace.ID != me.NamespaceID {
 		return nil, errors.New("invalid namespace")
@@ -2201,16 +2224,16 @@ func (c *Core) mountEntryView(me *routing.MountEntry) (barrier.View, error) {
 
 	switch me.Type {
 	case routing.MountTypeSystem, routing.MountTypeNSSystem:
-		return NamespaceScopedView(c.barrier, me.Namespace).SubView(systemBarrierPrefix), nil
+		return c.NamespaceView(me.Namespace).SubView(systemBarrierPrefix), nil
 	case routing.MountTypeToken:
-		return NamespaceScopedView(c.barrier, me.Namespace).SubView(systemBarrierPrefix + tokenSubPath), nil
+		return c.NamespaceView(me.Namespace).SubView(systemBarrierPrefix + tokenSubPath), nil
 	}
 
 	switch me.Table {
 	case routing.MountTableType:
-		return NamespaceScopedView(c.barrier, me.Namespace).SubView(path.Join(backendBarrierPrefix, me.UUID) + "/"), nil
+		return c.NamespaceView(me.Namespace).SubView(path.Join(backendBarrierPrefix, me.UUID) + "/"), nil
 	case routing.CredentialTableType:
-		return NamespaceScopedView(c.barrier, me.Namespace).SubView(path.Join(barrier.CredentialBarrierPrefix, me.UUID) + "/"), nil
+		return c.NamespaceView(me.Namespace).SubView(path.Join(barrier.CredentialBarrierPrefix, me.UUID) + "/"), nil
 	case auditTableType, configAuditTableType:
 		return NamespaceScopedView(c.barrier, me.Namespace).SubView(path.Join(auditBarrierPrefix, me.UUID) + "/"), nil
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -335,7 +335,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	c.mounts.Entries[1].Local = true
-	if err := c.persistMounts(t.Context(), nil, c.mounts, nil, ""); err != nil {
+	if err := c.persistMounts(t.Context(), c.barrier, c.mounts, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1105,19 +1105,19 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	// Now try saving invalid versions
 	origTableType := mt.Type
 	mt.Type = "foo"
-	if err := persistFunc(t.Context(), nil, mt, nil, ""); err == nil {
+	if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err == nil {
 		t.Fatal("expected error")
 	}
 
 	if len(mt.Entries) > 0 {
 		mt.Type = origTableType
 		mt.Entries[0].Table = "bar"
-		if err := persistFunc(t.Context(), nil, mt, nil, ""); err == nil {
+		if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err == nil {
 			t.Fatal("expected error")
 		}
 
 		mt.Entries[0].Table = mt.Type
-		if err := persistFunc(t.Context(), nil, mt, nil, ""); err != nil {
+		if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1278,7 +1278,9 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry without type nor table type leading to error",
 			mountEntry: &routing.MountEntry{
-				UUID: testMountEntryUUID,
+				UUID:        testMountEntryUUID,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantError: true,
@@ -1286,8 +1288,10 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry of 'system' mount type",
 			mountEntry: &routing.MountEntry{
-				UUID: testMountEntryUUID,
-				Type: routing.MountTypeSystem,
+				UUID:        testMountEntryUUID,
+				Type:        routing.MountTypeSystem,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantViewPrefix: systemBarrierPrefix,
@@ -1295,8 +1299,10 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry of 'token' mount type",
 			mountEntry: &routing.MountEntry{
-				UUID: testMountEntryUUID,
-				Type: routing.MountTypeToken,
+				UUID:        testMountEntryUUID,
+				Type:        routing.MountTypeToken,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantViewPrefix: systemBarrierPrefix + tokenSubPath,
@@ -1304,9 +1310,11 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry of 'credential' table type",
 			mountEntry: &routing.MountEntry{
-				UUID:  testMountEntryUUID,
-				Type:  "approle",
-				Table: routing.CredentialTableType,
+				UUID:        testMountEntryUUID,
+				Type:        "approle",
+				Table:       routing.CredentialTableType,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantViewPrefix: barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
@@ -1314,8 +1322,10 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry of 'audit' table type",
 			mountEntry: &routing.MountEntry{
-				UUID:  testMountEntryUUID,
-				Table: auditTableType,
+				UUID:        testMountEntryUUID,
+				Table:       auditTableType,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantViewPrefix: auditBarrierPrefix + testMountEntryUUID + "/",
@@ -1323,9 +1333,11 @@ func TestCore_MountEntryView(t *testing.T) {
 		{
 			name: "entry of 'mount' table type and 'identity' type",
 			mountEntry: &routing.MountEntry{
-				UUID:  testMountEntryUUID,
-				Table: routing.MountTableType,
-				Type:  routing.MountTypeIdentity,
+				UUID:        testMountEntryUUID,
+				Table:       routing.MountTableType,
+				Type:        routing.MountTypeIdentity,
+				NamespaceID: namespace.RootNamespaceID,
+				Namespace:   namespace.RootNamespace,
 			},
 
 			wantViewPrefix: backendBarrierPrefix + testMountEntryUUID + "/",
@@ -1380,16 +1392,6 @@ func TestCore_MountEntryView(t *testing.T) {
 			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
-			name: "entry of 'mount' table, and 'kv' type without namespace present",
-			mountEntry: &routing.MountEntry{
-				UUID:  testMountEntryUUID,
-				Table: routing.MountTableType,
-				Type:  routing.MountTypeKV,
-			},
-
-			wantViewPrefix: backendBarrierPrefix + testMountEntryUUID + "/",
-		},
-		{
 			name: "entry of 'auth' table, and 'userpass' type with namespace present",
 			mountEntry: &routing.MountEntry{
 				UUID:        testMountEntryUUID,
@@ -1412,16 +1414,6 @@ func TestCore_MountEntryView(t *testing.T) {
 			},
 
 			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
-		},
-		{
-			name: "entry of 'auth' table, and 'userpass' type without namespace present",
-			mountEntry: &routing.MountEntry{
-				UUID:  testMountEntryUUID,
-				Table: routing.CredentialTableType,
-				Type:  "userpass",
-			},
-
-			wantViewPrefix: barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 	}
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -121,8 +121,6 @@ func NewNamespaceStore(ctx context.Context, core *Core, logger hclog.Logger) (*N
 	return ns, nil
 }
 
-// TODO(wslabosz): with proper introduction of barrier storage we need to
-// change NamespaceScopedView to NamespaceView usage.
 // NamespaceScopedView scopes the passed storage down to the passed namespace.
 func NamespaceScopedView(storage logical.Storage, ns *namespace.Namespace) barrier.View {
 	return barrier.NewView(storage, NamespaceStoragePathPrefix(ns))
@@ -244,8 +242,7 @@ func (ns *NamespaceStore) loadNamespacesLocked(ctx context.Context) error {
 	}
 
 	if err := logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		rootStoreView := barrier.NewView(s, namespaceStoreSubPath)
-		return ns.loadNamespacesRecursive(ctx, s, rootStoreView, loadingCallback)
+		return ns.loadNamespacesRecursive(ctx, s, s, loadingCallback)
 	}); err != nil {
 		return err
 	}
@@ -269,8 +266,8 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 	ctx context.Context, barrier, view logical.Storage,
 	callback func(*namespace.Namespace) error,
 ) error {
-	return logical.HandleListPage(ctx, view, "", 100, func(page int, index int, entry string) (bool, error) {
-		item, err := view.Get(ctx, entry)
+	return logical.HandleListPage(ctx, view, namespaceStoreSubPath, 100, func(page int, index int, entry string) (bool, error) {
+		item, err := view.Get(ctx, namespaceStoreSubPath+entry)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch namespace %v (page %v / index %v): %w", entry, page, index, err)
 		}
@@ -290,7 +287,22 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 			return false, err
 		}
 
-		childView := NamespaceScopedView(barrier, &namespace).SubView(namespaceStoreSubPath)
+		childView := NamespaceScopedView(barrier, &namespace)
+
+		// Check if this namespace has a seal config, i.e., it is a sealable
+		// namespace. In that case, we can stop recursing this branch as the
+		// namespace isn't unsealed yet, as we would not be able to read any
+		// children.
+		if sealConfigEntry, err := childView.Get(ctx, barrierSealConfigPath); err != nil {
+			return false, fmt.Errorf("failed to read seal config entry for namespace %s: %w", namespace.ID, err)
+		} else if sealConfigEntry != nil {
+			var sealConfig SealConfig
+			if err := sealConfigEntry.DecodeJSON(&sealConfig); err != nil {
+				return false, fmt.Errorf("failed to decode seal config entry for namespace %s: %w", namespace.ID, err)
+			}
+			return true, ns.core.sealManager.SetSeal(ctx, &sealConfig, &namespace, false)
+		}
+
 		if err := ns.loadNamespacesRecursive(ctx, barrier, childView, callback); err != nil {
 			return false, err
 		}
@@ -464,11 +476,12 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 
 	defer cleanupFailed()
 
+	parentView := ns.core.NamespaceView(parent)
 	if !exists {
 		// This initial write sets up the namespace as tainted, preventing
 		// a lot of subsystems from using it if it is reloaded from storage.
 		entry.Tainted = true
-		if err := ns.writeNamespace(ctx, ns.storage, entry); err != nil {
+		if err := ns.writeNamespace(ctx, parentView, entry); err != nil {
 			return fmt.Errorf("failed to persist initial tainted namespace: %w", err)
 		}
 
@@ -489,8 +502,8 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 		unlocked = true
 
 		// Create sys/, token/ mounts and policies for the new namespace.
-		if err := ns.initializeNamespace(ctx, ns.storage, entry); err != nil {
-			return err
+		if err := ns.initializeNamespace(ctx, entry); err != nil {
+			return fmt.Errorf("failed to initialize namespace: %w", err)
 		}
 
 		// Reacquire the lock to undo tainting in storage. We need the lock
@@ -502,7 +515,7 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 
 	// Finally, write the non-tainted namespace or perform our only write if
 	// we are modifying an existing entry.
-	if err := ns.writeNamespace(ctx, ns.storage, entry); err != nil {
+	if err := ns.writeNamespace(ctx, parentView, entry); err != nil {
 		return fmt.Errorf("failed to persist namespace: %w", err)
 	}
 
@@ -517,20 +530,14 @@ func (ns *NamespaceStore) setNamespaceLocked(ctx context.Context, nsEntry *names
 	return ns.pushToMounts(ctx, entry)
 }
 
-func (ns *NamespaceStore) writeNamespace(ctx context.Context, storage logical.Storage, entry *namespace.Namespace) error {
-	parent, err := namespace.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	view := NamespaceScopedView(storage, parent).SubView(namespaceStoreSubPath)
+func (ns *NamespaceStore) writeNamespace(ctx context.Context, storage barrier.View, entry *namespace.Namespace) error {
 	item, err := logical.StorageEntryJSON(entry.UUID, &entry)
 	if err != nil {
 		return fmt.Errorf("error marshalling storage entry: %w", err)
 	}
 
-	if err := view.Put(ctx, item); err != nil {
-		return err
+	if err := storage.SubView(namespaceStoreSubPath).Put(ctx, item); err != nil {
+		return fmt.Errorf("error writing namespace: %w", err)
 	}
 
 	return nil
@@ -558,7 +565,7 @@ func (ns *NamespaceStore) assignIdentifier(path string) (string, error) {
 }
 
 // initializeNamespace initializes default policies and  sys/ and token/ mounts for a new namespace
-func (ns *NamespaceStore) initializeNamespace(ctx context.Context, storage logical.Storage, entry *namespace.Namespace) error {
+func (ns *NamespaceStore) initializeNamespace(ctx context.Context, entry *namespace.Namespace) error {
 	// ctx may have a namespace of the parent of our newly created namespace,
 	// so create a new context with the newly created child namespace.
 	nsCtx := namespace.ContextWithNamespace(ctx, entry.Clone(false))
@@ -571,11 +578,7 @@ func (ns *NamespaceStore) initializeNamespace(ctx context.Context, storage logic
 		return err
 	}
 
-	if err := ns.createMounts(nsCtx, storage); err != nil {
-		return err
-	}
-
-	return nil
+	return ns.createMounts(nsCtx, ns.core.NamespaceView(entry))
 }
 
 // initializeNamespacePolicies loads the default policies for the namespace store.
@@ -958,8 +961,8 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 	return errs
 }
 
-// taintNamespace is used to taint the namespace designated to be deleted
-func (ns *NamespaceStore) taintNamespace(ctx context.Context, namespaceToTaint *namespace.Namespace) error {
+// taintNamespace is used to taint the namespace designated to be deleted.
+func (ns *NamespaceStore) taintNamespace(ctx context.Context, parent, namespaceToTaint *namespace.Namespace) error {
 	// to be extra safe
 	if namespaceToTaint.ID == namespace.RootNamespaceID {
 		return errors.New("cannot taint root namespace")
@@ -968,13 +971,14 @@ func (ns *NamespaceStore) taintNamespace(ctx context.Context, namespaceToTaint *
 	ns.namespacesByUUID[namespaceToTaint.UUID].Tainted = true
 	ns.namespacesByAccessor[namespaceToTaint.ID].Tainted = true
 	namespaceToTaint.Tainted = true
+
 	err := ns.namespacesByPath.Insert(namespaceToTaint)
 	if err != nil {
 		return fmt.Errorf("failed to modify namespace tree: %w", err)
 	}
 
 	nsCopy := namespaceToTaint.Clone(true /* preserve unlock */)
-	if err := ns.writeNamespace(ctx, ns.storage, nsCopy); err != nil {
+	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
 		return fmt.Errorf("failed to persist namespace taint: %w", err)
 	}
 
@@ -1019,21 +1023,18 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", fmt.Errorf("cannot delete namespace (%q) containing child namespaces", namespaceToDelete.Path)
 	}
 
-	if !namespaceToDelete.Tainted {
-		// taint the namespace
-		err := ns.taintNamespace(ctx, namespaceToDelete)
-		if err != nil {
-			return "", fmt.Errorf("error tainting namespace: %w", err)
-		}
-	}
-
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
-	ns.creationDeletionMap[namespaceToDelete.UUID] = true
+	if !namespaceToDelete.Tainted {
+		if err = ns.taintNamespace(ctx, parent, namespaceToDelete); err != nil {
+			return "", err
+		}
+	}
 
+	ns.creationDeletionMap[namespaceToDelete.UUID] = true
 	ns.deletionDispatcher.AddJob(ns.newNamespaceDeletionJob(parent, namespaceToDelete), parent.UUID)
 
 	return "in-progress", nil
@@ -1425,6 +1426,8 @@ func (j *namespaceCreationFailureJob) Execute() error {
 			err = fmt.Errorf("failed to remove created namespace storage entry on failure: %w", err)
 			retErr = multierror.Append(retErr, err)
 		}
+
+		j.store.core.sealManager.RemoveNamespace(j.target)
 	}
 
 	return retErr

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -210,16 +210,15 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *routing.MountEntr
 
 	// update the mount table since we changed the runningSha
 	if oldSha != entry.RunningSha256 {
+		barrier := c.NamespaceView(entry.Namespace)
 		if isAuth {
-			err = c.persistAuth(ctx, nil, c.auth, &entry.Local, entry.UUID)
-			if err != nil {
-				return err
-			}
+			err = c.persistAuth(ctx, barrier, c.auth, &entry.Local, entry.UUID)
 		} else {
-			err = c.persistMounts(ctx, nil, c.mounts, &entry.Local, entry.UUID)
-			if err != nil {
-				return err
-			}
+			err = c.persistMounts(ctx, barrier, c.mounts, &entry.Local, entry.UUID)
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -390,7 +390,7 @@ func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*P
 
 // getACLView returns the ACL view for the given namespace
 func (ps *PolicyStore) getACLView(ns *namespace.Namespace) barrier.View {
-	return NamespaceScopedView(ps.core.barrier, ns).SubView(systemBarrierPrefix + policyACLSubPath)
+	return ps.core.NamespaceView(ns).SubView(systemBarrierPrefix + policyACLSubPath)
 }
 
 // getBarrierView returns the appropriate barrier view for the given namespace and policy type.

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -124,7 +124,7 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(t.Context(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(t.Context(), core.NamespaceView(mountEntry.Namespace), newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 
@@ -207,7 +207,7 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 			newTable.Entries = append(newTable.Entries, mountEntry)
 			core.mounts = newTable
 			err = core.router.Mount(b, "logical", mountEntry, view)
-			require.NoError(t, core.persistMounts(t.Context(), nil, newTable, &mountEntry.Local, mountEntry.UUID))
+			require.NoError(t, core.persistMounts(t.Context(), core.NamespaceView(mountEntry.Namespace), newTable, &mountEntry.Local, mountEntry.UUID))
 		}()
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -880,7 +880,7 @@ func (ts *TokenStore) teardown() {
 }
 
 func (ts *TokenStore) baseView(ns *namespace.Namespace) barrier.View {
-	return NamespaceScopedView(ts.core.barrier, ns).SubView(systemBarrierPrefix + tokenSubPath)
+	return ts.core.NamespaceView(ns).SubView(systemBarrierPrefix + tokenSubPath)
 }
 
 func (ts *TokenStore) idView(ns *namespace.Namespace) barrier.View {


### PR DESCRIPTION
## Description
- updates `auth.go` and `mount.go` mounts reading/writing logic to use barrier of the respective namespace
- updates legacy mount system to split mounts per namespace depending on the namespace "ownership"
- adjusts legacy mount invalidation logic

Introduced changes mostly based on #2204 PR 

## Rationale
Introduces writes/reads of mounts through namespace barriers.

This change is non-breaking, as existing behavior is retained, with possible extension in next PRs. 

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
