### PR TITLE
ui: address ember-engines.deprecation-camelized-engine-names deprecation

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -14,7 +14,7 @@ export default class App extends Application {
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
   engines = {
-    openApiExplorer: {
+    'open-api-explorer': {
       dependencies: {
         services: ['auth', 'flash-messages', 'namespace', 'router', 'version'],
       },

--- a/ui/app/deprecation-workflow.js
+++ b/ui/app/deprecation-workflow.js
@@ -19,6 +19,7 @@ export const deprecationWorkflowConfig = {
     { handler: 'log', matchId: 'setting-on-hash' },
     { handler: 'log', matchId: 'ember-cli-page-object.multiple' },
     { handler: 'log', matchId: 'ember-cli-mirage-config-routes-only-export' },
+    { handler: 'log', machtId: 'ember-engines.deprecation-camelized-engine-names' },
   ],
 };
 


### PR DESCRIPTION
Signed-off-by: Jan Martens <jan@martens.eu.org>

Part-Of: #2729

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.