### PR TITLE
Ensure workflow parses on update

### DIFF
--- a/changelog/2671.txt
+++ b/changelog/2671.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-self-init: add CEL support to self-initialization, allowing finer control over structuring requests
+command/server: Add CEL support to self-initialization, allowing finer control over structuring requests.
 ```

--- a/changelog/2727.txt
+++ b/changelog/2727.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-self-init: Add `text/template` support to self-initialization, allowing templating of values from other requests/responses.
+command/server: Add `text/template` support to self-initialization, allowing templating of values from other requests/responses.
 ```

--- a/changelog/2737.txt
+++ b/changelog/2737.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-self-init: Allow setting headers on requests.
+command/server: Allow setting headers on declarative self-initialization requests.
 ```

--- a/changelog/2739.txt
+++ b/changelog/2739.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-self-init: Allow conditional execution of requests with `when` keyword.
+command/server: Allow conditional execution of self-initialization requests with `when` keyword.
 ```

--- a/changelog/2883.txt
+++ b/changelog/2883.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Error parsing when unknown keys are present in the declarative self-initialization configuration.
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -166,6 +166,9 @@ func (c *Config) Validate(sourceFilePath string) []configutil.ConfigError {
 	for _, p := range c.Plugins {
 		results = append(results, p.Validate(sourceFilePath)...)
 	}
+	for _, o := range c.Initialization {
+		results = append(results, o.ValidateUnused(sourceFilePath)...)
+	}
 
 	// Validate plugin_download_behavior
 	if c.PluginDownloadBehavior != "" {

--- a/helper/configutil/lint.go
+++ b/helper/configutil/lint.go
@@ -18,8 +18,12 @@ type ConfigError struct {
 	Position token.Pos
 }
 
-func (c *ConfigError) String() string {
+func (c ConfigError) String() string {
 	return fmt.Sprintf("%s at %s", c.Problem, c.Position.String())
+}
+
+func (c ConfigError) Error() string {
+	return c.String()
 }
 
 type ValidatableConfig interface {

--- a/helper/profiles/config.go
+++ b/helper/profiles/config.go
@@ -116,6 +116,8 @@ func ParseOuterConfig(outerBlockType string, list *ast.ObjectList) ([]*OuterConf
 			}
 
 			i.Requests = requests
+
+			delete(i.UnusedKeys, "request")
 		}
 
 		result = append(result, &i)
@@ -132,6 +134,15 @@ func CreateOuterConfig(requests []*RequestConfig) []*OuterConfig {
 			Requests: requests,
 		},
 	}
+}
+
+func (o *OuterConfig) ValidateUnused(path string) []configutil.ConfigError {
+	var errs []configutil.ConfigError
+	errs = append(errs, configutil.ValidateUnusedFields(o.UnusedKeys, path)...)
+	for _, request := range o.Requests {
+		errs = append(errs, request.ValidateUnused(path)...)
+	}
+	return errs
 }
 
 // ParseRequestConfig handles parsing of individual requests from an HCL AST.
@@ -161,6 +172,10 @@ func ParseRequestConfig(list *ast.ObjectList) ([]*RequestConfig, error) {
 	}
 
 	return result, nil
+}
+
+func (r *RequestConfig) ValidateUnused(path string) []configutil.ConfigError {
+	return configutil.ValidateUnusedFields(r.UnusedKeys, path)
 }
 
 // ParseInputConfig is a helper for profile systems which support declaring
@@ -202,9 +217,20 @@ func ParseInputConfig(list *ast.ObjectList) (*InputConfig, error) {
 		}
 
 		i.Fields = fields
+
+		delete(i.UnusedKeys, "field")
 	}
 
 	return &i, nil
+}
+
+func (i *InputConfig) ValidateUnused(path string) []configutil.ConfigError {
+	var errs []configutil.ConfigError
+	errs = append(errs, configutil.ValidateUnusedFields(i.UnusedKeys, path)...)
+	for _, field := range i.Fields {
+		errs = append(errs, field.ValidateUnused(path)...)
+	}
+	return errs
 }
 
 // ParseFieldSchemaConfig handles parsing of individual field schemas from an
@@ -246,6 +272,22 @@ func ParseFieldSchemaConfig(list *ast.ObjectList) ([]*FieldSchemaConfig, error) 
 	return result, nil
 }
 
+func (s *FieldSchemaConfig) ToSchema() *framework.FieldSchema {
+	return &framework.FieldSchema{
+		Type:          s.Type,
+		Default:       s.Default,
+		Description:   s.Description,
+		Required:      s.Required,
+		Deprecated:    s.Deprecated,
+		Query:         s.Query,
+		AllowedValues: s.AllowedValues,
+	}
+}
+
+func (s *FieldSchemaConfig) ValidateUnused(path string) []configutil.ConfigError {
+	return configutil.ValidateUnusedFields(s.UnusedKeys, path)
+}
+
 // ParseOutputConfig is a helper for profile systems which support declaring
 // response output blocks so that the caller has information about the
 // output.
@@ -275,14 +317,6 @@ func ParseOutputConfig(list *ast.ObjectList) (*OutputConfig, error) {
 	return &i, nil
 }
 
-func (s FieldSchemaConfig) ToSchema() *framework.FieldSchema {
-	return &framework.FieldSchema{
-		Type:          s.Type,
-		Default:       s.Default,
-		Description:   s.Description,
-		Required:      s.Required,
-		Deprecated:    s.Deprecated,
-		Query:         s.Query,
-		AllowedValues: s.AllowedValues,
-	}
+func (o *OutputConfig) ValidateUnused(path string) []configutil.ConfigError {
+	return configutil.ValidateUnusedFields(o.UnusedKeys, path)
 }

--- a/vault/logical_system_workflows.go
+++ b/vault/logical_system_workflows.go
@@ -362,6 +362,10 @@ func (b *SystemBackend) handleWorkflowsUpdate() framework.OperationFunc {
 			AllowUnauthenticated: allowUnauthenticated,
 		}
 
+		if _, _, _, err := pe.Parse(ctx); err != nil {
+			return handleError(err)
+		}
+
 		err := b.Core.workflowStore.Set(ctx, pe, cas)
 		if err != nil {
 			return handleError(err)

--- a/vault/workflow_store.go
+++ b/vault/workflow_store.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/openbao/openbao/helper/configutil"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/profiles"
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -75,6 +76,24 @@ func (we *WorkflowEntry) Parse(ctx context.Context) (*profiles.InputConfig, []*p
 
 	if len(profile) == 0 {
 		return nil, nil, nil, fmt.Errorf("workflow must have at least one %q block", workflowOuterName)
+	}
+
+	var unused []configutil.ConfigError
+	if input != nil {
+		unused = append(unused, input.ValidateUnused("workflow")...)
+	}
+	for _, o := range profile {
+		unused = append(unused, o.ValidateUnused("workflow")...)
+	}
+	if output != nil {
+		unused = append(unused, output.ValidateUnused("workflow")...)
+	}
+	if len(unused) > 0 {
+		var asError []error
+		for _, unusedErr := range unused {
+			asError = append(asError, unusedErr)
+		}
+		return nil, nil, nil, errors.Join(asError...)
 	}
 
 	return input, profile, output, nil


### PR DESCRIPTION
Previously, OpenBao did not validate unused keys in profiles; this meant many forms of errors were silently ignored. Adding validation to both self-initialization and workflows API will help avoid this problem. Notably, the workflows API was lacking any set-time parsing, resulting in only runtime execution failures.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
