### PR TITLE
detect transaction leaks in inmem storage

### DIFF
--- a/changelog/2794.txt
+++ b/changelog/2794.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+inmem: detect, log, and rollback transactions that have never been committed or rolled-back. If you see the message "transaction was leaked" in your logs, please open an issue.
+```

--- a/sdk/physical/inmem/inmem.go
+++ b/sdk/physical/inmem/inmem.go
@@ -8,10 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 
 	"github.com/armon/go-radix"
 	log "github.com/hashicorp/go-hclog"
@@ -54,7 +57,8 @@ var _ physical.Backend = &InmemBackend{}
 type TransactionalInmemBackend struct {
 	InmemBackend
 
-	txnPermitPool *physical.PermitPool
+	txnPermitPool         *physical.PermitPool
+	leakedTransactionHook func(args []any)
 }
 
 var _ physical.TransactionalBackend = &TransactionalInmemBackend{}
@@ -121,6 +125,7 @@ type InmemBackendTransaction struct {
 	finishedTx bool
 	operations []*InmemOp
 	parent     *TransactionalInmemBackend
+	cleanup    runtime.Cleanup
 }
 
 var _ physical.Transaction = &InmemBackendTransaction{}
@@ -156,9 +161,24 @@ func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, erro
 		return b, nil
 	}
 
+	leakedTransactionHook := func(args []any) {
+		logger.Error("transaction was leaked", args...)
+	}
+	if testing.Testing() {
+		leakedTransactionHook = func(args []any) {
+			var buf strings.Builder
+			fmt.Fprint(&buf, "transaction was leaked:")
+			for _, arg := range args {
+				fmt.Fprintf(&buf, " %v", arg)
+			}
+			panic(buf.String())
+		}
+	}
+
 	return &TransactionalInmemBackend{
 		*b.(*InmemBackend),
 		physical.NewPermitPool(physical.DefaultParallelOperations),
+		leakedTransactionHook,
 	}, nil
 }
 
@@ -397,6 +417,15 @@ func (i *TransactionalInmemBackend) BeginTx(ctx context.Context) (physical.Trans
 		parent:   i,
 	}
 
+	params := []any{
+		"stack", string(debug.Stack()),
+	}
+
+	tx.cleanup = runtime.AddCleanup(tx, func(parent *TransactionalInmemBackend) {
+		parent.txnPermitPool.Release()
+		i.leakedTransactionHook(params)
+	}, i)
+
 	tx.failGet.Store(i.failGet.Load())
 	tx.failPut.Store(i.failPut.Load())
 	tx.failDelete.Store(i.failDelete.Load())
@@ -566,6 +595,7 @@ func (i *InmemBackendTransaction) Commit(ctx context.Context) error {
 	// At this point, we mark the transaction as finished either way.
 	i.finishedTx = true
 	i.parent.txnPermitPool.Release()
+	i.cleanup.Stop()
 
 	if !i.writable || !i.written {
 		// Nothing to do.
@@ -651,6 +681,7 @@ func (i *InmemBackendTransaction) Rollback(ctx context.Context) error {
 
 	i.finishedTx = true
 	i.parent.txnPermitPool.Release()
+	i.cleanup.Stop()
 
 	return nil
 }

--- a/sdk/physical/inmem/inmem_test.go
+++ b/sdk/physical/inmem/inmem_test.go
@@ -4,11 +4,16 @@
 package inmem
 
 import (
+	"runtime"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInmem(t *testing.T) {
@@ -21,4 +26,71 @@ func TestInmem(t *testing.T) {
 	physical.ExerciseBackend(t, inm)
 	physical.ExerciseTransactionalBackend(t, inm.(physical.TransactionalBackend))
 	physical.ExerciseBackend_ListPrefix(t, inm)
+}
+
+func TestInmem_TransactionLeak(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	inm, err := NewInmem(nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inmt := inm.(*TransactionalInmemBackend)
+
+	// start transaction
+	tx, err := inmt.BeginTx(t.Context())
+	require.NoError(t, err)
+
+	var callCount atomic.Int64
+	// Because we can't catch the panic in the cleanup hook (it runs in a
+	// dedicated go routine), we have to wrap the hook and do the asserts there.
+	originalHook := inmt.leakedTransactionHook
+	inmt.leakedTransactionHook = func(args []any) {
+		callCount.Add(1)
+		if assert.Len(t, args, 2) {
+			assert.Equal(t, "stack", args[0])
+			assert.Contains(t, args[1], ".BeginTx(")
+			assert.Contains(t, args[1], t.Name())
+		}
+		assert.Panics(t, func() {
+			originalHook(args)
+		}, "default hook should panic, if in testing")
+	}
+
+	_, err = tx.List(t.Context(), "list/me")
+	require.NoError(t, err)
+
+	_, err = tx.Get(t.Context(), "read/me")
+	require.NoError(t, err)
+
+	err = tx.Put(t.Context(), &physical.Entry{
+		Key:   "write/me",
+		Value: []byte("value"),
+	})
+	require.NoError(t, err)
+
+	err = tx.Delete(t.Context(), "delete/me")
+	require.NoError(t, err)
+
+	// leak transaction
+	tx = nil
+
+	// wait for hook
+	for range 100 {
+		runtime.GC()
+
+		if callCount.Load() == 1 {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.Equal(t, int64(1), callCount.Load(), "expected hook to be called once")
+
+	// assert clean-up
+	assert.Equal(t, 0, inmt.txnPermitPool.CurrentPermits())
 }


### PR DESCRIPTION
## Description

If the leak is detected while running a test (via `go test` as reported by [`testing.Testing()`](https://pkg.go.dev/testing#Testing)) instead of logging we will `panic`.

For the inmem backend I keep to severity of the log at error even for the 2nd and all following leaks (for raft we decided to decrease to debug after the first error).

## Rationale

See #2185

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
