### PR TITLE
fix(vault): don't leak share ordering on duplicate-share checks

### DIFF
--- a/changelog/2916.txt
+++ b/changelog/2916.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core: Prevent timing-based leak in Shamir key share duplicate checks during unseal, root token generation, key rotation, and rotation verification.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -1601,12 +1601,17 @@ func (c *Core) unsealWithRaft(combinedKey []byte) error {
 
 // recordUnsealPart takes in a key fragment, and returns true if it's a new fragment.
 func (c *Core) recordUnsealPart(key []byte) (bool, error) {
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the response time does not reveal which provision
+	// slot already holds the supplied share.
 	if c.unlockInfo != nil {
+		var found int
 		for _, existing := range c.unlockInfo.Parts {
-			if subtle.ConstantTimeCompare(existing, key) == 1 {
-				return false, nil
-			}
+			found |= subtle.ConstantTimeCompare(existing, key)
+		}
+		if found == 1 {
+			return false, nil
 		}
 	} else {
 		uuid, err := uuid.GenerateUUID()

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -4,8 +4,8 @@
 package vault
 
 import (
-	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -268,11 +268,16 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, errors.New("incorrect strategy supplied; a generate root operation of another type is already in progress")
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range c.generateRootProgress {
-		if bytes.Equal(existing, key) {
-			return nil, errors.New("given key has already been provided during this generation operation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, errors.New("given key has already been provided during this generation operation")
 	}
 
 	// Store this key

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -337,11 +337,16 @@ func (c *Core) BarrierRekeyUpdate(ctx context.Context, key []byte, nonce string)
 		return nil, logical.CodedError(http.StatusBadRequest, "incorrect nonce supplied; nonce for this rekey operation is %q", c.rootRotationConfig.Nonce)
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range c.rootRotationConfig.RotationProgress {
-		if subtle.ConstantTimeCompare(existing, key) == 1 {
-			return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this generation operation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this generation operation")
 	}
 
 	// Store this key
@@ -576,11 +581,16 @@ func (c *Core) RecoveryRekeyUpdate(ctx context.Context, key []byte, nonce string
 		return nil, logical.CodedError(http.StatusBadRequest, "incorrect nonce supplied; nonce for this rekey operation is %q", c.recoveryRotationConfig.Nonce)
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range c.recoveryRotationConfig.RotationProgress {
-		if subtle.ConstantTimeCompare(existing, key) == 1 {
-			return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this rekey operation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this rekey operation")
 	}
 
 	// Store this key
@@ -762,11 +772,16 @@ func (c *Core) RekeyVerify(ctx context.Context, key []byte, nonce string, recove
 		return nil, logical.CodedError(http.StatusBadRequest, "incorrect nonce supplied; nonce for this verify operation is %q", config.VerificationNonce)
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range config.VerificationProgress {
-		if subtle.ConstantTimeCompare(existing, key) == 1 {
-			return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this verify operation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this verify operation")
 	}
 
 	// Store this key

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -402,11 +402,16 @@ func (c *Core) progressRotation(rotationConfig, existingConfig *SealConfig, key 
 		return nil, logical.CodedError(http.StatusBadRequest, "incorrect nonce supplied; nonce for rotation is %q", rotationConfig.Nonce)
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range rotationConfig.RotationProgress {
-		if subtle.ConstantTimeCompare(existing, key) == 1 {
-			return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this rotation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this rotation")
 	}
 
 	// Store this key
@@ -577,11 +582,16 @@ func (c *Core) VerifyRotation(ctx context.Context, key []byte, nonce string, rec
 		return nil, logical.CodedError(http.StatusBadRequest, "incorrect nonce supplied; nonce for this verify operation is %q", config.VerificationNonce)
 	}
 
-	// Check if we already have this piece
+	// Check if we already have this piece. Scan every stored share in
+	// constant time: the bitwise OR forces each ConstantTimeCompare call
+	// to execute, so the duplicate-share response does not reveal in
+	// which provision slot the supplied share was already recorded.
+	var found int
 	for _, existing := range config.VerificationProgress {
-		if subtle.ConstantTimeCompare(existing, key) == 1 {
-			return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this verify operation")
-		}
+		found |= subtle.ConstantTimeCompare(existing, key)
+	}
+	if found == 1 {
+		return nil, logical.CodedError(http.StatusBadRequest, "given key has already been provided during this verify operation")
 	}
 
 	// Store this key

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -371,12 +371,16 @@ func (sm *SealManager) unsealFragment(ctx context.Context, ns *namespace.Namespa
 func (sm *SealManager) recordUnsealPart(ns *namespace.Namespace, key []byte) (bool, error) {
 	info, exists := sm.unlockInformationByNamespace[ns.UUID]
 	if exists {
-		found := false
+		// Scan every stored share in constant time. Using bitwise OR
+		// (instead of a short-circuiting boolean OR) forces each
+		// ConstantTimeCompare call to execute, so the response time
+		// does not reveal which provision slot matched.
+		var found int
 		for _, existing := range info.Parts {
-			found = found || subtle.ConstantTimeCompare(existing, key) == 1
+			found |= subtle.ConstantTimeCompare(existing, key)
 		}
 
-		if found {
+		if found == 1 {
 			return false, nil
 		}
 	} else {


### PR DESCRIPTION
## Summary
Closes #2663

When a user submits a key share during unseal, root token generation, root key rotation, recovery key rotation, or rotation verification, the duplicate-share check short-circuited as soon as the first match was found. An attacker observing response latency could infer the ordinal position at which the supplied share was previously registered.

## Change
Scan every stored share using \`crypto/subtle.ConstantTimeCompare\` and accumulate results via **bitwise OR into an integer** so every comparison executes and the total call count is independent of which slot (if any) matched. Branch on the accumulator after the loop.

## Why bitwise OR rather than boolean ||
\`seal_manager.go\` introduced this fix in #2460 with a boolean \`found = found || ...\` accumulator, but Go's \`||\` short-circuits, so later \`ConstantTimeCompare\` calls are skipped once the first match is found, which leaves a residual per-call-count side channel. Bitwise OR on \`int\` does not short-circuit, so every iteration runs. This PR applies the tighter pattern uniformly across all share-existence checks in \`vault/\`, including \`seal_manager.go\`, so the package has one consistent constant-time shape.

Sites fixed:
- \`vault/core.go\` \`recordUnsealPart\`
- \`vault/generate_root.go\` \`GenerateRootUpdate\` (also swaps \`bytes.Equal\` for \`subtle.ConstantTimeCompare\`)
- \`vault/rekey.go\` root rotation progress, recovery rotation progress, verification progress
- \`vault/rotate.go\` rotation progress, verification progress
- \`vault/seal_manager.go\` \`recordUnsealPart\` (tightens the existing #2460 pattern)

## Test plan
- [x] \`go build ./vault/\`
- [x] \`go vet ./vault/\`
- [x] \`gofmt -l\` on changed files
- [x] \`go test ./vault/ -run "TestSealManager|TestRecordUnseal"\`
- [ ] maintainers: any additional targeted test coverage you'd like added for these paths?