### PR TITLE
Prevent cross-namespace token accessor use (#2934)

### DIFF
--- a/changelog/2934.txt
+++ b/changelog/2934.txt
@@ -1,0 +1,3 @@
+```release-note:security
+auth/token: Prevent cross-namespace token renewal, revocation by accessor. GHSA-p49j-v9wc-wg57 / CVE-2026-40264.
+```

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2331,18 +2331,15 @@ func (ts *TokenStore) lookupByAccessor(ctx context.Context, id string, salted, t
 			if err != nil {
 				return nil, err
 			}
-			if accessorNS != nil {
-				if accessorNS.ID != ns.ID {
-					ns = accessorNS
-					ctx = namespace.ContextWithNamespace(ctx, accessorNS)
-				}
+			if accessorNS != nil && accessorNS.ID != ns.ID {
+				return nil, fmt.Errorf("cannot lookup token in different namespace")
 			}
-		} else {
-			// Any non-root-ns token should have an accessor and child
-			// namespaces cannot have custom IDs. If someone omits or tampers
+		} else if ns.ID != namespace.RootNamespaceID {
+			// Any non-root-ns token should have an accessor and child.
+			//
+			// Namespaces cannot have custom IDs. If someone omits or tampers
 			// with it, the lookup in the root namespace simply won't work.
-			ns = namespace.RootNamespace
-			ctx = namespace.ContextWithNamespace(ctx, ns)
+			return nil, fmt.Errorf("cannot lookup token in different namespace")
 		}
 
 		lookupID, err = ts.SaltID(ctx, id)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -782,6 +782,14 @@ func TestTokenStore_AccessorIndex(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ts := c.tokenStore
 
+	ns1 := &namespace.Namespace{
+		Path: "ns1",
+	}
+	ns2 := &namespace.Namespace{
+		Path: "ns1/ns2",
+	}
+	TestCoreCreateNamespaces(t, c, ns1, ns2)
+
 	ent := &logical.TokenEntry{
 		Path:        "test",
 		Policies:    []string{"dev", "ops"},
@@ -810,6 +818,24 @@ func TestTokenStore_AccessorIndex(t *testing.T) {
 	if aEntry.TokenID != ent.ID {
 		t.Fatalf("bad: got\n%s\nexpected\n%s\n", aEntry.TokenID, ent.ID)
 	}
+
+	// Verify we can't do cross-namespace token lookups.
+	aEntry, err = ts.lookupByAccessor(namespace.ContextWithNamespace(ctx, ns1), out.Accessor, false, false)
+	require.Error(t, err, "successfully looked up accessor: %v", out.Accessor)
+	require.Nil(t, aEntry)
+
+	ent2 := *ent
+	ent2.ID = ""
+	ent2.NamespaceID = ns1.ID
+	testMakeTokenDirectly(t, ctx, ts, &ent2)
+
+	aEntry, err = ts.lookupByAccessor(ctx, ent2.Accessor, false, false)
+	require.Error(t, err)
+	require.Nil(t, aEntry)
+
+	aEntry, err = ts.lookupByAccessor(namespace.ContextWithNamespace(ctx, ns2), ent2.Accessor, false, false)
+	require.Error(t, err)
+	require.Nil(t, aEntry)
 
 	// Make sure a batch token doesn't get an accessor
 	ent.Type = logical.TokenTypeBatch


### PR DESCRIPTION
## Description

Backport of #2934, clean cherry-pick.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
