### PR TITLE
Namespace mounts loading refactor

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/barrier"
 	"github.com/openbao/openbao/vault/routing"
 )
 
@@ -420,11 +421,6 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	srcPath := mountEntry.Path
 	mountEntry.Path = strings.TrimPrefix(dst.MountPath, routing.CredentialRoutePrefix)
 
-	dstBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
-
 	// Update the mount table
 	if err := c.persistAuth(ctx, c.NamespaceView(mountEntry.Namespace), c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.Namespace = src.Namespace
@@ -441,6 +437,12 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 			c.authLock.Unlock()
 			return err
 		}
+	}
+
+	dstBarrierView, err := c.mountEntryView(mountEntry)
+	if err != nil {
+		c.authLock.Unlock()
+		return err
 	}
 
 	// Remount the backend
@@ -553,86 +555,40 @@ func (c *Core) loadCredentials(ctx context.Context, standby bool) error {
 	return nil
 }
 
-// This function reads the transactional split auth (credential) table.
+// loadTransactionalCredentials reads the transactional split auth (credential)
+// table, populates the storage if there are no existing entries.
 func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical.Storage, standby bool) error {
 	allNamespaces, err := c.ListNamespaces(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	var needPersist bool
-	globalEntries := make(map[string][]string, len(allNamespaces))
-	localEntries := make(map[string][]string, len(allNamespaces))
-	for index, ns := range allNamespaces {
-		if ns.Tainted {
-			c.logger.Info("skipping loading auth mounts for tainted namespace", "ns", ns.ID)
-			continue
-		}
-
-		view := NamespaceScopedView(barrier, ns)
-		nsGlobal, nsLocal, err := listTransactionalCredentialsForNamespace(ctx, view)
-		if err != nil {
-			c.logger.Error("failed to list transactional auth mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
-			return err
-		}
-
-		if len(nsGlobal) > 0 {
-			globalEntries[ns.ID] = nsGlobal
-		}
-
-		if len(nsLocal) > 0 {
-			localEntries[ns.ID] = nsLocal
+	if c.auth == nil {
+		// Create the auth table if it doesn't exist.
+		c.auth = &routing.MountTable{
+			Type: routing.CredentialTableType,
 		}
 	}
 
-	if len(globalEntries) == 0 {
-		// TODO(ascheel) Assertion: globalEntries is empty iff there is only
-		// one namespace (the root namespace).
+	for _, ns := range allNamespaces {
+		if err = c.loadTransactionalCredentialsForNamespace(ctx, ns); err != nil {
+			return err
+		}
+	}
+
+	var needPersist bool
+	// This happens only on the first initialization run of the Core.
+	// If there's only root namespace, and there are no auth entries in storage.
+	if len(allNamespaces) == 1 && len(c.auth.Entries) == 0 {
 		c.logger.Info("no auth mounts in transactional auth mount table; adding default auth mount table")
 		c.auth, err = c.defaultAuthTable(ctx)
 		if err != nil {
 			panic(err.Error())
 		}
 		needPersist = true
-	} else {
-		c.auth = &routing.MountTable{
-			Type: routing.CredentialTableType,
-		}
-
-		for nsIndex, ns := range allNamespaces {
-			view := NamespaceScopedView(barrier, ns)
-			for index, uuid := range globalEntries[ns.ID] {
-				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreAuthConfigPath, uuid)
-				if err != nil {
-					return fmt.Errorf("error loading auth mount table entry (%v (%v)/%v/%v): %w", ns.ID, nsIndex, index, uuid, err)
-				}
-
-				if entry != nil {
-					c.auth.Entries = append(c.auth.Entries, entry)
-				}
-			}
-		}
-
 	}
 
-	if len(localEntries) > 0 {
-		for nsIndex, ns := range allNamespaces {
-			view := NamespaceScopedView(barrier, ns)
-			for index, uuid := range localEntries[ns.ID] {
-				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
-				if err != nil {
-					return fmt.Errorf("error loading local auth mount table entry (%v (%v)/%v/%v): %w", ns.ID, nsIndex, index, uuid, err)
-				}
-
-				if entry != nil {
-					c.auth.Entries = append(c.auth.Entries, entry)
-				}
-			}
-		}
-	}
-
-	err = c.runCredentialUpdates(ctx, barrier, needPersist, standby)
-	if err != nil {
+	if err = c.runCredentialUpdates(ctx, barrier, needPersist, standby); err != nil {
 		c.logger.Error("failed to run legacy auth mount table upgrades", "error", err)
 		return err
 	}
@@ -640,20 +596,50 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 	return nil
 }
 
-func getLegacyCredentialsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
-	globalEntry, err := barrier.Get(ctx, coreAuthConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read legacy auth mounts: %w", err)
+// loadTransactionalCredentialsForNamespace loads the auth mounts of a single namespace.
+func (c *Core) loadTransactionalCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if c.NamespaceSealed(ns) {
+		return barrier.ErrNamespaceSealed
 	}
 
-	localEntry, err := barrier.Get(ctx, coreLocalAuthConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read legacy local auth mounts: %w", err)
+	if ns.Tainted {
+		c.logger.Info("skipping loading auth mounts for tainted namespace", "ns", ns.ID)
+		return nil
 	}
 
-	return globalEntry, localEntry, nil
+	view := c.NamespaceView(ns)
+	globalEntries, localEntries, err := listTransactionalCredentialsForNamespace(ctx, view)
+	if err != nil {
+		return fmt.Errorf("failed to list auth mounts for namespace: %w", err)
+	}
+
+	for index, uuid := range globalEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreAuthConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading auth mount table entry ([%v] %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.auth.Entries = append(c.auth.Entries, entry)
+		}
+	}
+
+	for index, uuid := range localEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalAuthConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading local auth mount table entry ([%v] %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.auth.Entries = append(c.auth.Entries, entry)
+		}
+	}
+
+	return nil
 }
 
+// listTransactionalCredentialsForNamespace retrieves list of
+// auth mount entries (global & local) using provided barrier.
 func listTransactionalCredentialsForNamespace(ctx context.Context, barrier logical.Storage) ([]string, []string, error) {
 	globalEntries, err := barrier.List(ctx, coreAuthConfigPath+"/")
 	if err != nil {
@@ -668,9 +654,9 @@ func listTransactionalCredentialsForNamespace(ctx context.Context, barrier logic
 	return globalEntries, localEntries, nil
 }
 
-// This function reads the legacy, single-entry combined auth mount table,
-// returning true if it was used. This will let us know (if we're inside
-// a transaction) if we need to do an upgrade.
+// loadLegacyCredentials reads the legacy, single-entry combined auth
+// mount table, returning true if it was used. This will let us know
+// (if we're inside a transaction) if we need to do an upgrade.
 func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storage, standby bool) (bool, error) {
 	// Load the existing mount table per namespace
 	allNamespaces, err := c.ListNamespaces(ctx)
@@ -678,42 +664,21 @@ func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storag
 		return false, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	globalEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
-	localEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
-	for index, ns := range allNamespaces {
-		if ns.Tainted {
-			c.logger.Info("skipping loading auth mounts for tainted namespace", "ns", ns.ID)
-			continue
-		}
-
-		view := NamespaceScopedView(barrier, ns)
-		entry, localEntry, err := getLegacyCredentialsForNamespace(ctx, view)
-		if err != nil {
-			c.logger.Error("failed to get legacy auth mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
-			return false, err
-		}
-
-		if entry != nil {
-			globalEntries[ns.ID] = entry
-		}
-
-		if localEntry != nil {
-			localEntries[ns.ID] = localEntry
+	if c.auth == nil {
+		// Create the auth mount table if it doesn't exist.
+		c.auth = &routing.MountTable{
+			Type: routing.CredentialTableType,
 		}
 	}
 
-	if len(globalEntries) > 0 {
-		authTable, size, err := c.decodeMountTable(ctx, globalEntries)
-		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the auth table", "error", err)
+	for _, ns := range allNamespaces {
+		if err = c.loadLegacyCredentialsForNamespace(ctx, ns); err != nil {
 			return false, err
 		}
-		c.auth = authTable
-		c.tableMetrics(routing.CredentialTableType, false, len(c.auth.Entries), size)
 	}
 
 	var needPersist bool
-	if c.auth == nil {
+	if len(c.auth.Entries) == 0 {
 		// In the event we are inside a transaction, we do not yet know if
 		// we have a transactional mount table; exit early and load the new format.
 		if _, ok := barrier.(logical.Transaction); ok {
@@ -728,20 +693,8 @@ func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storag
 	} else {
 		if _, ok := barrier.(logical.Transaction); ok {
 			// We know we have legacy mount table entries, so force a migration.
-			c.logger.Info("migrating legacy mount table to transactional layout")
+			c.logger.Info("migrating legacy auth table to transactional layout")
 			needPersist = true
-		}
-	}
-
-	if len(localEntries) > 0 {
-		localAuthTable, size, err := c.decodeMountTable(ctx, localEntries)
-		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the legacy local auth mount table", "error", err)
-			return false, err
-		}
-		if localAuthTable != nil && len(localAuthTable.Entries) > 0 {
-			c.auth.Entries = append(c.auth.Entries, localAuthTable.Entries...)
-			c.tableMetrics(routing.CredentialTableType, true, len(localAuthTable.Entries), size)
 		}
 	}
 
@@ -760,6 +713,62 @@ func (c *Core) loadLegacyCredentials(ctx context.Context, barrier logical.Storag
 	// We loaded a legacy auth mount table and successfully migrated it, if
 	// necessary.
 	return true, nil
+}
+
+// loadLegacyCredentialsForNamespace reads the legacy, single-entry combined
+// auth mount table of a provided namespace and loads it to memory.
+func (c *Core) loadLegacyCredentialsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if c.NamespaceSealed(ns) {
+		return barrier.ErrNamespaceSealed
+	}
+
+	if ns.Tainted {
+		c.logger.Info("skipping loading auth mounts for tainted namespace", "ns", ns.ID)
+		return nil
+	}
+
+	view := c.NamespaceView(ns)
+	entry, localEntry, err := getLegacyCredentialsForNamespace(ctx, view)
+	if err != nil {
+		c.logger.Error("failed to get legacy auth mounts for namespace", "error", err, "namespace", ns.ID)
+		return err
+	}
+
+	if entry != nil {
+		mEntries, err := c.decodeMountTable(ctx, entry)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy auth table", "error", err)
+			return err
+		}
+		c.auth.Entries = append(c.auth.Entries, mEntries...)
+	}
+
+	if localEntry != nil {
+		mEntries, err := c.decodeMountTable(ctx, localEntry)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the local legacy auth table", "error", err)
+			return err
+		}
+		c.auth.Entries = append(c.auth.Entries, mEntries...)
+	}
+
+	return nil
+}
+
+// getLegacyCredentialsForNamespace retrieves the single-entry combined
+// mount table entry (global & local) using provided barrier.
+func getLegacyCredentialsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
+	globalEntry, err := barrier.Get(ctx, coreAuthConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy auth mounts: %w", err)
+	}
+
+	localEntry, err := barrier.Get(ctx, coreLocalAuthConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy local auth mounts: %w", err)
+	}
+
+	return globalEntry, localEntry, nil
 }
 
 // Note that this is only designed to work with singletons, as it checks by
@@ -892,35 +901,39 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 
 	// Handle writing the legacy auth mount table by default.
 	writeTable := func(mt *routing.MountTable, path string) (int, error) {
-		ns, err := namespace.FromContext(ctx)
+		allNamespaces, err := c.ListNamespaces(ctx)
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("failed to list namespaces: %w", err)
 		}
 
-		mountCopy := mt.ShallowClone()
-		mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
-			return e.NamespaceID != ns.ID
-		})
+		var size int
+		for _, ns := range allNamespaces {
+			mountCopy := mt.ShallowClone()
+			mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
+				return e.NamespaceID != ns.ID
+			})
 
-		// Encode the auth mount table into JSON and compress it (Gzip).
-		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
-		if err != nil {
-			c.logger.Error("failed to encode or compress auth mount table", "error", err)
-			return -1, err
+			// Encode the auth mount table into JSON and compress it (Gzip).
+			compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
+			if err != nil {
+				c.logger.Error("failed to encode or compress auth mount table", "error", err)
+				return -1, err
+			}
+
+			// Create an entry
+			entry := &logical.StorageEntry{
+				Key:   path,
+				Value: compressedBytes,
+			}
+
+			if err := c.NamespaceView(ns).Put(ctx, entry); err != nil {
+				c.logger.Error("failed to persist auth mount table", "error", err)
+				return -1, err
+			}
+			size += len(compressedBytes)
 		}
 
-		// Create an entry
-		entry := &logical.StorageEntry{
-			Key:   path,
-			Value: compressedBytes,
-		}
-
-		// Write using passed barrier.
-		if err := barrier.Put(ctx, entry); err != nil {
-			c.logger.Error("failed to persist auth mount table", "error", err)
-			return -1, err
-		}
-		return len(compressedBytes), nil
+		return size, nil
 	}
 
 	if _, ok := barrier.(logical.Transaction); ok {
@@ -1049,135 +1062,146 @@ func (c *Core) persistAuth(ctx context.Context, barrier logical.Storage, table *
 	return nil
 }
 
-// setupCredentials is invoked after we've loaded the auth table to
-// initialize the credential backends and setup the router
+// setupCredentials is invoked after we've loaded the auth mount table
+// to initialize the credential backends and setup the router.
 func (c *Core) setupCredentials(ctx context.Context) error {
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
 	for _, entry := range c.auth.SortEntriesByPathDepth().Entries {
-		view, err := c.mountEntryView(entry)
+		postUnsealFunc, err := c.setupCredential(ctx, entry)
 		if err != nil {
 			return err
 		}
 
-		origViewReadOnlyErr := view.GetReadOnlyErr()
-
-		// Mark the view as read-only until the mounting is complete and
-		// ensure that it is reset after. This ensures that there will be no
-		// writes during the construction of the backend.
-		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-		if slices.Contains(singletonMounts, entry.Type) {
-			defer view.SetReadOnlyErr(origViewReadOnlyErr)
+		if postUnsealFunc != nil {
+			c.postUnsealFuncs = append(c.postUnsealFuncs, postUnsealFunc)
 		}
-
-		// Initialize the backend
-		sysView := c.mountEntrySysView(entry)
-
-		var backend logical.Backend
-		backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
-		if err != nil {
-			c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
-
-			if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
-				c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
-				goto ROUTER_MOUNT
-			}
-			return errLoadAuthFailed
-		}
-		if backend == nil {
-			return fmt.Errorf("nil backend returned from %q factory", entry.Type)
-		}
-
-		// update the entry running version with the configured version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			if entry.RunningSha256 == "" {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-			}
-		}
-
-		// Do not start up deprecated builtin plugins. If this is a major
-		// upgrade, stop unsealing and shutdown. If we've already mounted this
-		// plugin, skip backend initialization and mount the data for posterity.
-		if versions.IsBuiltinVersion(entry.RunningVersion) {
-			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
-			if c.isMajorVersionFirstMount(ctx) && err != nil {
-				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
-				return errLoadAuthFailed
-			} else if err != nil {
-				c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
-				backend.Cleanup(ctx)
-				backend = nil
-				goto ROUTER_MOUNT
-			}
-		}
-
-		{
-			// Check for the correct backend type
-			backendType := backend.Type()
-			if backendType != logical.TypeCredential {
-				return fmt.Errorf("cannot mount %q of type %q as an auth backend", entry.Type, backendType)
-			}
-		}
-
-	ROUTER_MOUNT:
-		// Mount the backend
-		path := routing.CredentialRoutePrefix + entry.Path
-		err = c.router.Mount(backend, path, entry, view)
-		if err != nil {
-			c.logger.Error("failed to mount auth entry", "path", entry.Path, "namespace", entry.Namespace, "error", err)
-			return errLoadAuthFailed
-		}
-
-		if c.logger.IsInfo() {
-			c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace)
-		}
-
-		// Ensure the path is tainted if set in the mount table
-		if entry.Tainted {
-			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
-			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
-			path = entry.Namespace.Path + path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace.Path, "full_path", path)
-			c.router.Taint(ctx, path)
-		}
-
-		// Check if this is the token store
-		if entry.Type == routing.MountTypeToken {
-			c.tokenStore = backend.(*TokenStore)
-
-			// At some point when this isn't beta we may persist this but for
-			// now always set it on mount
-			entry.Config.TokenType = logical.TokenTypeDefaultService
-
-			// this is loaded *after* the normal mounts, including cubbyhole
-			c.router.SetTokenStoreSaltFunc(c.tokenStore.Salt)
-			c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, routing.MountPathCubbyhole).(*CubbyholeBackend)
-		}
-
-		// Initialize
-		// Bind locally
-		localEntry := entry
-		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
-			if backend == nil {
-				postUnsealLogger.Error("skipping initialization for nil auth backend")
-				return
-			}
-			if !slices.Contains(singletonMounts, localEntry.Type) {
-				view.SetReadOnlyErr(origViewReadOnlyErr)
-			}
-
-			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-			if err != nil {
-				postUnsealLogger.Error("failed to initialize auth backend", "error", err)
-			}
-		})
 	}
 
 	return nil
+}
+
+// setupCredential initializes the credential backend
+// and updates the router for specific mount entry.
+func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (func(), error) {
+	view, err := c.mountEntryView(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	origViewReadOnlyErr := view.GetReadOnlyErr()
+
+	// Mark the view as read-only until the mounting is complete and
+	// ensure that it is reset after. This ensures that there will be no
+	// writes during the construction of the backend.
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	if slices.Contains(singletonMounts, entry.Type) {
+		defer view.SetReadOnlyErr(origViewReadOnlyErr)
+	}
+
+	// Initialize the backend
+	var backend logical.Backend
+	sysView := c.mountEntrySysView(entry)
+	backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
+	if err != nil {
+		c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
+		if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
+			c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
+			goto ROUTER_MOUNT
+		}
+		return nil, errLoadAuthFailed
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("nil backend returned from %q factory", entry.Type)
+	}
+
+	// update the entry running version with the configured
+	// version, which was verified during registration.
+	entry.RunningVersion = entry.Version
+	if entry.RunningVersion == "" && entry.RunningSha256 == "" {
+		// don't set the running version to a builtin if it is running as an external plugin
+		entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
+	}
+
+	// Do not start up deprecated builtin plugins. If this is a major
+	// upgrade, stop unsealing and shutdown. If we've already mounted this
+	// plugin, skip backend initialization and mount the data for posterity.
+	if versions.IsBuiltinVersion(entry.RunningVersion) {
+		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
+		if c.isMajorVersionFirstMount(ctx) && err != nil {
+			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+			return nil, errLoadAuthFailed
+		} else if err != nil {
+			c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
+			backend.Cleanup(ctx)
+			backend = nil
+			goto ROUTER_MOUNT
+		}
+	}
+
+	{
+		// Check for the correct backend type
+		backendType := backend.Type()
+		if backendType != logical.TypeCredential {
+			return nil, fmt.Errorf("cannot mount %q of type %q as an auth backend", entry.Type, backendType)
+		}
+	}
+
+ROUTER_MOUNT:
+	path := routing.CredentialRoutePrefix + entry.Path
+	if err = c.router.Mount(backend, path, entry, view); err != nil {
+		c.logger.Error("failed to mount auth entry", "path", entry.Path, "namespace", entry.Namespace, "error", err)
+		return nil, errLoadAuthFailed
+	}
+
+	// Check if this is the token store
+	if entry.Type == routing.MountTypeToken {
+		c.tokenStore = backend.(*TokenStore)
+
+		// At some point when this isn't beta we may persist this but for
+		// now always set it on mount
+		entry.Config.TokenType = logical.TokenTypeDefaultService
+
+		// this is loaded *after* the normal mounts, including cubbyhole
+		c.router.SetTokenStoreSaltFunc(c.tokenStore.Salt)
+		c.tokenStore.cubbyholeBackend = c.router.MatchingBackend(ctx, routing.MountPathCubbyhole).(*CubbyholeBackend)
+	}
+
+	// Bind locally as mount entry might be mutated in-between.
+	localEntry := entry
+	postUnsealFunc := func() {
+		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
+		if backend == nil {
+			postUnsealLogger.Error("skipping initialization for nil auth backend")
+			return
+		}
+		if !slices.Contains(singletonMounts, localEntry.Type) {
+			view.SetReadOnlyErr(origViewReadOnlyErr)
+		}
+
+		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
+		if err != nil {
+			postUnsealLogger.Error("failed to initialize auth backend", "error", err)
+		}
+	}
+
+	if c.logger.IsInfo() {
+		c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace)
+	}
+
+	// Ensure the path is tainted if set in the auth table.
+	if entry.Tainted {
+		// Calculate any namespace prefixes here, because when Taint() is called, there won't be
+		// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
+		path = entry.Namespace.Path + path
+		c.logger.Debug("tainting a mount due to it being marked as tainted in auth table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace.Path, "full_path", path)
+		if err := c.router.Taint(ctx, path); err != nil {
+			return nil, err
+		}
+	}
+
+	return postUnsealFunc, nil
 }
 
 // teardownCredentials is used before we seal the vault to reset the credential

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -156,9 +156,6 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	if err != nil {
 		return err
 	}
-	if backend == nil {
-		return fmt.Errorf("nil backend returned from %q factory", entry.Type)
-	}
 
 	// Discard the backend if any remaining steps below fail.
 	var success bool
@@ -563,13 +560,6 @@ func (c *Core) loadTransactionalCredentials(ctx context.Context, barrier logical
 		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	if c.auth == nil {
-		// Create the auth table if it doesn't exist.
-		c.auth = &routing.MountTable{
-			Type: routing.CredentialTableType,
-		}
-	}
-
 	for _, ns := range allNamespaces {
 		if err = c.loadTransactionalCredentialsForNamespace(ctx, ns); err != nil {
 			return err
@@ -735,7 +725,7 @@ func (c *Core) loadLegacyCredentialsForNamespace(ctx context.Context, ns *namesp
 	}
 
 	if entry != nil {
-		mEntries, err := c.decodeMountTable(ctx, entry)
+		mEntries, err := c.decodeMountEntries(ctx, entry)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy auth table", "error", err)
 			return err
@@ -744,7 +734,7 @@ func (c *Core) loadLegacyCredentialsForNamespace(ctx context.Context, ns *namesp
 	}
 
 	if localEntry != nil {
-		mEntries, err := c.decodeMountTable(ctx, localEntry)
+		mEntries, err := c.decodeMountEntries(ctx, localEntry)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the local legacy auth table", "error", err)
 			return err
@@ -1106,41 +1096,37 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 	backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	if err != nil {
 		c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
-		if c.isMountable(ctx, entry, consts.PluginTypeCredential) {
-			c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
-			goto ROUTER_MOUNT
-		}
-		return nil, errLoadAuthFailed
-	}
-	if backend == nil {
-		return nil, fmt.Errorf("nil backend returned from %q factory", entry.Type)
-	}
-
-	// update the entry running version with the configured
-	// version, which was verified during registration.
-	entry.RunningVersion = entry.Version
-	if entry.RunningVersion == "" && entry.RunningSha256 == "" {
-		// don't set the running version to a builtin if it is running as an external plugin
-		entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-	}
-
-	// Do not start up deprecated builtin plugins. If this is a major
-	// upgrade, stop unsealing and shutdown. If we've already mounted this
-	// plugin, skip backend initialization and mount the data for posterity.
-	if versions.IsBuiltinVersion(entry.RunningVersion) {
-		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
-		if c.isMajorVersionFirstMount(ctx) && err != nil {
-			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+		if !c.isMountable(ctx, entry, consts.PluginTypeCredential) {
 			return nil, errLoadAuthFailed
-		} else if err != nil {
-			c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
-			backend.Cleanup(ctx)
-			backend = nil
-			goto ROUTER_MOUNT
+		}
+
+		c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
+	} else {
+		// update the entry running version with the configured
+		// version, which was verified during registration.
+		entry.RunningVersion = entry.Version
+		if entry.RunningVersion == "" && entry.RunningSha256 == "" {
+			// don't set the running version to a builtin if it is running as an external plugin
+			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
+		}
+
+		// Do not start up deprecated builtin plugins. If this is a major
+		// upgrade, stop unsealing and shutdown. If we've already mounted this
+		// plugin, skip backend initialization and mount the data for posterity.
+		if versions.IsBuiltinVersion(entry.RunningVersion) {
+			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeCredential)
+			if c.isMajorVersionFirstMount(ctx) && err != nil {
+				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+				return nil, errLoadAuthFailed
+			} else if err != nil {
+				c.logger.Error("skipping deprecated auth entry", "name", entry.Type, "path", entry.Path, "error", err)
+				backend.Cleanup(ctx)
+				backend = nil
+			}
 		}
 	}
 
-	{
+	if backend != nil {
 		// Check for the correct backend type
 		backendType := backend.Type()
 		if backendType != logical.TypeCredential {
@@ -1148,7 +1134,6 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 		}
 	}
 
-ROUTER_MOUNT:
 	path := routing.CredentialRoutePrefix + entry.Path
 	if err = c.router.Mount(backend, path, entry, view); err != nil {
 		c.logger.Error("failed to mount auth entry", "path", entry.Path, "namespace", entry.Namespace, "error", err)
@@ -1289,6 +1274,9 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEnt
 	b, err := f(ctx, config)
 	if err != nil {
 		return nil, "", err
+	}
+	if b == nil {
+		return nil, "", fmt.Errorf("nil backend of type %q returned from factory", t)
 	}
 
 	return b, runningSha, nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -2443,11 +2443,13 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 		seal.StartHealthCheck()
 	}
 
-	// This is intentionally the last block in this function. We want to allow
-	// writes just before allowing client requests, to ensure everything has
-	// been set up properly before any writes can have happened.
-	//
-	// Use a small temporary worker pool to run postUnsealFuncs in parallel
+	c.runPostUnsealFuncs(c.postUnsealFuncs)
+	c.logger.Info("post-unseal setup complete")
+	return nil
+}
+
+// runPostUnsealFuncs uses a small temporary worker pool to run postUnsealFuncs in parallel
+func (c *Core) runPostUnsealFuncs(postUnsealFuncs []func()) {
 	postUnsealFuncConcurrency := runtime.NumCPU() * 2
 	if v := api.ReadBaoVariable("BAO_POSTUNSEAL_FUNC_CONCURRENCY"); v != "" {
 		pv, err := strconv.Atoi(v)
@@ -2459,7 +2461,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	}
 	if postUnsealFuncConcurrency <= 1 {
 		// Out of paranoia, keep the old logic for parallism=1
-		for _, v := range c.postUnsealFuncs {
+		for _, v := range postUnsealFuncs {
 			v()
 		}
 	} else {
@@ -2473,7 +2475,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 				}
 			}()
 		}
-		for _, v := range c.postUnsealFuncs {
+		for _, v := range postUnsealFuncs {
 			wg.Add(1)
 			jobs <- v
 		}
@@ -2487,9 +2489,6 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 
 	c.loginMFABackend.usedCodes = zcache.New[string, struct{}](0, 30*time.Second)
 	c.loginMFABackend.rateLimits = zcache.New[string, uint32](0, 30*time.Second)
-
-	c.logger.Info("post-unseal setup complete")
-	return nil
 }
 
 // preSeal is invoked before the barrier is sealed, allowing

--- a/vault/core.go
+++ b/vault/core.go
@@ -2438,23 +2438,35 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 			c.logger.Warn("post-unseal upgrade seal keys failed", "error", err)
 		}
 
-		// Start a periodic but infrequent heartbeat to detect auto-seal backend outages at runtime rather than being
-		// surprised by this at the next need to unseal.
+		// Start a periodic but infrequent heartbeat to detect auto-seal backend
+		// outages at runtime rather than being surprised by this at the next
+		// need to unseal.
 		seal.StartHealthCheck()
 	}
 
+	// This is intentionally (almost) the last block in this function. We want
+	// to allow writes just before allowing client requests, to ensure
+	// everything has been set up properly before any writes happen.
 	c.runPostUnsealFuncs(c.postUnsealFuncs)
+
+	if api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
+		c.logger.Warn("disabling entities for local auth mounts through env var", "env", EnvVaultDisableLocalAuthMountEntities)
+	}
+
+	c.loginMFABackend.usedCodes = zcache.New[string, struct{}](0, 30*time.Second)
+	c.loginMFABackend.rateLimits = zcache.New[string, uint32](0, 30*time.Second)
+
 	c.logger.Info("post-unseal setup complete")
 	return nil
 }
 
-// runPostUnsealFuncs uses a small temporary worker pool to run postUnsealFuncs in parallel
+// runPostUnsealFuncs uses a small temporary worker pool to run postUnsealFuncs in parallel.
 func (c *Core) runPostUnsealFuncs(postUnsealFuncs []func()) {
 	postUnsealFuncConcurrency := runtime.NumCPU() * 2
 	if v := api.ReadBaoVariable("BAO_POSTUNSEAL_FUNC_CONCURRENCY"); v != "" {
 		pv, err := strconv.Atoi(v)
 		if err != nil || pv < 1 {
-			c.logger.Warn("invalid value for VAULT_POSTUNSEAL_FUNC_CURRENCY, must be a positive integer", "error", err, "value", pv)
+			c.logger.Warn("invalid value for BAO_POSTUNSEAL_FUNC_CURRENCY, must be a positive integer", "error", err, "value", pv)
 		} else {
 			postUnsealFuncConcurrency = pv
 		}
@@ -2482,13 +2494,6 @@ func (c *Core) runPostUnsealFuncs(postUnsealFuncs []func()) {
 		wg.Wait()
 		close(jobs)
 	}
-
-	if api.ReadBaoVariable(EnvVaultDisableLocalAuthMountEntities) != "" {
-		c.logger.Warn("disabling entities for local auth mounts through env var", "env", EnvVaultDisableLocalAuthMountEntities)
-	}
-
-	c.loginMFABackend.usedCodes = zcache.New[string, struct{}](0, 30*time.Second)
-	c.loginMFABackend.rateLimits = zcache.New[string, uint32](0, 30*time.Second)
 }
 
 // preSeal is invoked before the barrier is sealed, allowing

--- a/vault/logical_raw.go
+++ b/vault/logical_raw.go
@@ -73,6 +73,20 @@ func (b *RawBackend) storageByPath(ctx context.Context, path string) (StorageAcc
 	}
 }
 
+func (b *RawBackend) checkProtectedPaths(ctx context.Context, path string) error {
+	for _, p := range protectedPaths {
+		_, strippedPath, err := b.core.NamespaceByStoragePath(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(strippedPath, p) {
+			return fmt.Errorf("cannot read %q", strippedPath)
+		}
+	}
+	return nil
+}
+
 // handleRawRead is used to read directly from the barrier
 func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	path := data.Get("path").(string)
@@ -92,12 +106,8 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 		b.logger.Info("reading", "path", path)
 	}
 
-	// Prevent access of protected paths
-	for _, p := range protectedPaths {
-		if strings.HasPrefix(path, p) {
-			err := fmt.Sprintf("cannot read %q", path)
-			return logical.ErrorResponse(err), logical.ErrInvalidRequest
-		}
+	if err := b.checkProtectedPaths(ctx, path); err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	barrier, err := b.storageByPath(ctx, path)
@@ -161,12 +171,8 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 		b.logger.Info("writing", "path", path)
 	}
 
-	// Prevent access of protected paths
-	for _, p := range protectedPaths {
-		if strings.HasPrefix(path, p) {
-			err := fmt.Sprintf("cannot write %q", path)
-			return logical.ErrorResponse(err), logical.ErrInvalidRequest
-		}
+	if err := b.checkProtectedPaths(ctx, path); err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	v := data.Get("value").(string)
@@ -249,12 +255,8 @@ func (b *RawBackend) handleRawDelete(ctx context.Context, req *logical.Request, 
 		b.logger.Info("deleting", "path", path)
 	}
 
-	// Prevent access of protected paths
-	for _, p := range protectedPaths {
-		if strings.HasPrefix(path, p) {
-			err := fmt.Sprintf("cannot delete %q", path)
-			return logical.ErrorResponse(err), logical.ErrInvalidRequest
-		}
+	if err := b.checkProtectedPaths(ctx, path); err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	barrier, err := b.storageByPath(ctx, path)
@@ -285,12 +287,8 @@ func (b *RawBackend) handleRawList(ctx context.Context, req *logical.Request, da
 		b.logger.Info("listing", "path", path)
 	}
 
-	// Prevent access of protected paths
-	for _, p := range protectedPaths {
-		if strings.HasPrefix(path, p) {
-			err := fmt.Sprintf("cannot list %q", path)
-			return logical.ErrorResponse(err), logical.ErrInvalidRequest
-		}
+	if err := b.checkProtectedPaths(ctx, path); err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	barrier, err := b.storageByPath(ctx, path)

--- a/vault/logical_raw.go
+++ b/vault/logical_raw.go
@@ -51,6 +51,13 @@ func (b *RawBackend) storageByPath(ctx context.Context, path string) (StorageAcc
 		return nil, err
 	}
 
+	// check if we are trying to access protected path.
+	for _, p := range protectedPaths {
+		if strings.HasPrefix(rest, p) {
+			return nil, fmt.Errorf("cannot access %q", rest)
+		}
+	}
+
 	// These paths use the "upper" barrier, which is the direct physical layer
 	// for the root namespace.
 	specialPath := rest == barrierSealConfigPath || rest == recoverySealConfigPath
@@ -73,20 +80,6 @@ func (b *RawBackend) storageByPath(ctx context.Context, path string) (StorageAcc
 	}
 }
 
-func (b *RawBackend) checkProtectedPaths(ctx context.Context, path string) error {
-	for _, p := range protectedPaths {
-		_, strippedPath, err := b.core.NamespaceByStoragePath(ctx, path)
-		if err != nil {
-			return err
-		}
-
-		if strings.HasPrefix(strippedPath, p) {
-			return fmt.Errorf("cannot read %q", strippedPath)
-		}
-	}
-	return nil
-}
-
 // handleRawRead is used to read directly from the barrier
 func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	path := data.Get("path").(string)
@@ -104,10 +97,6 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 
 	if b.core.recoveryMode {
 		b.logger.Info("reading", "path", path)
-	}
-
-	if err := b.checkProtectedPaths(ctx, path); err != nil {
-		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	barrier, err := b.storageByPath(ctx, path)
@@ -169,10 +158,6 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 
 	if b.core.recoveryMode {
 		b.logger.Info("writing", "path", path)
-	}
-
-	if err := b.checkProtectedPaths(ctx, path); err != nil {
-		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	v := data.Get("value").(string)
@@ -255,10 +240,6 @@ func (b *RawBackend) handleRawDelete(ctx context.Context, req *logical.Request, 
 		b.logger.Info("deleting", "path", path)
 	}
 
-	if err := b.checkProtectedPaths(ctx, path); err != nil {
-		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
-	}
-
 	barrier, err := b.storageByPath(ctx, path)
 	if err != nil {
 		return handleErrorNoReadOnlyForward(err)
@@ -285,10 +266,6 @@ func (b *RawBackend) handleRawList(ctx context.Context, req *logical.Request, da
 
 	if b.core.recoveryMode {
 		b.logger.Info("listing", "path", path)
-	}
-
-	if err := b.checkProtectedPaths(ctx, path); err != nil {
-		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	barrier, err := b.storageByPath(ctx, path)

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -119,49 +119,32 @@ func (c *Core) generateMountAccessor(entryType string) (string, error) {
 	return accessor, nil
 }
 
-func (c *Core) decodeMountTable(ctx context.Context, entries map[string]*logical.StorageEntry) (*routing.MountTable, int, error) {
-	var mountEntries []*routing.MountEntry
-	var mountType string
-	var size int
-	for _, entry := range entries {
-		// Decode into single mount table
-		mountTable := new(routing.MountTable)
-		if err := jsonutil.DecodeJSON(entry.Value, mountTable); err != nil {
-			return nil, 0, err
-		}
-		size += size + len(entry.Value)
-
-		// Verify mountTable type on every level stays the same.
-		if mountType != "" && mountType != mountTable.Type {
-			return nil, 0, errors.New("broken mount table encountered; mismatched table types between namespaces")
-		}
-		mountType = mountTable.Type
-
-		// Populate the namespace in memory
-		for _, entry := range mountTable.Entries {
-			if entry.NamespaceID == "" {
-				entry.NamespaceID = namespace.RootNamespaceID
-			}
-
-			ns, err := c.NamespaceByID(ctx, entry.NamespaceID)
-			if err != nil {
-				return nil, 0, err
-			}
-
-			if ns == nil {
-				c.logger.Error("namespace on mount entry not found", "namespace_id", entry.NamespaceID, "mount_path", entry.Path, "mount_description", entry.Description)
-				continue
-			}
-			entry.Namespace = ns
-		}
-
-		mountEntries = append(mountEntries, mountTable.Entries...)
+func (c *Core) decodeMountTable(ctx context.Context, entry *logical.StorageEntry) ([]*routing.MountEntry, error) {
+	// Decode into mount table
+	mountTable := new(routing.MountTable)
+	if err := jsonutil.DecodeJSON(entry.Value, mountTable); err != nil {
+		return nil, err
 	}
 
-	return &routing.MountTable{
-		Type:    mountType,
-		Entries: mountEntries,
-	}, size, nil
+	// Populate the namespace in memory
+	for _, entry := range mountTable.Entries {
+		if entry.NamespaceID == "" {
+			entry.NamespaceID = namespace.RootNamespaceID
+		}
+
+		ns, err := c.NamespaceByID(ctx, entry.NamespaceID)
+		if err != nil {
+			return nil, err
+		}
+
+		if ns == nil {
+			c.logger.Error("namespace on mount entry not found", "namespace_id", entry.NamespaceID, "mount_path", entry.Path, "mount_description", entry.Description)
+			continue
+		}
+		entry.Namespace = ns
+	}
+
+	return mountTable.Entries, nil
 }
 
 func (c *Core) fetchAndDecodeMountTableEntry(ctx context.Context, barrier logical.Storage, prefix string, uuid string) (*routing.MountEntry, error) {
@@ -921,82 +904,37 @@ func (c *Core) loadMounts(ctx context.Context, standby bool) error {
 	return nil
 }
 
-// This function reads the transactional split mount table.
+// loadTransactionalMounts reads the transactional split mount table
+// populates the storage if there are no existing entries.
 func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Storage, standby bool) error {
 	allNamespaces, err := c.ListNamespaces(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	var needPersist bool
-	globalEntries := make(map[string][]string, len(allNamespaces))
-	localEntries := make(map[string][]string, len(allNamespaces))
-	for index, ns := range allNamespaces {
-		if ns.Tainted {
-			c.logger.Info("skipping loading mounts for tainted namespace", "ns", ns.ID)
-			continue
-		}
-
-		view := NamespaceScopedView(barrier, ns)
-		nsGlobal, nsLocal, err := listTransactionalMountsForNamespace(ctx, view)
-		if err != nil {
-			c.logger.Error("failed to list transactional mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
-			return err
-		}
-
-		if len(nsGlobal) > 0 {
-			globalEntries[ns.ID] = nsGlobal
-		}
-
-		if len(nsLocal) > 0 {
-			localEntries[ns.ID] = nsLocal
-		}
-	}
-
-	if len(globalEntries) == 0 {
-		// TODO(ascheel) Assertion: globalEntries is empty iff there is only
-		// one namespace (the root namespace).
-		c.logger.Info("no mounts in transactional mount table; adding default mount table")
-		c.mounts = c.defaultMountTable(ctx)
-		needPersist = true
-	} else {
+	if c.mounts == nil {
+		// Create the mount table if it doesn't exist.
 		c.mounts = &routing.MountTable{
 			Type: routing.MountTableType,
 		}
+	}
 
-		for nsIndex, ns := range allNamespaces {
-			view := NamespaceScopedView(barrier, ns)
-			for index, uuid := range globalEntries[ns.ID] {
-				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreMountConfigPath, uuid)
-				if err != nil {
-					return fmt.Errorf("error loading mount table entry (%v (%v)/%v/%v): %w", ns.ID, nsIndex, index, uuid, err)
-				}
-
-				if entry != nil {
-					c.mounts.Entries = append(c.mounts.Entries, entry)
-				}
-			}
+	for _, ns := range allNamespaces {
+		if err = c.loadTransactionalMountsForNamespace(ctx, ns); err != nil {
+			return err
 		}
 	}
 
-	if len(localEntries) > 0 {
-		for nsIndex, ns := range allNamespaces {
-			view := NamespaceScopedView(barrier, ns)
-			for index, uuid := range localEntries[ns.ID] {
-				entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalMountConfigPath, uuid)
-				if err != nil {
-					return fmt.Errorf("error loading local mount table entry (%v (%v)/%v/%v): %w", ns.ID, nsIndex, index, uuid, err)
-				}
-
-				if entry != nil {
-					c.mounts.Entries = append(c.mounts.Entries, entry)
-				}
-			}
-		}
+	var needPersist bool
+	// This happens only on the first initialization run of the Core.
+	// If there's only root namespace, and there are no mount entries in storage.
+	if len(allNamespaces) == 1 && len(c.mounts.Entries) == 0 {
+		c.logger.Info("no mounts in transactional mount table; adding default mount table")
+		c.mounts = c.defaultMountTable(ctx)
+		needPersist = true
 	}
 
-	err = c.runMountUpdates(ctx, barrier, needPersist, standby)
-	if err != nil {
+	if err = c.runMountUpdates(ctx, barrier, needPersist, standby); err != nil {
 		c.logger.Error("failed to run legacy mount table upgrades", "error", err)
 		return err
 	}
@@ -1004,20 +942,50 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 	return nil
 }
 
-func getLegacyMountsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
-	globalEntry, err := barrier.Get(ctx, coreMountConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read legacy mount table: %w", err)
+// loadTransactionalMountsForNamespace loads the mounts of a single namespace.
+func (c *Core) loadTransactionalMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if c.NamespaceSealed(ns) {
+		return barrier.ErrNamespaceSealed
 	}
 
-	localEntry, err := barrier.Get(ctx, coreLocalMountConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read legacy local mount table: %w", err)
+	if ns.Tainted {
+		c.logger.Info("skipping loading mounts for tainted namespace", "ns", ns.ID)
+		return nil
 	}
 
-	return globalEntry, localEntry, nil
+	view := c.NamespaceView(ns)
+	globalEntries, localEntries, err := listTransactionalMountsForNamespace(ctx, view)
+	if err != nil {
+		return fmt.Errorf("failed to list mounts for namespace: %w", err)
+	}
+
+	for index, uuid := range globalEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreMountConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading mount table entry ([%v] %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.mounts.Entries = append(c.mounts.Entries, entry)
+		}
+	}
+
+	for index, uuid := range localEntries {
+		entry, err := c.fetchAndDecodeMountTableEntry(ctx, view, coreLocalMountConfigPath, uuid)
+		if err != nil {
+			return fmt.Errorf("error loading local mount table entry ([%v] %v/%v): %w", ns.ID, index, uuid, err)
+		}
+
+		if entry != nil {
+			c.mounts.Entries = append(c.mounts.Entries, entry)
+		}
+	}
+
+	return nil
 }
 
+// listTransactionalMountsForNamespace retrieves list of mount
+// entries (global & local) using provided barrier.
 func listTransactionalMountsForNamespace(ctx context.Context, barrier logical.Storage) ([]string, []string, error) {
 	globalEntries, err := barrier.List(ctx, coreMountConfigPath+"/")
 	if err != nil {
@@ -1032,7 +1000,7 @@ func listTransactionalMountsForNamespace(ctx context.Context, barrier logical.St
 	return globalEntries, localEntries, nil
 }
 
-// This function reads the legacy, single-entry combined mount table,
+// loadLegacyMounts reads the legacy, single-entry combined mount table,
 // returning true if it was used. This will let us know (if we're inside
 // a transaction) if we need to do an upgrade.
 func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, standby bool) (bool, error) {
@@ -1042,42 +1010,21 @@ func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, st
 		return false, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	globalEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
-	localEntries := make(map[string]*logical.StorageEntry, len(allNamespaces))
-	for index, ns := range allNamespaces {
-		if ns.Tainted {
-			c.logger.Info("skipping loading mounts for tainted namespace", "ns", ns.ID)
-			continue
-		}
-
-		view := NamespaceScopedView(barrier, ns)
-		entry, localEntry, err := getLegacyMountsForNamespace(ctx, view)
-		if err != nil {
-			c.logger.Error("failed to get legacy mounts for namespace", "error", err, "ns_index", index, "namespace", ns.ID)
-			return false, err
-		}
-
-		if entry != nil {
-			globalEntries[ns.ID] = entry
-		}
-
-		if localEntry != nil {
-			localEntries[ns.ID] = localEntry
+	if c.mounts == nil {
+		// Create the mount table if it doesn't exist.
+		c.mounts = &routing.MountTable{
+			Type: routing.MountTableType,
 		}
 	}
 
-	if len(globalEntries) > 0 {
-		mountTable, size, err := c.decodeMountTable(ctx, globalEntries)
-		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
+	for _, ns := range allNamespaces {
+		if err = c.loadLegacyMountsForNamespace(ctx, ns); err != nil {
 			return false, err
 		}
-		c.mounts = mountTable
-		c.tableMetrics(routing.MountTableType, false, len(mountTable.Entries), size)
 	}
 
 	var needPersist bool
-	if c.mounts == nil {
+	if len(c.mounts.Entries) == 0 {
 		// In the event we are inside a transaction, we do not yet know if
 		// we have a transactional mount table; exit early and load the new format.
 		if _, ok := barrier.(logical.Transaction); ok {
@@ -1091,18 +1038,6 @@ func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, st
 			// We know we have legacy mount table entries, so force a migration.
 			c.logger.Info("migrating legacy mount table to transactional layout")
 			needPersist = true
-		}
-	}
-
-	if len(localEntries) > 0 {
-		localMountTable, size, err := c.decodeMountTable(ctx, localEntries)
-		if err != nil {
-			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
-			return false, err
-		}
-		if localMountTable != nil && len(localMountTable.Entries) > 0 {
-			c.mounts.Entries = append(c.mounts.Entries, localMountTable.Entries...)
-			c.tableMetrics(routing.MountTableType, true, len(localMountTable.Entries), size)
 		}
 	}
 
@@ -1121,6 +1056,62 @@ func (c *Core) loadLegacyMounts(ctx context.Context, barrier logical.Storage, st
 	// We loaded a legacy mount table and successfully migrated it, if
 	// necessary.
 	return true, nil
+}
+
+// loadLegacyMountsForNamespace reads the legacy, single-entry combined
+// mount table of a provided namespace and loads it to memory.
+func (c *Core) loadLegacyMountsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	if c.NamespaceSealed(ns) {
+		return barrier.ErrNamespaceSealed
+	}
+
+	if ns.Tainted {
+		c.logger.Info("skipping loading mounts for tainted namespace", "ns", ns.ID)
+		return nil
+	}
+
+	view := c.NamespaceView(ns)
+	entry, localEntry, err := getLegacyMountsForNamespace(ctx, view)
+	if err != nil {
+		c.logger.Error("failed to get legacy mounts for namespace", "error", err, "namespace", ns.ID)
+		return err
+	}
+
+	if entry != nil {
+		mEntries, err := c.decodeMountTable(ctx, entry)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
+			return err
+		}
+		c.mounts.Entries = append(c.mounts.Entries, mEntries...)
+	}
+
+	if localEntry != nil {
+		mEntries, err := c.decodeMountTable(ctx, localEntry)
+		if err != nil {
+			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
+			return err
+		}
+		c.mounts.Entries = append(c.mounts.Entries, mEntries...)
+	}
+
+	return nil
+}
+
+// getLegacyMountsForNamespace retrieves the single-entry combined
+// mount table entry (global & local) using provided barrier.
+func getLegacyMountsForNamespace(ctx context.Context, barrier logical.Storage) (*logical.StorageEntry, *logical.StorageEntry, error) {
+	globalEntry, err := barrier.Get(ctx, coreMountConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy mount table: %w", err)
+	}
+
+	localEntry, err := barrier.Get(ctx, coreLocalMountConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read legacy local mount table: %w", err)
+	}
+
+	return globalEntry, localEntry, nil
 }
 
 // Note that this is only designed to work with singletons, as it checks by
@@ -1294,35 +1285,39 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 
 	// Handle writing the legacy mount table by default.
 	writeTable := func(mt *routing.MountTable, path string) (int, error) {
-		ns, err := namespace.FromContext(ctx)
+		allNamespaces, err := c.ListNamespaces(ctx)
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("failed to list namespaces: %w", err)
 		}
 
-		mountCopy := mt.ShallowClone()
-		mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
-			return e.NamespaceID != ns.ID
-		})
+		var size int
+		for _, ns := range allNamespaces {
+			mountCopy := mt.ShallowClone()
+			mountCopy.Entries = slices.DeleteFunc(mountCopy.Entries, func(e *routing.MountEntry) bool {
+				return e.NamespaceID != ns.ID
+			})
 
-		// Encode the mount table into JSON and compress it (Gzip).
-		compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
-		if err != nil {
-			c.logger.Error("failed to encode or compress mount table", "error", err)
-			return -1, err
+			// Encode the auth mount table into JSON and compress it (Gzip).
+			compressedBytes, err := jsonutil.EncodeJSONAndCompress(mountCopy, nil)
+			if err != nil {
+				c.logger.Error("failed to encode or compress auth mount table", "error", err)
+				return -1, err
+			}
+
+			// Create an entry
+			entry := &logical.StorageEntry{
+				Key:   path,
+				Value: compressedBytes,
+			}
+
+			if err := c.NamespaceView(ns).Put(ctx, entry); err != nil {
+				c.logger.Error("failed to persist auth mount table", "error", err)
+				return -1, err
+			}
+			size += len(compressedBytes)
 		}
 
-		// Create an entry
-		entry := &logical.StorageEntry{
-			Key:   path,
-			Value: compressedBytes,
-		}
-
-		// Write using passed barrier.
-		if err := barrier.Put(ctx, entry); err != nil {
-			c.logger.Error("failed to persist mount table", "error", err)
-			return -1, err
-		}
-		return len(compressedBytes), nil
+		return size, nil
 	}
 
 	if _, ok := barrier.(logical.Transaction); ok {
@@ -1454,124 +1449,137 @@ func (c *Core) persistMounts(ctx context.Context, barrier logical.Storage, table
 	return nil
 }
 
-// setupMounts is invoked after we've loaded the mount table to
-// initialize the logical backends and setup the router
+// setupMounts is invoked after we've loaded the mount table
+// to initialize the logical backends and setup the router.
 func (c *Core) setupMounts(ctx context.Context) error {
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
 	for _, entry := range c.mounts.SortEntriesByPathDepth().Entries {
-		// Initialize the backend, special casing for system
-		view, err := c.mountEntryView(entry)
+		postUnsealFunc, err := c.setupMount(ctx, entry)
 		if err != nil {
 			return err
 		}
 
-		origReadOnlyErr := view.GetReadOnlyErr()
-
-		// Mark the view as read-only until the mounting is complete and
-		// ensure that it is reset after. This ensures that there will be no
-		// writes during the construction of the backend.
-		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-		if slices.Contains(singletonMounts, entry.Type) {
-			defer view.SetReadOnlyErr(origReadOnlyErr)
-		}
-
-		// Create the new backend
-		var backend logical.Backend
-		sysView := c.mountEntrySysView(entry)
-		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
-		if err != nil {
-			c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
-
-			if c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
-				c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
-				goto ROUTER_MOUNT
-			}
-			return errLoadMountsFailed
-		}
-		if backend == nil {
-			return fmt.Errorf("created mount entry of type %q is nil", entry.Type)
-		}
-
-		// update the entry running version with the configured version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			if entry.RunningSha256 == "" {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
-			}
-		}
-
-		// Do not start up deprecated builtin plugins. If this is a major
-		// upgrade, stop unsealing and shutdown. If we've already mounted this
-		// plugin, proceed with unsealing and skip backend initialization.
-		if versions.IsBuiltinVersion(entry.RunningVersion) {
-			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
-			if c.isMajorVersionFirstMount(ctx) && err != nil {
-				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
-				return errLoadMountsFailed
-			} else if err != nil {
-				c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
-				backend.Cleanup(ctx)
-				backend = nil
-				goto ROUTER_MOUNT
-			}
-		}
-
-		{
-			// Check for the correct backend type
-			backendType := backend.Type()
-
-			if backendType != logical.TypeLogical {
-				if err := knownMountType(entry.Type); err != nil {
-					return err
-				}
-			}
-
-			c.setCoreBackend(entry, backend, view)
-		}
-
-	ROUTER_MOUNT:
-		// Mount the backend
-		err = c.router.Mount(backend, entry.Path, entry, view)
-		if err != nil {
-			c.logger.Error("failed to mount entry", "path", entry.Path, "error", err)
-			return errLoadMountsFailed
-		}
-
-		// Bind locally
-		localEntry := entry
-		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-			postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
-			if backend == nil {
-				postUnsealLogger.Error("skipping initialization for nil backend", "path", localEntry.Path)
-				return
-			}
-			if !slices.Contains(singletonMounts, localEntry.Type) {
-				view.SetReadOnlyErr(origReadOnlyErr)
-			}
-
-			err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-			if err != nil {
-				postUnsealLogger.Error("failed to initialize mount backend", "error", err)
-			}
-		})
-
-		if c.logger.IsInfo() {
-			c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace)
-		}
-
-		// Ensure the path is tainted if set in the mount table
-		if entry.Tainted {
-			// Calculate any namespace prefixes here, because when Taint() is called, there won't be
-			// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
-			path := entry.Namespace.Path + entry.Path
-			c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace.Path, "full_path", path)
-			c.router.Taint(ctx, path)
+		if postUnsealFunc != nil {
+			c.postUnsealFuncs = append(c.postUnsealFuncs, postUnsealFunc)
 		}
 	}
+
 	return nil
+}
+
+// setupMount initializes the logical backend
+// and updates the router for specific mount entry.
+func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(), error) {
+	// Initialize the backend, special casing for system
+	view, err := c.mountEntryView(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	origReadOnlyErr := view.GetReadOnlyErr()
+
+	// Mark the view as read-only until the mounting is complete and
+	// ensure that it is reset after. This ensures that there will be no
+	// writes during the construction of the backend.
+	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
+	if slices.Contains(singletonMounts, entry.Type) {
+		defer view.SetReadOnlyErr(origReadOnlyErr)
+	}
+
+	// Create the new backend
+	var backend logical.Backend
+	sysView := c.mountEntrySysView(entry)
+	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
+	if err != nil {
+		c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
+		if c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
+			c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
+			goto ROUTER_MOUNT
+		}
+		return nil, errLoadMountsFailed
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("nil backend returned from %q factory", entry.Type)
+	}
+
+	// update the entry running version with the configured
+	// version, which was verified during registration.
+	entry.RunningVersion = entry.Version
+	if entry.RunningVersion == "" && entry.RunningSha256 == "" {
+		// don't set the running version to a builtin if it is running as an external plugin
+		entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
+	}
+
+	// Do not start up deprecated builtin plugins. If this is a major
+	// upgrade, stop unsealing and shutdown. If we've already mounted this
+	// plugin, proceed with unsealing and skip backend initialization.
+	if versions.IsBuiltinVersion(entry.RunningVersion) {
+		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
+		if c.isMajorVersionFirstMount(ctx) && err != nil {
+			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+			return nil, errLoadMountsFailed
+		} else if err != nil {
+			c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
+			backend.Cleanup(ctx)
+			backend = nil
+			goto ROUTER_MOUNT
+		}
+	}
+
+	{
+		// Check for the correct backend type
+		if backend.Type() != logical.TypeLogical {
+			if err := knownMountType(entry.Type); err != nil {
+				return nil, err
+			}
+		}
+
+		c.setCoreBackend(entry, backend, view)
+	}
+
+ROUTER_MOUNT:
+	err = c.router.Mount(backend, entry.Path, entry, view)
+	if err != nil {
+		c.logger.Error("failed to mount entry", "path", entry.Path, "error", err)
+		return nil, errLoadMountsFailed
+	}
+
+	// Bind locally as mount entry might be mutated in-between.
+	localEntry := entry
+	postUnsealFunc := func() {
+		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
+		if backend == nil {
+			postUnsealLogger.Error("skipping initialization for nil backend", "path", localEntry.Path)
+			return
+		}
+		if !slices.Contains(singletonMounts, localEntry.Type) {
+			view.SetReadOnlyErr(origReadOnlyErr)
+		}
+
+		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
+		if err != nil {
+			postUnsealLogger.Error("failed to initialize mount backend", "error", err)
+		}
+	}
+
+	if c.logger.IsInfo() {
+		c.logger.Info("successfully mounted", "type", entry.Type, "version", entry.RunningVersion, "path", entry.Path, "namespace", entry.Namespace)
+	}
+
+	// Ensure the path is tainted if set in the mount table.
+	if entry.Tainted {
+		// Calculate any namespace prefixes here, because when Taint() is called, there won't be
+		// a namespace to pull from the context. This is similar to what we do above in c.router.Mount().
+		path := entry.Namespace.Path + entry.Path
+		c.logger.Debug("tainting a mount due to it being marked as tainted in mount table", "entry.path", entry.Path, "entry.namespace.path", entry.Namespace.Path, "full_path", path)
+		if err := c.router.Taint(ctx, path); err != nil {
+			return nil, err
+		}
+	}
+
+	return postUnsealFunc, nil
 }
 
 // unloadMounts is used before we seal the vault to reset the mounts to
@@ -1986,12 +1994,12 @@ func (c *Core) reloadLegacyMounts(ctx context.Context, keys ...string) error {
 		}
 
 		if raw != nil {
-			mountTable, _, err := c.decodeMountTable(ctx, map[string]*logical.StorageEntry{ns.ID: raw})
+			entries, err := c.decodeMountTable(ctx, raw)
 			if err != nil {
 				return fmt.Errorf("failed to decompress and/or decode the legacy mount table: %w", err)
 			}
 
-			for _, mount := range mountTable.Entries {
+			for _, mount := range entries {
 				if ns.ID != namespace.RootNamespaceID && ns.ID != mount.NamespaceID {
 					continue
 				}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -119,8 +119,7 @@ func (c *Core) generateMountAccessor(entryType string) (string, error) {
 	return accessor, nil
 }
 
-func (c *Core) decodeMountTable(ctx context.Context, entry *logical.StorageEntry) ([]*routing.MountEntry, error) {
-	// Decode into mount table
+func (c *Core) decodeMountEntries(ctx context.Context, entry *logical.StorageEntry) ([]*routing.MountEntry, error) {
 	mountTable := new(routing.MountTable)
 	if err := jsonutil.DecodeJSON(entry.Value, mountTable); err != nil {
 		return nil, err
@@ -295,9 +294,6 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
-	}
-	if backend == nil {
-		return fmt.Errorf("nil backend of type %q returned from creation function", entry.Type)
 	}
 
 	// Discard the backend if any remaining steps below fail.
@@ -912,13 +908,6 @@ func (c *Core) loadTransactionalMounts(ctx context.Context, barrier logical.Stor
 		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	if c.mounts == nil {
-		// Create the mount table if it doesn't exist.
-		c.mounts = &routing.MountTable{
-			Type: routing.MountTableType,
-		}
-	}
-
 	for _, ns := range allNamespaces {
 		if err = c.loadTransactionalMountsForNamespace(ctx, ns); err != nil {
 			return err
@@ -1078,7 +1067,7 @@ func (c *Core) loadLegacyMountsForNamespace(ctx context.Context, ns *namespace.N
 	}
 
 	if entry != nil {
-		mEntries, err := c.decodeMountTable(ctx, entry)
+		mEntries, err := c.decodeMountEntries(ctx, entry)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy mount table", "error", err)
 			return err
@@ -1087,7 +1076,7 @@ func (c *Core) loadLegacyMountsForNamespace(ctx context.Context, ns *namespace.N
 	}
 
 	if localEntry != nil {
-		mEntries, err := c.decodeMountTable(ctx, localEntry)
+		mEntries, err := c.decodeMountEntries(ctx, localEntry)
 		if err != nil {
 			c.logger.Error("failed to decompress and/or decode the legacy local mount table", "error", err)
 			return err
@@ -1494,41 +1483,37 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
-		if c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
-			c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
-			goto ROUTER_MOUNT
-		}
-		return nil, errLoadMountsFailed
-	}
-	if backend == nil {
-		return nil, fmt.Errorf("nil backend returned from %q factory", entry.Type)
-	}
-
-	// update the entry running version with the configured
-	// version, which was verified during registration.
-	entry.RunningVersion = entry.Version
-	if entry.RunningVersion == "" && entry.RunningSha256 == "" {
-		// don't set the running version to a builtin if it is running as an external plugin
-		entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
-	}
-
-	// Do not start up deprecated builtin plugins. If this is a major
-	// upgrade, stop unsealing and shutdown. If we've already mounted this
-	// plugin, proceed with unsealing and skip backend initialization.
-	if versions.IsBuiltinVersion(entry.RunningVersion) {
-		_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
-		if c.isMajorVersionFirstMount(ctx) && err != nil {
-			go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+		if !c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
 			return nil, errLoadMountsFailed
-		} else if err != nil {
-			c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
-			backend.Cleanup(ctx)
-			backend = nil
-			goto ROUTER_MOUNT
+		}
+
+		c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
+	} else {
+		// update the entry running version with the configured
+		// version, which was verified during registration.
+		entry.RunningVersion = entry.Version
+		if entry.RunningVersion == "" && entry.RunningSha256 == "" {
+			// don't set the running version to a builtin if it is running as an external plugin
+			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
+		}
+
+		// Do not start up deprecated builtin plugins. If this is a major
+		// upgrade, stop unsealing and shutdown. If we've already mounted this
+		// plugin, proceed with unsealing and skip backend initialization.
+		if versions.IsBuiltinVersion(entry.RunningVersion) {
+			_, err := c.handleDeprecatedMountEntry(ctx, entry, consts.PluginTypeSecrets)
+			if c.isMajorVersionFirstMount(ctx) && err != nil {
+				go c.ShutdownCoreError(fmt.Errorf("could not mount %q: %w", entry.Type, err))
+				return nil, errLoadMountsFailed
+			} else if err != nil {
+				c.logger.Error("skipping deprecated mount entry", "name", entry.Type, "path", entry.Path, "error", err)
+				backend.Cleanup(ctx)
+				backend = nil
+			}
 		}
 	}
 
-	{
+	if backend != nil {
 		// Check for the correct backend type
 		if backend.Type() != logical.TypeLogical {
 			if err := knownMountType(entry.Type); err != nil {
@@ -1539,9 +1524,7 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 		c.setCoreBackend(entry, backend, view)
 	}
 
-ROUTER_MOUNT:
-	err = c.router.Mount(backend, entry.Path, entry, view)
-	if err != nil {
+	if err = c.router.Mount(backend, entry.Path, entry, view); err != nil {
 		c.logger.Error("failed to mount entry", "path", entry.Path, "error", err)
 		return nil, errLoadMountsFailed
 	}
@@ -1994,7 +1977,7 @@ func (c *Core) reloadLegacyMounts(ctx context.Context, keys ...string) error {
 		}
 
 		if raw != nil {
-			entries, err := c.decodeMountTable(ctx, raw)
+			entries, err := c.decodeMountEntries(ctx, raw)
 			if err != nil {
 				return fmt.Errorf("failed to decompress and/or decode the legacy mount table: %w", err)
 			}

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -191,9 +191,6 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *routing.MountEntr
 	if err != nil {
 		return err
 	}
-	if backend == nil {
-		return fmt.Errorf("nil backend of type %q returned from creation function", entry.Type)
-	}
 
 	// update the entry running version with the configured version, which was verified during registration.
 	entry.RunningVersion = entry.Version


### PR DESCRIPTION
## Description
- adds `(*rawBackend).checkProtectedPaths()` adjusted for namespace path
- adds `(*Core).runPostUnsealFuncs()` in preparation of per-ns post unseal funcs
- refactors mounts/credentials loading/setup
- fixes remount operation storing incorrect mounts when using legacy mount system

## Rationale
Part of the changes fixes bugs introduced by #2735, other are added in preparation for namespace unsealing operation (#2836)

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
