### PR TITLE
Use unique constraints, indices in PostgreSQL storage

### DIFF
--- a/changelog/2876.txt
+++ b/changelog/2876.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/postgresql: Set constraint name to table+"_pkey" and ha_table+"_pkey" and index to table+"_idx" for uniqueness when reusing the same database partition for multiple OpenBao instances.
+```

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -56,7 +56,10 @@ var (
 // PostgreSQL Backend is a physical backend that stores data
 // within a PostgreSQL database.
 type PostgreSQLBackend struct {
-	table  string
+	table           string
+	tableConstraint string
+	index           string
+
 	client *sql.DB
 
 	putQuery             string
@@ -67,6 +70,7 @@ type PostgreSQLBackend struct {
 	listPageLimitedQuery string
 
 	haTable                  string
+	haTableConstraint        string
 	haGetLockValueQuery      string
 	haUpsertLockIdentityExec string
 	haRenewLockIdentityExec  string
@@ -198,8 +202,10 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 
 	// Setup the backend.
 	m := &PostgreSQLBackend{
-		table:  quotedTable,
-		client: db,
+		table:           quotedTable,
+		tableConstraint: dbutil.QuoteIdentifier(unquotedTable + "_pkey"),
+		index:           dbutil.QuoteIdentifier(unquotedTable + "_idx"),
+		client:          db,
 		putQuery: "INSERT INTO " + quotedTable + " VALUES($1, $2, $3, $4)" +
 			" ON CONFLICT (path, key) DO " +
 			" UPDATE SET (parent_path, path, key, value) = ($1, $2, $3, $4)",
@@ -217,7 +223,8 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 			" UNION ALL SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " + quotedTable +
 			" WHERE parent_path LIKE $1 || '%' AND substring(substr(path, length($1)+1) from '^.*?/') > $2" +
 			" ORDER BY key LIMIT $3",
-		haTable: quotedHaTable,
+		haTable:           quotedHaTable,
+		haTableConstraint: dbutil.QuoteIdentifier(unquotedHaTable + "_pkey"),
 		haGetLockValueQuery:
 		// only read non expired data
 		" SELECT ha_value FROM " + quotedHaTable + " WHERE NOW() <= valid_until AND ha_key = $1 ",
@@ -324,7 +331,7 @@ func (m *PostgreSQLBackend) createTables() error {
 		`  path        TEXT COLLATE "C",` +
 		`  key         TEXT COLLATE "C",` +
 		`  value       BYTEA,` +
-		`  CONSTRAINT pkey PRIMARY KEY (path, key)` +
+		`  CONSTRAINT ` + m.tableConstraint + ` PRIMARY KEY (path, key)` +
 		`);`
 	if _, err := txn.Exec(createTableQuery); err != nil {
 		if strings.Contains(err.Error(), "SQLSTATE 25006") {
@@ -339,7 +346,7 @@ func (m *PostgreSQLBackend) createTables() error {
 		return fmt.Errorf("failed to execute create query: %w", err)
 	}
 
-	createIndexQuery := `CREATE INDEX IF NOT EXISTS parent_path_idx ON ` + m.table + ` (parent_path);`
+	createIndexQuery := `CREATE INDEX IF NOT EXISTS ` + m.index + ` ON ` + m.table + ` (parent_path);`
 	if _, err := txn.Exec(createIndexQuery); err != nil {
 		if strings.Contains(err.Error(), "SQLSTATE 23505") {
 			m.logger.Warn("Skipping table creation as other processes have already created the index", "err", err)
@@ -355,7 +362,7 @@ func (m *PostgreSQLBackend) createTables() error {
 			`  ha_identity TEXT COLLATE "C" NOT NULL,` +
 			`  ha_value    TEXT COLLATE "C",` +
 			`  valid_until TIMESTAMP WITH TIME ZONE NOT NULL,` +
-			`  CONSTRAINT ha_key PRIMARY KEY (ha_key)` +
+			`  CONSTRAINT ` + m.haTableConstraint + ` PRIMARY KEY (ha_key)` +
 			`);`
 		if _, err := txn.Exec(createTableQuery); err != nil {
 			if strings.Contains(err.Error(), "SQLSTATE 23505") {

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -194,9 +194,12 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		return nil, errors.New("PostgreSQL version must be at least 9.5")
 	}
 
-	unquotedHaTable, ok := conf["haTable"]
+	unquotedHaTable, ok := conf["ha_table"]
 	if !ok {
-		unquotedHaTable = "openbao_ha_locks"
+		unquotedHaTable, ok = conf["haTable"]
+		if !ok {
+			unquotedHaTable = "openbao_ha_locks"
+		}
 	}
 	quotedHaTable := dbutil.QuoteIdentifier(unquotedHaTable)
 

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -769,3 +769,33 @@ func TestPostgreSQLBackend_LockSemantics(t *testing.T) {
 	default:
 	}
 }
+
+func TestPostgreSQLBackend_ParallelTables(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	cleanup, connURL := postgresql.PrepareTestContainer(t, "11.1")
+	defer cleanup()
+
+	// Create two in the same database instance.
+	b1, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": connURL,
+		"table":          "store_1",
+		"ha_table":       "store_1_ha",
+		"ha_enabled":     "true",
+	}, logger)
+	require.NoError(t, err)
+
+	b2, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": connURL,
+		"table":          "store_2",
+		"ha_table":       "store_2_ha",
+		"ha_enabled":     "true",
+	}, logger)
+	require.NoError(t, err)
+
+	logger.Info("Running basic backend tests")
+	physical.ExerciseBackend(t, b1)
+	physical.ExerciseBackend(t, b2)
+}

--- a/physical/postgresql/testing.go
+++ b/physical/postgresql/testing.go
@@ -4,6 +4,7 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -15,6 +16,18 @@ import (
 )
 
 func SetupDatabaseObjects(t *testing.T, pg *PostgreSQLBackend) {
+	var haTable string
+	if pg.haEnabled {
+		haTable = pg.haTable
+	}
+
+	err := SetupDatabaseObjectsWithClient(pg.client, pg.table, pg.tableConstraint, pg.index, haTable, pg.haTableConstraint)
+	if err != nil {
+		t.Fatalf("failed to setup database: %v", err)
+	}
+}
+
+func SetupDatabaseObjectsWithClient(client *sql.DB, table string, constraint string, index string, haTable string, haTableConstraint string) error {
 	var err error
 	// Setup tables and indexes if not exists.
 	createTableSQL := fmt.Sprintf(
@@ -23,34 +36,38 @@ func SetupDatabaseObjects(t *testing.T, pg *PostgreSQLBackend) {
 			"  path        TEXT COLLATE \"C\", "+
 			"  key         TEXT COLLATE \"C\", "+
 			"  value       BYTEA, "+
-			"  CONSTRAINT pkey PRIMARY KEY (path, key) "+
-			" ); ", pg.table)
+			"  CONSTRAINT %v PRIMARY KEY (path, key) "+
+			" ); ", table, constraint)
 
-	_, err = pg.client.Exec(createTableSQL)
+	_, err = client.Exec(createTableSQL)
 	if err != nil {
-		t.Fatalf("Failed to create table: %v", err)
+		return fmt.Errorf("failed to create table: %v", err)
 	}
 
-	createIndexSQL := fmt.Sprintf(" CREATE INDEX IF NOT EXISTS parent_path_idx ON %v (parent_path); ", pg.table)
+	createIndexSQL := fmt.Sprintf(" CREATE INDEX IF NOT EXISTS %v ON %v (parent_path); ", index, table)
 
-	_, err = pg.client.Exec(createIndexSQL)
+	_, err = client.Exec(createIndexSQL)
 	if err != nil {
-		t.Fatalf("Failed to create index: %v", err)
+		return fmt.Errorf("failed to create index: %v", err)
 	}
 
-	createHaTableSQL := fmt.Sprintf(
-		" CREATE TABLE IF NOT EXISTS %v ( "+
-			" ha_key                                      TEXT COLLATE \"C\" NOT NULL, "+
-			" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, "+
-			" ha_value                                    TEXT COLLATE \"C\", "+
-			" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, "+
-			" CONSTRAINT ha_key PRIMARY KEY (ha_key) "+
-			" ); ", pg.haTable)
+	if haTable != "" {
+		createHaTableSQL := fmt.Sprintf(
+			" CREATE TABLE IF NOT EXISTS %v ( "+
+				" ha_key                                      TEXT COLLATE \"C\" NOT NULL, "+
+				" ha_identity                                 TEXT COLLATE \"C\" NOT NULL, "+
+				" ha_value                                    TEXT COLLATE \"C\", "+
+				" valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL, "+
+				" CONSTRAINT %v PRIMARY KEY (ha_key) "+
+				" ); ", haTable, haTableConstraint)
 
-	_, err = pg.client.Exec(createHaTableSQL)
-	if err != nil {
-		t.Fatalf("Failed to create hatable: %v", err)
+		_, err = client.Exec(createHaTableSQL)
+		if err != nil {
+			return fmt.Errorf("failed to create hatable: %v", err)
+		}
 	}
+
+	return nil
 }
 
 func GetTestPostgreSQLBackend(t *testing.T, logger log.Logger) (physical.Backend, func()) {

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -121,10 +121,10 @@ CREATE TABLE openbao_kv_store (
   path        TEXT COLLATE "C",
   key         TEXT COLLATE "C",
   value       BYTEA,
-  CONSTRAINT pkey PRIMARY KEY (path, key)
+  CONSTRAINT openbao_kv_store_pkey PRIMARY KEY (path, key)
 );
 
-CREATE INDEX parent_path_idx ON openbao_kv_store (parent_path);
+CREATE INDEX openbao_kv_store_idx ON openbao_kv_store (parent_path);
 ```
 
 Store for HAEnabled backend
@@ -135,7 +135,7 @@ CREATE TABLE openbao_ha_locks (
   ha_identity                                 TEXT COLLATE "C" NOT NULL,
   ha_value                                    TEXT COLLATE "C",
   valid_until                                 TIMESTAMP WITH TIME ZONE NOT NULL,
-  CONSTRAINT ha_key PRIMARY KEY (ha_key)
+  CONSTRAINT openbao_ha_locks_pkey PRIMARY KEY (ha_key)
 );
 ```
 


### PR DESCRIPTION
When creating multiple OpenBao instances with the same database in the PostgreSQL storage backend (to speed up testing), we'll want to keep `skip_create_table=false`. However, just setting `table` (and `ha_table`) isn't sufficient: we'll end up with constraint conflict errors like:

> ```
> error initializing storage of type postgresql: failed to create
> tables: failed to execute create query: ERROR: relation "pkey"
> already exists (SQLSTATE 42P07)
> ```

because of the `pkey` relation already existing in a separate table for a separate test.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
