### PR TITLE
Simplify request context chaining

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -594,9 +594,7 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	ctx, cancel := context.WithCancel(c.activeContext)
 	defer cancel()
 
-	stop := context.AfterFunc(httpCtx, func() {
-		cancel()
-	})
+	stop := context.AfterFunc(httpCtx, cancel)
 	defer stop()
 
 	// A namespace was manually passed to HandleRequest, as can be the case with:


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

While we want to avoid leaking most of the context placed in the `httpCtx`, we need to also ensure our context gets cancelled on the first of either http request cancellation or the active context cancellation. Using `AfterFunc` to bind the two avoids a long-lived goroutine while keeping the hierarchy as it is today.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
