### PR TITLE
fix: some dynamic secret engines did not forward the request to the primary

### DIFF
--- a/builtin/logical/database/path_creds_create.go
+++ b/builtin/logical/database/path_creds_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
 	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -106,6 +107,18 @@ func (b *databaseBackend) pathCredsCreateRead() framework.OperationFunc {
 				role.CredentialType.String()), nil
 		}
 
+		ttl, _, err := framework.CalculateTTL(b.System(), 0, role.DefaultTTL, 0, role.MaxTTL, 0, time.Time{})
+		if err != nil {
+			return nil, err
+		}
+
+		// basic request validation is now done, but before we actually connect
+		// to the database lets check, if we can even persist the lease in the
+		// end
+		if b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
+			return nil, logical.ErrReadOnly
+		}
+
 		// Get the Database object
 		dbi, err := b.GetConnection(ctx, req.Storage, role.DBName)
 		if err != nil {
@@ -115,10 +128,6 @@ func (b *databaseBackend) pathCredsCreateRead() framework.OperationFunc {
 		dbi.RLock()
 		defer dbi.RUnlock()
 
-		ttl, _, err := framework.CalculateTTL(b.System(), 0, role.DefaultTTL, 0, role.MaxTTL, 0, time.Time{})
-		if err != nil {
-			return nil, err
-		}
 		expiration := time.Now().Add(ttl)
 		// Adding a small buffer since the TTL will be calculated again after this call
 		// to ensure the database credential does not expire before the lease

--- a/builtin/logical/openldap/path_dynamic_creds.go
+++ b/builtin/logical/openldap/path_dynamic_creds.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/openbao/openbao/builtin/logical/openldap/client"
 	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/template"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"golang.org/x/text/encoding/unicode"
@@ -67,6 +68,12 @@ func (b *backend) pathDynamicCredsRead(ctx context.Context, req *logical.Request
 	}
 	if config == nil {
 		return nil, errors.New("missing LDAP configuration")
+	}
+
+	// basic request validation is now done, but before we actually connect to
+	// LDAP lets check, if we can even persist the lease in the end
+	if b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
+		return nil, logical.ErrReadOnly
 	}
 
 	// Generate dynamic data

--- a/builtin/logical/openldap/path_dynamic_creds_test.go
+++ b/builtin/logical/openldap/path_dynamic_creds_test.go
@@ -159,6 +159,7 @@ func TestDynamicCredsRead_failures(t *testing.T) {
 			Once()
 
 		b := Backend(client)
+		require.NoError(t, b.Setup(t.Context(), logical.TestBackendConfig()))
 
 		req := &logical.Request{
 			Storage:     storage,

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -11,6 +11,7 @@ import (
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
 	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/template"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -82,6 +83,12 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	up, err := template.NewTemplate(template.Template(usernameTemplate))
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize username template: %w", err)
+	}
+
+	// basic request validation is now done, but before we actually connect to
+	// RabbitMQ lets check, if we can even persist the lease in the end
+	if b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
+		return nil, logical.ErrReadOnly
 	}
 
 	um := UsernameMetadata{

--- a/changelog/2853.txt
+++ b/changelog/2853.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+secret/database: fix bug that caused dynamic secret requests to fail with an "Internal Server Error" on standby nodes
+```
+```release-note:bug
+secret/rabbitmq: fix bug that caused dynamic secret requests to fail with an "Internal Server Error" on standby nodes
+```
+```release-note:bug
+secret/openldap: fix bug that caused dynamic secret requests to fail with an "Internal Server Error" on standby nodes
+```


### PR DESCRIPTION

## Description

This caused the request to fail, because the lease could not be persisted.

## Rationale


~Resolves~: Releated #2815 (for now lets not close the issue as we might want to find a more long term solution)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
