### PR TITLE
feat(api): add namespace CRUD helpers to Sys client

### DIFF
--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -1,0 +1,144 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// ListNamespaces lists all available namespaces.
+func (c *Sys) ListNamespaces() (map[string]*Namespace, error) {
+	return c.ListNamespacesWithContext(context.Background())
+}
+
+// ListNamespacesWithContext lists all available namespaces.
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*Namespace, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/namespaces")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	namespaces := map[string]*Namespace{}
+	err = mapstructure.Decode(secret.Data, &namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaces, nil
+}
+
+// GetNamespace retrieves details about a specific namespace at the given path.
+func (c *Sys) GetNamespace(path string) (*Namespace, error) {
+	return c.GetNamespaceWithContext(context.Background(), path)
+}
+
+// GetNamespaceWithContext retrieves details about a specific namespace at the given path.
+func (c *Sys) GetNamespaceWithContext(ctx context.Context, path string) (*Namespace, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	var result Namespace
+	err = mapstructure.Decode(secret.Data, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CreateNamespace creates a new namespace at the given path.
+func (c *Sys) CreateNamespace(path string, ns *NamespaceInput) error {
+	return c.CreateNamespaceWithContext(context.Background(), path, ns)
+}
+
+// CreateNamespaceWithContext creates a new namespace at the given path.
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, ns *NamespaceInput) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	if err := r.SetJSONBody(ns); err != nil {
+		return err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	return nil
+}
+
+// DeleteNamespace deletes the namespace at the given path.
+func (c *Sys) DeleteNamespace(path string) error {
+	return c.DeleteNamespaceWithContext(context.Background(), path)
+}
+
+// DeleteNamespaceWithContext deletes the namespace at the given path.
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	return nil
+}
+
+// NamespaceInput represents the input for creating or updating a namespace.
+type NamespaceInput struct {
+	// CustomMetadata is metadata for the namespace that is persisted to storage.
+	CustomMetadata map[string]string `json:"custom_metadata,omitempty" mapstructure:"custom_metadata"`
+}
+
+// Namespace represents a namespace in OpenBao.
+type Namespace struct {
+	// ID is the unique identifier of the namespace.
+	ID string `json:"id" mapstructure:"id"`
+	// Path is the path of the namespace.
+	Path string `json:"path" mapstructure:"path"`
+	// CustomMetadata is the metadata associated with the namespace.
+	CustomMetadata map[string]string `json:"custom_metadata,omitempty" mapstructure:"custom_metadata"`
+}

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSysNamespaces_ListNamespaces(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/sys/namespaces" {
+			t.Fatalf("expected /v1/sys/namespaces, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"admin/": map[string]interface{}{
+				"id":             "some-uuid",
+				"path":           "admin/",
+				"custom_metadata": map[string]string{"team": "ops"},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": resp,
+		})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(&Config{Address: ts.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespaces, err := client.Sys().ListNamespaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(namespaces) != 1 {
+		t.Fatalf("expected 1 namespace, got %d", len(namespaces))
+	}
+
+	ns, ok := namespaces["admin/"]
+	if !ok {
+		t.Fatal("expected admin/ namespace")
+	}
+	if ns.ID != "some-uuid" {
+		t.Fatalf("expected ID some-uuid, got %s", ns.ID)
+	}
+	if ns.Path != "admin/" {
+		t.Fatalf("expected path admin/, got %s", ns.Path)
+	}
+}
+
+func TestSysNamespaces_GetNamespace(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/sys/namespaces/admin" {
+			t.Fatalf("expected /v1/sys/namespaces/admin, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"id":              "some-uuid",
+			"path":            "admin/",
+			"custom_metadata": map[string]string{"team": "ops"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": resp,
+		})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(&Config{Address: ts.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns, err := client.Sys().GetNamespace("admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ns.ID != "some-uuid" {
+		t.Fatalf("expected ID some-uuid, got %s", ns.ID)
+	}
+}
+
+func TestSysNamespaces_CreateNamespace(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/sys/namespaces/admin" {
+			t.Fatalf("expected /v1/sys/namespaces/admin, got %s", r.URL.Path)
+		}
+
+		var input NamespaceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatal(err)
+		}
+		if input.CustomMetadata["team"] != "ops" {
+			t.Fatalf("expected custom_metadata team=ops, got %v", input.CustomMetadata)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(&Config{Address: ts.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.Sys().CreateNamespace("admin", &NamespaceInput{
+		CustomMetadata: map[string]string{"team": "ops"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSysNamespaces_DeleteNamespace(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/sys/namespaces/admin" {
+			t.Fatalf("expected /v1/sys/namespaces/admin, got %s", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(&Config{Address: ts.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.Sys().DeleteNamespace("admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ListNamespaces`, `GetNamespace`, `CreateNamespace`, and `DeleteNamespace` methods to the `Sys` client, following the existing pattern used by mounts and other sys endpoints.

## Changes

- New file `api/sys_namespaces.go` with CRUD methods:
  - `ListNamespaces()` / `ListNamespacesWithContext()` - list all namespaces
  - `GetNamespace(path)` / `GetNamespaceWithContext(ctx, path)` - get namespace details
  - `CreateNamespace(path, input)` / `CreateNamespaceWithContext(ctx, path, input)` - create a namespace
  - `DeleteNamespace(path)` / `DeleteNamespaceWithContext(ctx, path)` - delete a namespace
- New types: `Namespace` and `NamespaceInput`
- Unit tests in `api/sys_namespaces_test.go` covering all 4 operations with httptest server

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v1/sys/namespaces` | List namespaces |
| GET | `/v1/sys/namespaces/:path` | Get namespace |
| POST | `/v1/sys/namespaces/:path` | Create/update namespace |
| DELETE | `/v1/sys/namespaces/:path` | Delete namespace |

## Testing

```
=== RUN   TestSysNamespaces_ListNamespaces
--- PASS
=== RUN   TestSysNamespaces_GetNamespace
--- PASS
=== RUN   TestSysNamespaces_CreateNamespace
--- PASS
=== RUN   TestSysNamespaces_DeleteNamespace
--- PASS
```

Closes: #2821

Signed-off-by: Bahtya <bahtyar153@qq.com>