### PR TITLE
bug?(OIDC-Provider): Use client name for sub/aud claims in Client Credentials Flow 🤖

### DIFF
--- a/changelog/2864.txt
+++ b/changelog/2864.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+clientCredentialsFlow: changed Subject and Audience from client.ClientID to client.Name for
+```
+```release-note:improvement
+OIDC Provider: Discovery Endpoint - Added "client_credentials" to grant_types_supported in the OIDC discovery response
+```

--- a/vault/identity/store_oidc_provider.go
+++ b/vault/identity/store_oidc_provider.go
@@ -1638,7 +1638,7 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		RequestURIParameter:   false,
 		ResponseTypes:         []string{"code"},
 		Subjects:              []string{"public"},
-		GrantTypes:            []string{"authorization_code"},
+		GrantTypes:            []string{"authorization_code", "client_credentials"},
 		AuthMethods: []string{
 			// PKCE is required for auth method "none"
 			"none",
@@ -2089,11 +2089,13 @@ func (i *IdentityStore) clientCredentialsFlow(ctx context.Context, req *logical.
 		return tokenResponse(nil, ErrTokenServerError, err.Error())
 	}
 
+	// For Client Credentials Flow, use client.Name for sub and aud claims
+	// to provide a meaningful, human-readable identifier instead of the UUID client_id
 	accessToken := accessToken{
 		Namespace: ns.ID,
 		Issuer:    provider.effectiveIssuer,
-		Subject:   client.ClientID,
-		Audience:  client.ClientID,
+		Subject:   client.Name,
+		Audience:  client.Name,
 		Expiry:    accessTokenExpiry.Unix(),
 		IssuedAt:  accessTokenIssuedAt.Unix(),
 		JTI:       jti,

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -835,6 +835,11 @@ func TestOIDC_Path_OIDC_Token_Client_Credentials_Flow(t *testing.T) {
 				// other reserved claims must be present in all cases
 				require.NotEmpty(t, claims[c])
 			}
+
+			// Assert that sub and aud claims contain the client name (not client_id)
+			// This is specific to Client Credentials Flow where the client itself is the subject
+			require.Equal(t, "test-client", claims["sub"], "sub claim should be client name")
+			require.Equal(t, "test-client", claims["aud"], "aud claim should be client name")
 		})
 	}
 }
@@ -3969,7 +3974,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthorizationEndpoint: "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
-		GrantTypes:            []string{"authorization_code"},
+		GrantTypes:            []string{"authorization_code", "client_credentials"},
 		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestParameter:      false,
 		RequestURIParameter:   false,
@@ -4025,7 +4030,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthorizationEndpoint: testIssuer + "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
-		GrantTypes:            []string{"authorization_code"},
+		GrantTypes:            []string{"authorization_code", "client_credentials"},
 		AuthMethods:           []string{"none", "client_secret_basic", "client_secret_post"},
 		RequestParameter:      false,
 		RequestURIParameter:   false,


### PR DESCRIPTION
## Description

Addition to my last PR. https://github.com/openbao/openbao/pull/1732 Not entirely free of AI. Since I discussed this changed and got the description from our chat.

This PR modifies the OIDC Provider's Client Credentials Flow to use the client's `name` field for the `sub` and `aud` claims instead of the `client_id` (UUID). Additionally, it updates the `.well-known/openid-configuration` discovery endpoint to advertise `client_credentials` as a supported grant type.

This is a addition to my the last feature I added here because I figured that the UUID makes it hard to use in a Flow based workflow.

### Changes

1. **Token Claims**: In `clientCredentialsFlow()`, changed `Subject` and `Audience` from `client.ClientID` to `client.Name`
2. **Discovery Endpoint**: Added `"client_credentials"` to `grant_types_supported` in the OIDC discovery response
3. **Tests**: Added assertions to verify `sub` and `aud` claims contain the client name, and updated discovery tests

### Token Output Comparison

**Before:**
```json
{
  "aud": "QPQJWno7zNLa3vJHdknEAEQVfv4pBPu2",
  "sub": "QPQJWno7zNLa3vJHdknEAEQVfv4pBPu2",
  "iss": "http://openbao:8200/v1/identity/oidc/provider/platform",
  "namespace": "root"
}
```

**After:**
```json
{
  "aud": "my-service",
  "sub": "my-service", 
  "iss": "http://openbao:8200/v1/identity/oidc/provider/platform",
  "namespace": "root"
}
```

## Rationale

When using OpenBao as an OIDC provider for service-to-service authentication.
Currently, the `sub` and `aud` claims contain only the `client_id`, which is a random UUID that doesn't convey meaning and requires maintaining a separate mapping table. By using the client's `name` field instead, tokens become immediately meaningful and can be used directly for routing decisions and make meaningful decisions.

Additionally, the `.well-known/openid-configuration` endpoint was not advertising `client_credentials` as a supported grant type, which could cause OIDC clients to incorrectly assume the flow is unsupported.

## Acknowledgements

 - [ ] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.