### PR TITLE
Correctly quote schema name in PostgreSQL revoke (#2931)

### DIFF
--- a/changelog/2931.txt
+++ b/changelog/2931.txt
@@ -1,0 +1,3 @@
+```release-note:security
+database/postgresql: Correctly quote schema name in revoke statement. GHSA-6vgr-cp5c-ffx3 / CVE-2026-39946.
+```

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -445,7 +445,7 @@ func (p *PostgreSQL) defaultDeleteUser(ctx context.Context, username string) err
 		}
 		revocationStmts = append(revocationStmts, fmt.Sprintf(
 			`REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s;`,
-			(schema),
+			dbutil.QuoteIdentifier(schema),
 			dbutil.QuoteIdentifier(username)))
 
 		revocationStmts = append(revocationStmts, fmt.Sprintf(


### PR DESCRIPTION
## Description

Backport of #2931, clean cherry-pick.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
