### PR TITLE
Add upgrade test capabilities

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -572,7 +572,7 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 		n.DataVolumeName = vol.Volume.Name
 		n.cleanupVolume = func() {
 			_, _ = n.DockerAPI.VolumeRemove(ctx, vol.Volume.Name, docker.VolumeRemoveOptions{
-				Force: false,
+				Force: true,
 			})
 		}
 	}
@@ -837,6 +837,40 @@ func (n *DockerClusterNode) Pause(ctx context.Context) error {
 	return err
 }
 
+func (n *DockerClusterNode) Upgrade(ctx context.Context, opts *DockerClusterOptions) error {
+	n.Stop()
+
+	tag, err := n.Cluster.setupImage(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("error setting up image: %w", err)
+	}
+
+	n.ImageTag = tag
+	n.WorkDir = filepath.Join(n.Cluster.tmpDir, n.NodeID+"-upgrade")
+	n.Logger = n.Cluster.Logger.Named(n.NodeID + "-upgrade")
+
+	if err := os.MkdirAll(n.WorkDir, 0o755); err != nil {
+		return err
+	}
+
+	if err := n.Start(ctx, opts); err != nil {
+		return fmt.Errorf("failed to start node: %w", err)
+	}
+
+	nodeIndex := -1
+	for idx, node := range n.Cluster.ClusterNodes {
+		if node == n {
+			nodeIndex = idx
+			break
+		}
+	}
+	if nodeIndex == -1 {
+		return fmt.Errorf("unable to find node in cluster: %v -> %v", n, n.Cluster.ClusterNodes)
+	}
+
+	return testcluster.UnsealNode(ctx, n.Cluster, nodeIndex)
+}
+
 func (n *DockerClusterNode) AddNetworkDelay(ctx context.Context, delay time.Duration, targetIP string) error {
 	ip := net.ParseIP(targetIP)
 	if ip == nil {
@@ -964,6 +998,7 @@ type DockerClusterOptions struct {
 	NetworkName string
 	ImageRepo   string
 	ImageTag    string
+	TagSuffix   string
 	CA          *testcluster.CA
 	VaultBinary string
 	Args        []string
@@ -1165,9 +1200,15 @@ func (dc *DockerCluster) setupImage(ctx context.Context, opts *DockerClusterOpti
 		return sourceTag, nil
 	}
 
-	suffix := "testing"
+	suffix := opts.ClusterName
+	if opts.ClusterName == "" {
+		suffix = "testing"
+	}
 	if sha := os.Getenv("COMMIT_SHA"); sha != "" {
-		suffix = sha
+		suffix += "-" + sha
+	}
+	if opts.TagSuffix != "" {
+		suffix += "-" + opts.TagSuffix
 	}
 	tag := sourceTag + "-" + suffix
 	if _, ok := dc.builtTags[tag]; ok {

--- a/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -257,3 +257,73 @@ func TestPostgreSQL_FatalInit(t *testing.T) {
 	cluster, err = docker.NewDockerCluster(t.Context(), opts)
 	require.Error(t, err, "node should continue to refuse startup")
 }
+
+func TestPostgreSQL_Upgrade(t *testing.T) {
+	t.Parallel()
+
+	binary := api.ReadBaoVariable("BAO_BINARY")
+	if binary == "" {
+		t.Skip("missing $BAO_BINARY")
+	}
+
+	psql := docker.NewPostgreSQLStorage(t, "")
+	defer func() { require.NoError(t, psql.Cleanup()) }()
+
+	// We do not set binary here as we want to use the last published image.
+	opts := &docker.DockerClusterOptions{
+		ImageRepo: "quay.io/openbao/openbao",
+		ImageTag:  "latest",
+		Storage:   psql,
+		ClusterOptions: testcluster.ClusterOptions{
+			ClusterName: "psql-upgrade",
+			NumCores:    3,
+		},
+	}
+
+	cluster := docker.NewTestDockerCluster(t, opts)
+	defer cluster.Cleanup()
+
+	nodes := cluster.Nodes()
+	client := nodes[0].APIClient()
+
+	t.Logf("token: %v vs %v", client.Token(), cluster.GetRootToken())
+
+	// Create some data to test persistence.
+	err := client.Sys().Mount("kv", &api.MountInput{
+		Type: "kv",
+		Options: map[string]string{
+			"version": "2",
+		},
+	})
+	require.NoError(t, err, "failed to mount kv")
+
+	_, err = client.KVv2("kv").Put(t.Context(), "a/key", map[string]interface{}{
+		"value": "known-value",
+	})
+	require.NoError(t, err, "failed writing k/v key")
+
+	// Now upgrade the nodes one at a time.
+	opts.VaultBinary = binary
+	for index, node := range cluster.ClusterNodes {
+		func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+
+			err = node.Upgrade(ctx, opts)
+			require.NoError(t, err, "failed upgrading node %v", index)
+		}()
+	}
+
+	// Find active leader.
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	activeIdx, err := testcluster.WaitForActiveNode(ctx, cluster)
+	require.NoError(t, err)
+
+	client = nodes[activeIdx].APIClient()
+
+	// Ensure we can read the secret.
+	value, err := client.KVv2("kv").Get(t.Context(), "a/key")
+	require.NoError(t, err, "failed reading k/v key")
+	require.Equal(t, value.Data["value"], "known-value")
+}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

The `DockerTestCluster` helpers are quite useful for building upgrade tests, but how to accomplish this was a little unclear. This upgrade strategy is a one-at-a-time replacement.

Notably, we needed to:

1. Ensure different tests had isolated container images so that we can choose when to upgrade different images. This includes the changes around tagging.
2. Stop+Start on the new image as the existing process is running as pid 1, meaning we can't keep the container running. Sadly this means ports for the container will change vs using a restart strategy.

Most of this was theoretically accessible via the existing API (sans tagging); this just makes it explicit how to accomplish.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Testing is important :laughing: 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
