### PR TITLE
agent: allow changing the uid and gid of a file sink

### DIFF
--- a/changelog/2851.txt
+++ b/changelog/2851.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+agent: Add uid and gid configuration options for the file sink
+```

--- a/changelog/2851.txt
+++ b/changelog/2851.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 agent: Add uid and gid configuration options for the file sink
 ```

--- a/command/agentproxyshared/sink/file/file_sink.go
+++ b/command/agentproxyshared/sink/file/file_sink.go
@@ -19,6 +19,8 @@ import (
 type fileSink struct {
 	path   string
 	mode   os.FileMode
+	uid    int
+	gid    int
 	logger hclog.Logger
 }
 
@@ -33,6 +35,8 @@ func NewFileSink(conf *sink.SinkConfig) (sink.Sink, error) {
 	f := &fileSink{
 		logger: conf.Logger,
 		mode:   0o640,
+		uid:    -1,
+		gid:    -1,
 	}
 
 	pathRaw, ok := conf.Config["path"]
@@ -59,6 +63,28 @@ func NewFileSink(conf *sink.SinkConfig) (sink.Sink, error) {
 
 		f.logger.Debug("overriding default file sink", "mode", mode)
 		f.mode = os.FileMode(mode)
+	}
+
+	if uidRaw, ok := conf.Config["uid"]; ok {
+		f.logger.Debug("verifying override for default file sink uid")
+		uid, typeOK := uidRaw.(int)
+		if !typeOK {
+			return nil, errors.New("could not parse 'uid' as integer")
+		}
+
+		f.logger.Debug("overriding default file sink", "uid", uid)
+		f.uid = uid
+	}
+
+	if gidRaw, ok := conf.Config["gid"]; ok {
+		f.logger.Debug("verifying override for default file sink gid")
+		gid, typeOK := gidRaw.(int)
+		if !typeOK {
+			return nil, errors.New("could not parse 'gid' as integer")
+		}
+
+		f.logger.Debug("overriding default file sink", "gid", gid)
+		f.gid = gid
 	}
 
 	if err := f.WriteToken(""); err != nil {
@@ -119,6 +145,11 @@ func (f *fileSink) WriteToken(token string) error {
 			return fmt.Errorf("error removing temp file %s during write check: %w", tmpFile.Name(), err)
 		}
 		return nil
+	}
+
+	// adjust file ownership if the sink has a none-default uid or gid configuration
+	if err := os.Chown(tmpFile.Name(), f.uid, f.gid); err != nil {
+		return fmt.Errorf("error changing file ownership of %s to uid %d and gid %d: %w", tmpFile.Name(), f.uid, f.gid, err)
 	}
 
 	err = os.Rename(tmpFile.Name(), f.path)

--- a/command/agentproxyshared/sink/file/file_sink_test.go
+++ b/command/agentproxyshared/sink/file/file_sink_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -133,6 +134,74 @@ func TestFileSinkMode(t *testing.T) {
 	}
 	if fi.Mode() != os.FileMode(0o644) {
 		t.Fatalf("wrong file mode was detected at %s", path)
+	}
+
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(fileBytes) != uuidStr {
+		t.Fatalf("expected %s, got %s", uuidStr, string(fileBytes))
+	}
+}
+
+func testFileSinkChown(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s.", fileServerTestDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(tmpDir, "token")
+
+	config := &sink.SinkConfig{
+		Logger: log.Named("sink.file"),
+		Config: map[string]interface{}{
+			"path": path,
+			"uid":  os.Getuid(),
+			"gid":  os.Getgid(),
+		},
+	}
+
+	s, err := NewFileSink(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Sink = s
+
+	return config, tmpDir
+}
+
+func TestFileSinkChown(t *testing.T) {
+	log := logging.NewVaultLogger(hclog.Trace)
+
+	fs, tmpDir := testFileSinkChown(t, log)
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "token")
+
+	uuidStr, _ := uuid.GenerateUUID()
+	if err := fs.WriteToken(uuidStr); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	fi, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat := fi.Sys().(*syscall.Stat_t)
+	if stat.Uid != uint32(os.Getuid()) {
+		t.Fatalf("expected uid %d, got %d", os.Getuid(), stat.Uid)
+	}
+	if stat.Gid != uint32(os.Getgid()) {
+		t.Fatalf("expected gid %d, got %d", os.Getgid(), stat.Gid)
 	}
 
 	fileBytes, err := os.ReadFile(path)

--- a/command/agentproxyshared/sink/file/file_sink_test.go
+++ b/command/agentproxyshared/sink/file/file_sink_test.go
@@ -147,11 +147,7 @@ func TestFileSinkMode(t *testing.T) {
 }
 
 func testFileSinkChown(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
-	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s.", fileServerTestDir))
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "token")
 
 	config := &sink.SinkConfig{
@@ -176,8 +172,6 @@ func TestFileSinkChown(t *testing.T) {
 	log := logging.NewVaultLogger(hclog.Trace)
 
 	fs, tmpDir := testFileSinkChown(t, log)
-	defer os.RemoveAll(tmpDir)
-
 	path := filepath.Join(tmpDir, "token")
 
 	uuidStr, _ := uuid.GenerateUUID()

--- a/command/agentproxyshared/sink/file/file_sink_test.go
+++ b/command/agentproxyshared/sink/file/file_sink_test.go
@@ -183,7 +183,7 @@ func TestFileSinkChown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	fi, err := file.Stat()
 	if err != nil {

--- a/website/content/docs/agent-and-proxy/autoauth/sinks/file.mdx
+++ b/website/content/docs/agent-and-proxy/autoauth/sinks/file.mdx
@@ -21,6 +21,8 @@ written with `0640` permissions as default, but can be overridden with the optio
 
 - `path` `(string: required)` - The path to use to write the token file
 - `mode` `(int: optional)` - A string containing an octal number representing the bit pattern for the file mode, similar to chmod. Set to `0000` to prevent OpenBao from modifying the file mode.
+- `uid` `(int: optional)` - The user ID to set as the owner of the file. Set to `-1` to prevent OpenBao from modifying the file owner.
+- `gid` `(int: optional)` - The group ID to set as the owner of the file. Set to `-1` to prevent OpenBao from modifying the file owner.
 
 Note: Configuration options for response-wrapping and encryption for the sink
 file are located within the [options common to all sinks](../index.mdx#configuration-sinks) documentation.


### PR DESCRIPTION
## Description

This PR introduces a new config option for the file sink of the openbao agent to change the UID and GID of the token file that the agent creates.

This makes it possible to create token files that can be read by services that are running as unprivileged users.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2850

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
