### PR TITLE
Forbid path traversal by default (#2910)

### DIFF
--- a/changelog/2910.txt
+++ b/changelog/2910.txt
@@ -1,0 +1,6 @@
+```release-note:security
+core: Forbid request path traversal using `.` and `..` segments by default. If required, set the `unsafe_relative_paths`. Upstream HCSEC-2026-05 / CVE-2026-3605.
+```
+```release-note:bug
+core: Loosen overly strict check for view path check, strictly forbidding `..` as a substring within path segments.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -2761,6 +2761,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		EnableResponseHeaderRaftNodeID: config.EnableResponseHeaderRaftNodeID,
 		AdministrativeNamespacePath:    config.AdministrativeNamespacePath,
 		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity,
+		UnsafeRelativePaths:            config.UnsafeRelativePaths,
 	}
 
 	if config.DisableSSCTokens != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -144,6 +144,10 @@ type Config struct {
 
 	// Whether read requests are disabled on standby nodes.
 	DisableStandbyReads bool `hcl:"disable_standby_reads"`
+
+	// Whether to allow unsafe (usually URL encoded) relative request paths
+	// (containing `..`).
+	UnsafeRelativePaths bool `hcl:"unsafe_relative_paths"`
 }
 
 func (c *Config) Validate(sourceFilePath string) []configutil.ConfigError {

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/openbao/openbao/api/v2"
 	auditFile "github.com/openbao/openbao/builtin/audit/file"
-	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	kv "github.com/openbao/openbao/builtin/logical/kv"
 	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
@@ -828,78 +827,6 @@ func TestLogical_AuditPort(t *testing.T) {
 	numExpectedEntries := (numFailures * 2) + 4
 	if count != numExpectedEntries {
 		t.Fatalf("wrong number of audit entries expected: %d got: %d", numExpectedEntries, count)
-	}
-}
-
-func TestLogical_ErrRelativePath(t *testing.T) {
-	coreConfig := &vault.CoreConfig{
-		CredentialBackends: map[string]logical.Factory{
-			"userpass": credUserpass.Factory,
-		},
-	}
-
-	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
-		HandlerFunc: Handler,
-	})
-
-	cluster.Start()
-	defer cluster.Cleanup()
-
-	cores := cluster.Cores
-
-	core := cores[0].Core
-	c := cluster.Cores[0].Client
-	vault.TestWaitActive(t, core)
-
-	err := c.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
-		Type: "userpass",
-	})
-	if err != nil {
-		t.Fatalf("failed to enable userpass, err: %v", err)
-	}
-
-	resp, err := c.Logical().Read("auth/userpass/users/user..aaa")
-
-	if err == nil || resp != nil {
-		t.Fatalf("expected read request to fail, resp: %#v, err: %v", resp, err)
-	}
-
-	respErr, ok := err.(*api.ResponseError)
-
-	if !ok {
-		t.Fatalf("unexpected error type, err: %#v", err)
-	}
-
-	if respErr.StatusCode != 400 {
-		t.Errorf("expected 400 response for read, actual: %d", respErr.StatusCode)
-	}
-
-	if !strings.Contains(respErr.Error(), logical.ErrRelativePath.Error()) {
-		t.Errorf("expected response for read to include %q", logical.ErrRelativePath.Error())
-	}
-
-	data := map[string]interface{}{
-		"password": "abc123",
-	}
-
-	resp, err = c.Logical().Write("auth/userpass/users/user..aaa", data)
-
-	if err == nil || resp != nil {
-		t.Fatalf("expected write request to fail, resp: %#v, err: %v", resp, err)
-	}
-
-	respErr, ok = err.(*api.ResponseError)
-
-	if !ok {
-		t.Fatalf("unexpected error type, err: %#v", err)
-	}
-
-	if respErr.StatusCode != 400 {
-		t.Errorf("expected 400 response for write, actual: %d", respErr.StatusCode)
-	}
-
-	if !strings.Contains(respErr.Error(), logical.ErrRelativePath.Error()) {
-		t.Errorf("expected response for write to include %q", logical.ErrRelativePath.Error())
 	}
 }
 

--- a/sdk/helper/keysutil/encrypted_key_storage.go
+++ b/sdk/helper/keysutil/encrypted_key_storage.go
@@ -309,6 +309,10 @@ func (s *encryptedKeyStorage) encryptPath(path string) (string, error) {
 		return s.prefix, nil
 	}
 
+	if logical.IsRelativePath(path) {
+		return "", logical.ErrRelativePath
+	}
+
 	path = paths.Clean(path)
 
 	// Trim the prefix if it starts with a "/"

--- a/sdk/logical/path.go
+++ b/sdk/logical/path.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+import "strings"
+
+// Check whether this request path is a relative path containing . or .. as
+// path segments.
+func IsRelativePath(path string) bool {
+	// We look for two patterns, `.` and `..` as path segments, maintaining
+	// that they're a portion of a relative path for the purpose of this
+	// comparison. We set a maximum complexity limit to ensure we don't
+	// endlessly recurse. We ignore double slashes (//), as they're also
+	// ignored by the ACL subsystem and are sometimes unfortunately present
+	// in OCSP-as-GET requests.
+
+	// Special cases; the rest all have / as a prefix.
+	if path == "." || path == ".." || strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") {
+		return true
+	}
+
+	// Check for relative path portions at the end of the request path.
+	if strings.HasSuffix(path, "/.") || strings.HasSuffix(path, "/..") {
+		return true
+	}
+
+	for index := range len(path) {
+		if path[index] == '/' {
+			// Check for relative path portions in the middle.
+			if (index+3 <= len(path) && path[index:index+3] == "/./") ||
+				(index+4 <= len(path) && path[index:index+4] == "/../") {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/sdk/logical/path_test.go
+++ b/sdk/logical/path_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelativePaths(t *testing.T) {
+	for path, result := range map[string]bool{
+		// Negative
+		"":       false,
+		"/":      false,
+		"/a":     false,
+		"a/":     false,
+		"//":     false,
+		"///":    false,
+		"/a/":    false,
+		"aa/":    false,
+		"a/a":    false,
+		"/aa":    false,
+		"/alex":  false,
+		"alex/":  false,
+		"/alex/": false,
+
+		// Triple or more dots have no special path meaning.
+		".../a":      false,
+		"..../a":     false,
+		"...../a":    false,
+		"....../a":   false,
+		"a/.../a":    false,
+		"a/..../a":   false,
+		"a/...../a":  false,
+		"a/....../a": false,
+		"a/...":      false,
+		"a/....":     false,
+		"a/.....":    false,
+		"a/......":   false,
+		"...":        false,
+		"....":       false,
+		".....":      false,
+		"......":     false,
+
+		// Positive
+		".":      true,
+		"./":     true,
+		"..":     true,
+		"/./":    true,
+		"../":    true,
+		"/../":   true,
+		"a/.":    true,
+		"a/./":   true,
+		"a/..":   true,
+		"a/../":  true,
+		"./a":    true,
+		"../a":   true,
+		"/./a":   true,
+		"/../a":  true,
+		"a/./a":  true,
+		"a/../a": true,
+	} {
+		require.Equal(t, result, IsRelativePath(path), "difference for path: %v", path)
+	}
+}

--- a/sdk/logical/storage_view.go
+++ b/sdk/logical/storage_view.go
@@ -145,7 +145,7 @@ func (s *storageView) SubView(prefix string) StorageView {
 
 // SanityCheck is used to perform a sanity check on a key
 func (s *storageView) SanityCheck(key string) error {
-	if strings.Contains(key, "..") {
+	if IsRelativePath(key) {
 		return ErrRelativePath
 	}
 	return nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -661,6 +661,8 @@ type Core struct {
 	// Core invalidation tracker handles dispatching invalidations and
 	// refreshing the Core-adjacent caches afterwards.
 	invalidations *invalidationManager
+
+	unsafeRelativePaths bool
 }
 
 // c.stateLock needs to be held in read mode before calling this function.
@@ -818,6 +820,8 @@ type CoreConfig struct {
 	//
 	// See also: https://github.com/openbao/openbao/issues/1110
 	UnsafeCrossNamespaceIdentity bool
+
+	UnsafeRelativePaths bool
 }
 
 // GetServiceRegistration returns the config's ServiceRegistration, or nil if it does
@@ -996,6 +1000,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		impreciseLeaseRoleTracking:     conf.ImpreciseLeaseRoleTracking,
 		detectDeadlocks:                detectDeadlocks,
 		unsafeCrossNamespaceIdentity:   conf.UnsafeCrossNamespaceIdentity,
+		unsafeRelativePaths:            conf.UnsafeRelativePaths,
 	}
 
 	c.standby.Store(true)

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -572,6 +572,10 @@ func (c *Core) HandleRequest(httpCtx context.Context, req *logical.Request) (res
 }
 
 func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.Request, doLocking bool) (resp *logical.Response, err error) {
+	if !c.unsafeRelativePaths && logical.IsRelativePath(req.Path) {
+		return nil, logical.CodedError(http.StatusBadRequest, logical.ErrRelativePath.Error())
+	}
+
 	if doLocking {
 		c.stateLock.RLock()
 		defer c.stateLock.RUnlock()

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -718,3 +718,45 @@ path "secret/metadata/by-metadata/subdir/both" {
 		}
 	}
 }
+
+func TestRequestHandling_RelativePath(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(t.Context())
+
+	req := &logical.Request{
+		Path:        "sys/policies/acl/../../../testing",
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+	}
+	resp, err := core.HandleRequest(ctx, req)
+	require.ErrorContains(t, err, logical.ErrRelativePath.Error())
+	require.Nil(t, resp)
+
+	req = &logical.Request{
+		Path:        "sys/policies/acl/./testing",
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+	}
+	resp, err = core.HandleRequest(ctx, req)
+	require.ErrorContains(t, err, logical.ErrRelativePath.Error())
+	require.NotContains(t, err.Error(), "read failed")
+	require.Nil(t, resp)
+}
+
+func TestRequestHandling_RelativePathAllowed(t *testing.T) {
+	core, _, root := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		UnsafeRelativePaths: true,
+	})
+	ctx := namespace.RootContext(t.Context())
+
+	req := &logical.Request{
+		Path:        "cubbyhole/asdf/../asdf",
+		ClientToken: root,
+		Operation:   logical.ReadOperation,
+	}
+	_, err := core.HandleRequest(ctx, req)
+
+	// While other places still disallow the relative paths (e.g., storage
+	// view), we know that we made it farther.
+	require.ErrorContains(t, err, "read failed")
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -200,6 +200,7 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	conf.AdministrativeNamespacePath = opts.AdministrativeNamespacePath
 	conf.ImpreciseLeaseRoleTracking = opts.ImpreciseLeaseRoleTracking
 	conf.UnsafeCrossNamespaceIdentity = opts.UnsafeCrossNamespaceIdentity
+	conf.UnsafeRelativePaths = opts.UnsafeRelativePaths
 
 	if opts.Logger != nil {
 		conf.Logger = opts.Logger


### PR DESCRIPTION
## Description

Backport of #2910.

Required fixing conflicts with new workflow-related config parameters that don't go to 2.5.x in several places.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
