### PR TITLE
listenerutil: only chown the unix socket when socket_user or socket_group is set

### DIFF
--- a/helper/listenerutil/listener.go
+++ b/helper/listenerutil/listener.go
@@ -224,9 +224,18 @@ GROUP:
 	}
 
 OWN:
-	if err := os.Chown(path, uid, gid); err != nil {
-		return fmt.Errorf("failed setting ownership to %d:%d on %q: %v",
-			uid, gid, path, err)
+	// Only Chown when the operator actually asked us to change ownership.
+	// A previous version always invoked os.Chown with the current uid/gid;
+	// in environments where the current user cannot chown its own files
+	// (e.g. restricted container runtimes) that call returns EPERM and we
+	// short-circuit out before ever reaching the mode change below.
+	// That is the reported failure mode in #2594: socket_mode alone, with
+	// no socket_user / socket_group, silently fails to apply.
+	if user != "" || group != "" {
+		if err := os.Chown(path, uid, gid); err != nil {
+			return fmt.Errorf("failed setting ownership to %d:%d on %q: %v",
+				uid, gid, path, err)
+		}
 	}
 
 	if mode != "" {


### PR DESCRIPTION
Fixes #2594.

`setFilePermissions` documents all three of `user`, `group`, `mode` as optional but unconditionally invokes `os.Chown` with the current uid/gid when neither user nor group is provided. In restricted environments (for example containers where the process cannot chown its own files) that call returns `EPERM`, the function short-circuits with `failed setting ownership to ...` and the subsequent `os.Chmod` never runs.

The user hits this on a plain mode-only listener config:

```hcl
listener "unix" {
    address     = "/run/sockets/openbao.sock"
    socket_mode = "0660"
}
```

The documented contract is that `socket_mode` alone should change the permissions without touching ownership. This gates the `Chown` call on `user != "" || group != ""` so the current-user chown only happens when the operator actually asked for an ownership change. When they did ask, we still fail loud on the `Chown` error as before.