### PR TITLE
Add Namespace Sealing

### DIFF
--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -52,6 +52,31 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 
 	return []*framework.Path{
 		{
+			Pattern: "namespaces/(?P<path>.+)/seal",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": namespacePathSchema,
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:  "Seal a namespace.",
+					Callback: b.handleNamespacesSeal(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{
+							Description: http.StatusText(http.StatusNoContent),
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
+		},
+
+		{
 			Pattern: "namespaces/(?P<path>.+)/unseal",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "namespaces",
@@ -84,6 +109,23 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
 			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
 		},
+	}
+}
+
+// handleNamespacesSeal handles the "/sys/namespaces/<path>/seal" endpoint to seal the namespace.
+func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+
+		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
+			return nil, errors.New("path must not contain /")
+		}
+
+		if err := b.Core.namespaceStore.SealNamespace(ctx, path); err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
 	}
 }
 

--- a/vault/logical_system_namespaces_seals_test.go
+++ b/vault/logical_system_namespaces_seals_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/openbao/openbao/helper/namespace"
@@ -12,12 +13,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNamespaceBackend_Unseal(t *testing.T) {
+func TestNamespaceBackend_SealUnseal(t *testing.T) {
 	t.Parallel()
 	c, _, _ := TestCoreUnsealed(t)
 	b := c.systemBackend
 
 	rootCtx := namespace.RootContext(context.Background())
+	t.Run("namespaces created with seal config are sealed by default", func(t *testing.T) {
+		TestCoreCreateSealedNamespaces(t, c, &namespace.Namespace{Path: "foo/"})
+
+		req := logical.TestRequest(t, logical.CreateOperation, "auth/token/create/foo")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+		require.Empty(t, res)
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foo/seal")
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Empty(t, res)
+	})
+
+	t.Run("cannot seal non-existent namespace", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/bar/seal")
+		_, err := b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+		require.Equal(t, "invalid request", err.Error())
+	})
+
 	t.Run("can unseal namespace with required number of keyshares", func(t *testing.T) {
 		req := logical.TestRequest(t, logical.UpdateOperation, "namespaces/baz")
 		req.Data["seal"] = map[string]any{"type": "shamir", "secret_shares": 3, "secret_threshold": 2}
@@ -61,5 +83,98 @@ func TestNamespaceBackend_Unseal(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// TODO(wslabosz): add additional tests with seal operation
+	t.Run("preserve mounts after unsealing namespaces", func(t *testing.T) {
+		keyshares := TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "foobar/"})
+		ns, err := c.namespaceStore.GetNamespaceByPath(rootCtx, "foobar")
+		require.NoError(t, err)
+		nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
+
+		// mount a kv engine
+		req := logical.TestRequest(t, logical.UpdateOperation, "mounts/my_secrets")
+		req.Data["type"] = "kv"
+		_, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+
+		// mount should appear
+		req = logical.TestRequest(t, logical.ReadOperation, "mounts")
+		res, err := b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_secrets/"])
+
+		// store something to the mount
+		req = logical.TestRequest(t, logical.UpdateOperation, "my_secrets/abc")
+		req.Data["test_key"] = "test_value"
+		_, err = c.router.Route(nsCtx, req)
+		require.NoError(t, err)
+
+		// mount an auth and use it
+		req = logical.TestRequest(t, logical.UpdateOperation, "auth/my_approle")
+		req.Data["type"] = "approle"
+		_, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "auth")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_approle/"])
+
+		req = logical.TestRequest(t, logical.CreateOperation, "auth/my_approle/role/myrole")
+		req.Data["token_policies"] = []string{"default"}
+		_, err = c.router.Route(nsCtx, req)
+		require.NoError(t, err)
+
+		// then seal the namespace
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/seal")
+		_, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		// unseal the namespace
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][0])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Data["progress"])
+		require.Equal(t, true, res.Data["sealed"])
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][1])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, 2, res.Data["progress"])
+		require.Equal(t, true, res.Data["sealed"])
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][2])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		// progress reset
+		require.Equal(t, 0, res.Data["progress"])
+		require.Equal(t, false, res.Data["sealed"])
+
+		// mount should appear
+		req = logical.TestRequest(t, logical.ReadOperation, "mounts")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_secrets/"])
+
+		// reading from mount should work
+		req = logical.TestRequest(t, logical.ReadOperation, "my_secrets/abc")
+		res, err = c.router.Route(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, "test_value", res.Data["test_key"])
+
+		// auth should appear
+		req = logical.TestRequest(t, logical.ReadOperation, "auth")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_approle/"])
+
+		// reading from auth should work
+		req = logical.TestRequest(t, logical.ReadOperation, "auth/my_approle/role/myrole")
+		res, err = c.router.Route(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1962,7 +1962,7 @@ func (c *Core) reloadNamespaceMounts(childCtx context.Context, uuid string, dele
 		}
 	}
 
-	c.logger.Debug("invalidating namespace mount", "ns", uuid, "keys", keys)
+	c.logger.Debug("invalidating namespace mounts", "ns", uuid, "keys", keys)
 	for _, key := range keys {
 		err := c.reloadMount(childCtx, key)
 		if err != nil {
@@ -2090,9 +2090,8 @@ func (c *Core) reloadMount(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
-	barrier := NamespaceScopedView(c.barrier, ns)
 
-	desiredMountEntry, err := c.fetchAndDecodeMountTableEntry(ctx, barrier, prefix, uuid)
+	desiredMountEntry, err := c.fetchAndDecodeMountTableEntry(ctx, c.NamespaceView(ns), prefix, uuid)
 	if err != nil {
 		if err.Error() != "unexpected empty storage entry for mount" {
 			return err

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -959,13 +959,40 @@ func (ns *NamespaceStore) ListNamespaces(ctx context.Context, includeParent bool
 	return ns.namespacesByPath.List(parent.Path, includeParent, recursive, ns.creationDeletionMap)
 }
 
-// sealNamespaceLocked assumes the read lock is hold, and seals provided namespace,
+// SealNamespace acquires a read lock, and seals provided namespace,
 // cleaning up namespace resources.
-//
-//nolint:unused // TODO(wslabosz): add usage and tests with namespace seal operation.
-func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSeal *namespace.Namespace) error {
+func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 
+	unlock, err := ns.lockWithInvalidation(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	namespaceToSeal, err := ns.getNamespaceByPathLocked(ctx, path, false)
+	if err != nil {
+		return err
+	}
+
+	if namespaceToSeal == nil {
+		return errors.New("namespace doesn't exist")
+	}
+
+	if namespaceToSeal.ID == namespace.RootNamespaceID {
+		return errors.New("unable to seal root namespace")
+	}
+
+	if namespaceToSeal.Tainted {
+		return errors.New("unable to seal tainted namespace")
+	}
+
+	return ns.sealNamespaceLocked(ctx, namespaceToSeal)
+}
+
+// sealNamespaceLocked assumes the read lock is hold, and seals provided namespace,
+// cleaning up namespace resources.
+func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSeal *namespace.Namespace) error {
 	var errs error
 	ns.namespacesByPath.PostOrderTraversal(namespaceToSeal.Path, func(entry *namespace.Namespace) {
 		if entry.ID == namespace.RootNamespaceID || ns.core.NamespaceSealed(entry) {
@@ -1105,6 +1132,10 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 	}
 	if namespaceToDelete == nil {
 		return "", nil
+	}
+
+	if ns.core.NamespaceSealed(namespaceToDelete) {
+		return "", errors.New("cannot delete sealed namespace")
 	}
 
 	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
@@ -1491,6 +1522,8 @@ func (j *namespaceDeletionJob) Execute() error {
 	delete(j.store.namespacesByUUID, j.target.UUID)
 	delete(j.store.namespacesByAccessor, j.target.ID)
 
+	j.store.core.sealManager.RemoveNamespace(j.target)
+
 	view := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
 	if err := view.Delete(ctx, j.target.UUID); err != nil {
 		return fmt.Errorf("failed to delete namespace storage entry: %w", err)
@@ -1558,14 +1591,13 @@ func (j *namespaceCreationFailureJob) Execute() error {
 		delete(j.store.namespacesByUUID, j.target.UUID)
 		delete(j.store.namespacesByAccessor, j.target.ID)
 
+		j.store.core.sealManager.RemoveNamespace(j.target)
+
 		nsView := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
-		if err := nsView.Delete(j.store.creationDeletionJobContext, j.target.UUID); err != nil {
+		if err := nsView.Delete(nsCtx, j.target.UUID); err != nil {
 			err = fmt.Errorf("failed to remove created namespace storage entry on failure: %w", err)
 			retErr = multierror.Append(retErr, err)
 		}
-
-		// TODO(wslabosz): think if sealmanager namespace removal should happen earlier.
-		j.store.core.sealManager.RemoveNamespace(j.target)
 	}
 
 	return retErr

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openbao/openbao/helper/benchhelpers"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/vault/seal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -886,4 +887,80 @@ func TestNamespaceStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, ns)
 	}
+}
+
+func TestNamespaceDeletionSealingInteraction(t *testing.T) {
+	c, keys, _ := TestCoreUnsealed(t)
+	s := c.namespaceStore
+	ctx := namespace.RootContext(t.Context())
+
+	namespaces := []*namespace.Namespace{
+		{Path: "ns1/"},
+		{Path: "ns2/"},
+		{Path: "ns3/"},
+	}
+	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, namespaces...)
+
+	t.Run("cannot seal tainted namespace", func(t *testing.T) {
+		_, err := s.DeleteNamespace(ctx, "ns1")
+		require.NoError(t, err)
+
+		require.Error(t, s.SealNamespace(ctx, "ns1"))
+		ns, err := s.GetNamespaceByPath(ctx, "ns1")
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.True(t, ns.Tainted)
+		require.False(t, c.NamespaceSealed(ns))
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, err := s.DeleteNamespace(ctx, "ns1")
+			require.NoError(collect, err)
+			require.Empty(collect, status)
+		}, time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("seal core while deleting namespace", func(t *testing.T) {
+		_, err := s.DeleteNamespace(ctx, "ns2")
+		require.NoError(t, err)
+
+		require.NoError(t, TestCoreSeal(c))
+		for _, key := range keys {
+			unsealed, err := TestCoreUnseal(c, key)
+			require.NoError(t, err)
+			if unsealed {
+				break
+			}
+		}
+		require.False(t, c.Sealed())
+
+		s = c.namespaceStore
+		ns, err := s.GetNamespaceByPath(ctx, "ns2")
+		require.NoError(t, err)
+		require.True(t, ns.Tainted)
+
+		_, err = s.DeleteNamespace(ctx, "ns2")
+		require.Error(t, err)
+
+		for _, key := range nsKeys["ns2/"] {
+			unsealed, err := TestNamespaceUnseal(c, ns, key)
+			require.NoError(t, err)
+			if unsealed {
+				break
+			}
+		}
+		require.False(t, c.NamespaceSealed(ns))
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, err := s.DeleteNamespace(ctx, "ns2")
+			require.NoError(collect, err)
+			require.Empty(collect, status)
+		}, time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("cannot delete currently sealed namespace", func(t *testing.T) {
+		require.NoError(t, s.SealNamespace(ctx, "ns3"))
+
+		_, err := s.DeleteNamespace(ctx, "ns3")
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Description
- added `handleNamespacesSeal()` to `vault/logical_system_namespaces_seals.go` 
- added `(*NamespaceStore).SealNamespace()` method
- added check for sealed namespaces in `(*NamespaceStore).DeleteNamespace()` method to reject deletion requests for sealed namespace (sealed namespace implementation yet to be done)
- added removal of namespace from `SealManager` memory in `(*namespaceDeletionJob).Execute()` method

## Rationale
Implements namespace sealing logic for the per-namespace seals feature 

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
