### PR TITLE
Fix PostgreSQL storage metric names in telemetry docs

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/postgresql/delete.mdx
+++ b/website/content/partials/telemetry-metrics/vault/postgresql/delete.mdx
@@ -1,4 +1,4 @@
-### vault.postgresql.delete {#vault-postgresql-delete}
+### vault.postgres.delete {#vault-postgres-delete}
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/postgresql/get.mdx
+++ b/website/content/partials/telemetry-metrics/vault/postgresql/get.mdx
@@ -1,4 +1,4 @@
-### vault.postgresql.get {#vault-postgresql-get}
+### vault.postgres.get {#vault-postgres-get}
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/postgresql/list.mdx
+++ b/website/content/partials/telemetry-metrics/vault/postgresql/list.mdx
@@ -1,10 +1,10 @@
-### vault.postgresql.list {#vault-postgresql-list}
+### vault.postgres.list {#vault-postgres-list}
 
 Metric type | Value | Description
 ----------- | ----- | -----------
 timer       | ms    | Time required to list all entries under the prefix
 
-### vault.postgresql.list-page {#vault-postgresql-list-page}
+### vault.postgres.list-page {#vault-postgres-list-page}
 
 Metric type | Value | Description
 ----------- | ----- | -----------

--- a/website/content/partials/telemetry-metrics/vault/postgresql/put.mdx
+++ b/website/content/partials/telemetry-metrics/vault/postgresql/put.mdx
@@ -1,4 +1,4 @@
-### vault.postgresql.put {#vault-postgresql-put}
+### vault.postgres.put {#vault-postgres-put}
 
 Metric type | Value | Description
 ----------- | ----- | -----------


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

The documented metric names use `vault.postgresql.*` but OpenBao actually emits `vault.postgres.*` (for example, `vault.postgres.list`). Update the docs to match the actual metric names.

## Rationale

Since this was added in https://github.com/openbao/openbao/commit/87d00319d27a86ad62efcefc1c0b52cd0e8ad2b4 almost 2y ago, I believe it's easier to fix the docs instead 😄

Resolves: https://github.com/openbao/openbao/issues/2790

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
