### PR TITLE
identity: stop LoadEntities / LoadGroups panicking when the packer is missing

### DIFF
--- a/vault/identity/store_util.go
+++ b/vault/identity/store_util.go
@@ -51,7 +51,14 @@ func (i *IdentityStore) LoadGroups(ctx context.Context, readOnly bool) error {
 	}
 
 	i.logger.Debug("identity loading groups", "namespace", ns.Path)
-	existing, err := i.GroupPacker(ctx).View().List(ctx, groupBucketsPrefix)
+	// See LoadEntities: GroupPacker(ctx) returns nil when the namespace
+	// view is missing from the identity store table, and calling .View()
+	// on nil crashes the unseal path (#2921).
+	packer := i.GroupPacker(ctx)
+	if packer == nil {
+		return fmt.Errorf("cannot load groups: identity store is missing the group packer for namespace %s", ns.ID)
+	}
+	existing, err := packer.View().List(ctx, groupBucketsPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to scan for groups: %w", err)
 	}
@@ -154,7 +161,18 @@ func (i *IdentityStore) LoadEntities(ctx context.Context, readOnly bool) error {
 	}
 
 	i.logger.Debug("loading entities", "namespace", ns.Path)
-	existing, err := i.EntityPacker(ctx).View().List(ctx, storagepacker.StoragePackerBucketsPrefix)
+	// EntityPacker returns nil when the namespace is missing from the
+	// identity store table (e.g. a half-created namespace left behind by
+	// a crash during creation). Calling .View() on that nil segfaults
+	// the unseal path and sends the process into a crash loop, because
+	// every subsequent unseal walks the same broken namespace (#2921).
+	// Fail soft instead so the core can continue unsealing and an
+	// operator can clean up the partial state.
+	packer := i.EntityPacker(ctx)
+	if packer == nil {
+		return fmt.Errorf("cannot load entities: identity store is missing the entity packer for namespace %s", ns.ID)
+	}
+	existing, err := packer.View().List(ctx, storagepacker.StoragePackerBucketsPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to scan for entities: %w", err)
 	}


### PR DESCRIPTION
Fixes #2921.

`IdentityStore.EntityPacker` / `GroupPacker` return `*storagepacker.StoragePacker` and explicitly return `nil` when the per-namespace view is missing from the identity store table:

```go
func (i *IdentityStore) EntityPacker(ctx context.Context) *storagepacker.StoragePacker {
    view, err := i.getNSView(ctx)
    if err != nil {
        i.logger.Error("failed to get entityPacker", "err", err)
        return nil
    }
    return view.entityPacker
}
```

`LoadEntities` and `LoadGroups` then did

```go
existing, err := i.EntityPacker(ctx).View().List(ctx, ...)
```

When the namespace table is missing the entry for a given UUID — which is exactly what the user in #2921 observed after a crash during namespace creation left a half-written namespace in storage — this deref segfaults the unseal path:

```
[ERROR] identity: failed to get entityPacker: err="namespace 2ee56127-... missing from identity store table"
panic: runtime error: invalid memory address or nil pointer dereference
  helper/storagepacker/storagepacker.go:41 (View)
  vault/identity/store_util.go:157 (LoadEntities)
```

and every subsequent restart walks the same broken namespace and crashes again — an unrecoverable crash loop.

This PR guards both `LoadEntities` and `LoadGroups` against a nil packer and returns a clear error naming the namespace so the unseal can continue with the remaining namespaces and an operator can clean up the partial state manually. No behaviour change on the happy path; only the crash-loop path now surfaces an error instead of a segfault.