### PR TITLE
Warn when using an Auto Seal that will move to a plugin

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1005,6 +1005,8 @@ func (c *ServerCommand) Run(args []string) int {
 		c.logger.Warn(cErr.String())
 	}
 
+	server.WarnHSMDeprecated(c.logger)
+
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
 	c.allLoggers = append(c.allLoggers, namedGRPCLogFaker)

--- a/command/server/hsm.go
+++ b/command/server/hsm.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build hsm
+
+package server
+
+import (
+	"github.com/hashicorp/go-hclog"
+)
+
+func WarnHSMDeprecated(logger hclog.Logger) {
+	logger.Warn("The HSM distribution of OpenBao is discontinued and will no " +
+		"longer receive updates beyond this minor version. PKCS#11 support has " +
+		"not been removed, but is now available via an external KMS plugin that " +
+		"is drop-in compatible with the previously built-in PKCS#11 seal. " +
+		"To remove this warning, migrate your deployment to the default distribution " +
+		"of OpenBao and use the PKCS#11 KMS plugin to regain PKCS#11 seal functionality. " +
+		"For more information, see https://openbao.org/docs/release-notes/2-6-0/#v260",
+	)
+}

--- a/command/server/no_hsm.go
+++ b/command/server/no_hsm.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !hsm
+
+package server
+
+import (
+	"github.com/hashicorp/go-hclog"
+)
+
+func WarnHSMDeprecated(logger hclog.Logger) {}

--- a/helper/kmsplugin/pkcs11.go
+++ b/helper/kmsplugin/pkcs11.go
@@ -11,5 +11,7 @@ import (
 )
 
 func init() {
-	builtinWrappers[wrapping.WrapperTypePkcs11] = toWrapper(pkcs11.NewWrapper)
+	// We do not mark the PKCS#11 wrapper as deprecated as a more specific
+	// warning is printed at server startup when the HSM distribution is used.
+	builtinWrappers[wrapping.WrapperTypePkcs11] = builtinWrapper{toWrapper(pkcs11.NewWrapper), false}
 }

--- a/helper/kmsplugin/wrapper.go
+++ b/helper/kmsplugin/wrapper.go
@@ -21,23 +21,30 @@ import (
 	"github.com/openbao/go-kms-wrapping/wrappers/transit/v2"
 )
 
-var builtinWrappers = map[wrapping.WrapperType]wrapperFactory{
+var builtinWrappers = map[wrapping.WrapperType]builtinWrapper{
 	// Standards-based or generic:
-	wrapping.WrapperTypeKmip:    toWrapper(kmip.NewWrapper),
-	wrapping.WrapperTypeStatic:  toWrapper(static.NewWrapper),
-	wrapping.WrapperTypeTransit: toWrapper(transit.NewWrapper),
+	wrapping.WrapperTypeKmip:    {toWrapper(kmip.NewWrapper), false},
+	wrapping.WrapperTypeStatic:  {toWrapper(static.NewWrapper), false},
+	wrapping.WrapperTypeTransit: {toWrapper(transit.NewWrapper), false},
 
 	// Cloud providers:
-	wrapping.WrapperTypeAliCloudKms:   toWrapper(alicloudkms.NewWrapper),
-	wrapping.WrapperTypeAwsKms:        toWrapper(awskms.NewWrapper),
-	wrapping.WrapperTypeAzureKeyVault: toWrapper(azurekeyvault.NewWrapper),
-	wrapping.WrapperTypeGcpCkms:       toWrapper(gcpckms.NewWrapper),
-	wrapping.WrapperTypeOciKms:        toWrapper(ocikms.NewWrapper),
+	wrapping.WrapperTypeAliCloudKms:   {toWrapper(alicloudkms.NewWrapper), true},
+	wrapping.WrapperTypeAwsKms:        {toWrapper(awskms.NewWrapper), true},
+	wrapping.WrapperTypeAzureKeyVault: {toWrapper(azurekeyvault.NewWrapper), true},
+	wrapping.WrapperTypeGcpCkms:       {toWrapper(gcpckms.NewWrapper), true},
+	wrapping.WrapperTypeOciKms:        {toWrapper(ocikms.NewWrapper), true},
 
-	wrapping.WrapperTypePkcs11: func() (wrapping.Wrapper, error) {
+	wrapping.WrapperTypePkcs11: {func() (wrapping.Wrapper, error) {
 		// The real wrapper is conditionally enabled pkcs11.go.
 		return nil, errors.New("this build of OpenBao has PKCS#11 disabled")
-	},
+	}, false},
+}
+
+// builtinWrapper only exists to track deprecation status. This construct can be
+// replaced with just wrapperFactory beyond OpenBao v2.6.
+type builtinWrapper struct {
+	factory    wrapperFactory
+	deprecated bool
 }
 
 type wrapperFactory func() (wrapping.Wrapper, error)
@@ -98,8 +105,16 @@ func (c *Catalog) getWrapper(name string) (wrapping.Wrapper, bool, error) {
 		return nil, false, err
 	case !ok:
 		// Try builtin wrappers.
-		if factory, ok := builtinWrappers[wrapping.WrapperType(name)]; ok {
-			w, err := factory()
+		if builtin, ok := builtinWrappers[wrapping.WrapperType(name)]; ok {
+			w, err := builtin.factory()
+			if builtin.deprecated {
+				c.logger.Warn("Support for this Auto Unseal mechanism has been "+
+					"moved into an external plugin and will be removed from the "+
+					"main OpenBao distribution in the next minor release. "+
+					"To ensure future-proof use of this mechanism, migrate your "+
+					"deployment to the fully compatible, drop-in plugin version. "+
+					"For more information, see https://openbao.org/docs/release-notes/2-6-0/#v260", "seal", name)
+			}
 			return w, true, err
 		}
 		return nil, false, fmt.Errorf("unknown wrapper: %s", name)


### PR DESCRIPTION
## Description

Log a warning when using an Auto Seal mechanism that will be removed from the main distribution and moved into a plugin beyond v2.6. Log a more specific warning when using the HSM distribution, which will generally not receive updates beyond v2.6.

## Rationale

I'll add more specific documentation on the deprecations we are making in another PR. If all goes to plan, we can remove all of this code again in v2.7.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
