### PR TITLE
Core using seal manager for unsealing

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -295,9 +294,6 @@ type Core struct {
 	// release the stateLock. This channel is marked atomic to prevent race
 	// conditions.
 	shutdownDoneCh *atomic.Value
-
-	// unlockInfo has the keys provided to Unseal until the threshold number of parts is available, as well as the operation nonce
-	unlockInfo *unlockInformation
 
 	// generateRootProgress holds the shares until we reach enough
 	// to verify the root key
@@ -1398,28 +1394,10 @@ func (c *Core) NamespaceSealed(ns *namespace.Namespace) bool {
 	return c.sealManager.NamespaceBarrierByLongestPrefix(ns.Path).Sealed()
 }
 
-// SecretProgress returns the number of keys provided so far. Lock
-// should only be false if the caller is already holding the read
-// statelock (such as calls originating from switchedLockHandleRequest).
-func (c *Core) SecretProgress(lock bool) (int, string) {
-	if lock {
-		c.stateLock.RLock()
-		defer c.stateLock.RUnlock()
-	}
-	switch c.unlockInfo {
-	case nil:
-		return 0, ""
-	default:
-		return len(c.unlockInfo.Parts), c.unlockInfo.Nonce
-	}
-}
-
 // ResetUnsealProcess removes the current unlock parts from memory, to reset
 // the unsealing process
 func (c *Core) ResetUnsealProcess() {
-	c.stateLock.Lock()
-	defer c.stateLock.Unlock()
-	c.unlockInfo = nil
+	c.sealManager.ResetUnsealProcess(namespace.RootNamespaceUUID)
 }
 
 func (c *Core) UnsealMigrate(key []byte) (bool, error) {
@@ -1439,29 +1417,28 @@ func (c *Core) Unseal(key []byte) (bool, error) {
 // target threshold.
 //
 // The provided key should be a recovery key fragment if the seal
-// is an autoseal, or a regular seal key fragment for shamir.  In
+// is an autoseal, or a regular seal key fragment for shamir. In
 // migration scenarios "seal" in the preceding sentence refers to
 // the migration seal in c.migrationInfo.seal.
 //
 // We use getUnsealKey to work out if we have enough fragments,
-// and if we don't have enough we return early.  Otherwise we get
+// and if we don't have enough we return early. Otherwise we get
 // back the combined key.
 //
 // For shamir the combined key is used to decrypt the root key
-// read from storage.  For autoseal the combined key isn't used
+// read from storage. For autoseal the combined key isn't used
 // except to verify that the stored recovery key matches.
 //
 // In migration scenarios a side-effect of unsealing is that
 // the members of c.migrationInfo are populated (excluding
-// .seal, which must already be populated before unseal is called.)
+// .seal, which must already be populated before unseal is called).
 func (c *Core) unsealFragment(key []byte, migrate bool) error {
 	defer metrics.MeasureSince([]string{"core", "unseal"}, time.Now())
 
 	c.stateLock.Lock()
 	defer c.stateLock.Unlock()
 
-	ctx := context.Background()
-
+	ctx := namespace.RootContext(context.Background())
 	if migrate && c.migrationInfo == nil {
 		return errors.New("can't perform a seal migration, no migration seal found")
 	}
@@ -1490,16 +1467,6 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 		return ErrNotInit
 	}
 
-	// Verify the key length
-	min, max := c.barrier.KeyLength()
-	max += shamir.ShareOverhead
-	if len(key) < min {
-		return &ErrInvalidKey{fmt.Sprintf("key is shorter than minimum %d bytes", min)}
-	}
-	if len(key) > max {
-		return &ErrInvalidKey{fmt.Sprintf("key is longer than maximum %d bytes", max)}
-	}
-
 	// Check if already unsealed
 	if !c.Sealed() {
 		return nil
@@ -1511,17 +1478,11 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 		sealToUse = c.migrationInfo.seal
 	}
 
-	newKey, err := c.recordUnsealPart(key)
-	if !newKey || err != nil {
-		return err
-	}
-
-	// getUnsealKey returns either a recovery key (in the case of an autoseal)
-	// or an unseal key (new-style shamir).
-	combinedKey, err := c.getUnsealKey(ctx, sealToUse)
+	combinedKey, err := c.sealManager.unsealFragment(ctx, namespace.RootNamespace, sealToUse, c.barrier, key)
 	if err != nil || combinedKey == nil {
 		return err
 	}
+
 	if migrate {
 		c.migrationInfo.unsealKey = combinedKey
 	}
@@ -1529,10 +1490,12 @@ func (c *Core) unsealFragment(key []byte, migrate bool) error {
 	if c.isRaftUnseal() {
 		return c.unsealWithRaft(combinedKey)
 	}
-	rootKey, err := c.unsealKeyToRootKeyPreUnseal(ctx, sealToUse, combinedKey)
+
+	rootKey, err := c.sealManager.unsealKeyToRootKey(ctx, sealToUse, combinedKey, false, true)
 	if err != nil {
 		return err
 	}
+
 	return c.unsealInternal(ctx, rootKey)
 }
 
@@ -1590,7 +1553,7 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 			}
 			if keyringFound && len(rootKey) == 0 {
 				var err error
-				rootKey, err = c.unsealKeyToRootKeyPreUnseal(ctx, c.seal, combinedKey)
+				rootKey, err = c.sealManager.unsealKeyToRootKey(ctx, c.seal, combinedKey, false, true)
 				if err != nil {
 					c.logger.Error("failed to read root key", "error", err)
 					return
@@ -1608,92 +1571,6 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 	}()
 
 	return nil
-}
-
-// recordUnsealPart takes in a key fragment, and returns true if it's a new fragment.
-func (c *Core) recordUnsealPart(key []byte) (bool, error) {
-	// Check if we already have this piece
-	if c.unlockInfo != nil {
-		for _, existing := range c.unlockInfo.Parts {
-			if subtle.ConstantTimeCompare(existing, key) == 1 {
-				return false, nil
-			}
-		}
-	} else {
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			return false, err
-		}
-		c.unlockInfo = &unlockInformation{
-			Nonce: uuid,
-		}
-	}
-
-	// Store this key
-	c.unlockInfo.Parts = append(c.unlockInfo.Parts, key)
-	return true, nil
-}
-
-// getUnsealKey uses key fragments recorded by recordUnsealPart and
-// returns the combined key if the key share threshold is met.
-// If the key fragments are part of a recovery key, also verify that
-// it matches the stored recovery key on disk.
-func (c *Core) getUnsealKey(ctx context.Context, seal Seal) ([]byte, error) {
-	var config *SealConfig
-	var err error
-
-	raftInfo := c.raftInfo.Load()
-
-	switch {
-	case seal.RecoveryKeySupported():
-		config, err = seal.RecoveryConfig(ctx)
-	case raftInfo != nil:
-		// Ignore follower's seal config and refer to leader's barrier
-		// configuration.
-		config = raftInfo.leaderBarrierConfig
-	default:
-		config, err = seal.BarrierConfig(ctx)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return nil, errors.New("failed to obtain seal/recovery configuration")
-	}
-
-	// Check if we don't have enough keys to unlock, proceed through the rest of
-	// the call only if we have met the threshold
-	if len(c.unlockInfo.Parts) < config.SecretThreshold {
-		if c.logger.IsDebug() {
-			c.logger.Debug("cannot unseal, not enough keys", "keys", len(c.unlockInfo.Parts), "threshold", config.SecretThreshold, "nonce", c.unlockInfo.Nonce)
-		}
-		return nil, nil
-	}
-
-	defer func() {
-		c.unlockInfo = nil
-	}()
-
-	// Recover the split key. recoveredKey is the shamir combined
-	// key, or the single provided key if the threshold is 1.
-	var unsealKey []byte
-	if config.SecretThreshold == 1 {
-		unsealKey = make([]byte, len(c.unlockInfo.Parts[0]))
-		copy(unsealKey, c.unlockInfo.Parts[0])
-	} else {
-		unsealKey, err = shamir.Combine(c.unlockInfo.Parts)
-		if err != nil {
-			return nil, &ErrInvalidKey{fmt.Sprintf("failed to compute combined key: %v", err)}
-		}
-	}
-
-	if seal.RecoveryKeySupported() {
-		if err := seal.VerifyRecoveryKey(ctx, unsealKey); err != nil {
-			return nil, &ErrInvalidKey{fmt.Sprintf("failed to verify recovery key: %v", err)}
-		}
-	}
-
-	return unsealKey, nil
 }
 
 // sealMigrated must be called with the stateLock held. It returns true if
@@ -2822,77 +2699,6 @@ func (c *Core) adjustSealConfigDuringMigration(existBarrierSealConfig, existReco
 
 		newRecoveryConfig := existBarrierSealConfig.Clone()
 		c.seal.SetCachedRecoveryConfig(newRecoveryConfig)
-	}
-}
-
-func (c *Core) unsealKeyToRootKeyPostUnseal(ctx context.Context, combinedKey []byte) ([]byte, error) {
-	return c.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
-}
-
-func (c *Core) unsealKeyToRootKeyPreUnseal(ctx context.Context, seal Seal, combinedKey []byte) ([]byte, error) {
-	return c.unsealKeyToRootKey(ctx, seal, combinedKey, false, true)
-}
-
-// unsealKeyToRootKey takes a key provided by the user, either a recovery key
-// if using an autoseal or an unseal key with Shamir. It returns a nil error
-// if the key is valid and an error otherwise. It also returns the root key
-// that can be used to unseal the barrier.
-// If useTestSeal is true, seal will not be modified; this is used when not
-// invoked as part of an unseal process; In shamir case the combinedKey
-// will be set in the seal, which means subsequent attempts to use the seal
-// to read the root key will succeed, assuming combinedKey is valid.
-// If allowMissing is true, a failure to find the root key in storage results
-// in a nil error and a nil root key being returned.
-func (c *Core) unsealKeyToRootKey(ctx context.Context, seal Seal, combinedKey []byte, useTestSeal bool, allowMissing bool) ([]byte, error) {
-	switch seal.BarrierType() {
-	case vaultseal.WrapperTypeShamir:
-		if useTestSeal {
-			testseal := NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
-			testseal.SetCore(c)
-			cfg, err := seal.BarrierConfig(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup test barrier config: %w", err)
-			}
-			testseal.SetCachedBarrierConfig(cfg)
-			seal = testseal
-		}
-
-		shamirWrapper, err := seal.GetShamirWrapper()
-		if err != nil {
-			return nil, err
-		}
-		err = shamirWrapper.SetAesGcmKeyBytes(combinedKey)
-		if err != nil {
-			return nil, &ErrInvalidKey{fmt.Sprintf("failed to setup unseal key: %v", err)}
-		}
-		storedKeys, err := seal.GetStoredKeys(ctx)
-		if storedKeys == nil && err == nil && allowMissing {
-			return nil, nil
-		}
-		if err == nil && len(storedKeys) != 1 {
-			err = fmt.Errorf("expected exactly one stored key, got %d", len(storedKeys))
-		}
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve stored keys: %w", err)
-		}
-		return storedKeys[0], nil
-	default:
-		if err := seal.VerifyRecoveryKey(ctx, combinedKey); err != nil {
-			return nil, fmt.Errorf("recovery key verification failed: %w", err)
-		}
-
-		storedKeys, err := seal.GetStoredKeys(ctx)
-		if storedKeys == nil && err == nil && allowMissing {
-			return nil, nil
-		}
-
-		if err == nil && len(storedKeys) != 1 {
-			err = fmt.Errorf("expected exactly one stored key, got %d", len(storedKeys))
-		}
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve stored keys: %w", err)
-		}
-		return storedKeys[0], nil
 	}
 }
 

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -398,8 +398,8 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 		t.Fatal("should be sealed")
 	}
 
-	if prog, _ := c.SecretProgress(true); prog != 0 {
-		t.Fatalf("bad progress: %d", prog)
+	if info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID); info != nil && len(info.Parts) != 0 {
+		t.Fatalf("bad progress: %d", len(info.Parts))
 	}
 
 	for i := range 5 {
@@ -417,15 +417,15 @@ func TestCore_Unseal_MultiShare(t *testing.T) {
 			if !unseal {
 				t.Fatal("should be unsealed")
 			}
-			if prog, _ := c.SecretProgress(true); prog != 0 {
-				t.Fatalf("bad progress: %d", prog)
+			if info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID); info != nil && len(info.Parts) != 0 {
+				t.Fatalf("bad progress: %d", len(info.Parts))
 			}
 		} else {
 			if unseal {
 				t.Fatal("should not be unsealed")
 			}
-			if prog, _ := c.SecretProgress(true); prog != i+1 {
-				t.Fatalf("bad progress: %d", prog)
+			if info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID); info != nil && len(info.Parts) != i+1 {
+				t.Fatalf("bad progress: %d", len(info.Parts))
 			}
 		}
 	}
@@ -577,8 +577,8 @@ func TestCore_Unseal_Single(t *testing.T) {
 		t.Fatal("should be sealed")
 	}
 
-	if prog, _ := c.SecretProgress(true); prog != 0 {
-		t.Fatalf("bad progress: %d", prog)
+	if info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID); info != nil && len(info.Parts) != 0 {
+		t.Fatalf("bad progress: %d", len(info.Parts))
 	}
 
 	unseal, err := TestCoreUnseal(c, res.SecretShares[0])
@@ -589,8 +589,8 @@ func TestCore_Unseal_Single(t *testing.T) {
 	if !unseal {
 		t.Fatal("should be unsealed")
 	}
-	if prog, _ := c.SecretProgress(true); prog != 0 {
-		t.Fatalf("bad progress: %d", prog)
+	if info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID); info != nil && len(info.Parts) != 0 {
+		t.Fatalf("bad progress: %d", len(info.Parts))
 	}
 
 	if c.Sealed() {

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -37,7 +37,7 @@ type GenerateRootStrategy interface {
 type generateStandardRootToken struct{}
 
 func (g generateStandardRootToken) authenticate(ctx context.Context, c *Core, combinedKey []byte) error {
-	rootKey, err := c.unsealKeyToRootKeyPostUnseal(ctx, combinedKey)
+	rootKey, err := c.sealManager.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
 	if err != nil {
 		return fmt.Errorf("unable to authenticate: %w", err)
 	}

--- a/vault/generate_root_recovery.go
+++ b/vault/generate_root_recovery.go
@@ -25,7 +25,7 @@ type generateRecoveryToken struct {
 }
 
 func (g *generateRecoveryToken) authenticate(ctx context.Context, c *Core, combinedKey []byte) error {
-	key, err := c.unsealKeyToRootKeyPostUnseal(ctx, combinedKey)
+	key, err := c.sealManager.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
 	if err != nil {
 		return fmt.Errorf("unable to authenticate: %w", err)
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4345,21 +4345,21 @@ type CoreSealStatusResponse struct {
 	Warnings    []string `json:"warnings,omitempty"`
 }
 
-func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatusResponse, error) {
-	sealed := core.Sealed()
-
-	initialized, err := core.Initialized(ctx)
+func (c *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatusResponse, error) {
+	sealed := c.Sealed()
+	initialized, err := c.Initialized(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var sealConfig *SealConfig
 	var recoveryType string
-	if core.SealAccess().RecoveryKeySupported() {
-		sealConfig, err = core.SealAccess().RecoveryConfig(ctx)
-		recoveryType = core.SealAccess().RecoveryType()
+	sealAccess := c.SealAccess()
+	if sealAccess.RecoveryKeySupported() {
+		sealConfig, err = sealAccess.RecoveryConfig(ctx)
+		recoveryType = sealAccess.RecoveryType()
 	} else {
-		sealConfig, err = core.SealAccess().BarrierConfig(ctx)
+		sealConfig, err = sealAccess.BarrierConfig(ctx)
 	}
 	if err != nil {
 		return nil, err
@@ -4367,15 +4367,16 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatus
 
 	cssr := &CoreSealStatusResponse{
 		SealStatusResponse: SealStatusResponse{
-			Type:             core.SealAccess().BarrierType().String(),
+			Type:             sealAccess.BarrierType().String(),
 			Initialized:      initialized,
 			Sealed:           sealed,
-			RecoverySeal:     core.SealAccess().RecoveryKeySupported(),
+			RecoverySeal:     sealAccess.RecoveryKeySupported(),
 			RecoverySealType: recoveryType,
 		},
-		StorageType: core.StorageType(),
+		StorageType: c.StorageType(),
 		Version:     version.GetVersion().VersionNumber(),
 		CommitDate:  version.CommitDate,
+		Migration:   c.IsInSealMigrationMode(lock) && !c.IsSealMigrated(lock),
 	}
 
 	if sealConfig == nil {
@@ -4383,8 +4384,8 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatus
 	}
 
 	// Fetch the local cluster name and identifier
-	if !sealed {
-		cluster, err := core.Cluster(ctx)
+	if !c.Sealed() {
+		cluster, err := c.Cluster(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -4393,13 +4394,12 @@ func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatus
 		cssr.ClusterID = cluster.ID
 	}
 
-	progress, nonce := core.SecretProgress(lock)
-
+	info := c.sealManager.NamespaceUnlockInformation(namespace.RootNamespaceUUID)
+	if info != nil {
+		cssr.Progress, cssr.Nonce = len(info.Parts), info.Nonce
+	}
 	cssr.T = sealConfig.SecretThreshold
 	cssr.N = sealConfig.SecretShares
-	cssr.Progress = progress
-	cssr.Nonce = nonce
-	cssr.Migration = core.IsInSealMigrationMode(lock) && !core.IsSealMigrated(lock)
 
 	return cssr, nil
 }

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -107,13 +107,8 @@ func (sm *SealManager) Reset() {
 		namespace.RootNamespaceUUID: sm.core.seal,
 	}
 
-	sm.unlockInformationByNamespace = map[string]*unlockInformation{
-		namespace.RootNamespaceUUID: {},
-	}
-
-	sm.rotationConfigByNamespace = map[string]*rotationConfig{
-		namespace.RootNamespaceUUID: {},
-	}
+	sm.unlockInformationByNamespace = map[string]*unlockInformation{}
+	sm.rotationConfigByNamespace = map[string]*rotationConfig{}
 }
 
 // SetSeal creates a seal with provided config and sets it as provided namespace seal;
@@ -144,11 +139,6 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 
 	sm.barrierByNamespace.Insert(ns.Path, barrier.NewAESGCMBarrier(sm.core.physical, metaPrefix))
 	sm.sealByNamespace[ns.UUID] = defaultSeal
-	sm.unlockInformationByNamespace[ns.UUID] = &unlockInformation{}
-	sm.rotationConfigByNamespace[ns.UUID] = &rotationConfig{
-		rootConfig:     nil,
-		recoveryConfig: nil,
-	}
 
 	if writeToStorage {
 		if err := defaultSeal.SetBarrierConfig(ctx, sealConfig); err != nil {
@@ -319,37 +309,16 @@ func (sm *SealManager) UnsealNamespace(ctx context.Context, ns *namespace.Namesp
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
+	sm.logger.Debug("namespace unseal key supplied")
+
 	barrier := sm.namespaceBarrier(ns.Path)
 	if barrier == nil {
 		return false, ErrNotSealable
 	}
 
-	return sm.unsealFragment(ctx, ns, barrier, key)
-}
-
-// unsealFragment verifies and records one part of the unseal shares,
-// and attempts to unseal the namespace.
-func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespace, b barrier.SecurityBarrier, key []byte) (bool, error) {
-	sm.logger.Debug("namespace unseal key supplied")
-
 	// Check if already unsealed
-	if !b.Sealed() {
+	if !barrier.Sealed() {
 		return true, nil
-	}
-
-	// Verify the key length
-	min, max := b.KeyLength()
-	max += shamir.ShareOverhead
-	if len(key) < min {
-		return false, &ErrInvalidKey{fmt.Sprintf("key is shorter than minimum %d bytes", min)}
-	}
-	if len(key) > max {
-		return false, &ErrInvalidKey{fmt.Sprintf("key is longer than maximum %d bytes", max)}
-	}
-
-	newKey, err := sm.recordUnsealPart(ns, key)
-	if !newKey || err != nil {
-		return false, err
 	}
 
 	seal := sm.sealByNamespace[ns.UUID]
@@ -357,9 +326,7 @@ func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespa
 		return false, ErrNotSealable
 	}
 
-	// getUnsealKey returns either a recovery key (in the case of an autoseal)
-	// or an unseal key (new-style shamir).
-	combinedKey, err := sm.getUnsealKey(ctx, seal, ns)
+	combinedKey, err := sm.unsealFragment(ctx, ns, seal, barrier, key)
 	if err != nil || combinedKey == nil {
 		return false, err
 	}
@@ -370,7 +337,7 @@ func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespa
 	}
 
 	// Attempt to unseal
-	if err := b.Unseal(ctx, rootKey); err != nil {
+	if err := barrier.Unseal(ctx, rootKey); err != nil {
 		return false, err
 	}
 
@@ -379,10 +346,33 @@ func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespa
 	return true, nil
 }
 
+// unsealFragment verifies and records one part of the unseal shares,
+// and attempts to unseal the namespace.
+func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespace, seal Seal, b barrier.SecurityBarrier, key []byte) ([]byte, error) {
+	// Verify the key length
+	min, max := b.KeyLength()
+	max += shamir.ShareOverhead
+	if len(key) < min {
+		return nil, &ErrInvalidKey{fmt.Sprintf("key is shorter than minimum %d bytes", min)}
+	}
+	if len(key) > max {
+		return nil, &ErrInvalidKey{fmt.Sprintf("key is longer than maximum %d bytes", max)}
+	}
+
+	newKey, err := sm.recordUnsealPart(ns, key)
+	if !newKey || err != nil {
+		return nil, err
+	}
+
+	// getUnsealKey returns either a recovery key
+	// (in the case of an autoseal) or an unseal key (shamir).
+	return sm.getUnsealKey(ctx, seal, ns)
+}
+
 // recordUnsealPart takes in a key fragment, and returns true if it's a new fragment.
 func (sm *SealManager) recordUnsealPart(ns *namespace.Namespace, key []byte) (bool, error) {
-	info, exists := sm.unlockInformationByNamespace[ns.UUID]
-	if exists {
+	info := sm.unlockInformationByNamespace[ns.UUID]
+	if info != nil {
 		found := false
 		for _, existing := range info.Parts {
 			found = found || subtle.ConstantTimeCompare(existing, key) == 1

--- a/vault/seal_manager_test.go
+++ b/vault/seal_manager_test.go
@@ -21,8 +21,8 @@ func TestSealManager_Reset(t *testing.T) {
 	// verify initial state of seal manager
 	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 1)
 	require.Len(t, c.sealManager.sealByNamespace, 1)
-	require.Len(t, c.sealManager.unlockInformationByNamespace, 1)
-	require.Len(t, c.sealManager.rotationConfigByNamespace, 1)
+	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
+	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 
 	sealConfig := &SealConfig{
 		Type:            "shamir",
@@ -36,15 +36,16 @@ func TestSealManager_Reset(t *testing.T) {
 	}
 	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 11)
 	require.Len(t, c.sealManager.sealByNamespace, 11)
-	require.Len(t, c.sealManager.unlockInformationByNamespace, 11)
-	require.Len(t, c.sealManager.rotationConfigByNamespace, 11)
+	// until we start unlock/rotation process for the namespace, we do not populate the map.
+	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
+	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 
 	c.sealManager.Reset()
 
 	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 1)
 	require.Len(t, c.sealManager.sealByNamespace, 1)
-	require.Len(t, c.sealManager.unlockInformationByNamespace, 1)
-	require.Len(t, c.sealManager.rotationConfigByNamespace, 1)
+	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
+	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 }
 
 func TestSealManager_SetSeal(t *testing.T) {
@@ -105,8 +106,6 @@ func TestSealManager_SetSeal(t *testing.T) {
 
 			require.NotEmpty(t, c.sealManager.NamespaceBarrier(tt.ns.Path))
 			require.NotEmpty(t, c.sealManager.NamespaceSeal(tt.ns.UUID))
-			require.NotNil(t, c.sealManager.NamespaceUnlockInformation(tt.ns.UUID))
-			require.NotNil(t, c.sealManager.NamespaceRotationConfig(tt.ns.UUID))
 
 			// verify storage
 			cfg, err := seal.BarrierConfig(ctx)
@@ -263,6 +262,8 @@ func TestSealManager_UnsealBarrier(t *testing.T) {
 	require.NotNil(t, b)
 	require.False(t, b.Sealed())
 
+	require.Nil(t, c.sealManager.NamespaceUnlockInformation(ns.UUID))
+
 	err = b.Seal()
 	require.NoError(t, err)
 	require.True(t, b.Sealed())
@@ -271,8 +272,13 @@ func TestSealManager_UnsealBarrier(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, unsealed)
 
+	info := c.sealManager.NamespaceUnlockInformation(ns.UUID)
+	require.Len(t, info.Parts, 1)
+	require.NotEmpty(t, info.Nonce)
+
 	unsealed, err = c.sealManager.UnsealNamespace(ctx, ns, keyShares[1])
 	require.NoError(t, err)
 	require.True(t, unsealed)
 	require.False(t, b.Sealed())
+	require.Nil(t, c.sealManager.NamespaceUnlockInformation(ns.UUID))
 }


### PR DESCRIPTION
## Description
- removed `unlockInfo` from `Core` struct with unlock information tracking moved to `SealManager` (for root namespace the information was stored in both places, but operations were done on the `Core` property)
- removed duplicated method from `Core`, opting for usage of the same methods in `SealManager`
- adjusted `(*Core).GetSealStatus()` method
- adjusted `SealManager` code accordingly

## Rationale
With the introduction of `SealManager` we should track and manage all unseal operations through it. This PR aims at consolidation of the unseal logic, making the root namespace (core) use seal manager methods.

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
