### PR TITLE
Apply several "go fix" analyzers

### DIFF
--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -733,9 +734,7 @@ func readThenWrite(ctx context.Context, client *Client, mountPath string, secret
 
 	// Copy new data over with existing data
 	combinedData := existingVersion.Data
-	for k, v := range newData {
-		combinedData[k] = v
-	}
+	maps.Copy(combinedData, newData)
 
 	updatedSecret, err := client.KVv2(mountPath).Put(ctx, secretPath, combinedData, WithCheckAndSet(existingVersion.VersionMetadata.Version))
 	if err != nil {

--- a/audit/format.go
+++ b/audit/format.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -212,9 +213,7 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 		if elideListResponseData && resp.Data != nil {
 			// Copy the data map before making changes, but we only need to go one level deep in this case
 			respData = make(map[string]interface{}, len(resp.Data))
-			for k, v := range resp.Data {
-				respData[k] = v
-			}
+			maps.Copy(respData, resp.Data)
 
 			doElideListResponseData(respData)
 		} else {

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1676,9 +1677,7 @@ func testAccStepCertWithExtraParams(t *testing.T, name string, cert []byte, poli
 		"allowed_metadata_extensions":  testData.metadata_ext,
 		"lease":                        1000,
 	}
-	for k, v := range extraParams {
-		data[k] = v
-	}
+	maps.Copy(data, extraParams)
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "certs/" + name,

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -13,6 +13,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -156,9 +157,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, data *fra
 
 	// Add metadata from allowed_metadata_extensions when present,
 	// with sanitized oids (dash-separated instead of dot-separated) as keys.
-	for k, v := range b.certificateExtensionsMetadata(clientCerts[0], matched) {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, b.certificateExtensionsMetadata(clientCerts[0], matched))
 
 	auth := &logical.Auth{
 		InternalData: map[string]interface{}{

--- a/builtin/credential/jwt/path_config.go
+++ b/builtin/credential/jwt/path_config.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -279,9 +280,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 	// Omit sensitive keys from provider-specific config
 	providerConfig := make(map[string]interface{})
 	if provider != nil {
-		for k, v := range config.ProviderConfig {
-			providerConfig[k] = v
-		}
+		maps.Copy(providerConfig, config.ProviderConfig)
 
 		for _, k := range provider.SensitiveKeys() {
 			delete(providerConfig, k)

--- a/builtin/credential/jwt/path_login.go
+++ b/builtin/credential/jwt/path_login.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/hashicorp/cap/jwt"
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -169,9 +170,7 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 	}
 
 	tokenMetadata := make(map[string]string)
-	for k, v := range alias.Metadata {
-		tokenMetadata[k] = v
-	}
+	maps.Copy(tokenMetadata, alias.Metadata)
 
 	auth := &logical.Auth{
 		DisplayName:  alias.Name,

--- a/builtin/credential/jwt/path_login_test.go
+++ b/builtin/credential/jwt/path_login_test.go
@@ -1493,9 +1493,9 @@ func TestLogin_JWKS_Concurrent(t *testing.T) {
 
 	var g errgroup.Group
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		g.Go(func() error {
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				resp, err := b.HandleRequest(t.Context(), req)
 				if err != nil {
 					return err

--- a/builtin/credential/jwt/path_oidc.go
+++ b/builtin/credential/jwt/path_oidc.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -484,9 +485,7 @@ func (b *jwtAuthBackend) processToken(ctx context.Context, req *logical.Request,
 	}
 
 	tokenMetadata := make(map[string]string)
-	for k, v := range alias.Metadata {
-		tokenMetadata[k] = v
-	}
+	maps.Copy(tokenMetadata, alias.Metadata)
 	for k, v := range oauth2Metadata {
 		tokenMetadata["oauth2_"+k] = v
 	}

--- a/builtin/credential/kubernetes/backend.go
+++ b/builtin/credential/kubernetes/backend.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -458,10 +459,8 @@ func (b *kubeAuthBackend) updateTLSConfig(config *kubeConfig) error {
 }
 
 func validateAliasNameSource(source string) error {
-	for _, s := range aliasNameSources {
-		if s == source {
-			return nil
-		}
+	if slices.Contains(aliasNameSources, source) {
+		return nil
 	}
 	return errInvalidAliasNameSource
 }

--- a/builtin/credential/kubernetes/backend_test.go
+++ b/builtin/credential/kubernetes/backend_test.go
@@ -473,7 +473,7 @@ func Test_kubeAuthBackend_runTLSConfigUpdater(t *testing.T) {
 			b.tlsMu.RUnlock()
 
 			if configCount > 0 {
-				for idx := 0; idx < configCount; idx++ {
+				for idx := range configCount {
 					t.Run(fmt.Sprintf("config-%d", idx), func(t *testing.T) {
 						config := tt.configs[idx]
 						if config.config != nil {

--- a/builtin/credential/radius/path_config.go
+++ b/builtin/credential/radius/path_config.go
@@ -5,6 +5,7 @@ package radius
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -227,10 +228,8 @@ func (b *backend) pathConfigCreateUpdate(ctx context.Context, req *logical.Reque
 		unregisteredUserPoliciesStr := unregisteredUserPoliciesRaw.(string)
 		if strings.TrimSpace(unregisteredUserPoliciesStr) != "" {
 			policies = strings.Split(unregisteredUserPoliciesStr, ",")
-			for _, policy := range policies {
-				if policy == "root" {
-					return logical.ErrorResponse("root policy cannot be granted by an auth method"), nil
-				}
+			if slices.Contains(policies, "root") {
+				return logical.ErrorResponse("root policy cannot be granted by an auth method"), nil
 			}
 		}
 		cfg.UnregisteredUserPolicies = policies

--- a/builtin/credential/radius/path_users.go
+++ b/builtin/credential/radius/path_users.go
@@ -6,6 +6,7 @@ package radius
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -151,10 +152,8 @@ func (b *backend) pathUserRead(ctx context.Context, req *logical.Request, d *fra
 
 func (b *backend) pathUserWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	policies := policyutil.ParsePolicies(d.Get("policies"))
-	for _, policy := range policies {
-		if policy == "root" {
-			return logical.ErrorResponse("root policy cannot be granted by an auth method"), nil
-		}
+	if slices.Contains(policies, "root") {
+		return logical.ErrorResponse("root policy cannot be granted by an auth method"), nil
 	}
 
 	// Store it

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -6,6 +6,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/rpc"
 	"strings"
 	"sync"
@@ -129,9 +130,7 @@ func (b *databaseBackend) collectPluginInstanceGaugeValues(context.Context) ([]m
 		b.connLock.RLock()
 		defer b.connLock.RUnlock()
 		mapCopy := map[string]*dbPluginInstance{}
-		for k, v := range b.connections {
-			mapCopy[k] = v
-		}
+		maps.Copy(mapCopy, b.connections)
 		return mapCopy
 	}()
 	counts := map[string]int{}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"sort"
 
@@ -447,9 +448,7 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 			if config.ConnectionDetails == nil {
 				config.ConnectionDetails = make(map[string]interface{})
 			}
-			for k, v := range data.Raw {
-				config.ConnectionDetails[k] = v
-			}
+			maps.Copy(config.ConnectionDetails, data.Raw)
 		}
 
 		// Create a database plugin and initialize it.

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -6,6 +6,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -176,9 +177,7 @@ func fieldsForType(roleType string) map[string]*framework.FieldSchema {
 		typeFields = dynamicFields()
 	}
 
-	for k, v := range typeFields {
-		fields[k] = v
-	}
+	maps.Copy(fields, typeFields)
 
 	return fields
 }

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -6,6 +6,7 @@ package database
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -290,9 +291,7 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 				"rotation_statements": testRoleStaticUpdate,
 			}
 
-			for k, v := range tc.account {
-				data[k] = v
-			}
+			maps.Copy(data, tc.account)
 
 			path := "static-roles/" + tc.path
 
@@ -768,7 +767,7 @@ func TestWALsDeletedOnRoleCreationFailed(t *testing.T) {
 	defer b.Cleanup(ctx)
 	configureDBMount(t, storage)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		mockDB.On("UpdateUser", mock.Anything, mock.Anything).
 			Return(v5.UpdateUserResponse{}, errors.New("forced error")).
 			Once()

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -741,9 +742,7 @@ func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts
 		"verify_connection": false,
 		"allowed_roles":     []string{"*"},
 	}
-	for k, v := range opts {
-		data[k] = v
-	}
+	maps.Copy(data, opts)
 
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -912,7 +911,7 @@ func TestBackend_StaticRole_LockRegression(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
-	for i := 0; i < 25; i++ {
+	for range 25 {
 		req = &logical.Request{
 			Operation: logical.UpdateOperation,
 			Path:      "static-roles/plugin-role-test",
@@ -1197,7 +1196,7 @@ func TestDeletesOlderWALsOnLoad(t *testing.T) {
 		NewPassword:       "some-new-password",
 		LastVaultRotation: time.Now(),
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := framework.PutWAL(ctx, storage, staticWALKey, wal)
 		if err != nil {
 			t.Fatal(err)

--- a/builtin/logical/kubernetes/client.go
+++ b/builtin/logical/kubernetes/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	maps0 "maps"
 	"strings"
 	"time"
 
@@ -263,9 +264,7 @@ func makeRoleType(roleType string) string {
 func combineMaps(maps ...map[string]string) map[string]string {
 	newMap := make(map[string]string)
 	for _, m := range maps {
-		for k, v := range m {
-			newMap[k] = v
-		}
+		maps0.Copy(newMap, m)
 	}
 	return newMap
 }

--- a/builtin/logical/kubernetes/integrationtest/helpers.go
+++ b/builtin/logical/kubernetes/integrationtest/helpers.go
@@ -6,6 +6,7 @@ package integrationtest
 import (
 	"context"
 	"fmt"
+	maps0 "maps"
 	"math/rand"
 	"os"
 	"strings"
@@ -405,9 +406,7 @@ func testK8sTokenAudiences(t *testing.T, expectedAudiences []interface{}, token 
 func combineMaps(maps ...map[string]string) map[string]string {
 	newMap := make(map[string]string)
 	for _, m := range maps {
-		for k, v := range m {
-			newMap[k] = v
-		}
+		maps0.Copy(newMap, m)
 	}
 	return newMap
 }

--- a/builtin/logical/kv/delete_version_after_test.go
+++ b/builtin/logical/kv/delete_version_after_test.go
@@ -25,7 +25,6 @@ func TestDeletionTimeCalc(t *testing.T) {
 		{ds, ds, ct.Add(ds), true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("mount=%v,meta=%v", tt.mount, tt.meta), func(t *testing.T) {
 			t.Parallel()
 			got, gotOk := deletionTime(ct, tt.mount, tt.meta)
@@ -105,7 +104,6 @@ func TestDeleteVersionAfter(t *testing.T) {
 		{nd, ds, 0, false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("mount=%v,meta=%v", tt.mount, tt.meta), func(t *testing.T) {
 			t.Parallel()
 

--- a/builtin/logical/kv/path_config_test.go
+++ b/builtin/logical/kv/path_config_test.go
@@ -86,7 +86,6 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 		{"-1h", "0h", 0},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("ds1=%v,ds2=%v", tt.ds1, tt.ds2), func(t *testing.T) {
 			t.Parallel()
 

--- a/builtin/logical/kv/path_data.go
+++ b/builtin/logical/kv/path_data.go
@@ -718,14 +718,6 @@ func (k *KeyMetadata) AddVersion(createdTime, deletionTime *timestamppb.Timestam
 	return vm, 0
 }
 
-func max(a, b uint32) uint32 {
-	if b > a {
-		return b
-	}
-
-	return a
-}
-
 const (
 	dataHelpSyn  = `Write, Patch, Read, and Delete data in the Key-Value Store.`
 	dataHelpDesc = `

--- a/builtin/logical/kv/path_data_test.go
+++ b/builtin/logical/kv/path_data_test.go
@@ -389,7 +389,7 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 	b, storage := getBackend(t)
 
 	// Write 10 versions
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		data := map[string]interface{}{
 			"data": map[string]interface{}{
 				"bar": "baz",
@@ -477,7 +477,7 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 	b, storage := getBackend(t)
 
 	// Write 10 versions
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		data := map[string]interface{}{
 			"data": map[string]interface{}{
 				"bar": "baz",
@@ -571,7 +571,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 	}
 
 	// Write 10 versions
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 
 		req := &logical.Request{
 			Operation: logical.CreateOperation,
@@ -599,7 +599,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 	}
 
 	// Read values back out
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		req := &logical.Request{
 			Operation: logical.ReadOperation,
 			Path:      fmt.Sprintf("data/%d", i),

--- a/builtin/logical/kv/path_metadata_test.go
+++ b/builtin/logical/kv/path_metadata_test.go
@@ -622,7 +622,7 @@ func TestVersionedKv_Metadata_Put_Too_Many_CustomMetadata_Keys(t *testing.T) {
 
 	customMetadata := map[string]string{}
 
-	for i := 0; i < maxCustomMetadataKeys+1; i++ {
+	for i := range maxCustomMetadataKeys + 1 {
 		k := fmt.Sprint(i)
 		customMetadata[k] = k
 	}

--- a/builtin/logical/kv/upgrade_test.go
+++ b/builtin/logical/kv/upgrade_test.go
@@ -14,7 +14,7 @@ import (
 func TestVersionedKV_Upgrade(t *testing.T) {
 	b, storage := testPassthroughBackendWithStorage(t.Context())
 
-	for i := 0; i < 1024*1024; i++ {
+	for i := range 1024 * 1024 {
 		data := map[string]interface{}{
 			"bar": i,
 		}
@@ -66,7 +66,7 @@ func TestVersionedKV_Upgrade(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 
-	for i := 0; i < 1024*1024; i++ {
+	for i := range 1024 * 1024 {
 		data := map[string]interface{}{
 			"bar": float64(i),
 		}

--- a/builtin/logical/openldap/client/entry_test.go
+++ b/builtin/logical/openldap/client/entry_test.go
@@ -13,7 +13,7 @@ import (
 // Since `$ make test` is run with the -race flag, this will detect a race and fail if parsing
 // fields at once is racy.
 func TestIfEntryCreationIsRacy(t *testing.T) {
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		go func() {
 			ldapEntry := &ldap.Entry{
 				Attributes: []*ldap.EntryAttribute{

--- a/builtin/logical/openldap/path_checkout_sets.go
+++ b/builtin/logical/openldap/path_checkout_sets.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -30,10 +31,8 @@ func (l *librarySet) Validate() error {
 	if len(l.ServiceAccountNames) < 1 {
 		return errors.New("at least one service account must be configured")
 	}
-	for _, name := range l.ServiceAccountNames {
-		if name == "" {
-			return errors.New("service account name must not be empty")
-		}
+	if slices.Contains(l.ServiceAccountNames, "") {
+		return errors.New("service account name must not be empty")
 	}
 	if l.MaxTTL > 0 {
 		if l.MaxTTL < l.TTL {

--- a/builtin/logical/openldap/path_checkout_sets_test.go
+++ b/builtin/logical/openldap/path_checkout_sets_test.go
@@ -75,7 +75,7 @@ func TestCheckOutRaces(t *testing.T) {
 	numParallel := 100
 	start := make(chan bool, 1)
 	end := make(chan bool, numParallel)
-	for i := 0; i < numParallel; i++ {
+	for range numParallel {
 		go func() {
 			<-start
 			b.HandleRequest(ctx, &logical.Request{
@@ -182,7 +182,7 @@ func TestCheckOutRaces(t *testing.T) {
 
 	// Wait for them all to finish.
 	timer := time.NewTimer(15 * time.Second)
-	for i := 0; i < numParallel; i++ {
+	for range numParallel {
 		select {
 		case <-timer.C:
 			t.Fatal("test took more than 15 seconds, may be deadlocked")

--- a/builtin/logical/openldap/path_rotate.go
+++ b/builtin/logical/openldap/path_rotate.go
@@ -185,7 +185,7 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 // because LDAP may still be propagating the previous password change.
 func (b *backend) rollBackPassword(ctx context.Context, config *config, oldPassword string) error {
 	var err error
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		waitSeconds := math.Pow(float64(i), 2)
 		timer := time.NewTimer(time.Duration(waitSeconds) * time.Second)
 		select {

--- a/builtin/logical/openldap/path_static_roles.go
+++ b/builtin/logical/openldap/path_static_roles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -104,9 +105,7 @@ func fieldsForType(roleType string) map[string]*framework.FieldSchema {
 		typeFields = staticFields()
 	}
 
-	for k, v := range typeFields {
-		fields[k] = v
-	}
+	maps.Copy(fields, typeFields)
 
 	return fields
 }

--- a/builtin/logical/openldap/path_static_roles_test.go
+++ b/builtin/logical/openldap/path_static_roles_test.go
@@ -772,7 +772,7 @@ func TestWALsDeletedOnRoleCreationFailed(t *testing.T) {
 	defer b.Cleanup(ctx)
 	configureOpenLDAPMount(t, b, storage)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		resp, err := b.HandleRequest(ctx, &logical.Request{
 			Operation: logical.CreateOperation,
 			Path:      staticRolePath + "hashicorp",

--- a/builtin/logical/openldap/rotation_test.go
+++ b/builtin/logical/openldap/rotation_test.go
@@ -369,7 +369,7 @@ func TestDeletesOlderWALsOnLoad(t *testing.T) {
 		NewPassword:       "some-new-password",
 		LastVaultRotation: time.Now(),
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := framework.PutWAL(ctx, storage, staticWALKey, wal)
 		if err != nil {
 			t.Fatal(err)

--- a/builtin/logical/pki/acme_authorizations.go
+++ b/builtin/logical/pki/acme_authorizations.go
@@ -5,6 +5,7 @@ package pki
 
 import (
 	"errors"
+	"maps"
 	"time"
 )
 
@@ -129,9 +130,7 @@ func (ac *ACMEChallenge) NetworkMarshal(acmeCtx *acmeContext, authId string) map
 		resp["error"] = ac.Error
 	}
 
-	for field, value := range ac.ChallengeFields {
-		resp[field] = value
-	}
+	maps.Copy(resp, ac.ChallengeFields)
 
 	return resp
 }

--- a/builtin/logical/pki/acme_challenges_test.go
+++ b/builtin/logical/pki/acme_challenges_test.go
@@ -182,7 +182,7 @@ func TestAcmeValidateHTTP01Challenge(t *testing.T) {
 		w.Write([]byte("my-token.my-thumbprint"))
 	}
 	tooLarge := func(w http.ResponseWriter, r *http.Request) {
-		for i := 0; i < 512; i++ {
+		for range 512 {
 			w.Write([]byte("my-token.my-thumbprint\n"))
 		}
 	}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -139,13 +140,7 @@ func (b *backend) acmeParsedWrapper(op acmeParsedOperation) framework.OperationF
 				resp.Headers["Link"] = genAcmeLinkHeader(acmeCtx)
 			} else {
 				directory := genAcmeLinkHeader(acmeCtx)[0]
-				addDirectory := true
-				for _, item := range resp.Headers["Link"] {
-					if item == directory {
-						addDirectory = false
-						break
-					}
-				}
+				addDirectory := !slices.Contains(resp.Headers["Link"], directory)
 				if addDirectory {
 					resp.Headers["Link"] = append(resp.Headers["Link"], directory)
 				}
@@ -354,11 +349,8 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 		if !allowAnyRole {
 
 			var foundRole bool
-			for _, name := range config.AllowedRoles {
-				if name == role.Name {
-					foundRole = true
-					break
-				}
+			if slices.Contains(config.AllowedRoles, role.Name) {
+				foundRole = true
 			}
 
 			if !foundRole {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -336,8 +336,6 @@ func TestBackend_Roles(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			initTest.Do(setCerts)
 			b, _ := CreateBackendWithStorage(t)
@@ -2176,7 +2174,6 @@ func TestBackend_SignVerbatim(t *testing.T) {
 		{testName: "Any", keyType: "any"},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			runTestSignVerbatim(t, tc.keyType)
 		})
@@ -4696,7 +4693,6 @@ func TestBackend_Root_FullCAChain(t *testing.T) {
 		{testName: "EC", keyType: "ec"},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			runFullCAChainTest(t, tc.keyType)
 		})

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -310,22 +311,16 @@ func validateCommonName(b *backend, data *inputBundle, name string) string {
 	// Otherwise, ensure hostname is allowed.
 	if strings.Contains(name, "@") {
 		var allowsEmails bool
-		for _, validation := range data.role.CNValidations {
-			if validation == "email" {
-				allowsEmails = true
-				break
-			}
+		if slices.Contains(data.role.CNValidations, "email") {
+			allowsEmails = true
 		}
 		if !allowsEmails {
 			return name
 		}
 	} else {
 		var allowsHostnames bool
-		for _, validation := range data.role.CNValidations {
-			if validation == "hostname" {
-				allowsHostnames = true
-				break
-			}
+		if slices.Contains(data.role.CNValidations, "hostname") {
+			allowsHostnames = true
 		}
 		if !allowsHostnames {
 			return name

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -216,8 +216,6 @@ func TestPki_PermitFQDNs(t *testing.T) {
 	}
 
 	for name, testCase := range cases {
-		name := name
-		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			cb, _, err := generateCreationBundle(&b, testCase.input, nil, nil)
 			if err != nil {

--- a/builtin/logical/pki/chain_util.go
+++ b/builtin/logical/pki/chain_util.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
@@ -67,13 +68,7 @@ func (sc *storageContext) rebuildIssuersChains(referenceCert *issuerEntry /* opt
 	// Our provided reference cert might not be in the list of issuers. In
 	// that case, add it manually.
 	if referenceCert != nil {
-		missing := true
-		for _, issuer := range issuers {
-			if issuer == referenceCert.ID {
-				missing = false
-				break
-			}
-		}
+		missing := !slices.Contains(issuers, referenceCert.ID)
 
 		if missing {
 			issuers = append(issuers, referenceCert.ID)
@@ -658,13 +653,7 @@ func processAnyCliqueOrCycle(
 			// the nodes of whatever grouping
 			foundNode := false
 			for _, clique := range cliques {
-				inClique := false
-				for _, cliqueNode := range clique {
-					if cliqueNode == node {
-						inClique = true
-						break
-					}
-				}
+				inClique := slices.Contains(clique, node)
 
 				if inClique {
 					foundNode = true
@@ -962,13 +951,7 @@ func containsIssuer(collection []issuerID, target issuerID) bool {
 		return false
 	}
 
-	for _, needle := range collection {
-		if needle == target {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(collection, target)
 }
 
 func appendCycleIfNotExisting(knownCycles [][]issuerID, candidate []issuerID) [][]issuerID {
@@ -1147,13 +1130,7 @@ func findAllCyclesWithNode(
 				continue
 			}
 
-			skipNode := false
-			for _, excluded := range exclude {
-				if excluded == child {
-					skipNode = true
-					break
-				}
-			}
+			skipNode := slices.Contains(exclude, child)
 
 			if skipNode {
 				continue
@@ -1187,13 +1164,7 @@ func findAllCyclesWithNode(
 					// We only care about source->source cycles. If this
 					// cycles, but isn't a source->source cycle, don't add
 					// this path.
-					foundSelf := false
-					for _, node := range path {
-						if child == node {
-							foundSelf = true
-							break
-						}
-					}
+					foundSelf := slices.Contains(path, child)
 					if foundSelf {
 						// Skip this path.
 						continue

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -281,7 +281,7 @@ func crlEnableDisableTestForBackend(t *testing.T, b *backend, s logical.Storage,
 	}
 
 	serials := make(map[int]string)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		resp, err := CBWrite(b, s, "issue/test", map[string]interface{}{
 			"common_name": "test.foobar.com",
 		})

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1122,13 +1123,7 @@ func buildAnyCRLsWithCerts(
 	// alternate, equivalent issuer however, we'll keep updating the shared
 	// CRL; all equivalent issuers must have their CRLs disabled.
 	for mapIssuerId := range internalCRLConfig.IssuerIDCRLMap {
-		stillHaveIssuer := false
-		for _, listedIssuerId := range issuers {
-			if mapIssuerId == listedIssuerId {
-				stillHaveIssuer = true
-				break
-			}
-		}
+		stillHaveIssuer := slices.Contains(issuers, mapIssuerId)
 
 		if !stillHaveIssuer {
 			delete(internalCRLConfig.IssuerIDCRLMap, mapIssuerId)

--- a/builtin/logical/pki/dnstest/server.go
+++ b/builtin/logical/pki/dnstest/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -294,10 +295,8 @@ func (ts *TestServer) AddDomain(domain string) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 
-	for _, existing := range ts.domains {
-		if existing == domain {
-			return
-		}
+	if slices.Contains(ts.domains, domain) {
+		return
 	}
 
 	ts.domains = append(ts.domains, domain)
@@ -324,11 +323,9 @@ func (ts *TestServer) AddRecord(domain string, record string, value string) {
 	}
 
 	if values, present := ts.records[domain][record]; present {
-		for _, candidate := range values {
-			if candidate == value {
-				// Already present; skip adding.
-				return
-			}
+		if slices.Contains(values, value) {
+			// Already present; skip adding.
+			return
 		}
 	}
 

--- a/builtin/logical/pki/path_manage_keys_test.go
+++ b/builtin/logical/pki/path_manage_keys_test.go
@@ -38,7 +38,6 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 		{"error-bad-type", "dskjfkdsfjdkf", []int{0}, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		for _, keyBitParam := range tt.keyBits {
 			keyName := fmt.Sprintf("%s-%d", tt.name, keyBitParam)
 			t.Run(keyName, func(t *testing.T) {

--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -653,7 +653,7 @@ func setupOcspEnvWithCaKeyConfig(t *testing.T, keyType string, caKeyBits int, ca
 	})
 	requireSuccessNonNilResponse(t, resp, err, "config/crl failed")
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
 			"key_type":       keyType,
 			"key_bits":       caKeyBits,

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -995,13 +996,7 @@ func (b *backend) getRole(ctx context.Context, s logical.Storage, n string) (*ro
 		modified = true
 	}
 	if result.AllowedBaseDomain != "" {
-		found := false
-		for _, v := range result.AllowedDomains {
-			if v == result.AllowedBaseDomain {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(result.AllowedDomains, result.AllowedBaseDomain)
 		if !found {
 			result.AllowedDomains = append(result.AllowedDomains, result.AllowedBaseDomain)
 		}

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -332,7 +332,7 @@ func TestTidyCancellation(t *testing.T) {
 		"key_type":          "ec",
 	})
 	require.NoError(t, err)
-	for i := 0; i < numLeaves; i++ {
+	for range numLeaves {
 		_, err = CBWrite(b, s, "issue/local-testing", map[string]interface{}{
 			"common_name": "testing",
 			"ttl":         "1s",
@@ -1745,7 +1745,7 @@ func TestTidyPagination(t *testing.T) {
 	// Issue 27 leaf certificates to populate the cert store.
 	// This number is chosen to ensure that the tidy operation can process multiple pages,
 	// even when the page size limit is set below the total number of certificates.
-	for i := 0; i < 26; i++ {
+	for range 26 {
 		_, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
 			"common_name": "example.com",
 			"ttl":         "1s",
@@ -1762,7 +1762,7 @@ func TestTidyPagination(t *testing.T) {
 
 	// Issue another 4 leaf certificates then revoke them. This is done to ensure that
 	// the tidy operation can process certificates less than its the page size.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		resp, err = client.Logical().Write("pki/issue/local-testing", map[string]interface{}{
 			"common_name": "revoked.com",
 			"ttl":         "1s",

--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -5,6 +5,7 @@ package pkiext
 
 import (
 	"encoding/json"
+	"slices"
 	"sync"
 	"testing"
 
@@ -135,13 +136,7 @@ func RunZLintRootTest(t *testing.T, keyType string, keyBits int, usePSS bool, ig
 		}
 
 		if result == "error" {
-			skip := false
-			for _, allowedFailures := range ignored {
-				if allowedFailures == key {
-					skip = true
-					break
-				}
-			}
+			skip := slices.Contains(ignored, key)
 
 			if !skip {
 				t.Fatalf("got unexpected error from test %v: %v", key, value)

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -2336,7 +2336,7 @@ func TestBackend_CleanupDynamicHostKeys(t *testing.T) {
 	require.Contains(t, resp.Data["message"], "0 of 0")
 
 	// Write a bunch of bogus entries.
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		data := map[string]interface{}{
 			"host": "localhost",
 			"key":  "nothing-to-see-here",

--- a/builtin/logical/ssh/path_creds_create.go
+++ b/builtin/logical/ssh/path_creds_create.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	uuid "github.com/hashicorp/go-uuid"
@@ -239,10 +240,8 @@ func (b *backend) GenerateOTPCredential(ctx context.Context, req *logical.Reques
 // excluded CIDR blocks.
 func validateIP(ip, roleName, cidrList, excludeCidrList string, zeroAddressRoles []string) error {
 	// Search IP in the zero-address list
-	for _, role := range zeroAddressRoles {
-		if roleName == role {
-			return nil
-		}
+	if slices.Contains(zeroAddressRoles, roleName) {
+		return nil
 	}
 
 	// Search IP in allowed CIDR blocks

--- a/builtin/logical/totp/path_keys.go
+++ b/builtin/logical/totp/path_keys.go
@@ -261,23 +261,23 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 		// Set up query object
 		urlQuery := urlObject.Query()
 		path := strings.TrimPrefix(urlObject.Path, "/")
-		index := strings.Index(path, ":")
+		before, after, ok := strings.Cut(path, ":")
 
 		// Read issuer
 		urlIssuer := urlQuery.Get("issuer")
 		if urlIssuer != "" {
 			issuer = urlIssuer
 		} else {
-			if index != -1 {
-				issuer = path[:index]
+			if ok {
+				issuer = before
 			}
 		}
 
 		// Read account name
-		if index == -1 {
+		if !ok {
 			accountName = path
 		} else {
-			accountName = path[index+1:]
+			accountName = after
 		}
 
 		// Read key string

--- a/builtin/logical/transit/path_decrypt_bench_test.go
+++ b/builtin/logical/transit/path_decrypt_bench_test.go
@@ -42,7 +42,7 @@ func BTransit_BatchDecryption(b *testing.B, bsize int) {
 	backend, s := createBackendWithStorage(b)
 
 	batchEncryptionInput := make([]interface{}, 0, bsize)
-	for i := 0; i < bsize; i++ {
+	for range bsize {
 		batchEncryptionInput = append(
 			batchEncryptionInput,
 			map[string]interface{}{"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="},

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -5,6 +5,7 @@ package transit
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"reflect"
 	"testing"
@@ -237,9 +238,7 @@ func TestTransit_BatchDecryption_DerivedKey(t *testing.T) {
 					"batch_input": tt.in,
 				},
 			}
-			for k, v := range tt.params {
-				req.Data[k] = v
-			}
+			maps.Copy(req.Data, tt.params)
 			resp, err = b.HandleRequest(t.Context(), req)
 
 			didErr := err != nil || (resp != nil && resp.IsError())

--- a/builtin/logical/transit/path_encrypt_bench_test.go
+++ b/builtin/logical/transit/path_encrypt_bench_test.go
@@ -42,7 +42,7 @@ func BTransit_BatchEncryption(b *testing.B, bsize int) {
 	backend, s := createBackendWithStorage(b)
 
 	batchEncryptionInput := make([]interface{}, 0, bsize)
-	for i := 0; i < bsize; i++ {
+	for range bsize {
 		batchEncryptionInput = append(
 			batchEncryptionInput,
 			map[string]interface{}{"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="},

--- a/builtin/logical/transit/path_trim_test.go
+++ b/builtin/logical/transit/path_trim_test.go
@@ -59,7 +59,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 
 	// Ensure that there are 5 key versions, by rotating the key 4 times
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		req.Path = "keys/aes/rotate"
 		req.Data = nil
 		doReq(t, req)
@@ -156,7 +156,7 @@ func TestTransit_Trim(t *testing.T) {
 	doErrReq(t, req)
 
 	// Rotate 5 more times
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		doReq(t, &logical.Request{
 			Path:      "keys/aes/rotate",
 			Storage:   storage,

--- a/command/agent_generate_config_test.go
+++ b/command/agent_generate_config_test.go
@@ -126,8 +126,6 @@ func TestConstructTemplates(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
-
 		t.Run(name, func(t *testing.T) {
 			templates, err := constructTemplates(ctx, client, tc.paths)
 
@@ -248,8 +246,6 @@ exec \{
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
-
 		t.Run(name, func(t *testing.T) {
 			var config bytes.Buffer
 

--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -535,11 +535,7 @@ func newAutoAuthBackoff(min, max time.Duration, exitErr bool) *autoAuthBackoff {
 // next determines the next backoff duration that is roughly twice
 // the current value, capped to a max value, with a measure of randomness.
 func (b *autoAuthBackoff) next() {
-	maxBackoff := 2 * b.current
-
-	if maxBackoff > b.max {
-		maxBackoff = b.max
-	}
+	maxBackoff := min(2*b.current, b.max)
 
 	// Trim a random amount (0-25%) off the doubled duration
 	trim := rand.Int63n(int64(maxBackoff) / 4)

--- a/command/agentproxyshared/auth/auth_test.go
+++ b/command/agentproxyshared/auth/auth_test.go
@@ -121,7 +121,7 @@ func TestAgentBackoff(t *testing.T) {
 	}
 
 	// Test that backoff values are in expected range (75-100% of 2*previous)
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		old := backoff.current
 		backoff.next()
 
@@ -134,7 +134,7 @@ func TestAgentBackoff(t *testing.T) {
 	}
 
 	// Test that backoff is capped
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		backoff.next()
 		if backoff.current > max {
 			t.Fatalf("backoff exceeded max of 100s: %v", backoff)
@@ -171,7 +171,7 @@ func TestAgentMinBackoffCustom(t *testing.T) {
 		}
 
 		// Test that backoff values are in expected range (75-100% of 2*previous)
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			old := backoff.current
 			backoff.next()
 
@@ -184,7 +184,7 @@ func TestAgentMinBackoffCustom(t *testing.T) {
 		}
 
 		// Test that backoff is capped
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			backoff.next()
 			if backoff.current > max {
 				t.Fatalf("backoff exceeded max of 100s: %v", backoff)

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"net"
 	"net/http"
@@ -320,9 +321,7 @@ func TestCache_TokenRevocations_RevokeOrphan(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	// Revoke-orphan the intermediate token. This should result in its own
@@ -420,9 +419,7 @@ func TestCache_TokenRevocations_LeafLevelToken(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	// Revoke the lef token. This should evict all the leases belonging to this
@@ -519,9 +516,7 @@ func TestCache_TokenRevocations_IntermediateLevelToken(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	// Revoke the second level token. This should evict all the leases
@@ -616,9 +611,7 @@ func TestCache_TokenRevocations_TopLevelToken(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	// Revoke the top level token. This should evict all the leases belonging
@@ -711,9 +704,7 @@ func TestCache_TokenRevocations_Shutdown(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	rootCancelFunc()
@@ -799,9 +790,7 @@ func TestCache_TokenRevocations_BaseContextCancellation(t *testing.T) {
 	sampleSpace[lease3] = "lease"
 
 	expected := make(map[string]string)
-	for k, v := range sampleSpace {
-		expected[k] = v
-	}
+	maps.Copy(expected, sampleSpace)
 	tokenRevocationValidation(t, sampleSpace, expected, leaseCache)
 
 	// Cancel the base context of the lease cache. This should trigger

--- a/command/agentproxyshared/cache/lease_cache_test.go
+++ b/command/agentproxyshared/cache/lease_cache_test.go
@@ -549,7 +549,7 @@ func TestLeaseCache_Concurrent_NonCacheable(t *testing.T) {
 	go func() {
 		var wg sync.WaitGroup
 		// 100 concurrent requests
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			wg.Add(1)
 
 			go func() {
@@ -601,7 +601,7 @@ func TestLeaseCache_Concurrent_Cacheable(t *testing.T) {
 	go func() {
 		var wg sync.WaitGroup
 		// Start 100 concurrent requests
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			wg.Add(1)
 
 			go func() {

--- a/command/approle_concurrency_integ_test.go
+++ b/command/approle_concurrency_integ_test.go
@@ -68,7 +68,7 @@ func TestAppRole_Integ_ConcurrentLogins(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/command/audit_disable_test.go
+++ b/command/audit_disable_test.go
@@ -58,8 +58,6 @@ func TestAuditDisableCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/audit_enable_test.go
+++ b/command/audit_enable_test.go
@@ -66,8 +66,6 @@ func TestAuditEnableCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/audit_list_test.go
+++ b/command/audit_list_test.go
@@ -52,8 +52,6 @@ func TestAuditListCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/auth_disable_test.go
+++ b/command/auth_disable_test.go
@@ -48,8 +48,6 @@ func TestAuthDisableCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -55,8 +55,6 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/auth_help_test.go
+++ b/command/auth_help_test.go
@@ -52,8 +52,6 @@ func TestAuthHelpCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/auth_list_test.go
+++ b/command/auth_list_test.go
@@ -54,8 +54,6 @@ func TestAuthListCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/auth_move_test.go
+++ b/command/auth_move_test.go
@@ -55,8 +55,6 @@ func TestAuthMoveCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -51,8 +51,6 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/base_flags.go
+++ b/command/base_flags.go
@@ -749,8 +749,8 @@ func newStringMapValue(def map[string]string, target *map[string]string, hidden 
 }
 
 func (s *stringMapValue) Set(val string) error {
-	idx := strings.Index(val, "=")
-	if idx == -1 {
+	before, after, ok := strings.Cut(val, "=")
+	if !ok {
 		return fmt.Errorf("missing = in KV pair: %q", val)
 	}
 
@@ -758,7 +758,7 @@ func (s *stringMapValue) Set(val string) error {
 		*s.target = make(map[string]string)
 	}
 
-	k, v := val[0:idx], val[idx+1:]
+	k, v := before, after
 	(*s.target)[k] = v
 	return nil
 }

--- a/command/base_helpers_test.go
+++ b/command/base_helpers_test.go
@@ -151,8 +151,6 @@ func TestTruncateToSeconds(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.d.String(), func(t *testing.T) {
 			t.Parallel()
 
@@ -198,8 +196,6 @@ func TestParseFlagFile(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.value, func(t *testing.T) {
 			content, err := parseFlagFile(tc.value)
 			if err != nil {
@@ -271,8 +267,6 @@ func TestArgWarnings(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.expected, func(t *testing.T) {
 			warnings := generateFlagWarnings(tc.args)
 			if !strings.Contains(warnings, tc.expected) {

--- a/command/base_predict_test.go
+++ b/command/base_predict_test.go
@@ -209,7 +209,6 @@ func TestPredictVaultPaths(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -263,7 +262,6 @@ func TestPredict_Audits(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -307,7 +305,6 @@ func TestPredict_Mounts(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -377,7 +374,6 @@ func TestPredict_Plugins(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -446,7 +442,6 @@ func TestPredict_Policies(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -519,7 +514,6 @@ func TestPredict_Paths(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -594,7 +588,6 @@ func TestPredict_PathsKVv2(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -655,7 +648,6 @@ func TestPredict_ListPaths(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -707,7 +699,6 @@ func TestPredict_HasPathArg(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -161,11 +161,11 @@ var (
 
 func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.CommandFactory {
 	loginHandlers := map[string]LoginHandler{
-		"cert":     &credCert.CLIHandler{},
-		"kerberos": &credKerb.CLIHandler{},
+		"cert":       &credCert.CLIHandler{},
+		"kerberos":   &credKerb.CLIHandler{},
 		"kubernetes": &credKube.CLIHandler{},
-		"ldap":     &credLdap.CLIHandler{},
-		"oidc":     &credOIDC.CLIHandler{},
+		"ldap":       &credLdap.CLIHandler{},
+		"oidc":       &credOIDC.CLIHandler{},
 		"radius": &credUserpass.CLIHandler{
 			DefaultMount: "radius",
 		},

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -77,8 +77,6 @@ func TestDebugCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -128,8 +126,6 @@ func TestDebugCommand_Archive(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -259,8 +255,6 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -477,8 +471,6 @@ func TestDebugCommand_TimingChecks(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -592,8 +584,6 @@ func TestDebugCommand_OutputExists(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -757,7 +747,6 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// set insecure umask

--- a/command/delete_test.go
+++ b/command/delete_test.go
@@ -54,8 +54,6 @@ func TestDeleteCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -256,8 +256,6 @@ func Test_Format_Parsing(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			client, closer := testVaultServer(t)
 			defer closer()

--- a/command/healthcheck/pki_audit_visibility.go
+++ b/command/healthcheck/pki_audit_visibility.go
@@ -5,6 +5,7 @@ package healthcheck
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 )
@@ -155,13 +156,7 @@ func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
 		}
 
 		for _, param := range visibleList {
-			found := false
-			for _, tuned := range actual {
-				if param == tuned {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(actual, param)
 
 			if !found {
 				ret := Result{
@@ -184,13 +179,7 @@ func (h *AuditVisibility) Evaluate(e *Executor) (results []*Result, err error) {
 			return nil, fmt.Errorf("error parsing %v from server: %v", source, err)
 		}
 		for _, param := range hiddenList {
-			found := false
-			for _, tuned := range actual {
-				if param == tuned {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(actual, param)
 
 			if found {
 				ret := Result{

--- a/command/kv_helpers_test.go
+++ b/command/kv_helpers_test.go
@@ -68,7 +68,6 @@ func TestAddPrefixToKVPath(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"strings"
@@ -337,9 +338,7 @@ func (c *KVPatchCommand) readThenWrite(client *api.Client, path string, newData 
 	}
 
 	// Copy new data over
-	for k, v := range newData {
-		data[k] = v
-	}
+	maps.Copy(data, newData)
 
 	secret, err = client.Logical().Write(path, map[string]interface{}{
 		"data": data,

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -178,8 +178,6 @@ func TestKVPutCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -522,8 +520,6 @@ func TestKVGetCommand(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -672,8 +668,6 @@ func TestKVListCommand(t *testing.T) {
 		t.Parallel()
 
 		for _, testCase := range testCases {
-			testCase := testCase
-
 			t.Run(testCase.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -690,7 +684,7 @@ func TestKVListCommand(t *testing.T) {
 				time.Sleep(time.Second)
 
 				ctx := t.Context()
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					path := fmt.Sprintf("my-prefix/secret-%d", i)
 					_, err := client.KVv2("kv/").Put(ctx, path, map[string]interface{}{
 						"foo": "bar",
@@ -793,8 +787,6 @@ func TestKVMetadataGetCommand(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -899,7 +891,6 @@ func TestKVPatchCommand_ArgValidation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1202,8 +1193,6 @@ func TestKVPatchCommand_CAS(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1285,8 +1274,6 @@ func TestKVPatchCommand_Methods(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1439,8 +1426,6 @@ func TestKVPatchCommand_RWMethodPolicyVariations(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, closer := testVaultServer(t)
@@ -1507,7 +1492,6 @@ func TestPadEqualSigns(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/lease_renew_test.go
+++ b/command/lease_renew_test.go
@@ -83,8 +83,6 @@ func TestLeaseRenewCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/lease_revoke_test.go
+++ b/command/lease_revoke_test.go
@@ -73,8 +73,6 @@ func TestLeaseRevokeCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -66,8 +66,6 @@ func TestListCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/namespace_scan_test.go
+++ b/command/namespace_scan_test.go
@@ -45,8 +45,6 @@ func TestNamespaceScanCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -479,7 +479,6 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client, closer := testVaultServer(t)

--- a/command/operator_init_test.go
+++ b/command/operator_init_test.go
@@ -104,8 +104,6 @@ func TestOperatorInitCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/operator_key_status_test.go
+++ b/command/operator_key_status_test.go
@@ -42,8 +42,6 @@ func TestOperatorKeyStatusCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/operator_migrate_test.go
+++ b/command/operator_migrate_test.go
@@ -350,9 +350,9 @@ func (l randomLister) Delete(ctx context.Context, path string) error {
 // generateData creates a map of 500 random keys and values
 func generateData() map[string][]byte {
 	result := make(map[string][]byte)
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		segments := make([]string, rand.Intn(8)+1)
-		for j := 0; j < len(segments); j++ {
+		for j := range segments {
 			s, _ := base62.Random(6)
 			segments[j] = s
 		}

--- a/command/operator_rotate_test.go
+++ b/command/operator_rotate_test.go
@@ -42,8 +42,6 @@ func TestOperatorRotateCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/operator_seal_test.go
+++ b/command/operator_seal_test.go
@@ -42,8 +42,6 @@ func TestOperatorSealCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/operator_step_down_test.go
+++ b/command/operator_step_down_test.go
@@ -48,8 +48,6 @@ func TestOperatorStepDownCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/patch_test.go
+++ b/command/patch_test.go
@@ -77,8 +77,6 @@ func TestPatchCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/path_help_test.go
+++ b/command/path_help_test.go
@@ -63,8 +63,6 @@ func TestPathHelpCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/pki_reissue_intermediate.go
+++ b/command/pki_reissue_intermediate.go
@@ -13,9 +13,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/posener/complete"
@@ -131,9 +133,7 @@ func (c *PKIReIssueCACommand) Run(args []string) int {
 func updateTemplateWithData(template map[string]interface{}, changes map[string]interface{}) map[string]interface{} {
 	data := map[string]interface{}{}
 
-	for key, value := range template {
-		data[key] = value
-	}
+	maps.Copy(data, template)
 
 	// ttl and not_after set the same thing.  Delete template ttl if using not_after:
 	if _, ok := changes["not_after"]; ok {
@@ -145,9 +145,7 @@ func updateTemplateWithData(template map[string]interface{}, changes map[string]
 		delete(data, "key_bits")
 	}
 
-	for key, value := range changes {
-		data[key] = value
-	}
+	maps.Copy(data, changes)
 
 	return data
 }
@@ -227,20 +225,12 @@ func determineExcludeCnFromSans(certificate x509.Certificate) bool {
 	}
 
 	emails := certificate.EmailAddresses
-	for _, email := range emails {
-		if email == cn {
-			return false
-		}
+	if slices.Contains(emails, cn) {
+		return false
 	}
 
 	dnses := certificate.DNSNames
-	for _, dns := range dnses {
-		if dns == cn {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(dnses, cn)
 }
 
 func findBitLength(publicKey any) int {

--- a/command/pki_verify_sign.go
+++ b/command/pki_verify_sign.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -139,11 +140,8 @@ func verifySignBetween(client *api.Client, issuerResp *issuerResponse, issuedPat
 	} else if err == nil {
 		for _, chain := range trusts {
 			// Output of this Should Only Have One Trust with Chain of Length Two (Child followed by Parent)
-			for _, cert := range chain {
-				if issuedCertBundle.certificate.Equal(cert) {
-					trust = true
-					break
-				}
+			if slices.ContainsFunc(chain, issuedCertBundle.certificate.Equal) {
+				trust = true
 			}
 		}
 	}

--- a/command/plugin_deregister_test.go
+++ b/command/plugin_deregister_test.go
@@ -54,8 +54,6 @@ func TestPluginDeregisterCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/plugin_info_test.go
+++ b/command/plugin_info_test.go
@@ -52,8 +52,6 @@ func TestPluginInfoCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/plugin_list_test.go
+++ b/command/plugin_list_test.go
@@ -49,8 +49,6 @@ func TestPluginListCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/plugin_register_test.go
+++ b/command/plugin_register_test.go
@@ -56,8 +56,6 @@ func TestPluginRegisterCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/plugin_reload_test.go
+++ b/command/plugin_reload_test.go
@@ -47,8 +47,6 @@ func TestPluginReloadCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -128,8 +126,6 @@ func TestPluginReloadStatusCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/policy_delete_test.go
+++ b/command/policy_delete_test.go
@@ -49,8 +49,6 @@ func TestPolicyDeleteCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/policy_fmt_test.go
+++ b/command/policy_fmt_test.go
@@ -49,8 +49,6 @@ func TestPolicyFmtCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/policy_list_test.go
+++ b/command/policy_list_test.go
@@ -42,8 +42,6 @@ func TestPolicyListCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/policy_read_test.go
+++ b/command/policy_read_test.go
@@ -48,8 +48,6 @@ func TestPolicyReadCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/policy_write_test.go
+++ b/command/policy_write_test.go
@@ -66,8 +66,6 @@ func TestPolicyWriteCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -78,8 +78,6 @@ func TestReadCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/scan_test.go
+++ b/command/scan_test.go
@@ -66,8 +66,6 @@ func TestScanCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/secrets_disable_test.go
+++ b/command/secrets_disable_test.go
@@ -61,8 +61,6 @@ func TestSecretsDisableCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -76,8 +76,6 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -235,8 +233,8 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 				continue
 			}
 			potPlug := strings.TrimPrefix(splitLine[0], "github.com/openbao/")
-			if strings.HasPrefix(potPlug, "vault-plugin-secrets-") {
-				backends = append(backends, strings.TrimPrefix(potPlug, "vault-plugin-secrets-"))
+			if after, ok := strings.CutPrefix(potPlug, "vault-plugin-secrets-"); ok {
+				backends = append(backends, after)
 			}
 		}
 

--- a/command/secrets_list_test.go
+++ b/command/secrets_list_test.go
@@ -54,8 +54,6 @@ func TestSecretsListCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/secrets_move_test.go
+++ b/command/secrets_move_test.go
@@ -54,8 +54,6 @@ func TestSecretsMoveCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -51,8 +51,6 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -508,15 +509,9 @@ func (c *Config) Merge(c2 *Config) *Config {
 	}
 
 	// merge these integers via a MAX operation
-	result.MaxLeaseTTL = c.MaxLeaseTTL
-	if c2.MaxLeaseTTL > result.MaxLeaseTTL {
-		result.MaxLeaseTTL = c2.MaxLeaseTTL
-	}
+	result.MaxLeaseTTL = max(c2.MaxLeaseTTL, c.MaxLeaseTTL)
 
-	result.DefaultLeaseTTL = c.DefaultLeaseTTL
-	if c2.DefaultLeaseTTL > result.DefaultLeaseTTL {
-		result.DefaultLeaseTTL = c2.DefaultLeaseTTL
-	}
+	result.DefaultLeaseTTL = max(c2.DefaultLeaseTTL, c.DefaultLeaseTTL)
 
 	result.ClusterCipherSuites = c.ClusterCipherSuites
 	if c2.ClusterCipherSuites != "" {
@@ -1374,9 +1369,7 @@ func (c *Config) Sanitized() map[string]interface{} {
 		"unsafe_allow_api_audit_creation": c.UnsafeAllowAPIAuditCreation,
 		"allow_audit_log_prefixing":       c.AllowAuditLogPrefixing,
 	}
-	for k, v := range sharedResult {
-		result[k] = v
-	}
+	maps.Copy(result, sharedResult)
 
 	// Sanitize storage stanza
 	if c.Storage != nil {

--- a/command/server/tls_util.go
+++ b/command/server/tls_util.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
@@ -70,13 +71,7 @@ func GenerateCert(caCertTemplate *x509.Certificate, caSigner crypto.Signer) (str
 	}
 
 	// Only add our hostname to SANs if it isn't found.
-	foundHostname := false
-	for _, value := range template.DNSNames {
-		if value == hostname {
-			foundHostname = true
-			break
-		}
-	}
+	foundHostname := slices.Contains(template.DNSNames, hostname)
 	if !foundHostname {
 		template.DNSNames = append(template.DNSNames, hostname)
 	}

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -293,8 +293,6 @@ func TestServer(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -773,12 +774,7 @@ func (c *SSHCommand) isSingleSSHArg(arg string) bool {
 	// We want to get the first character after the dash. This is so args like -vvv are picked up as just being -v
 	flag := string(arg[1])
 
-	for _, a := range singleArgs {
-		if flag == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(singleArgs, flag)
 }
 
 // Finds the hostname, username (optional) and port (optional) from any valid ssh command

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -58,8 +58,6 @@ func TestStatusCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/token/helper_external_test.go
+++ b/command/token/helper_external_test.go
@@ -6,6 +6,7 @@ package token
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"runtime"
 	"strings"
@@ -30,9 +31,7 @@ func TestExternalTokenHelperPath(t *testing.T) {
 		runtimeCases = unixCases
 	}
 
-	for k, v := range runtimeCases {
-		cases[k] = v
-	}
+	maps.Copy(cases, runtimeCases)
 
 	// We don't expect those to actually exist, so we expect an error. For now,
 	// I'm commenting out the rest of this code as we don't have real external

--- a/command/token_capabilities_test.go
+++ b/command/token_capabilities_test.go
@@ -40,8 +40,6 @@ func TestTokenCapabilitiesCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command/token_create_test.go
+++ b/command/token_create_test.go
@@ -83,8 +83,6 @@ func TestTokenCreateCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/token_lookup_test.go
+++ b/command/token_lookup_test.go
@@ -54,8 +54,6 @@ func TestTokenLookupCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/token_renew_test.go
+++ b/command/token_renew_test.go
@@ -62,8 +62,6 @@ func TestTokenRenewCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/token_revoke_test.go
+++ b/command/token_revoke_test.go
@@ -84,8 +84,6 @@ func TestTokenRevokeCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range validations {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/unwrap_test.go
+++ b/command/unwrap_test.go
@@ -74,8 +74,6 @@ func TestUnwrapCommand_Run(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range cases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/command/write_test.go
+++ b/command/write_test.go
@@ -95,8 +95,6 @@ func TestWriteCommand_Run(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -4,6 +4,8 @@
 package builtinplugins
 
 import (
+	"slices"
+
 	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
 	credCert "github.com/openbao/openbao/builtin/credential/cert"
 	credJWT "github.com/openbao/openbao/builtin/credential/jwt"
@@ -152,12 +154,7 @@ func (r *registry) Keys(pluginType consts.PluginType) []string {
 }
 
 func (r *registry) Contains(name string, pluginType consts.PluginType) bool {
-	for _, key := range r.Keys(pluginType) {
-		if key == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.Keys(pluginType), name)
 }
 
 // DeprecationStatus returns the Deprecation status for a builtin with type `pluginType`

--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	slices0 "slices"
 	"testing"
 
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
@@ -295,13 +296,11 @@ func Test_RegistryMatchesGenOpenapi(t *testing.T) {
 	ensureInScript := func(t *testing.T, scriptBackends []string, name string) {
 		t.Helper()
 
-		for _, excluded := range []string{
-			"oidc",     // alias for "jwt"
-			"openldap", // alias for "ldap"
-		} {
-			if name == excluded {
-				return
-			}
+		if slices0.Contains([]string{
+			"oidc",
+			"openldap",
+		}, name) {
+			return
 		}
 
 		if !slices.Contains(scriptBackends, name) {

--- a/helper/configutil/config_test.go
+++ b/helper/configutil/config_test.go
@@ -76,8 +76,6 @@ func TestSharedConfig_Sanitized_LogFields(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		name := name
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			cfg := tc.Value.Sanitized()
 			switch {

--- a/helper/configutil/merge.go
+++ b/helper/configutil/merge.go
@@ -24,10 +24,7 @@ func (c *SharedConfig) Merge(c2 *SharedConfig) *SharedConfig {
 		result.Telemetry = c2.Telemetry
 	}
 
-	result.DefaultMaxRequestDuration = c.DefaultMaxRequestDuration
-	if c2.DefaultMaxRequestDuration > result.DefaultMaxRequestDuration {
-		result.DefaultMaxRequestDuration = c2.DefaultMaxRequestDuration
-	}
+	result.DefaultMaxRequestDuration = max(c2.DefaultMaxRequestDuration, c.DefaultMaxRequestDuration)
 
 	result.LogLevel = c.LogLevel
 	if c2.LogLevel != "" {

--- a/helper/fairshare/jobmanager_test.go
+++ b/helper/fairshare/jobmanager_test.go
@@ -91,7 +91,7 @@ func TestJobManager_Start(t *testing.T) {
 	}
 	onFail := func(_ error) {}
 
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		// distribute jobs between 3 queues in the job manager
 		job := newTestJob(t, fmt.Sprintf("test-job-%d", i), ex, onFail)
 		j.AddJob(&job, fmt.Sprintf("queue-%d", i%3))
@@ -142,7 +142,7 @@ func TestJobManager_StartAndPause(t *testing.T) {
 	// now that the work queue is empty, let's add more jobs and make sure
 	// we pick up where we left off
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		numAdditionalJobs := 5
 		wg.Add(numAdditionalJobs)
 
@@ -288,7 +288,7 @@ func TestJobManager_GetPendingJobCount(t *testing.T) {
 	numJobs := 15
 	j := NewJobManager("test-job-mgr", 3, newTestLogger("jobmanager-test"), nil)
 
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		job := newDefaultTestJob(t, fmt.Sprintf("job-%d", i))
 		j.AddJob(&job, fmt.Sprintf("queue-%d", i%4))
 	}
@@ -303,7 +303,7 @@ func TestJobManager_GetWorkQueueLengths(t *testing.T) {
 	j := NewJobManager("test-job-mgr", 3, newTestLogger("jobmanager-test"), nil)
 
 	expected := make(map[string]int)
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		queueID := fmt.Sprintf("queue-%d", i%4)
 		job := newDefaultTestJob(t, fmt.Sprintf("job-%d", i))
 
@@ -505,17 +505,17 @@ func TestFairshare_StressTest(t *testing.T) {
 	j.Start()
 	defer j.Stop()
 
-	for i := 0; i < 3000; i++ {
+	for i := range 3000 {
 		wg.Add(1)
 		job := newTestJob(t, fmt.Sprintf("a-job-%d", i), ex, onFail)
 		j.AddJob(&job, "a")
 	}
-	for i := 0; i < 4000; i++ {
+	for i := range 4000 {
 		wg.Add(1)
 		job := newTestJob(t, fmt.Sprintf("b-job-%d", i), ex, onFail)
 		j.AddJob(&job, "b")
 	}
-	for i := 0; i < 3000; i++ {
+	for i := range 3000 {
 		wg.Add(1)
 		job := newTestJob(t, fmt.Sprintf("c-job-%d", i), ex, onFail)
 		j.AddJob(&job, "c")
@@ -546,7 +546,7 @@ func TestFairshare_nilLoggerJobManager(t *testing.T) {
 func TestFairshare_getNextQueue(t *testing.T) {
 	j := NewJobManager("test-job-mgr", 18, nil, nil)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		job := newDefaultTestJob(t, fmt.Sprintf("job-%d", i))
 		j.AddJob(&job, "a")
 		j.AddJob(&job, "b")
@@ -701,7 +701,7 @@ func TestFairshare_queueWorkersSaturated(t *testing.T) {
 	j.AddJob(&job, "b")
 
 	// no more than 9 workers can be assigned to a single queue in this example
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		j.incrementWorkerCount("a")
 		j.incrementWorkerCount("b")
 

--- a/helper/fairshare/workerpool_test.go
+++ b/helper/fairshare/workerpool_test.go
@@ -149,7 +149,7 @@ func TestFairshare_initializeWorker(t *testing.T) {
 
 	d := createDispatcher("", numWorkers, newTestLogger("workerpool-test"))
 
-	for workerNum := 0; workerNum < numWorkers; workerNum++ {
+	for workerNum := range numWorkers {
 		d.initializeWorker()
 
 		w := d.workers[workerNum]
@@ -224,7 +224,7 @@ func TestFairshare_start(t *testing.T) {
 		doneCh <- struct{}{}
 	}()
 
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		job := newTestJob(t, fmt.Sprintf("job-%d", i), ex, onFail)
 		d.dispatch(&job, nil, nil)
 	}
@@ -375,7 +375,7 @@ func TestFairshare_jobFailure(t *testing.T) {
 		doneCh <- struct{}{}
 	}()
 
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		job := newTestJob(t, fmt.Sprintf("job-%d", i), ex, onFail)
 		d.dispatch(&job, nil, nil)
 	}

--- a/helper/flag-kv/flag.go
+++ b/helper/flag-kv/flag.go
@@ -17,8 +17,8 @@ func (v *Flag) String() string {
 }
 
 func (v *Flag) Set(raw string) error {
-	idx := strings.Index(raw, "=")
-	if idx == -1 {
+	before, after, ok := strings.Cut(raw, "=")
+	if !ok {
 		return fmt.Errorf("no '=' value in arg: %q", raw)
 	}
 
@@ -26,7 +26,7 @@ func (v *Flag) Set(raw string) error {
 		*v = make(map[string]string)
 	}
 
-	key, value := raw[0:idx], raw[idx+1:]
+	key, value := before, after
 	(*v)[key] = value
 	return nil
 }

--- a/helper/identity/identity.go
+++ b/helper/identity/identity.go
@@ -6,6 +6,7 @@ package identity
 import (
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"google.golang.org/protobuf/proto"
@@ -84,9 +85,7 @@ func ToSDKAlias(a *Alias) *logical.Alias {
 		return nil
 	}
 	metadata := make(map[string]string, len(a.Metadata))
-	for k, v := range a.Metadata {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, a.Metadata)
 
 	return &logical.Alias{
 		Name:           a.Name,
@@ -112,9 +111,7 @@ func ToSDKEntity(e *Entity) *logical.Entity {
 	}
 
 	metadata := make(map[string]string, len(e.Metadata))
-	for k, v := range e.Metadata {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, e.Metadata)
 
 	return &logical.Entity{
 		ID:          e.ID,
@@ -133,9 +130,7 @@ func ToSDKGroup(g *Group) *logical.Group {
 	}
 
 	metadata := make(map[string]string, len(g.Metadata))
-	for k, v := range g.Metadata {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, g.Metadata)
 
 	return &logical.Group{
 		ID:          g.ID,

--- a/helper/logging/logger_test.go
+++ b/helper/logging/logger_test.go
@@ -239,8 +239,6 @@ func TestLogger_SetupLoggerWithInvalidLogFilePath(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name := name
-		tc := tc
 		cfg := newTestLogConfig(t)
 		cfg.LogLevel = hclog.Info
 		cfg.LogFilePath = tc.path

--- a/helper/metricsutil/wrapped_metrics_test.go
+++ b/helper/metricsutil/wrapped_metrics_test.go
@@ -4,6 +4,7 @@
 package metricsutil
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -11,12 +12,7 @@ import (
 )
 
 func isLabelPresent(toFind Label, ls []Label) bool {
-	for _, l := range ls {
-		if l == toFind {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ls, toFind)
 }
 
 // We can use a sink directly, or wrap the top-level

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -36,8 +36,8 @@ func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 
 	usernames := make([]string, 0, len(input))
 	for _, v := range input {
-		if strings.HasPrefix(v, kbPrefix) {
-			usernames = append(usernames, strings.TrimPrefix(v, kbPrefix))
+		if after, ok := strings.CutPrefix(v, kbPrefix); ok {
+			usernames = append(usernames, after)
 		}
 	}
 

--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/go-hclog"
@@ -562,16 +563,12 @@ func (p *ProfileEngine) evaluateTypedField(ctx context.Context, history *Evaluat
 		return nil, fmt.Errorf("failed to validate source '%v': %w", source, err)
 	}
 
-	for _, req := range accessedRequests {
-		if req == "" {
-			return nil, fmt.Errorf("invalid empty request name found")
-		}
+	if slices.Contains(accessedRequests, "") {
+		return nil, fmt.Errorf("invalid empty request name found")
 	}
 
-	for _, resp := range accessedResponses {
-		if resp == "" {
-			return nil, fmt.Errorf("invalid empty response name found")
-		}
+	if slices.Contains(accessedResponses, "") {
+		return nil, fmt.Errorf("invalid empty response name found")
 	}
 
 	val, err := sourceEval.Evaluate(ctx, history)

--- a/helper/random/rules.go
+++ b/helper/random/rules.go
@@ -5,6 +5,7 @@ package random
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/go-viper/mapstructure/v2"
 )
@@ -85,10 +86,5 @@ func (c CharsetRule) Pass(value []rune) bool {
 }
 
 func charIn(search rune, charset []rune) bool {
-	for _, r := range charset {
-		if search == r {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(charset, search)
 }

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -203,7 +203,7 @@ func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, e
 		}
 
 		// Append characters until either we're out of indexes or the length is long enough
-		for i := 0; i < numBytes; i++ {
+		for i := range numBytes {
 			// Be careful to ensure that maxAllowedRNGValue isn't >= 256 as it will overflow and this
 			// comparison will prevent characters from being selected from the charset
 			if data[i] > byte(maxAllowedRNGValue) {

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -81,7 +81,7 @@ func TestStringGenerator_Generate_successful(t *testing.T) {
 			runeset := map[rune]bool{}
 			runesFound := []rune{}
 
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				actual, err := test.generator.Generate(ctx, nil)
 				if err != nil {
 					t.Fatalf("no error expected, but got: %s", err)
@@ -286,7 +286,7 @@ func TestRandomRunes_successful(t *testing.T) {
 			runeset := map[rune]bool{}
 			runesFound := []rune{}
 
-			for i := 0; i < 10000; i++ {
+			for range 10000 {
 				actual, err := randomRunes(rand.Reader, test.charset, test.length)
 				if err != nil {
 					t.Fatalf("no error expected, but got: %s", err)

--- a/helper/storagepacker/storagepacker_test.go
+++ b/helper/storagepacker/storagepacker_test.go
@@ -189,7 +189,7 @@ func TestStoragePacker_DeleteMultiple(t *testing.T) {
 	ctx := t.Context()
 
 	// Persist a storage entry
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		item := &Item{
 			ID: fmt.Sprintf("item%d", i),
 		}
@@ -224,7 +224,7 @@ func TestStoragePacker_DeleteMultiple(t *testing.T) {
 	}
 
 	// Check that the deletion was successful
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		fetchedItem, err := storagePacker.GetItem(fmt.Sprintf("item%d", i))
 		if err != nil {
 			t.Fatal(err)
@@ -249,7 +249,7 @@ func TestStoragePacker_DeleteMultiple_ALL(t *testing.T) {
 
 	// Persist a storage entry
 	itemsToDelete := make([]string, 0, 10000)
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		item := &Item{
 			ID: fmt.Sprintf("item%d", i),
 		}

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -192,12 +193,7 @@ func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 }
 
 func (m *mockBuiltinRegistry) Contains(name string, pluginType consts.PluginType) bool {
-	for _, key := range m.Keys(pluginType) {
-		if key == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.Keys(pluginType), name)
 }
 
 func (m *mockBuiltinRegistry) DeprecationStatus(name string, pluginType consts.PluginType) (consts.DeprecationStatus, bool) {

--- a/helper/versions/version.go
+++ b/helper/versions/version.go
@@ -6,6 +6,7 @@ package versions
 import (
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"sync"
 
@@ -71,11 +72,5 @@ func IsBuiltinVersion(v string) bool {
 	}
 
 	metadataIdentifiers := strings.Split(semanticVersion.Metadata(), ".")
-	for _, identifier := range metadataIdentifiers {
-		if identifier == BuiltinMetadata {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(metadataIdentifiers, BuiltinMetadata)
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"mime"
 	"net"
 	"net/http"
@@ -809,9 +810,7 @@ func forwardRequest(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for k, v := range header {
-		w.Header()[k] = v
-	}
+	maps.Copy(w.Header(), header)
 
 	w.WriteHeader(statusCode)
 	w.Write(retBytes)

--- a/http/json_test.go
+++ b/http/json_test.go
@@ -168,7 +168,7 @@ func makeRandomMap(size int) interface{} {
 
 func fakeSizeOf(t *testing.T, input []byte) int64 {
 	min := fakeSizeOfInternal(t, input)
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		time.Sleep(5 * time.Millisecond)
 
 		v := fakeSizeOfInternal(t, input)
@@ -185,7 +185,7 @@ func fakeSizeOfInternal(t *testing.T, input []byte) int64 {
 	var obj interface{}
 
 	// Run GC multiple times to fully clear any sync.Pools.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		runtime.GC()
 	}
 
@@ -198,7 +198,7 @@ func fakeSizeOfInternal(t *testing.T, input []byte) int64 {
 	require.NoError(t, err)
 
 	// Run GC multiple times to fully clear any sync.Pools.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		runtime.GC()
 	}
 

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -102,8 +102,6 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/http/sys_wrapping_test.go
+++ b/http/sys_wrapping_test.go
@@ -111,7 +111,7 @@ func TestHTTP_Wrapping(t *testing.T) {
 	wrapInfo := secret.WrapInfo
 
 	// Test this twice to ensure no ill effect to the wrapping token as a result of the lookup
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		secret, err = client.Logical().Write("sys/wrapping/lookup", map[string]interface{}{
 			"token": wrapInfo.Token,
 		})

--- a/physical/crosstest/cross_test.go
+++ b/physical/crosstest/cross_test.go
@@ -803,7 +803,7 @@ func exerciseBackends(t *testing.T, backends map[string]physical.Backend) {
 
 	// Finally, test pagination exhaustively.
 	var created []string
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("key-%d", i)
 		allDoSamePut(t, backends, name, testString, false)
 		created = append(created, name)
@@ -1033,7 +1033,7 @@ func getRandomOps(t *testing.T, count int, transactional bool, txLimit int) []*i
 		opContents[len(opContents)-1] += "0123456789"
 	}
 
-	for i := 0; i < count; i++ {
+	for range count {
 		opI := rand.Intn(len(opTypes))
 		op := opTypes[opI]
 
@@ -1307,7 +1307,7 @@ func BenchmarkClearView(b *testing.B) {
 }
 
 func randomData(t testing.TB, s logical.Storage, prefix string, count int, size int) {
-	for i := 0; i < count; i++ {
+	for i := range count {
 		contents := fmt.Sprintf("%d", i%10)
 		for len(contents) < size {
 			contents += contents

--- a/physical/raft/bolt_64bit_test.go
+++ b/physical/raft/bolt_64bit_test.go
@@ -26,8 +26,6 @@ func Test_BoltOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.env != "" {
 				current := os.Getenv(key)

--- a/physical/raft/chunking_test.go
+++ b/physical/raft/chunking_test.go
@@ -51,7 +51,7 @@ func TestRaft_Chunking_Lifecycle(t *testing.T) {
 	var logs []*raft.Log
 	for i, b := range cmdBytes {
 		// Stage multiple operations so we can test restoring across multiple opnums
-		for j := 0; j < 10; j++ {
+		for j := range 10 {
 			chunkInfo := &raftchunkingtypes.ChunkInfo{
 				OpNum:       uint64(32 + j),
 				SequenceNum: uint32(i),
@@ -208,7 +208,7 @@ func TestRaft_Chunking_AppliedIndex(t *testing.T) {
 
 	currentIndex := raft.AppliedIndex()
 	// Write some data
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		err := raft.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: val,
@@ -225,7 +225,7 @@ func TestRaft_Chunking_AppliedIndex(t *testing.T) {
 		t.Fatalf("Did not apply chunks as expected, applied index = %d - %d = %d", newIndex, currentIndex, newIndex-currentIndex)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		entry, err := raft.Get(t.Context(), fmt.Sprintf("key-%d", i))
 		if err != nil {
 			t.Fatal(err)

--- a/physical/raft/fsm_test.go
+++ b/physical/raft/fsm_test.go
@@ -95,10 +95,10 @@ func TestFSM_Batching(t *testing.T) {
 	}
 
 	totalKeys := 0
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		batchSize := rand.Intn(64)
 		batch := make([]*raft.Log, batchSize)
-		for j := 0; j < batchSize; j++ {
+		for j := range batchSize {
 			var keys int
 			index++
 			keys, batch[j] = getLog(index)

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -611,7 +611,7 @@ func BenchmarkDB_Snapshot(b *testing.B) {
 	}
 	testName := b.Name()
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		pe.Key = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s-%d", testName, i)))
 		err = raft.Put(b.Context(), pe)
 		if err != nil {

--- a/physical/raft/snapshot.go
+++ b/physical/raft/snapshot.go
@@ -380,7 +380,7 @@ func (s *BoltSnapshotSink) writeBoltDBFile() error {
 
 				// Commit in batches of 50k. Bolt holds all the data in memory and
 				// doesn't split the pages until commit so we do incremental writes.
-				for i := 0; i < 50000; i++ {
+				for range 50000 {
 					err := protoReader.ReadMsg(entry)
 					if err != nil {
 						if err == io.EOF {

--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -55,7 +55,7 @@ func TestRaft_Snapshot_Loading(t *testing.T) {
 	raft := GetRaft(t, true, false)
 
 	// Write some data
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		err := raft.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: fmt.Appendf(nil, "value-%d", i),
@@ -156,7 +156,7 @@ func TestRaft_Snapshot_Index(t *testing.T) {
 	}
 
 	// Write some data
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		err := raft.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: fmt.Appendf(nil, "value-%d", i),
@@ -195,7 +195,7 @@ func TestRaft_Snapshot_Index(t *testing.T) {
 	}
 
 	// Write some more data
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		err := raft.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: fmt.Appendf(nil, "value-%d", i),
@@ -228,7 +228,7 @@ func TestRaft_Snapshot_Peers(t *testing.T) {
 	raft3 := GetRaft(t, false, false)
 
 	// Write some data
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		err := raft1.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: fmt.Appendf(nil, "value-%d", i),
@@ -308,7 +308,7 @@ func TestRaft_Snapshot_Restart(t *testing.T) {
 	raft2 := GetRaft(t, false, false)
 
 	// Write some data
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		err := raft1.Put(t.Context(), &physical.Entry{
 			Key:   fmt.Sprintf("key-%d", i),
 			Value: fmt.Appendf(nil, "value-%d", i),

--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"maps"
 	"os"
 	"testing"
 	"time"
@@ -146,9 +147,7 @@ func TestSelfSignedCA(t *testing.T) {
 			}
 
 			// Apply the generated & common fields to the config to be sent to the DB
-			for k, v := range test.config {
-				config[k] = v
-			}
+			maps.Copy(config, test.config)
 
 			db := new()
 			initReq := dbplugin.InitializeRequest{

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -6,6 +6,7 @@ package influxdb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	"reflect"
@@ -214,9 +215,7 @@ func makeConfig(rootConfig map[string]interface{}, keyValues ...interface{}) map
 
 	// Make a copy of the map so there isn't a chance of test bleedover between maps
 	config := make(map[string]interface{}, len(rootConfig)+(len(keyValues)/2))
-	for k, v := range rootConfig {
-		config[k] = v
-	}
+	maps.Copy(config, rootConfig)
 	for i := 0; i < len(keyValues); i += 2 {
 		k := keyValues[i].(string) // Will panic if the key field isn't a string and that's fine in a test
 		v := keyValues[i+1]

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -28,9 +29,7 @@ func getPostgreSQL(t *testing.T, options map[string]interface{}) (*PostgreSQL, f
 	connectionDetails := map[string]interface{}{
 		"connection_url": connURL,
 	}
-	for k, v := range options {
-		connectionDetails[k] = v
-	}
+	maps.Copy(connectionDetails, options)
 
 	req := dbplugin.InitializeRequest{
 		Config:           connectionDetails,
@@ -995,7 +994,7 @@ func TestUsernameGeneration(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			for i := 0; i < 1000; i++ {
+			for range 1000 {
 				username, err := up.Generate(test.data)
 				require.NoError(t, err)
 				require.Regexp(t, test.expectedRegex, username)

--- a/sdk/database/dbplugin/v5/grpc_server_test.go
+++ b/sdk/database/dbplugin/v5/grpc_server_test.go
@@ -6,6 +6,7 @@ package dbplugin
 import (
 	"context"
 	"errors"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -183,9 +184,7 @@ func TestCoerceFloatsToInt(t *testing.T) {
 
 func copyMap(m map[string]interface{}) map[string]interface{} {
 	newMap := map[string]interface{}{}
-	for k, v := range m {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, m)
 	return newMap
 }
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"regexp"
 	"sort"
@@ -169,9 +170,7 @@ func (b *Backend) HandleExistenceCheck(ctx context.Context, req *logical.Request
 	// Build up the data for the route, with the URL taking priority
 	// for the fields over the PUT data.
 	raw := make(map[string]interface{}, len(path.Fields))
-	for k, v := range req.Data {
-		raw[k] = v
-	}
+	maps.Copy(raw, req.Data)
 	for k, v := range captures {
 		raw[k] = v
 	}

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"strings"
@@ -39,9 +40,7 @@ func (d *FieldData) CloneSchema() *FieldData {
 	clone.Raw = d.Raw
 	clone.Schema = make(map[string]*FieldSchema, len(d.Schema))
 
-	for key, schema := range d.Schema {
-		clone.Schema[key] = schema
-	}
+	maps.Copy(clone.Schema, d.Schema)
 
 	return clone
 }

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -999,7 +999,6 @@ func TestFieldDataGet(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			data := &FieldData{
@@ -1117,7 +1116,6 @@ func TestFieldDataGet_Error(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			data := &FieldData{
@@ -1256,7 +1254,6 @@ func TestValidateStrict(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -569,7 +569,7 @@ func specialPathMatch(path string, specialPaths []string) bool {
 		if len(pathParts) < len(specialPathParts) {
 			return false
 		}
-		for i := 0; i < len(specialPathParts); i++ {
+		for i := range specialPathParts {
 			var (
 				part    = pathParts[i]
 				pattern = specialPathParts[i]

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -809,7 +809,6 @@ func TestOpenAPI_constructOperationID(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := constructOperationID(
@@ -851,7 +850,6 @@ func TestOpenAPI_hyphenatedToTitleCase(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := hyphenatedToTitleCase(test.in)

--- a/sdk/framework/path_map.go
+++ b/sdk/framework/path_map.go
@@ -6,6 +6,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -201,9 +202,7 @@ func (p *PathMap) Paths() []*Path {
 
 	// Build the schema by simply adding the "key"
 	schema := make(map[string]*FieldSchema)
-	for k, v := range p.Schema {
-		schema[k] = v
-	}
+	maps.Copy(schema, p.Schema)
 	schema["key"] = &FieldSchema{
 		Type:        TypeString,
 		Description: fmt.Sprintf("Key for the %s mapping", p.Name),

--- a/sdk/framework/secret.go
+++ b/sdk/framework/secret.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -48,9 +49,7 @@ func (s *Secret) Response(
 	data, internal map[string]interface{},
 ) *logical.Response {
 	internalData := make(map[string]interface{})
-	for k, v := range internal {
-		internalData[k] = v
-	}
+	maps.Copy(internalData, internal)
 	internalData["secret_type"] = s.Type
 
 	return &logical.Response{

--- a/sdk/helper/cel/helpers_test.go
+++ b/sdk/helper/cel/helpers_test.go
@@ -40,7 +40,6 @@ func TestCELHelpers(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			tc := tc
 			t.Run(tc.expr, func(t *testing.T) {
 				t.Parallel()
 				prog := buildTestProgram(t, env, tc.expr)
@@ -101,7 +100,6 @@ func TestCELHelpers(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			tc := tc
 			t.Run(tc.expr, func(t *testing.T) {
 				t.Parallel()
 				prog := buildTestProgram(t, env, tc.expr)

--- a/sdk/helper/custommetadata/custom_metadata_test.go
+++ b/sdk/helper/custommetadata/custom_metadata_test.go
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 			func() map[string]string {
 				cm := make(map[string]string)
 
-				for i := 0; i < maxKeyLength+1; i++ {
+				for i := range maxKeyLength + 1 {
 					s := strconv.Itoa(i)
 					cm[s] = s
 				}
@@ -69,8 +69,6 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/sdk/helper/keysutil/encrypted_key_storage_test.go
+++ b/sdk/helper/keysutil/encrypted_key_storage_test.go
@@ -272,7 +272,7 @@ func BenchmarkEncrytedKeyStorage_List(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		err = es.Wrap(s).Put(ctx, &logical.StorageEntry{
 			Key:   fmt.Sprintf("test/%d", i),
 			Value: []byte("test"),

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"math/big"
 	"path"
 	"strconv"
@@ -610,9 +611,7 @@ func (p *Policy) Persist(ctx context.Context, storage logical.Storage) (retErr e
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}
-		for k, v := range p.Keys {
-			priorKeys[k] = v
-		}
+		maps.Copy(priorKeys, p.Keys)
 	}
 
 	defer func() {
@@ -694,9 +693,7 @@ func (p *Policy) Upgrade(ctx context.Context, storage logical.Storage, randReade
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}
-		for k, v := range p.Keys {
-			priorKeys[k] = v
-		}
+		maps.Copy(priorKeys, p.Keys)
 	}
 
 	defer func() {
@@ -1642,9 +1639,7 @@ func (p *Policy) Rotate(ctx context.Context, storage logical.Storage, randReader
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}
-		for k, v := range p.Keys {
-			priorKeys[k] = v
-		}
+		maps.Copy(priorKeys, p.Keys)
 	}
 
 	defer func() {

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -504,7 +504,7 @@ func (c *Client) performLdapTokenGroupsSearch(cfg *ConfigEntry, conn Connection,
 	groupAttrValues := userEntry.GetRawAttributeValues("tokenGroups")
 	groupEntries := make([]*ldap.Entry, 0, len(groupAttrValues))
 
-	for i := 0; i < maxWorkers; i++ {
+	for range maxWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -639,7 +639,7 @@ func EscapeLDAPValue(input string) string {
 	}
 
 	inputLen := len(input)
-	for i := 0; i < inputLen; i++ {
+	for i := range inputLen {
 		char := input[i]
 		switch {
 		case i == 0 && char == ' ' || char == '#':

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -327,13 +328,7 @@ func (c *Client) retryOCSP(
 					retErr = multierror.Append(retErr, err)
 					continue
 				}
-				haveEKU := false
-				for _, ku := range ocspRes.Certificate.ExtKeyUsage {
-					if ku == x509.ExtKeyUsageOCSPSigning {
-						haveEKU = true
-						break
-					}
-				}
+				haveEKU := slices.Contains(ocspRes.Certificate.ExtKeyUsage, x509.ExtKeyUsageOCSPSigning)
 				if !haveEKU {
 					err := fmt.Errorf("error checking delegated OCSP responder on %v OCSP response: certificate lacks the OCSP Signing EKU", method)
 					retErr = multierror.Append(retErr, err)
@@ -568,7 +563,7 @@ func (c *Client) VerifyLeafCertificate(ctx context.Context, subject, issuer *x50
 
 // VerifyPeerCertificate verifies all of certificate revocation status
 func (c *Client) VerifyPeerCertificate(ctx context.Context, verifiedChains [][]*x509.Certificate, conf *VerifyConfig) error {
-	for i := 0; i < len(verifiedChains); i++ {
+	for i := range verifiedChains {
 		// Certificate signed by Root CA. This should be one before the last in the Certificate Chain
 		numberOfNoneRootCerts := len(verifiedChains[i]) - 1
 		if !verifiedChains[i][numberOfNoneRootCerts].IsCA || string(verifiedChains[i][numberOfNoneRootCerts].RawIssuer) != string(verifiedChains[i][numberOfNoneRootCerts].RawSubject) {
@@ -629,7 +624,7 @@ func (c *Client) canEarlyExitForOCSP(results []*ocspStatus, chainSize int, conf 
 
 func (c *Client) validateWithCacheForAllCertificates(verifiedChains []*x509.Certificate) (bool, error) {
 	n := len(verifiedChains) - 1
-	for j := 0; j < n; j++ {
+	for j := range n {
 		subject := verifiedChains[j]
 		issuer := verifiedChains[j+1]
 		status, _, _, err := c.validateWithCache(subject, issuer)
@@ -666,7 +661,7 @@ func (c *Client) GetAllRevocationStatus(ctx context.Context, verifiedChains []*x
 	}
 	n := len(verifiedChains) - 1
 	results := make([]*ocspStatus, n)
-	for j := 0; j < n; j++ {
+	for j := range n {
 		results[j], err = c.GetRevocationStatus(ctx, verifiedChains[j], verifiedChains[j+1], conf)
 		if err != nil {
 			return nil, err

--- a/sdk/helper/pathmanager/pathmanager.go
+++ b/sdk/helper/pathmanager/pathmanager.go
@@ -35,8 +35,8 @@ func (p *PathManager) AddPaths(paths []string) {
 		}
 
 		var exception bool
-		if strings.HasPrefix(prefix, "!") {
-			prefix = strings.TrimPrefix(prefix, "!")
+		if after, ok := strings.CutPrefix(prefix, "!"); ok {
+			prefix = after
 			exception = true
 		}
 

--- a/sdk/helper/shamir/shamir.go
+++ b/sdk/helper/shamir/shamir.go
@@ -92,9 +92,9 @@ func (p *polynomial) evaluate(x uint8) uint8 {
 func interpolatePolynomial(x_samples, y_samples []uint8, x uint8) uint8 {
 	limit := len(x_samples)
 	var result, basis uint8
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		basis = 1
-		for j := 0; j < limit; j++ {
+		for j := range limit {
 			if i == j {
 				continue
 			}
@@ -235,7 +235,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 		// Generate a `parts` number of (x,y) pairs
 		// We cheat by encoding the x value once as the final index,
 		// so that it only needs to be stored once.
-		for i := 0; i < parts; i++ {
+		for i := range parts {
 			x := xCoordinates[i]
 			y := p.evaluate(x)
 			out[i][idx] = y

--- a/sdk/helper/shamir/shamir_test.go
+++ b/sdk/helper/shamir/shamir_test.go
@@ -94,12 +94,12 @@ func TestCombine(t *testing.T) {
 
 	// There is 5*4*3 possible choices,
 	// we will just brute force try them all
-	for i := 0; i < 5; i++ {
-		for j := 0; j < 5; j++ {
+	for i := range 5 {
+		for j := range 5 {
 			if j == i {
 				continue
 			}
-			for k := 0; k < 5; k++ {
+			for k := range 5 {
 				if k == i || k == j {
 					continue
 				}
@@ -195,7 +195,7 @@ func TestPolynomial_Eval(t *testing.T) {
 }
 
 func TestInterpolate_Rand(t *testing.T) {
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		p, err := makePolynomial(uint8(i), 2)
 		if err != nil {
 			t.Fatalf("err: %v", err)

--- a/sdk/helper/template/funcs_test.go
+++ b/sdk/helper/template/funcs_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestUnixTimestamp(t *testing.T) {
 	now := time.Now().Unix()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		str := unixTime()
 		actual, err := strconv.Atoi(str)
 		require.NoError(t, err)
@@ -24,7 +24,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 func TestNowNano(t *testing.T) {
 	now := time.Now().UnixNano() / int64(time.Millisecond)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		str := unixTimeMillis()
 		actual, err := strconv.ParseUint(str, 10, 64)
 		require.NoError(t, err)
@@ -415,7 +415,7 @@ func TestReplace(t *testing.T) {
 
 func TestUUID(t *testing.T) {
 	re := "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		id, err := uuid()
 		require.NoError(t, err)
 		require.Regexp(t, re, id)

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -135,7 +135,7 @@ Some string 6841cf80`,
 	})
 
 	t.Run("unix_time", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			st, err := NewTemplate(
 				Template("{{unix_time}}"),
 			)
@@ -149,7 +149,7 @@ Some string 6841cf80`,
 	})
 
 	t.Run("unix_time_millis", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			st, err := NewTemplate(
 				Template("{{unix_time_millis}}"),
 			)
@@ -163,7 +163,7 @@ Some string 6841cf80`,
 	})
 
 	t.Run("timestamp", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			st, err := NewTemplate(
 				Template(`{{timestamp "2006-01-02T15:04:05.000Z"}}`),
 			)

--- a/sdk/helper/testhelpers/schema/response_validation_test.go
+++ b/sdk/helper/testhelpers/schema/response_validation_test.go
@@ -339,7 +339,6 @@ func TestValidateResponse(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/sdk/physical/testing.go
+++ b/sdk/physical/testing.go
@@ -315,7 +315,7 @@ func ExerciseBackend(t testing.TB, b Backend) {
 	// Create multiple items in a path iteratively and ensure
 	// paginated lists work as expected.
 	var created []string
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("key-%d", i)
 		e = &Entry{Key: "foo/" + name, Value: []byte("baz")}
 		err = b.Put(context.Background(), e)

--- a/serviceregistration/kubernetes/retry_handler_test.go
+++ b/serviceregistration/kubernetes/retry_handler_test.go
@@ -231,7 +231,7 @@ func TestRetryHandlerRacesAndDeadlocks(t *testing.T) {
 	start := make(chan struct{})
 	done := make(chan bool)
 	numRoutines := 100
-	for i := 0; i < numRoutines; i++ {
+	for range numRoutines {
 		go func() {
 			<-start
 			r.Notify(testPatch)

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -837,7 +837,7 @@ func TestACL_CreationRace(t *testing.T) {
 	errs := make(chan error)
 	stopTime := time.Now().Add(20 * time.Second)
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 	"slices"
 	"strings"
@@ -1209,9 +1210,7 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEnt
 	}
 	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
-	for k, v := range entry.Options {
-		conf[k] = v
-	}
+	maps.Copy(conf, entry.Options)
 
 	switch entry.Type {
 	case "plugin":

--- a/vault/cluster/inmem_layer.go
+++ b/vault/cluster/inmem_layer.go
@@ -383,7 +383,7 @@ func NewInmemLayerCluster(clusterName string, nodes int, logger log.Logger) (*In
 	}
 
 	layers := make([]*InmemLayer, nodes)
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		layers[i] = NewInmemLayer(fmt.Sprintf("%s_node_%d", clusterName, i), logger)
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -1175,9 +1176,7 @@ func (c *Core) configureLogRequestsLevel(level string) {
 func (c *Core) configureAuditBackends(backends map[string]audit.Factory) {
 	auditBackends := make(map[string]audit.Factory, len(backends))
 
-	for k, f := range backends {
-		auditBackends[k] = f
-	}
+	maps.Copy(auditBackends, backends)
 
 	c.auditBackends = auditBackends
 }
@@ -1187,9 +1186,7 @@ func (c *Core) configureAuditBackends(backends map[string]audit.Factory) {
 func (c *Core) configureCredentialsBackends(backends map[string]logical.Factory, logger log.Logger) {
 	credentialBackends := make(map[string]logical.Factory, len(backends))
 
-	for k, f := range backends {
-		credentialBackends[k] = f
-	}
+	maps.Copy(credentialBackends, backends)
 
 	credentialBackends[routing.MountTypeToken] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		tsLogger := logger.Named("token")
@@ -1211,9 +1208,7 @@ func (c *Core) configureCredentialsBackends(backends map[string]logical.Factory,
 func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, logger log.Logger) {
 	logicalBackends := make(map[string]logical.Factory, len(backends))
 
-	for k, f := range backends {
-		logicalBackends[k] = f
-	}
+	maps.Copy(logicalBackends, backends)
 
 	// KV
 	_, ok := logicalBackends[routing.MountTypeKV]

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -91,7 +91,7 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 		}
 	}
 	for _, p := range v2secrets {
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			req := logical.TestRequest(t, logical.CreateOperation, p)
 			req.Data["data"] = map[string]interface{}{"foo": "bar"}
 			req.ClientToken = root

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -400,7 +400,7 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 		t.Fatalf("bad progress: %d", prog)
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		unseal, err := TestCoreUnseal(c, res.SecretShares[i])
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -2234,7 +2234,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Put several random entries
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		keyUUID, err := uuid.GenerateUUID()
 		if err != nil {
 			t.Fatal(err)

--- a/vault/counters_test.go
+++ b/vault/counters_test.go
@@ -49,7 +49,7 @@ func TestTokenStore_CountActiveTokens(t *testing.T) {
 	}
 
 	tokens := make([]string, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 
 		// Create some service tokens
 		req := &logical.Request{
@@ -75,7 +75,7 @@ func TestTokenStore_CountActiveTokens(t *testing.T) {
 	}
 
 	// Revoke the service tokens
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 
 		req := &logical.Request{
 			ClientToken: root,
@@ -96,7 +96,7 @@ func TestTokenStore_CountActiveTokens(t *testing.T) {
 	// token deletion works by setting the TTL of the token to 0 and waiting
 	// for it to get cleaned up by the expiration manager, occasionally we will
 	// have to wait briefly for all the tokens to actually get deleted.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		count = testCountActiveTokens(t, c, root)
 		if count == 1 {
 			return
@@ -144,7 +144,7 @@ func TestIdentityStore_CountActiveEntities(t *testing.T) {
 		Path:        "entity",
 	}
 	ids := make([]string, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		resp, err := c.identityStore.HandleRequest(rootCtx, req)
 		if err != nil || (resp != nil && resp.IsError()) {
 			t.Fatalf("bad: resp: %#v\n err: %v", resp, err)
@@ -155,7 +155,7 @@ func TestIdentityStore_CountActiveEntities(t *testing.T) {
 	}
 
 	req.Operation = logical.DeleteOperation
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		req.Path = "entity/id/" + ids[i]
 		resp, err := c.identityStore.HandleRequest(rootCtx, req)
 		if err != nil || (resp != nil && resp.IsError()) {

--- a/vault/diagnose/mock_storage_backend.go
+++ b/vault/diagnose/mock_storage_backend.go
@@ -103,7 +103,7 @@ func callTypeToOp(ctype string) string {
 func (m mockStorageBackend) GetConfigurationOffline() (*raft.RaftConfigurationResponse, error) {
 	twoServerList := []*raft.RaftServer{}
 	threeServerList := []*raft.RaftServer{}
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		twoServerList = append(twoServerList, &raft.RaftServer{Voter: true})
 		threeServerList = append(threeServerList, &raft.RaftServer{Voter: true})
 	}

--- a/vault/diagnose/output.go
+++ b/vault/diagnose/output.go
@@ -48,7 +48,7 @@ func (s status) String() string {
 }
 
 func (s status) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprint("\"", s.String(), "\"")), nil
+	return fmt.Append(nil, "\"", s.String(), "\""), nil
 }
 
 type Result struct {
@@ -311,7 +311,7 @@ const (
 )
 
 func indent(sb *strings.Builder, depth int) {
-	for i := 0; i < depth; i++ {
+	for range depth {
 		sb.WriteString(indentString)
 	}
 }

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/openbao/openbao/helper/identity"
@@ -307,9 +308,7 @@ func (d dynamicSystemView) EntityInfo(entityID string) (*logical.Entity, error) 
 
 	if entity.Metadata != nil {
 		ret.Metadata = make(map[string]string, len(entity.Metadata))
-		for k, v := range entity.Metadata {
-			ret.Metadata[k] = v
-		}
+		maps.Copy(ret.Metadata, entity.Metadata)
 	}
 
 	aliases := make([]*logical.Alias, 0, len(entity.Aliases))

--- a/vault/dynamic_system_view_test.go
+++ b/vault/dynamic_system_view_test.go
@@ -220,7 +220,7 @@ func TestDynamicSystemView_GeneratePasswordFromPolicy_successful(t *testing.T) {
 	runeset := map[rune]bool{}
 	runesFound := []rune{}
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		actual, err := dsv.GeneratePasswordFromPolicy(ctx, testPolicyName)
 		if err != nil {
 			t.Fatalf("no error expected, but got: %s", err)

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -342,7 +343,7 @@ func TestExpiration_TotalLeaseCount_WithRoles(t *testing.T) {
 	}
 	TestCoreCreateNamespaces(t, c, ns)
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		le := &leaseEntry{
 			LeaseID:    "lease" + fmt.Sprintf("%d", i),
 			Path:       "foo/bar/" + fmt.Sprintf("%d", i),
@@ -564,7 +565,7 @@ func TestExpiration_Tidy(t *testing.T) {
 		t.Fatalf("bad: lease count; expected:0 actual:%d", count)
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		req := &logical.Request{
 			Operation:   logical.ReadOperation,
 			Path:        "invalid/lease/" + fmt.Sprintf("%d", i+1),
@@ -613,7 +614,7 @@ func TestExpiration_Tidy(t *testing.T) {
 
 	var err1, err2 error
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case err1 = <-errCh1:
 		case err2 = <-errCh2:
@@ -717,7 +718,7 @@ func benchmarkExpirationBackend(b *testing.B, physicalBackend physical.Backend, 
 	}
 
 	// Register fake leases
-	for i := 0; i < numLeases; i++ {
+	for range numLeases {
 		pathUUID, err := uuid.GenerateUUID()
 		if err != nil {
 			b.Fatal(err)
@@ -2853,10 +2854,8 @@ func findMatchingPath(path string, tokenEntries []*logical.TokenEntry) bool {
 
 func findMatchingPolicy(policy string, tokenEntries []*logical.TokenEntry) bool {
 	for _, te := range tokenEntries {
-		for _, p := range te.Policies {
-			if policy == p {
-				return true
-			}
+		if slices.Contains(te.Policies, policy) {
+			return true
 		}
 	}
 	return false
@@ -3377,7 +3376,7 @@ func TestExpiration_getIrrevocableLeaseCounts(t *testing.T) {
 	exp := c.expiration
 
 	expectedPerMount := 10
-	for i := 0; i < expectedPerMount; i++ {
+	for range expectedPerMount {
 		for _, backend := range backends {
 			if _, err := c.AddIrrevocableLease(namespace.RootContext(t.Context()), backend.path); err != nil {
 				t.Fatal(err)
@@ -3453,7 +3452,7 @@ func TestExpiration_listIrrevocableLeases(t *testing.T) {
 
 	expectedLeases := make([]*basicLeaseTestInfo, 0)
 	expectedPerMount := 10
-	for i := 0; i < expectedPerMount; i++ {
+	for range expectedPerMount {
 		for _, backend := range backends {
 			le, err := c.AddIrrevocableLease(namespace.RootContext(t.Context()), backend.path)
 			if err != nil {
@@ -3519,7 +3518,7 @@ func TestExpiration_listIrrevocableLeases_includeAll(t *testing.T) {
 	exp := c.expiration
 
 	expectedNumLeases := MaxIrrevocableLeasesToReturn + 10
-	for i := 0; i < expectedNumLeases; i++ {
+	for range expectedNumLeases {
 		if _, err := c.AddIrrevocableLease(namespace.RootContext(t.Context()), "foo/"); err != nil {
 			t.Fatal(err)
 		}

--- a/vault/expiration_testing_util_common.go
+++ b/vault/expiration_testing_util_common.go
@@ -77,7 +77,7 @@ func (c *Core) AddIrrevocableLease(ctx context.Context, pathPrefix string) (*bas
 // It returns a map of the mount accessor to the number of leases stored there
 func (c *Core) InjectIrrevocableLeases(ctx context.Context, count int) (map[string]int, error) {
 	out := make(map[string]int)
-	for i := 0; i < count; i++ {
+	for range count {
 		le, err := c.AddIrrevocableLease(ctx, "foo/")
 		if err != nil {
 			return nil, err

--- a/vault/external_tests/api/secret_test.go
+++ b/vault/external_tests/api/secret_test.go
@@ -149,8 +149,6 @@ func TestSecret_TokenID(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -417,8 +415,6 @@ func TestSecret_TokenAccessor(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -651,8 +647,6 @@ func TestSecret_TokenRemainingUses(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -954,8 +948,6 @@ func TestSecret_TokenPolicies(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1252,8 +1244,6 @@ func TestSecret_TokenMetadata(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1544,8 +1534,6 @@ func TestSecret_TokenIsRenewable(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1818,8 +1806,6 @@ func TestSecret_TokenTTL(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/vault/external_tests/api/sys_rotate_ext_test.go
+++ b/vault/external_tests/api/sys_rotate_ext_test.go
@@ -164,7 +164,7 @@ func testSysRekey_VerificationDeprecated(t *testing.T, recovery bool) {
 
 	doStartVerify := func() {
 		// Start the process
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			status, err := verificationUpdateFunc(newKeys[i], verificationNonce)
 			if err != nil {
 				t.Fatal(err)

--- a/vault/external_tests/identity/userlockouts_test.go
+++ b/vault/external_tests/identity/userlockouts_test.go
@@ -139,7 +139,7 @@ func TestIdentityStore_DisableUserLockoutTest(t *testing.T) {
 			}
 
 			// login for default lockout threshold times with wrong credentials
-			for i := 0; i < UserLockoutThresholdDefault; i++ {
+			for range UserLockoutThresholdDefault {
 				_, err = client.Logical().Write("auth/userpass/login/bsmith", map[string]interface{}{
 					"password": "wrongPassword",
 				})

--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -461,7 +461,7 @@ func TestLoginMFA_LoginEnforcement_CRUD(t *testing.T) {
 	// first create a few configs
 	configIDs := make([]string, 0)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp, err := client.Logical().Write("identity/mfa/method/totp", map[string]interface{}{
 			"issuer":    fmt.Sprintf("fooCorp%d", i),
 			"period":    10,
@@ -639,7 +639,7 @@ func TestLoginMFA_LoginEnforcement_RequiredParameters(t *testing.T) {
 	// first create a few configs
 	configIDs := make([]string, 0)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp, err := client.Logical().Write("identity/mfa/method/totp", map[string]interface{}{
 			"issuer":    fmt.Sprintf("fooCorp%d", i),
 			"period":    10,

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -315,8 +315,7 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 	t.Run("parallel execution group", func(t *testing.T) {
 		// loop to mount 5 auth methods that will each share a single
 		// plugin process
-		for i := 0; i < 5; i++ {
-			i := i
+		for i := range 5 {
 			pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
 			client := cluster.Cores[i].Client
 			t.Run(pluginPath, func(t *testing.T) {
@@ -515,7 +514,7 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 	t.Run("parallel execution group", func(t *testing.T) {
 		// loop to mount 5 secrets engines that will each share a single
 		// plugin process
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
 			t.Run(pluginPath, func(t *testing.T) {
 				t.Parallel()
@@ -643,7 +642,7 @@ func TestExternalPlugin_Database(t *testing.T) {
 	t.Run("parallel execution group", func(t *testing.T) {
 		// loop to mount 5 database connections that will each share a single
 		// plugin process
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			dbName := fmt.Sprintf("%s-%d", plugin.Name, i)
 			t.Run(dbName, func(t *testing.T) {
 				t.Parallel()

--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -536,7 +536,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 			if backendType == logical.TypeCredential {
 				pathPrefix = "auth/" + pathPrefix
 			}
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				// Update internal value in the backend
 				resp, err := client.Logical().Write(fmt.Sprintf("%s%d/internal", pathPrefix, i), map[string]interface{}{
 					"value": "baz",
@@ -561,7 +561,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 				t.Fatal("no reload_id in response")
 			}
 
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				// Ensure internal backed value is reset
 				resp, err := client.Logical().Read(fmt.Sprintf("%s%d/internal", pathPrefix, i))
 				if err != nil {
@@ -617,7 +617,7 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 	case logical.TypeLogical:
 		plugin := logicalVersionMap[pluginVersion]
 		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeSecrets, "", plugin, env, tempDir)
-		for i := 0; i < numMounts; i++ {
+		for i := range numMounts {
 			// Alternate input styles for plugin_name on every other mount
 			options := map[string]interface{}{
 				"type": "mock-plugin",
@@ -633,7 +633,7 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 	case logical.TypeCredential:
 		plugin := credentialVersionMap[pluginVersion]
 		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", consts.PluginTypeCredential, "", plugin, env, tempDir)
-		for i := 0; i < numMounts; i++ {
+		for i := range numMounts {
 			// Alternate input styles for plugin_name on every other mount
 			options := map[string]interface{}{
 				"type": "mock-plugin",

--- a/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -53,7 +53,7 @@ func TestPostgreSQL_FencedWrites(t *testing.T) {
 	var logLock sync.Mutex
 	var logs []string
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -61,7 +61,7 @@ func TestPostgreSQL_FencedWrites(t *testing.T) {
 			var localLogs []string
 
 			// 5 iterations is roughly 2.5 seconds with the 5ms sleep.
-			for j := 0; j < 500; j++ {
+			for range 500 {
 				// This should now fail since the fenced write will fail.
 				resp, err := client.Logical().Write("sys/policies/acl/custom", map[string]interface{}{
 					"policy": `path "*" {

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -257,7 +257,7 @@ func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
 
 	cli := cluster.Cores[0].Client
 	// Write more keys than snapshot_threshold
-	for i := 0; i < 250; i++ {
+	for i := range 250 {
 		_, err := cli.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 			"test": "data",
 		})

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -107,7 +107,7 @@ func TestRaft_BoltDBMetrics(t *testing.T) {
 	leaderClient := cluster.Cores[0].Client
 
 	// Write a few keys
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 			fmt.Sprintf("foo%d", i): fmt.Sprintf("bar%d", i),
 		})
@@ -453,7 +453,7 @@ func TestRaft_SnapshotAPI(t *testing.T) {
 	leaderClient := cluster.Cores[0].Client
 
 	// Write a few keys
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 			"test": "data",
 		})
@@ -522,7 +522,7 @@ func TestRaft_SnapshotAPI_MidstreamFailure(t *testing.T) {
 	// Write a bunch of keys; if too few, the detection code in api.RaftSnapshot
 	// will never make it into the tar part, it'll fail merely when trying to
 	// decompress the stream.
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 			"test": "data",
 		})
@@ -595,7 +595,7 @@ func TestRaft_SnapshotAPI_Rotate_Backward(t *testing.T) {
 			leaderClient := cluster.Cores[0].Client
 
 			// Write a few keys
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 					"test": "data",
 				})
@@ -760,7 +760,7 @@ func TestRaft_SnapshotAPI_Rotate_Forward(t *testing.T) {
 			leaderClient := cluster.Cores[0].Client
 
 			// Write a few keys
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 					"test": "data",
 				})
@@ -936,7 +936,7 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 	leaderClient := cluster.Cores[0].Client
 
 	// Write a few keys
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err := leaderClient.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
 			"test": "data",
 		})

--- a/vault/external_tests/sealmigration/testshared.go
+++ b/vault/external_tests/sealmigration/testshared.go
@@ -391,7 +391,7 @@ func migratePost14(t *testing.T, storage teststorage.ReusableStorage, cluster *v
 
 	// Wait for the followers to establish a new leader
 	var leaderIdx int
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		leaderIdx, err = testhelpers.AwaitLeader(t, cluster)
 		if err != nil {
 			t.Fatal(err)

--- a/vault/external_tests/storage/crosstest/cross_test.go
+++ b/vault/external_tests/storage/crosstest/cross_test.go
@@ -698,7 +698,7 @@ func exerciseBackends(t *testing.T, backends map[string]logical.Storage) {
 
 	// Finally, test pagination exhaustively.
 	var created []string
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("key-%d", i)
 		allDoSamePut(t, backends, name, testString, false)
 		created = append(created, name)
@@ -928,7 +928,7 @@ func getRandomOps(t *testing.T, count int, transactional bool, txLimit int) []*i
 		opContents[len(opContents)-1] += "0123456789"
 	}
 
-	for i := 0; i < count; i++ {
+	for range count {
 		opI := rand.Intn(len(opTypes))
 		op := opTypes[opI]
 

--- a/vault/external_tests/token/batch_token_test.go
+++ b/vault/external_tests/token/batch_token_test.go
@@ -180,7 +180,7 @@ path "kv/*" {
 	leaseID := resp.LeaseID
 
 	lastDuration := resp.LeaseDuration
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		time.Sleep(time.Second)
 		resp, err = client.Sys().Renew(leaseID, 0)
 		if err != nil {

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -555,7 +555,7 @@ func TestTokenStore_RevocationOnStartup(t *testing.T) {
 	var err error
 	var tokens []string
 	// Create tokens
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		secret, err = client.Auth().Token().Create(&api.TokenCreateRequest{
 			Policies: []string{"default"},
 		})

--- a/vault/ha_test.go
+++ b/vault/ha_test.go
@@ -49,7 +49,6 @@ func TestGrabLockOrStop(t *testing.T) {
 
 	// Start a bunch of worker goroutines.
 	for g := range workers {
-		g := g
 		go func() {
 			defer workerWg.Done()
 			for time.Since(start) < testDuration {

--- a/vault/identity/store_util.go
+++ b/vault/identity/store_util.go
@@ -173,7 +173,7 @@ func (i *IdentityStore) LoadEntities(ctx context.Context, readOnly bool) error {
 	wg := &sync.WaitGroup{}
 
 	// Create 64 workers to distribute work to
-	for j := 0; j < consts.ExpirationRestoreWorkerCount; j++ {
+	for range consts.ExpirationRestoreWorkerCount {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -227,7 +227,7 @@ func (i *IdentityStore) LoadEntities(ctx context.Context, readOnly bool) error {
 
 	// Restore each key by pulling from the result chan
 LOOP:
-	for j := 0; j < len(existing); j++ {
+	for range existing {
 		select {
 		case err = <-errs:
 			// Close all go routines

--- a/vault/identity_store_entities_test.go
+++ b/vault/identity_store_entities_test.go
@@ -417,7 +417,7 @@ func TestIdentityStore_BatchDelete(t *testing.T) {
 	is, _, _ := testIdentityStoreWithAppRoleAuth(ctx, t)
 
 	ids := make([]string, 10000)
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		entityData := map[string]interface{}{
 			"name": fmt.Sprintf("entity-%d", i),
 		}
@@ -613,7 +613,7 @@ func TestIdentityStore_ListEntities(t *testing.T) {
 	}
 
 	expected := []string{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		resp, err = is.HandleRequest(ctx, entityReq)
 		if err != nil || (resp != nil && resp.IsError()) {
 			t.Fatalf("err:%v resp:%#v", err, resp)

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1085,7 +1085,6 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 	}
 
 	for _, testSet := range testSets {
-		testSet := testSet
 		t.Run(testSet.namedKey.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -175,7 +175,7 @@ func TestIdentityStore_UnsealingWhenConflictingAliasNames(t *testing.T) {
 	}
 
 	var unsealed bool
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		unsealed, err = c.Unseal(unsealKey[i])
 		if err != nil {
 			t.Fatal(err)
@@ -927,7 +927,7 @@ func TestIdentityStore_DeleteCaseSensitivityKey(t *testing.T) {
 	}
 
 	var unsealed bool
-	for i := 0; i < len(unsealKey); i++ {
+	for i := range unsealKey {
 		unsealed, err = c.Unseal(unsealKey[i])
 		if err != nil {
 			t.Fatal(err)
@@ -1507,7 +1507,7 @@ func TestIdentityStore_NamespaceEdgeCases(t *testing.T) {
 		entityIDs := make(chan string, 20)
 
 		// Create 10 entities concurrently in each namespace
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			// Root namespace
 			wg.Add(1)
 			go func(index int) {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5244,7 +5244,7 @@ func TestHandlePoliciesPasswordGenerate(t *testing.T) {
 		}
 
 		// Run the test a bunch of times to help ensure we don't have flaky behavior
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			req := &logical.Request{
 				Storage: storage,
 			}
@@ -5677,8 +5677,6 @@ func TestSystemBackend_Loggers(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("all-loggers-%s", tc.level), func(t *testing.T) {
 			t.Parallel()
 
@@ -5922,8 +5920,6 @@ func TestSystemBackend_LoggersByName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("loggers-by-name-%s", tc.logger), func(t *testing.T) {
 			t.Parallel()
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 	"reflect"
 	"slices"
@@ -208,10 +209,8 @@ func (c *Core) mount(ctx context.Context, entry *routing.MountEntry) error {
 	}
 
 	// Do not allow more than one instance of a singleton mount
-	for _, p := range singletonMounts {
-		if entry.Type == p {
-			return logical.CodedError(403, "mount type of %q is not mountable", entry.Type)
-		}
+	if slices.Contains(singletonMounts, entry.Type) {
+		return logical.CodedError(403, "mount type of %q is not mountable", entry.Type)
 	}
 
 	// Mount internally
@@ -1608,9 +1607,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *routing.MountEntry,
 	}
 	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
-	for k, v := range entry.Options {
-		conf[k] = v
-	}
+	maps.Copy(conf, entry.Options)
 
 	switch entry.Type {
 	case routing.MountTypePlugin:

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -582,7 +582,7 @@ func TestPluginCatalog_MakeExternalPluginsKey_Comparable(t *testing.T) {
 	hasher := sha256.New()
 	hasher.Write([]byte("Some random input"))
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		plugins = append(plugins, pluginutil.PluginRunner{
 			Name:    "Name",
 			Type:    consts.PluginTypeDatabase,

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -396,12 +396,12 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			pc.HasSegmentWildcards = true
 		}
 
-		if strings.HasSuffix(pc.Path, "*") {
+		if before, ok := strings.CutSuffix(pc.Path, "*"); ok {
 			// If there are segment wildcards, don't actually strip the
 			// trailing asterisk, but don't want to hit the default case
 			if !pc.HasSegmentWildcards {
 				// Strip the glob character if found
-				pc.Path = strings.TrimSuffix(pc.Path, "*")
+				pc.Path = before
 				pc.IsPrefix = true
 			}
 		}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -374,8 +374,6 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		name := name
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -34,8 +34,6 @@ func TestNewRateLimitQuota(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink())
 			require.Equal(t, tc.expectErr, err != nil, err)
@@ -99,7 +97,7 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 
 	start := time.Now()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 
 		addr := fmt.Sprintf("127.0.0.%d", i)
@@ -180,7 +178,7 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 
 	results := make(map[string]*clientResult)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 
 		addr := fmt.Sprintf("127.0.0.%d", i)

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -1298,9 +1299,7 @@ type answerResp struct {
 
 func newDiscover() (*discover.Discover, error) {
 	providers := make(map[string]discover.Provider)
-	for k, v := range discover.Providers {
-		providers[k] = v
-	}
+	maps.Copy(providers, discover.Providers)
 
 	providers["k8s"] = &discoverk8s.Provider{}
 

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -273,7 +273,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 
 	// Provide the parts root
 	oldResult := result
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		result, err = c.RekeyUpdate(t.Context(), TestKeyCopy(oldResult.SecretShares[i]), rkconf.Nonce, recovery)
 		if err != nil {
 			t.Fatalf("err: %v", err)

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -97,7 +97,7 @@ func TestRollbackManager_ManyWorkers(t *testing.T) {
 	// create 10 backends
 	// when a rollback happens, each backend will try to write to an unbuffered
 	// channel, then wait to be released
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		b := &be.Noop{}
 		b.RequestHandler = func(ctx context.Context, request *logical.Request) (*logical.Response, error) {
 			if request.Operation == logical.RollbackOperation {
@@ -180,7 +180,7 @@ func TestRollbackManager_WorkerPool(t *testing.T) {
 	// create 10 backends
 	// when a rollback happens, each backend will try to write to an unbuffered
 	// channel, then wait to be released
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		b := &be.Noop{}
 		b.RequestHandler = func(ctx context.Context, request *logical.Request) (*logical.Response, error) {
 			if request.Operation == logical.RollbackOperation {

--- a/vault/routing/router.go
+++ b/vault/routing/router.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 	"sync"
@@ -132,9 +133,7 @@ func (entry *RouteEntry) Deserialize() map[string]interface{} {
 		"tainted":        entry.tainted,
 		"storage_prefix": entry.StoragePrefix,
 	}
-	for k, v := range entry.MountEntry.Deserialize() {
-		ret[k] = v
-	}
+	maps.Copy(ret, entry.MountEntry.Deserialize())
 	return ret
 }
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -209,16 +210,10 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 		conf.RedirectAddr = opts.RedirectAddr
 	}
 
-	for k, v := range opts.LogicalBackends {
-		conf.LogicalBackends[k] = v
-	}
-	for k, v := range opts.CredentialBackends {
-		conf.CredentialBackends[k] = v
-	}
+	maps.Copy(conf.LogicalBackends, opts.LogicalBackends)
+	maps.Copy(conf.CredentialBackends, opts.CredentialBackends)
 
-	for k, v := range opts.AuditBackends {
-		conf.AuditBackends[k] = v
-	}
+	maps.Copy(conf.AuditBackends, opts.AuditBackends)
 	if opts.RollbackPeriod != time.Duration(0) {
 		conf.RollbackPeriod = opts.RollbackPeriod
 	}
@@ -254,22 +249,14 @@ func testCoreConfig(t testing.T, physicalBackend physical.Backend, logger log.Lo
 	}
 
 	credentialBackends := make(map[string]logical.Factory)
-	for backendName, backendFactory := range noopBackends {
-		credentialBackends[backendName] = backendFactory
-	}
-	for backendName, backendFactory := range be.TestCredentialBackends {
-		credentialBackends[backendName] = backendFactory
-	}
+	maps.Copy(credentialBackends, noopBackends)
+	maps.Copy(credentialBackends, be.TestCredentialBackends)
 
 	logicalBackends := make(map[string]logical.Factory)
-	for backendName, backendFactory := range noopBackends {
-		logicalBackends[backendName] = backendFactory
-	}
+	maps.Copy(logicalBackends, noopBackends)
 
 	logicalBackends["kv"] = LeasedPassthroughBackendFactory
-	for backendName, backendFactory := range be.TestLogicalBackends {
-		logicalBackends[backendName] = backendFactory
-	}
+	maps.Copy(logicalBackends, be.TestLogicalBackends)
 
 	conf := &CoreConfig{
 		Physical:           physicalBackend,
@@ -1530,19 +1517,13 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		}
 
 		if base.LogicalBackends != nil {
-			for k, v := range base.LogicalBackends {
-				coreConfig.LogicalBackends[k] = v
-			}
+			maps.Copy(coreConfig.LogicalBackends, base.LogicalBackends)
 		}
 		if base.CredentialBackends != nil {
-			for k, v := range base.CredentialBackends {
-				coreConfig.CredentialBackends[k] = v
-			}
+			maps.Copy(coreConfig.CredentialBackends, base.CredentialBackends)
 		}
 		if base.AuditBackends != nil {
-			for k, v := range base.AuditBackends {
-				coreConfig.AuditBackends[k] = v
-			}
+			maps.Copy(coreConfig.AuditBackends, base.AuditBackends)
 		}
 		if base.Logger != nil {
 			coreConfig.Logger = base.Logger

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"slices"
@@ -210,9 +211,7 @@ func (ts *TokenStore) paths() []*framework.Path {
 			Description: "Name of the role",
 		},
 	}
-	for k, v := range commonFieldsForCreate {
-		fieldsForCreateWithRole[k] = v
-	}
+	maps.Copy(fieldsForCreateWithRole, commonFieldsForCreate)
 
 	const operationPrefixToken = "token"
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -1757,7 +1757,7 @@ func TestTokenStore_RevokeSelf(t *testing.T) {
 	var out *logical.TokenEntry
 	for _, id := range lookup {
 		var found bool
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			out, err = ts.Lookup(ctx, id)
 			if err != nil {
 				t.Fatalf("err: %v", err)
@@ -6026,7 +6026,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 
 	leases := []string{}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		leaseID, err := exp.Register(ctx, req, resp, "")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This is the result of:

```sh
for mod in $(find . -name go.mod) ; do
  (cd "$(dirname "$mod")" && go fix -minmax -fmtappendf -forvar -mapsloop -rangeint -slicescontains -slicessort -stringscut -stringscutprefix ./...)
done
make fmt
```

_twice_.

This diff should be reproducible via the above commands if made from the same head commit (094e5f6957afedc34d1ae4224fc4a88969af404b).

```console
$ git diff | sha256sum -
11b17ba5af58e53541207e68a0d55486fa07ce7e6420d79d532ca7b92dfd7ad8  -

$ curl -sL https://github.com/openbao/openbao/pull/2789.diff | sha256sum -
11b17ba5af58e53541207e68a0d55486fa07ce7e6420d79d532ca7b92dfd7ad8  -
```

Note that it takes 2 passes of the above to reach a stable hash, the second pass gets rid of one extra unnecessary loop variable.

I've omitted several analyzers that would lead to a very large diff (running all of them at once leads to a -8000 diff :D). Optimally we'd get all analyzers besides `any` out of the way, and keep that one for last, with a diff that's easy to automatically verify.

For a list of all passes, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize.

## Rationale

I'd like to get the codebase "modernized", i.e., apply Go modernizers until we can't no more, and then add a CI check to ensure this remains the case. This is step 1!


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
