### PR TITLE
Skip OuterName validation when not required

### DIFF
--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -172,9 +172,12 @@ func (p *ProfileEngine) validate() error {
 	}
 
 	for _, outer := range p.profile {
-		if err := validateNameConvention("outer block", outer.Type); err != nil {
-			return err
+		if len(p.profile) > 1 {
+			if err := validateNameConvention("outer block", outer.Type); err != nil {
+				return err
+			}
 		}
+
 		for _, req := range outer.Requests {
 			if err := validateNameConvention(fmt.Sprintf("request in block '%s'", outer.Type), req.Type); err != nil {
 				return err

--- a/helper/profiles/profiles_test.go
+++ b/helper/profiles/profiles_test.go
@@ -296,7 +296,10 @@ func TestValidateRequestNameUniqueness_EmptyType(t *testing.T) {
 func TestValidateNameConvention_Fail(t *testing.T) {
 	_, err := NewEngine(
 		WithProfileAndHandler(
-			[]*OuterConfig{{Type: "#bad", Requests: []*RequestConfig{{Type: "r"}}}},
+			[]*OuterConfig{
+				{Type: "#bad", Requests: []*RequestConfig{{Type: "r"}}},
+				{Type: "good", Requests: []*RequestConfig{{Type: "r"}}},
+			},
 			testHandler,
 			"#bad",
 		),
@@ -332,9 +335,7 @@ func TestValidate_SingleBlockEmptyOuterName(t *testing.T) {
 			"",
 		),
 	)
-	if err != nil {
-		t.Fatalf("expected no error for single block, got: %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func Test_Evaluate_Success(t *testing.T) {


### PR DESCRIPTION
When `OuterBlockName` is not provided as an option, we expect strictly one outer block (to simplify typing). This outer block should be empty, to simplify indexing in various places; properly validate and enforce this.

Previously, we'd incorrectly err as the `OuterBlock.Type` field must have had a valid non-empty name.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This is not used at all. Currently every profile system use case has an outer context, though in the future that might change. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
