### PR TITLE
refactor: use testify require/assert consistently in sdk tests

### DIFF
--- a/sdk/helper/shamir/shamir_test.go
+++ b/sdk/helper/shamir/shamir_test.go
@@ -4,93 +4,76 @@
 package shamir
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplit_invalid(t *testing.T) {
 	secret := []byte("test")
 
-	if _, err := Split(secret, 0, 0); err == nil {
-		t.Fatal("expect error")
-	}
+	_, err := Split(secret, 0, 0)
+	require.Error(t, err)
 
-	if _, err := Split(secret, 2, 3); err == nil {
-		t.Fatal("expect error")
-	}
+	_, err = Split(secret, 2, 3)
+	require.Error(t, err)
 
-	if _, err := Split(secret, 1000, 3); err == nil {
-		t.Fatal("expect error")
-	}
+	_, err = Split(secret, 1000, 3)
+	require.Error(t, err)
 
-	if _, err := Split(secret, 10, 1); err == nil {
-		t.Fatal("expect error")
-	}
+	_, err = Split(secret, 10, 1)
+	require.Error(t, err)
 
-	if _, err := Split(nil, 3, 2); err == nil {
-		t.Fatal("expect error")
-	}
+	_, err = Split(nil, 3, 2)
+	require.Error(t, err)
 }
 
 func TestSplit(t *testing.T) {
 	secret := []byte("test")
 
 	out, err := Split(secret, 5, 3)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if len(out) != 5 {
-		t.Fatalf("bad: %v", out)
-	}
+	require.NoError(t, err)
+	require.Len(t, out, 5)
 
 	for _, share := range out {
-		if len(share) != len(secret)+1 {
-			t.Fatalf("bad: %v", out)
-		}
+		require.Len(t, share, len(secret)+1)
 	}
 }
 
 func TestCombine_invalid(t *testing.T) {
 	// Not enough parts
-	if _, err := Combine(nil); err == nil {
-		t.Fatal("should err")
-	}
+	_, err := Combine(nil)
+	require.Error(t, err)
 
 	// Mis-match in length
 	parts := [][]byte{
 		[]byte("foo"),
 		[]byte("ba"),
 	}
-	if _, err := Combine(parts); err == nil {
-		t.Fatal("should err")
-	}
+	_, err = Combine(parts)
+	require.Error(t, err)
 
 	// Too short
 	parts = [][]byte{
 		[]byte("f"),
 		[]byte("b"),
 	}
-	if _, err := Combine(parts); err == nil {
-		t.Fatal("should err")
-	}
+	_, err = Combine(parts)
+	require.Error(t, err)
 
 	parts = [][]byte{
 		[]byte("foo"),
 		[]byte("foo"),
 	}
-	if _, err := Combine(parts); err == nil {
-		t.Fatal("should err")
-	}
+	_, err = Combine(parts)
+	require.Error(t, err)
 }
 
 func TestCombine(t *testing.T) {
 	secret := []byte("test")
 
 	out, err := Split(secret, 5, 3)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	// There is 5*4*3 possible choices,
 	// we will just brute force try them all
@@ -106,106 +89,55 @@ func TestCombine(t *testing.T) {
 
 				parts := [][]byte{out[i], out[j], out[k]}
 				recomb, err := Combine(parts)
-				if err != nil {
-					t.Fatalf("err: %v", err)
-				}
-
-				if !bytes.Equal(recomb, secret) {
-					t.Errorf("parts: (i:%d, j:%d, k:%d) %v", i, j, k, parts)
-					t.Fatalf("bad: %v %v", recomb, secret)
-				}
+				require.NoError(t, err)
+				require.Equal(t, secret, recomb, "parts: (i:%d, j:%d, k:%d)", i, j, k)
 			}
 		}
 	}
 }
 
 func TestField_Add(t *testing.T) {
-	if out := add(16, 16); out != 0 {
-		t.Fatalf("Bad: %v 16", out)
-	}
-
-	if out := add(3, 4); out != 7 {
-		t.Fatalf("Bad: %v 7", out)
-	}
+	require.Equal(t, uint8(0), add(16, 16))
+	require.Equal(t, uint8(7), add(3, 4))
 }
 
 func TestField_Mult(t *testing.T) {
-	if out := mult(3, 7); out != 9 {
-		t.Fatalf("Bad: %v 9", out)
-	}
-
-	if out := mult(3, 0); out != 0 {
-		t.Fatalf("Bad: %v 0", out)
-	}
-
-	if out := mult(0, 3); out != 0 {
-		t.Fatalf("Bad: %v 0", out)
-	}
+	require.Equal(t, uint8(9), mult(3, 7))
+	require.Equal(t, uint8(0), mult(3, 0))
+	require.Equal(t, uint8(0), mult(0, 3))
 }
 
 func TestField_Divide(t *testing.T) {
-	if out := div(0, 7); out != 0 {
-		t.Fatalf("Bad: %v 0", out)
-	}
-
-	if out := div(3, 3); out != 1 {
-		t.Fatalf("Bad: %v 1", out)
-	}
-
-	if out := div(6, 3); out != 2 {
-		t.Fatalf("Bad: %v 2", out)
-	}
+	require.Equal(t, uint8(0), div(0, 7))
+	require.Equal(t, uint8(1), div(3, 3))
+	require.Equal(t, uint8(2), div(6, 3))
 }
 
 func TestPolynomial_Random(t *testing.T) {
 	p, err := makePolynomial(42, 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if p.coefficients[0] != 42 {
-		t.Fatalf("bad: %v", p.coefficients)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint8(42), p.coefficients[0])
 }
 
 func TestPolynomial_Eval(t *testing.T) {
 	p, err := makePolynomial(42, 1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
-	func() {
-		defer func() {
-			r := recover()
-			if r == nil {
-				t.Fatal("expected panic trying to call p.evaluate(0)")
-			}
-		}()
-
-		if out := p.evaluate(0); out != 42 {
-			t.Fatalf("bad: %v", out)
-		}
-	}()
+	require.Panics(t, func() { p.evaluate(0) }, "expected panic trying to call p.evaluate(0)")
 
 	out := p.evaluate(1)
 	exp := add(42, mult(1, p.coefficients[1]))
-	if out != exp {
-		t.Fatalf("bad: %v %v %v", out, exp, p.coefficients)
-	}
+	require.Equal(t, exp, out)
 }
 
 func TestInterpolate_Rand(t *testing.T) {
 	for i := range 256 {
 		p, err := makePolynomial(uint8(i), 2)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		require.NoError(t, err)
 
 		x_vals := []uint8{1, 2, 3}
 		y_vals := []uint8{p.evaluate(1), p.evaluate(2), p.evaluate(3)}
 		out := interpolatePolynomial(x_vals, y_vals, 0)
-		if out != uint8(i) {
-			t.Fatalf("Bad: %v %d", out, i)
-		}
+		require.Equal(t, uint8(i), out)
 	}
 }

--- a/sdk/logical/lease_test.go
+++ b/sdk/logical/lease_test.go
@@ -6,6 +6,8 @@ package logical
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLeaseOptionsLeaseTotal(t *testing.T) {
@@ -13,10 +15,7 @@ func TestLeaseOptionsLeaseTotal(t *testing.T) {
 	l.TTL = 1 * time.Hour
 
 	actual := l.LeaseTotal()
-	expected := l.TTL
-	if actual != expected {
-		t.Fatalf("bad: %s", actual)
-	}
+	require.Equal(t, l.TTL, actual)
 }
 
 func TestLeaseOptionsLeaseTotal_grace(t *testing.T) {
@@ -24,9 +23,7 @@ func TestLeaseOptionsLeaseTotal_grace(t *testing.T) {
 	l.TTL = 1 * time.Hour
 
 	actual := l.LeaseTotal()
-	if actual != l.TTL {
-		t.Fatalf("bad: %s", actual)
-	}
+	require.Equal(t, l.TTL, actual)
 }
 
 func TestLeaseOptionsLeaseTotal_negLease(t *testing.T) {
@@ -34,10 +31,7 @@ func TestLeaseOptionsLeaseTotal_negLease(t *testing.T) {
 	l.TTL = -1 * 1 * time.Hour
 
 	actual := l.LeaseTotal()
-	expected := time.Duration(0)
-	if actual != expected {
-		t.Fatalf("bad: %s", actual)
-	}
+	require.Equal(t, time.Duration(0), actual)
 }
 
 func TestLeaseOptionsExpirationTime(t *testing.T) {
@@ -46,14 +40,10 @@ func TestLeaseOptionsExpirationTime(t *testing.T) {
 
 	limit := time.Now().Add(time.Hour)
 	exp := l.ExpirationTime()
-	if exp.Before(limit) {
-		t.Fatalf("bad: %s", exp)
-	}
+	require.False(t, exp.Before(limit), "expiration time %s should not be before %s", exp, limit)
 }
 
 func TestLeaseOptionsExpirationTime_noLease(t *testing.T) {
 	var l LeaseOptions
-	if !l.ExpirationTime().IsZero() {
-		t.Fatal("should be zero")
-	}
+	require.True(t, l.ExpirationTime().IsZero(), "should be zero")
 }

--- a/sdk/logical/logical_storage_test.go
+++ b/sdk/logical/logical_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical/file"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -76,21 +77,16 @@ func makeStorage(t *testing.T) Storage {
 	b, err := file.NewFileBackend(map[string]string{
 		"path": dir,
 	}, logger)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	return NewLogicalStorage(b)
 }
 
 func makeTxStorage(t *testing.T) Transaction {
 	logicalStorage := makeStorage(t)
-	if txStorage, ok := logicalStorage.(TransactionalStorage); ok {
-		txn, err := txStorage.BeginTx(t.Context())
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		return txn
-	}
-	t.Fatalf("storage is not transactional")
-	return nil
+	txStorage, ok := logicalStorage.(TransactionalStorage)
+	require.True(t, ok, "storage is not transactional")
+
+	txn, err := txStorage.BeginTx(t.Context())
+	require.NoError(t, err)
+	return txn
 }

--- a/sdk/logical/response_util_test.go
+++ b/sdk/logical/response_util_test.go
@@ -5,8 +5,9 @@ package logical
 
 import (
 	"errors"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponseUtil_RespondErrorCommon_basic(t *testing.T) {
@@ -87,19 +88,14 @@ func TestResponseUtil_RespondErrorCommon_basic(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			var status int
-			var err, respErr error
+			var respErr error
 			if tc.respErr != nil {
 				respErr = tc.respErr
 			}
-			status, err = RespondErrorCommon(tc.req, tc.resp, respErr)
-			if status != tc.expectedStatus {
-				t.Fatalf("Expected (%d) status code, got (%d)", tc.expectedStatus, status)
-			}
+			status, err := RespondErrorCommon(tc.req, tc.resp, respErr)
+			require.Equal(t, tc.expectedStatus, status)
 			if tc.expectedErr != nil {
-				if !strings.Contains(tc.expectedErr.Error(), err.Error()) {
-					t.Fatalf("Expected error to contain:\n%s\n\ngot:\n%s\n", tc.expectedErr, err)
-				}
+				require.Contains(t, tc.expectedErr.Error(), err.Error())
 			}
 		})
 	}

--- a/sdk/logical/storage_test.go
+++ b/sdk/logical/storage_test.go
@@ -5,12 +5,11 @@ package logical
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,13 +33,8 @@ func TestScanView(t *testing.T) {
 	err := ScanView(t.Context(), s, func(path string) {
 		keys = append(keys, path)
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := deep.Equal(keys, keyList); diff != nil {
-		t.Fatal(diff)
-	}
+	require.NoError(t, err)
+	require.Equal(t, keyList, keys)
 }
 
 func TestScanView_CancelContext(t *testing.T) {
@@ -53,12 +47,8 @@ func TestScanView_CancelContext(t *testing.T) {
 		i++
 	})
 
-	if err == nil {
-		t.Error("Want context cancel err, got none")
-	}
-	if i != 1 {
-		t.Errorf("Want i==1, got %d", i)
-	}
+	assert.Error(t, err, "Want context cancel err, got none")
+	assert.Equal(t, 1, i, "Want i==1")
 }
 
 func TestScanViewPaginated(t *testing.T) {
@@ -68,13 +58,8 @@ func TestScanViewPaginated(t *testing.T) {
 	err := ScanViewWithLogger(t.Context(), s, nil, func(path string) {
 		keys = append(keys, path)
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := deep.Equal(keys, keyList); diff != nil {
-		t.Fatal(diff)
-	}
+	require.NoError(t, err)
+	require.Equal(t, keyList, keys)
 
 	// Validate that recursing into a folder which only has references to
 	// itself and/or files which bear the same name works.
@@ -86,17 +71,13 @@ func TestScanViewPaginated(t *testing.T) {
 			keys = append(keys, path)
 			return true, nil
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		trimmedExpected := make([]string, 0)
 		for _, path := range keyList[len(keyList)-3:] {
-			trimmedExpected = append(trimmedExpected, strings.TrimPrefix(path, "bar/"))
+			trimmedExpected = append(trimmedExpected, path[len("bar/"):])
 		}
-		if diff := deep.Equal(keys, trimmedExpected); diff != nil {
-			t.Fatalf("page size: %v\ndiff: %v\n\tkeys: %v\n\texpected: %v", pageSize, diff, keys, trimmedExpected)
-		}
+		require.Equal(t, trimmedExpected, keys, "page size: %v", pageSize)
 	}
 }
 
@@ -104,32 +85,22 @@ func TestCollectKeys(t *testing.T) {
 	s := prepKeyStorage(t)
 
 	keys, err := CollectKeys(t.Context(), s)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := deep.Equal(keys, keyList); diff != nil {
-		t.Fatal(diff)
-	}
+	require.NoError(t, err)
+	require.Equal(t, keyList, keys)
 }
 
 func TestCollectKeysPrefix(t *testing.T) {
 	s := prepKeyStorage(t)
 
 	keys, err := CollectKeysWithPrefix(t.Context(), s, "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	exp := []string{
 		"foo",
 		"foo42",
 		"foo/a/b/c",
 	}
-
-	if diff := deep.Equal(keys, exp); diff != nil {
-		t.Fatal(diff)
-	}
+	require.Equal(t, exp, keys)
 }
 
 func TestClearView(t *testing.T) {
@@ -219,13 +190,12 @@ func prepKeyStorage(t *testing.T) Storage {
 	s := &InmemStorage{}
 
 	for _, key := range keyList {
-		if err := s.Put(t.Context(), &StorageEntry{
+		err := s.Put(t.Context(), &StorageEntry{
 			Key:      key,
 			Value:    nil,
 			SealWrap: false,
-		}); err != nil {
-			t.Fatal(err)
-		}
+		})
+		require.NoError(t, err)
 	}
 
 	return s

--- a/sdk/logical/token_test.go
+++ b/sdk/logical/token_test.go
@@ -8,43 +8,30 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONSerialization(t *testing.T) {
 	tt := TokenTypeDefaultBatch
 	s, err := json.Marshal(tt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var utt TokenType
 	err = json.Unmarshal(s, &utt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if tt != utt {
-		t.Fatalf("expected %v, got %v", tt, utt)
-	}
+	require.NoError(t, err)
+	require.Equal(t, tt, utt)
 
 	utt = TokenTypeDefault
 	err = json.Unmarshal([]byte(`"default-batch"`), &utt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tt != utt {
-		t.Fatalf("expected %v, got %v", tt, utt)
-	}
+	require.NoError(t, err)
+	require.Equal(t, tt, utt)
 
 	// Test on an empty value, which should unmarshal into TokenTypeDefault
 	tt = TokenTypeDefault
 	err = json.Unmarshal([]byte(`""`), &utt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tt != utt {
-		t.Fatalf("expected %v, got %v", tt, utt)
-	}
+	require.NoError(t, err)
+	require.Equal(t, tt, utt)
 }
 
 // TestCreateClientID verifies that CreateClientID uses the entity ID for a token
@@ -52,55 +39,43 @@ func TestJSONSerialization(t *testing.T) {
 func TestCreateClientID(t *testing.T) {
 	entry := TokenEntry{NamespaceID: "namespaceFoo", Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE := entry.CreateClientID()
-	if !isTWE {
-		t.Fatal("TWE token should return true value in isTWE bool")
-	}
+	require.True(t, isTWE, "TWE token should return true value in isTWE bool")
+
 	expectedIDPlaintext := "banana" + string(SortedPoliciesTWEDelimiter) + "bar" +
 		string(SortedPoliciesTWEDelimiter) + "baz" +
 		string(SortedPoliciesTWEDelimiter) + "foo" + string(ClientIDTWEDelimiter) + "namespaceFoo"
 
 	hashed := sha256.Sum256([]byte(expectedIDPlaintext))
 	expectedID := base64.StdEncoding.EncodeToString(hashed[:])
-	if expectedID != id {
-		t.Fatalf("wrong ID: expected %s, found %s", expectedID, id)
-	}
+	require.Equal(t, expectedID, id)
+
 	// Test with entityID
 	entry = TokenEntry{EntityID: "entityFoo", NamespaceID: "namespaceFoo", Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE = entry.CreateClientID()
-	if isTWE {
-		t.Fatal("token with entity should return false value in isTWE bool")
-	}
-	if id != "entityFoo" {
-		t.Fatal("client ID should be entity ID")
-	}
+	require.False(t, isTWE, "token with entity should return false value in isTWE bool")
+	require.Equal(t, "entityFoo", id, "client ID should be entity ID")
 
 	// Test without namespace
 	entry = TokenEntry{Policies: []string{"bar", "baz", "foo", "banana"}}
 	id, isTWE = entry.CreateClientID()
-	if !isTWE {
-		t.Fatal("TWE token should return true value in isTWE bool")
-	}
+	require.True(t, isTWE, "TWE token should return true value in isTWE bool")
+
 	expectedIDPlaintext = "banana" + string(SortedPoliciesTWEDelimiter) + "bar" +
 		string(SortedPoliciesTWEDelimiter) + "baz" +
 		string(SortedPoliciesTWEDelimiter) + "foo" + string(ClientIDTWEDelimiter)
 
 	hashed = sha256.Sum256([]byte(expectedIDPlaintext))
 	expectedID = base64.StdEncoding.EncodeToString(hashed[:])
-	if expectedID != id {
-		t.Fatalf("wrong ID: expected %s, found %s", expectedID, id)
-	}
+	require.Equal(t, expectedID, id)
 
 	// Test without policies
 	entry = TokenEntry{NamespaceID: "namespaceFoo"}
 	id, isTWE = entry.CreateClientID()
-	if !isTWE {
-		t.Fatal("TWE token should return true value in isTWE bool")
-	}
+	require.True(t, isTWE, "TWE token should return true value in isTWE bool")
+
 	expectedIDPlaintext = "namespaceFoo"
 
 	hashed = sha256.Sum256([]byte(expectedIDPlaintext))
 	expectedID = base64.StdEncoding.EncodeToString(hashed[:])
-	if expectedID != id {
-		t.Fatalf("wrong ID: expected %s, found %s", expectedID, id)
-	}
+	require.Equal(t, expectedID, id)
 }


### PR DESCRIPTION
## Summary

Addresses #2736 — replaces manual `if err != nil { t.Fatalf(...) }` and similar patterns with testify `require` and `assert` calls in SDK test packages.

### Packages updated

- **sdk/helper/shamir**: Converted all 32 manual assertion patterns to `require.*`
- **sdk/logical**: Converted across 5 test files (token_test, storage_test, lease_test, logical_storage_test, response_util_test) — ~38 patterns total

### Approach

- `t.Fatal` / `t.Fatalf` → `require.*` (test-stopping assertions)
- `t.Error` / `t.Errorf` → `assert.*` (non-fatal assertions)
- Removed unused `go-test/deep` and `strings` imports where no longer needed
- Replaced `defer/recover` panic check with `require.Panics`
- Preserved test semantics — no behavioral changes

### Test plan

- [ ] CI passes for `sdk/helper/shamir` tests
- [ ] CI passes for `sdk/logical` tests