### PR TITLE
pki: Copy subject from CSR as raw bytes for sign-verbatim

### DIFF
--- a/changelog/2861.txt
+++ b/changelog/2861.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: sign-verbatim now preserves the original subject encoding from the CSR. Previously, UTF8String values were re-encoded as PrintableString when the subject contained only ASCII characters.
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1392,7 +1392,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	}
 
 	if data.Params.UseCSRValues {
-		certTemplate.Subject = data.CSR.Subject
+		certTemplate.RawSubject = data.CSR.RawSubject
 		certTemplate.Subject.ExtraNames = certTemplate.Subject.Names
 
 		certTemplate.DNSNames = data.CSR.DNSNames


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This PR ensures that the subject name is copied verbatim as raw bytes from the CSR when signing a certificate, preserving the original encoding in the CSR. This change makes the implementation align with the `sign-verbatim` endpoint documentation ([link](https://openbao.org/api-docs/secret/pki/#sign-verbatim)) which states:

> This endpoint signs a new certificate based upon the provided CSR. Values are taken verbatim from the CSR

Previously, if a subject name in CSR used `UTF8String`, OpenBao would re-encode it as a `PrintableString` if the DN contained only ASCII characters. This was caused by the ASN.1 -> `pkix.Name` -> ASN.1 "round-trip" conversion and [this logic](https://github.com/golang/go/blob/ce4459cf0ee339b3bcf0ed10427079a234aade36/src/encoding/asn1/marshal.go#L638-L652) in go ASN1 marshaller that prefers `PrintableString` for pure ASCII strings. This behavior contradicts with the `sign-verbatim` documentation.

Similar encoding issues were previously reported in [hashicorp/vault#10550](https://www.github.com/hashicorp/vault/issues/10550).

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2860

Related to: https://github.com/orgs/openbao/discussions/2721

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
