### PR TITLE
Make root token generation namespace aware

### DIFF
--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -54,7 +54,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Get the generation configuration
-	generationConfig, err := core.GenerateRootConfiguration()
+	generationConfig, err := core.GenerateRootConfiguration(ctx)
 	switch {
 	// we return the progress as 0 in this case, root generation has not started
 	case errors.Is(err, vault.ErrNoRootGeneration):
@@ -64,7 +64,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Get the progress
-	progress, err := core.GenerateRootProgress()
+	progress, err := core.GenerateRootProgress(ctx)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
@@ -95,7 +95,9 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 }
 
 func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r *http.Request, generateStrategy vault.GenerateRootStrategy) {
-	// Parse the request
+	ctx, cancel := core.GetContext()
+	defer cancel()
+
 	var req GenerateRootInitRequest
 	if err := parseJSONRequest(r, w, &req); err != nil && err != io.EOF {
 		respondError(w, http.StatusBadRequest, err)
@@ -121,7 +123,7 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Attemptialize the generation
-	if err := core.GenerateRootInit(req.OTP, req.PGPKey, generateStrategy); err != nil {
+	if err := core.GenerateRootInit(ctx, req.OTP, req.PGPKey, generateStrategy); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -135,7 +137,10 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 }
 
 func handleSysGenerateRootAttemptDelete(core *vault.Core, w http.ResponseWriter, r *http.Request) {
-	err := core.GenerateRootCancel()
+	ctx, cancel := core.GetContext()
+	defer cancel()
+
+	err := core.GenerateRootCancel(ctx)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return

--- a/vault/core.go
+++ b/vault/core.go
@@ -295,11 +295,10 @@ type Core struct {
 	// conditions.
 	shutdownDoneCh *atomic.Value
 
-	// generateRootProgress holds the shares until we reach enough
-	// to verify the root key
-	generateRootConfig   *GenerateRootConfig
-	generateRootProgress [][]byte
-	generateRootLock     sync.Mutex
+	// namespaceRootGens holds the shares for each namespace
+	// until we reach enough to verify the root key.
+	namespaceRootGens    map[string]*rootTokenGeneration
+	namespaceRootGenLock sync.RWMutex
 
 	// These variables holds the config and shares we have until we reach
 	// enough to verify the appropriate root key. Note that the same lock is
@@ -945,6 +944,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		unsafeCrossNamespaceIdentity:   conf.UnsafeCrossNamespaceIdentity,
 		allowUnauthedWorkflows:         conf.AllowUnauthenticatedWorkflows,
 		unsafeRelativePaths:            conf.UnsafeRelativePaths,
+		namespaceRootGens:              make(map[string]*rootTokenGeneration),
 	}
 
 	c.standby.Store(true)

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -11,11 +11,17 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 )
+
+type rootTokenGeneration struct {
+	Config   *GenerateRootConfig
+	Progress [][]byte
+}
 
 // GenerateStandardRootTokenStrategy is the strategy used to
 // generate a typical root token.
@@ -37,15 +43,12 @@ type GenerateRootStrategy interface {
 type generateStandardRootToken struct{}
 
 func (g generateStandardRootToken) authenticate(ctx context.Context, c *Core, combinedKey []byte) error {
-	rootKey, err := c.sealManager.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
+	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to authenticate: %w", err)
-	}
-	if err := c.barrier.VerifyRoot(rootKey); err != nil {
-		return fmt.Errorf("root key verification failed: %w", err)
+		return err
 	}
 
-	return nil
+	return c.sealManager.AuthenticateRootKey(ctx, ns, combinedKey)
 }
 
 func (g generateStandardRootToken) generate(ctx context.Context, c *Core) (string, func(), error) {
@@ -66,8 +69,7 @@ func (g generateStandardRootToken) generate(ctx context.Context, c *Core) (strin
 	return te.ExternalID, cleanupFunc, nil
 }
 
-// GenerateRootConfig holds the configuration for a root generation
-// command.
+// GenerateRootConfig holds the configuration for a root token generation.
 type GenerateRootConfig struct {
 	Nonce          string
 	PGPKey         string
@@ -76,8 +78,7 @@ type GenerateRootConfig struct {
 	Strategy       GenerateRootStrategy
 }
 
-// GenerateRootResult holds the result of a root generation update
-// command
+// GenerateRootResult holds the result of a root token generation update.
 type GenerateRootResult struct {
 	Progress       int
 	Required       int
@@ -85,55 +86,103 @@ type GenerateRootResult struct {
 	PGPFingerprint string
 }
 
-// GenerateRootProgress is used to return the root generation progress (num shares)
-func (c *Core) GenerateRootProgress() (int, error) {
+// lockRootGeneration is used to lock the stateLock of the Core,
+// check the seal, standby and recoveryMode statuses, and return
+// back an unlock func.
+func (c *Core) lockRootGeneration() (func(), error) {
 	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
+
 	if c.Sealed() && !c.recoveryMode {
-		return 0, consts.ErrSealed
-	}
-	if c.standby.Load() && !c.recoveryMode {
-		return 0, consts.ErrStandby
-	}
-
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	return len(c.generateRootProgress), nil
-}
-
-// GenerateRootConfiguration is used to read the root generation configuration
-// It stubbornly refuses to return the OTP if one is there.
-func (c *Core) GenerateRootConfiguration() (*GenerateRootConfig, error) {
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrSealed
 	}
 	if c.standby.Load() && !c.recoveryMode {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrStandby
 	}
+	if !c.barrier.Sealed() && c.recoveryMode {
+		c.stateLock.RUnlock()
+		return nil, errors.New("attempted to generate recovery operation token when already unsealed")
+	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
+	return c.stateLock.RUnlock, nil
+}
 
-	if c.generateRootConfig == nil {
+// GenerateRootProgress is used to return the root token generation progress.
+func (c *Core) GenerateRootProgress(ctx context.Context) (int, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	c.namespaceRootGenLock.RLock()
+	defer c.namespaceRootGenLock.RUnlock()
+
+	if c.namespaceRootGens[ns.UUID] == nil {
+		return 0, nil
+	}
+
+	return len(c.namespaceRootGens[ns.UUID].Progress), nil
+}
+
+// GenerateRootConfiguration is used to read the root generation configuration.
+// It stubbornly refuses to return the OTP if one is there.
+func (c *Core) GenerateRootConfiguration(ctx context.Context) (*GenerateRootConfig, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.namespaceRootGenLock.RLock()
+	defer c.namespaceRootGenLock.RUnlock()
+
+	namespaceRootGen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
 		return nil, ErrNoRootGeneration
 	}
 
-	config := *c.generateRootConfig
+	config := *namespaceRootGen.Config
 	config.OTP = ""
 	config.Strategy = nil
 
 	return &config, nil
 }
 
-// GenerateRootInit is used to initialize the root generation settings
-func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrategy) error {
+// GenerateRootInit is used to initialize the root generation attempt.
+func (c *Core) GenerateRootInit(ctx context.Context, otp, pgpKey string, strategy GenerateRootStrategy) error {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	var fingerprint string
 	switch {
 	case len(otp) > 0:
-		expectedLength := TokenLength
+		var expectedLength int
+		if ns.UUID == namespace.RootNamespaceUUID {
+			expectedLength = TokenLength
+		} else {
+			expectedLength = NSTokenLength
+		}
+
 		if c.DisableSSCTokens() {
 			expectedLength += OldTokenPrefixLength
 		} else {
@@ -158,35 +207,27 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 		return errors.New("otp or pgp_key parameter must be provided")
 	}
 
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return consts.ErrSealed
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
+
+	gen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
+		gen = &rootTokenGeneration{}
+		c.namespaceRootGens[ns.UUID] = gen
 	}
 
-	if !c.barrier.Sealed() && c.recoveryMode {
-		return errors.New("attempt to generate recovery operation token when already unsealed")
-	}
-	if c.standby.Load() && !c.recoveryMode {
-		return consts.ErrStandby
+	// Prevent multiple concurrent root generations per namespace.
+	if gen.Config != nil {
+		return errors.New("root generation already in progress for this namespace")
 	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	// Prevent multiple concurrent root generations
-	if c.generateRootConfig != nil {
-		return errors.New("root generation already in progress")
-	}
-
-	// Copy the configuration
-	generationNonce, err := uuid.GenerateUUID()
+	nonce, err := uuid.GenerateUUID()
 	if err != nil {
 		return err
 	}
 
-	c.generateRootConfig = &GenerateRootConfig{
-		Nonce:          generationNonce,
+	gen.Config = &GenerateRootConfig{
+		Nonce:          nonce,
 		OTP:            otp,
 		PGPKey:         pgpKey,
 		PGPFingerprint: fingerprint,
@@ -196,21 +237,37 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 	if c.logger.IsInfo() {
 		switch strategy.(type) {
 		case generateStandardRootToken:
-			c.logger.Info("root generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("root generation initialized", "nonce", gen.Config.Nonce)
 		case *generateRecoveryToken:
-			c.logger.Info("recovery operation token generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("recovery operation token generation initialized", "nonce", gen.Config.Nonce)
 		default:
-			c.logger.Info("dr operation token generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("dr operation token generation initialized", "nonce", gen.Config.Nonce)
 		}
 	}
 
 	return nil
 }
 
-// GenerateRootUpdate is used to provide a new key part
+// GenerateRootUpdate is used to provide a new key part to progress root generation.
 func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string, strategy GenerateRootStrategy) (*GenerateRootResult, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	barrier := c.sealManager.NamespaceBarrier(ns.Path)
+	if barrier == nil {
+		return nil, ErrNotSealable
+	}
+
 	// Verify the key length
-	min, max := c.barrier.KeyLength()
+	min, max := barrier.KeyLength()
 	max += shamir.ShareOverhead
 	if len(key) < min {
 		return nil, &ErrInvalidKey{fmt.Sprintf("key is shorter than minimum %d bytes", min)}
@@ -219,13 +276,17 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, &ErrInvalidKey{fmt.Sprintf("key is longer than maximum %d bytes", max)}
 	}
 
+	seal := c.sealManager.NamespaceSeal(ns.UUID)
+	if seal == nil {
+		return nil, ErrNotSealable
+	}
+
 	// Get the seal configuration
 	var config *SealConfig
-	var err error
-	if c.seal.RecoveryKeySupported() {
-		config, err = c.seal.RecoveryConfig(ctx)
+	if seal.RecoveryKeySupported() {
+		config, err = seal.RecoveryConfig(ctx)
 	} else {
-		config, err = c.seal.BarrierConfig(ctx)
+		config, err = seal.BarrierConfig(ctx)
 	}
 
 	if err != nil {
@@ -237,47 +298,32 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, ErrNotInit
 	}
 
-	// Ensure we are already unsealed
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return nil, consts.ErrSealed
-	}
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
 
-	if !c.barrier.Sealed() && c.recoveryMode {
-		return nil, errors.New("attempt to generate recovery operation token when already unsealed")
-	}
-
-	if c.standby.Load() && !c.recoveryMode {
-		return nil, consts.ErrStandby
-	}
-
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	// Ensure a generateRoot is in progress
-	if c.generateRootConfig == nil {
+	gen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
 		return nil, ErrNoRootGeneration
 	}
 
-	if nonce != c.generateRootConfig.Nonce {
-		return nil, fmt.Errorf("incorrect nonce supplied; nonce for this root generation operation is %q", c.generateRootConfig.Nonce)
+	if nonce != gen.Config.Nonce {
+		return nil, fmt.Errorf("incorrect nonce supplied; nonce for this root generation operation is %q", gen.Config.Nonce)
 	}
 
-	if strategy != c.generateRootConfig.Strategy {
+	if strategy != gen.Config.Strategy {
 		return nil, errors.New("incorrect strategy supplied; a generate root operation of another type is already in progress")
 	}
 
 	// Check if we already have this piece
-	for _, existing := range c.generateRootProgress {
+	for _, existing := range gen.Progress {
 		if bytes.Equal(existing, key) {
 			return nil, errors.New("given key has already been provided during this generation operation")
 		}
 	}
 
 	// Store this key
-	c.generateRootProgress = append(c.generateRootProgress, key)
-	progress := len(c.generateRootProgress)
+	gen.Progress = append(gen.Progress, key)
+	progress := len(gen.Progress)
 
 	// Check if we don't have enough keys to unlock
 	if progress < config.SecretThreshold {
@@ -287,18 +333,18 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return &GenerateRootResult{
 			Progress:       progress,
 			Required:       config.SecretThreshold,
-			PGPFingerprint: c.generateRootConfig.PGPFingerprint,
+			PGPFingerprint: gen.Config.PGPFingerprint,
 		}, nil
 	}
 
 	// Combine the key parts
 	var combinedKey []byte
 	if config.SecretThreshold == 1 {
-		combinedKey = c.generateRootProgress[0]
-		c.generateRootProgress = nil
+		combinedKey = gen.Progress[0]
+		gen.Progress = nil
 	} else {
-		combinedKey, err = shamir.Combine(c.generateRootProgress)
-		c.generateRootProgress = nil
+		combinedKey, err = shamir.Combine(gen.Progress)
+		gen.Progress = nil
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute root key: %w", err)
 		}
@@ -318,11 +364,11 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 	var encodedToken string
 
 	switch {
-	case len(c.generateRootConfig.OTP) > 0:
-		encodedToken, err = roottoken.EncodeToken(token, c.generateRootConfig.OTP)
-	case len(c.generateRootConfig.PGPKey) > 0:
+	case len(gen.Config.OTP) > 0:
+		encodedToken, err = roottoken.EncodeToken(token, gen.Config.OTP)
+	case len(gen.Config.PGPKey) > 0:
 		var tokenBytesArr [][]byte
-		_, tokenBytesArr, err = pgpkeys.EncryptShares([][]byte{[]byte(token)}, []string{c.generateRootConfig.PGPKey})
+		_, tokenBytesArr, err = pgpkeys.EncryptShares([][]byte{[]byte(token)}, []string{gen.Config.PGPKey})
 		encodedToken = base64.StdEncoding.EncodeToString(tokenBytesArr[0])
 	default:
 		err = errors.New("unreachable condition")
@@ -337,39 +383,39 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		Progress:       progress,
 		Required:       config.SecretThreshold,
 		EncodedToken:   encodedToken,
-		PGPFingerprint: c.generateRootConfig.PGPFingerprint,
+		PGPFingerprint: gen.Config.PGPFingerprint,
 	}
 
 	switch strategy.(type) {
 	case generateStandardRootToken:
-		c.logger.Info("root generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("root generation finished", "nonce", gen.Config.Nonce)
 	case *generateRecoveryToken:
-		c.logger.Info("recovery operation token generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("recovery operation token generation finished", "nonce", gen.Config.Nonce)
 	default:
-		c.logger.Info("dr operation token generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("dr operation token generation finished", "nonce", gen.Config.Nonce)
 	}
 
-	c.generateRootProgress = nil
-	c.generateRootConfig = nil
+	delete(c.namespaceRootGens, ns.UUID)
 	return results, nil
 }
 
 // GenerateRootCancel is used to cancel an in-progress root generation
-func (c *Core) GenerateRootCancel() error {
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return consts.ErrSealed
+func (c *Core) GenerateRootCancel(ctx context.Context) error {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return err
 	}
-	if c.standby.Load() && !c.recoveryMode {
-		return consts.ErrStandby
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
 
 	// Clear any progress or config
-	c.generateRootConfig = nil
-	c.generateRootProgress = nil
+	delete(c.namespaceRootGens, ns.UUID)
 	return nil
 }

--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -16,296 +16,249 @@ import (
 
 func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Lifecycle_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Lifecycle_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Lifecycle_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, keys [][]byte) {
+func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
 	// Verify update not allowed
-	if _, err := c.GenerateRootUpdate(namespace.RootContext(t.Context()), keys[0], "", GenerateStandardRootTokenStrategy); err == nil {
-		t.Fatal("no root generation in progress")
-	}
+	_, err := c.GenerateRootUpdate(ctx, keys[0], "", GenerateStandardRootTokenStrategy)
+	require.Error(t, err)
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	// Cancel should be idempotent
-	err = c.GenerateRootCancel()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootCancel(ctx))
 
 	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
 
 	// Start a root generation
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Should get config
-	conf, err = c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if conf == nil {
-		t.Fatalf("expected conf != nil")
-	}
+	conf, err = c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conf)
 
 	// Cancel should be clear
-	err = c.GenerateRootCancel()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootCancel(ctx))
 
 	// Should be no config
-	conf, err = c.GenerateRootConfiguration()
+	conf, err = c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 }
 
 func TestCore_GenerateRoot_Init(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Init_Common(t, c)
+	ns := &namespace.Namespace{Path: "test1/"}
+	TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Init_Common(t, c, namespace.RootNamespace)
 
 	bc := &SealConfig{SecretShares: 5, SecretThreshold: 3}
 	rc := &SealConfig{SecretShares: 5, SecretThreshold: 3}
 	c, _, _, _ = TestCoreUnsealedWithConfigs(t, bc, rc)
-	testCore_GenerateRoot_Init_Common(t, c)
+	testCore_GenerateRoot_Init_Common(t, c, namespace.RootNamespace)
+
+	testCore_GenerateRoot_Init_Common(t, c, ns)
 }
 
-func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core) {
-	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
-	}
+func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core, ns *namespace.Namespace) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	tokenLength := TokenLength
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
+
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Second should fail
-	err = c.GenerateRootInit("", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy)
-	if err == nil {
-		t.Fatal("should fail")
-	}
+	require.Error(t, c.GenerateRootInit(ctx, "", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy))
 }
 
 func TestCore_GenerateRoot_InvalidRootNonce(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	// Pass in root keys as they'll be invalid
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	// incrementing root keys will make them invalid
 	rootKeys[0][0]++
-	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, rootKeys)
+	keysPerNamespace[ns.Path][0][0]++
+
+	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, keys [][]byte) {
-	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
-	}
+func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	tokenLength := TokenLength
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
+
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rgconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rgconf == nil {
-		t.Fatal("bad: no rotate config received")
-	}
+	rgconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rgconf)
 
-	// Provide the nonce (invalid)
-	_, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), keys[0], "abcd", GenerateStandardRootTokenStrategy)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	// Provide the invalid nonce
+	_, err = c.GenerateRootUpdate(ctx, keys[0], "abcd", GenerateStandardRootTokenStrategy)
+	require.Error(t, err)
 
-	// Provide the root (invalid)
+	// Provide the invalid root key
 	for _, key := range keys {
-		_, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
+		_, err = c.GenerateRootUpdate(ctx, key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
 	}
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 }
 
 func TestCore_GenerateRoot_Update_OTP(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_OTP_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Update_OTP_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Update_OTP_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byte) {
+func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
 	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
 
 	// Start a root generation
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rkconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rkconf == nil {
-		t.Fatal("bad: no root generation config received")
-	}
+	rkconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rkconf)
 
 	// Provide the keys
 	var result *GenerateRootResult
 	for _, key := range keys {
-		result, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		result, err = c.GenerateRootUpdate(ctx, key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
+		require.NoError(t, err)
 		if result.EncodedToken != "" {
 			break
 		}
 	}
-	if result == nil {
-		t.Fatal("Bad, result is nil")
-	}
+	require.NotNil(t, result)
 
 	encodedToken := result.EncodedToken
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	tokenBytes, err := base64.RawStdEncoding.DecodeString(encodedToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	tokenBytes, err = xor.XORBytes(tokenBytes, []byte(otp))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	token := string(tokenBytes)
 
 	// Ensure that the token is a root token
-	te, err := c.tokenStore.Lookup(namespace.RootContext(t.Context()), token)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if te == nil {
-		t.Fatal("token was nil")
-	}
-	if te.ID != token || te.Parent != "" ||
-		len(te.Policies) != 1 || te.Policies[0] != "root" {
-		t.Fatalf("bad: %#v", *te)
-	}
+	te, err := c.tokenStore.Lookup(ctx, token)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	require.False(t, te.ID != token || te.Parent != "" ||
+		len(te.Policies) != 1 || te.Policies[0] != "root")
 }
 
 func TestCore_GenerateRoot_Update_PGP(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_PGP_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Update_PGP_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Update_PGP_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byte) {
-	// Start a root generation
-	err := c.GenerateRootInit("", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
+	require.NoError(t, c.GenerateRootInit(ctx, "", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rkconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rkconf == nil {
-		t.Fatal("bad: no root generation config received")
-	}
+	rkconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rkconf)
 
 	// Provide the keys
 	var result *GenerateRootResult
 	for _, key := range keys {
-		result, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		result, err = c.GenerateRootUpdate(ctx, key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
+		require.NoError(t, err)
 		if result.EncodedToken != "" {
 			break
 		}
 	}
-	if result == nil {
-		t.Fatal("Bad, result is nil")
-	}
+	require.NotNil(t, result)
 
 	encodedToken := result.EncodedToken
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	ptBuf, err := pgpkeys.DecryptBytes(encodedToken, pgpkeys.TestPrivKey1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ptBuf == nil {
-		t.Fatal("Got nil plaintext key")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, ptBuf)
 
 	token := ptBuf.String()
 
 	// Ensure that the token is a root token
-	te, err := c.tokenStore.Lookup(namespace.RootContext(t.Context()), token)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if te == nil {
-		t.Fatal("token was nil")
-	}
-	if te.ID != token || te.Parent != "" ||
-		len(te.Policies) != 1 || te.Policies[0] != "root" {
-		t.Fatalf("bad: %#v", *te)
-	}
+	te, err := c.tokenStore.Lookup(ctx, token)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	require.False(t, te.ID != token || te.Parent != "" ||
+		len(te.Policies) != 1 || te.Policies[0] != "root")
 }

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -477,8 +477,14 @@ func (sm *SealManager) unsealKeyToRootKey(ctx context.Context, seal Seal, combin
 	switch seal.BarrierType() {
 	case vaultseal.WrapperTypeShamir:
 		if useTestSeal {
+			ns, err := namespace.FromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+
 			testseal := NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 			testseal.SetCore(sm.core)
+			testseal.SetMetaPrefix(NamespaceStoragePathPrefix(ns))
 			cfg, err := seal.BarrierConfig(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to setup test barrier config: %w", err)
@@ -531,7 +537,7 @@ func (sm *SealManager) AuthenticateRootKey(ctx context.Context, ns *namespace.Na
 		return ErrNotSealable
 	}
 
-	rootKey, err := sm.unsealKeyToRootKey(ctx, seal, combinedKey, false, false)
+	rootKey, err := sm.unsealKeyToRootKey(ctx, seal, combinedKey, true, false)
 	if err != nil {
 		return fmt.Errorf("unable to authenticate: %w", err)
 	}


### PR DESCRIPTION
## Description
- encapsulated root generation progress and config in one struct contained within a map of namespace key (root namespace accommodated in the same struct)
- consolidated root token generation methods to reuse `SealManager` methods
- adjusted tests and code references

## Rationale
Required to enable per-namespace root token generation.

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
