### PR TITLE
Make self-init failures fatal (#2908 & #2195)

### DIFF
--- a/changelog/2908.txt
+++ b/changelog/2908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Refuse repeated startup if self-initialization failed on initial run.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1324,8 +1324,10 @@ func (c *ServerCommand) Run(args []string) int {
 	// OpenBao cluster with multiple servers is configured with auto-unseal but is
 	// uninitialized. Once one server initializes the storage backend, this
 	// goroutine will pick up the unseal keys and unseal this instance.
+	var sealShutdownCh chan struct{}
 	if !core.IsInSealMigrationMode(true) {
-		go runUnseal(c, core, context.Background())
+		sealShutdownCh = make(chan struct{})
+		go runUnseal(c, core, sealShutdownCh)
 	}
 
 	// When the underlying storage is raft, kick off retry join if it was specified
@@ -1359,8 +1361,10 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	// Else if we're in production mode, initialize the core as well.
-	err = c.Initialize(core, config)
-	if err != nil {
+	if err = c.Initialize(core, config); err != nil {
+		// Bubble this error up to both the logger and the UI for better
+		// visibility.
+		c.logger.Error("failed to initialize", "error", err)
 		c.UI.Error(err.Error())
 		return 1
 	}
@@ -1456,6 +1460,10 @@ func (c *ServerCommand) Run(args []string) int {
 
 	for !shutdownTriggered {
 		select {
+		case <-sealShutdownCh:
+			c.UI.Output("==> OpenBao core was shut down")
+			retCode = 1
+			shutdownTriggered = true
 		case <-coreShutdownDoneCh:
 			c.UI.Output("==> OpenBao core was shut down")
 			retCode = 1
@@ -1761,11 +1769,9 @@ func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) erro
 		RecoveryConfig: recoveryConfig,
 	})
 	if err != nil {
-		core.Logger().Error("failed to initialize", "error", err)
 		if errors.Is(err, vault.ErrParallelInit) || errors.Is(err, vault.ErrAlreadyInit) {
 			return nil
 		}
-
 		return fmt.Errorf("self-initialization failed: %w", err)
 	}
 
@@ -1781,8 +1787,20 @@ func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) erro
 		return fmt.Errorf("initializing node did not win leadership election: ensure only one active, voting node during initialization")
 	}
 
-	// Now perform the component requests of self-initialization.
-	return c.doSelfInit(core, config, init.RootToken)
+	// Begin by marking self-init as started:
+	if err := core.MarkSelfInitStarted(ctx); err != nil {
+		return fmt.Errorf("failed to mark self-init started: %w", err)
+	}
+	// Then perform self-init steps:
+	if err := c.doSelfInit(core, config, init.RootToken); err != nil {
+		return err
+	}
+	// Then mark self-init as completed:
+	if err := core.MarkSelfInitCompleted(ctx); err != nil {
+		return fmt.Errorf("failed to mark self-init complete: %w", err)
+	}
+
+	return nil
 }
 
 // doSelfInit is the internal helper that uses the profile system with this
@@ -2668,17 +2686,25 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	return nil
 }
 
-func runUnseal(c *ServerCommand, core *vault.Core, ctx context.Context) {
+func runUnseal(c *ServerCommand, core *vault.Core, sealShutdownCh chan<- struct{}) {
 	for {
-		err := core.UnsealWithStoredKeys(ctx)
+		err := core.UnsealWithStoredKeys(context.Background())
 		if err == nil {
 			return
 		}
 
-		if vault.IsFatalError(err) {
+		if errors.Is(err, vault.ErrSelfInitFailed) {
 			c.logger.Error("error unsealing core", "error", err)
+			if err := core.Shutdown(); err != nil {
+				c.logger.Error("error shutting down core", "error", err)
+			}
+			// Shutting down core only triggers an exit in Run() if
+			// flagExitOnCoreShutdown is set, so send a notification on this
+			// channel additionally. This will trigger a process exit.
+			close(sealShutdownCh)
 			return
 		}
+
 		c.logger.Warn("failed to unseal core", "error", err)
 
 		timer := time.NewTimer(5 * time.Second)

--- a/command/server/test-fixtures/self-init-failure.hcl
+++ b/command/server/test-fixtures/self-init-failure.hcl
@@ -1,0 +1,6 @@
+initialize "failure" {
+  request "bogus" {
+    operation = "update"
+    path = "sys/foo/bar"
+  }
+}

--- a/command/server/test-fixtures/self-init.hcl
+++ b/command/server/test-fixtures/self-init.hcl
@@ -1,0 +1,33 @@
+initialize "identity" {
+  request "mount-userpass" {
+    operation = "update"
+    path = "sys/auth/userpass"
+    data = {
+      "type" = "userpass"
+      "path" = "userpass"
+    }
+  }
+
+  request "userpass-add-admin" {
+    operation = "update"
+    path = "auth/userpass/users/admin"
+    data = {
+      "password" = "password"
+      "token_policies" = ["superuser"]
+    }
+  }
+}
+
+initialize "policy" {
+  request "add-superuser-policy" {
+    operation = "update"    
+    path = "sys/policies/acl/superuser"
+    data = {
+      policy = <<-EOF
+        path "*" {
+          capabilities = ["create", "update", "read", "delete", "list", "scan", "sudo"]
+        }
+      EOF
+    }
+  }
+}

--- a/command/server/test-fixtures/static-seal.hcl
+++ b/command/server/test-fixtures/static-seal.hcl
@@ -1,0 +1,4 @@
+seal "static" {
+  current_key = "542a91c2aff86797e8dfa16adf86dcbea5706410791b319798936a1b08e4ef8b"
+  current_key_id = "20250630"
+}

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -1,13 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build !race && !hsm
-
-// NOTE: we can't use this with HSM. We can't set testing mode on and it's not
-// safe to use env vars since that provides an attack vector in the real world.
-//
-// The server tests have a go-metrics/exp manager race condition :(.
-
 package command
 
 import (

--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -277,13 +277,15 @@ func (p *ProfileEngine) evaluateRequest(ctx context.Context, history *Evaluation
 	// 2. Call the request handler.
 	resp, err := p.requestHandler(ctx, req)
 	isFailure := err != nil || resp.IsError()
-	if err == nil && resp.IsError() {
+	if err == nil {
 		err = resp.Error()
 	}
 	if !allowFailure && isFailure {
 		if err != nil {
 			return fmt.Errorf("failed to evaluate request: %w", err)
 		}
+		// Fallback in case IsError() is true but Error() returned nil.
+		return errors.New("failed to evaluate request: request failed")
 	}
 
 	// 3. Stash request & response for future use.

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -683,11 +684,13 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 
 	caDir := filepath.Join(n.Cluster.tmpDir, "ca")
 
-	// setup plugin bin copy if needed
+	// Copy certificates and generated configs.
 	copyFromTo := map[string]string{
 		n.WorkDir: "/openbao/config",
 		caDir:     "/usr/local/share/ca-certificates/",
 	}
+	// Copy any additional files.
+	maps.Copy(copyFromTo, opts.CopyFromTo)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -946,6 +949,7 @@ type DockerClusterOptions struct {
 	CA          *testcluster.CA
 	VaultBinary string
 	Args        []string
+	CopyFromTo  map[string]string
 	StartProbe  func(*api.Client) error
 	Storage     testcluster.ClusterStorage
 	StorageType string

--- a/vault/core.go
+++ b/vault/core.go
@@ -156,6 +156,10 @@ type NonFatalError struct {
 	Err error
 }
 
+func (e *NonFatalError) Unwrap() error {
+	return e.Err
+}
+
 func (e *NonFatalError) WrappedErrors() []error {
 	return []error{e.Err}
 }
@@ -1908,6 +1912,10 @@ func (c *Core) migrateSeal(ctx context.Context) error {
 func (c *Core) unsealInternal(ctx context.Context, rootKey []byte) error {
 	// Attempt to unlock
 	if err := c.barrier.Unseal(ctx, rootKey); err != nil {
+		return err
+	}
+
+	if err := c.checkSelfInit(ctx); err != nil {
 		return err
 	}
 

--- a/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
+	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster/docker"
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -202,4 +204,59 @@ func TestPostgreSQL_ParallelInit(t *testing.T) {
 
 	t.Logf("State: total=%d active=%d sealed=%d", len(nodes), active, sealed)
 	require.Equal(t, len(nodes), active, "all nodes active")
+}
+
+func TestPostgreSQL_FatalInit(t *testing.T) {
+	t.Parallel()
+
+	binary := api.ReadBaoVariable("BAO_BINARY")
+	if binary == "" {
+		t.Skip("missing $BAO_BINARY")
+	}
+
+	psql := docker.NewPostgreSQLStorage(t, "")
+	defer func() {
+		require.NoError(t, psql.Cleanup())
+	}()
+
+	opts := &docker.DockerClusterOptions{
+		ImageRepo:   "quay.io/openbao/openbao",
+		ImageTag:    "latest",
+		VaultBinary: binary,
+		CopyFromTo: map[string]string{
+			"../../../command/server/test-fixtures/self-init.hcl":         "/openbao/config/self-init.hcl",
+			"../../../command/server/test-fixtures/self-init-failure.hcl": "/openbao/config/self-init-failure.hcl",
+			"../../../command/server/test-fixtures/static-seal.hcl":       "/openbao/config/static-seal.hcl",
+		},
+		Storage: psql,
+		ClusterOptions: testcluster.ClusterOptions{
+			NumCores: 1,
+			SkipInit: true,
+			// Set these manually since we don't use NewTestDockerCluster(), but
+			// NewDockerCluster directly.
+			ClusterName: strings.ReplaceAll(t.Name(), "/", "-"),
+			Logger:      logging.NewVaultLogger(log.Trace).Named(t.Name()),
+		},
+	}
+
+	cluster, err := docker.NewDockerCluster(t.Context(), opts)
+
+	// Don't forget to clean up just in case the assertion below fails and the
+	// test cluster didn't fail as expected.
+	defer func() {
+		if err == nil {
+			cluster.Cleanup()
+		}
+	}()
+
+	require.Error(t, err, "node should fail with bad self-init config")
+
+	// Remove the bad config:
+	opts.CopyFromTo = map[string]string{
+		"../../../command/server/test-fixtures/self-init.hcl":   "/openbao/config/self-init.hcl",
+		"../../../command/server/test-fixtures/static-seal.hcl": "/openbao/config/static-seal.hcl",
+	}
+
+	cluster, err = docker.NewDockerCluster(t.Context(), opts)
+	require.Error(t, err, "node should continue to refuse startup")
 }

--- a/vault/self_init.go
+++ b/vault/self_init.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+const (
+	// selfInitFailedMarker is present in storage while self-init hasn't yet
+	// completed.
+	selfInitFailedMarker = "failed"
+
+	// selfInitStatusPath is where selfInitFailedMarker is written.
+	selfInitStatusPath = "core/status/self-init"
+)
+
+// ErrSelfInitFailed is returned when unsealing a core that detects a self-init
+// failure marker.
+var ErrSelfInitFailed = errors.New("self-initialization failed")
+
+// MarkSelfInitStarted writes the selfInitFailedMarker to storage. This
+// ensures that self-init is considered "failed" if interrupted before we reach
+// MarkSelfInitCompleted.
+func (c *Core) MarkSelfInitStarted(ctx context.Context) error {
+	return c.barrier.Put(ctx, &logical.StorageEntry{
+		Key:   selfInitStatusPath,
+		Value: []byte(selfInitFailedMarker),
+	})
+}
+
+// MarkSelfInitCompleted removes the marker written by MarkSelfInitStarted.
+func (c *Core) MarkSelfInitCompleted(ctx context.Context) error {
+	return c.barrier.Delete(ctx, selfInitStatusPath)
+}
+
+// checkSelfInit errors if selfInitFailedMarker or an unknown marker value is
+// present at selfInitStatusPath.
+func (c *Core) checkSelfInit(ctx context.Context) error {
+	entry, err := c.barrier.Get(ctx, selfInitStatusPath)
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		// This is the only happy path.
+		return nil
+	}
+
+	switch string(entry.Value) {
+	case selfInitFailedMarker:
+		return fmt.Errorf("%w: refusing to unseal", ErrSelfInitFailed)
+	default:
+		return fmt.Errorf("%w: unknown status %q, is storage corrupted?",
+			ErrSelfInitFailed, string(entry.Value))
+	}
+}


### PR DESCRIPTION
## Description

Backport of #2908, including a backport of the test-only #2195 because this introduced test helpers and fixtures reused in #2908.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
