### PR TITLE
refactor(tests): replace os.MkdirTemp with t.TempDir()

### DIFF
--- a/physical/raft/fsm_test.go
+++ b/physical/raft/fsm_test.go
@@ -6,7 +6,6 @@ package raft
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -20,11 +19,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func getFSM(t testing.TB) (*FSM, string) {
-	raftDir, err := os.MkdirTemp("", "vault-raft-")
-	if err != nil {
-		t.Fatal(err)
-	}
+func getFSM(t testing.TB) *FSM {
+	raftDir := t.TempDir()
 	t.Logf("raft dir: %s", raftDir)
 
 	logger := hclog.New(&hclog.LoggerOptions{
@@ -37,13 +33,12 @@ func getFSM(t testing.TB) (*FSM, string) {
 		t.Fatal(err)
 	}
 
-	return fsm, raftDir
+	return fsm
 }
 
 func TestFSM_Batching(t *testing.T) {
 	t.Parallel()
-	fsm, dir := getFSM(t)
-	defer func() { _ = os.RemoveAll(dir) }()
+	fsm := getFSM(t)
 
 	var index uint64
 	var term uint64 = 1
@@ -145,8 +140,7 @@ func TestFSM_Batching(t *testing.T) {
 
 func TestFSM_List(t *testing.T) {
 	t.Parallel()
-	fsm, dir := getFSM(t)
-	defer func() { _ = os.RemoveAll(dir) }()
+	fsm := getFSM(t)
 
 	ctx := t.Context()
 	count := 100

--- a/vault/plugin_catalog_oci_test.go
+++ b/vault/plugin_catalog_oci_test.go
@@ -98,11 +98,7 @@ func TestExtractPluginFromImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a temporary directory for the test
-			tempDir, err := os.MkdirTemp("", "oci-plugin-test")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			defer os.RemoveAll(tempDir) //nolint:errcheck
+			tempDir := t.TempDir()
 
 			// Create the test OCI image
 			img := createTestOCIImage(t, tt.binaryName, tt.binaryContent)
@@ -370,11 +366,7 @@ func TestReconcileOCIPlugins(t *testing.T) {
 // TestPluginCacheStructure tests the new hidden cache structure and symlink functionality
 func TestPluginCacheStructure(t *testing.T) {
 	// Create a temporary directory for plugins
-	tempDir, err := os.MkdirTemp("", "oci-cache-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := t.TempDir()
 
 	// Test plugin configuration
 	pluginConfig := &server.PluginConfig{


### PR DESCRIPTION
## Summary

Replaces `os.MkdirTemp("", ...) + defer os.RemoveAll(...)` with `t.TempDir()` in test files, as requested in #2869.

- **`physical/raft/fsm_test.go`**: Convert `getFSM` to use `t.TempDir()`, simplify return type from `(*FSM, string)` to `*FSM` since callers only used the path for manual cleanup, remove `defer os.RemoveAll` from both callers, remove now-unused `"os"` import.
- **`vault/plugin_catalog_oci_test.go`**: Replace two `os.MkdirTemp + defer os.RemoveAll` patterns with `t.TempDir()` (sub-test and top-level test).

`t.TempDir()` automatically registers cleanup via `t.Cleanup()`, ensuring the directory is removed even if the test panics, while eliminating the error-handling boilerplate.

## Test plan

- [ ] `go test ./physical/raft/ -run TestFSM` passes
- [ ] `go test ./vault/ -run TestPluginCatalogOCI` passes (or skip if OCI deps unavailable)
- [ ] `go vet ./physical/raft/ ./vault/` shows no errors

Fixes #2869