### PR TITLE
Properly decode Type, Name

### DIFF
--- a/helper/profiles/config.go
+++ b/helper/profiles/config.go
@@ -54,15 +54,15 @@ type FieldSchemaConfig struct {
 	UnusedKeys configutil.UnusedKeyMap `hcl:",unusedKeyPositions"`
 	RawConfig  map[string]interface{}
 
-	Type          framework.FieldType
-	TypeRaw       string        `hcl:"type"`
-	Name          string        `hcl:"name"`
-	Default       interface{}   `hcl:"default"`
-	Description   string        `hcl:"description"`
-	Required      bool          `hcl:"required"`
-	Deprecated    bool          `hcl:"deprecated"`
-	Query         bool          `hcl:"query"`
-	AllowedValues []interface{} `hcl:"allowed_values"`
+	Type          framework.FieldType `hcl:"-"`
+	TypeRaw       string              `hcl:"type"`
+	Name          string              `hcl:"name"`
+	Default       interface{}         `hcl:"default"`
+	Description   string              `hcl:"description"`
+	Required      bool                `hcl:"required"`
+	Deprecated    bool                `hcl:"deprecated"`
+	Query         bool                `hcl:"query"`
+	AllowedValues []interface{}       `hcl:"allowed_values"`
 }
 
 // OutputConfig is an untyped configuration object that controls the output
@@ -85,12 +85,12 @@ func ParseOuterConfig(outerBlockType string, list *ast.ObjectList) ([]*OuterConf
 	for index, item := range list.Items {
 		var i OuterConfig
 		if err := hcl.DecodeObject(&i, item.Val); err != nil {
-			return result, fmt.Errorf("%v.%d: %w", outerBlockType, index, err)
+			return result, fmt.Errorf("%v.%d: decoding into object failed with error: %w", outerBlockType, index, err)
 		}
 
 		var m map[string]interface{}
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
-			return result, fmt.Errorf("%v.%d: %w", outerBlockType, index, err)
+			return result, fmt.Errorf("%v.%d: decoding into map failed with error: %w", outerBlockType, index, err)
 		}
 		i.RawConfig = m
 
@@ -140,12 +140,12 @@ func ParseRequestConfig(list *ast.ObjectList) ([]*RequestConfig, error) {
 	for i, item := range list.Items {
 		var r RequestConfig
 		if err := hcl.DecodeObject(&r, item.Val); err != nil {
-			return result, fmt.Errorf("request.%d: %w", i, err)
+			return result, fmt.Errorf("request.%d: decoding into object failed with error: %w", i, err)
 		}
 
 		var m map[string]interface{}
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
-			return result, fmt.Errorf("request.%d: %w", i, err)
+			return result, fmt.Errorf("request.%d: decoding into map failed with error: %w", i, err)
 		}
 		r.RawConfig = m
 
@@ -174,12 +174,12 @@ func ParseInputConfig(list *ast.ObjectList) (*InputConfig, error) {
 
 	var i InputConfig
 	if err := hcl.DecodeObject(&i, item.Val); err != nil {
-		return nil, fmt.Errorf("input: %w", err)
+		return nil, fmt.Errorf("input: decoding into object failed with error: %w", err)
 	}
 
 	var m map[string]interface{}
 	if err := hcl.DecodeObject(&m, item.Val); err != nil {
-		return nil, fmt.Errorf("input: %w", err)
+		return nil, fmt.Errorf("input: decoding into map failed with error: %w", err)
 	}
 	i.RawConfig = m
 
@@ -214,24 +214,26 @@ func ParseFieldSchemaConfig(list *ast.ObjectList) ([]*FieldSchemaConfig, error) 
 	for i, item := range list.Items {
 		var r FieldSchemaConfig
 		if err := hcl.DecodeObject(&r, item.Val); err != nil {
-			return result, fmt.Errorf("field.%d: %w", i, err)
+			return result, fmt.Errorf("field.%d: decoding into object failed with error: %w", i, err)
 		}
 
 		var m map[string]interface{}
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
-			return result, fmt.Errorf("field.%d: %w", i, err)
+			return result, fmt.Errorf("field.%d: decoding into map failed with error: %w", i, err)
 		}
 		r.RawConfig = m
 
 		switch {
 		case r.TypeRaw != "" && r.Name != "":
-		case r.TypeRaw != "" && len(item.Keys) == 1:
+		case r.TypeRaw != "" && r.Name == "" && len(item.Keys) == 1:
 			r.Name = item.Keys[0].Token.Value().(string)
-		case len(item.Keys) == 2:
+		case r.TypeRaw == "" && r.Name != "" && len(item.Keys) == 1:
+			r.TypeRaw = item.Keys[0].Token.Value().(string)
+		case r.TypeRaw == "" && r.Name == "" && len(item.Keys) == 2:
 			r.TypeRaw = item.Keys[0].Token.Value().(string)
 			r.Name = item.Keys[1].Token.Value().(string)
 		default:
-			return result, fmt.Errorf("field.%d: field type and name must be specified", i)
+			return result, fmt.Errorf("field.%d: field type and name must be specified either as keys or block parameters", i)
 		}
 
 		var err error

--- a/helper/profiles/config_test.go
+++ b/helper/profiles/config_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/hclutil"
+	"github.com/stretchr/testify/require"
 )
 
 func parseBlockList(hclStr, blockName string) (*ast.ObjectList, error) {
@@ -174,4 +176,57 @@ request {
 	if err == nil || !strings.Contains(err.Error(), "type must be specified") {
 		t.Fatalf("expected missing-type error, got %v", err)
 	}
+}
+
+func TestParseInput_FieldNames(t *testing.T) {
+	hclStr := `
+input {
+  field "namespace" {
+    type = "string"
+    description = "name of the namespace to create"
+    required = true
+  }
+
+  field "string" {
+    name = "username"
+    description = "username to provision into auth mount"
+    required = true
+  }
+
+  field "int" "password" {
+    description = "password to authenticate with"
+    required = false
+  }
+}
+`
+	list, err := parseBlockList(hclStr, "input")
+	require.NoError(t, err)
+	require.NotNil(t, list)
+
+	input, err := ParseInputConfig(list)
+	require.NoError(t, err)
+	require.NotNil(t, input)
+	require.Equal(t, 3, len(input.Fields))
+
+	namespace := input.Fields[0]
+	username := input.Fields[1]
+	password := input.Fields[2]
+
+	require.Equal(t, namespace.Type, framework.TypeString)
+	require.Equal(t, namespace.TypeRaw, "string")
+	require.Equal(t, namespace.Name, "namespace")
+	require.NotEmpty(t, namespace.Description)
+	require.True(t, namespace.Required)
+
+	require.Equal(t, username.Type, framework.TypeString)
+	require.Equal(t, username.TypeRaw, "string")
+	require.Equal(t, username.Name, "username")
+	require.NotEmpty(t, username.Description)
+	require.True(t, username.Required)
+
+	require.Equal(t, password.Type, framework.TypeInt)
+	require.Equal(t, password.TypeRaw, "int")
+	require.Equal(t, password.Name, "password")
+	require.NotEmpty(t, password.Description)
+	require.False(t, password.Required)
 }


### PR DESCRIPTION
Due to a bug in our definitions (missing `hcl:"-"` bypass on both `Fields` in `input` and the parsed `Type` in `FieldSchemaConfig`), we failed to decode the following two forms of input:

    fields "namespace" {
      type = "string"
      description = "name of the namespace to create"
      required = true
    }

    fields "string" {
      name = "namespace"
      description = "name of the namespace to create"
      required = true
    }

These now behave correctly.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: https://github.com/openbao/openbao/pull/2874#discussion_r3078364393

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
