### PR TITLE
Move `PolicyStore` into new `policy` package

### DIFF
--- a/command/policy_fmt.go
+++ b/command/policy_fmt.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/openbao/openbao/helper/homedir"
 	"github.com/openbao/openbao/helper/namespace"
-	"github.com/openbao/openbao/vault"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/posener/complete"
 )
 
@@ -93,7 +93,7 @@ func (c *PolicyFmtCommand) Run(args []string) int {
 
 	// Actually parse the policy. We always use the root namespace here because
 	// we don't want to modify the results.
-	if _, err := vault.ParseACLPolicy(namespace.RootNamespace, string(b)); err != nil {
+	if _, err := policy.ParseACLPolicy(namespace.RootNamespace, string(b)); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/helper/template/template.go
+++ b/helper/template/template.go
@@ -1,0 +1,14 @@
+package template
+
+import "github.com/openbao/openbao/sdk/v2/helper/template"
+
+func UseTemplateForFiltering(t template.StringTemplate, path string, key string) (string, error) {
+	return t.Generate(map[string]interface{}{
+		"key":  key,
+		"path": path,
+	})
+}
+
+func CompileTemplatePathForFiltering(tmpl string) (template.StringTemplate, error) {
+	return template.NewTemplate(template.Template(tmpl))
+}

--- a/vault/barrier/barrier.go
+++ b/vault/barrier/barrier.go
@@ -75,6 +75,10 @@ const (
 	// used by standbys to handle rotations. It also comes into play when
 	// restoring raft snapshots.
 	ShamirKekPath = "core/shamir-kek"
+
+	// SystemBarrierPrefix is the prefix used for the
+	// system logical backend.
+	SystemBarrierPrefix = "sys/"
 )
 
 const (

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 )
 
 // Capabilities is used to fetch the capabilities of the given token on the
@@ -62,9 +63,9 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	}
 
 	// Add capabilities of the inline policy if it's set
-	policies := make([]*Policy, 0)
+	policies := make([]*policy.Policy, 0)
 	if te.InlinePolicy != "" {
-		inlinePolicy, err := ParseACLPolicy(tokenNS, te.InlinePolicy)
+		inlinePolicy, err := policy.ParseACLPolicy(tokenNS, te.InlinePolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +74,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	}
 
 	if policyCount == 0 {
-		return []string{DenyCapability}, nil
+		return []string{policy.DenyCapability}, nil
 	}
 
 	// Construct the corresponding ACL object. ACL construction should be

--- a/vault/capabilities_test.go
+++ b/vault/capabilities_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
+	policy_testing "github.com/openbao/openbao/vault/policy/testing"
 )
 
 func TestCapabilities_DerivedPolicies(t *testing.T) {
@@ -41,20 +43,20 @@ path "secret/sample" {
 }
 `
 	// Create the above policies
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, policy1)
-	err = c.policyStore.SetPolicy(ctx, policy, nil)
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, policy1)
+	err = c.policyStore.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, policy2)
-	err = c.policyStore.SetPolicy(ctx, policy, nil)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policy2)
+	err = c.policyStore.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, policy3)
-	err = c.policyStore.SetPolicy(ctx, policy, nil)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policy3)
+	err = c.policyStore.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -174,7 +176,7 @@ func TestCapabilities_TemplatedPolicies(t *testing.T) {
 	}
 	for _, tCase := range tCases {
 		// Create the above policies
-		policy, err := ParseACLPolicy(namespace.RootNamespace, tCase.policy)
+		policy, err := policy.ParseACLPolicy(namespace.RootNamespace, tCase.policy)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -208,7 +210,7 @@ func TestCapabilities(t *testing.T) {
 	}
 
 	// Create a policy
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, aclPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, policy_testing.ACLPolicy)
 	err = c.policyStore.SetPolicy(ctx, policy, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/capabilities_test.go
+++ b/vault/capabilities_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/policy"
-	policy_testing "github.com/openbao/openbao/vault/policy/testing"
+	"github.com/openbao/openbao/vault/policy/policytest"
 )
 
 func TestCapabilities_DerivedPolicies(t *testing.T) {
@@ -210,7 +210,7 @@ func TestCapabilities(t *testing.T) {
 	}
 
 	// Create a policy
-	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, policy_testing.ACLPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, policytest.ACLPolicy)
 	err = c.policyStore.SetPolicy(ctx, policy, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/core.go
+++ b/vault/core.go
@@ -362,7 +362,7 @@ type Core struct {
 	rollback *RollbackManager
 
 	// policy store is used to manage named ACL policies
-	policyStore *PolicyStore
+	policyStore *policy.PolicyStore
 
 	// token store is used to manage authentication tokens
 	tokenStore *TokenStore
@@ -1108,7 +1108,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	c.configureAuditBackends(conf.AuditBackends)
 
 	// UI
-	uiStoragePrefix := systemBarrierPrefix + "ui"
+	uiStoragePrefix := barrier.SystemBarrierPrefix + "ui"
 	c.uiConfig = NewUIConfig(conf.EnableUI, physical.NewView(c.physical, uiStoragePrefix), barrier.NewView(c.barrier, uiStoragePrefix))
 
 	// Listeners
@@ -4171,4 +4171,32 @@ func (c *Core) performPolicyChecks(ctx context.Context, acl *policy.ACL, te *log
 	ret.Allowed = true
 
 	return ret
+}
+
+// setupPolicyStore is used to initialize the policy store
+// when the vault is being unsealed.
+func (c *Core) setupPolicyStore(ctx context.Context) error {
+	// Create the policy store
+	var err error
+	sysView := &dynamicSystemView{core: c}
+	psLogger := c.baseLogger.Named("policy")
+	c.AddLogger(psLogger)
+	c.policyStore, err = policy.NewPolicyStore(ctx, c, c.systemBarrierView, sysView, psLogger)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that the default policy exists, and if not, create it
+	if err := c.policyStore.LoadDefaultPolicies(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// teardownPolicyStore is used to reverse setupPolicyStore
+// when the vault is being sealed.
+func (c *Core) teardownPolicyStore() error {
+	c.policyStore = nil
+	return nil
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -362,7 +362,7 @@ type Core struct {
 	rollback *RollbackManager
 
 	// policy store is used to manage named ACL policies
-	policyStore *policy.PolicyStore
+	policyStore *policy.Store
 
 	// token store is used to manage authentication tokens
 	tokenStore *TokenStore
@@ -2064,7 +2064,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	}
 
 	// Verify that this operation is allowed
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.CheckOpts{
 		RootPrivsRequired: true,
 	})
 	if !authResults.Allowed {
@@ -4143,7 +4143,7 @@ func (c *Core) UnsafeCrossNamespaceIdentity() bool {
 	return c.unsafeCrossNamespaceIdentity
 }
 
-func (c *Core) performPolicyChecks(ctx context.Context, acl *policy.ACL, te *logical.TokenEntry, req *logical.Request, inEntity *identity.Entity, opts *policy.PolicyCheckOpts) *policy.AuthResults {
+func (c *Core) performPolicyChecks(ctx context.Context, acl *policy.ACL, te *logical.TokenEntry, req *logical.Request, inEntity *identity.Entity, opts *policy.CheckOpts) *policy.AuthResults {
 	ret := new(policy.AuthResults)
 
 	// First, perform normal ACL checks if requested. The only time no ACL
@@ -4181,7 +4181,7 @@ func (c *Core) setupPolicyStore(ctx context.Context) error {
 	sysView := &dynamicSystemView{core: c}
 	psLogger := c.baseLogger.Named("policy")
 	c.AddLogger(psLogger)
-	c.policyStore, err = policy.NewPolicyStore(ctx, c, c.systemBarrierView, sysView, psLogger)
+	c.policyStore, err = policy.NewStore(ctx, c, c.systemBarrierView, sysView, psLogger)
 	if err != nil {
 		return err
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/command/server"
 	fwd "github.com/openbao/openbao/helper/forwarding"
+	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/identity/mfa"
 	"github.com/openbao/openbao/helper/locking"
 	"github.com/openbao/openbao/helper/metricsutil"
@@ -60,6 +61,7 @@ import (
 	"github.com/openbao/openbao/vault/cluster"
 	"github.com/openbao/openbao/vault/forwarding"
 	ident "github.com/openbao/openbao/vault/identity"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/quotas"
 	"github.com/openbao/openbao/vault/routing"
 	vaultseal "github.com/openbao/openbao/vault/seal"
@@ -2062,7 +2064,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	}
 
 	// Verify that this operation is allowed
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
 		RootPrivsRequired: true,
 	})
 	if !authResults.Allowed {
@@ -4139,4 +4141,34 @@ func (c *Core) RedirectAddr() string {
 
 func (c *Core) UnsafeCrossNamespaceIdentity() bool {
 	return c.unsafeCrossNamespaceIdentity
+}
+
+func (c *Core) performPolicyChecks(ctx context.Context, acl *policy.ACL, te *logical.TokenEntry, req *logical.Request, inEntity *identity.Entity, opts *policy.PolicyCheckOpts) *policy.AuthResults {
+	ret := new(policy.AuthResults)
+
+	// First, perform normal ACL checks if requested. The only time no ACL
+	// should be applied is if we are only processing EGPs against a login
+	// path in which case opts.Unauth will be set.
+	if acl != nil && !opts.Unauth {
+		ret.ACLResults = acl.AllowOperation(ctx, req, false)
+		ret.RootPrivs = ret.ACLResults.RootPrivs
+		// Root is always allowed; skip Sentinel/MFA checks
+		if ret.ACLResults.IsRoot {
+			// logger.Warn("token is root, skipping checks")
+			ret.Allowed = true
+			return ret
+		}
+		if !ret.ACLResults.Allowed {
+			return ret
+		}
+		// Since HelpOperation was fast-pathed inside AllowOperation, RootPrivs will not have been populated in this
+		// case, so we need to special-case that here as well, or we'll block HelpOperation on all sudo-protected paths.
+		if !ret.RootPrivs && opts.RootPrivsRequired && req.Operation != logical.HelpOperation {
+			return ret
+		}
+	}
+
+	ret.Allowed = true
+
+	return ret
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -4154,7 +4154,6 @@ func (c *Core) performPolicyChecks(ctx context.Context, acl *policy.ACL, te *log
 		ret.RootPrivs = ret.ACLResults.RootPrivs
 		// Root is always allowed; skip Sentinel/MFA checks
 		if ret.ACLResults.IsRoot {
-			// logger.Warn("token is root, skipping checks")
 			ret.Allowed = true
 			return ret
 		}
@@ -4187,11 +4186,7 @@ func (c *Core) setupPolicyStore(ctx context.Context) error {
 	}
 
 	// Ensure that the default policy exists, and if not, create it
-	if err := c.policyStore.LoadDefaultPolicies(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return c.policyStore.LoadDefaultPolicies(ctx)
 }
 
 // teardownPolicyStore is used to reverse setupPolicyStore

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/quotas"
 )
 
@@ -462,7 +463,7 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 
 func (ij *invalidationJob) policyInvalidation(ctx context.Context) error {
 	policyPath := strings.TrimPrefix(ij.nsKey, systemBarrierPrefix+policyACLSubPath)
-	return ij.im.core.policyStore.invalidate(ctx, policyPath, PolicyTypeACL)
+	return ij.im.core.policyStore.invalidate(ctx, policyPath, policy.PolicyTypeACL)
 }
 
 func (ij *invalidationJob) quotaInvalidation(ctx context.Context) error {

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -361,12 +361,12 @@ func (ij *invalidationJob) Execute() error {
 	case strings.HasPrefix(key, namespaceStoreSubPath):
 		ij.fatal = true
 		return ij.namespaceInvalidation(ctx)
-	case strings.HasPrefix(key, systemBarrierPrefix+policyACLSubPath):
+	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+policy.PolicyACLSubPath):
 		// Policy invalidation is not fatal as it contains a LRU cache: we
 		// know removal is strict and it is only potentially preloading an
 		// entry which may err.
 		return ij.policyInvalidation(ctx)
-	case strings.HasPrefix(key, systemBarrierPrefix+quotas.StoragePrefix):
+	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+quotas.StoragePrefix):
 		ij.fatal = true
 		return ij.quotaInvalidation(ctx)
 	case key == coreAuditConfigPath || key == coreLocalAuditConfigPath:
@@ -451,7 +451,7 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 	childCtx := namespace.ContextWithNamespace(ctx, preferredNs)
 
 	// Invalidate all policies within the namespace.
-	ij.im.core.policyStore.invalidateNamespace(childCtx, namespaceUUID)
+	ij.im.core.policyStore.InvalidateNamespace(childCtx, namespaceUUID)
 
 	// Now reload all mounts within the namespace.
 	if err := ij.im.core.reloadNamespaceMounts(childCtx, namespaceUUID, deleted); err != nil {
@@ -462,12 +462,12 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 }
 
 func (ij *invalidationJob) policyInvalidation(ctx context.Context) error {
-	policyPath := strings.TrimPrefix(ij.nsKey, systemBarrierPrefix+policyACLSubPath)
-	return ij.im.core.policyStore.invalidate(ctx, policyPath, policy.PolicyTypeACL)
+	policyPath := strings.TrimPrefix(ij.nsKey, barrier.SystemBarrierPrefix+policy.PolicyACLSubPath)
+	return ij.im.core.policyStore.Invalidate(ctx, policyPath, policy.PolicyTypeACL)
 }
 
 func (ij *invalidationJob) quotaInvalidation(ctx context.Context) error {
-	quotaPath := strings.TrimPrefix(ij.nsKey, systemBarrierPrefix+quotas.StoragePrefix)
+	quotaPath := strings.TrimPrefix(ij.nsKey, barrier.SystemBarrierPrefix+quotas.StoragePrefix)
 	return ij.im.core.quotaManager.Invalidate(quotaPath)
 }
 

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -361,7 +361,7 @@ func (ij *invalidationJob) Execute() error {
 	case strings.HasPrefix(key, namespaceStoreSubPath):
 		ij.fatal = true
 		return ij.namespaceInvalidation(ctx)
-	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+policy.PolicyACLSubPath):
+	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+policy.ACLSubPath):
 		// Policy invalidation is not fatal as it contains a LRU cache: we
 		// know removal is strict and it is only potentially preloading an
 		// entry which may err.
@@ -462,8 +462,8 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 }
 
 func (ij *invalidationJob) policyInvalidation(ctx context.Context) error {
-	policyPath := strings.TrimPrefix(ij.nsKey, barrier.SystemBarrierPrefix+policy.PolicyACLSubPath)
-	return ij.im.core.policyStore.Invalidate(ctx, policyPath, policy.PolicyTypeACL)
+	policyPath := strings.TrimPrefix(ij.nsKey, barrier.SystemBarrierPrefix+policy.ACLSubPath)
+	return ij.im.core.policyStore.Invalidate(ctx, policyPath, policy.TypeACL)
 }
 
 func (ij *invalidationJob) quotaInvalidation(ctx context.Context) error {

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/quotas"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/stretchr/testify/assert"
@@ -304,10 +305,10 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			testCore_Invalidate_handleRequest(t, ctx, c, req)
 
 			// 2. Manipulate Storage
-			policy, err := c.policyStore.GetPolicy(ctx, "test-policy", PolicyTypeACL)
+			pol, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.PolicyTypeACL)
 			require.NoError(t, err)
 
-			clone := policy.ShallowClone()
+			clone := pol.ShallowClone()
 			clone.Expiration = time.Date(2099, 1, 1, 12, 0, 0, 0, time.UTC)
 
 			newEntry, err := logical.StorageEntryJSON(storagePath, clone)
@@ -326,7 +327,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			c.invalidateSynchronous(storagePath)
 
 			// 4. Check cache was properly invalidated
-			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", PolicyTypeACL)
+			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.PolicyTypeACL)
 			require.NoError(t, err)
 
 			require.Equal(t, clone.Expiration, updatedPolicy.Expiration)

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -305,7 +305,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			testCore_Invalidate_handleRequest(t, ctx, c, req)
 
 			// 2. Manipulate Storage
-			pol, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.PolicyTypeACL)
+			pol, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.TypeACL)
 			require.NoError(t, err)
 
 			clone := pol.ShallowClone()
@@ -327,7 +327,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			c.invalidateSynchronous(storagePath)
 
 			// 4. Check cache was properly invalidated
-			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.PolicyTypeACL)
+			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.TypeACL)
 			require.NoError(t, err)
 
 			require.Equal(t, clone.Expiration, updatedPolicy.Expiration)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openbao/openbao/command/server"
 	be "github.com/openbao/openbao/vault/backend"
 	ident "github.com/openbao/openbao/vault/identity"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 
 	logicalDb "github.com/openbao/openbao/builtin/logical/database"
@@ -2823,7 +2824,7 @@ path "secret/*" {
 `
 
 	ps := c.policyStore
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, secretWritingPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, secretWritingPolicy)
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openbao/openbao/command/server"
 	be "github.com/openbao/openbao/vault/backend"
+	"github.com/openbao/openbao/vault/barrier"
 	ident "github.com/openbao/openbao/vault/identity"
 	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
@@ -667,8 +668,8 @@ func TestCore_LoadLoginMFAConfigs(t *testing.T) {
 
 	// prepare views
 	nsView := NamespaceScopedView(c.barrier, ns1)
-	mfaConfigBarrierView := nsView.SubView(systemBarrierPrefix).SubView(loginMFAConfigPrefix)
-	mfaEnforcementConfigBarrierView := nsView.SubView(systemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+	mfaConfigBarrierView := nsView.SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	mfaEnforcementConfigBarrierView := nsView.SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
 
 	// verify empty storage
 	mfaConfigKeys, err := mfaConfigBarrierView.List(ctx, "")

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/pluginutil"
 	"github.com/openbao/openbao/sdk/v2/helper/wrapping"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/version"
 )
@@ -97,9 +98,9 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
 
 	// Add the inline policy if it's set
-	policies := make([]*Policy, 0)
+	policies := make([]*policy.Policy, 0)
 	if te.InlinePolicy != "" {
-		inlinePolicy, err := ParseACLPolicy(tokenNS, te.InlinePolicy)
+		inlinePolicy, err := policy.ParseACLPolicy(tokenNS, te.InlinePolicy)
 		if err != nil {
 			e.core.logger.Error("failed to parse the token's inline policy", "error", err)
 			return false

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -445,11 +445,11 @@ func (c *Core) stopExpiration() error {
 }
 
 func (m *ExpirationManager) leaseView(ns *namespace.Namespace) barrier.View {
-	return NamespaceScopedView(m.core.barrier, ns).SubView(systemBarrierPrefix + expirationSubPath + leaseViewPrefix)
+	return NamespaceScopedView(m.core.barrier, ns).SubView(barrier.SystemBarrierPrefix + expirationSubPath + leaseViewPrefix)
 }
 
 func (m *ExpirationManager) tokenIndexView(ns *namespace.Namespace) barrier.View {
-	return NamespaceScopedView(m.core.barrier, ns).SubView(systemBarrierPrefix + expirationSubPath + tokenViewPrefix)
+	return NamespaceScopedView(m.core.barrier, ns).SubView(barrier.SystemBarrierPrefix + expirationSubPath + tokenViewPrefix)
 }
 
 func (m *ExpirationManager) collectLeases() (map[*namespace.Namespace][]string, int, error) {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/seal"
 )
 
@@ -339,7 +340,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	}
 
 	// Verify that this operation is allowed
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
 		RootPrivsRequired: true,
 	})
 	if !authResults.Allowed {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -340,7 +340,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	}
 
 	// Verify that this operation is allowed
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.CheckOpts{
 		RootPrivsRequired: true,
 	})
 	if !authResults.Allowed {

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -30,6 +30,7 @@ import (
 	be "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/barrier"
 	ident "github.com/openbao/openbao/vault/identity"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 )
 
@@ -485,7 +486,7 @@ func TestIdentityStore_WrapInfoInheritance(t *testing.T) {
 	// sys/wrapping/wrap
 	te := &logical.TokenEntry{
 		Path:     "test",
-		Policies: []string{"default", responseWrappingPolicyName},
+		Policies: []string{"default", policy.ResponseWrappingPolicyName},
 		EntityID: entityID,
 		TTL:      time.Hour,
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3147,7 +3147,7 @@ func (b *SystemBackend) handleWrappingUnwrap(ctx context.Context, req *logical.R
 
 	var response string
 	switch te.Policies[0] {
-	case responseWrappingPolicyName:
+	case policy.ResponseWrappingPolicyName:
 		response, err = b.responseWrappingUnwrap(unwrapCtx, te, thirdParty)
 	}
 	if err != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
 	"github.com/openbao/openbao/sdk/v2/helper/wrapping"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/version"
 )
@@ -2441,7 +2442,7 @@ func (b *SystemBackend) handleDisableAuth(ctx context.Context, req *logical.Requ
 }
 
 // handlePoliciesList handles /sys/policy/ and /sys/policies/<type> endpoints to provide the enabled policies
-func (b *SystemBackend) handlePoliciesList(policyType PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesList(policyType policy.PolicyType) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		prefix := ""
 		if _, present := data.Schema["name"]; present {
@@ -2458,7 +2459,7 @@ func (b *SystemBackend) handlePoliciesList(policyType PolicyType) framework.Oper
 		}
 
 		switch policyType {
-		case PolicyTypeACL:
+		case policy.PolicyTypeACL:
 			if ns.ID == namespace.RootNamespaceID && prefix == "" {
 				policies = append(policies, "root")
 			}
@@ -2476,23 +2477,23 @@ func (b *SystemBackend) handlePoliciesList(policyType PolicyType) framework.Oper
 }
 
 // handlePoliciesRead handles the "/sys/policy/<name>" and "/sys/policies/<type>/<name>" endpoints to read a policy
-func (b *SystemBackend) handlePoliciesRead(policyType PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesRead(policyType policy.PolicyType) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		name := data.Get("name").(string)
 
-		policy, err := b.Core.policyStore.GetPolicy(ctx, name, policyType)
+		pol, err := b.Core.policyStore.GetPolicy(ctx, name, policyType)
 		if err != nil {
 			return handleError(err)
 		}
 
-		if policy == nil {
+		if pol == nil {
 			return nil, nil
 		}
 
-		respData := readPolicyResponse(policy)
+		respData := readPolicyResponse(pol)
 
 		// If the request is from sys/policy/ we handle backwards compatibility
-		if policyType == PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
+		if policyType == policy.PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
 			respData["rules"] = respData["policy"]
 			delete(respData, "policy")
 		}
@@ -2503,7 +2504,7 @@ func (b *SystemBackend) handlePoliciesRead(policyType PolicyType) framework.Oper
 	}
 }
 
-func readPolicyResponse(policy *Policy) map[string]interface{} {
+func readPolicyResponse(policy *policy.Policy) map[string]interface{} {
 	data := map[string]interface{}{
 		"name":         policy.Name,
 		"version":      policy.DataVersion,
@@ -2523,7 +2524,7 @@ func readPolicyResponse(policy *Policy) map[string]interface{} {
 }
 
 // handlePoliciesSet handles the "/sys/policy/<name>" and "/sys/policies/<type>/<name>" endpoints to set a policy
-func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesSet(policyType policy.PolicyType) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		var resp *logical.Response
 
@@ -2533,33 +2534,33 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 		}
 
 		name := data.Get("name").(string)
-		policy := &Policy{
+		pol := &policy.Policy{
 			Name:      strings.ToLower(name),
 			Type:      policyType,
-			namespace: ns,
+			Namespace: ns,
 		}
-		if policy.Name == "" {
+		if pol.Name == "" {
 			return logical.ErrorResponse("policy name must be provided in the URL"), nil
 		}
-		if name != policy.Name {
+		if name != pol.Name {
 			resp = &logical.Response{}
-			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", policy.Name))
+			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", pol.Name))
 		}
 
-		policy.Raw = data.Get("policy").(string)
-		if policy.Raw == "" && policyType == PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
-			policy.Raw = data.Get("rules").(string)
+		pol.Raw = data.Get("policy").(string)
+		if pol.Raw == "" && policyType == policy.PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
+			pol.Raw = data.Get("rules").(string)
 			if resp == nil {
 				resp = &logical.Response{}
 			}
 			resp.AddWarning("'rules' is deprecated, please use 'policy' instead")
 		}
-		if policy.Raw == "" {
+		if pol.Raw == "" {
 			return logical.ErrorResponse("'policy' parameter not supplied or empty"), nil
 		}
 
-		if polBytes, err := base64.StdEncoding.DecodeString(policy.Raw); err == nil {
-			policy.Raw = string(polBytes)
+		if polBytes, err := base64.StdEncoding.DecodeString(pol.Raw); err == nil {
+			pol.Raw = string(polBytes)
 		}
 
 		expirationRaw, expirationOk := data.GetOk("expiration")
@@ -2567,23 +2568,23 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 		if expirationOk && ttlOk {
 			return logical.ErrorResponse("cannot supply both 'expiration' and 'ttl' for policies"), nil
 		} else if expirationOk {
-			policy.Expiration = expirationRaw.(time.Time)
+			pol.Expiration = expirationRaw.(time.Time)
 		} else if ttlOk {
-			policy.Expiration = time.Now().Add(time.Duration(ttlRaw.(int)) * time.Second)
+			pol.Expiration = time.Now().Add(time.Duration(ttlRaw.(int)) * time.Second)
 		}
 
-		if !policy.Expiration.IsZero() && !time.Now().Before(policy.Expiration) {
+		if !pol.Expiration.IsZero() && !time.Now().Before(pol.Expiration) {
 			return logical.ErrorResponse("refusing to update policy as expiration time has already elapsed"), nil
 		}
 
 		switch policyType {
-		case PolicyTypeACL:
-			p, err := ParseACLPolicy(ns, policy.Raw)
+		case policy.PolicyTypeACL:
+			p, err := policy.ParseACLPolicy(ns, pol.Raw)
 			if err != nil {
 				return handleError(err)
 			}
-			policy.Paths = p.Paths
-			policy.Templated = p.Templated
+			pol.Paths = p.Paths
+			pol.Templated = p.Templated
 
 		default:
 			return logical.ErrorResponse("unknown policy type"), nil
@@ -2597,10 +2598,10 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 		}
 
 		casRequired := data.Get("cas_required").(bool)
-		policy.CASRequired = casRequired
+		pol.CASRequired = casRequired
 
 		// Update the policy
-		if err := b.Core.policyStore.SetPolicy(ctx, policy, cas); err != nil {
+		if err := b.Core.policyStore.SetPolicy(ctx, pol, cas); err != nil {
 			return handleError(err)
 		}
 
@@ -2608,7 +2609,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 	}
 }
 
-func (b *SystemBackend) handlePoliciesDelete(policyType PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesDelete(policyType policy.PolicyType) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		name := data.Get("name").(string)
 
@@ -2833,7 +2834,7 @@ func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc 
 		}
 
 		// Get policies list
-		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, PolicyTypeACL, prefix, true)
+		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, policy.PolicyTypeACL, prefix, true)
 		if err != nil {
 			return nil, err
 		}
@@ -2850,7 +2851,7 @@ func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc 
 		// Get detailed information for each policy
 		policyInfos := make(map[string]interface{})
 		for _, policyName := range policies {
-			policy, err := b.Core.policyStore.GetPolicy(ctx, policyName, PolicyTypeACL)
+			policy, err := b.Core.policyStore.GetPolicy(ctx, policyName, policy.PolicyTypeACL)
 			if err != nil {
 				continue
 			}
@@ -3700,7 +3701,7 @@ func (b *SystemBackend) pathRandomWrite(_ context.Context, _ *logical.Request, d
 	return random.HandleRandomAPI(d)
 }
 
-func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
+func hasMountAccess(ctx context.Context, acl *policy.ACL, path string) bool {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return false
@@ -3709,7 +3710,7 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 	// If a policy is giving us direct access to the mount path then we can do
 	// a fast return.
 	capabilities := acl.Capabilities(ctx, ns.TrimmedPath(path))
-	if !slices.Contains(capabilities, DenyCapability) {
+	if !slices.Contains(capabilities, policy.DenyCapability) {
 		return true
 	}
 
@@ -3719,20 +3720,20 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 			return false
 		}
 
-		perms := v.(*ACLPermissions)
+		perms := v.(*policy.ACLPermissions)
 
 		switch {
-		case perms.CapabilitiesBitmap&DenyCapabilityInt > 0:
+		case perms.CapabilitiesBitmap&policy.DenyCapabilityInt > 0:
 			return false
 
-		case perms.CapabilitiesBitmap&CreateCapabilityInt > 0,
-			perms.CapabilitiesBitmap&DeleteCapabilityInt > 0,
-			perms.CapabilitiesBitmap&ListCapabilityInt > 0,
-			perms.CapabilitiesBitmap&ReadCapabilityInt > 0,
-			perms.CapabilitiesBitmap&SudoCapabilityInt > 0,
-			perms.CapabilitiesBitmap&UpdateCapabilityInt > 0,
-			perms.CapabilitiesBitmap&PatchCapabilityInt > 0,
-			perms.CapabilitiesBitmap&ScanCapabilityInt > 0:
+		case perms.CapabilitiesBitmap&policy.CreateCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.DeleteCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.ListCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.ReadCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.SudoCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.UpdateCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.PatchCapabilityInt > 0,
+			perms.CapabilitiesBitmap&policy.ScanCapabilityInt > 0:
 
 			aclCapabilitiesGiven = true
 
@@ -3742,9 +3743,9 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 		return false
 	}
 
-	acl.exactRules.WalkPrefix(path, walkFn)
+	acl.ExactRules().WalkPrefix(path, walkFn)
 	if !aclCapabilitiesGiven {
-		acl.prefixRules.WalkPrefix(path, walkFn)
+		acl.PrefixRules().WalkPrefix(path, walkFn)
 	}
 
 	if !aclCapabilitiesGiven {
@@ -3771,7 +3772,7 @@ func (b *SystemBackend) pathInternalUIMountsRead(ctx context.Context, req *logic
 	resp.Data["secret"] = secretMounts
 	resp.Data["auth"] = authMounts
 
-	var acl *ACL
+	var acl *policy.ACL
 	var isAuthed bool
 	if req.ClientToken != "" {
 		isAuthed = true
@@ -4071,7 +4072,7 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 		},
 	}
 
-	if acl.root != nil {
+	if acl.Root() != nil {
 		resp.Data["root"] = true
 		return resp, nil
 	}
@@ -4084,38 +4085,38 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 			return
 		}
 
-		perms := v.(*ACLPermissions)
+		perms := v.(*policy.ACLPermissions)
 		capabilities := []string{}
 
-		if perms.CapabilitiesBitmap&CreateCapabilityInt > 0 {
-			capabilities = append(capabilities, CreateCapability)
+		if perms.CapabilitiesBitmap&policy.CreateCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.CreateCapability)
 		}
-		if perms.CapabilitiesBitmap&DeleteCapabilityInt > 0 {
-			capabilities = append(capabilities, DeleteCapability)
+		if perms.CapabilitiesBitmap&policy.DeleteCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.DeleteCapability)
 		}
-		if perms.CapabilitiesBitmap&ListCapabilityInt > 0 {
-			capabilities = append(capabilities, ListCapability)
+		if perms.CapabilitiesBitmap&policy.ListCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.ListCapability)
 		}
-		if perms.CapabilitiesBitmap&ReadCapabilityInt > 0 {
-			capabilities = append(capabilities, ReadCapability)
+		if perms.CapabilitiesBitmap&policy.ReadCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.ReadCapability)
 		}
-		if perms.CapabilitiesBitmap&SudoCapabilityInt > 0 {
-			capabilities = append(capabilities, SudoCapability)
+		if perms.CapabilitiesBitmap&policy.SudoCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.SudoCapability)
 		}
-		if perms.CapabilitiesBitmap&UpdateCapabilityInt > 0 {
-			capabilities = append(capabilities, UpdateCapability)
+		if perms.CapabilitiesBitmap&policy.UpdateCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.UpdateCapability)
 		}
-		if perms.CapabilitiesBitmap&PatchCapabilityInt > 0 {
-			capabilities = append(capabilities, PatchCapability)
+		if perms.CapabilitiesBitmap&policy.PatchCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.PatchCapability)
 		}
-		if perms.CapabilitiesBitmap&ScanCapabilityInt > 0 {
-			capabilities = append(capabilities, ScanCapability)
+		if perms.CapabilitiesBitmap&policy.ScanCapabilityInt > 0 {
+			capabilities = append(capabilities, policy.ScanCapability)
 		}
 
 		// If "deny" is explicitly set or if the path has no capabilities at all,
 		// set the path capabilities to "deny"
-		if perms.CapabilitiesBitmap&DenyCapabilityInt > 0 || len(capabilities) == 0 {
-			capabilities = []string{DenyCapability}
+		if perms.CapabilitiesBitmap&policy.DenyCapabilityInt > 0 || len(capabilities) == 0 {
+			capabilities = []string{policy.DenyCapability}
 		}
 
 		res := map[string]interface{}{}
@@ -4151,8 +4152,8 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 		return false
 	}
 
-	acl.exactRules.Walk(exactWalkFn)
-	acl.prefixRules.Walk(globWalkFn)
+	acl.ExactRules().Walk(exactWalkFn)
+	acl.PrefixRules().Walk(globWalkFn)
 
 	resp.Data["exact_paths"] = exact
 	resp.Data["glob_paths"] = glob

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2442,7 +2442,7 @@ func (b *SystemBackend) handleDisableAuth(ctx context.Context, req *logical.Requ
 }
 
 // handlePoliciesList handles /sys/policy/ and /sys/policies/<type> endpoints to provide the enabled policies
-func (b *SystemBackend) handlePoliciesList(policyType policy.PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesList(policyType policy.Type) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		prefix := ""
 		if _, present := data.Schema["name"]; present {
@@ -2459,7 +2459,7 @@ func (b *SystemBackend) handlePoliciesList(policyType policy.PolicyType) framewo
 		}
 
 		switch policyType {
-		case policy.PolicyTypeACL:
+		case policy.TypeACL:
 			if ns.ID == namespace.RootNamespaceID && prefix == "" {
 				policies = append(policies, "root")
 			}
@@ -2477,7 +2477,7 @@ func (b *SystemBackend) handlePoliciesList(policyType policy.PolicyType) framewo
 }
 
 // handlePoliciesRead handles the "/sys/policy/<name>" and "/sys/policies/<type>/<name>" endpoints to read a policy
-func (b *SystemBackend) handlePoliciesRead(policyType policy.PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesRead(policyType policy.Type) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		name := data.Get("name").(string)
 
@@ -2493,7 +2493,7 @@ func (b *SystemBackend) handlePoliciesRead(policyType policy.PolicyType) framewo
 		respData := readPolicyResponse(pol)
 
 		// If the request is from sys/policy/ we handle backwards compatibility
-		if policyType == policy.PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
+		if policyType == policy.TypeACL && strings.HasPrefix(req.Path, "policy") {
 			respData["rules"] = respData["policy"]
 			delete(respData, "policy")
 		}
@@ -2524,7 +2524,7 @@ func readPolicyResponse(policy *policy.Policy) map[string]interface{} {
 }
 
 // handlePoliciesSet handles the "/sys/policy/<name>" and "/sys/policies/<type>/<name>" endpoints to set a policy
-func (b *SystemBackend) handlePoliciesSet(policyType policy.PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesSet(policyType policy.Type) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		var resp *logical.Response
 
@@ -2548,7 +2548,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.PolicyType) framewor
 		}
 
 		pol.Raw = data.Get("policy").(string)
-		if pol.Raw == "" && policyType == policy.PolicyTypeACL && strings.HasPrefix(req.Path, "policy") {
+		if pol.Raw == "" && policyType == policy.TypeACL && strings.HasPrefix(req.Path, "policy") {
 			pol.Raw = data.Get("rules").(string)
 			if resp == nil {
 				resp = &logical.Response{}
@@ -2578,7 +2578,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.PolicyType) framewor
 		}
 
 		switch policyType {
-		case policy.PolicyTypeACL:
+		case policy.TypeACL:
 			p, err := policy.ParseACLPolicy(ns, pol.Raw)
 			if err != nil {
 				return handleError(err)
@@ -2609,7 +2609,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.PolicyType) framewor
 	}
 }
 
-func (b *SystemBackend) handlePoliciesDelete(policyType policy.PolicyType) framework.OperationFunc {
+func (b *SystemBackend) handlePoliciesDelete(policyType policy.Type) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		name := data.Get("name").(string)
 
@@ -2834,7 +2834,7 @@ func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc 
 		}
 
 		// Get policies list
-		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, policy.PolicyTypeACL, prefix, true)
+		policies, err := b.Core.policyStore.ListPoliciesWithPrefix(ctx, policy.TypeACL, prefix, true)
 		if err != nil {
 			return nil, err
 		}
@@ -2851,7 +2851,7 @@ func (b *SystemBackend) handlePoliciesDetailedAclList() framework.OperationFunc 
 		// Get detailed information for each policy
 		policyInfos := make(map[string]interface{})
 		for _, policyName := range policies {
-			policy, err := b.Core.policyStore.GetPolicy(ctx, policyName, policy.PolicyTypeACL)
+			policy, err := b.Core.policyStore.GetPolicy(ctx, policyName, policy.TypeACL)
 			if err != nil {
 				continue
 			}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 )
 
 func (b *SystemBackend) configPaths() []*framework.Path {
@@ -3539,7 +3540,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3556,7 +3557,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3620,7 +3621,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesRead(PolicyTypeACL),
+					Callback: b.handlePoliciesRead(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3659,7 +3660,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Retrieve the policy body for the named policy.",
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3676,7 +3677,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesSet(PolicyTypeACL),
+					Callback: b.handlePoliciesSet(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3686,7 +3687,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Add a new or update an existing policy.",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesDelete(PolicyTypeACL),
+					Callback: b.handlePoliciesDelete(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3711,7 +3712,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3770,7 +3771,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesRead(PolicyTypeACL),
+					Callback: b.handlePoliciesRead(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3809,7 +3810,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Retrieve information about the named ACL policy.",
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3826,7 +3827,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesSet(PolicyTypeACL),
+					Callback: b.handlePoliciesSet(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3836,7 +3837,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Add a new or update an existing ACL policy.",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesDelete(PolicyTypeACL),
+					Callback: b.handlePoliciesDelete(policy.PolicyTypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3540,7 +3540,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3557,7 +3557,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3621,7 +3621,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesRead(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesRead(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3660,7 +3660,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Retrieve the policy body for the named policy.",
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3677,7 +3677,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesSet(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesSet(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3687,7 +3687,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Add a new or update an existing policy.",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesDelete(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesDelete(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3712,7 +3712,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3771,7 +3771,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesRead(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesRead(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3810,7 +3810,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Retrieve information about the named ACL policy.",
 				},
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesList(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesList(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -3827,7 +3827,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesSet(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesSet(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
@@ -3837,7 +3837,7 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Summary: "Add a new or update an existing ACL policy.",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handlePoliciesDelete(policy.PolicyTypeACL),
+					Callback: b.handlePoliciesDelete(policy.TypeACL),
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	be "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/version"
 	"github.com/stretchr/testify/require"
@@ -552,7 +553,7 @@ func TestSystemBackend_PathCapabilities(t *testing.T) {
 
 	core, b, rootToken := testCoreSystemBackend(t)
 
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
 	err = core.policyStore.SetPolicy(namespace.RootContext(t.Context()), policy, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -761,7 +762,7 @@ func testCapabilities(t *testing.T, endpoint string) {
 		t.Fatalf("bad: got\n%#v\nexpected\n%#v\n", actual, expected)
 	}
 
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
 	err = core.policyStore.SetPolicy(namespace.RootContext(t.Context()), policy, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -817,7 +818,7 @@ func TestSystemBackend_CapabilitiesAccessor_BC(t *testing.T) {
 		t.Fatalf("bad: got\n%#v\nexpected\n%#v\n", actual, expected)
 	}
 
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, capabilitiesPolicy)
 	err = core.policyStore.SetPolicy(namespace.RootContext(t.Context()), policy, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -3398,10 +3399,10 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 	c, b, _ := testCoreSystemBackendRaw(t)
 
 	// set the policy!
-	p := &Policy{
+	p := &policy.Policy{
 		Name:      "test",
-		Type:      PolicyTypeACL,
-		namespace: namespace.RootNamespace,
+		Type:      policy.PolicyTypeACL,
+		Namespace: namespace.RootNamespace,
 	}
 	err := c.policyStore.SetPolicy(namespace.RootContext(t.Context()), p, nil)
 	if err != nil {
@@ -3427,7 +3428,7 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 
 	// Policy should be gone
 	c.policyStore.tokenPoliciesLRU.Purge()
-	out, err := c.policyStore.GetPolicy(namespace.RootContext(t.Context()), "test", PolicyTypeToken)
+	out, err := c.policyStore.GetPolicy(namespace.RootContext(t.Context()), "test", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3401,7 +3401,7 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 	// set the policy!
 	p := &policy.Policy{
 		Name:      "test",
-		Type:      policy.PolicyTypeACL,
+		Type:      policy.TypeACL,
 		Namespace: namespace.RootNamespace,
 	}
 	err := c.policyStore.SetPolicy(namespace.RootContext(t.Context()), p, nil)
@@ -3428,7 +3428,7 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 
 	// Policy should be gone
 	c.policyStore.PurgeCache()
-	out, err := c.policyStore.GetPolicy(namespace.RootContext(t.Context()), "test", policy.PolicyTypeToken)
+	out, err := c.policyStore.GetPolicy(namespace.RootContext(t.Context()), "test", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3427,7 +3427,7 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 	)
 
 	// Policy should be gone
-	c.policyStore.tokenPoliciesLRU.Purge()
+	c.policyStore.PurgeCache()
 	out, err := c.policyStore.GetPolicy(namespace.RootContext(t.Context()), "test", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	memDBMFALoginEnforcementsTable = "login_enforcements"
-	mfaTOTPKeysPrefix              = systemBarrierPrefix + "mfa/totpkeys/"
+	mfaTOTPKeysPrefix              = barrier.SystemBarrierPrefix + "mfa/totpkeys/"
 
 	// loginMFAConfigPrefix is the storage prefix for persisting login MFA method
 	// configs
@@ -177,7 +177,7 @@ func (b *LoginMFABackend) ResetLoginMFAMemDB() error {
 // loadMFAMethodConfigs loads MFA method configs for login MFA
 func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespace.Namespace) error {
 	b.mfaLogger.Trace("loading login MFA configurations")
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
 	existing, err := barrierView.List(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to list MFA configurations for namespace %s and prefix %s: %w", ns.Path, loginMFAConfigPrefix, err)
@@ -213,7 +213,7 @@ func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespac
 // loadMFAEnforcementConfigs loads MFA method configs for login MFA
 func (b *LoginMFABackend) loadMFAEnforcementConfigs(ctx context.Context, ns *namespace.Namespace) ([]*mfa.MFAEnforcementConfig, error) {
 	b.mfaLogger.Trace("loading login MFA enforcement configurations")
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
 	existing, err := barrierView.List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list MFA enforcement configurations for namespace %s with prefix %s: %w", ns.Path, mfaLoginEnforcementPrefix, err)
@@ -1876,7 +1876,7 @@ func (b *LoginMFABackend) DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx 
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
 	err = barrierView.Delete(ctx, eConfig.ID)
 	if err != nil {
 		return err
@@ -1948,7 +1948,7 @@ func (b *LoginMFABackend) DeleteMFAConfigByMethodID(ctx context.Context, configI
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
 	err = barrierView.Delete(ctx, configID)
 	if err != nil {
 		return err
@@ -2052,7 +2052,7 @@ func (b *LoginMFABackend) PutMFAConfigByID(ctx context.Context, mConfig *mfa.Con
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
 	marshaledEntry, err := proto.Marshal(mConfig)
 	if err != nil {
 		return err
@@ -2113,7 +2113,7 @@ func (b *LoginMFABackend) PutMFALoginEnforcementConfig(ctx context.Context, eCon
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(systemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
 
 	return barrierView.Put(ctx, &logical.StorageEntry{
 		Key:   eConfig.ID,

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -42,10 +42,6 @@ const (
 	// backendBarrierPrefix is the prefix to the UUID used in the
 	// barrier view for the backends.
 	backendBarrierPrefix = "logical/"
-
-	// systemBarrierPrefix is the prefix used for the
-	// system logical backend.
-	systemBarrierPrefix = "sys/"
 )
 
 // DeprecationStatus errors
@@ -2221,9 +2217,9 @@ func (c *Core) mountEntryView(me *routing.MountEntry) (barrier.View, error) {
 
 	switch me.Type {
 	case routing.MountTypeSystem, routing.MountTypeNSSystem:
-		return c.NamespaceView(me.Namespace).SubView(systemBarrierPrefix), nil
+		return c.NamespaceView(me.Namespace).SubView(barrier.SystemBarrierPrefix), nil
 	case routing.MountTypeToken:
-		return c.NamespaceView(me.Namespace).SubView(systemBarrierPrefix + tokenSubPath), nil
+		return c.NamespaceView(me.Namespace).SubView(barrier.SystemBarrierPrefix + tokenSubPath), nil
 	}
 
 	switch me.Table {

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1294,7 +1294,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   namespace.RootNamespace,
 			},
 
-			wantViewPrefix: systemBarrierPrefix,
+			wantViewPrefix: barrier.SystemBarrierPrefix,
 		},
 		{
 			name: "entry of 'token' mount type",
@@ -1305,7 +1305,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   namespace.RootNamespace,
 			},
 
-			wantViewPrefix: systemBarrierPrefix + tokenSubPath,
+			wantViewPrefix: barrier.SystemBarrierPrefix + tokenSubPath,
 		},
 		{
 			name: "entry of 'credential' table type",

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1138,7 +1138,7 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, parent,
 }
 
 func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace *namespace.Namespace, physicalDeletion bool) error {
-	policiesToClear, err := ns.core.policyStore.ListPolicies(ctx, policy.PolicyTypeACL, false)
+	policiesToClear, err := ns.core.policyStore.ListPolicies(ctx, policy.TypeACL, false)
 	if err != nil {
 		ns.logger.Error("failed to retrieve namespace policies", "namespace", namespace.Path, "error", err.Error())
 		return err
@@ -1146,12 +1146,12 @@ func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace 
 
 	for _, pol := range policiesToClear {
 		if physicalDeletion {
-			if err := ns.core.policyStore.DeletePolicyForce(ctx, pol, policy.PolicyTypeACL); err != nil {
+			if err := ns.core.policyStore.DeletePolicyForce(ctx, pol, policy.TypeACL); err != nil {
 				ns.logger.Error(fmt.Sprintf("failed to delete policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}
 		} else {
-			if err := ns.core.policyStore.Invalidate(ctx, pol, policy.PolicyTypeACL); err != nil {
+			if err := ns.core.policyStore.Invalidate(ctx, pol, policy.TypeACL); err != nil {
 				ns.logger.Error(fmt.Sprintf("failed to invalidate policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 )
 
 // Namespace id length; upstream uses 5 characters so we use one more to
@@ -1137,21 +1138,21 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, parent,
 }
 
 func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace *namespace.Namespace, physicalDeletion bool) error {
-	policiesToClear, err := ns.core.policyStore.ListPolicies(ctx, PolicyTypeACL, false)
+	policiesToClear, err := ns.core.policyStore.ListPolicies(ctx, policy.PolicyTypeACL, false)
 	if err != nil {
 		ns.logger.Error("failed to retrieve namespace policies", "namespace", namespace.Path, "error", err.Error())
 		return err
 	}
 
-	for _, policy := range policiesToClear {
+	for _, pol := range policiesToClear {
 		if physicalDeletion {
-			if err := ns.core.policyStore.deletePolicyForce(ctx, policy, PolicyTypeACL); err != nil {
-				ns.logger.Error(fmt.Sprintf("failed to delete policy %q", policy), "namespace", namespace.Path, "error", err.Error())
+			if err := ns.core.policyStore.deletePolicyForce(ctx, pol, policy.PolicyTypeACL); err != nil {
+				ns.logger.Error(fmt.Sprintf("failed to delete policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}
 		} else {
-			if err := ns.core.policyStore.invalidate(ctx, policy, PolicyTypeACL); err != nil {
-				ns.logger.Error(fmt.Sprintf("failed to invalidate policy %q", policy), "namespace", namespace.Path, "error", err.Error())
+			if err := ns.core.policyStore.invalidate(ctx, pol, policy.PolicyTypeACL); err != nil {
+				ns.logger.Error(fmt.Sprintf("failed to invalidate policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}
 		}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -615,7 +615,7 @@ func (ns *NamespaceStore) initializeNamespace(ctx context.Context, entry *namesp
 
 // initializeNamespacePolicies loads the default policies for the namespace store.
 func (ns *NamespaceStore) initializeNamespacePolicies(ctx context.Context) error {
-	if err := ns.core.policyStore.loadDefaultPolicies(ctx); err != nil {
+	if err := ns.core.policyStore.LoadDefaultPolicies(ctx); err != nil {
 		return fmt.Errorf("error creating default policies: %w", err)
 	}
 	return nil
@@ -1146,12 +1146,12 @@ func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace 
 
 	for _, pol := range policiesToClear {
 		if physicalDeletion {
-			if err := ns.core.policyStore.deletePolicyForce(ctx, pol, policy.PolicyTypeACL); err != nil {
+			if err := ns.core.policyStore.DeletePolicyForce(ctx, pol, policy.PolicyTypeACL); err != nil {
 				ns.logger.Error(fmt.Sprintf("failed to delete policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}
 		} else {
-			if err := ns.core.policyStore.invalidate(ctx, pol, policy.PolicyTypeACL); err != nil {
+			if err := ns.core.policyStore.Invalidate(ctx, pol, policy.PolicyTypeACL); err != nil {
 				ns.logger.Error(fmt.Sprintf("failed to invalidate policy %q", pol), "namespace", namespace.Path, "error", err.Error())
 				return err
 			}

--- a/vault/policy/acl.go
+++ b/vault/policy/acl.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package vault
+package policy
 
 import (
 	"context"
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/copystructure"
-	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -816,34 +815,20 @@ SWCPATH:
 	return wcPathDescrs[len(wcPathDescrs)-1].perms
 }
 
-func (c *Core) performPolicyChecks(ctx context.Context, acl *ACL, te *logical.TokenEntry, req *logical.Request, inEntity *identity.Entity, opts *PolicyCheckOpts) *AuthResults {
-	ret := new(AuthResults)
+func (a *ACL) ExactRules() *radix.Tree {
+	return a.exactRules
+}
 
-	// First, perform normal ACL checks if requested. The only time no ACL
-	// should be applied is if we are only processing EGPs against a login
-	// path in which case opts.Unauth will be set.
-	if acl != nil && !opts.Unauth {
-		ret.ACLResults = acl.AllowOperation(ctx, req, false)
-		ret.RootPrivs = ret.ACLResults.RootPrivs
-		// Root is always allowed; skip Sentinel/MFA checks
-		if ret.ACLResults.IsRoot {
-			// logger.Warn("token is root, skipping checks")
-			ret.Allowed = true
-			return ret
-		}
-		if !ret.ACLResults.Allowed {
-			return ret
-		}
-		// Since HelpOperation was fast-pathed inside AllowOperation, RootPrivs will not have been populated in this
-		// case, so we need to special-case that here as well, or we'll block HelpOperation on all sudo-protected paths.
-		if !ret.RootPrivs && opts.RootPrivsRequired && req.Operation != logical.HelpOperation {
-			return ret
-		}
+func (a *ACL) PrefixRules() *radix.Tree {
+	return a.prefixRules
+}
+
+func (a *ACL) Root() *namespace.Namespace {
+	if a.root == nil {
+		return nil
 	}
 
-	ret.Allowed = true
-
-	return ret
+	return a.root.Clone(false)
 }
 
 func valueInParameterList(v interface{}, list []interface{}) bool {

--- a/vault/policy/acl.go
+++ b/vault/policy/acl.go
@@ -38,7 +38,7 @@ type ACL struct {
 	root *namespace.Namespace
 }
 
-type PolicyCheckOpts struct {
+type CheckOpts struct {
 	RootPrivsRequired bool
 	Unauth            bool
 }
@@ -93,7 +93,7 @@ func NewACL(ctx context.Context, policies []*Policy) (*ACL, error) {
 		}
 
 		switch policy.Type {
-		case PolicyTypeACL:
+		case TypeACL:
 		default:
 			return nil, errors.New("unable to parse policy (wrong type)")
 		}

--- a/vault/policy/acl_test.go
+++ b/vault/policy/acl_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package vault
+package policy
 
 import (
 	"fmt"
@@ -47,19 +47,19 @@ func TestACL_MFAMethods(t *testing.T) {
 
 func testACLMFAMethods(t *testing.T, ns *namespace.Namespace) {
 	mfaRules := `
-path "secret/foo/*" {
-	mfa_methods = ["mfa_method_1", "mfa_method_2", "mfa_method_3"]
-}
-path "secret/exact/path" {
-	mfa_methods = ["mfa_method_4", "mfa_method_5"]
-}
-path "secret/split/definition" {
-	mfa_methods = ["mfa_method_6", "mfa_method_7"]
-}
-path "secret/split/definition" {
-	mfa_methods = ["mfa_method_7", "mfa_method_8", "mfa_method_9"]
-}
-	`
+ path "secret/foo/*" {
+ 	mfa_methods = ["mfa_method_1", "mfa_method_2", "mfa_method_3"]
+ }
+ path "secret/exact/path" {
+ 	mfa_methods = ["mfa_method_4", "mfa_method_5"]
+ }
+ path "secret/split/definition" {
+ 	mfa_methods = ["mfa_method_6", "mfa_method_7"]
+ }
+ path "secret/split/definition" {
+ 	mfa_methods = ["mfa_method_7", "mfa_method_8", "mfa_method_9"]
+ }
+ 	`
 
 	policy, err := ParseACLPolicy(ns, mfaRules)
 	if err != nil {
@@ -651,43 +651,43 @@ func TestACL_SegmentWildcardPriority(t *testing.T) {
 			// Verify edge conditions.  Here '*' is more specific both because
 			// of first wildcard position (0 vs -1/infinity) and #wildcards.
 			`
-path "+/*" { capabilities = ["read"] }
-path "*" { capabilities = ["update"] }
-`,
+ path "+/*" { capabilities = ["read"] }
+ path "*" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify edge conditions.  Here '+/*' is less specific because of
 			// first wildcard position.
 			`
-path "+/*" { capabilities = ["read"] }
-path "foo/+/*" { capabilities = ["update"] }
-`,
+ path "+/*" { capabilities = ["read"] }
+ path "foo/+/*" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that more wildcard segments is lower priority.
 			`
-path "foo/+/+/*" { capabilities = ["read"] }
-path "foo/+/bar/baz" { capabilities = ["update"] }
-`,
+ path "foo/+/+/*" { capabilities = ["read"] }
+ path "foo/+/bar/baz" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that more wildcard segments is lower priority.
 			`
-path "foo/+/+/baz" { capabilities = ["read"] }
-path "foo/+/bar/baz" { capabilities = ["update"] }
-`,
+ path "foo/+/+/baz" { capabilities = ["read"] }
+ path "foo/+/bar/baz" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that first wildcard position is lower priority.
 			// '(' is used here because it is lexicographically smaller than "+"
 			`
-path "foo/+/(ar/baz" { capabilities = ["read"] }
-path "foo/(ar/+/baz" { capabilities = ["update"] }
-`,
+ path "foo/+/(ar/baz" { capabilities = ["read"] }
+ path "foo/(ar/+/baz" { capabilities = ["update"] }
+ `,
 			"foo/(ar/(ar/baz",
 		},
 
@@ -695,17 +695,17 @@ path "foo/(ar/+/baz" { capabilities = ["update"] }
 			// Verify that a glob has lower priority, even if the prefix is the
 			// same otherwise.
 			`
-path "foo/bar/+/baz*" { capabilities = ["read"] }
-path "foo/bar/+/baz" { capabilities = ["update"] }
-`,
+ path "foo/bar/+/baz*" { capabilities = ["read"] }
+ path "foo/bar/+/baz" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that a shorter prefix has lower priority.
 			`
-path "foo/bar/+/b*" { capabilities = ["read"] }
-path "foo/bar/+/ba*" { capabilities = ["update"] }
-`,
+ path "foo/bar/+/b*" { capabilities = ["read"] }
+ path "foo/bar/+/ba*" { capabilities = ["update"] }
+ `,
 			"foo/bar/bar/baz",
 		},
 	}
@@ -933,415 +933,408 @@ func TestACLGrantingPolicies(t *testing.T) {
 }
 
 var grantingTestPolicy = `
-name = "granting_policy"
-path "kv/foo" {
-	capabilities = ["update", "read"]
-}
-
-path "kv/path/*" {
-	capabilities = ["read"]
-}
-
-path "kv/path/longer" {
-	capabilities = ["update", "read"]
-}
-
-path "kv/path/longer2" {
-	capabilities = ["update"]
-}
-
-path "kv/deny" {
-	capabilities = ["deny"]
-}
-
-path "ns1/kv/foo" {
-	capabilities = ["update", "read"]
-}
-`
+ name = "granting_policy"
+ path "kv/foo" {
+ 	capabilities = ["update", "read"]
+ }
+ 
+ path "kv/path/*" {
+ 	capabilities = ["read"]
+ }
+ 
+ path "kv/path/longer" {
+ 	capabilities = ["update", "read"]
+ }
+ 
+ path "kv/path/longer2" {
+ 	capabilities = ["update"]
+ }
+ 
+ path "kv/deny" {
+ 	capabilities = ["deny"]
+ }
+ 
+ path "ns1/kv/foo" {
+ 	capabilities = ["update", "read"]
+ }
+ `
 
 var grantingTestPolicyMerged = `
-name = "granting_policy_merged"
-path "kv/foo" {
-	capabilities = ["update", "read"]
-}
-
-path "kv/bar" {
-	capabilities = ["update", "read"]
-}
-
-path "kv/path/*" {
-	capabilities = ["read"]
-}
-
-path "kv/path/longer" {
-	capabilities = ["read"]
-}
-
-path "kv/path/longer3" {
-	capabilities = ["read"]
-}
-
-path "kv/deny" {
-	capabilities = ["update"]
-}
-`
-
-var tokenCreationPolicy = `
-name = "tokenCreation"
-path "auth/token/create*" {
-	capabilities = ["update", "create", "sudo"]
-}
-`
+ name = "granting_policy_merged"
+ path "kv/foo" {
+ 	capabilities = ["update", "read"]
+ }
+ 
+ path "kv/bar" {
+ 	capabilities = ["update", "read"]
+ }
+ 
+ path "kv/path/*" {
+ 	capabilities = ["read"]
+ }
+ 
+ path "kv/path/longer" {
+ 	capabilities = ["read"]
+ }
+ 
+ path "kv/path/longer3" {
+ 	capabilities = ["read"]
+ }
+ 
+ path "kv/deny" {
+ 	capabilities = ["update"]
+ }
+ `
 
 var aclPolicy = `
-name = "DeV"
-path "dev/*" {
-	policy = "sudo"
-}
-path "stage/*" {
-	policy = "write"
-}
-path "stage/aws/*" {
-	policy = "read"
-	capabilities = ["update", "sudo"]
-}
-path "stage/aws/policy/*" {
-	policy = "sudo"
-}
-path "prod/*" {
-	policy = "read"
-}
-path "prod/aws/*" {
-	policy = "deny"
-}
-path "sys/*" {
-	policy = "deny"
-}
-path "foo/bar" {
-	capabilities = ["read", "create", "sudo"]
-}
-path "baz/quux" {
-	capabilities = ["read", "create", "patch"]
-}
-path "test/+/segment" {
-	capabilities = ["read"]
-}
-path "+/segment/at/front" {
-	capabilities = ["read"]
-}
-path "test/segment/at/end/+" {
-	capabilities = ["read"]
-}
-path "test/segment/at/end/v2/+/" {
-	capabilities = ["read"]
-}
-path "test/+/wildcard/+/*" {
-	capabilities = ["read"]
-}
-path "test/+/wildcardglob/+/end*" {
-	capabilities = ["read"]
-}
-path "1/2/*" {
-	capabilities = ["create"]
-}
-path "1/2/+" {
-	capabilities = ["read"]
-}
-path "1/2/+/+" {
-	capabilities = ["update"]
-}
-path "asdf/fdsa" {
-	capabilities = ["scan"]
-}
-`
+ name = "DeV"
+ path "dev/*" {
+ 	policy = "sudo"
+ }
+ path "stage/*" {
+ 	policy = "write"
+ }
+ path "stage/aws/*" {
+ 	policy = "read"
+ 	capabilities = ["update", "sudo"]
+ }
+ path "stage/aws/policy/*" {
+ 	policy = "sudo"
+ }
+ path "prod/*" {
+ 	policy = "read"
+ }
+ path "prod/aws/*" {
+ 	policy = "deny"
+ }
+ path "sys/*" {
+ 	policy = "deny"
+ }
+ path "foo/bar" {
+ 	capabilities = ["read", "create", "sudo"]
+ }
+ path "baz/quux" {
+ 	capabilities = ["read", "create", "patch"]
+ }
+ path "test/+/segment" {
+ 	capabilities = ["read"]
+ }
+ path "+/segment/at/front" {
+ 	capabilities = ["read"]
+ }
+ path "test/segment/at/end/+" {
+ 	capabilities = ["read"]
+ }
+ path "test/segment/at/end/v2/+/" {
+ 	capabilities = ["read"]
+ }
+ path "test/+/wildcard/+/*" {
+ 	capabilities = ["read"]
+ }
+ path "test/+/wildcardglob/+/end*" {
+ 	capabilities = ["read"]
+ }
+ path "1/2/*" {
+ 	capabilities = ["create"]
+ }
+ path "1/2/+" {
+ 	capabilities = ["read"]
+ }
+ path "1/2/+/+" {
+ 	capabilities = ["update"]
+ }
+ path "asdf/fdsa" {
+ 	capabilities = ["scan"]
+ }
+ `
 
 var aclPolicy2 = `
-name = "OpS"
-path "dev/hide/*" {
-	policy = "deny"
-}
-path "stage/aws/policy/*" {
-	policy = "deny"
-	# This should have no effect
-	capabilities = ["read", "update", "sudo"]
-}
-path "prod/*" {
-	policy = "write"
-}
-path "sys/seal" {
-	policy = "sudo"
-}
-path "foo/bar" {
-	capabilities = ["deny"]
-}
-path "baz/quux" {
-	capabilities = ["deny"]
-}
-`
+ name = "OpS"
+ path "dev/hide/*" {
+ 	policy = "deny"
+ }
+ path "stage/aws/policy/*" {
+ 	policy = "deny"
+ 	# This should have no effect
+ 	capabilities = ["read", "update", "sudo"]
+ }
+ path "prod/*" {
+ 	policy = "write"
+ }
+ path "sys/seal" {
+ 	policy = "sudo"
+ }
+ path "foo/bar" {
+ 	capabilities = ["deny"]
+ }
+ path "baz/quux" {
+ 	capabilities = ["deny"]
+ }
+ `
 
 // test merging
 var mergingPolicies = `
-name = "ops"
-path "foo/bar" {
-	policy = "write"
-	denied_parameters = {
-		"baz" = []
-	}
-	required_parameters = ["baz"]
-}
-path "foo/bar" {
-	policy = "write"
-	denied_parameters = {
-		"zip" = []
-	}
-}
-path "hello/universe" {
-	policy = "write"
-	allowed_parameters = {
-		"foo" = []
-	}
-	required_parameters = ["foo"]
-	max_wrapping_ttl = 300
-	min_wrapping_ttl = 100
-}
-path "hello/universe" {
-	policy = "write"
-	allowed_parameters = {
-		"bar" = []
-	}
-	required_parameters = ["bar"]
-	max_wrapping_ttl = 200
-	min_wrapping_ttl = 50
-}
-path "allow/all" {
-	policy = "write"
-	allowed_parameters = {
-		"test" = []
-		"test1" = ["foo"]
-	}
-}
-path "allow/all" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-	}
-}
-path "allow/all1" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-	}
-}
-path "allow/all1" {
-	policy = "write"
-	allowed_parameters = {
-		"test" = []
-		"test1" = ["foo"]
-	}
-}
-path "deny/all" {
-	policy = "write"
-	denied_parameters = {
-		"test" = []
-	}
-}
-path "deny/all" {
-	policy = "write"
-	denied_parameters = {
-		"*" = []
-	}
-}
-path "deny/all1" {
-	policy = "write"
-	denied_parameters = {
-		"*" = []
-	}
-}
-path "deny/all1" {
-	policy = "write"
-	denied_parameters = {
-		"test" = []
-	}
-}
-path "value/merge" {
-	policy = "write"
-	allowed_parameters = {
-		"test" = [1, 2]
-	}
-	denied_parameters = {
-		"test" = [1, 2]
-	}
-}
-path "value/merge" {
-	policy = "write"
-	allowed_parameters = {
-		"test" = [3, 4]
-	}
-	denied_parameters = {
-		"test" = [3, 4]
-	}
-}
-path "value/empty" {
-	policy = "write"
-	allowed_parameters = {
-		"empty" = []
-	}
-	denied_parameters = {
-		"empty" = [1]
-	}
-}
-path "value/empty" {
-	policy = "write"
-	allowed_parameters = {
-		"empty" = [1]
-	}
-	denied_parameters = {
-		"empty" = []
-	}
-}
-`
+ name = "ops"
+ path "foo/bar" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"baz" = []
+ 	}
+ 	required_parameters = ["baz"]
+ }
+ path "foo/bar" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"zip" = []
+ 	}
+ }
+ path "hello/universe" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"foo" = []
+ 	}
+ 	required_parameters = ["foo"]
+ 	max_wrapping_ttl = 300
+ 	min_wrapping_ttl = 100
+ }
+ path "hello/universe" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"bar" = []
+ 	}
+ 	required_parameters = ["bar"]
+ 	max_wrapping_ttl = 200
+ 	min_wrapping_ttl = 50
+ }
+ path "allow/all" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"test" = []
+ 		"test1" = ["foo"]
+ 	}
+ }
+ path "allow/all" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "allow/all1" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "allow/all1" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"test" = []
+ 		"test1" = ["foo"]
+ 	}
+ }
+ path "deny/all" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"test" = []
+ 	}
+ }
+ path "deny/all" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "deny/all1" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "deny/all1" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"test" = []
+ 	}
+ }
+ path "value/merge" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"test" = [1, 2]
+ 	}
+ 	denied_parameters = {
+ 		"test" = [1, 2]
+ 	}
+ }
+ path "value/merge" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"test" = [3, 4]
+ 	}
+ 	denied_parameters = {
+ 		"test" = [3, 4]
+ 	}
+ }
+ path "value/empty" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"empty" = []
+ 	}
+ 	denied_parameters = {
+ 		"empty" = [1]
+ 	}
+ }
+ path "value/empty" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"empty" = [1]
+ 	}
+ 	denied_parameters = {
+ 		"empty" = []
+ 	}
+ }
+ `
 
 // allow operation testing
 var permissionsPolicy = `
-name = "dev"
-path "dev/*" {
-	policy = "write"
-	allowed_parameters = {
-		"zip" = []
-	}
-}
-path "foo/bar" {
-	policy = "write"
-	denied_parameters = {
-		"zap" = []
-	}
-	min_wrapping_ttl = 300
-	max_wrapping_ttl = 400
-}
-path "foo/baz" {
-	policy = "write"
-	allowed_parameters = {
-		"hello" = []
-	}
-	denied_parameters = {
-		"zap" = []
-	}
-	min_wrapping_ttl = 300
-}
-path "working/phone" {
-	policy = "write"
-	max_wrapping_ttl = 400
-}
-path "broken/phone" {
-	policy = "write"
-	allowed_parameters = {
-	  "steve" = []
-	}
-	denied_parameters = {
-	  "steve" = []
-	}
-}
-path "hello/world" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-	}
-	denied_parameters = {
-		"*" = []
-	}
-}
-path "tree/fort" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-	}
-	denied_parameters = {
-		"foo" = []
-	}
-}
-path "fruit/apple" {
-	policy = "write"
-	allowed_parameters = {
-		"pear" = []
-	}
-	denied_parameters = {
-		"*" = []
-	}
-}
-path "cold/weather" {
-	policy = "write"
-	allowed_parameters = {}
-	denied_parameters = {}
-}
-path "var/aws" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-	}
-	denied_parameters = {
-		"soft" = []
-		"warm" = []
-		"kitty" = []
-	}
-}
-path "var/req" {
-	policy = "write"
-	required_parameters = ["foo"]
-}
-`
+ name = "dev"
+ path "dev/*" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"zip" = []
+ 	}
+ }
+ path "foo/bar" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"zap" = []
+ 	}
+ 	min_wrapping_ttl = 300
+ 	max_wrapping_ttl = 400
+ }
+ path "foo/baz" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"hello" = []
+ 	}
+ 	denied_parameters = {
+ 		"zap" = []
+ 	}
+ 	min_wrapping_ttl = 300
+ }
+ path "working/phone" {
+ 	policy = "write"
+ 	max_wrapping_ttl = 400
+ }
+ path "broken/phone" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 	  "steve" = []
+ 	}
+ 	denied_parameters = {
+ 	  "steve" = []
+ 	}
+ }
+ path "hello/world" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 	}
+ 	denied_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "tree/fort" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 	}
+ 	denied_parameters = {
+ 		"foo" = []
+ 	}
+ }
+ path "fruit/apple" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"pear" = []
+ 	}
+ 	denied_parameters = {
+ 		"*" = []
+ 	}
+ }
+ path "cold/weather" {
+ 	policy = "write"
+ 	allowed_parameters = {}
+ 	denied_parameters = {}
+ }
+ path "var/aws" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 	}
+ 	denied_parameters = {
+ 		"soft" = []
+ 		"warm" = []
+ 		"kitty" = []
+ 	}
+ }
+ path "var/req" {
+ 	policy = "write"
+ 	required_parameters = ["foo"]
+ }
+ `
 
 // allow operation testing
 var valuePermissionsPolicy = `
-name = "op"
-path "dev/*" {
-	policy = "write"
-	allowed_parameters = {
-		"allow" = ["good"]
-	}
-}
-path "foo/bar" {
-	policy = "write"
-	denied_parameters = {
-		"deny" = ["bad*"]
-	}
-}
-path "foo/baz" {
-	policy = "write"
-	allowed_parameters = {
-		"ALLOW" = ["good"]
-	}
-	denied_parameters = {
-		"dEny" = ["bad"]
-	}
-}
-path "fizz/buzz" {
-	policy = "write"
-	allowed_parameters = {
-		"allow_multi" = ["good", "good1", "good2", "*good3"]
-		"allow" = ["good"]
-	}
-	denied_parameters = {
-		"deny_multi" = ["bad", "bad1", "bad2"]
-	}
-}
-path "test/types" {
-	policy = "write"
-	allowed_parameters = {
-		"map" = [{"good" = "one"}]
-		"int" = [1, 2]
-		"bool" = [false]
-	}
-	denied_parameters = {
-	}
-}
-path "test/star" {
-	policy = "write"
-	allowed_parameters = {
-		"*" = []
-		"foo" = []
-		"bar" = [false]
-	}
-	denied_parameters = {
-	}
-}
-`
+ name = "op"
+ path "dev/*" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"allow" = ["good"]
+ 	}
+ }
+ path "foo/bar" {
+ 	policy = "write"
+ 	denied_parameters = {
+ 		"deny" = ["bad*"]
+ 	}
+ }
+ path "foo/baz" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"ALLOW" = ["good"]
+ 	}
+ 	denied_parameters = {
+ 		"dEny" = ["bad"]
+ 	}
+ }
+ path "fizz/buzz" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"allow_multi" = ["good", "good1", "good2", "*good3"]
+ 		"allow" = ["good"]
+ 	}
+ 	denied_parameters = {
+ 		"deny_multi" = ["bad", "bad1", "bad2"]
+ 	}
+ }
+ path "test/types" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"map" = [{"good" = "one"}]
+ 		"int" = [1, 2]
+ 		"bool" = [false]
+ 	}
+ 	denied_parameters = {
+ 	}
+ }
+ path "test/star" {
+ 	policy = "write"
+ 	allowed_parameters = {
+ 		"*" = []
+ 		"foo" = []
+ 		"bar" = [false]
+ 	}
+ 	denied_parameters = {
+ 	}
+ }
+ `

--- a/vault/policy/acl_test.go
+++ b/vault/policy/acl_test.go
@@ -47,19 +47,19 @@ func TestACL_MFAMethods(t *testing.T) {
 
 func testACLMFAMethods(t *testing.T, ns *namespace.Namespace) {
 	mfaRules := `
- path "secret/foo/*" {
- 	mfa_methods = ["mfa_method_1", "mfa_method_2", "mfa_method_3"]
- }
- path "secret/exact/path" {
- 	mfa_methods = ["mfa_method_4", "mfa_method_5"]
- }
- path "secret/split/definition" {
- 	mfa_methods = ["mfa_method_6", "mfa_method_7"]
- }
- path "secret/split/definition" {
- 	mfa_methods = ["mfa_method_7", "mfa_method_8", "mfa_method_9"]
- }
- 	`
+path "secret/foo/*" {
+	mfa_methods = ["mfa_method_1", "mfa_method_2", "mfa_method_3"]
+}
+path "secret/exact/path" {
+	mfa_methods = ["mfa_method_4", "mfa_method_5"]
+}
+path "secret/split/definition" {
+	mfa_methods = ["mfa_method_6", "mfa_method_7"]
+}
+path "secret/split/definition" {
+	mfa_methods = ["mfa_method_7", "mfa_method_8", "mfa_method_9"]
+}
+`
 
 	policy, err := ParseACLPolicy(ns, mfaRules)
 	if err != nil {
@@ -651,43 +651,43 @@ func TestACL_SegmentWildcardPriority(t *testing.T) {
 			// Verify edge conditions.  Here '*' is more specific both because
 			// of first wildcard position (0 vs -1/infinity) and #wildcards.
 			`
- path "+/*" { capabilities = ["read"] }
- path "*" { capabilities = ["update"] }
- `,
+path "+/*" { capabilities = ["read"] }
+path "*" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify edge conditions.  Here '+/*' is less specific because of
 			// first wildcard position.
 			`
- path "+/*" { capabilities = ["read"] }
- path "foo/+/*" { capabilities = ["update"] }
- `,
+path "+/*" { capabilities = ["read"] }
+path "foo/+/*" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that more wildcard segments is lower priority.
 			`
- path "foo/+/+/*" { capabilities = ["read"] }
- path "foo/+/bar/baz" { capabilities = ["update"] }
- `,
+path "foo/+/+/*" { capabilities = ["read"] }
+path "foo/+/bar/baz" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that more wildcard segments is lower priority.
 			`
- path "foo/+/+/baz" { capabilities = ["read"] }
- path "foo/+/bar/baz" { capabilities = ["update"] }
- `,
+path "foo/+/+/baz" { capabilities = ["read"] }
+path "foo/+/bar/baz" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that first wildcard position is lower priority.
 			// '(' is used here because it is lexicographically smaller than "+"
 			`
- path "foo/+/(ar/baz" { capabilities = ["read"] }
- path "foo/(ar/+/baz" { capabilities = ["update"] }
- `,
+path "foo/+/(ar/baz" { capabilities = ["read"] }
+path "foo/(ar/+/baz" { capabilities = ["update"] }
+`,
 			"foo/(ar/(ar/baz",
 		},
 
@@ -695,17 +695,17 @@ func TestACL_SegmentWildcardPriority(t *testing.T) {
 			// Verify that a glob has lower priority, even if the prefix is the
 			// same otherwise.
 			`
- path "foo/bar/+/baz*" { capabilities = ["read"] }
- path "foo/bar/+/baz" { capabilities = ["update"] }
- `,
+path "foo/bar/+/baz*" { capabilities = ["read"] }
+path "foo/bar/+/baz" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that a shorter prefix has lower priority.
 			`
- path "foo/bar/+/b*" { capabilities = ["read"] }
- path "foo/bar/+/ba*" { capabilities = ["update"] }
- `,
+path "foo/bar/+/b*" { capabilities = ["read"] }
+path "foo/bar/+/ba*" { capabilities = ["update"] }
+`,
 			"foo/bar/bar/baz",
 		},
 	}
@@ -933,408 +933,408 @@ func TestACLGrantingPolicies(t *testing.T) {
 }
 
 var grantingTestPolicy = `
- name = "granting_policy"
- path "kv/foo" {
- 	capabilities = ["update", "read"]
- }
- 
- path "kv/path/*" {
- 	capabilities = ["read"]
- }
- 
- path "kv/path/longer" {
- 	capabilities = ["update", "read"]
- }
- 
- path "kv/path/longer2" {
- 	capabilities = ["update"]
- }
- 
- path "kv/deny" {
- 	capabilities = ["deny"]
- }
- 
- path "ns1/kv/foo" {
- 	capabilities = ["update", "read"]
- }
- `
+name = "granting_policy"
+path "kv/foo" {
+	capabilities = ["update", "read"]
+}
+
+path "kv/path/*" {
+	capabilities = ["read"]
+}
+
+path "kv/path/longer" {
+	capabilities = ["update", "read"]
+}
+
+path "kv/path/longer2" {
+	capabilities = ["update"]
+}
+
+path "kv/deny" {
+	capabilities = ["deny"]
+}
+
+path "ns1/kv/foo" {
+	capabilities = ["update", "read"]
+}
+`
 
 var grantingTestPolicyMerged = `
- name = "granting_policy_merged"
- path "kv/foo" {
- 	capabilities = ["update", "read"]
- }
- 
- path "kv/bar" {
- 	capabilities = ["update", "read"]
- }
- 
- path "kv/path/*" {
- 	capabilities = ["read"]
- }
- 
- path "kv/path/longer" {
- 	capabilities = ["read"]
- }
- 
- path "kv/path/longer3" {
- 	capabilities = ["read"]
- }
- 
- path "kv/deny" {
- 	capabilities = ["update"]
- }
- `
+name = "granting_policy_merged"
+path "kv/foo" {
+	capabilities = ["update", "read"]
+}
+
+path "kv/bar" {
+	capabilities = ["update", "read"]
+}
+
+path "kv/path/*" {
+	capabilities = ["read"]
+}
+
+path "kv/path/longer" {
+	capabilities = ["read"]
+}
+
+path "kv/path/longer3" {
+	capabilities = ["read"]
+}
+
+path "kv/deny" {
+	capabilities = ["update"]
+}
+`
 
 var aclPolicy = `
- name = "DeV"
- path "dev/*" {
- 	policy = "sudo"
- }
- path "stage/*" {
- 	policy = "write"
- }
- path "stage/aws/*" {
- 	policy = "read"
- 	capabilities = ["update", "sudo"]
- }
- path "stage/aws/policy/*" {
- 	policy = "sudo"
- }
- path "prod/*" {
- 	policy = "read"
- }
- path "prod/aws/*" {
- 	policy = "deny"
- }
- path "sys/*" {
- 	policy = "deny"
- }
- path "foo/bar" {
- 	capabilities = ["read", "create", "sudo"]
- }
- path "baz/quux" {
- 	capabilities = ["read", "create", "patch"]
- }
- path "test/+/segment" {
- 	capabilities = ["read"]
- }
- path "+/segment/at/front" {
- 	capabilities = ["read"]
- }
- path "test/segment/at/end/+" {
- 	capabilities = ["read"]
- }
- path "test/segment/at/end/v2/+/" {
- 	capabilities = ["read"]
- }
- path "test/+/wildcard/+/*" {
- 	capabilities = ["read"]
- }
- path "test/+/wildcardglob/+/end*" {
- 	capabilities = ["read"]
- }
- path "1/2/*" {
- 	capabilities = ["create"]
- }
- path "1/2/+" {
- 	capabilities = ["read"]
- }
- path "1/2/+/+" {
- 	capabilities = ["update"]
- }
- path "asdf/fdsa" {
- 	capabilities = ["scan"]
- }
- `
+name = "DeV"
+path "dev/*" {
+	policy = "sudo"
+}
+path "stage/*" {
+	policy = "write"
+}
+path "stage/aws/*" {
+	policy = "read"
+	capabilities = ["update", "sudo"]
+}
+path "stage/aws/policy/*" {
+	policy = "sudo"
+}
+path "prod/*" {
+	policy = "read"
+}
+path "prod/aws/*" {
+	policy = "deny"
+}
+path "sys/*" {
+	policy = "deny"
+}
+path "foo/bar" {
+	capabilities = ["read", "create", "sudo"]
+}
+path "baz/quux" {
+	capabilities = ["read", "create", "patch"]
+}
+path "test/+/segment" {
+	capabilities = ["read"]
+}
+path "+/segment/at/front" {
+	capabilities = ["read"]
+}
+path "test/segment/at/end/+" {
+	capabilities = ["read"]
+}
+path "test/segment/at/end/v2/+/" {
+	capabilities = ["read"]
+}
+path "test/+/wildcard/+/*" {
+	capabilities = ["read"]
+}
+path "test/+/wildcardglob/+/end*" {
+	capabilities = ["read"]
+}
+path "1/2/*" {
+	capabilities = ["create"]
+}
+path "1/2/+" {
+	capabilities = ["read"]
+}
+path "1/2/+/+" {
+	capabilities = ["update"]
+}
+path "asdf/fdsa" {
+	capabilities = ["scan"]
+}
+`
 
 var aclPolicy2 = `
- name = "OpS"
- path "dev/hide/*" {
- 	policy = "deny"
- }
- path "stage/aws/policy/*" {
- 	policy = "deny"
- 	# This should have no effect
- 	capabilities = ["read", "update", "sudo"]
- }
- path "prod/*" {
- 	policy = "write"
- }
- path "sys/seal" {
- 	policy = "sudo"
- }
- path "foo/bar" {
- 	capabilities = ["deny"]
- }
- path "baz/quux" {
- 	capabilities = ["deny"]
- }
- `
+name = "OpS"
+path "dev/hide/*" {
+	policy = "deny"
+}
+path "stage/aws/policy/*" {
+	policy = "deny"
+	# This should have no effect
+	capabilities = ["read", "update", "sudo"]
+}
+path "prod/*" {
+	policy = "write"
+}
+path "sys/seal" {
+	policy = "sudo"
+}
+path "foo/bar" {
+	capabilities = ["deny"]
+}
+path "baz/quux" {
+	capabilities = ["deny"]
+}
+`
 
 // test merging
 var mergingPolicies = `
- name = "ops"
- path "foo/bar" {
- 	policy = "write"
- 	denied_parameters = {
- 		"baz" = []
- 	}
- 	required_parameters = ["baz"]
- }
- path "foo/bar" {
- 	policy = "write"
- 	denied_parameters = {
- 		"zip" = []
- 	}
- }
- path "hello/universe" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"foo" = []
- 	}
- 	required_parameters = ["foo"]
- 	max_wrapping_ttl = 300
- 	min_wrapping_ttl = 100
- }
- path "hello/universe" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"bar" = []
- 	}
- 	required_parameters = ["bar"]
- 	max_wrapping_ttl = 200
- 	min_wrapping_ttl = 50
- }
- path "allow/all" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"test" = []
- 		"test1" = ["foo"]
- 	}
- }
- path "allow/all" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 	}
- }
- path "allow/all1" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 	}
- }
- path "allow/all1" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"test" = []
- 		"test1" = ["foo"]
- 	}
- }
- path "deny/all" {
- 	policy = "write"
- 	denied_parameters = {
- 		"test" = []
- 	}
- }
- path "deny/all" {
- 	policy = "write"
- 	denied_parameters = {
- 		"*" = []
- 	}
- }
- path "deny/all1" {
- 	policy = "write"
- 	denied_parameters = {
- 		"*" = []
- 	}
- }
- path "deny/all1" {
- 	policy = "write"
- 	denied_parameters = {
- 		"test" = []
- 	}
- }
- path "value/merge" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"test" = [1, 2]
- 	}
- 	denied_parameters = {
- 		"test" = [1, 2]
- 	}
- }
- path "value/merge" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"test" = [3, 4]
- 	}
- 	denied_parameters = {
- 		"test" = [3, 4]
- 	}
- }
- path "value/empty" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"empty" = []
- 	}
- 	denied_parameters = {
- 		"empty" = [1]
- 	}
- }
- path "value/empty" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"empty" = [1]
- 	}
- 	denied_parameters = {
- 		"empty" = []
- 	}
- }
- `
+name = "ops"
+path "foo/bar" {
+	policy = "write"
+	denied_parameters = {
+		"baz" = []
+	}
+	required_parameters = ["baz"]
+}
+path "foo/bar" {
+	policy = "write"
+	denied_parameters = {
+		"zip" = []
+	}
+}
+path "hello/universe" {
+	policy = "write"
+	allowed_parameters = {
+		"foo" = []
+	}
+	required_parameters = ["foo"]
+	max_wrapping_ttl = 300
+	min_wrapping_ttl = 100
+}
+path "hello/universe" {
+	policy = "write"
+	allowed_parameters = {
+		"bar" = []
+	}
+	required_parameters = ["bar"]
+	max_wrapping_ttl = 200
+	min_wrapping_ttl = 50
+}
+path "allow/all" {
+	policy = "write"
+	allowed_parameters = {
+		"test" = []
+		"test1" = ["foo"]
+	}
+}
+path "allow/all" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+	}
+}
+path "allow/all1" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+	}
+}
+path "allow/all1" {
+	policy = "write"
+	allowed_parameters = {
+		"test" = []
+		"test1" = ["foo"]
+	}
+}
+path "deny/all" {
+	policy = "write"
+	denied_parameters = {
+		"test" = []
+	}
+}
+path "deny/all" {
+	policy = "write"
+	denied_parameters = {
+		"*" = []
+	}
+}
+path "deny/all1" {
+	policy = "write"
+	denied_parameters = {
+		"*" = []
+	}
+}
+path "deny/all1" {
+	policy = "write"
+	denied_parameters = {
+		"test" = []
+	}
+}
+path "value/merge" {
+	policy = "write"
+	allowed_parameters = {
+		"test" = [1, 2]
+	}
+	denied_parameters = {
+		"test" = [1, 2]
+	}
+}
+path "value/merge" {
+	policy = "write"
+	allowed_parameters = {
+		"test" = [3, 4]
+	}
+	denied_parameters = {
+		"test" = [3, 4]
+	}
+}
+path "value/empty" {
+	policy = "write"
+	allowed_parameters = {
+		"empty" = []
+	}
+	denied_parameters = {
+		"empty" = [1]
+	}
+}
+path "value/empty" {
+	policy = "write"
+	allowed_parameters = {
+		"empty" = [1]
+	}
+	denied_parameters = {
+		"empty" = []
+	}
+}
+`
 
 // allow operation testing
 var permissionsPolicy = `
- name = "dev"
- path "dev/*" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"zip" = []
- 	}
- }
- path "foo/bar" {
- 	policy = "write"
- 	denied_parameters = {
- 		"zap" = []
- 	}
- 	min_wrapping_ttl = 300
- 	max_wrapping_ttl = 400
- }
- path "foo/baz" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"hello" = []
- 	}
- 	denied_parameters = {
- 		"zap" = []
- 	}
- 	min_wrapping_ttl = 300
- }
- path "working/phone" {
- 	policy = "write"
- 	max_wrapping_ttl = 400
- }
- path "broken/phone" {
- 	policy = "write"
- 	allowed_parameters = {
- 	  "steve" = []
- 	}
- 	denied_parameters = {
- 	  "steve" = []
- 	}
- }
- path "hello/world" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 	}
- 	denied_parameters = {
- 		"*" = []
- 	}
- }
- path "tree/fort" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 	}
- 	denied_parameters = {
- 		"foo" = []
- 	}
- }
- path "fruit/apple" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"pear" = []
- 	}
- 	denied_parameters = {
- 		"*" = []
- 	}
- }
- path "cold/weather" {
- 	policy = "write"
- 	allowed_parameters = {}
- 	denied_parameters = {}
- }
- path "var/aws" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 	}
- 	denied_parameters = {
- 		"soft" = []
- 		"warm" = []
- 		"kitty" = []
- 	}
- }
- path "var/req" {
- 	policy = "write"
- 	required_parameters = ["foo"]
- }
- `
+name = "dev"
+path "dev/*" {
+	policy = "write"
+	allowed_parameters = {
+		"zip" = []
+	}
+}
+path "foo/bar" {
+	policy = "write"
+	denied_parameters = {
+		"zap" = []
+	}
+	min_wrapping_ttl = 300
+	max_wrapping_ttl = 400
+}
+path "foo/baz" {
+	policy = "write"
+	allowed_parameters = {
+		"hello" = []
+	}
+	denied_parameters = {
+		"zap" = []
+	}
+	min_wrapping_ttl = 300
+}
+path "working/phone" {
+	policy = "write"
+	max_wrapping_ttl = 400
+}
+path "broken/phone" {
+	policy = "write"
+	allowed_parameters = {
+	  "steve" = []
+	}
+	denied_parameters = {
+	  "steve" = []
+	}
+}
+path "hello/world" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+	}
+	denied_parameters = {
+		"*" = []
+	}
+}
+path "tree/fort" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+	}
+	denied_parameters = {
+		"foo" = []
+	}
+}
+path "fruit/apple" {
+	policy = "write"
+	allowed_parameters = {
+		"pear" = []
+	}
+	denied_parameters = {
+		"*" = []
+	}
+}
+path "cold/weather" {
+	policy = "write"
+	allowed_parameters = {}
+	denied_parameters = {}
+}
+path "var/aws" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+	}
+	denied_parameters = {
+		"soft" = []
+		"warm" = []
+		"kitty" = []
+	}
+}
+path "var/req" {
+	policy = "write"
+	required_parameters = ["foo"]
+}
+`
 
 // allow operation testing
 var valuePermissionsPolicy = `
- name = "op"
- path "dev/*" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"allow" = ["good"]
- 	}
- }
- path "foo/bar" {
- 	policy = "write"
- 	denied_parameters = {
- 		"deny" = ["bad*"]
- 	}
- }
- path "foo/baz" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"ALLOW" = ["good"]
- 	}
- 	denied_parameters = {
- 		"dEny" = ["bad"]
- 	}
- }
- path "fizz/buzz" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"allow_multi" = ["good", "good1", "good2", "*good3"]
- 		"allow" = ["good"]
- 	}
- 	denied_parameters = {
- 		"deny_multi" = ["bad", "bad1", "bad2"]
- 	}
- }
- path "test/types" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"map" = [{"good" = "one"}]
- 		"int" = [1, 2]
- 		"bool" = [false]
- 	}
- 	denied_parameters = {
- 	}
- }
- path "test/star" {
- 	policy = "write"
- 	allowed_parameters = {
- 		"*" = []
- 		"foo" = []
- 		"bar" = [false]
- 	}
- 	denied_parameters = {
- 	}
- }
- `
+name = "op"
+path "dev/*" {
+	policy = "write"
+	allowed_parameters = {
+		"allow" = ["good"]
+	}
+}
+path "foo/bar" {
+	policy = "write"
+	denied_parameters = {
+		"deny" = ["bad*"]
+	}
+}
+path "foo/baz" {
+	policy = "write"
+	allowed_parameters = {
+		"ALLOW" = ["good"]
+	}
+	denied_parameters = {
+		"dEny" = ["bad"]
+	}
+}
+path "fizz/buzz" {
+	policy = "write"
+	allowed_parameters = {
+		"allow_multi" = ["good", "good1", "good2", "*good3"]
+		"allow" = ["good"]
+	}
+	denied_parameters = {
+		"deny_multi" = ["bad", "bad1", "bad2"]
+	}
+}
+path "test/types" {
+	policy = "write"
+	allowed_parameters = {
+		"map" = [{"good" = "one"}]
+		"int" = [1, 2]
+		"bool" = [false]
+	}
+	denied_parameters = {
+	}
+}
+path "test/star" {
+	policy = "write"
+	allowed_parameters = {
+		"*" = []
+		"foo" = []
+		"bar" = [false]
+	}
+	denied_parameters = {
+	}
+}
+`

--- a/vault/policy/policy.go
+++ b/vault/policy/policy.go
@@ -62,18 +62,18 @@ const (
 // policy type. However, if we do so, we should build the cache lazily,
 // which both improves memory consumption with large number of policies and
 // better supports namespace sealing.
-type PolicyType uint32
+type Type uint32
 
 const (
-	PolicyTypeACL PolicyType = iota
+	TypeACL Type = iota
 
 	// Triggers a lookup in the map to figure out if ACL or RGP
-	PolicyTypeToken PolicyType = iota + 2
+	TypeToken Type = iota + 2
 )
 
-func (p PolicyType) String() string {
+func (p Type) String() string {
 	switch p {
-	case PolicyTypeACL:
+	case TypeACL:
 		return "acl"
 	}
 
@@ -99,7 +99,7 @@ type Policy struct {
 	CASRequired bool
 	Paths       []*PathRules `hcl:"-"`
 	Raw         string
-	Type        PolicyType
+	Type        Type
 	Templated   bool
 	Expiration  time.Time
 	Modified    time.Time
@@ -284,7 +284,7 @@ func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	// Create the initial policy and store the raw text of the rules
 	p := Policy{
 		Raw:       rules,
-		Type:      PolicyTypeACL,
+		Type:      TypeACL,
 		Namespace: ns,
 	}
 	if err := hcl.DecodeObject(&p, list); err != nil {

--- a/vault/policy/policy.go
+++ b/vault/policy/policy.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package vault
+package policy
 
 import (
 	"errors"
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/copystructure"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/template"
 	"github.com/openbao/openbao/sdk/v2/helper/hclutil"
 	"github.com/openbao/openbao/sdk/v2/helper/identitytpl"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -102,7 +103,7 @@ type Policy struct {
 	Templated   bool
 	Expiration  time.Time
 	Modified    time.Time
-	namespace   *namespace.Namespace
+	Namespace   *namespace.Namespace
 }
 
 // ShallowClone returns a shallow clone of the policy. This should not be used
@@ -116,7 +117,7 @@ func (p *Policy) ShallowClone() *Policy {
 		Raw:         p.Raw,
 		Type:        p.Type,
 		Templated:   p.Templated,
-		namespace:   p.namespace,
+		Namespace:   p.Namespace,
 	}
 }
 
@@ -238,8 +239,8 @@ func addGrantingPoliciesToMap(m map[uint32][]logical.PolicyInfo, policy *Policy,
 
 		m[capability] = append(m[capability], logical.PolicyInfo{
 			Name:          policy.Name,
-			NamespaceId:   policy.namespace.ID,
-			NamespacePath: policy.namespace.Path,
+			NamespaceId:   policy.Namespace.ID,
+			NamespacePath: policy.Namespace.Path,
 			Type:          "acl",
 		})
 	}
@@ -251,14 +252,14 @@ func addGrantingPoliciesToMap(m map[uint32][]logical.PolicyInfo, policy *Policy,
 // intermediary set of policies, before being compiled into
 // the ACL
 func ParseACLPolicy(ns *namespace.Namespace, rules string) (*Policy, error) {
-	return parseACLPolicyWithTemplating(ns, rules, false, nil, nil)
+	return ParseACLPolicyWithTemplating(ns, rules, false, nil, nil)
 }
 
-// parseACLPolicyWithTemplating performs the actual work and checks whether we
+// ParseACLPolicyWithTemplating performs the actual work and checks whether we
 // should perform substitutions. If performTemplating is true we know that it
 // is templated so we don't check again, otherwise we check to see if it's a
 // templated policy.
-func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
+func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
 	// Parse the rules
 	root, err := hclutil.ParseConfig([]byte(rules))
 	if err != nil {
@@ -284,7 +285,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	p := Policy{
 		Raw:       rules,
 		Type:      PolicyTypeACL,
-		namespace: ns,
+		Namespace: ns,
 	}
 	if err := hcl.DecodeObject(&p, list); err != nil {
 		return nil, fmt.Errorf("failed to parse policy: %w", err)
@@ -314,7 +315,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				String:      key,
 				Entity:      identity.ToSDKEntity(entity),
 				Groups:      identity.ToSDKGroups(groups),
-				NamespaceID: result.namespace.ID,
+				NamespaceID: result.Namespace.ID,
 			})
 			if err != nil {
 				continue
@@ -386,7 +387,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		}
 
 		// Ensure we are using the full request path internally
-		pc.Path = result.namespace.Path + pc.Path
+		pc.Path = result.Namespace.Path + pc.Path
 
 		if strings.Contains(pc.Path, "+*") {
 			return fmt.Errorf("path %q: invalid use of wildcards ('+*' is forbidden)", pc.Path)
@@ -483,7 +484,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				return errors.New("list_scan_response_keys_filter_path needs to be used on a path with the list capability")
 			}
 
-			tmpl, err := compileTemplatePathForFiltering(pc.Permissions.ResponseKeysFilterPath)
+			tmpl, err := template.CompileTemplatePathForFiltering(pc.Permissions.ResponseKeysFilterPath)
 			if err != nil {
 				return fmt.Errorf("unable to compile template for list_scan_response_keys_filter_path: %w", err)
 			}
@@ -499,12 +500,12 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				return fmt.Errorf("failed to generate random string to validate policy: %w", err)
 			}
 
-			checkPathOne, err := useTemplateForFiltering(tmpl, pc.Path, keyOne)
+			checkPathOne, err := template.UseTemplateForFiltering(tmpl, pc.Path, keyOne)
 			if err != nil {
 				return fmt.Errorf("failed to validate list_scan_response_keys_filter_path: %w", err)
 			}
 
-			checkPathTwo, err := useTemplateForFiltering(tmpl, pc.Path, keyTwo)
+			checkPathTwo, err := template.UseTemplateForFiltering(tmpl, pc.Path, keyTwo)
 			if err != nil {
 				return fmt.Errorf("failed to validate list_scan_response_keys_filter_path: %w", err)
 			}

--- a/vault/policy/policy_store.go
+++ b/vault/policy/policy_store.go
@@ -28,7 +28,7 @@ var ErrPolicyNotExist = errors.New("policy does not exist")
 const (
 	// policySubPath is the sub-path used for the policy store view. This is
 	// nested under the system view.
-	PolicyACLSubPath = "policy/"
+	ACLSubPath = "policy/"
 
 	// policyCacheSize is the number of policies that are kept cached
 	policyCacheSize = 1024
@@ -151,9 +151,9 @@ var (
 	}
 )
 
-// PolicyStore is used to provide durable storage of policy, and to
+// Store is used to provide durable storage of policy, and to
 // manage ACLs associated with them.
-type PolicyStore struct {
+type Store struct {
 	core core
 
 	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
@@ -167,14 +167,14 @@ type PolicyStore struct {
 	logger log.Logger
 }
 
-// PolicyEntry is used to store a policy by name
-type PolicyEntry struct {
+// Entry is used to store a policy by name
+type Entry struct {
 	Version     int
 	DataVersion int
 	CASRequired bool
 	Raw         string
 	Templated   bool
-	Type        PolicyType
+	Type        Type
 	Expiration  time.Time
 	Modified    time.Time
 }
@@ -185,10 +185,10 @@ type core interface {
 	NamespaceView(*namespace.Namespace) barrier.View
 }
 
-// NewPolicyStore creates a new PolicyStore that is backed
+// NewStore creates a new PolicyStore that is backed
 // using a given view. It used used to durable store and manage named policy.
-func NewPolicyStore(ctx context.Context, core core, baseView barrier.View, system logical.SystemView, logger log.Logger) (*PolicyStore, error) {
-	ps := &PolicyStore{
+func NewStore(ctx context.Context, core core, baseView barrier.View, system logical.SystemView, logger log.Logger) (*Store, error) {
+	ps := &Store{
 		modifyLocks: locksutil.CreateLocks(),
 		logger:      logger,
 		core:        core,
@@ -202,7 +202,7 @@ func NewPolicyStore(ctx context.Context, core core, baseView barrier.View, syste
 	return ps, nil
 }
 
-func (ps *PolicyStore) lockWithUnlock(ctx context.Context) func() {
+func (ps *Store) lockWithUnlock(ctx context.Context) func() {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil || ns == nil {
 		ns = namespace.RootNamespace
@@ -215,7 +215,7 @@ func (ps *PolicyStore) lockWithUnlock(ctx context.Context) func() {
 	return lock.Unlock
 }
 
-func (ps *PolicyStore) rLockWithUnlock(ctx context.Context) func() {
+func (ps *Store) rLockWithUnlock(ctx context.Context) func() {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil || ns == nil {
 		ns = namespace.RootNamespace
@@ -228,7 +228,7 @@ func (ps *PolicyStore) rLockWithUnlock(ctx context.Context) func() {
 	return lock.RUnlock
 }
 
-func (ps *PolicyStore) InvalidateNamespace(ctx context.Context, uuid string) {
+func (ps *Store) InvalidateNamespace(ctx context.Context, uuid string) {
 	// Skip invalidation if no cache exists.
 	if ps.tokenPoliciesLRU == nil {
 		return
@@ -243,7 +243,7 @@ func (ps *PolicyStore) InvalidateNamespace(ctx context.Context, uuid string) {
 	}
 }
 
-func (ps *PolicyStore) Invalidate(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *Store) Invalidate(ctx context.Context, name string, policyType Type) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -258,7 +258,7 @@ func (ps *PolicyStore) Invalidate(ctx context.Context, name string, policyType P
 	// We don't lock before removing from the LRU here because the worst that
 	// can happen is we load again if something since added it
 	switch policyType {
-	case PolicyTypeACL:
+	case TypeACL:
 		if ps.tokenPoliciesLRU != nil {
 			ps.tokenPoliciesLRU.Remove(index)
 		}
@@ -271,7 +271,7 @@ func (ps *PolicyStore) Invalidate(ctx context.Context, name string, policyType P
 }
 
 // SetPolicy is used to create or update the given policy
-func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy, casVersion *int) error {
+func (ps *Store) SetPolicy(ctx context.Context, p *Policy, casVersion *int) error {
 	defer metrics.MeasureSince([]string{"policy", "set_policy"}, time.Now())
 	if p == nil {
 		return errors.New("nil policy passed in for storage")
@@ -288,7 +288,7 @@ func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy, casVersion *int
 	return ps.setPolicyInternal(ctx, p, casVersion)
 }
 
-func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVersion *int) error {
+func (ps *Store) setPolicyInternal(ctx context.Context, p *Policy, casVersion *int) error {
 	defer ps.lockWithUnlock(ctx)()
 
 	// Get the appropriate view based on policy type and namespace
@@ -301,7 +301,7 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 		return fmt.Errorf("unable to get existing policy for check-and-set: %w", err)
 	}
 
-	var existing PolicyEntry
+	var existing Entry
 	if existingEntry != nil {
 		if err := existingEntry.DecodeJSON(&existing); err != nil {
 			return fmt.Errorf("failed to decode existing policy: %w", err)
@@ -324,7 +324,7 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 
 	// Create the entry
 	p.DataVersion = existing.DataVersion + 1
-	entry, err := logical.StorageEntryJSON(p.Name, &PolicyEntry{
+	entry, err := logical.StorageEntryJSON(p.Name, &Entry{
 		Version:     2,
 		DataVersion: p.DataVersion,
 		CASRequired: p.CASRequired,
@@ -342,7 +342,7 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 	index := ps.cacheKey(p.Namespace, p.Name)
 
 	switch p.Type {
-	case PolicyTypeACL:
+	case TypeACL:
 		if err := view.Put(ctx, entry); err != nil {
 			return fmt.Errorf("failed to persist policy: %w", err)
 		}
@@ -360,9 +360,9 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 // GetNonEGPPolicyType returns a policy's type.
 // It will return an error if the policy doesn't exist in the store or isn't
 // an ACL.
-func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*PolicyType, error) {
+func (ps *Store) GetNonEGPPolicyType(ctx context.Context, name string) (*Type, error) {
 	// We only support ACL policies at the moment.
-	policy, err := ps.GetPolicy(ctx, name, PolicyTypeACL)
+	policy, err := ps.GetPolicy(ctx, name, TypeACL)
 	if err != nil {
 		return nil, err
 	}
@@ -375,22 +375,22 @@ func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*P
 }
 
 // GetACLView returns the ACL view for the given namespace
-func (ps *PolicyStore) GetACLView(ns *namespace.Namespace) barrier.View {
-	return ps.core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + PolicyACLSubPath)
+func (ps *Store) GetACLView(ns *namespace.Namespace) barrier.View {
+	return ps.core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + ACLSubPath)
 }
 
 // getBarrierView returns the appropriate barrier view for the given namespace and policy type.
 // Currently, this only supports ACL policies, so it delegates to getACLView.
-func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) barrier.View {
+func (ps *Store) getBarrierView(ns *namespace.Namespace, _ Type) barrier.View {
 	return ps.GetACLView(ns)
 }
 
 // GetPolicy is used to fetch the named policy
-func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType PolicyType) (*Policy, error) {
+func (ps *Store) GetPolicy(ctx context.Context, name string, policyType Type) (*Policy, error) {
 	return ps.switchedGetPolicy(ctx, name, policyType, true)
 }
 
-func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, policyType PolicyType, grabLock bool) (*Policy, error) {
+func (ps *Store) switchedGetPolicy(ctx context.Context, name string, policyType Type, grabLock bool) (*Policy, error) {
 	defer metrics.MeasureSince([]string{"policy", "get_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -406,10 +406,10 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	var view barrier.View
 
 	switch policyType {
-	case PolicyTypeACL, PolicyTypeToken:
+	case TypeACL, TypeToken:
 		cache = ps.tokenPoliciesLRU
 		view = ps.GetACLView(ns)
-		policyType = PolicyTypeACL
+		policyType = TypeACL
 	}
 
 	if cache != nil {
@@ -431,11 +431,11 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	// Special case the root policy
-	if policyType == PolicyTypeACL && name == "root" {
+	if policyType == TypeACL && name == "root" {
 		p := &Policy{
 			Name:      "root",
 			Namespace: ns,
-			Type:      PolicyTypeACL,
+			Type:      TypeACL,
 		}
 		if cache != nil {
 			cache.Add(index, p)
@@ -486,7 +486,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 		return nil, nil
 	}
 
-	policyEntry := new(PolicyEntry)
+	policyEntry := new(Entry)
 	pol := new(Policy)
 	err = out.DecodeJSON(policyEntry)
 	if err != nil {
@@ -514,7 +514,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	pol.Modified = policyEntry.Modified
 	pol.Namespace = ns
 	switch policyEntry.Type {
-	case PolicyTypeACL:
+	case TypeACL:
 		// Parse normally
 		p, err := ParseACLPolicy(ns, policyEntry.Raw)
 		if err != nil {
@@ -537,14 +537,14 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 }
 
 // ListPolicies is used to list the available policies
-func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType PolicyType, omitNonAssignable bool) ([]string, error) {
+func (ps *Store) ListPolicies(ctx context.Context, policyType Type, omitNonAssignable bool) ([]string, error) {
 	return ps.ListPoliciesWithPrefix(ctx, policyType, "", omitNonAssignable)
 }
 
 // ListPoliciesWithPrefix is used to list policies with the given prefix in the specified namespace
 // omitNonAssignable dictates whether result list
 // should also contain the nonAssignable policies
-func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType PolicyType, prefix string, omitNonAssignable bool) ([]string, error) {
+func (ps *Store) ListPoliciesWithPrefix(ctx context.Context, policyType Type, prefix string, omitNonAssignable bool) ([]string, error) {
 	defer metrics.MeasureSince([]string{"policy", "list_policies"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -562,7 +562,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 	// key names.
 	var keys []string
 	switch policyType {
-	case PolicyTypeACL:
+	case TypeACL:
 		keys, err = logical.CollectKeysWithPrefix(ctx, view, prefix)
 	default:
 		return nil, fmt.Errorf("unknown policy type %q", policyType)
@@ -578,7 +578,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 }
 
 // DeletePolicy is used to delete the named policy
-func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *Store) DeletePolicy(ctx context.Context, name string, policyType Type) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, false)
 }
 
@@ -586,11 +586,11 @@ func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType
 // default or a singleton. It's used for invalidations or namespace deletion
 // where we internally need to actually remove a policy that the user normally
 // isn't allowed to remove.
-func (ps *PolicyStore) DeletePolicyForce(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *Store) DeletePolicyForce(ctx context.Context, name string, policyType Type) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, true)
 }
 
-func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, policyType PolicyType, physicalDeletion, force bool) error {
+func (ps *Store) switchedDeletePolicy(ctx context.Context, name string, policyType Type, physicalDeletion, force bool) error {
 	defer metrics.MeasureSince([]string{"policy", "delete_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -610,7 +610,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	view := ps.getBarrierView(ns, policyType)
 
 	switch policyType {
-	case PolicyTypeACL:
+	case TypeACL:
 		if !force {
 			if slices.Contains(immutablePolicies, name) {
 				return fmt.Errorf("cannot delete %q policy", name)
@@ -638,7 +638,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
+func (ps *Store) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
 	var allPolicies []*Policy
 
 	// Fetch the named policies
@@ -652,7 +652,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 		}
 		policyCtx := namespace.ContextWithNamespace(ctx, policyNS)
 		for _, nsPolicyName := range nsPolicyNames {
-			p, err := ps.GetPolicy(policyCtx, nsPolicyName, PolicyTypeToken)
+			p, err := ps.GetPolicy(policyCtx, nsPolicyName, TypeToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get policy: %w", err)
 			}
@@ -668,7 +668,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 	var fetchedGroups bool
 	var groups []*identity.Group
 	for i, pol := range allPolicies {
-		if pol.Type == PolicyTypeACL && pol.Templated {
+		if pol.Type == TypeACL && pol.Templated {
 			if !fetchedGroups {
 				fetchedGroups = true
 				if entity != nil {
@@ -699,14 +699,14 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 
 // LoadACLPolicy is used to load default ACL policies in a specific
 // namespace.
-func (ps *PolicyStore) LoadACLPolicy(ctx context.Context, policyName, policyText string) error {
+func (ps *Store) LoadACLPolicy(ctx context.Context, policyName, policyText string) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Check if the pol already exists
-	pol, err := ps.GetPolicy(ctx, policyName, PolicyTypeACL)
+	pol, err := ps.GetPolicy(ctx, policyName, TypeACL)
 	if err != nil {
 		return fmt.Errorf("error fetching %s policy from store: %w", policyName, err)
 	}
@@ -727,20 +727,20 @@ func (ps *PolicyStore) LoadACLPolicy(ctx context.Context, policyName, policyText
 
 	cas := &pol.DataVersion
 	pol.Name = policyName
-	pol.Type = PolicyTypeACL
+	pol.Type = TypeACL
 	return ps.setPolicyInternal(ctx, pol, cas)
 }
 
-func (ps *PolicyStore) sanitizeName(name string) string {
+func (ps *Store) sanitizeName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
-func (ps *PolicyStore) cacheKey(ns *namespace.Namespace, name string) string {
+func (ps *Store) cacheKey(ns *namespace.Namespace, name string) string {
 	return path.Join(ns.UUID, name)
 }
 
 // LoadDefaultPolicies loads default policies for the namespace in the provided context
-func (ps *PolicyStore) LoadDefaultPolicies(ctx context.Context) error {
+func (ps *Store) LoadDefaultPolicies(ctx context.Context) error {
 	// Load the default policy into the namespace
 	if err := ps.LoadACLPolicy(ctx, defaultPolicyName, DefaultPolicy); err != nil {
 		return fmt.Errorf("failed to load default policy: %w", err)
@@ -754,6 +754,6 @@ func (ps *PolicyStore) LoadDefaultPolicies(ctx context.Context) error {
 	return nil
 }
 
-func (ps *PolicyStore) PurgeCache() {
+func (ps *Store) PurgeCache() {
 	ps.tokenPoliciesLRU.Purge()
 }

--- a/vault/policy/policy_store.go
+++ b/vault/policy/policy_store.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package vault
+package policy
 
 import (
 	"context"
@@ -20,13 +20,15 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/barrier"
-	"github.com/openbao/openbao/vault/policy"
+	vaultidentity "github.com/openbao/openbao/vault/identity"
 )
+
+var ErrPolicyNotExist = errors.New("policy does not exist")
 
 const (
 	// policySubPath is the sub-path used for the policy store view. This is
 	// nested under the system view.
-	policyACLSubPath = "policy/"
+	PolicyACLSubPath = "policy/"
 
 	// policyCacheSize is the number of policies that are kept cached
 	policyCacheSize = 1024
@@ -34,12 +36,12 @@ const (
 	// defaultPolicyName is the name of the default policy
 	defaultPolicyName = "default"
 
-	// responseWrappingPolicyName is the name of the fixed policy
-	responseWrappingPolicyName = "response-wrapping"
+	// ResponseWrappingPolicyName is the name of the fixed policy
+	ResponseWrappingPolicyName = "response-wrapping"
 
-	// responseWrappingPolicy is the policy that ensures cubbyhole response
+	// ResponseWrappingPolicy is the policy that ensures cubbyhole response
 	// wrapping can always succeed.
-	responseWrappingPolicy = `
+	ResponseWrappingPolicy = `
 path "cubbyhole/response" {
     capabilities = ["create", "read"]
 }
@@ -48,8 +50,8 @@ path "sys/wrapping/unwrap" {
     capabilities = ["update"]
 }
 `
-	// defaultPolicy is the "default" policy
-	defaultPolicy = `
+	// DefaultPolicy is the "default" policy
+	DefaultPolicy = `
 # Allow tokens to look up their own properties
 path "auth/token/lookup-self" {
     capabilities = ["read"]
@@ -142,19 +144,19 @@ path "identity/oidc/provider/+/authorize" {
 var (
 	immutablePolicies = []string{
 		"root",
-		responseWrappingPolicyName,
+		ResponseWrappingPolicyName,
 	}
-	nonAssignablePolicies = []string{
-		responseWrappingPolicyName,
+	NonAssignablePolicies = []string{
+		ResponseWrappingPolicyName,
 	}
 )
 
 // PolicyStore is used to provide durable storage of policy, and to
 // manage ACLs associated with them.
 type PolicyStore struct {
-	core *Core
+	core core
 
-	tokenPoliciesLRU *lru.TwoQueueCache[string, *policy.Policy]
+	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
 
 	// This is used to ensure that writes to the store (acl) or to the egp
 	// path tree don't happen concurrently. We are okay reading stale data so
@@ -172,14 +174,20 @@ type PolicyEntry struct {
 	CASRequired bool
 	Raw         string
 	Templated   bool
-	Type        policy.PolicyType
+	Type        PolicyType
 	Expiration  time.Time
 	Modified    time.Time
 }
 
+type core interface {
+	NamespaceByID(context.Context, string) (*namespace.Namespace, error)
+	IdentityStore() *vaultidentity.IdentityStore
+	NamespaceView(*namespace.Namespace) barrier.View
+}
+
 // NewPolicyStore creates a new PolicyStore that is backed
 // using a given view. It used used to durable store and manage named policy.
-func NewPolicyStore(ctx context.Context, core *Core, baseView barrier.View, system logical.SystemView, logger log.Logger) (*PolicyStore, error) {
+func NewPolicyStore(ctx context.Context, core core, baseView barrier.View, system logical.SystemView, logger log.Logger) (*PolicyStore, error) {
 	ps := &PolicyStore{
 		modifyLocks: locksutil.CreateLocks(),
 		logger:      logger,
@@ -187,39 +195,11 @@ func NewPolicyStore(ctx context.Context, core *Core, baseView barrier.View, syst
 	}
 
 	if !system.CachingDisabled() {
-		cache, _ := lru.New2Q[string, *policy.Policy](policyCacheSize)
+		cache, _ := lru.New2Q[string, *Policy](policyCacheSize)
 		ps.tokenPoliciesLRU = cache
 	}
 
 	return ps, nil
-}
-
-// setupPolicyStore is used to initialize the policy store
-// when the vault is being unsealed.
-func (c *Core) setupPolicyStore(ctx context.Context) error {
-	// Create the policy store
-	var err error
-	sysView := &dynamicSystemView{core: c}
-	psLogger := c.baseLogger.Named("policy")
-	c.AddLogger(psLogger)
-	c.policyStore, err = NewPolicyStore(ctx, c, c.systemBarrierView, sysView, psLogger)
-	if err != nil {
-		return err
-	}
-
-	// Ensure that the default policy exists, and if not, create it
-	if err := c.policyStore.loadDefaultPolicies(ctx); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// teardownPolicyStore is used to reverse setupPolicyStore
-// when the vault is being sealed.
-func (c *Core) teardownPolicyStore() error {
-	c.policyStore = nil
-	return nil
 }
 
 func (ps *PolicyStore) lockWithUnlock(ctx context.Context) func() {
@@ -248,7 +228,7 @@ func (ps *PolicyStore) rLockWithUnlock(ctx context.Context) func() {
 	return lock.RUnlock
 }
 
-func (ps *PolicyStore) invalidateNamespace(ctx context.Context, uuid string) {
+func (ps *PolicyStore) InvalidateNamespace(ctx context.Context, uuid string) {
 	// Skip invalidation if no cache exists.
 	if ps.tokenPoliciesLRU == nil {
 		return
@@ -263,7 +243,7 @@ func (ps *PolicyStore) invalidateNamespace(ctx context.Context, uuid string) {
 	}
 }
 
-func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType policy.PolicyType) error {
+func (ps *PolicyStore) Invalidate(ctx context.Context, name string, policyType PolicyType) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -278,7 +258,7 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType p
 	// We don't lock before removing from the LRU here because the worst that
 	// can happen is we load again if something since added it
 	switch policyType {
-	case policy.PolicyTypeACL:
+	case PolicyTypeACL:
 		if ps.tokenPoliciesLRU != nil {
 			ps.tokenPoliciesLRU.Remove(index)
 		}
@@ -291,7 +271,7 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType p
 }
 
 // SetPolicy is used to create or update the given policy
-func (ps *PolicyStore) SetPolicy(ctx context.Context, p *policy.Policy, casVersion *int) error {
+func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy, casVersion *int) error {
 	defer metrics.MeasureSince([]string{"policy", "set_policy"}, time.Now())
 	if p == nil {
 		return errors.New("nil policy passed in for storage")
@@ -308,7 +288,7 @@ func (ps *PolicyStore) SetPolicy(ctx context.Context, p *policy.Policy, casVersi
 	return ps.setPolicyInternal(ctx, p, casVersion)
 }
 
-func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *policy.Policy, casVersion *int) error {
+func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVersion *int) error {
 	defer ps.lockWithUnlock(ctx)()
 
 	// Get the appropriate view based on policy type and namespace
@@ -362,7 +342,7 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *policy.Policy, 
 	index := ps.cacheKey(p.Namespace, p.Name)
 
 	switch p.Type {
-	case policy.PolicyTypeACL:
+	case PolicyTypeACL:
 		if err := view.Put(ctx, entry); err != nil {
 			return fmt.Errorf("failed to persist policy: %w", err)
 		}
@@ -380,9 +360,9 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *policy.Policy, 
 // GetNonEGPPolicyType returns a policy's type.
 // It will return an error if the policy doesn't exist in the store or isn't
 // an ACL.
-func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*policy.PolicyType, error) {
+func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*PolicyType, error) {
 	// We only support ACL policies at the moment.
-	policy, err := ps.GetPolicy(ctx, name, policy.PolicyTypeACL)
+	policy, err := ps.GetPolicy(ctx, name, PolicyTypeACL)
 	if err != nil {
 		return nil, err
 	}
@@ -394,23 +374,23 @@ func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*p
 	return &policy.Type, nil
 }
 
-// getACLView returns the ACL view for the given namespace
-func (ps *PolicyStore) getACLView(ns *namespace.Namespace) barrier.View {
-	return ps.core.NamespaceView(ns).SubView(systemBarrierPrefix + policyACLSubPath)
+// GetACLView returns the ACL view for the given namespace
+func (ps *PolicyStore) GetACLView(ns *namespace.Namespace) barrier.View {
+	return ps.core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + PolicyACLSubPath)
 }
 
 // getBarrierView returns the appropriate barrier view for the given namespace and policy type.
 // Currently, this only supports ACL policies, so it delegates to getACLView.
-func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ policy.PolicyType) barrier.View {
-	return ps.getACLView(ns)
+func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) barrier.View {
+	return ps.GetACLView(ns)
 }
 
 // GetPolicy is used to fetch the named policy
-func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType policy.PolicyType) (*policy.Policy, error) {
+func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType PolicyType) (*Policy, error) {
 	return ps.switchedGetPolicy(ctx, name, policyType, true)
 }
 
-func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, policyType policy.PolicyType, grabLock bool) (*policy.Policy, error) {
+func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, policyType PolicyType, grabLock bool) (*Policy, error) {
 	defer metrics.MeasureSince([]string{"policy", "get_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -422,14 +402,14 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	name = ps.sanitizeName(name)
 	index := ps.cacheKey(ns, name)
 
-	var cache *lru.TwoQueueCache[string, *policy.Policy]
+	var cache *lru.TwoQueueCache[string, *Policy]
 	var view barrier.View
 
 	switch policyType {
-	case policy.PolicyTypeACL, policy.PolicyTypeToken:
+	case PolicyTypeACL, PolicyTypeToken:
 		cache = ps.tokenPoliciesLRU
-		view = ps.getACLView(ns)
-		policyType = policy.PolicyTypeACL
+		view = ps.GetACLView(ns)
+		policyType = PolicyTypeACL
 	}
 
 	if cache != nil {
@@ -451,11 +431,11 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	// Special case the root policy
-	if policyType == policy.PolicyTypeACL && name == "root" {
-		p := &policy.Policy{
+	if policyType == PolicyTypeACL && name == "root" {
+		p := &Policy{
 			Name:      "root",
 			Namespace: ns,
-			Type:      policy.PolicyTypeACL,
+			Type:      PolicyTypeACL,
 		}
 		if cache != nil {
 			cache.Add(index, p)
@@ -507,7 +487,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	policyEntry := new(PolicyEntry)
-	pol := new(policy.Policy)
+	pol := new(Policy)
 	err = out.DecodeJSON(policyEntry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse policy: %w", err)
@@ -534,9 +514,9 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	pol.Modified = policyEntry.Modified
 	pol.Namespace = ns
 	switch policyEntry.Type {
-	case policy.PolicyTypeACL:
+	case PolicyTypeACL:
 		// Parse normally
-		p, err := policy.ParseACLPolicy(ns, policyEntry.Raw)
+		p, err := ParseACLPolicy(ns, policyEntry.Raw)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse policy: %w", err)
 		}
@@ -557,14 +537,14 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 }
 
 // ListPolicies is used to list the available policies
-func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType policy.PolicyType, omitNonAssignable bool) ([]string, error) {
+func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType PolicyType, omitNonAssignable bool) ([]string, error) {
 	return ps.ListPoliciesWithPrefix(ctx, policyType, "", omitNonAssignable)
 }
 
 // ListPoliciesWithPrefix is used to list policies with the given prefix in the specified namespace
 // omitNonAssignable dictates whether result list
 // should also contain the nonAssignable policies
-func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType policy.PolicyType, prefix string, omitNonAssignable bool) ([]string, error) {
+func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType PolicyType, prefix string, omitNonAssignable bool) ([]string, error) {
 	defer metrics.MeasureSince([]string{"policy", "list_policies"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -582,7 +562,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType po
 	// key names.
 	var keys []string
 	switch policyType {
-	case policy.PolicyTypeACL:
+	case PolicyTypeACL:
 		keys, err = logical.CollectKeysWithPrefix(ctx, view, prefix)
 	default:
 		return nil, fmt.Errorf("unknown policy type %q", policyType)
@@ -590,7 +570,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType po
 
 	if omitNonAssignable {
 		keys = slices.DeleteFunc(keys, func(policyName string) bool {
-			return slices.Contains(nonAssignablePolicies, policyName)
+			return slices.Contains(NonAssignablePolicies, policyName)
 		})
 	}
 
@@ -598,19 +578,19 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType po
 }
 
 // DeletePolicy is used to delete the named policy
-func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType policy.PolicyType) error {
+func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType PolicyType) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, false)
 }
 
-// deletePolicyForce is used to delete the named policy and force it even if
+// DeletePolicyForce is used to delete the named policy and force it even if
 // default or a singleton. It's used for invalidations or namespace deletion
 // where we internally need to actually remove a policy that the user normally
 // isn't allowed to remove.
-func (ps *PolicyStore) deletePolicyForce(ctx context.Context, name string, policyType policy.PolicyType) error {
+func (ps *PolicyStore) DeletePolicyForce(ctx context.Context, name string, policyType PolicyType) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, true)
 }
 
-func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, policyType policy.PolicyType, physicalDeletion, force bool) error {
+func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, policyType PolicyType, physicalDeletion, force bool) error {
 	defer metrics.MeasureSince([]string{"policy", "delete_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -630,7 +610,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	view := ps.getBarrierView(ns, policyType)
 
 	switch policyType {
-	case policy.PolicyTypeACL:
+	case PolicyTypeACL:
 		if !force {
 			if slices.Contains(immutablePolicies, name) {
 				return fmt.Errorf("cannot delete %q policy", name)
@@ -658,8 +638,8 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*policy.Policy) (*policy.ACL, error) {
-	var allPolicies []*policy.Policy
+func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
+	var allPolicies []*Policy
 
 	// Fetch the named policies
 	for nsID, nsPolicyNames := range policyNames {
@@ -672,7 +652,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 		}
 		policyCtx := namespace.ContextWithNamespace(ctx, policyNS)
 		for _, nsPolicyName := range nsPolicyNames {
-			p, err := ps.GetPolicy(policyCtx, nsPolicyName, policy.PolicyTypeToken)
+			p, err := ps.GetPolicy(policyCtx, nsPolicyName, PolicyTypeToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get policy: %w", err)
 			}
@@ -688,18 +668,18 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 	var fetchedGroups bool
 	var groups []*identity.Group
 	for i, pol := range allPolicies {
-		if pol.Type == policy.PolicyTypeACL && pol.Templated {
+		if pol.Type == PolicyTypeACL && pol.Templated {
 			if !fetchedGroups {
 				fetchedGroups = true
 				if entity != nil {
-					directGroups, inheritedGroups, err := ps.core.identityStore.GroupsByEntityID(ctx, entity.ID)
+					directGroups, inheritedGroups, err := ps.core.IdentityStore().GroupsByEntityID(ctx, entity.ID)
 					if err != nil {
 						return nil, fmt.Errorf("failed to fetch group memberships: %w", err)
 					}
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := policy.ParseACLPolicyWithTemplating(pol.Namespace, pol.Raw, true, entity, groups)
+			p, err := ParseACLPolicyWithTemplating(pol.Namespace, pol.Raw, true, entity, groups)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing templated policy %q: %w", pol.Name, err)
 			}
@@ -709,7 +689,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 	}
 
 	// Construct the ACL
-	acl, err := policy.NewACL(ctx, allPolicies)
+	acl, err := NewACL(ctx, allPolicies)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct ACL: %w", err)
 	}
@@ -717,16 +697,16 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 	return acl, nil
 }
 
-// loadACLPolicy is used to load default ACL policies in a specific
+// LoadACLPolicy is used to load default ACL policies in a specific
 // namespace.
-func (ps *PolicyStore) loadACLPolicy(ctx context.Context, policyName, policyText string) error {
+func (ps *PolicyStore) LoadACLPolicy(ctx context.Context, policyName, policyText string) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Check if the pol already exists
-	pol, err := ps.GetPolicy(ctx, policyName, policy.PolicyTypeACL)
+	pol, err := ps.GetPolicy(ctx, policyName, PolicyTypeACL)
 	if err != nil {
 		return fmt.Errorf("error fetching %s policy from store: %w", policyName, err)
 	}
@@ -736,7 +716,7 @@ func (ps *PolicyStore) loadACLPolicy(ctx context.Context, policyName, policyText
 		}
 	}
 
-	pol, err = policy.ParseACLPolicy(ns, policyText)
+	pol, err = ParseACLPolicy(ns, policyText)
 	if err != nil {
 		return fmt.Errorf("error parsing %s policy: %w", policyName, err)
 	}
@@ -747,7 +727,7 @@ func (ps *PolicyStore) loadACLPolicy(ctx context.Context, policyName, policyText
 
 	cas := &pol.DataVersion
 	pol.Name = policyName
-	pol.Type = policy.PolicyTypeACL
+	pol.Type = PolicyTypeACL
 	return ps.setPolicyInternal(ctx, pol, cas)
 }
 
@@ -759,17 +739,21 @@ func (ps *PolicyStore) cacheKey(ns *namespace.Namespace, name string) string {
 	return path.Join(ns.UUID, name)
 }
 
-// loadDefaultPolicies loads default policies for the namespace in the provided context
-func (ps *PolicyStore) loadDefaultPolicies(ctx context.Context) error {
+// LoadDefaultPolicies loads default policies for the namespace in the provided context
+func (ps *PolicyStore) LoadDefaultPolicies(ctx context.Context) error {
 	// Load the default policy into the namespace
-	if err := ps.loadACLPolicy(ctx, defaultPolicyName, defaultPolicy); err != nil {
+	if err := ps.LoadACLPolicy(ctx, defaultPolicyName, DefaultPolicy); err != nil {
 		return fmt.Errorf("failed to load default policy: %w", err)
 	}
 
 	// Load the response wrapping policy into the namespace
-	if err := ps.loadACLPolicy(ctx, responseWrappingPolicyName, responseWrappingPolicy); err != nil {
+	if err := ps.LoadACLPolicy(ctx, ResponseWrappingPolicyName, ResponseWrappingPolicy); err != nil {
 		return fmt.Errorf("failed to load response wrapping policy: %w", err)
 	}
 
 	return nil
+}
+
+func (ps *PolicyStore) PurgeCache() {
+	ps.tokenPoliciesLRU.Purge()
 }

--- a/vault/policy/policy_test.go
+++ b/vault/policy/policy_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package vault
+package policy
 
 import (
 	"strings"

--- a/vault/policy/policytest/acl.go
+++ b/vault/policy/policytest/acl.go
@@ -1,4 +1,4 @@
-package policy_testing
+package policytest
 
 import (
 	"context"

--- a/vault/policy/testing/acl.go
+++ b/vault/policy/testing/acl.go
@@ -1,0 +1,173 @@
+package policy_testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
+)
+
+func TestLayeredACL(t *testing.T, acl *policy.ACL, ns *namespace.Namespace) {
+	// Type of operation is not important here as we only care about checking
+	// sudo/root
+	ctx := namespace.ContextWithNamespace(context.Background(), ns)
+	request := new(logical.Request)
+	request.Operation = logical.ReadOperation
+	request.Path = "sys/mount/foo"
+
+	authResults := acl.AllowOperation(ctx, request, false)
+	if authResults.RootPrivs {
+		t.Fatal("unexpected root")
+	}
+
+	type tcase struct {
+		op        logical.Operation
+		path      string
+		allowed   bool
+		rootPrivs bool
+	}
+	tcases := []tcase{
+		{logical.ReadOperation, "root", false, false},
+		{logical.HelpOperation, "root", true, false},
+
+		{logical.ReadOperation, "dev/foo", true, true},
+		{logical.UpdateOperation, "dev/foo", true, true},
+		{logical.ReadOperation, "dev/hide/foo", false, false},
+		{logical.UpdateOperation, "dev/hide/foo", false, false},
+
+		{logical.DeleteOperation, "stage/foo", true, false},
+		{logical.ListOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/policy/foo", false, false},
+
+		{logical.DeleteOperation, "prod/foo", true, false},
+		{logical.UpdateOperation, "prod/foo", true, false},
+		{logical.ReadOperation, "prod/foo", true, false},
+		{logical.ListOperation, "prod/foo", true, false},
+		{logical.ReadOperation, "prod/aws/foo", false, false},
+
+		{logical.ReadOperation, "sys/status", false, false},
+		{logical.UpdateOperation, "sys/seal", true, true},
+
+		{logical.ReadOperation, "foo/bar", false, false},
+		{logical.ListOperation, "foo/bar", false, false},
+		{logical.UpdateOperation, "foo/bar", false, false},
+		{logical.CreateOperation, "foo/bar", false, false},
+
+		{logical.ReadOperation, "baz/quux", false, false},
+		{logical.ListOperation, "baz/quux", false, false},
+		{logical.UpdateOperation, "baz/quux", false, false},
+		{logical.CreateOperation, "baz/quux", false, false},
+		{logical.PatchOperation, "baz/quux", false, false},
+	}
+
+	for _, tc := range tcases {
+		ctx := namespace.ContextWithNamespace(context.Background(), ns)
+		request := new(logical.Request)
+		request.Operation = tc.op
+		request.Path = tc.path
+
+		authResults := acl.AllowOperation(ctx, request, false)
+		if authResults.Allowed != tc.allowed {
+			t.Fatalf("bad: case %#v: %v, %v", tc, authResults.Allowed, authResults.RootPrivs)
+		}
+		if authResults.RootPrivs != tc.rootPrivs {
+			t.Fatalf("bad: case %#v: %v, %v", tc, authResults.Allowed, authResults.RootPrivs)
+		}
+	}
+}
+
+var ACLPolicy = `
+name = "DeV"
+path "dev/*" {
+	policy = "sudo"
+}
+path "stage/*" {
+	policy = "write"
+}
+path "stage/aws/*" {
+	policy = "read"
+	capabilities = ["update", "sudo"]
+}
+path "stage/aws/policy/*" {
+	policy = "sudo"
+}
+path "prod/*" {
+	policy = "read"
+}
+path "prod/aws/*" {
+	policy = "deny"
+}
+path "sys/*" {
+	policy = "deny"
+}
+path "foo/bar" {
+	capabilities = ["read", "create", "sudo"]
+}
+path "baz/quux" {
+	capabilities = ["read", "create", "patch"]
+}
+path "test/+/segment" {
+	capabilities = ["read"]
+}
+path "+/segment/at/front" {
+	capabilities = ["read"]
+}
+path "test/segment/at/end/+" {
+	capabilities = ["read"]
+}
+path "test/segment/at/end/v2/+/" {
+	capabilities = ["read"]
+}
+path "test/+/wildcard/+/*" {
+	capabilities = ["read"]
+}
+path "test/+/wildcardglob/+/end*" {
+	capabilities = ["read"]
+}
+path "1/2/*" {
+	capabilities = ["create"]
+}
+path "1/2/+" {
+	capabilities = ["read"]
+}
+path "1/2/+/+" {
+	capabilities = ["update"]
+}
+path "asdf/fdsa" {
+	capabilities = ["scan"]
+}
+`
+
+var ACLPolicy2 = `
+name = "OpS"
+path "dev/hide/*" {
+	policy = "deny"
+}
+path "stage/aws/policy/*" {
+	policy = "deny"
+	# This should have no effect
+	capabilities = ["read", "update", "sudo"]
+}
+path "prod/*" {
+	policy = "write"
+}
+path "sys/seal" {
+	policy = "sudo"
+}
+path "foo/bar" {
+	capabilities = ["deny"]
+}
+path "baz/quux" {
+	capabilities = ["deny"]
+}
+`
+
+var TokenCreationPolicy = `
+name = "tokenCreation"
+path "auth/token/create*" {
+	capabilities = ["update", "create", "sudo"]
+}
+`

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 )
 
 const (
@@ -153,7 +154,7 @@ var (
 type PolicyStore struct {
 	core *Core
 
-	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
+	tokenPoliciesLRU *lru.TwoQueueCache[string, *policy.Policy]
 
 	// This is used to ensure that writes to the store (acl) or to the egp
 	// path tree don't happen concurrently. We are okay reading stale data so
@@ -171,7 +172,7 @@ type PolicyEntry struct {
 	CASRequired bool
 	Raw         string
 	Templated   bool
-	Type        PolicyType
+	Type        policy.PolicyType
 	Expiration  time.Time
 	Modified    time.Time
 }
@@ -186,7 +187,7 @@ func NewPolicyStore(ctx context.Context, core *Core, baseView barrier.View, syst
 	}
 
 	if !system.CachingDisabled() {
-		cache, _ := lru.New2Q[string, *Policy](policyCacheSize)
+		cache, _ := lru.New2Q[string, *policy.Policy](policyCacheSize)
 		ps.tokenPoliciesLRU = cache
 	}
 
@@ -262,7 +263,7 @@ func (ps *PolicyStore) invalidateNamespace(ctx context.Context, uuid string) {
 	}
 }
 
-func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType policy.PolicyType) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -277,7 +278,7 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 	// We don't lock before removing from the LRU here because the worst that
 	// can happen is we load again if something since added it
 	switch policyType {
-	case PolicyTypeACL:
+	case policy.PolicyTypeACL:
 		if ps.tokenPoliciesLRU != nil {
 			ps.tokenPoliciesLRU.Remove(index)
 		}
@@ -290,7 +291,7 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 }
 
 // SetPolicy is used to create or update the given policy
-func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy, casVersion *int) error {
+func (ps *PolicyStore) SetPolicy(ctx context.Context, p *policy.Policy, casVersion *int) error {
 	defer metrics.MeasureSince([]string{"policy", "set_policy"}, time.Now())
 	if p == nil {
 		return errors.New("nil policy passed in for storage")
@@ -307,11 +308,11 @@ func (ps *PolicyStore) SetPolicy(ctx context.Context, p *Policy, casVersion *int
 	return ps.setPolicyInternal(ctx, p, casVersion)
 }
 
-func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVersion *int) error {
+func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *policy.Policy, casVersion *int) error {
 	defer ps.lockWithUnlock(ctx)()
 
 	// Get the appropriate view based on policy type and namespace
-	view := ps.getBarrierView(p.namespace, p.Type)
+	view := ps.getBarrierView(p.Namespace, p.Type)
 
 	p.Modified = time.Now()
 
@@ -358,10 +359,10 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 	}
 
 	// Construct the cache key
-	index := ps.cacheKey(p.namespace, p.Name)
+	index := ps.cacheKey(p.Namespace, p.Name)
 
 	switch p.Type {
-	case PolicyTypeACL:
+	case policy.PolicyTypeACL:
 		if err := view.Put(ctx, entry); err != nil {
 			return fmt.Errorf("failed to persist policy: %w", err)
 		}
@@ -379,9 +380,9 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 // GetNonEGPPolicyType returns a policy's type.
 // It will return an error if the policy doesn't exist in the store or isn't
 // an ACL.
-func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*PolicyType, error) {
+func (ps *PolicyStore) GetNonEGPPolicyType(ctx context.Context, name string) (*policy.PolicyType, error) {
 	// We only support ACL policies at the moment.
-	policy, err := ps.GetPolicy(ctx, name, PolicyTypeACL)
+	policy, err := ps.GetPolicy(ctx, name, policy.PolicyTypeACL)
 	if err != nil {
 		return nil, err
 	}
@@ -400,16 +401,16 @@ func (ps *PolicyStore) getACLView(ns *namespace.Namespace) barrier.View {
 
 // getBarrierView returns the appropriate barrier view for the given namespace and policy type.
 // Currently, this only supports ACL policies, so it delegates to getACLView.
-func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) barrier.View {
+func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ policy.PolicyType) barrier.View {
 	return ps.getACLView(ns)
 }
 
 // GetPolicy is used to fetch the named policy
-func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType PolicyType) (*Policy, error) {
+func (ps *PolicyStore) GetPolicy(ctx context.Context, name string, policyType policy.PolicyType) (*policy.Policy, error) {
 	return ps.switchedGetPolicy(ctx, name, policyType, true)
 }
 
-func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, policyType PolicyType, grabLock bool) (*Policy, error) {
+func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, policyType policy.PolicyType, grabLock bool) (*policy.Policy, error) {
 	defer metrics.MeasureSince([]string{"policy", "get_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -421,14 +422,14 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	name = ps.sanitizeName(name)
 	index := ps.cacheKey(ns, name)
 
-	var cache *lru.TwoQueueCache[string, *Policy]
+	var cache *lru.TwoQueueCache[string, *policy.Policy]
 	var view barrier.View
 
 	switch policyType {
-	case PolicyTypeACL, PolicyTypeToken:
+	case policy.PolicyTypeACL, policy.PolicyTypeToken:
 		cache = ps.tokenPoliciesLRU
 		view = ps.getACLView(ns)
-		policyType = PolicyTypeACL
+		policyType = policy.PolicyTypeACL
 	}
 
 	if cache != nil {
@@ -450,11 +451,11 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	// Special case the root policy
-	if policyType == PolicyTypeACL && name == "root" {
-		p := &Policy{
+	if policyType == policy.PolicyTypeACL && name == "root" {
+		p := &policy.Policy{
 			Name:      "root",
-			namespace: ns,
-			Type:      PolicyTypeACL,
+			Namespace: ns,
+			Type:      policy.PolicyTypeACL,
 		}
 		if cache != nil {
 			cache.Add(index, p)
@@ -506,7 +507,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	}
 
 	policyEntry := new(PolicyEntry)
-	policy := new(Policy)
+	pol := new(policy.Policy)
 	err = out.DecodeJSON(policyEntry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse policy: %w", err)
@@ -523,47 +524,47 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 
 	// Set these up here so that they're available for loading into
 	// Sentinel
-	policy.Name = name
-	policy.DataVersion = policyEntry.DataVersion
-	policy.CASRequired = policyEntry.CASRequired
-	policy.Raw = policyEntry.Raw
-	policy.Type = policyEntry.Type
-	policy.Templated = policyEntry.Templated
-	policy.Expiration = policyEntry.Expiration
-	policy.Modified = policyEntry.Modified
-	policy.namespace = ns
+	pol.Name = name
+	pol.DataVersion = policyEntry.DataVersion
+	pol.CASRequired = policyEntry.CASRequired
+	pol.Raw = policyEntry.Raw
+	pol.Type = policyEntry.Type
+	pol.Templated = policyEntry.Templated
+	pol.Expiration = policyEntry.Expiration
+	pol.Modified = policyEntry.Modified
+	pol.Namespace = ns
 	switch policyEntry.Type {
-	case PolicyTypeACL:
+	case policy.PolicyTypeACL:
 		// Parse normally
-		p, err := ParseACLPolicy(ns, policyEntry.Raw)
+		p, err := policy.ParseACLPolicy(ns, policyEntry.Raw)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse policy: %w", err)
 		}
-		policy.Paths = p.Paths
+		pol.Paths = p.Paths
 
 		// Reset this in case they set the name in the policy itself
-		policy.Name = name
+		pol.Name = name
 	default:
 		return nil, fmt.Errorf("unknown policy type %q", policyEntry.Type.String())
 	}
 
 	if cache != nil {
 		// Update the LRU cache
-		cache.Add(index, policy)
+		cache.Add(index, pol)
 	}
 
-	return policy, nil
+	return pol, nil
 }
 
 // ListPolicies is used to list the available policies
-func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType PolicyType, omitNonAssignable bool) ([]string, error) {
+func (ps *PolicyStore) ListPolicies(ctx context.Context, policyType policy.PolicyType, omitNonAssignable bool) ([]string, error) {
 	return ps.ListPoliciesWithPrefix(ctx, policyType, "", omitNonAssignable)
 }
 
 // ListPoliciesWithPrefix is used to list policies with the given prefix in the specified namespace
 // omitNonAssignable dictates whether result list
 // should also contain the nonAssignable policies
-func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType PolicyType, prefix string, omitNonAssignable bool) ([]string, error) {
+func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType policy.PolicyType, prefix string, omitNonAssignable bool) ([]string, error) {
 	defer metrics.MeasureSince([]string{"policy", "list_policies"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -581,7 +582,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 	// key names.
 	var keys []string
 	switch policyType {
-	case PolicyTypeACL:
+	case policy.PolicyTypeACL:
 		keys, err = logical.CollectKeysWithPrefix(ctx, view, prefix)
 	default:
 		return nil, fmt.Errorf("unknown policy type %q", policyType)
@@ -597,7 +598,7 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 }
 
 // DeletePolicy is used to delete the named policy
-func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType policy.PolicyType) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, false)
 }
 
@@ -605,11 +606,11 @@ func (ps *PolicyStore) DeletePolicy(ctx context.Context, name string, policyType
 // default or a singleton. It's used for invalidations or namespace deletion
 // where we internally need to actually remove a policy that the user normally
 // isn't allowed to remove.
-func (ps *PolicyStore) deletePolicyForce(ctx context.Context, name string, policyType PolicyType) error {
+func (ps *PolicyStore) deletePolicyForce(ctx context.Context, name string, policyType policy.PolicyType) error {
 	return ps.switchedDeletePolicy(ctx, name, policyType, true, true)
 }
 
-func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, policyType PolicyType, physicalDeletion, force bool) error {
+func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, policyType policy.PolicyType, physicalDeletion, force bool) error {
 	defer metrics.MeasureSince([]string{"policy", "delete_policy"}, time.Now())
 
 	ns, err := namespace.FromContext(ctx)
@@ -629,7 +630,7 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	view := ps.getBarrierView(ns, policyType)
 
 	switch policyType {
-	case PolicyTypeACL:
+	case policy.PolicyTypeACL:
 		if !force {
 			if slices.Contains(immutablePolicies, name) {
 				return fmt.Errorf("cannot delete %q policy", name)
@@ -657,8 +658,8 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
-	var allPolicies []*Policy
+func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*policy.Policy) (*policy.ACL, error) {
+	var allPolicies []*policy.Policy
 
 	// Fetch the named policies
 	for nsID, nsPolicyNames := range policyNames {
@@ -671,7 +672,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 		}
 		policyCtx := namespace.ContextWithNamespace(ctx, policyNS)
 		for _, nsPolicyName := range nsPolicyNames {
-			p, err := ps.GetPolicy(policyCtx, nsPolicyName, PolicyTypeToken)
+			p, err := ps.GetPolicy(policyCtx, nsPolicyName, policy.PolicyTypeToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get policy: %w", err)
 			}
@@ -686,8 +687,8 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 
 	var fetchedGroups bool
 	var groups []*identity.Group
-	for i, policy := range allPolicies {
-		if policy.Type == PolicyTypeACL && policy.Templated {
+	for i, pol := range allPolicies {
+		if pol.Type == policy.PolicyTypeACL && pol.Templated {
 			if !fetchedGroups {
 				fetchedGroups = true
 				if entity != nil {
@@ -698,17 +699,17 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := policy.ParseACLPolicyWithTemplating(pol.Namespace, pol.Raw, true, entity, groups)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing templated policy %q: %w", policy.Name, err)
+				return nil, fmt.Errorf("error parsing templated policy %q: %w", pol.Name, err)
 			}
-			p.Name = policy.Name
+			p.Name = pol.Name
 			allPolicies[i] = p
 		}
 	}
 
 	// Construct the ACL
-	acl, err := NewACL(ctx, allPolicies)
+	acl, err := policy.NewACL(ctx, allPolicies)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct ACL: %w", err)
 	}
@@ -724,30 +725,30 @@ func (ps *PolicyStore) loadACLPolicy(ctx context.Context, policyName, policyText
 		return err
 	}
 
-	// Check if the policy already exists
-	policy, err := ps.GetPolicy(ctx, policyName, PolicyTypeACL)
+	// Check if the pol already exists
+	pol, err := ps.GetPolicy(ctx, policyName, policy.PolicyTypeACL)
 	if err != nil {
 		return fmt.Errorf("error fetching %s policy from store: %w", policyName, err)
 	}
-	if policy != nil {
-		if !slices.Contains(immutablePolicies, policyName) || policyText == policy.Raw {
+	if pol != nil {
+		if !slices.Contains(immutablePolicies, policyName) || policyText == pol.Raw {
 			return nil
 		}
 	}
 
-	policy, err = ParseACLPolicy(ns, policyText)
+	pol, err = policy.ParseACLPolicy(ns, policyText)
 	if err != nil {
 		return fmt.Errorf("error parsing %s policy: %w", policyName, err)
 	}
 
-	if policy == nil {
+	if pol == nil {
 		return fmt.Errorf("parsing %q policy resulted in nil policy", policyName)
 	}
 
-	cas := &policy.DataVersion
-	policy.Name = policyName
-	policy.Type = PolicyTypeACL
-	return ps.setPolicyInternal(ctx, policy, cas)
+	cas := &pol.DataVersion
+	pol.Name = policyName
+	pol.Type = policy.PolicyTypeACL
+	return ps.setPolicyInternal(ctx, pol, cas)
 }
 
 func (ps *PolicyStore) sanitizeName(name string) string {

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/policy"
-	poltesting "github.com/openbao/openbao/vault/policy/testing"
+	"github.com/openbao/openbao/vault/policy/policytest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +140,7 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.Store, ns *namespace.Na
 
 	// Set should work
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	pol, _ := policy.ParseACLPolicy(ns, policytest.ACLPolicy)
 	err = ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -281,13 +281,13 @@ func TestPolicyStore_ACL(t *testing.T) {
 
 func testPolicyStoreACL(t *testing.T, ps *policy.Store, ns *namespace.Namespace) {
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	pol, _ := policy.ParseACLPolicy(ns, policytest.ACLPolicy)
 	err := ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pol, _ = policy.ParseACLPolicy(ns, poltesting.ACLPolicy2)
+	pol, _ = policy.ParseACLPolicy(ns, policytest.ACLPolicy2)
 	err = ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -298,7 +298,7 @@ func testPolicyStoreACL(t *testing.T, ps *policy.Store, ns *namespace.Namespace)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	poltesting.TestLayeredACL(t, acl, ns)
+	policytest.TestLayeredACL(t, acl, ns)
 }
 
 func TestDefaultPolicy(t *testing.T) {
@@ -482,7 +482,7 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 
 	// Create policy in namespace
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
-	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	pol, _ := policy.ParseACLPolicy(ns, policytest.ACLPolicy)
 	pol.Name = "test-policy"
 	require.NoError(t, ps.SetPolicy(nsCtx, pol, nil))
 

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, [][]byte, string, *policy.PolicyStore) {
+func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, [][]byte, string, *policy.Store) {
 	conf := &CoreConfig{
 		DisableCache: disableCache,
 	}
@@ -37,10 +37,10 @@ func TestPolicyStore_Root(t *testing.T) {
 	})
 }
 
-func testPolicyRoot(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace, expectFound bool) {
+func testPolicyRoot(t *testing.T, ps *policy.Store, ns *namespace.Namespace, expectFound bool) {
 	// Get should return a special policy
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	p, err := ps.GetPolicy(ctx, "root", policy.PolicyTypeToken)
+	p, err := ps.GetPolicy(ctx, "root", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -73,7 +73,7 @@ func testPolicyRoot(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespac
 
 	// Delete should fail
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "root", policy.PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "root", policy.TypeACL)
 	if err.Error() != `cannot delete "root" policy` {
 		t.Fatalf("err: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestPolicyStore_CRUD(t *testing.T) {
 	})
 }
 
-func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ps *policy.PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ps *policy.Store, ns *namespace.Namespace) {
 	testPolicyStoreCRUDOneShot(t, ps, ns)
 
 	// Seal, unseal, and try again.
@@ -110,10 +110,10 @@ func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string
 	testPolicyStoreCRUDOneShot(t, ps, ns)
 }
 
-func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.Store, ns *namespace.Namespace) {
 	// Get should return nothing
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	p, err := ps.GetPolicy(ctx, "Dev", policy.PolicyTypeToken)
+	p, err := ps.GetPolicy(ctx, "Dev", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -123,14 +123,14 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namesp
 
 	// Delete should be no-op
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "deV", policy.PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "deV", policy.TypeACL)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// List should be blank
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	out, err := ps.ListPolicies(ctx, policy.TypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namesp
 
 	// Get should work
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	p, err = ps.GetPolicy(ctx, "dEv", policy.PolicyTypeToken)
+	p, err = ps.GetPolicy(ctx, "dEv", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -158,7 +158,7 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namesp
 
 	// List should contain two elements
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err = ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	out, err = ps.ListPolicies(ctx, policy.TypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -173,14 +173,14 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namesp
 
 	// Delete should be clear the entry
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "Dev", policy.PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "Dev", policy.TypeACL)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// List should contain one element
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err = ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	out, err = ps.ListPolicies(ctx, policy.TypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -190,7 +190,7 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namesp
 
 	// Get should fail
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	p, err = ps.GetPolicy(ctx, "deV", policy.PolicyTypeToken)
+	p, err = ps.GetPolicy(ctx, "deV", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -207,10 +207,10 @@ func TestPolicyStore_Predefined(t *testing.T) {
 }
 
 // Test predefined policy handling
-func testPolicyStorePredefined(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
+func testPolicyStorePredefined(t *testing.T, ps *policy.Store, ns *namespace.Namespace) {
 	// List should be two elements
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	out, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	out, err := ps.ListPolicies(ctx, policy.TypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -221,7 +221,7 @@ func testPolicyStorePredefined(t *testing.T, ps *policy.PolicyStore, ns *namespa
 
 	// Response-wrapping policy checks
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pCubby, err := ps.GetPolicy(ctx, "response-wrapping", policy.PolicyTypeToken)
+	pCubby, err := ps.GetPolicy(ctx, "response-wrapping", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -237,14 +237,14 @@ func testPolicyStorePredefined(t *testing.T, ps *policy.PolicyStore, ns *namespa
 		t.Fatalf("expected err setting %s", pCubby.Name)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, pCubby.Name, policy.PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, pCubby.Name, policy.TypeACL)
 	if err == nil {
 		t.Fatalf("expected err deleting %s", pCubby.Name)
 	}
 
 	// Root policy checks, behavior depending on namespace
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pRoot, err := ps.GetPolicy(ctx, "root", policy.PolicyTypeToken)
+	pRoot, err := ps.GetPolicy(ctx, "root", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -266,7 +266,7 @@ func testPolicyStorePredefined(t *testing.T, ps *policy.PolicyStore, ns *namespa
 		t.Fatalf("expected err setting %s", pRoot.Name)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, pRoot.Name, policy.PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, pRoot.Name, policy.TypeACL)
 	if err == nil {
 		t.Fatalf("expected err deleting %s", pRoot.Name)
 	}
@@ -279,7 +279,7 @@ func TestPolicyStore_ACL(t *testing.T) {
 	})
 }
 
-func testPolicyStoreACL(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreACL(t *testing.T, ps *policy.Store, ns *namespace.Namespace) {
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
 	err := ps.SetPolicy(ctx, pol, nil)
@@ -354,20 +354,20 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 		policyStoreValue     any
 		paramNamespace       string
 		paramPolicyName      string
-		paramPolicyType      policy.PolicyType
+		paramPolicyType      policy.Type
 		isErrorExpected      bool
 		expectedErrorMessage string
 	}{
 		"happy-acl": {
 			policyStoreKey:   "root/default",
-			policyStoreValue: policy.PolicyTypeACL,
+			policyStoreValue: policy.TypeACL,
 			paramNamespace:   "root",
 			paramPolicyName:  "default",
-			paramPolicyType:  policy.PolicyTypeACL,
+			paramPolicyType:  policy.TypeACL,
 		},
 		"not-in-map-acl": {
 			policyStoreKey:       "root/policy2",
-			policyStoreValue:     policy.PolicyTypeACL,
+			policyStoreValue:     policy.TypeACL,
 			paramNamespace:       "root",
 			paramPolicyName:      "policy2",
 			isErrorExpected:      true,
@@ -433,7 +433,7 @@ path "secret/*" {
 	require.NoError(t, err)
 
 	// Verify the policy exists in the namespace
-	nsPolicy, err := ps.GetPolicy(nsCtx, "test-load-policy", policy.PolicyTypeToken)
+	nsPolicy, err := ps.GetPolicy(nsCtx, "test-load-policy", policy.TypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, nsPolicy, "expected policy to exist in namespace")
 
@@ -453,7 +453,7 @@ path "secret/*" {
 	require.NoError(t, err)
 
 	// Verify the policies are now different
-	nsPolicy, _ = ps.GetPolicy(nsCtx, "test-load-policy", policy.PolicyTypeToken)
+	nsPolicy, _ = ps.GetPolicy(nsCtx, "test-load-policy", policy.TypeToken)
 	assert.Equal(t, modifiedPolicy, nsPolicy.Raw)
 }
 
@@ -487,12 +487,12 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 	require.NoError(t, ps.SetPolicy(nsCtx, pol, nil))
 
 	// Verify the policy exists in the namespace
-	p, err := ps.GetPolicy(nsCtx, "test-policy", policy.PolicyTypeToken)
+	p, err := ps.GetPolicy(nsCtx, "test-policy", policy.TypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, p, "expected policy to exist in namespace")
 
 	// Verify the policy is not retrievable from the root namespace
-	rootP, err := ps.GetPolicy(ctx, "test-policy", policy.PolicyTypeToken)
+	rootP, err := ps.GetPolicy(ctx, "test-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, rootP, "unexpected policy found in root namespace")
 
@@ -512,17 +512,17 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 	assert.Nil(t, rootOut, "policy should not exist in root storage")
 
 	// Check policy listings
-	policies, err := ps.ListPolicies(nsCtx, policy.PolicyTypeACL, true)
+	policies, err := ps.ListPolicies(nsCtx, policy.TypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, policies, "test-policy", "policy not found in namespace listing")
 
-	rootPolicies, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	rootPolicies, err := ps.ListPolicies(ctx, policy.TypeACL, true)
 	require.NoError(t, err)
 	assert.NotContains(t, rootPolicies, "test-policy", "namespace policy found in root listing")
 
 	// Delete and verify
-	require.NoError(t, ps.DeletePolicy(nsCtx, "test-policy", policy.PolicyTypeACL))
-	p, err = ps.GetPolicy(nsCtx, "test-policy", policy.PolicyTypeToken)
+	require.NoError(t, ps.DeletePolicy(nsCtx, "test-policy", policy.TypeACL))
+	p, err = ps.GetPolicy(nsCtx, "test-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, p, "policy should be deleted")
 }
@@ -736,19 +736,19 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 	}
 
 	// Verify child namespace only sees its own policy
-	childPolicies, err := ps.ListPolicies(childCtx, policy.PolicyTypeACL, true)
+	childPolicies, err := ps.ListPolicies(childCtx, policy.TypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "child-policy"}, childPolicies,
 		"child namespace should only contain its own policy and default")
 
 	// Verify parent namespace listing
-	parentPolicies, err := ps.ListPolicies(parentCtx, policy.PolicyTypeACL, true)
+	parentPolicies, err := ps.ListPolicies(parentCtx, policy.TypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "parent-policy"}, parentPolicies,
 		"parent namespace should contain its own policy and default")
 
 	// Verify root namespace listing
-	rootPolicies, err := ps.ListPolicies(rootCtx, policy.PolicyTypeACL, true)
+	rootPolicies, err := ps.ListPolicies(rootCtx, policy.TypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "root-policy"}, rootPolicies,
 		"root namespace should contain its own policy and default")
@@ -812,17 +812,17 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	require.NoError(t, ps.SetPolicy(childCtx, pol, nil))
 
 	// Verify policies were stored in correct locations
-	rootP, err := ps.GetPolicy(ctx, "test-nested-policy", policy.PolicyTypeToken)
+	rootP, err := ps.GetPolicy(ctx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, rootP, "expected policy in root namespace")
 	assert.Contains(t, rootP.Raw, `capabilities = ["read"]`)
 
-	parentP, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.PolicyTypeToken)
+	parentP, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, parentP, "expected policy in parent namespace")
 	assert.Contains(t, parentP.Raw, `capabilities = ["read", "list"]`)
 
-	childP, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
+	childP, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, childP, "expected policy in child namespace")
 	assert.Contains(t, childP.Raw, `capabilities = ["read", "list", "create"]`)
@@ -845,15 +845,15 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	require.NotNil(t, childViewEntry, "policy not found in child storage")
 
 	// Verify namespace visibility
-	rootList, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
+	rootList, err := ps.ListPolicies(ctx, policy.TypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, rootList, "test-nested-policy", "policy missing in root listing")
 
-	parentList, err := ps.ListPolicies(parentCtx, policy.PolicyTypeACL, true)
+	parentList, err := ps.ListPolicies(parentCtx, policy.TypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, parentList, "test-nested-policy", "policy missing in parent listing")
 
-	childList, err := ps.ListPolicies(childCtx, policy.PolicyTypeACL, true)
+	childList, err := ps.ListPolicies(childCtx, policy.TypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, childList, "test-nested-policy", "policy missing in child listing")
 
@@ -863,7 +863,7 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 
 	// Test policy inheritance
 	// Child namespace should not see root policy when using its own context
-	rootPolicyInChild, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
+	rootPolicyInChild, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.NotEqual(t, rootP.Raw, rootPolicyInChild.Raw, "child namespace should not inherit root policy")
 
@@ -871,31 +871,31 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	// We error here due to the relative path; in the past this
 	// was treated like a not-found policy, which is technically
 	// correct but less informative.
-	parentPolicyInChild, err := ps.GetPolicy(childCtx, "../test-nested-policy", policy.PolicyTypeToken)
+	parentPolicyInChild, err := ps.GetPolicy(childCtx, "../test-nested-policy", policy.TypeToken)
 	require.Error(t, err)
 	assert.Nil(t, parentPolicyInChild, "child namespace should not access parent policy via relative path")
 
 	// Test cross-namespace policy access
 	// Root namespace should not see child's policy
-	childPolicyInRoot, err := ps.GetPolicy(ctx, childNS.ID+"/test-nested-policy", policy.PolicyTypeToken)
+	childPolicyInRoot, err := ps.GetPolicy(ctx, childNS.ID+"/test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, childPolicyInRoot, "root namespace should not see child policy")
 
 	// Test policy deletion isolation
 	// Delete policy in child namespace
-	require.NoError(t, ps.DeletePolicy(childCtx, "test-nested-policy", policy.PolicyTypeACL))
+	require.NoError(t, ps.DeletePolicy(childCtx, "test-nested-policy", policy.TypeACL))
 
 	// Verify policy was deleted only in child namespace
-	deletedChildPolicy, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
+	deletedChildPolicy, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, deletedChildPolicy, "policy should be deleted in child namespace")
 
 	// Verify parent and root policies still exist
-	parentPolicyAfterDelete, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.PolicyTypeToken)
+	parentPolicyAfterDelete, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.NotNil(t, parentPolicyAfterDelete, "parent policy should still exist")
 
-	rootPolicyAfterDelete, err := ps.GetPolicy(ctx, "test-nested-policy", policy.PolicyTypeToken)
+	rootPolicyAfterDelete, err := ps.GetPolicy(ctx, "test-nested-policy", policy.TypeToken)
 	require.NoError(t, err)
 	assert.NotNil(t, rootPolicyAfterDelete, "root policy should still exist")
 }

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, [][]byte, string, *PolicyStore) {
+func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, [][]byte, string, *policy.PolicyStore) {
 	conf := &CoreConfig{
 		DisableCache: disableCache,
 	}
@@ -37,7 +37,7 @@ func TestPolicyStore_Root(t *testing.T) {
 	})
 }
 
-func testPolicyRoot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace, expectFound bool) {
+func testPolicyRoot(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace, expectFound bool) {
 	// Get should return a special policy
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	p, err := ps.GetPolicy(ctx, "root", policy.PolicyTypeToken)
@@ -93,7 +93,7 @@ func TestPolicyStore_CRUD(t *testing.T) {
 	})
 }
 
-func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ps *PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ps *policy.PolicyStore, ns *namespace.Namespace) {
 	testPolicyStoreCRUDOneShot(t, ps, ns)
 
 	// Seal, unseal, and try again.
@@ -110,7 +110,7 @@ func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string
 	testPolicyStoreCRUDOneShot(t, ps, ns)
 }
 
-func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
 	// Get should return nothing
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	p, err := ps.GetPolicy(ctx, "Dev", policy.PolicyTypeToken)
@@ -207,7 +207,7 @@ func TestPolicyStore_Predefined(t *testing.T) {
 }
 
 // Test predefined policy handling
-func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
+func testPolicyStorePredefined(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
 	// List should be two elements
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	out, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
@@ -228,8 +228,8 @@ func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Name
 	if pCubby == nil {
 		t.Fatal("nil cubby policy")
 	}
-	if pCubby.Raw != responseWrappingPolicy {
-		t.Fatalf("bad: expected\n%s\ngot\n%s\n", responseWrappingPolicy, pCubby.Raw)
+	if pCubby.Raw != policy.ResponseWrappingPolicy {
+		t.Fatalf("bad: expected\n%s\ngot\n%s\n", policy.ResponseWrappingPolicy, pCubby.Raw)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
 	err = ps.SetPolicy(ctx, pCubby, nil)
@@ -279,7 +279,7 @@ func TestPolicyStore_ACL(t *testing.T) {
 	})
 }
 
-func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
+func testPolicyStoreACL(t *testing.T, ps *policy.PolicyStore, ns *namespace.Namespace) {
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
 	err := ps.SetPolicy(ctx, pol, nil)
@@ -304,7 +304,7 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 func TestDefaultPolicy(t *testing.T) {
 	ctx := namespace.ContextWithNamespace(t.Context(), namespace.RootNamespace)
 
-	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, defaultPolicy)
+	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, policy.DefaultPolicy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +429,7 @@ path "secret/*" {
 `
 
 	// Load the policy through loadACLPolicyNamespaces from the namespace context
-	err = ps.loadACLPolicy(nsCtx, "test-load-policy", testPolicy)
+	err = ps.LoadACLPolicy(nsCtx, "test-load-policy", testPolicy)
 	require.NoError(t, err)
 
 	// Verify the policy exists in the namespace
@@ -497,14 +497,14 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 	assert.Nil(t, rootP, "unexpected policy found in root namespace")
 
 	// Check storage locations
-	nsBarrierView := ps.getACLView(ns)
+	nsBarrierView := ps.GetACLView(ns)
 	require.NotNil(t, nsBarrierView, "expected namespace storage")
 
 	out, err := nsBarrierView.Get(nsCtx, "test-policy")
 	require.NoError(t, err)
 	require.NotNil(t, out, "expected policy in namespace storage")
 
-	rootBarrierView := ps.getACLView(namespace.RootNamespace)
+	rootBarrierView := ps.GetACLView(namespace.RootNamespace)
 	require.NotNil(t, rootBarrierView, "expected root namespace storage")
 
 	rootOut, err := rootBarrierView.Get(ctx, "test-policy")
@@ -828,9 +828,9 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	assert.Contains(t, childP.Raw, `capabilities = ["read", "list", "create"]`)
 
 	// Verify storage locations by directly accessing the barrier views
-	rootView := ps.getACLView(namespace.RootNamespace)
-	parentView := ps.getACLView(parentNS)
-	childView := ps.getACLView(childNS)
+	rootView := ps.GetACLView(namespace.RootNamespace)
+	parentView := ps.GetACLView(parentNS)
+	childView := ps.GetACLView(childNS)
 
 	rootEntry, err := rootView.Get(ctx, "test-nested-policy")
 	require.NoError(t, err)

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
+	poltesting "github.com/openbao/openbao/vault/policy/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +40,7 @@ func TestPolicyStore_Root(t *testing.T) {
 func testPolicyRoot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace, expectFound bool) {
 	// Get should return a special policy
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	p, err := ps.GetPolicy(ctx, "root", PolicyTypeToken)
+	p, err := ps.GetPolicy(ctx, "root", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -57,7 +59,7 @@ func testPolicyRoot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace, expe
 		}
 		// Create root policy for subsequent modification and deletion failure
 		// tests
-		p = &Policy{
+		p = &policy.Policy{
 			Name: "root",
 		}
 	}
@@ -71,7 +73,7 @@ func testPolicyRoot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace, expe
 
 	// Delete should fail
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "root", PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "root", policy.PolicyTypeACL)
 	if err.Error() != `cannot delete "root" policy` {
 		t.Fatalf("err: %v", err)
 	}
@@ -111,7 +113,7 @@ func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string
 func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
 	// Get should return nothing
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	p, err := ps.GetPolicy(ctx, "Dev", PolicyTypeToken)
+	p, err := ps.GetPolicy(ctx, "Dev", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -121,14 +123,14 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Nam
 
 	// Delete should be no-op
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "deV", PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "deV", policy.PolicyTypeACL)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// List should be blank
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err := ps.ListPolicies(ctx, PolicyTypeACL, true)
+	out, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -138,25 +140,25 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Nam
 
 	// Set should work
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	policy, _ := ParseACLPolicy(ns, aclPolicy)
-	err = ps.SetPolicy(ctx, policy, nil)
+	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	err = ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Get should work
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	p, err = ps.GetPolicy(ctx, "dEv", PolicyTypeToken)
+	p, err = ps.GetPolicy(ctx, "dEv", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if !reflect.DeepEqual(p, policy) {
+	if !reflect.DeepEqual(p, pol) {
 		t.Fatalf("bad: %v", p)
 	}
 
 	// List should contain two elements
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err = ps.ListPolicies(ctx, PolicyTypeACL, true)
+	out, err = ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -171,14 +173,14 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Nam
 
 	// Delete should be clear the entry
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, "Dev", PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, "Dev", policy.PolicyTypeACL)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// List should contain one element
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	out, err = ps.ListPolicies(ctx, PolicyTypeACL, true)
+	out, err = ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -188,7 +190,7 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *PolicyStore, ns *namespace.Nam
 
 	// Get should fail
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	p, err = ps.GetPolicy(ctx, "deV", PolicyTypeToken)
+	p, err = ps.GetPolicy(ctx, "deV", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -208,7 +210,7 @@ func TestPolicyStore_Predefined(t *testing.T) {
 func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
 	// List should be two elements
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	out, err := ps.ListPolicies(ctx, PolicyTypeACL, true)
+	out, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -219,7 +221,7 @@ func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Name
 
 	// Response-wrapping policy checks
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pCubby, err := ps.GetPolicy(ctx, "response-wrapping", PolicyTypeToken)
+	pCubby, err := ps.GetPolicy(ctx, "response-wrapping", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -235,14 +237,14 @@ func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Name
 		t.Fatalf("expected err setting %s", pCubby.Name)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, pCubby.Name, PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, pCubby.Name, policy.PolicyTypeACL)
 	if err == nil {
 		t.Fatalf("expected err deleting %s", pCubby.Name)
 	}
 
 	// Root policy checks, behavior depending on namespace
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	pRoot, err := ps.GetPolicy(ctx, "root", PolicyTypeToken)
+	pRoot, err := ps.GetPolicy(ctx, "root", policy.PolicyTypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -254,7 +256,7 @@ func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Name
 		if pRoot != nil {
 			t.Fatal("expected nil root policy")
 		}
-		pRoot = &Policy{
+		pRoot = &policy.Policy{
 			Name: "root",
 		}
 	}
@@ -264,7 +266,7 @@ func testPolicyStorePredefined(t *testing.T, ps *PolicyStore, ns *namespace.Name
 		t.Fatalf("expected err setting %s", pRoot.Name)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	err = ps.DeletePolicy(ctx, pRoot.Name, PolicyTypeACL)
+	err = ps.DeletePolicy(ctx, pRoot.Name, policy.PolicyTypeACL)
 	if err == nil {
 		t.Fatalf("expected err deleting %s", pRoot.Name)
 	}
@@ -279,14 +281,14 @@ func TestPolicyStore_ACL(t *testing.T) {
 
 func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) {
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	policy, _ := ParseACLPolicy(ns, aclPolicy)
-	err := ps.SetPolicy(ctx, policy, nil)
+	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	err := ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	ctx = namespace.ContextWithNamespace(t.Context(), ns)
-	policy, _ = ParseACLPolicy(ns, aclPolicy2)
-	err = ps.SetPolicy(ctx, policy, nil)
+	pol, _ = policy.ParseACLPolicy(ns, poltesting.ACLPolicy2)
+	err = ps.SetPolicy(ctx, pol, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -296,17 +298,17 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	testLayeredACL(t, acl, ns)
+	poltesting.TestLayeredACL(t, acl, ns)
 }
 
 func TestDefaultPolicy(t *testing.T) {
 	ctx := namespace.ContextWithNamespace(t.Context(), namespace.RootNamespace)
 
-	policy, err := ParseACLPolicy(namespace.RootNamespace, defaultPolicy)
+	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, defaultPolicy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	acl, err := NewACL(ctx, []*Policy{policy})
+	acl, err := policy.NewACL(ctx, []*policy.Policy{pol})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,20 +354,20 @@ func TestPolicyStore_GetNonEGPPolicyType(t *testing.T) {
 		policyStoreValue     any
 		paramNamespace       string
 		paramPolicyName      string
-		paramPolicyType      PolicyType
+		paramPolicyType      policy.PolicyType
 		isErrorExpected      bool
 		expectedErrorMessage string
 	}{
 		"happy-acl": {
 			policyStoreKey:   "root/default",
-			policyStoreValue: PolicyTypeACL,
+			policyStoreValue: policy.PolicyTypeACL,
 			paramNamespace:   "root",
 			paramPolicyName:  "default",
-			paramPolicyType:  PolicyTypeACL,
+			paramPolicyType:  policy.PolicyTypeACL,
 		},
 		"not-in-map-acl": {
 			policyStoreKey:       "root/policy2",
-			policyStoreValue:     PolicyTypeACL,
+			policyStoreValue:     policy.PolicyTypeACL,
 			paramNamespace:       "root",
 			paramPolicyName:      "policy2",
 			isErrorExpected:      true,
@@ -431,7 +433,7 @@ path "secret/*" {
 	require.NoError(t, err)
 
 	// Verify the policy exists in the namespace
-	nsPolicy, err := ps.GetPolicy(nsCtx, "test-load-policy", PolicyTypeToken)
+	nsPolicy, err := ps.GetPolicy(nsCtx, "test-load-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, nsPolicy, "expected policy to exist in namespace")
 
@@ -444,14 +446,14 @@ path "secret/*" {
 }
 `
 
-	// Create a new policy in the namespace
-	policy, _ := ParseACLPolicy(ns, modifiedPolicy)
-	policy.Name = "test-load-policy"
-	err = ps.SetPolicy(nsCtx, policy, nil)
+	// Create a new pol in the namespace
+	pol, _ := policy.ParseACLPolicy(ns, modifiedPolicy)
+	pol.Name = "test-load-policy"
+	err = ps.SetPolicy(nsCtx, pol, nil)
 	require.NoError(t, err)
 
 	// Verify the policies are now different
-	nsPolicy, _ = ps.GetPolicy(nsCtx, "test-load-policy", PolicyTypeToken)
+	nsPolicy, _ = ps.GetPolicy(nsCtx, "test-load-policy", policy.PolicyTypeToken)
 	assert.Equal(t, modifiedPolicy, nsPolicy.Raw)
 }
 
@@ -480,17 +482,17 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 
 	// Create policy in namespace
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
-	policy, _ := ParseACLPolicy(ns, aclPolicy)
-	policy.Name = "test-policy"
-	require.NoError(t, ps.SetPolicy(nsCtx, policy, nil))
+	pol, _ := policy.ParseACLPolicy(ns, poltesting.ACLPolicy)
+	pol.Name = "test-policy"
+	require.NoError(t, ps.SetPolicy(nsCtx, pol, nil))
 
 	// Verify the policy exists in the namespace
-	p, err := ps.GetPolicy(nsCtx, "test-policy", PolicyTypeToken)
+	p, err := ps.GetPolicy(nsCtx, "test-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, p, "expected policy to exist in namespace")
 
 	// Verify the policy is not retrievable from the root namespace
-	rootP, err := ps.GetPolicy(ctx, "test-policy", PolicyTypeToken)
+	rootP, err := ps.GetPolicy(ctx, "test-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, rootP, "unexpected policy found in root namespace")
 
@@ -510,17 +512,17 @@ func TestPolicyStore_NamespaceStorage(t *testing.T) {
 	assert.Nil(t, rootOut, "policy should not exist in root storage")
 
 	// Check policy listings
-	policies, err := ps.ListPolicies(nsCtx, PolicyTypeACL, true)
+	policies, err := ps.ListPolicies(nsCtx, policy.PolicyTypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, policies, "test-policy", "policy not found in namespace listing")
 
-	rootPolicies, err := ps.ListPolicies(ctx, PolicyTypeACL, true)
+	rootPolicies, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	require.NoError(t, err)
 	assert.NotContains(t, rootPolicies, "test-policy", "namespace policy found in root listing")
 
 	// Delete and verify
-	require.NoError(t, ps.DeletePolicy(nsCtx, "test-policy", PolicyTypeACL))
-	p, err = ps.GetPolicy(nsCtx, "test-policy", PolicyTypeToken)
+	require.NoError(t, ps.DeletePolicy(nsCtx, "test-policy", policy.PolicyTypeACL))
+	p, err = ps.GetPolicy(nsCtx, "test-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, p, "policy should be deleted")
 }
@@ -673,7 +675,7 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 	}
 
 	for _, tmpl := range policyTemplates {
-		policy, _ := ParseACLPolicy(tmpl.ns, tmpl.content)
+		policy, _ := policy.ParseACLPolicy(tmpl.ns, tmpl.content)
 		policy.Name = tmpl.name
 		require.NoError(t, ps.SetPolicy(tmpl.ctx, policy, nil))
 	}
@@ -734,19 +736,19 @@ func TestPolicyStore_ListPoliciesByNamespace(t *testing.T) {
 	}
 
 	// Verify child namespace only sees its own policy
-	childPolicies, err := ps.ListPolicies(childCtx, PolicyTypeACL, true)
+	childPolicies, err := ps.ListPolicies(childCtx, policy.PolicyTypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "child-policy"}, childPolicies,
 		"child namespace should only contain its own policy and default")
 
 	// Verify parent namespace listing
-	parentPolicies, err := ps.ListPolicies(parentCtx, PolicyTypeACL, true)
+	parentPolicies, err := ps.ListPolicies(parentCtx, policy.PolicyTypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "parent-policy"}, parentPolicies,
 		"parent namespace should contain its own policy and default")
 
 	// Verify root namespace listing
-	rootPolicies, err := ps.ListPolicies(rootCtx, PolicyTypeACL, true)
+	rootPolicies, err := ps.ListPolicies(rootCtx, policy.PolicyTypeACL, true)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"default", "root-policy"}, rootPolicies,
 		"root namespace should contain its own policy and default")
@@ -795,32 +797,32 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	childPolicy := `path "secret/*" { capabilities = ["read", "list", "create"] }`
 
 	// Create in root namespace
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, rootPolicy)
-	policy.Name = "test-nested-policy"
-	require.NoError(t, ps.SetPolicy(ctx, policy, nil))
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, rootPolicy)
+	pol.Name = "test-nested-policy"
+	require.NoError(t, ps.SetPolicy(ctx, pol, nil))
 
 	// Create in parent namespace
-	policy, _ = ParseACLPolicy(parentNS, parentPolicy)
-	policy.Name = "test-nested-policy"
-	require.NoError(t, ps.SetPolicy(parentCtx, policy, nil))
+	pol, _ = policy.ParseACLPolicy(parentNS, parentPolicy)
+	pol.Name = "test-nested-policy"
+	require.NoError(t, ps.SetPolicy(parentCtx, pol, nil))
 
 	// Create in child namespace
-	policy, _ = ParseACLPolicy(childNS, childPolicy)
-	policy.Name = "test-nested-policy"
-	require.NoError(t, ps.SetPolicy(childCtx, policy, nil))
+	pol, _ = policy.ParseACLPolicy(childNS, childPolicy)
+	pol.Name = "test-nested-policy"
+	require.NoError(t, ps.SetPolicy(childCtx, pol, nil))
 
 	// Verify policies were stored in correct locations
-	rootP, err := ps.GetPolicy(ctx, "test-nested-policy", PolicyTypeToken)
+	rootP, err := ps.GetPolicy(ctx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, rootP, "expected policy in root namespace")
 	assert.Contains(t, rootP.Raw, `capabilities = ["read"]`)
 
-	parentP, err := ps.GetPolicy(parentCtx, "test-nested-policy", PolicyTypeToken)
+	parentP, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, parentP, "expected policy in parent namespace")
 	assert.Contains(t, parentP.Raw, `capabilities = ["read", "list"]`)
 
-	childP, err := ps.GetPolicy(childCtx, "test-nested-policy", PolicyTypeToken)
+	childP, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	require.NotNil(t, childP, "expected policy in child namespace")
 	assert.Contains(t, childP.Raw, `capabilities = ["read", "list", "create"]`)
@@ -843,15 +845,15 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	require.NotNil(t, childViewEntry, "policy not found in child storage")
 
 	// Verify namespace visibility
-	rootList, err := ps.ListPolicies(ctx, PolicyTypeACL, true)
+	rootList, err := ps.ListPolicies(ctx, policy.PolicyTypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, rootList, "test-nested-policy", "policy missing in root listing")
 
-	parentList, err := ps.ListPolicies(parentCtx, PolicyTypeACL, true)
+	parentList, err := ps.ListPolicies(parentCtx, policy.PolicyTypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, parentList, "test-nested-policy", "policy missing in parent listing")
 
-	childList, err := ps.ListPolicies(childCtx, PolicyTypeACL, true)
+	childList, err := ps.ListPolicies(childCtx, policy.PolicyTypeACL, true)
 	require.NoError(t, err)
 	assert.Contains(t, childList, "test-nested-policy", "policy missing in child listing")
 
@@ -861,7 +863,7 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 
 	// Test policy inheritance
 	// Child namespace should not see root policy when using its own context
-	rootPolicyInChild, err := ps.GetPolicy(childCtx, "test-nested-policy", PolicyTypeToken)
+	rootPolicyInChild, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.NotEqual(t, rootP.Raw, rootPolicyInChild.Raw, "child namespace should not inherit root policy")
 
@@ -869,31 +871,31 @@ func TestPolicyStore_NestedNamespaces(t *testing.T) {
 	// We error here due to the relative path; in the past this
 	// was treated like a not-found policy, which is technically
 	// correct but less informative.
-	parentPolicyInChild, err := ps.GetPolicy(childCtx, "../test-nested-policy", PolicyTypeToken)
+	parentPolicyInChild, err := ps.GetPolicy(childCtx, "../test-nested-policy", policy.PolicyTypeToken)
 	require.Error(t, err)
 	assert.Nil(t, parentPolicyInChild, "child namespace should not access parent policy via relative path")
 
 	// Test cross-namespace policy access
 	// Root namespace should not see child's policy
-	childPolicyInRoot, err := ps.GetPolicy(ctx, childNS.ID+"/test-nested-policy", PolicyTypeToken)
+	childPolicyInRoot, err := ps.GetPolicy(ctx, childNS.ID+"/test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, childPolicyInRoot, "root namespace should not see child policy")
 
 	// Test policy deletion isolation
 	// Delete policy in child namespace
-	require.NoError(t, ps.DeletePolicy(childCtx, "test-nested-policy", PolicyTypeACL))
+	require.NoError(t, ps.DeletePolicy(childCtx, "test-nested-policy", policy.PolicyTypeACL))
 
 	// Verify policy was deleted only in child namespace
-	deletedChildPolicy, err := ps.GetPolicy(childCtx, "test-nested-policy", PolicyTypeToken)
+	deletedChildPolicy, err := ps.GetPolicy(childCtx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.Nil(t, deletedChildPolicy, "policy should be deleted in child namespace")
 
 	// Verify parent and root policies still exist
-	parentPolicyAfterDelete, err := ps.GetPolicy(parentCtx, "test-nested-policy", PolicyTypeToken)
+	parentPolicyAfterDelete, err := ps.GetPolicy(parentCtx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.NotNil(t, parentPolicyAfterDelete, "parent policy should still exist")
 
-	rootPolicyAfterDelete, err := ps.GetPolicy(ctx, "test-nested-policy", PolicyTypeToken)
+	rootPolicyAfterDelete, err := ps.GetPolicy(ctx, "test-nested-policy", policy.PolicyTypeToken)
 	require.NoError(t, err)
 	assert.NotNil(t, rootPolicyAfterDelete, "root policy should still exist")
 }
@@ -905,7 +907,7 @@ func TestPolicyStore_Expiration(t *testing.T) {
 
 	ctx := namespace.ContextWithNamespace(t.Context(), namespace.RootNamespace)
 
-	p, err := ParseACLPolicy(namespace.RootNamespace, `path "*" { capabilities = ["read"] }`)
+	p, err := policy.ParseACLPolicy(namespace.RootNamespace, `path "*" { capabilities = ["read"] }`)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 
@@ -934,7 +936,7 @@ func TestPolicyStore_CAS(t *testing.T) {
 
 	ctx := namespace.ContextWithNamespace(t.Context(), namespace.RootNamespace)
 
-	p, err := ParseACLPolicy(namespace.RootNamespace, `path "*" { capabilities = ["read"] }`)
+	p, err := policy.ParseACLPolicy(namespace.RootNamespace, `path "*" { capabilities = ["read"] }`)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -69,7 +69,6 @@ var (
 	DefaultMaxJsonStrings = int64(1000)
 
 	ErrNoApplicablePolicies = errors.New("no applicable policies")
-	ErrPolicyNotExist       = errors.New("policy does not exist")
 
 	// restrictedSysAPIs is the set of `sys/` APIs available only in the root namespace.
 	restrictedSysAPIs = pathmanager.New()
@@ -246,7 +245,7 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 	for _, policyName := range nsPolicies {
 		policyNSCtx := namespace.ContextWithNamespace(ctx, policyNS)
 		t, err := c.policyStore.GetNonEGPPolicyType(policyNSCtx, policyName)
-		if err != nil && errors.Is(err, ErrPolicyNotExist) {
+		if err != nil && errors.Is(err, policy.ErrPolicyNotExist) {
 			// When we attempt to get a non-EGP policy type, and receive an
 			// explicit error that it doesn't exist (in the type map) we log the
 			// ns/policy and continue without error.
@@ -362,7 +361,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 	var tokenCtx context.Context
 	if len(policyNames) == 1 &&
 		len(policyNames[te.NamespaceID]) == 1 &&
-		policyNames[te.NamespaceID][0] == responseWrappingPolicyName &&
+		policyNames[te.NamespaceID][0] == policy.ResponseWrappingPolicyName &&
 		(strings.HasSuffix(req.Path, "sys/wrapping/unwrap") ||
 			strings.HasSuffix(req.Path, "sys/wrapping/lookup") ||
 			strings.HasSuffix(req.Path, "sys/wrapping/rewrap")) {
@@ -1473,7 +1472,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	if resp != nil &&
 		req.Path == "cubbyhole/response" &&
 		len(te.Policies) == 1 &&
-		te.Policies[0] == responseWrappingPolicyName {
+		te.Policies[0] == policy.ResponseWrappingPolicyName {
 		resp.AddWarning("Reading from 'cubbyhole/response' is deprecated. Please use sys/wrapping/unwrap to unwrap responses, as it provides additional security checks and other benefits.")
 	}
 
@@ -1919,12 +1918,12 @@ func (c *Core) LoginCreateToken(ctx context.Context, ns *namespace.Namespace, re
 	// Prevent internal policies from being assigned to tokens. We check
 	// this on auth.Policies including derived ones from Identity before
 	// actually making the token.
-	for _, policy := range allPolicies {
-		if policy == "root" {
+	for _, pol := range allPolicies {
+		if pol == "root" {
 			return false, logical.ErrorResponse("auth methods cannot create root tokens"), logical.ErrInvalidRequest
 		}
-		if slices.Contains(nonAssignablePolicies, policy) {
-			return false, logical.ErrorResponse("cannot assign policy %q", policy), logical.ErrInvalidRequest
+		if slices.Contains(policy.NonAssignablePolicies, pol) {
+			return false, logical.ErrorResponse("cannot assign policy %q", pol), logical.ErrInvalidRequest
 		}
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/wrapping"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	ident "github.com/openbao/openbao/vault/identity"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/vault/tokens"
 )
@@ -257,7 +258,7 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 		}
 
 		switch *t {
-		case PolicyTypeACL:
+		case policy.PolicyTypeACL:
 			if policyApplicationMode != groupPolicyApplicationModeWithinNamespaceHierarchy {
 				// Group policy application mode isn't set to enforce
 				// the namespace hierarchy, so apply all the ACLs,
@@ -278,7 +279,7 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 	return filteredPolicies, nil
 }
 
-func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Request) (*ACL, *logical.TokenEntry, *identity.Entity, map[string][]string, error) {
+func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Request) (*policy.ACL, *logical.TokenEntry, *identity.Entity, map[string][]string, error) {
 	defer metrics.MeasureSince([]string{"core", "fetch_acl_and_token"}, time.Now())
 
 	// Ensure there is a client token
@@ -374,9 +375,9 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 	}
 
 	// Add the inline policy if it's set
-	policies := make([]*Policy, 0)
+	policies := make([]*policy.Policy, 0)
 	if te.InlinePolicy != "" {
-		inlinePolicy, err := ParseACLPolicy(tokenNS, te.InlinePolicy)
+		inlinePolicy, err := policy.ParseACLPolicy(tokenNS, te.InlinePolicy)
 		if err != nil {
 			return nil, nil, nil, nil, ErrInternalError
 		}
@@ -394,10 +395,10 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 	return acl, te, entity, identityPolicies, nil
 }
 
-func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool) (*logical.Auth, *ACL, *logical.TokenEntry, *identity.Entity, error) {
+func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool) (*logical.Auth, *policy.ACL, *logical.TokenEntry, *identity.Entity, error) {
 	defer metrics.MeasureSince([]string{"core", "check_token"}, time.Now())
 
-	var acl *ACL
+	var acl *policy.ACL
 	var te *logical.TokenEntry
 	var entity *identity.Entity
 	var identityPolicies map[string][]string
@@ -534,7 +535,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 
 	// Check the standard non-root ACLs. Return the token entry if it's not
 	// allowed so we can decrement the use count.
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
 		Unauth:            unauth,
 		RootPrivsRequired: rootPath,
 	})
@@ -1509,7 +1510,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 
 	// Do an unauth check. This will cause EGP policies to be checked
 	var auth *logical.Auth
-	var acl *ACL
+	var acl *policy.ACL
 	var te *logical.TokenEntry
 	var entity *identity.Entity
 	var ctErr error

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -257,7 +257,7 @@ func (c *Core) getApplicableGroupPolicies(ctx context.Context, tokenNS *namespac
 		}
 
 		switch *t {
-		case policy.PolicyTypeACL:
+		case policy.TypeACL:
 			if policyApplicationMode != groupPolicyApplicationModeWithinNamespaceHierarchy {
 				// Group policy application mode isn't set to enforce
 				// the namespace hierarchy, so apply all the ACLs,
@@ -534,7 +534,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 
 	// Check the standard non-root ACLs. Return the token entry if it's not
 	// allowed so we can decrement the use count.
-	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.PolicyCheckOpts{
+	authResults := c.performPolicyChecks(ctx, acl, te, req, entity, &policy.CheckOpts{
 		Unauth:            unauth,
 		RootPrivsRequired: rootPath,
 	})

--- a/vault/request_handling_list_filtering.go
+++ b/vault/request_handling_list_filtering.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 
 	"github.com/openbao/openbao/helper/identity"
-	"github.com/openbao/openbao/sdk/v2/helper/template"
+	"github.com/openbao/openbao/helper/template"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 )
 
-func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, unauth bool, auth *logical.Auth, acl *ACL, te *logical.TokenEntry, entity *identity.Entity, resp *logical.Response) error {
+func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, unauth bool, auth *logical.Auth, acl *policy.ACL, te *logical.TokenEntry, entity *identity.Entity, resp *logical.Response) error {
 	// Ignore non-list operations.
 	switch req.Operation {
 	case logical.ListOperation:
@@ -73,14 +74,14 @@ func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, una
 	}
 
 	filteredKeys := make([]string, 0, len(keys))
-	tmpl, err := compileTemplatePathForFiltering(auth.ResponseKeysFilterPath)
+	tmpl, err := template.CompileTemplatePathForFiltering(auth.ResponseKeysFilterPath)
 	if err != nil {
 		c.logger.Error("failed to compile template on filtered list response", "path", req.Path, "err", err)
 		return ErrInternalError
 	}
 
 	for _, key := range keys {
-		checkPath, err := useTemplateForFiltering(tmpl, req.Path, key)
+		checkPath, err := template.UseTemplateForFiltering(tmpl, req.Path, key)
 		if err != nil {
 			c.logger.Error("failed to use template on filtered list response", "path", req.Path, "err", err)
 			return ErrInternalError
@@ -110,7 +111,7 @@ func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, una
 			continue
 		}
 
-		authResults := c.performPolicyChecks(ctx, acl, te, checkReq, entity, &PolicyCheckOpts{
+		authResults := c.performPolicyChecks(ctx, acl, te, checkReq, entity, &policy.PolicyCheckOpts{
 			Unauth:            unauth,
 			RootPrivsRequired: rootPath,
 		})
@@ -134,15 +135,4 @@ func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, una
 	}
 
 	return nil
-}
-
-func compileTemplatePathForFiltering(tmpl string) (template.StringTemplate, error) {
-	return template.NewTemplate(template.Template(tmpl))
-}
-
-func useTemplateForFiltering(t template.StringTemplate, path string, key string) (string, error) {
-	return t.Generate(map[string]interface{}{
-		"key":  key,
-		"path": path,
-	})
 }

--- a/vault/request_handling_list_filtering.go
+++ b/vault/request_handling_list_filtering.go
@@ -111,7 +111,7 @@ func (c *Core) filterListResponse(ctx context.Context, req *logical.Request, una
 			continue
 		}
 
-		authResults := c.performPolicyChecks(ctx, acl, te, checkReq, entity, &policy.PolicyCheckOpts{
+		authResults := c.performPolicyChecks(ctx, acl, te, checkReq, entity, &policy.CheckOpts{
 			Unauth:            unauth,
 			RootPrivsRequired: rootPath,
 		})

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/plugin/pb"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/vault/tokens"
 	"google.golang.org/protobuf/proto"
@@ -1272,7 +1273,7 @@ func (ts *TokenStore) create(ctx context.Context, entry *logical.TokenEntry, per
 
 	// Validate the inline policy if it's set
 	if entry.InlinePolicy != "" {
-		if _, err := ParseACLPolicy(tokenNS, entry.InlinePolicy); err != nil {
+		if _, err := policy.ParseACLPolicy(tokenNS, entry.InlinePolicy); err != nil {
 			return fmt.Errorf("failed to parse inline policy for token entry: %v", err)
 		}
 	}
@@ -3184,7 +3185,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 	}
 
 	for _, p := range te.Policies {
-		policy, err := ts.core.policyStore.GetPolicy(ctx, p, PolicyTypeToken)
+		policy, err := ts.core.policyStore.GetPolicy(ctx, p, policy.PolicyTypeToken)
 		if err != nil {
 			return logical.ErrorResponse("could not look up policy %s", p), nil
 		}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -880,7 +880,7 @@ func (ts *TokenStore) teardown() {
 }
 
 func (ts *TokenStore) baseView(ns *namespace.Namespace) barrier.View {
-	return ts.core.NamespaceView(ns).SubView(systemBarrierPrefix + tokenSubPath)
+	return ts.core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + tokenSubPath)
 }
 
 func (ts *TokenStore) idView(ns *namespace.Namespace) barrier.View {
@@ -4349,9 +4349,9 @@ func (ts *TokenStore) resolveTokenPolicies(ctx context.Context, req *logical.Req
 	}
 
 	// Prevent internal policies from being assigned to tokens
-	for _, policy := range finalPolicies {
-		if slices.Contains(nonAssignablePolicies, policy) {
-			return logical.ErrorResponse(fmt.Sprintf("cannot assign policy %q", policy)), nil, nil
+	for _, pol := range finalPolicies {
+		if slices.Contains(policy.NonAssignablePolicies, pol) {
+			return logical.ErrorResponse(fmt.Sprintf("cannot assign policy %q", pol)), nil, nil
 		}
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3185,7 +3185,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 	}
 
 	for _, p := range te.Policies {
-		policy, err := ts.core.policyStore.GetPolicy(ctx, p, policy.PolicyTypeToken)
+		policy, err := ts.core.policyStore.GetPolicy(ctx, p, policy.TypeToken)
 		if err != nil {
 			return logical.ErrorResponse("could not look up policy %s", p), nil
 		}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -1789,7 +1789,7 @@ func TestTokenStore_HandleRequest_NonAssignable(t *testing.T) {
 		t.Fatalf("err: %v\nresp: %#v", err, resp)
 	}
 
-	req.Data["policies"] = []string{"default", "foo", responseWrappingPolicyName}
+	req.Data["policies"] = []string{"default", "foo", policy.ResponseWrappingPolicyName}
 
 	resp, err = ts.HandleRequest(namespace.RootContext(t.Context()), req)
 	if err != nil {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -41,7 +41,7 @@ import (
 	be "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/barrier"
 	"github.com/openbao/openbao/vault/policy"
-	poltesting "github.com/openbao/openbao/vault/policy/testing"
+	"github.com/openbao/openbao/vault/policy/policytest"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/stretchr/testify/require"
 )
@@ -2133,7 +2133,7 @@ func TestTokenStore_HandleRequest_CreateToken_NonRoot_RootChild(t *testing.T) {
 	ts := core.tokenStore
 	ps := core.policyStore
 
-	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	policy.Name = "test1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
 		t.Fatal(err)
@@ -3671,19 +3671,19 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 	ps := core.policyStore
 
 	// Create 3 different policies
-	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test2"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test3"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
@@ -3939,25 +3939,25 @@ func TestTokenStore_RoleDisallowedPoliciesGlob(t *testing.T) {
 	ps := core.policyStore
 
 	// Create 4 different policies
-	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test2"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test3"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	pol.Name = "test3b"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
@@ -5249,7 +5249,7 @@ func TestTokenStore_NoDefaultPolicy(t *testing.T) {
 	core, _, root := TestCoreUnsealed(t)
 	ts := core.tokenStore
 	ps := core.policyStore
-	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, policytest.TokenCreationPolicy)
 	policy.Name = "policy1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
 		t.Fatal(err)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -40,6 +40,8 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	be "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/barrier"
+	"github.com/openbao/openbao/vault/policy"
+	poltesting "github.com/openbao/openbao/vault/policy/testing"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/stretchr/testify/require"
 )
@@ -2131,7 +2133,7 @@ func TestTokenStore_HandleRequest_CreateToken_NonRoot_RootChild(t *testing.T) {
 	ts := core.tokenStore
 	ps := core.policyStore
 
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
 	policy.Name = "test1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
 		t.Fatal(err)
@@ -3669,21 +3671,21 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 	ps := core.policyStore
 
 	// Create 3 different policies
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test1"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test1"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test2"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test2"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test3"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test3"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3937,27 +3939,27 @@ func TestTokenStore_RoleDisallowedPoliciesGlob(t *testing.T) {
 	ps := core.policyStore
 
 	// Create 4 different policies
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test1"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test1"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test2"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test2"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test3"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test3"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
-	policy.Name = "test3b"
-	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
+	pol, _ = policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
+	pol.Name = "test3b"
+	if err := ps.SetPolicy(namespace.RootContext(t.Context()), pol, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -5247,7 +5249,7 @@ func TestTokenStore_NoDefaultPolicy(t *testing.T) {
 	core, _, root := TestCoreUnsealed(t)
 	ts := core.tokenStore
 	ps := core.policyStore
-	policy, _ := ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
+	policy, _ := policy.ParseACLPolicy(namespace.RootNamespace, poltesting.TokenCreationPolicy)
 	policy.Name = "policy1"
 	if err := ps.SetPolicy(namespace.RootContext(t.Context()), policy, nil); err != nil {
 		t.Fatal(err)

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault/policy"
 )
 
 const (
@@ -460,7 +461,7 @@ func IsWrappingToken(te *logical.TokenEntry) bool {
 		return false
 	}
 
-	if te.Policies[0] != responseWrappingPolicyName {
+	if te.Policies[0] != policy.ResponseWrappingPolicyName {
 		return false
 	}
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Moves `PolicyStore` and related code into new `policy` package.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Part 5 of splitting up the `vault` package into smaller and more manageable packages.

Previously:
- #2425
- #2458
- #2551
- #2626

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
