### PR TITLE
ui: Fix ember-data:no-a-with-array-like

### DIFF
--- a/ui/app/deprecation-workflow.js
+++ b/ui/app/deprecation-workflow.js
@@ -15,6 +15,7 @@ export const deprecationWorkflowConfig = {
     { handler: 'log', matchId: 'ember-data:deprecate-promise-proxies' },
     { handler: 'log', matchId: 'ember-data:deprecate-has-record-for-id' },
     { handler: 'log', matchId: 'ember-data:deprecate-promise-many-array-behaviors' },
+    { handler: 'log', matchId: 'ember-data:no-a-with-array-like' },
     { handler: 'log', matchId: 'setting-on-hash' },
   ],
 };

--- a/ui/app/services/csp-event.js
+++ b/ui/app/services/csp-event.js
@@ -4,13 +4,12 @@
  */
 
 import { computed } from '@ember/object';
-import { A } from '@ember/array';
 import Service from '@ember/service';
 import { task, waitForEvent } from 'ember-concurrency';
 
 export default Service.extend({
   events: computed(function () {
-    return A([]);
+    return [];
   }),
   connectionViolations: computed('events.@each.violatedDirective', function () {
     return this.events.filter((e) => e.violatedDirective.startsWith('connect-src'));

--- a/ui/app/transforms/array.js
+++ b/ui/app/transforms/array.js
@@ -4,7 +4,7 @@
  */
 
 import Transform from '@ember-data/serializer/transform';
-import { isArray, A } from '@ember/array';
+import { isArray } from '@ember/array';
 /*
   This should go inside a globally available place for all apps
 
@@ -13,16 +13,16 @@ import { isArray, A } from '@ember/array';
 export default Transform.extend({
   deserialize(value) {
     if (isArray(value)) {
-      return A(value);
+      return value;
     } else {
-      return A();
+      return [];
     }
   },
   serialize(value) {
     if (isArray(value)) {
-      return A(value);
+      return value;
     } else {
-      return A();
+      return [];
     }
   },
 });

--- a/ui/types/ember-cli-flash/services/flash-messages.d.ts
+++ b/ui/types/ember-cli-flash/services/flash-messages.d.ts
@@ -6,7 +6,6 @@
 declare module 'ember-cli-flash/services/flash-messages' {
   import Service from '@ember/service';
   import FlashObject from 'ember-cli-flash/flash/object';
-  import { A } from '@ember/array';
 
   type Partial<T> = { [K in keyof T]?: T[K] };
 
@@ -31,7 +30,7 @@ declare module 'ember-cli-flash/services/flash-messages' {
   }
 
   class FlashMessageService extends Service {
-    queue: A<FlashObject>;
+    queue: FlashObject[];
     success: FlashFunction;
     warning: FlashFunction;
     info: FlashFunction;


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Stop calling A() on array like values to fix the [ember-data:no-a-with-array-like](https://deprecations.emberjs.com/id/ember-data-no-a-with-array-like/) deprecation. 



## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Part of #2729.

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
