### PR TITLE
Tidy up the Deprecations FAQ

### DIFF
--- a/sdk/helper/consts/deprecation_status.go
+++ b/sdk/helper/consts/deprecation_status.go
@@ -6,7 +6,7 @@ package consts
 // EnvVaultAllowPendingRemovalMounts allows Pending Removal builtins to be
 // mounted as if they are Deprecated to facilitate migration to supported
 // builtin plugins.
-const EnvVaultAllowPendingRemovalMounts = "VAULT_ALLOW_PENDING_REMOVAL_MOUNTS"
+const EnvVaultAllowPendingRemovalMounts = "BAO_ALLOW_PENDING_REMOVAL_MOUNTS"
 
 // DeprecationStatus represents the current deprecation state for builtins
 type DeprecationStatus uint32

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -90,13 +90,13 @@ flags](index.mdx) included on all commands.
   number of older log file archives to keep. Defaults to 0 (no files are ever deleted).
   Set to -1 to discard old log files when a new one is created.
 
-- `VAULT_ALLOW_PENDING_REMOVAL_MOUNTS` `(bool: false)` - (environment variable)
-  Allow OpenBao to be started with builtin engines which have the `Pending Removal`
+- `BAO_ALLOW_PENDING_REMOVAL_MOUNTS` `(bool: false)` - (environment variable)
+  Allow OpenBao to be started with builtin engines which have the "Pending Removal"
   deprecation state. This is a temporary stopgap in place in order to perform an
-  upgrade and disable these engines. Once these engines are marked `Removed` (in
+  upgrade and disable these engines. Once these engines are marked "Removed" (in
   the next major release of OpenBao), the environment variable will no longer work
   and a downgrade must be performed in order to remove the offending engines. For
-  more information, see the [deprecation faq](../deprecation/faq.mdx#q-what-are-the-phases-of-deprecation).
+  more information, see the [Deprecation FAQ](../deprecation/faq.mdx#q-what-are-the-phases-of-deprecation).
 
 ### Dev options
 

--- a/website/content/docs/deprecation/faq.mdx
+++ b/website/content/docs/deprecation/faq.mdx
@@ -1,107 +1,89 @@
 ---
 sidebar_label: FAQ
 description: |-
-  An FAQ page to communicate frequently asked questions concerning feature deprecations.
+  An FAQ page to communicate frequently asked questions concerning feature
+  deprecations.
 ---
+
 # Feature deprecation FAQ
 
-This page provides frequently asked questions concerning decisions made about OpenBao feature deprecations. Please refer to the [Feature Deprecation Notice and Plans](index.mdx) document for up-to-date information on OpenBao feature deprecations and notice.
+This page provides frequently asked questions concerning decisions made about
+OpenBao feature deprecations. Please refer to the [Overview](index.mdx) page for
+up-to-date information on OpenBao feature deprecations and notices.
 
-- [Q: What is the impact of removing support for X.509 certificates with signatures that use SHA-1?](#q-what-is-the-impact-of-removing-support-for-x509-certificates-with-signatures-that-use-sha-1)
 - [Q: What are the phases of deprecation?](#q-what-are-the-phases-of-deprecation)
 
-### Q: what is the impact of removing support for x.509 certificates with signatures that use SHA-1?
+### Q: What are the phases of deprecation?
 
-OpenBao is built with Go 1.21 or later.  The standard library in Go 1.18 and
-later [rejects X.509 signatures](https://go.dev/doc/go1.18#sha1) that use a
-SHA-1 hash.
+OpenBao implements a multi-phased approach to deprecation. The intent of this
+approach is to provide sufficient warning that a feature will be removed and
+safe handling of stored data when the associated feature has been removed.
 
-If this issue impacts your usage of OpenBao, you can temporarily work around it by deploying OpenBao with the environment variable `GODEBUG=x509sha1=1` set.
-This workaround will fail in a future version of Go, however, the Go team has not said when they will remove this workaround.
+The phases of deprecation are also known as "Deprecation Status". These statuses
+apply to all feature deprecations but are specially reflected in builtin auth &
+secrets engines, which expose this information at runtime via the `/sys/auth`,
+`/sys/mounts` and `/sys/plugins` endpoints. For more information, refer to the
+corresponding documentation.
 
-If you want to check whether a certificate or CA contains a problematic signature, you can use the OpenSSL CLI:
-
-```shell-session
-$ openssl x509 -text -noout -in somecert.pem | grep sha1
-
-    Signature Algorithm: sha1WithRSAEncryption
-    Signature Algorithm: sha1WithRSAEncryption
-```
-
-Any signature algorithms that contain `sha1` will be potentially problematic.
-
-Here are the use cases that may still use certificates with SHA-1:
-
-#### Auth methods
-
-- [Kerberos Auth Method](../auth/kerberos.mdx)
-- [Kubernetes Auth Method](../auth/kubernetes.mdx)
-- [LDAP Auth Method](../auth/ldap.mdx)
-- [JWT/OIDC Auth Method](../auth/jwt/index.mdx)
-- [TLS Certificates Auth Method](../auth/cert.mdx)
-
-#### Database secrets engines
-
-- [Cassandra Database Secrets Engine](../secrets/databases/cassandra.mdx)
-- [InfluxDB Database Secrets Engine](../secrets/databases/influxdb.mdx)
-- [MySQL/MariaDB Database Secrets Engine](../secrets/databases/mysql-maria.mdx)
-
-#### Secrets engines
-
-- [Kubernetes Secrets Engine](../secrets/kubernetes.mdx)
-- [LDAP Secrets Engine](../secrets/ldap.mdx)
-- [PKI Secrets Engine](../secrets/pki/index.mdx)
-
-### Q: what are the phases of deprecation?
-
-OpenBao implements a multi-phased approach to deprecation. The intent of this approach is to provide sufficient warning that a feature will be removed and safe handling of stored data when the associated feature has been removed.
-
-The phases of deprecation are also known as "Deprecation Status". These statuses are currently reflected in builtin plugins and are exposed via the OpenBao `auth`, `secrets`, and `plugins` CLI/API endpoints. For more information, refer to the corresponding documentation.
-
-The four phases of deprecation are: `Supported`, `Deprecated`, `Pending Removal`, and `Removed`.
-
-**Note:** Deprecation Status currently only applies to builtin `auth` and `secrets` plugins. All external plugins will report a status of `n/a`. This is expected behavior.
+The four phases of deprecation are: "Supported", "Deprecated", "Pending
+Removal", and "Removed".
 
 #### Supported
 
-This is the default status and reflects a feature which is still supported. There is no unique behavior or functionality associated with this status.
+This is the default status and reflects a feature which is still supported.
+There is no unique behavior or functionality associated with this status.
 
 #### Deprecated
 
-This status reflects a feature which has been marked for deprecation in a later release of OpenBao. This is the first phase of the deprecation process. A status of `Deprecated` has two effects:
+This status reflects a feature which has been marked for deprecation in a later
+release of OpenBao. This is the first phase of the deprecation process. A status
+of "Deprecated" has two effects:
 
-1. After an upgrade, any existing `Deprecated` feature (builtin auth/secrets plugins enabled via CLI or API prior to upgrade) will log `Warn`-level messages on unseal.
-
-2. All new usage of `Deprecated` features will log `Warn`-level messages.
-
-3. All `POST/GET/LIST` endpoints associated with this feature will return `warnings` in response data.
+1. After an upgrade, "Deprecated" features already in use (enabled prior to
+   upgrade) will log warnings when loaded, e.g., on startup or unseal.
+2. All new usage of "Deprecated" features will log warnings.
+3. HTTP endpoints associated with this feature will include a `warnings` field
+   in response data.
 
 #### Pending removal
 
-This status reflects a feature which has been officially deprecated in this release of OpenBao. This is the first phase in the process that fundamentally alters the behavior of OpenBao. The effects are two-fold:
+This status reflects a feature which has been officially deprecated in this
+release of OpenBao. This is the first phase in the process that fundamentally
+alters the behavior of OpenBao. The effects are two-fold:
 
-1. After an upgrade, any existing `Pending Removal` feature (builtin auth/secrets plugins enabled via CLI or API prior to upgrade) will log `Error`-level messages to the OpenBao log and cause an immediate shutdown of the OpenBao core.
+1. After an upgrade, any existing "Pending Removal" feature (enabled prior
+   to upgrade) will log errors and cause an immediate shutdown of OpenBao if
+   irrecoverable.
+2. All new usage of "Pending Removal" will fail with errors emitted as logs or
+   in API responses as appropriate.
 
-2. Any new `Pending Removal` will fail and log `Error`-level messages to the OpenBao log and CLI/API.
+The "Pending Removal" behavior of builtin plugins may be overridden via the
+[`BAO_ALLOW_PENDING_REMOVAL_MOUNTS`](../commands/server.mdx#bao_allow_pending_removal_mounts)
+environment variable. This effectively allows all "Pending Removal" features to
+be treated as "Deprecated".
 
-##### VAULT_ALLOW_PENDING_REMOVAL_MOUNTS
+:::note
 
-The `Pending Removal` behavior may be overridden using a new environment variable: [`VAULT_ALLOW_PENDING_REMOVAL_MOUNTS`](../commands/server.mdx#vault_allow_pending_removal_mounts). This environment variable effectively allows all `Pending Removal` features to be treated as `Deprecated`.
+This deprecation status typically only applies to deprecations of entire
+builtin plugins. Other feature deprecations tend to skip this phase and go from
+"Deprecated" to "Removed" right away in the next major or minor release.
+
+:::
 
 #### Removed
 
-This status reflects a feature which has been officially removed from OpenBao. `Removed` is the last phase of the deprecation process. During this phase, code for this feature no longer exists within OpenBao.
-
-1. After an upgrade, any existing `Removed` feature will log `Error`-level messages to the OpenBao log and cause an immediate shutdown of the OpenBao core.
-
-2. Any new `Removed` features will fail and log `Error`-level messages to the OpenBao log and CLI/API.
+This status reflects a feature which has been officially removed from OpenBao.
+"Removed" is the last phase of the deprecation process. Once reached, code for
+this feature no longer exists within OpenBao, and thus attempted use of the
+feature will fail.
 
 #### Migration path
 
-In order to successfully upgrade, use of the `Removed` feature must be discontinued. To accomplish this:
+In order to successfully upgrade, use of the "Removed" feature must be
+discontinued. To accomplish this:
 
-1. Downgrade OpenBao to a previous version.
-
-2. Replace any `Removed` or `Pending Removal` feature with the preferred alternative feature.
-
+1. Downgrade OpenBao to a previous version if a premature upgrade was performed
+   and the migration requires live access to the removed feature.
+2. Replace any "Removed" or "Pending Removal" feature with the preferred
+   alternative feature.
 3. Upgrade to latest desired version.

--- a/website/content/docs/policies/brand.mdx
+++ b/website/content/docs/policies/brand.mdx
@@ -194,7 +194,7 @@ logo, such as in Secrets Management for our table banner image:
 
 ![OpenBao-Table-Banner](https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-banner-color.svg)
 
-please use [DM Sans](https://fonts.google.com/specimen/DM+Sans?preview.text=Open-Source%20Secrets%20Maanagement).
+please use [DM Sans](https://fonts.google.com/specimen/DM+Sans?preview.text=Open-Source%20Secrets%20Management).
 
 ## Stickers
 

--- a/website/content/docs/policies/deprecation.mdx
+++ b/website/content/docs/policies/deprecation.mdx
@@ -57,5 +57,3 @@ or decide upon a different voting mechanism.
    enact deprecation and removal.
 2. Follow approach similar to upstream after first release candidate
    (described above).
-
-


### PR DESCRIPTION
## Description

This tidies up the page at https://openbao.org/docs/deprecation/faq:

- Remove the section on SHA-1 signatures
- Change up the wording used to explain deprecation status / phases to apply more generally to feature deprecations in OpenBao opposed to a strong focus on deprecation phases for builtin auth/secrets engines.
- Wrap text I guess?

## Rationale

I'll tackle the main deprecations overview in a follow up, I'd like to get rid of the very crowded table and refactor it into sections, plus align wording between the deprecation phases outlined in the FAQ with the timelines given in the overview.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
