### PR TITLE
Add baseline dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,16 @@ updates:
       semver-patch-days: 7
       semver-minor-days: 14
       semver-major-days: 30
+    groups: 
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      google-golang:
+        patterns:
+          - "google.golang.org/*"
     ignore:
       # armon/go-metrics was moved to hashicorp/go-metrics, but we cannot
       # drop the indirect dependency on it just yet. This causes errors in


### PR DESCRIPTION
## Description
Introduces dependabot groups, grouping updates of:
- golang.org/x/*
- k8s.io/*
- google.golang.org/*

dependencies.

## Rationale
Added dependency group should lower the number of open dependabot PRs every week, while also ensuring that these specific group shouldn't conflict within each one.

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
