### PR TITLE
Improve Workflow auditability

### DIFF
--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -47,6 +47,8 @@ type ProfileEngine struct {
 	request *logical.Request
 	data    *framework.FieldData
 
+	reqIdPrefix string
+
 	output *OutputConfig
 	logger hclog.Logger
 }
@@ -118,6 +120,14 @@ func WithLogger(logger hclog.Logger) func(*ProfileEngine) {
 func WithOutput(config *OutputConfig) func(*ProfileEngine) {
 	return func(p *ProfileEngine) {
 		p.output = config
+	}
+}
+
+// Sets the request id prefix for this engine, allowing better auditing by
+// tying the request to an inbound request.
+func WithRequestIdentifierPrefix(prefix string) func(*ProfileEngine) {
+	return func(p *ProfileEngine) {
+		p.reqIdPrefix = prefix
 	}
 }
 
@@ -398,6 +408,9 @@ func (p *ProfileEngine) buildRequest(ctx context.Context, history *EvaluationHis
 	reqName := fmt.Sprintf("request[%d].%v", requestIndex, requestBlock.Type)
 	if p.outerBlockName != "" {
 		reqName = fmt.Sprintf("%v[%d].%v.%v", p.outerBlockName, outerIndex, outerBlock.Type, reqName)
+	}
+	if p.reqIdPrefix != "" {
+		reqName = fmt.Sprintf("%v.%v", p.reqIdPrefix, reqName)
 	}
 
 	req = &logical.Request{

--- a/vault/external_tests/workflows/workflow_test.go
+++ b/vault/external_tests/workflows/workflow_test.go
@@ -6,6 +6,7 @@ package workflows
 import (
 	"testing"
 
+	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/builtin/credential/userpass"
 	logicalKv "github.com/openbao/openbao/builtin/logical/kv"
 	vaulthttp "github.com/openbao/openbao/http"
@@ -15,7 +16,6 @@ import (
 )
 
 func TestWorkflow(t *testing.T) {
-	var err error
 	coreConfig := &vault.CoreConfig{
 		DisableCache: true,
 		CredentialBackends: map[string]logical.Factory{
@@ -40,6 +40,24 @@ func TestWorkflow(t *testing.T) {
 
 	client := cores[0].Client
 
+	t.Run("acceptance", func(t *testing.T) {
+		_, err := client.Logical().Write("sys/namespaces/acceptance", map[string]any{})
+		require.NoError(t, err)
+
+		client := client.WithNamespace("acceptance")
+		testWorkflowAcceptance(t, client)
+	})
+
+	t.Run("recursion", func(t *testing.T) {
+		_, err := client.Logical().Write("sys/namespaces/recursion", map[string]any{})
+		require.NoError(t, err)
+
+		client := client.WithNamespace("recursion")
+		testWorkflowRecursion(t, client)
+	})
+}
+
+func testWorkflowAcceptance(t *testing.T, client *api.Client) {
 	// No workflows to start.
 	resp, err := client.Logical().List("sys/workflows/manage")
 	require.NoError(t, err)
@@ -74,7 +92,7 @@ func TestWorkflow(t *testing.T) {
 	require.Contains(t, resp.Data["keys"], "test/")
 
 	// The token should work.
-	testClient := client.WithNamespace("test/")
+	testClient := client.WithNamespace("acceptance/test/")
 	testClient.SetToken(workflowResp.Data["token"].(string))
 	resp, err = testClient.Logical().Write("secret/data/test", map[string]interface{}{
 		"data": map[string]interface{}{
@@ -97,6 +115,16 @@ func TestWorkflow(t *testing.T) {
 	resp, err = client.Logical().List("sys/workflows/manage")
 	require.NoError(t, err)
 	require.Nil(t, resp)
+}
+
+func testWorkflowRecursion(t *testing.T, client *api.Client) {
+	_, err := client.Logical().Write("sys/workflows/manage/endless-recursion", map[string]any{
+		"workflow": endlessRecursionWorkflow,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Logical().Write("sys/workflows/execute/endless-recursion", nil)
+	require.Contains(t, err.Error(), "too much workflow recursion")
 }
 
 const createNamespaceWorkflow = `
@@ -214,10 +242,19 @@ output {
     token = {
       eval_type = "string"
       eval_source = "response"
-	  flow_name = "authentication"
+      flow_name = "authentication"
       response_name = "login"
       field_selector = ["auth", "client_token"]
     }
+  }
+}
+`
+
+const endlessRecursionWorkflow = `
+flow "loop" {
+  request "recursion" {
+    path = "sys/workflows/execute/endless-recursion"
+    operation = "update"
   }
 }
 `

--- a/vault/logical_system_workflows.go
+++ b/vault/logical_system_workflows.go
@@ -386,10 +386,6 @@ func (b *SystemBackend) handleWorkflowsDelete() framework.OperationFunc {
 func (b *SystemBackend) handleWorkflowsExecute(unauthed bool, trace bool) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := data.Get("path").(string)
-		if unauthed {
-			trace = false
-		}
-
-		return b.Core.workflowStore.Execute(ctx, path, unauthed, trace, req, data)
+		return b.Core.workflowStore.Execute(ctx, req.ID, path, unauthed, trace, req, data)
 	}
 }

--- a/vault/workflow_store.go
+++ b/vault/workflow_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	urlpath "path"
 	"path/filepath"
 	"strings"
 
@@ -23,6 +24,8 @@ import (
 const (
 	workflowSubPath   = "workflows/"
 	workflowOuterName = "flow"
+
+	maxWorkflowRecursion = 5
 )
 
 type WorkflowEntry struct {
@@ -269,10 +272,15 @@ func (ws *WorkflowStore) List(ctx context.Context, prefix string, recursive bool
 	return results, nil
 }
 
-func (ws *WorkflowStore) Execute(ctx context.Context, path string, unauthed bool, trace bool, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (ws *WorkflowStore) Execute(ctx context.Context, reqId string, path string, unauthed bool, trace bool, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find namespace in context: %w", err)
+	}
+
+	// Reject trace requests when unauthenticated.
+	if unauthed && trace {
+		return nil, logical.ErrPermissionDenied
 	}
 
 	workflow, err := func() (*WorkflowEntry, error) {
@@ -292,15 +300,40 @@ func (ws *WorkflowStore) Execute(ctx context.Context, path string, unauthed bool
 		return nil, logical.CodedError(http.StatusNotFound, "workflow does not exist")
 	}
 
+	// Reject recursive calls starting from an unauthenticated workflow. That
+	// is, don't allow a call like:
+	//
+	// unauthed -> unauthed
+	// unauthed -> authed
+	//
+	// However, recursive calls like authed -> unauthed are allowed (though,
+	// cannot subsequently call another profile!) or the recursive authed
+	// chain of authed -> authed [ -> authed ].
+	if strings.Contains(reqId, ".unauthed.workflow.") {
+		return nil, logical.ErrPermissionDenied
+	}
+
+	// Similarly, set a maximum limit on authenticated recursion based on
+	// number of workflows in the request identifier.
+	if strings.Count(reqId, ".workflow.") == maxWorkflowRecursion {
+		return nil, logical.CodedError(http.StatusBadRequest, "too much workflow recursion")
+	}
+
 	input, contents, output, err := workflow.Parse(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse workflow: %w", err)
+	}
+
+	authedStr := "authed"
+	if unauthed {
+		authedStr = "unauthed"
 	}
 
 	engine, err := profiles.NewEngine(
 		// Do not allow sources which could bypass authorization.
 		profiles.WithRequestSource(),
 		profiles.WithResponseSource(),
+		profiles.WithCELSource(),
 		profiles.WithTemplateSource(),
 		profiles.WithInputSource(input, req, data),
 		profiles.WithOutput(output),
@@ -313,6 +346,11 @@ func (ws *WorkflowStore) Execute(ctx context.Context, path string, unauthed bool
 
 		// Default token to use.
 		profiles.WithDefaultToken(req.ClientToken),
+
+		// Allow auditing our generated requests by tying this to the input
+		// API request. When handling recursive requests, this could get
+		// long.
+		profiles.WithRequestIdentifierPrefix(fmt.Sprintf("%v.%v.workflow.%v", reqId, authedStr, path)),
 
 		// Execute our request handler here; here is where we validate that
 		// this policy can only access requests under its own namespace and
@@ -327,7 +365,7 @@ func (ws *WorkflowStore) Execute(ctx context.Context, path string, unauthed bool
 				}
 
 				nsHeader := namespace.HeaderFromContext(ctx)
-				nsHeader = filepath.Join(nsHeader, values[0])
+				nsHeader = urlpath.Join(nsHeader, values[0])
 				ctx = namespace.ContextWithNamespaceHeader(ctx, nsHeader)
 			}
 
@@ -359,7 +397,7 @@ func (ws *WorkflowStore) Execute(ctx context.Context, path string, unauthed bool
 	}
 
 	if err := engine.Evaluate(noNsCtx); err != nil {
-		return nil, fmt.Errorf("failed to evaluate namespace: %w", err)
+		return nil, fmt.Errorf("failed to evaluate workflow: %w", err)
 	}
 
 	// Return 200 OK with no associated data rather than 204 to keep the


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Only the top commit is new; will rebase after #2728 lands. 

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

With workflows coming in from requests which already have assigned
identifiers, we should be able to have a synthetic request identifier
which references the inbound API request. This gives us an effective
way of limiting recursion, as well as identifying what state a given
workflow was executed in (authenticated or unauthenticated) well
downstream of it.

A synthetic identifier from this looks like:

> ```
> 7adb61a6-6ca6-1a6c-7992-ec31d8fbf47b.authed.workflow.
>   boom.flow[0].test.request[0].boom.authed.workflow.
>   boom.flow[0].test.request[0].boom.authed.workflow.
>   boom.flow[0].test.request[0].boom
> ```

Where:

 - `7ad...` is the original request identifier,
 - `authed.workflow` signifies the request was an authenticated workflow
   execution, and
 - `boom.flow[0].test.request[0].boom` is specific request executing in
   the profile engine.

`Signed-off-by: Alexander Scheel <alex.scheel@control-plane.io>`

cc: @wslabosz-reply @satoqz

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
