### PR TITLE
Fix OCI image download URLs

### DIFF
--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -310,7 +310,7 @@ const DockerList = ({ version, registry }) => {
           <div key={label}>
             <p>{label}</p>
             <CodeBlock language="shell">
-              {`docker pull ${registry}/${image}:${version}`}
+              {`docker pull ${registry}/${image}:${dockerVersion}`}
             </CodeBlock>
           </div>
         ))}


### PR DESCRIPTION
## Description

We upload the tags with out a `v` prefix. This was missed in the recent
download page refactoring

Signed-off-by: Jan Martens <jan@martens.eu.org>

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.