### PR TITLE
Add Adfinis as adopter

### DIFF
--- a/website/content/ecosystem/adopters.mdx
+++ b/website/content/ecosystem/adopters.mdx
@@ -16,6 +16,11 @@ import Member from './lib/Member.tsx';
         uses OpenBao for 
         [Secrets Management and PKI](https://apeirora.eu/content/impact/security-kms/).
       </Member>
+      <Member title="Adfinis">
+        [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
+        relies on OpenBao to secure its own internal infrastructure and in
+        support of customer-related 24/7 managed services.
+      </Member>
     </Randomize>
   </div>
 </div>

--- a/website/content/ecosystem/supporters.mdx
+++ b/website/content/ecosystem/supporters.mdx
@@ -11,9 +11,9 @@ import Member from './lib/Member.tsx';
 <div className="row">
 <Randomize>
   <Member title="Adfinis">
-    Several developers employed by
-    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website) work
-    full time on OpenBao.
+    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
+    commits to OpenBao through core contributions, open source leadership, and
+    by fostering community advocacy and growth.
   </Member>
   <Member title="GitLab">
     GitLab contributes to development and open-source community efforts of OpenBao.


### PR DESCRIPTION
## Description

Adds Adfinis as an adopter for running OpenBao in production in support of its internal IT services, and also polishes the supporter entry slightly.

## Rationale

n/a

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
