### PR TITLE
Add Namespace Unsealing

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -552,6 +552,19 @@ func (c *Core) loadCredentials(ctx context.Context, standby bool) error {
 	return nil
 }
 
+// loadCredentialsForNamespace is invoked as part of postNamespaceUnseal
+// to load the auth mounts of a namespace.
+func (c *Core) loadCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	// Check if we're on a non-transactional storage
+	if _, ok := c.barrier.(logical.TransactionalStorage); !ok {
+		return c.loadLegacyCredentialsForNamespace(ctx, ns)
+	}
+	return c.loadTransactionalCredentialsForNamespace(ctx, ns)
+}
+
 // loadTransactionalCredentials reads the transactional split auth (credential)
 // table, populates the storage if there are no existing entries.
 func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical.Storage, standby bool) error {
@@ -1070,6 +1083,32 @@ func (c *Core) setupCredentials(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// setupCredentialsForNamespace is invoked after we've loaded auth mounts
+// of a namespace to initialize the credential backends and update the router.
+func (c *Core) setupCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) ([]func(), error) {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	postUnsealFuncs := make([]func(), 0)
+	for _, entry := range c.auth.SortEntriesByPath().Entries {
+		// Only process entries with matching namespace ID
+		if entry.NamespaceID != ns.ID {
+			continue
+		}
+
+		postUnsealFunc, err := c.setupCredential(ctx, entry)
+		if err != nil {
+			return postUnsealFuncs, err
+		}
+
+		if postUnsealFunc != nil {
+			postUnsealFuncs = append(postUnsealFuncs, postUnsealFunc)
+		}
+	}
+
+	return postUnsealFuncs, nil
 }
 
 // setupCredential initializes the credential backend

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -836,73 +836,120 @@ func TestCore_RemountCredential_Cleanup(t *testing.T) {
 
 func TestCore_RemountCredential_Namespaces(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
-	rootCtx := namespace.RootContext(t.Context())
-	ns1 := &namespace.Namespace{Path: "ns1/"}
-	ns2 := &namespace.Namespace{Path: "ns1/ns2/"}
-	ns3 := &namespace.Namespace{Path: "ns1/ns3/"}
-	TestCoreCreateNamespaces(t, c, ns1, ns2, ns3)
-	ns1Ctx := namespace.ContextWithNamespace(rootCtx, ns1)
-	ns2Ctx := namespace.ContextWithNamespace(rootCtx, ns2)
-	ns3Ctx := namespace.ContextWithNamespace(rootCtx, ns3)
+	ns := &namespace.Namespace{Path: "ns/"}
+	unsealable1 := &namespace.Namespace{Path: "ns/unsealable1/"}
+	unsealable2 := &namespace.Namespace{Path: "ns/unsealable2/"}
+	sealable1 := &namespace.Namespace{Path: "ns/sealable1/"}
+	sealable2 := &namespace.Namespace{Path: "ns/sealable2/"}
+	TestCoreCreateNamespaces(t, c, ns, unsealable1, unsealable2)
+	unsealKeys := TestCoreCreateUnsealedNamespaces(t, c, sealable1, sealable2)
+	unsealKeys["root"] = keys
 
 	me := &routing.MountEntry{
 		Table: routing.CredentialTableType,
 		Path:  "foo",
 		Type:  "noop",
 	}
-	err := c.enableCredential(ns2Ctx, me)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	require.NoError(t, c.enableCredential(namespace.ContextWithNamespace(ctx, unsealable1), me))
+
+	tests := []struct {
+		name string
+		src  namespace.MountPathDetails
+		dst  namespace.MountPathDetails
+	}{
+		{
+			name: "remount unsealable -> unsealable",
+			src: namespace.MountPathDetails{
+				Namespace: unsealable1,
+				MountPath: "auth/foo/",
+			},
+			dst: namespace.MountPathDetails{
+				Namespace: unsealable2,
+				MountPath: "auth/bar/",
+			},
+		},
+		{
+			name: "remount unsealable -> sealable",
+			src: namespace.MountPathDetails{
+				Namespace: unsealable2,
+				MountPath: "auth/bar/",
+			},
+			dst: namespace.MountPathDetails{
+				Namespace: sealable1,
+				MountPath: "auth/foo/",
+			},
+		},
+		{
+			name: "remount sealable -> sealable",
+			src: namespace.MountPathDetails{
+				Namespace: sealable1,
+				MountPath: "auth/foo/",
+			},
+			dst: namespace.MountPathDetails{
+				Namespace: sealable2,
+				MountPath: "auth/bar/",
+			},
+		},
+		{
+			name: "remount sealable -> unsealable",
+			src: namespace.MountPathDetails{
+				Namespace: sealable2,
+				MountPath: "auth/bar/",
+			},
+			dst: namespace.MountPathDetails{
+				Namespace: unsealable1,
+				MountPath: "auth/foo/",
+			},
+		},
 	}
 
-	src := namespace.MountPathDetails{
-		Namespace: ns2,
-		MountPath: "auth/foo/",
-	}
-	dst := namespace.MountPathDetails{
-		Namespace: ns3,
-		MountPath: "auth/bar/",
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, ns := range []*namespace.Namespace{tt.src.Namespace, tt.dst.Namespace} {
+				for i, key := range unsealKeys[ns.Path] {
+					unsealed, err := TestNamespaceUnseal(c, ns, key)
+					require.NoError(t, err)
+					require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
+				}
+			}
 
-	match := c.router.MatchingMount(ns2Ctx, "auth/foo/bar")
-	if match != ns2.Path+"auth/foo/" {
-		t.Fatalf("missing mount, match: %q", match)
-	}
+			srcCtx := namespace.ContextWithNamespace(ctx, tt.src.Namespace)
+			dstCtx := namespace.ContextWithNamespace(ctx, tt.dst.Namespace)
 
-	err = c.remountCredential(ns1Ctx, src, dst, true)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+			match := c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, tt.src.Namespace.Path+tt.src.MountPath, match, "missing mount, match: %q", match)
 
-	match = c.router.MatchingMount(ns2Ctx, "auth/foo/bar")
-	if match != "" {
-		t.Fatalf("auth method still at old location, match: %q", err)
-	}
+			require.NoError(t, c.remountCredential(ctx, tt.src, tt.dst, true))
 
-	match = c.router.MatchingMount(ns3Ctx, "auth/bar/baz")
-	if match != ns3.Path+"auth/bar/" {
-		t.Fatalf("auth method not at new location, match: %q", match)
-	}
+			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, "", match, "auth method still at old location, match: %q", match)
 
-	c.sealInternal()
-	for i, key := range keys {
-		unseal, err := TestCoreUnseal(c, key)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if i+1 == len(keys) && !unseal {
-			t.Fatal("should be unsealed")
-		}
-	}
+			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
+			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "auth method not at new location, match: %q", match)
 
-	match = c.router.MatchingMount(ns2Ctx, "auth/foo/bar")
-	if match != "" {
-		t.Fatalf("auth method still at old location after unseal, match: %q", match)
-	}
+			require.NoError(t, c.sealInternal())
+			for i, key := range unsealKeys["root"] {
+				unsealed, err := TestCoreUnseal(c, key)
+				require.NoError(t, err)
+				require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
+			}
 
-	match = c.router.MatchingMount(ns3Ctx, "auth/bar/baz")
-	if match != ns3.Path+"auth/bar/" {
-		t.Fatalf("auth method not at new location after unseal, match: %q", match)
+			for _, ns := range []*namespace.Namespace{tt.src.Namespace, tt.dst.Namespace} {
+				for i, key := range unsealKeys[ns.Path] {
+					unsealed, err := TestNamespaceUnseal(c, ns, key)
+					require.NoError(t, err)
+					require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
+				}
+			}
+
+			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, "", match, "auth method still at old location after unseal, match: %q", match)
+
+			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
+			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "auth method not at new location after unseal, match: %q", match)
+		})
 	}
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -141,6 +141,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	b.Paths = append(b.Paths, b.lockedUserPaths()...)
 	b.Paths = append(b.Paths, b.leasePaths()...)
 	b.Paths = append(b.Paths, b.policyPaths()...)
+	b.Paths = append(b.Paths, b.namespaceSealPaths()...)
 	b.Paths = append(b.Paths, b.namespacePaths()...)
 	b.Paths = append(b.Paths, b.wrappingPaths()...)
 	b.Paths = append(b.Paths, b.toolsPaths()...)

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/barrier"
+)
+
+func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
+	sealStatusSchema := map[string]*framework.FieldSchema{
+		"type": {
+			Type:     framework.TypeString,
+			Required: true,
+		},
+		"initialized": {
+			Type:     framework.TypeBool,
+			Required: true,
+		},
+		"sealed": {
+			Type:     framework.TypeBool,
+			Required: true,
+		},
+		"t": {
+			Type:     framework.TypeInt,
+			Required: true,
+		},
+		"n": {
+			Type:     framework.TypeInt,
+			Required: true,
+		},
+		"progress": {
+			Type:     framework.TypeInt,
+			Required: true,
+		},
+		"nonce": {
+			Type:     framework.TypeString,
+			Required: true,
+		},
+	}
+
+	return []*framework.Path{
+		{
+			Pattern: "namespaces/(?P<path>.+)/unseal",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": namespacePathSchema,
+				"key": {
+					Type:        framework.TypeString,
+					Description: "Specifies a single namespace unseal key share.",
+				},
+				"reset": {
+					Type:        framework.TypeBool,
+					Description: "Specifies whether to reset an unseal process progress.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Unseal a namespace.",
+					Callback: b.handleNamespacesUnseal(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields:      sealStatusSchema,
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
+		},
+	}
+}
+
+// handleNamespacesUnseal handles the "/sys/namespaces/<path>/unseal" endpoint to unseal the namespace.
+func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
+			return nil, errors.New("path must not contain /")
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, path)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", path)
+		}
+
+		resetFlag := data.Get("reset").(bool)
+		if resetFlag {
+			b.Core.sealManager.ResetUnsealProcess(ns.UUID)
+		} else {
+			key := data.Get("key").(string)
+			if key == "" {
+				return nil, errors.New("provided key is empty")
+			}
+
+			var decodedKey []byte
+			decodedKey, err = hex.DecodeString(key)
+			if err != nil {
+				decodedKey, err = base64.StdEncoding.DecodeString(key)
+				if err != nil {
+					return handleError(err)
+				}
+			}
+
+			err = b.Core.namespaceStore.UnsealNamespace(ctx, path, decodedKey)
+			if err != nil {
+				invalidKeyErr := &ErrInvalidKey{}
+				switch {
+				case errors.As(err, &invalidKeyErr):
+				case errors.Is(err, barrier.ErrBarrierInvalidKey):
+				case errors.Is(err, barrier.ErrBarrierNotInit):
+				case errors.Is(err, barrier.ErrBarrierSealed):
+				default:
+					return handleError(logical.CodedError(http.StatusInternalServerError, err.Error()))
+				}
+				return handleError(err)
+			}
+		}
+
+		status, err := b.Core.sealManager.SealStatus(ctx, ns)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"type":        status.Type,
+				"initialized": status.Initialized,
+				"sealed":      status.Sealed,
+				"t":           status.T,
+				"n":           status.N,
+				"progress":    status.Progress,
+				"nonce":       status.Nonce,
+			},
+		}, nil
+	}
+}
+
+var sysNamespacesSealsHelp = map[string][2]string{
+	"namespaces-seal": {
+		"Seal, unseal and check seal status of a namespace.",
+		`
+This path responds to the following HTTP methods.
+
+	POST /<path>/seal
+		Seal a namespace.
+
+	POST /<path>/unseal
+		Unseal a namespace.
+
+	GET /<path>/seal-status
+		Returns the seal status of the namespace.
+
+	GET /<path>/key-status
+		Provides the namespace current backend encryption key term and installation time.
+		`,
+	},
+}

--- a/vault/logical_system_namespaces_seals_test.go
+++ b/vault/logical_system_namespaces_seals_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceBackend_Unseal(t *testing.T) {
+	t.Parallel()
+	c, _, _ := TestCoreUnsealed(t)
+	b := c.systemBackend
+
+	rootCtx := namespace.RootContext(context.Background())
+	t.Run("can unseal namespace with required number of keyshares", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/baz")
+		req.Data["seal"] = map[string]any{"type": "shamir", "secret_shares": 3, "secret_threshold": 2}
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		keyShares := res.Data["key_shares"].([]string)
+		require.Len(t, keyShares, 3)
+
+		ns, err := c.namespaceStore.GetNamespaceByPath(rootCtx, "baz")
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
+
+		// call to sealed namespace should fail
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/child")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.Error(t, err)
+		require.NotNil(t, res.Error())
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/baz/unseal")
+		req.Data["key"] = keyShares[0]
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Data["progress"])
+		require.Equal(t, true, res.Data["sealed"])
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/baz/unseal")
+		req.Data["key"] = keyShares[1]
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		// progress reset
+		require.Equal(t, 0, res.Data["progress"])
+		require.Equal(t, false, res.Data["sealed"])
+
+		// call to unsealed namespace should succeed
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/child")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NotNil(t, res)
+		require.NoError(t, err)
+	})
+
+	// TODO(wslabosz): add additional tests with seal operation
+}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -896,6 +896,19 @@ func (c *Core) loadMounts(ctx context.Context, standby bool) error {
 	return nil
 }
 
+// loadMountsForNamespace is invoked as part of postNamespaceUnseal to
+// load the mounts of a namespace.
+func (c *Core) loadMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	// Check if we're on a non-transactional storage
+	if _, ok := c.barrier.(logical.TransactionalStorage); !ok {
+		return c.loadLegacyMountsForNamespace(ctx, ns)
+	}
+	return c.loadTransactionalMountsForNamespace(ctx, ns)
+}
+
 // loadTransactionalMounts reads the transactional split mount table
 // populates the storage if there are no existing entries.
 func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Storage, standby bool) error {
@@ -1452,6 +1465,32 @@ func (c *Core) setupMounts(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// setupMountsForNamespace is invoked after we've loaded mounts of a namespace
+// to initialize the logical backends and update the router.
+func (c *Core) setupMountsForNamespace(ctx context.Context, ns *namespace.Namespace) ([]func(), error) {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	postUnsealFuncs := make([]func(), 0)
+	for _, entry := range c.mounts.SortEntriesByPath().Entries {
+		// Only process entries with matching namespace ID
+		if entry.NamespaceID != ns.ID {
+			continue
+		}
+
+		postUnsealFunc, err := c.setupMount(ctx, entry)
+		if err != nil {
+			return postUnsealFuncs, err
+		}
+
+		if postUnsealFunc != nil {
+			postUnsealFuncs = append(postUnsealFuncs, postUnsealFunc)
+		}
+	}
+
+	return postUnsealFuncs, nil
 }
 
 // setupMount initializes the logical backend

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -737,137 +737,122 @@ func TestCore_Remount_Protected(t *testing.T) {
 	}
 }
 
-type RemountStruct struct {
-	Title        string
-	SrcParentCtx context.Context
-	DstParentCtx context.Context
-	SrcNS        namespace.MountPathDetails
-	DstNs        namespace.MountPathDetails
-	TestSecret   *logical.Request
-}
+func TestCore_RemountMount_Namespaces(t *testing.T) {
+	c, keys, _ := TestCoreUnsealed(t)
+	ns := &namespace.Namespace{Path: "ns/"}
+	unsealable1 := &namespace.Namespace{Path: "ns/unsealable1/"}
+	unsealable2 := &namespace.Namespace{Path: "ns/unsealable2/"}
+	sealable1 := &namespace.Namespace{Path: "ns/sealable1/"}
+	sealable2 := &namespace.Namespace{Path: "ns/sealable2/"}
+	TestCoreCreateNamespaces(t, c, ns, unsealable1, unsealable2)
+	unsealKeys := TestCoreCreateUnsealedNamespaces(t, c, sealable1, sealable2)
+	unsealKeys["root"] = keys
 
-func TestCore_Remount_Namespaces(t *testing.T) {
-	c, keys, token := TestCoreUnsealed(t)
-	rootCtx := namespace.RootContext(t.Context())
-	ns1 := testCreateNamespace(t, rootCtx, c.systemBackend, "ns1", nil)
-	ns1Ctx := namespace.ContextWithNamespace(rootCtx, ns1)
-	ns2 := testCreateNamespace(t, ns1Ctx, c.systemBackend, "ns2", nil)
-	// ns2Ctx := namespace.ContextWithNamespace(rootCtx, ns2)
-	ns3 := testCreateNamespace(t, ns1Ctx, c.systemBackend, "ns3", nil)
-	// ns3Ctx := namespace.ContextWithNamespace(rootCtx, ns3)
+	me := &routing.MountEntry{
+		Table: routing.MountTableType,
+		Path:  "foo",
+		Type:  "kv",
+	}
 
-	table := []RemountStruct{
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	err := c.mount(namespace.ContextWithNamespace(ctx, unsealable1), me)
+	require.NoError(t, err)
+
+	table := []struct {
+		name string
+		src  namespace.MountPathDetails
+		dst  namespace.MountPathDetails
+	}{
 		{
-			Title:        "Remount Namespace ns1/ns2 to Namespace ns1/ns3",
-			SrcParentCtx: ns1Ctx,
-			SrcNS: namespace.MountPathDetails{
-				Namespace: ns2,
-				MountPath: "secret/",
+			name: "remount unsealable -> unsealable",
+			src: namespace.MountPathDetails{
+				Namespace: unsealable1,
+				MountPath: "foo/",
 			},
-			DstParentCtx: ns1Ctx,
-			DstNs: namespace.MountPathDetails{
-				Namespace: ns3,
-				MountPath: "secret1/",
+			dst: namespace.MountPathDetails{
+				Namespace: unsealable2,
+				MountPath: "bar/",
 			},
 		},
 		{
-			Title:        "Remount Namespace ns1 to Root",
-			SrcParentCtx: rootCtx,
-			SrcNS: namespace.MountPathDetails{
-				Namespace: ns1,
-				MountPath: "secret/",
+			name: "remount unsealable -> sealable",
+			src: namespace.MountPathDetails{
+				Namespace: unsealable2,
+				MountPath: "bar/",
 			},
-			DstParentCtx: rootCtx,
-			DstNs: namespace.MountPathDetails{
-				Namespace: namespace.RootNamespace,
-				MountPath: "secret2/",
+			dst: namespace.MountPathDetails{
+				Namespace: sealable1,
+				MountPath: "foo/",
 			},
 		},
 		{
-			Title:        "Remount Root to Root",
-			SrcParentCtx: rootCtx,
-			SrcNS: namespace.MountPathDetails{
-				Namespace: namespace.RootNamespace,
-				MountPath: "secret/",
+			name: "remount sealable -> sealable",
+			src: namespace.MountPathDetails{
+				Namespace: sealable1,
+				MountPath: "foo/",
 			},
-			DstParentCtx: rootCtx,
-			DstNs: namespace.MountPathDetails{
-				Namespace: namespace.RootNamespace,
-				MountPath: "secretFoo/",
+			dst: namespace.MountPathDetails{
+				Namespace: sealable2,
+				MountPath: "bar/",
 			},
 		},
 		{
-			Title:        "Remount Root to Namespace ns1/ns2",
-			SrcParentCtx: rootCtx,
-			SrcNS: namespace.MountPathDetails{
-				Namespace: namespace.RootNamespace,
-				MountPath: "secretFoo/", // Note that this is depending on previous test case
+			name: "remount sealable -> unsealable",
+			src: namespace.MountPathDetails{
+				Namespace: sealable2,
+				MountPath: "bar/",
 			},
-			DstParentCtx: ns1Ctx,
-			DstNs: namespace.MountPathDetails{
-				Namespace: ns2,
-				MountPath: "secret3/",
+			dst: namespace.MountPathDetails{
+				Namespace: unsealable1,
+				MountPath: "foo/",
 			},
 		},
 	}
 
-	for _, test := range table {
-		t.Run(test.Title, func(t *testing.T) {
-			src := test.SrcNS
-			dst := test.DstNs
-
-			srcNSCtx := namespace.ContextWithNamespace(test.SrcParentCtx, src.Namespace)
-			dstNSCtx := namespace.ContextWithNamespace(test.DstParentCtx, dst.Namespace)
-
-			srcMountPath := src.MountPath
-			dstMountPath := dst.MountPath
-
-			// Create a secret in the source namespace
-			// Already present in root
-			if src.Namespace != namespace.RootNamespace {
-				testCoreAddSecretMountContext(srcNSCtx, t, c, srcMountPath, token)
-			}
-
-			match := c.router.MatchingMount(srcNSCtx, srcMountPath+"bar")
-			if match != src.Namespace.Path+srcMountPath {
-				t.Fatalf("missing mount, match %q", match)
-			}
-
-			err := c.remountSecretsEngine(test.SrcParentCtx, src, dst, true)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-
-			match = c.router.MatchingMount(srcNSCtx, srcMountPath+"bar")
-			if match != "" {
-				t.Fatalf("secret still at old location, match %q", match)
-			}
-
-			match = c.router.MatchingMount(dstNSCtx, dstMountPath+"bar")
-			if match != dst.Namespace.Path+dstMountPath {
-				t.Fatalf("secret not at new location, match %q", match)
-			}
-
-			c.sealInternal()
-			for i, key := range keys {
-				unseal, err := TestCoreUnseal(c, key)
-				if err != nil {
-					t.Fatalf("err: %v", err)
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, ns := range []*namespace.Namespace{tt.src.Namespace, tt.dst.Namespace} {
+				for i, key := range unsealKeys[ns.Path] {
+					unsealed, err := TestNamespaceUnseal(c, ns, key)
+					require.NoError(t, err)
+					require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
 				}
-				if i+1 == len(keys) && !unseal {
-					t.Fatal("should be unsealed")
+			}
+			srcCtx := namespace.ContextWithNamespace(ctx, tt.src.Namespace)
+			dstCtx := namespace.ContextWithNamespace(ctx, tt.dst.Namespace)
+
+			match := c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, tt.src.Namespace.Path+tt.src.MountPath, match, "missing mount, match: %q", match)
+
+			err := c.remountSecretsEngine(ctx, tt.src, tt.dst, true)
+			require.NoError(t, err)
+
+			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, "", match, "mount still at old location, match: %q", match)
+
+			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
+			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "mount not at new location, match: %q", match)
+
+			_ = c.sealInternal()
+			for i, key := range unsealKeys["root"] {
+				unsealed, err := TestCoreUnseal(c, key)
+				require.NoError(t, err)
+				require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
+			}
+
+			for _, ns := range []*namespace.Namespace{tt.src.Namespace, tt.dst.Namespace} {
+				for i, key := range unsealKeys[ns.Path] {
+					unsealed, err := TestNamespaceUnseal(c, ns, key)
+					require.NoError(t, err)
+					require.False(t, i+1 == len(keys) && !unsealed, "should be unsealed")
 				}
 			}
 
-			match = c.router.MatchingMount(srcNSCtx, srcMountPath+"bar")
-			if match != "" {
-				t.Fatalf("secret still at old location after unseal, match %q", match)
-			}
+			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
+			require.Equalf(t, "", match, "mount still at old location after unseal, match: %q", match)
 
-			match = c.router.MatchingMount(dstNSCtx, dstMountPath+"bar")
-			if match != dst.Namespace.Path+dstMountPath {
-				t.Fatalf("secret not at new location after unseal, match %q", match)
-			}
+			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
+			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "mount not at new location after unseal, match: %q", match)
 		})
 	}
 }

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -995,6 +995,75 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 	return errs
 }
 
+// UnsealNamespace attempts unsealing namespace with a given path, using provided unseal key.
+func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key []byte) error {
+	defer metrics.MeasureSince([]string{"namespace", "unseal_namespace"}, time.Now())
+
+	namespaceToUnseal, err := ns.GetNamespaceByPath(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	if namespaceToUnseal == nil {
+		return fmt.Errorf("namespace %q not found", path)
+	}
+
+	if namespaceToUnseal.ID == namespace.RootNamespaceID {
+		return errors.New("cannot unseal root namespace with this operation")
+	}
+
+	_, err = ns.unsealNamespace(ctx, namespaceToUnseal, key)
+	return err
+}
+
+func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal *namespace.Namespace, key []byte) (bool, error) {
+	// Namespace wasn't sealed before the call.
+	if !ns.core.NamespaceSealed(namespaceToUnseal) {
+		return true, nil
+	}
+
+	unsealed, err := ns.core.sealManager.UnsealNamespace(ctx, namespaceToUnseal, key)
+	if err != nil {
+		return false, err
+	}
+
+	// We do not have enough shards yet, namespace is still sealed, return early.
+	if !unsealed {
+		return unsealed, nil
+	}
+
+	return unsealed, ns.postNamespaceUnseal(ctx, namespaceToUnseal)
+}
+
+// postNamespaceUnseal loads namespace credential and secret mounts,
+// initializes the backends and updates the router.
+func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) error {
+	if err := ns.core.loadMountsForNamespace(ctx, unsealedNamespace); err != nil {
+		return err
+	}
+
+	var postUnsealFuncs []func()
+	if postUnsealMountFuncs, err := ns.core.setupMountsForNamespace(ctx, unsealedNamespace); err != nil {
+		return err
+	} else {
+		postUnsealFuncs = append(postUnsealFuncs, postUnsealMountFuncs...)
+	}
+
+	if err := ns.core.loadCredentialsForNamespace(ctx, unsealedNamespace); err != nil {
+		return err
+	}
+
+	if postUnsealCredFuncs, err := ns.core.setupCredentialsForNamespace(ctx, unsealedNamespace); err != nil {
+		return err
+	} else {
+		postUnsealFuncs = append(postUnsealFuncs, postUnsealCredFuncs...)
+	}
+
+	// now we run the collected post unseal functions to finalize unsealing
+	ns.core.runPostUnsealFuncs(postUnsealFuncs)
+	return nil
+}
+
 // taintNamespace is used to taint the namespace designated to be deleted.
 func (ns *NamespaceStore) taintNamespace(ctx context.Context, parent, namespaceToTaint *namespace.Namespace) error {
 	// to be extra safe

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -313,12 +313,24 @@ func (sm *SealManager) SealStatus(ctx context.Context, ns *namespace.Namespace) 
 	}, nil
 }
 
+// UnsealNamespace unseals the barrier of the given namespace
+// using provided key shares.
+func (sm *SealManager) UnsealNamespace(ctx context.Context, ns *namespace.Namespace, key []byte) (bool, error) {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	barrier := sm.namespaceBarrier(ns.Path)
+	if barrier == nil {
+		return false, ErrNotSealable
+	}
+
+	return sm.unsealFragment(ctx, ns, barrier, key)
+}
+
 // unsealFragment verifies and records one part of the unseal shares,
 // and attempts to unseal the namespace.
 func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespace, b barrier.SecurityBarrier, key []byte) (bool, error) {
 	sm.logger.Debug("namespace unseal key supplied")
-	sm.lock.Lock()
-	defer sm.lock.Unlock()
 
 	// Check if already unsealed
 	if !b.Sealed() {

--- a/vault/seal_manager_test.go
+++ b/vault/seal_manager_test.go
@@ -267,11 +267,11 @@ func TestSealManager_UnsealBarrier(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, b.Sealed())
 
-	unsealed, err := c.sealManager.unsealFragment(ctx, ns, b, keyShares[0])
+	unsealed, err := c.sealManager.UnsealNamespace(ctx, ns, keyShares[0])
 	require.NoError(t, err)
 	require.False(t, unsealed)
 
-	unsealed, err = c.sealManager.unsealFragment(ctx, ns, b, keyShares[1])
+	unsealed, err = c.sealManager.UnsealNamespace(ctx, ns, keyShares[1])
 	require.NoError(t, err)
 	require.True(t, unsealed)
 	require.False(t, b.Sealed())

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -317,6 +317,10 @@ func TestCoreSeal(core *Core) error {
 	return core.sealInternal()
 }
 
+func TestNamespaceUnseal(core *Core, ns *namespace.Namespace, key []byte) (bool, error) {
+	return core.namespaceStore.unsealNamespace(namespace.ContextWithNamespace(context.Background(), ns), ns, TestKeyCopy(key))
+}
+
 func TestCoreCreateNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) {
 	t.Helper()
 	ctx := namespace.RootContext(context.Background())
@@ -328,6 +332,49 @@ func TestCoreCreateNamespaces(t testing.T, core *Core, namespaces ...*namespace.
 		err = core.namespaceStore.SetNamespace(parentCtx, ns)
 		require.NoError(t, err)
 	}
+}
+
+// TestCoreCreateSealedNamespaces creates sealed namespaces with 3 key shares and
+// returns the key shares for each namespace in a map with namespace path as key.
+func TestCoreCreateSealedNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) map[string][][]byte {
+	t.Helper()
+	sealConfig := &SealConfig{
+		Type:            "shamir",
+		SecretShares:    3,
+		SecretThreshold: 3,
+	}
+	ctx := namespace.RootContext(context.Background())
+	keysPerNamespace := make(map[string][][]byte)
+	for _, ns := range namespaces {
+		parentPath, _ := ns.ParentPath()
+		parent, err := core.namespaceStore.GetNamespaceByPath(ctx, parentPath)
+		require.NoError(t, err)
+
+		nsSealKeyShares, err := core.namespaceStore.SetNamespaceWithSeal(namespace.ContextWithNamespace(ctx, parent), ns, sealConfig)
+		require.NoError(t, err)
+		keysPerNamespace[ns.Path] = nsSealKeyShares
+	}
+	return keysPerNamespace
+}
+
+// TestCoreCreateUnsealedNamespaces creates sealed namespaces with 3 key shares.
+// unseals the namespaces and returns back the key shares for each namespace
+// in a map with namespace path as key.
+func TestCoreCreateUnsealedNamespaces(t testing.T, core *Core, namespaces ...*namespace.Namespace) map[string][][]byte {
+	t.Helper()
+	keyShares := TestCoreCreateSealedNamespaces(t, core, namespaces...)
+	for _, ns := range namespaces {
+		for _, key := range keyShares[ns.Path] {
+			unsealed, err := TestNamespaceUnseal(core, ns, key)
+			require.NoError(t, err)
+			if unsealed {
+				break
+			}
+		}
+
+		require.False(t, core.NamespaceSealed(ns))
+	}
+	return keyShares
 }
 
 // TestCoreUnsealed returns a pure in-memory core that is already


### PR DESCRIPTION
## Description
- added [logical_system_namespaces_seals.go‎](https://github.com/openbao/openbao/pull/2836/changes/6c77d883892115374daf470b7da209826f0ecd2b#diff-a9b63d42c00ac8767e7754a43f927cdc488c23c693907016b0624dd1ff5feb64) with (for now) namespace unseal endpoint
- added load/setup(Mounts/Credentials)ForNamespace methods
- added namespace unseal handling logic in `namespace_store.go`

## Rationale
Implements namespace unsealing logic in similar way as the root namespace (core) unseal semantics. 

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
