### PR TITLE
Fix namespace invalidation without caching

### DIFF
--- a/changelog/2822.txt
+++ b/changelog/2822.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix namespace invalidation on standby when disable_cache=true is set.
+```

--- a/vault/external_tests/policy/policy_test.go
+++ b/vault/external_tests/policy/policy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openbao/openbao/builtin/credential/ldap"
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	logicalKv "github.com/openbao/openbao/builtin/logical/kv"
+	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	ldaphelper "github.com/openbao/openbao/helper/testhelpers/ldap"
 	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -508,4 +509,52 @@ func testPagination(t *testing.T, client *api.Client, path string, raw bool, lim
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Data)
 	require.LessOrEqual(t, len(resp.Data["keys"].([]interface{})), 10)
+}
+
+func TestPolicyStore_DisabledCacheInvalidation(t *testing.T) {
+	t.Parallel()
+
+	coreConfig := &vault.CoreConfig{
+		DisableCache: true,
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+		NumCores:    2,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+
+	_, err := client.Logical().Write("sys/namespaces/my-test", nil)
+	require.NoError(t, err)
+
+	testPolicy := `
+path "secret/*" {
+	capabilities = ["read"]
+}
+`
+
+	err = client.Sys().PutPolicy("admin-reader", testPolicy)
+	require.NoError(t, err)
+
+	corehelpers.RetryUntil(t, 10*time.Second, func() error {
+		standby := cores[1].Client
+		policy, err := standby.Sys().GetPolicy("admin-reader")
+		if err != nil {
+			return err
+		}
+
+		if policy != testPolicy {
+			return fmt.Errorf("expected policy:\n%v\n\ngot policy: %v\n", testPolicy, policy)
+		}
+
+		return nil
+	})
 }

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -248,6 +248,11 @@ func (ps *PolicyStore) rLockWithUnlock(ctx context.Context) func() {
 }
 
 func (ps *PolicyStore) invalidateNamespace(ctx context.Context, uuid string) {
+	// Skip invalidation if no cache exists.
+	if ps.tokenPoliciesLRU == nil {
+		return
+	}
+
 	defer ps.lockWithUnlock(ctx)()
 
 	for _, key := range ps.tokenPoliciesLRU.Keys() {


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When caching is disabled in the configuration, the invalidation manager will dispatch an invalidation to the policy store on namespace creation which will panic due to a missing cache object. Resolve this by ignoring the invalidation in such a scenario; there is no policy cache to contend with.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
