### PR TITLE
Validate downloaded plugin binary size (#2941)

### DIFF
--- a/changelog/2941.txt
+++ b/changelog/2941.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/plugins: Validate and restrict downloaded plugin binary size from OCI images; set `plugin_download_max_size` to limit the size (defaults to 512MB). GHSA-r65v-xgwc-g56j / CVE-2026-39396.
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -87,6 +87,9 @@ type Config struct {
 	PluginAutoRegister     bool            `hcl:"-"`
 	PluginAutoRegisterRaw  interface{}     `hcl:"plugin_auto_register"`
 
+	PluginDownloadMaxSize    int64       `hcl:"-"`
+	PluginDownloadMaxSizeRaw interface{} `hcl:"plugin_download_max_size"`
+
 	EnableIntrospectionEndpoint    bool        `hcl:"-"`
 	EnableIntrospectionEndpointRaw interface{} `hcl:"introspection_endpoint,alias:EnableIntrospectionEndpoint"`
 
@@ -699,6 +702,12 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.PluginAutoRegisterRaw = c2.PluginAutoRegisterRaw
 	}
 
+	result.PluginDownloadMaxSize = c.PluginDownloadMaxSize
+	if c2.PluginAutoDownloadRaw != nil {
+		result.PluginDownloadMaxSize = c2.PluginDownloadMaxSize
+		result.PluginDownloadMaxSizeRaw = c2.PluginDownloadMaxSizeRaw
+	}
+
 	return result
 }
 
@@ -1040,6 +1049,14 @@ func ParseConfig(d, source string) (*Config, error) {
 			return nil, err
 		}
 		result.PluginAutoRegister = autoRegister
+	}
+
+	if result.PluginDownloadMaxSizeRaw != nil {
+		maxSize, err := parseutil.ParseInt(result.PluginDownloadMaxSizeRaw)
+		if err != nil {
+			return nil, err
+		}
+		result.PluginDownloadMaxSize = maxSize
 	}
 
 	// Remove all unused keys from Config that were satisfied by SharedConfig.

--- a/helper/pluginutil/oci/downloader.go
+++ b/helper/pluginutil/oci/downloader.go
@@ -23,10 +23,12 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/osutil"
+	"github.com/shirou/gopsutil/v4/disk"
 )
 
 const (
-	PluginCacheDir = ".oci-cache"
+	PluginCacheDir     = ".oci-cache"
+	PluginMaxSizeBytes = 512 * 1024 * 1024 // 512 MB
 )
 
 // PluginDownloader handles downloading and managing OCI-based plugins
@@ -106,6 +108,15 @@ func (d *PluginDownloader) shouldFailOnPluginError() bool {
 	}
 
 	return behavior == server.PluginDownloadFail
+}
+
+// maxPluginSize returns the maximum allowed plugin binary size
+func (d *PluginDownloader) maxPluginSize() int64 {
+	if d.config.PluginDownloadMaxSize > 0 {
+		return d.config.PluginDownloadMaxSize
+	}
+
+	return PluginMaxSizeBytes
 }
 
 // IsPluginCacheValid checks if the plugin already exists in the plugin directory
@@ -290,6 +301,19 @@ func (d *PluginDownloader) ExtractPluginFromImage(img v1.Image, targetPath strin
 				continue
 			}
 
+			if header.Size > d.maxPluginSize() {
+				return fmt.Errorf("plugin binary size of %d MiB exceeds allowed size of %d MiB", header.Size/1024/1024, d.maxPluginSize()/1024/1024)
+			}
+
+			diskUsage, err := disk.Usage(filepath.Dir(targetPath))
+			if err != nil {
+				return fmt.Errorf("failed to get disk usage: %w", err)
+			}
+
+			if diskUsage.Free < uint64(header.Size) {
+				return fmt.Errorf("not enough space left on disk to download plugin")
+			}
+
 			logger.Info("found plugin binary in OCI image", "entry", header.Name, "size", header.Size)
 
 			// Create the output file
@@ -298,8 +322,15 @@ func (d *PluginDownloader) ExtractPluginFromImage(img v1.Image, targetPath strin
 				return fmt.Errorf("failed to create output file: %w", err)
 			}
 
-			if _, copyErr := io.Copy(outFile, tarReader); copyErr != nil {
+			// wrap tarReader in an io.LimitReader to protect against malicious Tar Headers that report a wrong file size
+			limitReader := io.LimitReader(tarReader, header.Size+1)
+
+			n, copyErr := io.Copy(outFile, limitReader)
+			if copyErr != nil {
 				err = fmt.Errorf("failed to extract binary data: %w", copyErr)
+			}
+			if n != header.Size {
+				err = fmt.Errorf("file size was different than reported in tar header")
 			}
 
 			if closeErr := outFile.Close(); closeErr != nil {

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -163,6 +163,10 @@ plugin_auto_register = true
 - `true` - server startup and `SIGHUP` triggers registering of plugins; can still be manually registered with `bao plugin register`.
 - `false` - only `bao plugin register` will manually register plugins.
 
+## `plugin_download_max_size`
+
+A number defining the maximum allowed plugin binary size in bytes when extracted from an OCI image. Defaults to `536870912` (512 MiB) if not set.
+
 ## Authentication
 
 When downloading plugin images from a private registry, OpenBao will use


### PR DESCRIPTION
## Description

Backport of #2941, clean cherry-pick.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
