### PR TITLE
Correctly handle default_rate_limit_exempt_paths_toggle invalidation

### DIFF
--- a/changelog/2953.txt
+++ b/changelog/2953.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/quotas: Correctly handle default rate limit exempt paths on quota configuration invalidation.
+```

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync/atomic"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -97,7 +98,8 @@ const (
 	// rate limit resource quotas. Specifically, when this toggle is false, we can
 	// infer a Vault node is operating with an initial default set and on a subsequent
 	// update to that set, we should not overwrite it on Setup.
-	DefaultRateLimitExemptPathsToggle = StoragePrefix + "default_rate_limit_exempt_paths_toggle"
+	DefaultRateLimitExemptPathsToggle     = StoragePrefix + DefaultRateLimitExemptPathsToggleName
+	DefaultRateLimitExemptPathsToggleName = "default_rate_limit_exempt_paths_toggle"
 )
 
 var (
@@ -148,7 +150,8 @@ type Manager struct {
 	db *memdb.MemDB
 
 	// config containing operator preferences and quota behaviors
-	config *Config
+	config                 *Config
+	usingConfigExemptPaths atomic.Bool
 
 	rateLimitPathManager *pathmanager.PathManager
 
@@ -944,15 +947,26 @@ func dbSchema() *memdb.DBSchema {
 // updates the caches and data structures to reflect those updates.
 func (m *Manager) Invalidate(key string) error {
 	switch key {
+	case DefaultRateLimitExemptPathsToggleName:
+		if err := m.loadQuotaExemptConfig(m.ctx, m.storage); err != nil {
+			return fmt.Errorf("error loading quota default exempt paths configuration: %w", err)
+		}
+
+		fallthrough
 	case "config":
 		config, err := LoadConfig(m.ctx, m.storage)
 		if err != nil {
 			return fmt.Errorf("failed to invalidate quota config: %w", err)
 		}
 
+		exemptPaths := defaultExemptPaths
+		if m.usingConfigExemptPaths.Load() {
+			exemptPaths = config.RateLimitExemptPaths
+		}
+
 		m.SetEnableRateLimitAuditLogging(config.EnableRateLimitAuditLogging)
 		m.SetEnableRateLimitResponseHeaders(config.EnableRateLimitResponseHeaders)
-		m.SetRateLimitExemptPaths(config.RateLimitExemptPaths)
+		m.SetRateLimitExemptPaths(exemptPaths)
 
 	default:
 		splitKeys := strings.Split(key, "/")
@@ -1043,6 +1057,10 @@ func (m *Manager) Setup(ctx context.Context, storage logical.Storage) error {
 	m.storage = storage
 	m.ctx = ctx
 
+	if err := m.loadQuotaExemptConfig(ctx, storage); err != nil {
+		return fmt.Errorf("error loading quota default exempt paths configuration: %w", err)
+	}
+
 	// Load the quota configuration from storage and load it into the quota
 	// manager.
 	config, err := LoadConfig(ctx, storage)
@@ -1050,6 +1068,27 @@ func (m *Manager) Setup(ctx context.Context, storage logical.Storage) error {
 		return err
 	}
 
+	exemptPaths := defaultExemptPaths
+	if m.usingConfigExemptPaths.Load() {
+		exemptPaths = config.RateLimitExemptPaths
+	}
+
+	m.setEnableRateLimitAuditLoggingLocked(config.EnableRateLimitAuditLogging)
+	m.setEnableRateLimitResponseHeadersLocked(config.EnableRateLimitResponseHeaders)
+	m.setRateLimitExemptPathsLocked(exemptPaths)
+	if err = m.resetCache(); err != nil {
+		return err
+	}
+
+	for _, qType := range quotaTypes() {
+		m.setupQuotaType(ctx, storage, qType)
+	}
+
+	return nil
+}
+
+func (m *Manager) loadQuotaExemptConfig(ctx context.Context, storage logical.Storage) error {
+	// Reload our toggle value.
 	entry, err := storage.Get(ctx, DefaultRateLimitExemptPathsToggle)
 	if err != nil {
 		return err
@@ -1066,22 +1105,7 @@ func (m *Manager) Setup(ctx context.Context, storage logical.Storage) error {
 		}
 	}
 
-	exemptPaths := defaultExemptPaths
-	if toggle {
-		exemptPaths = config.RateLimitExemptPaths
-	}
-
-	m.setEnableRateLimitAuditLoggingLocked(config.EnableRateLimitAuditLogging)
-	m.setEnableRateLimitResponseHeadersLocked(config.EnableRateLimitResponseHeaders)
-	m.setRateLimitExemptPathsLocked(exemptPaths)
-	if err = m.resetCache(); err != nil {
-		return err
-	}
-
-	for _, qType := range quotaTypes() {
-		m.setupQuotaType(ctx, storage, qType)
-	}
-
+	m.usingConfigExemptPaths.Store(toggle)
 	return nil
 }
 

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -1081,7 +1081,9 @@ func (m *Manager) Setup(ctx context.Context, storage logical.Storage) error {
 	}
 
 	for _, qType := range quotaTypes() {
-		m.setupQuotaType(ctx, storage, qType)
+		if err := m.setupQuotaType(ctx, storage, qType); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

    This now correctly handles invalidation of the rate limit exempt paths
    detection entry by checking our state on configuration writes and fully
    reloading the configuration on writes to this storage entry. Previously
    we'd ignore changes to this path which would cause a reload of the
    entire cluster which is excessive in this case.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
