### PR TITLE
Add Sys() API client helpers for namespaces

### DIFF
--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -5,10 +5,11 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // CreateNamespaceInput is the input for the CreateNamespace operation.
@@ -60,19 +61,13 @@ type PatchNamespaceResponse struct {
 	KeyShares      []string          `json:"key_shares"`
 }
 
-// ListNamespacesResponse is the response from the ListNamespaces operation.
-type ListNamespacesResponse struct {
-	Keys    []string                         `json:"keys"`
-	KeyInfo map[string]ReadNamespaceResponse `json:"key_info"`
-}
-
 // ListNamespaces lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespaces() (*ListNamespacesResponse, error) {
+func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {
 	return c.ListNamespacesWithContext(context.Background())
 }
 
 // ListNamespacesWithContext lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesResponse, error) {
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNamespaceResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -93,26 +88,34 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 		return nil, errors.New("data from server response is empty")
 	}
 
-	dataJSON, err := json.Marshal(secret.Data)
+	keyInfoRaw, ok := secret.Data["key_info"]
+	if !ok {
+		return map[string]ReadNamespaceResponse{}, nil
+	}
+
+	result := map[string]ReadNamespaceResponse{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &result,
+	})
 	if err != nil {
 		return nil, err
 	}
-	result := &ListNamespacesResponse{}
-	if err := json.Unmarshal(dataJSON, result); err != nil {
+	if err := decoder.Decode(keyInfoRaw); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-// CreateNamespace creates a new namespace at the given path.
-func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
-	return c.CreateNamespaceWithContext(context.Background(), path, i)
+// CreateNamespace creates a new namespace with the given name.
+func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	return c.CreateNamespaceWithContext(context.Background(), name, i)
 }
 
-// CreateNamespaceWithContext creates a new namespace at the given path.
-func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// CreateNamespaceWithContext creates a new namespace with the given name.
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 	if i == nil {
 		i = &CreateNamespaceInput{}
@@ -121,7 +124,7 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *Cr
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 	if err := r.SetJSONBody(i); err != nil {
 		return nil, err
 	}
@@ -141,15 +144,15 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *Cr
 	return result.Data, nil
 }
 
-// PatchNamespace updates the metadata of an existing namespace at the given path.
-func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
-	return c.PatchNamespaceWithContext(context.Background(), path, i)
+// PatchNamespace updates the metadata of an existing namespace with the given name.
+func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	return c.PatchNamespaceWithContext(context.Background(), name, i)
 }
 
-// PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
-func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// PatchNamespaceWithContext updates the metadata of an existing namespace with the given name.
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 	if i == nil {
 		return nil, errors.New("input must not be nil")
@@ -158,7 +161,7 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *Pat
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 	r.Headers.Set("Content-Type", "application/merge-patch+json")
 	if err := r.SetJSONBody(i); err != nil {
 		return nil, err
@@ -179,21 +182,21 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *Pat
 	return result.Data, nil
 }
 
-// DeleteNamespace removes the namespace at the given path.
-func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
-	return c.DeleteNamespaceWithContext(context.Background(), path)
+// DeleteNamespace removes the namespace with the given name.
+func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceResponse, error) {
+	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
-// DeleteNamespaceWithContext removes the namespace at the given path.
-func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// DeleteNamespaceWithContext removes the namespace with the given name.
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -210,21 +213,21 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*Del
 	return result.Data, nil
 }
 
-// ReadNamespace returns information about the namespace at the given path.
-func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
-	return c.ReadNamespaceWithContext(context.Background(), path)
+// ReadNamespace returns information about the namespace with the given name.
+func (c *Sys) ReadNamespace(name string) (*ReadNamespaceResponse, error) {
+	return c.ReadNamespaceWithContext(context.Background(), name)
 }
 
-// ReadNamespaceWithContext returns information about the namespace at the given path.
-func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// ReadNamespaceWithContext returns information about the namespace with the given name.
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// CreateNamespaceInput is the input for the CreateNamespace operation.
+type CreateNamespaceInput struct {
+	CustomMetadata map[string]string `json:"custom_metadata"`
+}
+
+// CreateNamespaceResponse is the response from the CreateNamespace operation.
+type CreateNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// ReadNamespaceResponse is the response from the ReadNamespace operation.
+type ReadNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// DeleteNamespaceResponse is the response from the DeleteNamespace operation.
+type DeleteNamespaceResponse struct {
+	Status string `json:"status"`
+}
+
+// PatchNamespaceInput is the input for the PatchNamespace operation.
+// CustomMetadata values can be nil to remove a key.
+type PatchNamespaceInput struct {
+	CustomMetadata map[string]interface{} `json:"custom_metadata"`
+}
+
+// PatchNamespaceResponse is the response from the PatchNamespace operation.
+type PatchNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// ListNamespacesResponse is the response from the ListNamespaces operation.
+type ListNamespacesResponse struct {
+	Keys    []string                         `json:"keys"`
+	KeyInfo map[string]ReadNamespaceResponse `json:"key_info"`
+}
+
+// ListNamespaces lists all child namespaces relative to the current namespace.
+func (c *Sys) ListNamespaces() (*ListNamespacesResponse, error) {
+	return c.ListNamespacesWithContext(context.Background())
+}
+
+// ListNamespacesWithContext lists all child namespaces relative to the current namespace.
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest("LIST", "/v1/sys/namespaces")
+	r.Method = http.MethodGet
+	r.Params.Set("list", "true")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	result := &ListNamespacesResponse{}
+	if err := mapstructure.Decode(secret.Data["keys"], &result.Keys); err != nil {
+		return nil, err
+	}
+
+	keyInfoJSON, err := json.Marshal(secret.Data["key_info"])
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(keyInfoJSON, &result.KeyInfo); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateNamespace creates a new namespace at the given path.
+func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	return c.CreateNamespaceWithContext(context.Background(), path, i)
+}
+
+// CreateNamespaceWithContext creates a new namespace at the given path.
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	if err := r.SetJSONBody(i); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *CreateNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// PatchNamespace updates the metadata of an existing namespace at the given path.
+func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	return c.PatchNamespaceWithContext(context.Background(), path, i)
+}
+
+// PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r.Headers.Set("Content-Type", "application/merge-patch+json")
+	if err := r.SetJSONBody(i); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *PatchNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// DeleteNamespace removes the namespace at the given path.
+func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
+	return c.DeleteNamespaceWithContext(context.Background(), path)
+}
+
+// DeleteNamespaceWithContext removes the namespace at the given path.
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *DeleteNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// ReadNamespace returns information about the namespace at the given path.
+func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
+	return c.ReadNamespaceWithContext(context.Background(), path)
+}
+
+// ReadNamespaceWithContext returns information about the namespace at the given path.
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *ReadNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -227,10 +227,15 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadN
 	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if resp != nil {
+		defer resp.Body.Close() //nolint:errcheck
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *ReadNamespaceResponse

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -17,41 +17,42 @@ type CreateNamespaceInput struct {
 	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
-// CreateNamespaceResponse is the response from the CreateNamespace operation.
-type CreateNamespaceResponse struct {
+// PatchNamespaceInput is the input for the PatchNamespace operation.
+// CustomMetadata values can be string to add or modify a key, or nil to remove
+// a key.
+type PatchNamespaceInput struct {
+	CustomMetadata map[string]interface{} `json:"custom_metadata"`
+}
+
+// NamespaceOutput is returned by ReadNamespace, PatchNamespace and ListNamespaces.
+type NamespaceOutput struct {
 	UUID           string            `json:"uuid"`
 	ID             string            `json:"id"`
 	Path           string            `json:"path"`
 	Tainted        bool              `json:"tainted"`
 	Locked         bool              `json:"locked"`
 	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
 }
 
-// ReadNamespaceResponse is the response from the ReadNamespace operation.
-type ReadNamespaceResponse = CreateNamespaceResponse
+// CreateNamespaceOutput is returned by CreateNamespace and extends NamespaceOutput
+// with the key shares generated at creation time.
+type CreateNamespaceOutput struct {
+	NamespaceOutput
+	KeyShares []string `json:"key_shares"`
+}
 
-// DeleteNamespaceResponse is the response from the DeleteNamespace operation.
-type DeleteNamespaceResponse struct {
+// DeleteNamespaceOutput is returned by DeleteNamespace.
+type DeleteNamespaceOutput struct {
 	Status string `json:"status"`
 }
 
-// PatchNamespaceInput is the input for the PatchNamespace operation.
-// CustomMetadata values can be nil to remove a key.
-type PatchNamespaceInput struct {
-	CustomMetadata map[string]interface{} `json:"custom_metadata"`
-}
-
-// PatchNamespaceResponse is the response from the PatchNamespace operation.
-type PatchNamespaceResponse = CreateNamespaceResponse
-
 // ListNamespaces lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {
+func (c *Sys) ListNamespaces() (map[string]*NamespaceOutput, error) {
 	return c.ListNamespacesWithContext(context.Background())
 }
 
 // ListNamespacesWithContext lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNamespaceResponse, error) {
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*NamespaceOutput, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -74,10 +75,10 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNam
 
 	keyInfoRaw, ok := secret.Data["key_info"]
 	if !ok {
-		return map[string]ReadNamespaceResponse{}, nil
+		return map[string]*NamespaceOutput{}, nil
 	}
 
-	result := map[string]ReadNamespaceResponse{}
+	result := map[string]*NamespaceOutput{}
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "json",
 		Result:  &result,
@@ -92,12 +93,12 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNam
 }
 
 // CreateNamespace creates a new namespace with the given name.
-func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceOutput, error) {
 	return c.CreateNamespaceWithContext(context.Background(), name, i)
 }
 
 // CreateNamespaceWithContext creates a new namespace with the given name.
-func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -120,7 +121,7 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *Cr
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *CreateNamespaceResponse
+		Data *CreateNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -129,12 +130,12 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *Cr
 }
 
 // PatchNamespace updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
 	return c.PatchNamespaceWithContext(context.Background(), name, i)
 }
 
 // PatchNamespaceWithContext updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -158,7 +159,7 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *PatchNamespaceResponse
+		Data *NamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -167,12 +168,12 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 }
 
 // DeleteNamespace removes the namespace with the given name.
-func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceResponse, error) {
+func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceOutput, error) {
 	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
 // DeleteNamespaceWithContext removes the namespace with the given name.
-func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceResponse, error) {
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -189,7 +190,7 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*Del
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *DeleteNamespaceResponse
+		Data *DeleteNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -198,12 +199,12 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*Del
 }
 
 // ReadNamespace returns information about the namespace with the given name.
-func (c *Sys) ReadNamespace(name string) (*ReadNamespaceResponse, error) {
+func (c *Sys) ReadNamespace(name string) (*NamespaceOutput, error) {
 	return c.ReadNamespaceWithContext(context.Background(), name)
 }
 
 // ReadNamespaceWithContext returns information about the namespace with the given name.
-func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadNamespaceResponse, error) {
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*NamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -225,7 +226,7 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadN
 	}
 
 	var result struct {
-		Data *ReadNamespaceResponse
+		Data *NamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -29,15 +29,7 @@ type CreateNamespaceResponse struct {
 }
 
 // ReadNamespaceResponse is the response from the ReadNamespace operation.
-type ReadNamespaceResponse struct {
-	UUID           string            `json:"uuid"`
-	ID             string            `json:"id"`
-	Path           string            `json:"path"`
-	Tainted        bool              `json:"tainted"`
-	Locked         bool              `json:"locked"`
-	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
-}
+type ReadNamespaceResponse = CreateNamespaceResponse
 
 // DeleteNamespaceResponse is the response from the DeleteNamespace operation.
 type DeleteNamespaceResponse struct {
@@ -51,15 +43,7 @@ type PatchNamespaceInput struct {
 }
 
 // PatchNamespaceResponse is the response from the PatchNamespace operation.
-type PatchNamespaceResponse struct {
-	UUID           string            `json:"uuid"`
-	ID             string            `json:"id"`
-	Path           string            `json:"path"`
-	Tainted        bool              `json:"tainted"`
-	Locked         bool              `json:"locked"`
-	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
-}
+type PatchNamespaceResponse = CreateNamespaceResponse
 
 // ListNamespaces lists all child namespaces relative to the current namespace.
 func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-
-	"github.com/go-viper/mapstructure/v2"
 )
 
 // CreateNamespaceInput is the input for the CreateNamespace operation.
@@ -78,8 +76,7 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest("LIST", "/v1/sys/namespaces")
-	r.Method = http.MethodGet
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/namespaces/")
 	r.Params.Set("list", "true")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
@@ -96,16 +93,12 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 		return nil, errors.New("data from server response is empty")
 	}
 
-	result := &ListNamespacesResponse{}
-	if err := mapstructure.Decode(secret.Data["keys"], &result.Keys); err != nil {
-		return nil, err
-	}
-
-	keyInfoJSON, err := json.Marshal(secret.Data["key_info"])
+	dataJSON, err := json.Marshal(secret.Data)
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(keyInfoJSON, &result.KeyInfo); err != nil {
+	result := &ListNamespacesResponse{}
+	if err := json.Unmarshal(dataJSON, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -118,6 +111,13 @@ func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateName
 
 // CreateNamespaceWithContext creates a new namespace at the given path.
 func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+	if i == nil {
+		i = &CreateNamespaceInput{}
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -148,6 +148,13 @@ func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespa
 
 // PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
 func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+	if i == nil {
+		return nil, errors.New("input must not be nil")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -179,6 +186,10 @@ func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
 
 // DeleteNamespaceWithContext removes the namespace at the given path.
 func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -206,6 +217,10 @@ func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
 
 // ReadNamespaceWithContext returns information about the namespace at the given path.
 func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -80,6 +80,17 @@ type CreateNamespaceInput struct {
 	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
+// CreateNamespaceOutput is returned by CreateNamespace.
+type CreateNamespaceOutput struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
 // PatchNamespaceInput is the input for the PatchNamespace operation.
 // CustomMetadata values can be string to add or modify a key, or nil to remove
 // a key.
@@ -87,8 +98,8 @@ type PatchNamespaceInput struct {
 	CustomMetadata map[string]interface{} `json:"custom_metadata"`
 }
 
-// NamespaceOutput is returned by ReadNamespace, PatchNamespace and ListNamespaces.
-type NamespaceOutput struct {
+// PatchNamespaceOutput is returned by PatchNamespace.
+type PatchNamespaceOutput struct {
 	UUID           string            `json:"uuid"`
 	ID             string            `json:"id"`
 	Path           string            `json:"path"`
@@ -97,11 +108,14 @@ type NamespaceOutput struct {
 	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
-// CreateNamespaceOutput is returned by CreateNamespace and extends NamespaceOutput
-// with the key shares generated at creation time.
-type CreateNamespaceOutput struct {
-	NamespaceOutput
-	KeyShares []string `json:"key_shares"`
+// ReadNamespaceOutput is returned by ReadNamespace.
+type ReadNamespaceOutput struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
 // DeleteNamespaceOutput is returned by DeleteNamespace.
@@ -109,13 +123,23 @@ type DeleteNamespaceOutput struct {
 	Status string `json:"status"`
 }
 
+// ListNamespaceOutput is returned by ListNamespaces for each namespace entry.
+type ListNamespaceOutput struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+}
+
 // ListNamespaces lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespaces() (map[string]*NamespaceOutput, error) {
+func (c *Sys) ListNamespaces() (map[string]*ListNamespaceOutput, error) {
 	return c.ListNamespacesWithContext(context.Background())
 }
 
 // ListNamespacesWithContext lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*NamespaceOutput, error) {
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*ListNamespaceOutput, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -138,10 +162,10 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*Namesp
 
 	keyInfoRaw, ok := secret.Data["key_info"]
 	if !ok {
-		return map[string]*NamespaceOutput{}, nil
+		return map[string]*ListNamespaceOutput{}, nil
 	}
 
-	result := map[string]*NamespaceOutput{}
+	result := map[string]*ListNamespaceOutput{}
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "json",
 		Result:  &result,
@@ -193,12 +217,12 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *Cr
 }
 
 // PatchNamespace updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
+func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*PatchNamespaceOutput, error) {
 	return c.PatchNamespaceWithContext(context.Background(), name, i)
 }
 
 // PatchNamespaceWithContext updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*PatchNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -222,7 +246,7 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *NamespaceOutput
+		Data *PatchNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -262,12 +286,12 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*Del
 }
 
 // ReadNamespace returns information about the namespace with the given name.
-func (c *Sys) ReadNamespace(name string) (*NamespaceOutput, error) {
+func (c *Sys) ReadNamespace(name string) (*ReadNamespaceOutput, error) {
 	return c.ReadNamespaceWithContext(context.Background(), name)
 }
 
 // ReadNamespaceWithContext returns information about the namespace with the given name.
-func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*NamespaceOutput, error) {
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -289,7 +313,7 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*Names
 	}
 
 	var result struct {
-		Data *NamespaceOutput
+		Data *ReadNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -1,9 +1,16 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type UnsealNamespaceInput struct {
@@ -67,4 +74,217 @@ func (c *Sys) SealNamespaceWithContext(ctx context.Context, name string) error {
 		return err
 	}
 	return nil
+}
+
+// CreateNamespaceInput is the input for the CreateNamespace operation.
+type CreateNamespaceInput struct {
+	CustomMetadata map[string]string `json:"custom_metadata"`
+}
+
+// CreateNamespaceResponse is the response from the CreateNamespace operation.
+type CreateNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// ReadNamespaceResponse is the response from the ReadNamespace operation.
+type ReadNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// DeleteNamespaceResponse is the response from the DeleteNamespace operation.
+type DeleteNamespaceResponse struct {
+	Status string `json:"status"`
+}
+
+// PatchNamespaceInput is the input for the PatchNamespace operation.
+// CustomMetadata values can be nil to remove a key.
+type PatchNamespaceInput struct {
+	CustomMetadata map[string]interface{} `json:"custom_metadata"`
+}
+
+// PatchNamespaceResponse is the response from the PatchNamespace operation.
+type PatchNamespaceResponse struct {
+	UUID           string            `json:"uuid"`
+	ID             string            `json:"id"`
+	Path           string            `json:"path"`
+	Tainted        bool              `json:"tainted"`
+	Locked         bool              `json:"locked"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+	KeyShares      []string          `json:"key_shares"`
+}
+
+// ListNamespacesResponse is the response from the ListNamespaces operation.
+type ListNamespacesResponse struct {
+	Keys    []string                         `json:"keys"`
+	KeyInfo map[string]ReadNamespaceResponse `json:"key_info"`
+}
+
+// ListNamespaces lists all child namespaces relative to the current namespace.
+func (c *Sys) ListNamespaces() (*ListNamespacesResponse, error) {
+	return c.ListNamespacesWithContext(context.Background())
+}
+
+// ListNamespacesWithContext lists all child namespaces relative to the current namespace.
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest("LIST", "/v1/sys/namespaces")
+	r.Method = http.MethodGet
+	r.Params.Set("list", "true")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	result := &ListNamespacesResponse{}
+	if err := mapstructure.Decode(secret.Data["keys"], &result.Keys); err != nil {
+		return nil, err
+	}
+
+	keyInfoJSON, err := json.Marshal(secret.Data["key_info"])
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(keyInfoJSON, &result.KeyInfo); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateNamespace creates a new namespace at the given path.
+func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	return c.CreateNamespaceWithContext(context.Background(), path, i)
+}
+
+// CreateNamespaceWithContext creates a new namespace at the given path.
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	if err := r.SetJSONBody(i); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *CreateNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// PatchNamespace updates the metadata of an existing namespace at the given path.
+func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	return c.PatchNamespaceWithContext(context.Background(), path, i)
+}
+
+// PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r.Headers.Set("Content-Type", "application/merge-patch+json")
+	if err := r.SetJSONBody(i); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *PatchNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// DeleteNamespace removes the namespace at the given path.
+func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
+	return c.DeleteNamespaceWithContext(context.Background(), path)
+}
+
+// DeleteNamespaceWithContext removes the namespace at the given path.
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *DeleteNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// ReadNamespace returns information about the namespace at the given path.
+func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
+	return c.ReadNamespaceWithContext(context.Background(), path)
+}
+
+// ReadNamespaceWithContext returns information about the namespace at the given path.
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *ReadNamespaceResponse
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Data, nil
 }

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -92,15 +92,7 @@ type CreateNamespaceResponse struct {
 }
 
 // ReadNamespaceResponse is the response from the ReadNamespace operation.
-type ReadNamespaceResponse struct {
-	UUID           string            `json:"uuid"`
-	ID             string            `json:"id"`
-	Path           string            `json:"path"`
-	Tainted        bool              `json:"tainted"`
-	Locked         bool              `json:"locked"`
-	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
-}
+type ReadNamespaceResponse = CreateNamespaceResponse
 
 // DeleteNamespaceResponse is the response from the DeleteNamespace operation.
 type DeleteNamespaceResponse struct {
@@ -114,15 +106,7 @@ type PatchNamespaceInput struct {
 }
 
 // PatchNamespaceResponse is the response from the PatchNamespace operation.
-type PatchNamespaceResponse struct {
-	UUID           string            `json:"uuid"`
-	ID             string            `json:"id"`
-	Path           string            `json:"path"`
-	Tainted        bool              `json:"tainted"`
-	Locked         bool              `json:"locked"`
-	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
-}
+type PatchNamespaceResponse = CreateNamespaceResponse
 
 // ListNamespaces lists all child namespaces relative to the current namespace.
 func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -78,6 +78,11 @@ func (c *Sys) SealNamespaceWithContext(ctx context.Context, name string) error {
 // CreateNamespaceInput is the input for the CreateNamespace operation.
 type CreateNamespaceInput struct {
 	CustomMetadata map[string]string `json:"custom_metadata"`
+	// Seal is a HCL string with exactly one seal stanza, e.g.:
+	//   seal "shamir" { shares = 5 threshold = 3 }
+	// If empty the namespace is not sealable.
+	Seal    string   `json:"seal,omitempty"`
+	PGPKeys []string `json:"pgp_keys,omitempty"`
 }
 
 // CreateNamespaceOutput is returned by CreateNamespace.

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -80,41 +80,42 @@ type CreateNamespaceInput struct {
 	CustomMetadata map[string]string `json:"custom_metadata"`
 }
 
-// CreateNamespaceResponse is the response from the CreateNamespace operation.
-type CreateNamespaceResponse struct {
+// PatchNamespaceInput is the input for the PatchNamespace operation.
+// CustomMetadata values can be string to add or modify a key, or nil to remove
+// a key.
+type PatchNamespaceInput struct {
+	CustomMetadata map[string]interface{} `json:"custom_metadata"`
+}
+
+// NamespaceOutput is returned by ReadNamespace, PatchNamespace and ListNamespaces.
+type NamespaceOutput struct {
 	UUID           string            `json:"uuid"`
 	ID             string            `json:"id"`
 	Path           string            `json:"path"`
 	Tainted        bool              `json:"tainted"`
 	Locked         bool              `json:"locked"`
 	CustomMetadata map[string]string `json:"custom_metadata"`
-	KeyShares      []string          `json:"key_shares"`
 }
 
-// ReadNamespaceResponse is the response from the ReadNamespace operation.
-type ReadNamespaceResponse = CreateNamespaceResponse
+// CreateNamespaceOutput is returned by CreateNamespace and extends NamespaceOutput
+// with the key shares generated at creation time.
+type CreateNamespaceOutput struct {
+	NamespaceOutput
+	KeyShares []string `json:"key_shares"`
+}
 
-// DeleteNamespaceResponse is the response from the DeleteNamespace operation.
-type DeleteNamespaceResponse struct {
+// DeleteNamespaceOutput is returned by DeleteNamespace.
+type DeleteNamespaceOutput struct {
 	Status string `json:"status"`
 }
 
-// PatchNamespaceInput is the input for the PatchNamespace operation.
-// CustomMetadata values can be nil to remove a key.
-type PatchNamespaceInput struct {
-	CustomMetadata map[string]interface{} `json:"custom_metadata"`
-}
-
-// PatchNamespaceResponse is the response from the PatchNamespace operation.
-type PatchNamespaceResponse = CreateNamespaceResponse
-
 // ListNamespaces lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {
+func (c *Sys) ListNamespaces() (map[string]*NamespaceOutput, error) {
 	return c.ListNamespacesWithContext(context.Background())
 }
 
 // ListNamespacesWithContext lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNamespaceResponse, error) {
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]*NamespaceOutput, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -137,10 +138,10 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNam
 
 	keyInfoRaw, ok := secret.Data["key_info"]
 	if !ok {
-		return map[string]ReadNamespaceResponse{}, nil
+		return map[string]*NamespaceOutput{}, nil
 	}
 
-	result := map[string]ReadNamespaceResponse{}
+	result := map[string]*NamespaceOutput{}
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "json",
 		Result:  &result,
@@ -155,12 +156,12 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNam
 }
 
 // CreateNamespace creates a new namespace with the given name.
-func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceOutput, error) {
 	return c.CreateNamespaceWithContext(context.Background(), name, i)
 }
 
 // CreateNamespaceWithContext creates a new namespace with the given name.
-func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -183,7 +184,7 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *Cr
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *CreateNamespaceResponse
+		Data *CreateNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -192,12 +193,12 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *Cr
 }
 
 // PatchNamespace updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
 	return c.PatchNamespaceWithContext(context.Background(), name, i)
 }
 
 // PatchNamespaceWithContext updates the metadata of an existing namespace with the given name.
-func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*NamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -221,7 +222,7 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *PatchNamespaceResponse
+		Data *NamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -230,12 +231,12 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 }
 
 // DeleteNamespace removes the namespace with the given name.
-func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceResponse, error) {
+func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceOutput, error) {
 	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
 // DeleteNamespaceWithContext removes the namespace with the given name.
-func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceResponse, error) {
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -252,7 +253,7 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*Del
 	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
-		Data *DeleteNamespaceResponse
+		Data *DeleteNamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err
@@ -261,12 +262,12 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*Del
 }
 
 // ReadNamespace returns information about the namespace with the given name.
-func (c *Sys) ReadNamespace(name string) (*ReadNamespaceResponse, error) {
+func (c *Sys) ReadNamespace(name string) (*NamespaceOutput, error) {
 	return c.ReadNamespaceWithContext(context.Background(), name)
 }
 
 // ReadNamespaceWithContext returns information about the namespace with the given name.
-func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadNamespaceResponse, error) {
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*NamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}
@@ -288,7 +289,7 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadN
 	}
 
 	var result struct {
-		Data *ReadNamespaceResponse
+		Data *NamespaceOutput
 	}
 	if err := resp.DecodeJSON(&result); err != nil {
 		return nil, err

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -5,10 +5,11 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type UnsealNamespaceInput struct {
@@ -123,19 +124,13 @@ type PatchNamespaceResponse struct {
 	KeyShares      []string          `json:"key_shares"`
 }
 
-// ListNamespacesResponse is the response from the ListNamespaces operation.
-type ListNamespacesResponse struct {
-	Keys    []string                         `json:"keys"`
-	KeyInfo map[string]ReadNamespaceResponse `json:"key_info"`
-}
-
 // ListNamespaces lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespaces() (*ListNamespacesResponse, error) {
+func (c *Sys) ListNamespaces() (map[string]ReadNamespaceResponse, error) {
 	return c.ListNamespacesWithContext(context.Background())
 }
 
 // ListNamespacesWithContext lists all child namespaces relative to the current namespace.
-func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesResponse, error) {
+func (c *Sys) ListNamespacesWithContext(ctx context.Context) (map[string]ReadNamespaceResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -156,26 +151,34 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 		return nil, errors.New("data from server response is empty")
 	}
 
-	dataJSON, err := json.Marshal(secret.Data)
+	keyInfoRaw, ok := secret.Data["key_info"]
+	if !ok {
+		return map[string]ReadNamespaceResponse{}, nil
+	}
+
+	result := map[string]ReadNamespaceResponse{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &result,
+	})
 	if err != nil {
 		return nil, err
 	}
-	result := &ListNamespacesResponse{}
-	if err := json.Unmarshal(dataJSON, result); err != nil {
+	if err := decoder.Decode(keyInfoRaw); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-// CreateNamespace creates a new namespace at the given path.
-func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
-	return c.CreateNamespaceWithContext(context.Background(), path, i)
+// CreateNamespace creates a new namespace with the given name.
+func (c *Sys) CreateNamespace(name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	return c.CreateNamespaceWithContext(context.Background(), name, i)
 }
 
-// CreateNamespaceWithContext creates a new namespace at the given path.
-func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// CreateNamespaceWithContext creates a new namespace with the given name.
+func (c *Sys) CreateNamespaceWithContext(ctx context.Context, name string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 	if i == nil {
 		i = &CreateNamespaceInput{}
@@ -184,7 +187,7 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *Cr
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 	if err := r.SetJSONBody(i); err != nil {
 		return nil, err
 	}
@@ -204,15 +207,15 @@ func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *Cr
 	return result.Data, nil
 }
 
-// PatchNamespace updates the metadata of an existing namespace at the given path.
-func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
-	return c.PatchNamespaceWithContext(context.Background(), path, i)
+// PatchNamespace updates the metadata of an existing namespace with the given name.
+func (c *Sys) PatchNamespace(name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	return c.PatchNamespaceWithContext(context.Background(), name, i)
 }
 
-// PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
-func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// PatchNamespaceWithContext updates the metadata of an existing namespace with the given name.
+func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 	if i == nil {
 		return nil, errors.New("input must not be nil")
@@ -221,7 +224,7 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *Pat
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodPatch, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 	r.Headers.Set("Content-Type", "application/merge-patch+json")
 	if err := r.SetJSONBody(i); err != nil {
 		return nil, err
@@ -242,21 +245,21 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *Pat
 	return result.Data, nil
 }
 
-// DeleteNamespace removes the namespace at the given path.
-func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
-	return c.DeleteNamespaceWithContext(context.Background(), path)
+// DeleteNamespace removes the namespace with the given name.
+func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceResponse, error) {
+	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
-// DeleteNamespaceWithContext removes the namespace at the given path.
-func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// DeleteNamespaceWithContext removes the namespace with the given name.
+func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -273,21 +276,21 @@ func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*Del
 	return result.Data, nil
 }
 
-// ReadNamespace returns information about the namespace at the given path.
-func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
-	return c.ReadNamespaceWithContext(context.Background(), path)
+// ReadNamespace returns information about the namespace with the given name.
+func (c *Sys) ReadNamespace(name string) (*ReadNamespaceResponse, error) {
+	return c.ReadNamespaceWithContext(context.Background(), name)
 }
 
-// ReadNamespaceWithContext returns information about the namespace at the given path.
-func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
-	if path == "" {
-		return nil, errors.New("path must not be empty")
+// ReadNamespaceWithContext returns information about the namespace with the given name.
+func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadNamespaceResponse, error) {
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
 
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -290,10 +290,15 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadN
 	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/namespaces/%s", path))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if resp != nil {
+		defer resp.Body.Close() //nolint:errcheck
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
 
 	var result struct {
 		Data *ReadNamespaceResponse

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-
-	"github.com/go-viper/mapstructure/v2"
 )
 
 type UnsealNamespaceInput struct {
@@ -141,8 +139,7 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest("LIST", "/v1/sys/namespaces")
-	r.Method = http.MethodGet
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/namespaces/")
 	r.Params.Set("list", "true")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
@@ -159,16 +156,12 @@ func (c *Sys) ListNamespacesWithContext(ctx context.Context) (*ListNamespacesRes
 		return nil, errors.New("data from server response is empty")
 	}
 
-	result := &ListNamespacesResponse{}
-	if err := mapstructure.Decode(secret.Data["keys"], &result.Keys); err != nil {
-		return nil, err
-	}
-
-	keyInfoJSON, err := json.Marshal(secret.Data["key_info"])
+	dataJSON, err := json.Marshal(secret.Data)
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(keyInfoJSON, &result.KeyInfo); err != nil {
+	result := &ListNamespacesResponse{}
+	if err := json.Unmarshal(dataJSON, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -181,6 +174,13 @@ func (c *Sys) CreateNamespace(path string, i *CreateNamespaceInput) (*CreateName
 
 // CreateNamespaceWithContext creates a new namespace at the given path.
 func (c *Sys) CreateNamespaceWithContext(ctx context.Context, path string, i *CreateNamespaceInput) (*CreateNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+	if i == nil {
+		i = &CreateNamespaceInput{}
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -211,6 +211,13 @@ func (c *Sys) PatchNamespace(path string, i *PatchNamespaceInput) (*PatchNamespa
 
 // PatchNamespaceWithContext updates the metadata of an existing namespace at the given path.
 func (c *Sys) PatchNamespaceWithContext(ctx context.Context, path string, i *PatchNamespaceInput) (*PatchNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+	if i == nil {
+		return nil, errors.New("input must not be nil")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -242,6 +249,10 @@ func (c *Sys) DeleteNamespace(path string) (*DeleteNamespaceResponse, error) {
 
 // DeleteNamespaceWithContext removes the namespace at the given path.
 func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, path string) (*DeleteNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -269,6 +280,10 @@ func (c *Sys) ReadNamespace(path string) (*ReadNamespaceResponse, error) {
 
 // ReadNamespaceWithContext returns information about the namespace at the given path.
 func (c *Sys) ReadNamespaceWithContext(ctx context.Context, path string) (*ReadNamespaceResponse, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -72,34 +72,36 @@ func TestCreateNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
 		input    CreateNamespaceInput
-		expected CreateNamespaceResponse
+		expected CreateNamespaceOutput
 	}{
 		"namespace with custom metadata": {
 			body: createNamespaceResponse,
 			input: CreateNamespaceInput{
 				CustomMetadata: map[string]string{"env": "prod"},
 			},
-			expected: CreateNamespaceResponse{
-				UUID:           "abc123",
-				ID:             "ns1",
-				Path:           "ns1/",
-				Tainted:        false,
-				Locked:         false,
-				CustomMetadata: map[string]string{"env": "prod"},
-				KeyShares:      nil,
+			expected: CreateNamespaceOutput{
+				NamespaceOutput: NamespaceOutput{
+					UUID:           "abc123",
+					ID:             "ns1",
+					Path:           "ns1/",
+					Tainted:        false,
+					Locked:         false,
+					CustomMetadata: map[string]string{"env": "prod"},
+				},
 			},
 		},
 		"namespace without custom metadata": {
 			body:  createNamespaceResponseNoMetadata,
 			input: CreateNamespaceInput{},
-			expected: CreateNamespaceResponse{
-				UUID:           "def456",
-				ID:             "ns2",
-				Path:           "ns2/",
-				Tainted:        false,
-				Locked:         false,
-				CustomMetadata: nil,
-				KeyShares:      nil,
+			expected: CreateNamespaceOutput{
+				NamespaceOutput: NamespaceOutput{
+					UUID:           "def456",
+					ID:             "ns2",
+					Path:           "ns2/",
+					Tainted:        false,
+					Locked:         false,
+					CustomMetadata: nil,
+				},
 			},
 		},
 	} {
@@ -129,42 +131,36 @@ func TestCreateNamespace(t *testing.T) {
 func TestReadNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
-		expected ReadNamespaceResponse
+		expected NamespaceOutput
 	}{
 		"existing namespace": {
 			body: readNamespaceResponse,
-			expected: ReadNamespaceResponse{
+			expected: NamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
 				Tainted:        false,
 				Locked:         false,
 				CustomMetadata: map[string]string{"env": "prod"},
-				KeyShares:      nil,
 			},
 		},
 		"tainted namespace": {
 			body: readNamespaceTaintedResponse,
-			expected: ReadNamespaceResponse{
-				UUID:           "abc123",
-				ID:             "ns1",
-				Path:           "ns1/",
-				Tainted:        true,
-				Locked:         false,
-				CustomMetadata: nil,
-				KeyShares:      nil,
+			expected: NamespaceOutput{
+				UUID:    "abc123",
+				ID:      "ns1",
+				Path:    "ns1/",
+				Tainted: true,
+				Locked:  false,
 			},
 		},
 		"locked namespace": {
 			body: readNamespaceLockedResponse,
-			expected: ReadNamespaceResponse{
-				UUID:           "abc123",
-				ID:             "ns1",
-				Path:           "ns1/",
-				Tainted:        false,
-				Locked:         true,
-				CustomMetadata: nil,
-				KeyShares:      nil,
+			expected: NamespaceOutput{
+				UUID:   "abc123",
+				ID:     "ns1",
+				Path:   "ns1/",
+				Locked: true,
 			},
 		},
 	} {
@@ -195,21 +191,18 @@ func TestPatchNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
 		input    PatchNamespaceInput
-		expected PatchNamespaceResponse
+		expected NamespaceOutput
 	}{
 		"add metadata key": {
 			body: patchNamespaceResponse,
 			input: PatchNamespaceInput{
 				CustomMetadata: map[string]interface{}{"env": "staging"},
 			},
-			expected: PatchNamespaceResponse{
+			expected: NamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
-				Tainted:        false,
-				Locked:         false,
 				CustomMetadata: map[string]string{"env": "staging"},
-				KeyShares:      nil,
 			},
 		},
 		"remove metadata key": {
@@ -217,14 +210,11 @@ func TestPatchNamespace(t *testing.T) {
 			input: PatchNamespaceInput{
 				CustomMetadata: map[string]interface{}{"env": nil},
 			},
-			expected: PatchNamespaceResponse{
+			expected: NamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
-				Tainted:        false,
-				Locked:         false,
 				CustomMetadata: map[string]string{"env": "staging"},
-				KeyShares:      nil,
 			},
 		},
 	} {
@@ -287,26 +277,21 @@ func TestDeleteNamespace(t *testing.T) {
 func TestListNamespaces(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
-		expected map[string]ReadNamespaceResponse
+		expected map[string]*NamespaceOutput
 	}{
 		"multiple namespaces": {
 			body: listNamespacesResponse,
-			expected: map[string]ReadNamespaceResponse{
+			expected: map[string]*NamespaceOutput{
 				"ns1/": {
 					UUID:           "abc123",
 					ID:             "ns1",
 					Path:           "ns1/",
-					Tainted:        false,
-					Locked:         false,
 					CustomMetadata: map[string]string{"env": "prod"},
 				},
 				"ns2/": {
-					UUID:           "def456",
-					ID:             "ns2",
-					Path:           "ns2/",
-					Tainted:        false,
-					Locked:         false,
-					CustomMetadata: nil,
+					UUID: "def456",
+					ID:   "ns2",
+					Path: "ns2/",
 				},
 			},
 		},

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -1,0 +1,439 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// mockNamespaceHandler returns an HTTP handler that writes the given body.
+func mockNamespaceHandler(body string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestCreateNamespace(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body     string
+		input    CreateNamespaceInput
+		expected CreateNamespaceResponse
+	}{
+		"namespace with custom metadata": {
+			body: createNamespaceResponse,
+			input: CreateNamespaceInput{
+				CustomMetadata: map[string]string{"env": "prod"},
+			},
+			expected: CreateNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: map[string]string{"env": "prod"},
+				KeyShares:      nil,
+			},
+		},
+		"namespace without custom metadata": {
+			body:  createNamespaceResponseNoMetadata,
+			input: CreateNamespaceInput{},
+			expected: CreateNamespaceResponse{
+				UUID:           "def456",
+				ID:             "ns2",
+				Path:           "ns2/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: nil,
+				KeyShares:      nil,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(mockNamespaceHandler(tc.body)))
+			defer mockServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Sys().CreateNamespaceWithContext(t.Context(), "ns1", &tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.expected, *resp) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, *resp)
+			}
+		})
+	}
+}
+
+func TestReadNamespace(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body     string
+		expected ReadNamespaceResponse
+	}{
+		"existing namespace": {
+			body: readNamespaceResponse,
+			expected: ReadNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: map[string]string{"env": "prod"},
+				KeyShares:      nil,
+			},
+		},
+		"tainted namespace": {
+			body: readNamespaceTaintedResponse,
+			expected: ReadNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        true,
+				Locked:         false,
+				CustomMetadata: nil,
+				KeyShares:      nil,
+			},
+		},
+		"locked namespace": {
+			body: readNamespaceLockedResponse,
+			expected: ReadNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         true,
+				CustomMetadata: nil,
+				KeyShares:      nil,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(mockNamespaceHandler(tc.body)))
+			defer mockServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Sys().ReadNamespaceWithContext(t.Context(), "ns1")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.expected, *resp) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, *resp)
+			}
+		})
+	}
+}
+
+func TestPatchNamespace(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body     string
+		input    PatchNamespaceInput
+		expected PatchNamespaceResponse
+	}{
+		"add metadata key": {
+			body: patchNamespaceResponse,
+			input: PatchNamespaceInput{
+				CustomMetadata: map[string]interface{}{"env": "staging"},
+			},
+			expected: PatchNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: map[string]string{"env": "staging"},
+				KeyShares:      nil,
+			},
+		},
+		"remove metadata key": {
+			body: patchNamespaceResponse,
+			input: PatchNamespaceInput{
+				CustomMetadata: map[string]interface{}{"env": nil},
+			},
+			expected: PatchNamespaceResponse{
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: map[string]string{"env": "staging"},
+				KeyShares:      nil,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(mockNamespaceHandler(tc.body)))
+			defer mockServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Sys().PatchNamespaceWithContext(t.Context(), "ns1", &tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.expected, *resp) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, *resp)
+			}
+		})
+	}
+}
+
+func TestDeleteNamespace(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body           string
+		expectedStatus string
+	}{
+		"successful delete": {
+			body:           deleteNamespaceResponse,
+			expectedStatus: "deleting",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(mockNamespaceHandler(tc.body)))
+			defer mockServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Sys().DeleteNamespaceWithContext(t.Context(), "ns1")
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if resp.Status != tc.expectedStatus {
+				t.Errorf("expected status %q but got %q", tc.expectedStatus, resp.Status)
+			}
+		})
+	}
+}
+
+func TestListNamespaces(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body     string
+		expected ListNamespacesResponse
+	}{
+		"multiple namespaces": {
+			body: listNamespacesResponse,
+			expected: ListNamespacesResponse{
+				Keys: []string{"ns1/", "ns2/"},
+				KeyInfo: map[string]ReadNamespaceResponse{
+					"ns1/": {
+						UUID:           "abc123",
+						ID:             "ns1",
+						Path:           "ns1/",
+						Tainted:        false,
+						Locked:         false,
+						CustomMetadata: map[string]string{"env": "prod"},
+					},
+					"ns2/": {
+						UUID:           "def456",
+						ID:             "ns2",
+						Path:           "ns2/",
+						Tainted:        false,
+						Locked:         false,
+						CustomMetadata: nil,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(mockNamespaceHandler(tc.body)))
+			defer mockServer.Close()
+
+			cfg := DefaultConfig()
+			cfg.Address = mockServer.URL
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Sys().ListNamespacesWithContext(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.expected, *resp) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, *resp)
+			}
+		})
+	}
+}
+
+const createNamespaceResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "abc123",
+		"id": "ns1",
+		"path": "ns1/",
+		"tainted": false,
+		"locked": false,
+		"custom_metadata": {"env": "prod"}
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const createNamespaceResponseNoMetadata = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "def456",
+		"id": "ns2",
+		"path": "ns2/",
+		"tainted": false,
+		"locked": false,
+		"custom_metadata": null
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const readNamespaceResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "abc123",
+		"id": "ns1",
+		"path": "ns1/",
+		"tainted": false,
+		"locked": false,
+		"custom_metadata": {"env": "prod"}
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const readNamespaceTaintedResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "abc123",
+		"id": "ns1",
+		"path": "ns1/",
+		"tainted": true,
+		"locked": false,
+		"custom_metadata": null
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const readNamespaceLockedResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "abc123",
+		"id": "ns1",
+		"path": "ns1/",
+		"tainted": false,
+		"locked": true,
+		"custom_metadata": null
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const patchNamespaceResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"uuid": "abc123",
+		"id": "ns1",
+		"path": "ns1/",
+		"tainted": false,
+		"locked": false,
+		"custom_metadata": {"env": "staging"}
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const deleteNamespaceResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"status": "deleting"
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`
+
+const listNamespacesResponse = `{
+	"request_id": "abc",
+	"lease_id": "",
+	"renewable": false,
+	"lease_duration": 0,
+	"data": {
+		"keys": ["ns1/", "ns2/"],
+		"key_info": {
+			"ns1/": {
+				"uuid": "abc123",
+				"id": "ns1",
+				"path": "ns1/",
+				"tainted": false,
+				"locked": false,
+				"custom_metadata": {"env": "prod"}
+			},
+			"ns2/": {
+				"uuid": "def456",
+				"id": "ns2",
+				"path": "ns2/",
+				"tainted": false,
+				"locked": false,
+				"custom_metadata": null
+			}
+		}
+	},
+	"wrap_info": null,
+	"warnings": null,
+	"auth": null
+}`

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -287,29 +287,26 @@ func TestDeleteNamespace(t *testing.T) {
 func TestListNamespaces(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
-		expected ListNamespacesResponse
+		expected map[string]ReadNamespaceResponse
 	}{
 		"multiple namespaces": {
 			body: listNamespacesResponse,
-			expected: ListNamespacesResponse{
-				Keys: []string{"ns1/", "ns2/"},
-				KeyInfo: map[string]ReadNamespaceResponse{
-					"ns1/": {
-						UUID:           "abc123",
-						ID:             "ns1",
-						Path:           "ns1/",
-						Tainted:        false,
-						Locked:         false,
-						CustomMetadata: map[string]string{"env": "prod"},
-					},
-					"ns2/": {
-						UUID:           "def456",
-						ID:             "ns2",
-						Path:           "ns2/",
-						Tainted:        false,
-						Locked:         false,
-						CustomMetadata: nil,
-					},
+			expected: map[string]ReadNamespaceResponse{
+				"ns1/": {
+					UUID:           "abc123",
+					ID:             "ns1",
+					Path:           "ns1/",
+					Tainted:        false,
+					Locked:         false,
+					CustomMetadata: map[string]string{"env": "prod"},
+				},
+				"ns2/": {
+					UUID:           "def456",
+					ID:             "ns2",
+					Path:           "ns2/",
+					Tainted:        false,
+					Locked:         false,
+					CustomMetadata: nil,
 				},
 			},
 		},
@@ -330,8 +327,8 @@ func TestListNamespaces(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(tc.expected, *resp) {
-				t.Errorf("expected: %#v\ngot: %#v", tc.expected, *resp)
+			if !reflect.DeepEqual(tc.expected, resp) {
+				t.Errorf("expected: %#v\ngot: %#v", tc.expected, resp)
 			}
 		})
 	}

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -17,6 +17,57 @@ func mockNamespaceHandler(body string) func(w http.ResponseWriter, r *http.Reque
 	}
 }
 
+func TestCreateNamespaceValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Sys().CreateNamespace("", nil); err == nil {
+		t.Error("expected error for empty path, got nil")
+	}
+}
+
+func TestPatchNamespaceValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Sys().PatchNamespace("", nil); err == nil {
+		t.Error("expected error for empty path, got nil")
+	}
+	if _, err := client.Sys().PatchNamespace("ns1", nil); err == nil {
+		t.Error("expected error for nil input, got nil")
+	}
+}
+
+func TestReadNamespaceValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Sys().ReadNamespace(""); err == nil {
+		t.Error("expected error for empty path, got nil")
+	}
+}
+
+func TestDeleteNamespaceValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Sys().DeleteNamespace(""); err == nil {
+		t.Error("expected error for empty path, got nil")
+	}
+}
+
 func TestCreateNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string

--- a/api/sys_namespaces_test.go
+++ b/api/sys_namespaces_test.go
@@ -80,28 +80,24 @@ func TestCreateNamespace(t *testing.T) {
 				CustomMetadata: map[string]string{"env": "prod"},
 			},
 			expected: CreateNamespaceOutput{
-				NamespaceOutput: NamespaceOutput{
-					UUID:           "abc123",
-					ID:             "ns1",
-					Path:           "ns1/",
-					Tainted:        false,
-					Locked:         false,
-					CustomMetadata: map[string]string{"env": "prod"},
-				},
+				UUID:           "abc123",
+				ID:             "ns1",
+				Path:           "ns1/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: map[string]string{"env": "prod"},
 			},
 		},
 		"namespace without custom metadata": {
 			body:  createNamespaceResponseNoMetadata,
 			input: CreateNamespaceInput{},
 			expected: CreateNamespaceOutput{
-				NamespaceOutput: NamespaceOutput{
-					UUID:           "def456",
-					ID:             "ns2",
-					Path:           "ns2/",
-					Tainted:        false,
-					Locked:         false,
-					CustomMetadata: nil,
-				},
+				UUID:           "def456",
+				ID:             "ns2",
+				Path:           "ns2/",
+				Tainted:        false,
+				Locked:         false,
+				CustomMetadata: nil,
 			},
 		},
 	} {
@@ -131,11 +127,11 @@ func TestCreateNamespace(t *testing.T) {
 func TestReadNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
-		expected NamespaceOutput
+		expected ReadNamespaceOutput
 	}{
 		"existing namespace": {
 			body: readNamespaceResponse,
-			expected: NamespaceOutput{
+			expected: ReadNamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
@@ -146,7 +142,7 @@ func TestReadNamespace(t *testing.T) {
 		},
 		"tainted namespace": {
 			body: readNamespaceTaintedResponse,
-			expected: NamespaceOutput{
+			expected: ReadNamespaceOutput{
 				UUID:    "abc123",
 				ID:      "ns1",
 				Path:    "ns1/",
@@ -156,7 +152,7 @@ func TestReadNamespace(t *testing.T) {
 		},
 		"locked namespace": {
 			body: readNamespaceLockedResponse,
-			expected: NamespaceOutput{
+			expected: ReadNamespaceOutput{
 				UUID:   "abc123",
 				ID:     "ns1",
 				Path:   "ns1/",
@@ -191,14 +187,14 @@ func TestPatchNamespace(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
 		input    PatchNamespaceInput
-		expected NamespaceOutput
+		expected PatchNamespaceOutput
 	}{
 		"add metadata key": {
 			body: patchNamespaceResponse,
 			input: PatchNamespaceInput{
 				CustomMetadata: map[string]interface{}{"env": "staging"},
 			},
-			expected: NamespaceOutput{
+			expected: PatchNamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
@@ -210,7 +206,7 @@ func TestPatchNamespace(t *testing.T) {
 			input: PatchNamespaceInput{
 				CustomMetadata: map[string]interface{}{"env": nil},
 			},
-			expected: NamespaceOutput{
+			expected: PatchNamespaceOutput{
 				UUID:           "abc123",
 				ID:             "ns1",
 				Path:           "ns1/",
@@ -277,11 +273,11 @@ func TestDeleteNamespace(t *testing.T) {
 func TestListNamespaces(t *testing.T) {
 	for name, tc := range map[string]struct {
 		body     string
-		expected map[string]*NamespaceOutput
+		expected map[string]*ListNamespaceOutput
 	}{
 		"multiple namespaces": {
 			body: listNamespacesResponse,
-			expected: map[string]*NamespaceOutput{
+			expected: map[string]*ListNamespaceOutput{
 				"ns1/": {
 					UUID:           "abc123",
 					ID:             "ns1",

--- a/changelog/2955.txt
+++ b/changelog/2955.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+namespaces: add CreateNamespace, ReadNamespace, ListNamespaces, PatchNamespace and DeleteNamespace to the Sys() API client; fix PATCH returning 500 on missing or nonexistent namespace
+```

--- a/changelog/2955.txt
+++ b/changelog/2955.txt
@@ -1,3 +1,6 @@
 ```release-note:improvement
-namespaces: add CreateNamespace, ReadNamespace, ListNamespaces, PatchNamespace and DeleteNamespace to the Sys() API client; fix PATCH returning 500 on missing or nonexistent namespace
+api: Add first-class support for `/sys/namespaces` APIs via `.Sys().CreateNamespace(...)` & co.
+```
+```release-note:bug
+core/namespaces: Fix PATCH on a namespace returning status 500 on missing or nonexistent namespace.
 ```

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -4,10 +4,10 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/posener/complete"
@@ -119,14 +119,16 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 	return OutputData(c.UI, out)
 }
 
-// structToMap converts a struct to map[string]interface{} via JSON round-trip.
 func structToMap(v interface{}) (map[string]interface{}, error) {
-	b, err := json.Marshal(v)
+	m := map[string]interface{}{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &m,
+	})
 	if err != nil {
 		return nil, err
 	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(b, &m); err != nil {
+	if err := decoder.Decode(v); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -4,10 +4,12 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
 	"github.com/posener/complete"
 )
 
@@ -96,20 +98,36 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
-	data := map[string]interface{}{
-		"custom_metadata": c.flagCustomMetadata,
-	}
-
-	secret, err := client.Logical().Write("sys/namespaces/"+namespacePath, data)
+	resp, err := client.Sys().CreateNamespace(namespacePath, &api.CreateNamespaceInput{
+		CustomMetadata: c.flagCustomMetadata,
+	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error creating namespace: %s", err))
 		return 2
 	}
 
-	// Handle single field output
-	if c.flagField != "" {
-		return PrintRawField(c.UI, secret, c.flagField)
+	out, err := structToMap(resp)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
+		return 2
 	}
 
-	return OutputSecret(c.UI, secret)
+	if c.flagField != "" {
+		return PrintRawField(c.UI, out, c.flagField)
+	}
+
+	return OutputData(c.UI, out)
+}
+
+// structToMap converts a struct to map[string]interface{} via JSON round-trip.
+func structToMap(v interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
 	"github.com/posener/complete"
 )
 
@@ -106,30 +106,11 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
-	out, err := structToMap(resp)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
-		return 2
-	}
+	out := structtomap.Map(resp)
 
 	if c.flagField != "" {
 		return PrintRawField(c.UI, out, c.flagField)
 	}
 
 	return OutputData(c.UI, out)
-}
-
-func structToMap(v interface{}) (map[string]interface{}, error) {
-	m := map[string]interface{}{}
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "json",
-		Result:  &m,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if err := decoder.Decode(v); err != nil {
-		return nil, err
-	}
-	return m, nil
 }

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -4,11 +4,11 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/helper/pgpkeys"
@@ -161,14 +161,16 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 	return OutputData(c.UI, out)
 }
 
-// structToMap converts a struct to map[string]interface{} via JSON round-trip.
 func structToMap(v interface{}) (map[string]interface{}, error) {
-	b, err := json.Marshal(v)
+	m := map[string]interface{}{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &m,
+	})
 	if err != nil {
 		return nil, err
 	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(b, &m); err != nil {
+	if err := decoder.Decode(v); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -4,11 +4,13 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/posener/complete"
 )
@@ -138,47 +140,38 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
-	sealConfig, err := c.readSealConfig()
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error while parsing seal configs: %s", err))
-		return 2
-	}
-
-	data := map[string]interface{}{
-		"custom_metadata": c.flagCustomMetadata,
-	}
-
-	if sealConfig != nil {
-		data["seal"] = string(sealConfig)
-	}
-
-	if c.flagKeyShares != 0 || c.flagKeyThreshold != 0 {
-		// if either -key-shares or -key-threshold is given, assume we create a
-		// shamir-sealed namespace; unless an explicit seal config was given
-		if _, ok := data["seal"]; !ok {
-			data["seal"] = fmt.Sprintf(`seal "shamir" {
-    shares = %d
-    threshold = %d
-}`, c.flagKeyShares, c.flagKeyThreshold)
-		}
-	}
-
-	if len(c.flagPGPKeys) > 0 {
-		data["pgp_keys"] = c.flagPGPKeys
-	}
-
-	secret, err := client.Logical().Write("sys/namespaces/"+namespacePath, data)
+	resp, err := client.Sys().CreateNamespace(namespacePath, &api.CreateNamespaceInput{
+		CustomMetadata: c.flagCustomMetadata,
+	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error creating namespace: %s", err))
 		return 2
 	}
 
-	// Handle single field output
-	if c.flagField != "" {
-		return PrintRawField(c.UI, secret, c.flagField)
+	out, err := structToMap(resp)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
+		return 2
 	}
 
-	return OutputSecret(c.UI, secret)
+	if c.flagField != "" {
+		return PrintRawField(c.UI, out, c.flagField)
+	}
+
+	return OutputData(c.UI, out)
+}
+
+// structToMap converts a struct to map[string]interface{} via JSON round-trip.
+func structToMap(v interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func (c *NamespaceCreateCommand) readSealConfig() ([]byte, error) {

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/helper/pgpkeys"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
 	"github.com/posener/complete"
 )
 
@@ -148,32 +148,13 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
-	out, err := structToMap(resp)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
-		return 2
-	}
+	out := structtomap.Map(resp)
 
 	if c.flagField != "" {
 		return PrintRawField(c.UI, out, c.flagField)
 	}
 
 	return OutputData(c.UI, out)
-}
-
-func structToMap(v interface{}) (map[string]interface{}, error) {
-	m := map[string]interface{}{}
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "json",
-		Result:  &m,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if err := decoder.Decode(v); err != nil {
-		return nil, err
-	}
-	return m, nil
 }
 
 func (c *NamespaceCreateCommand) readSealConfig() ([]byte, error) {

--- a/command/namespace_create.go
+++ b/command/namespace_create.go
@@ -50,6 +50,14 @@ Usage: bao namespace create [options] PATH
 
       $ bao namespace create -namespace=ns1 ns2
 
+  Create a sealable namespace with Shamir seal:
+
+      $ bao namespace create -key-shares=5 -key-threshold=3 ns1
+
+  Create a sealable namespace from a HCL seal config file:
+
+      $ bao namespace create -seal=seal.hcl ns1
+
 ` + c.Flags().Help()
 
 	return strings.TrimSpace(helpText)
@@ -67,6 +75,7 @@ func (c *NamespaceCreateCommand) Flags() *FlagSets {
 			"This can be specified multiple times to add multiple pieces of metadata.",
 	})
 
+	f = set.NewFlagSet("Seal Options")
 	f.StringVar(&StringVar{
 		Name:       "seal",
 		Target:     &c.flagSealConfigPath,
@@ -140,12 +149,43 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 		return 2
 	}
 
-	resp, err := client.Sys().CreateNamespace(namespacePath, &api.CreateNamespaceInput{
+	input := &api.CreateNamespaceInput{
 		CustomMetadata: c.flagCustomMetadata,
-	})
+		PGPKeys:        c.flagPGPKeys,
+	}
+
+	if c.flagSealConfigPath != "" {
+		hcl, err := os.ReadFile(c.flagSealConfigPath)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error reading seal config file: %s", err))
+			return 2
+		}
+		input.Seal = string(hcl)
+	} else if c.flagKeyShares != 0 || c.flagKeyThreshold != 0 {
+		input.Seal = fmt.Sprintf("seal \"shamir\" {\n    shares = %d\n    threshold = %d\n}",
+			c.flagKeyShares, c.flagKeyThreshold)
+	}
+
+	resp, err := client.Sys().CreateNamespace(namespacePath, input)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error creating namespace: %s", err))
 		return 2
+	}
+
+	if resp != nil && len(resp.KeyShares) > 0 {
+		for i, key := range resp.KeyShares {
+			c.UI.Output(fmt.Sprintf("Unseal Key %d: %s", i+1, key))
+		}
+		c.UI.Output("")
+		c.UI.Output(wrapAtLength(fmt.Sprintf(
+			"Namespace initialized with %d key shares and a key threshold of %d. Please "+
+				"securely distribute the key shares printed above. When the namespace is "+
+				"re-sealed, you must supply at least %d of these keys to unseal it.",
+			c.flagKeyShares,
+			c.flagKeyThreshold,
+			c.flagKeyThreshold,
+		)))
+		c.UI.Output("")
 	}
 
 	out := structtomap.Map(resp)
@@ -155,13 +195,4 @@ func (c *NamespaceCreateCommand) Run(args []string) int {
 	}
 
 	return OutputData(c.UI, out)
-}
-
-func (c *NamespaceCreateCommand) readSealConfig() ([]byte, error) {
-	path := c.flagSealConfigPath
-	if path == "" {
-		return nil, nil
-	}
-
-	return os.ReadFile(path)
 }

--- a/command/namespace_create_test.go
+++ b/command/namespace_create_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceCreateCommand(tb testing.TB) (*cli.MockUi, *NamespaceCreateCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceCreateCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceCreateCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceCreateCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceCreateCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -83,15 +83,15 @@ func (c *NamespaceDeleteCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Logical().Delete("sys/namespaces/" + namespacePath)
+	resp, err := client.Sys().DeleteNamespace(namespacePath)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error deleting namespace: %s", err))
 		return 2
 	}
 
-	if secret != nil {
-		// Likely, we have warnings
-		return OutputSecret(c.UI, secret)
+	if resp == nil || resp.Status == "" {
+		c.UI.Warn("Requested namespace does not exist")
+		return 0
 	}
 
 	if !strings.HasSuffix(namespacePath, "/") {

--- a/command/namespace_delete_test.go
+++ b/command/namespace_delete_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceDeleteCommand(tb testing.TB) (*cli.MockUi, *NamespaceDeleteCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceDeleteCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceDeleteCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceDeleteCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceDeleteCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -88,14 +88,18 @@ func (c *NamespaceListCommand) Run(args []string) int {
 		return 2
 	}
 
-	if resp == nil || len(resp.Keys) == 0 {
+	if len(resp) == 0 {
 		c.UI.Error("No namespaces found")
 		return 2
 	}
 
 	if c.flagDetailed && Format(c.UI) != "table" {
-		return OutputData(c.UI, resp.KeyInfo)
+		return OutputData(c.UI, resp)
 	}
 
-	return OutputData(c.UI, resp.Keys)
+	keys := make([]string, 0, len(resp))
+	for k := range resp {
+		keys = append(keys, k)
+	}
+	return OutputData(c.UI, keys)
 }

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -82,42 +82,20 @@ func (c *NamespaceListCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Logical().List("sys/namespaces")
+	resp, err := client.Sys().ListNamespaces()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error listing namespaces: %s", err))
 		return 2
 	}
 
-	_, ok := extractListData(secret)
-	if Format(c.UI) != "table" {
-		if secret == nil || secret.Data == nil || !ok {
-			OutputData(c.UI, map[string]interface{}{})
-			return 2
-		}
-	}
-
-	if secret == nil {
+	if resp == nil || len(resp.Keys) == 0 {
 		c.UI.Error("No namespaces found")
 		return 2
 	}
 
-	// There could be e.g. warnings
-	if secret.Data == nil {
-		return OutputSecret(c.UI, secret)
-	}
-
-	if secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
-		return OutputSecret(c.UI, secret)
-	}
-
-	if !ok {
-		c.UI.Error("No entries found")
-		return 2
-	}
-
 	if c.flagDetailed && Format(c.UI) != "table" {
-		return OutputData(c.UI, secret.Data["key_info"])
+		return OutputData(c.UI, resp.KeyInfo)
 	}
 
-	return OutputList(c.UI, secret)
+	return OutputData(c.UI, resp.Keys)
 }

--- a/command/namespace_list_test.go
+++ b/command/namespace_list_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceListCommand(tb testing.TB) (*cli.MockUi, *NamespaceListCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceListCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceListCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"no_namespaces",
+			[]string{},
+			"Error listing namespaces",
+			2,
+		},
+		{
+			"too_many_args",
+			[]string{"foo"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceListCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceListCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_lookup.go
+++ b/command/namespace_lookup.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
 	"github.com/posener/complete"
 )
 
@@ -89,11 +90,5 @@ func (c *NamespaceLookupCommand) Run(args []string) int {
 		return 2
 	}
 
-	out, err := structToMap(resp)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
-		return 2
-	}
-
-	return OutputData(c.UI, out)
+	return OutputData(c.UI, structtomap.Map(resp))
 }

--- a/command/namespace_lookup.go
+++ b/command/namespace_lookup.go
@@ -79,15 +79,21 @@ func (c *NamespaceLookupCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Logical().Read("sys/namespaces/" + namespacePath)
+	resp, err := client.Sys().ReadNamespace(namespacePath)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error looking up namespace: %s", err))
 		return 2
 	}
-	if secret == nil {
+	if resp == nil {
 		c.UI.Error("Namespace not found")
 		return 2
 	}
 
-	return OutputSecret(c.UI, secret)
+	out, err := structToMap(resp)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
+		return 2
+	}
+
+	return OutputData(c.UI, out)
 }

--- a/command/namespace_lookup_test.go
+++ b/command/namespace_lookup_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceLookupCommand(tb testing.TB) (*cli.MockUi, *NamespaceLookupCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceLookupCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceLookupCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceLookupCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceLookupCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -99,6 +99,11 @@ func (c *NamespacePatchCommand) Run(args []string) int {
 
 	namespacePath := strings.TrimSpace(args[0])
 
+	if len(c.flagCustomMetadata) == 0 && len(c.flagRemoveCustomMetadata) == 0 {
+		c.UI.Error("Must supply at least one of -custom-metadata or -remove-custom-metadata")
+		return 1
+	}
+
 	client, err := c.Client()
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
 	"github.com/posener/complete"
 )
 
@@ -127,11 +128,7 @@ func (c *NamespacePatchCommand) Run(args []string) int {
 		return 2
 	}
 
-	out, err := structToMap(resp)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
-		return 2
-	}
+	out := structtomap.Map(resp)
 
 	if c.flagField != "" {
 		return PrintRawField(c.UI, out, c.flagField)

--- a/command/namespace_patch.go
+++ b/command/namespace_patch.go
@@ -4,9 +4,7 @@
 package command
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/hashicorp/cli"
@@ -107,35 +105,32 @@ func (c *NamespacePatchCommand) Run(args []string) int {
 		return 2
 	}
 
-	data := make(map[string]interface{})
 	customMetadata := make(map[string]interface{})
-
 	for key, value := range c.flagCustomMetadata {
 		customMetadata[key] = value
 	}
-
 	for _, key := range c.flagRemoveCustomMetadata {
 		// A null in a JSON merge patch payload will remove the associated key
 		customMetadata[key] = nil
 	}
 
-	data["custom_metadata"] = customMetadata
-
-	secret, err := client.Logical().JSONMergePatch(context.Background(), "sys/namespaces/"+namespacePath, data)
+	resp, err := client.Sys().PatchNamespace(namespacePath, &api.PatchNamespaceInput{
+		CustomMetadata: customMetadata,
+	})
 	if err != nil {
-		if re, ok := err.(*api.ResponseError); ok && re.StatusCode == http.StatusNotFound {
-			c.UI.Error("Namespace not found")
-			return 2
-		}
-
 		c.UI.Error(fmt.Sprintf("Error patching namespace: %s", err))
 		return 2
 	}
 
-	// Handle single field output
-	if c.flagField != "" {
-		return PrintRawField(c.UI, secret, c.flagField)
+	out, err := structToMap(resp)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error formatting response: %s", err))
+		return 2
 	}
 
-	return OutputSecret(c.UI, secret)
+	if c.flagField != "" {
+		return PrintRawField(c.UI, out, c.flagField)
+	}
+
+	return OutputData(c.UI, out)
 }

--- a/command/namespace_patch_test.go
+++ b/command/namespace_patch_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespacePatchCommand(tb testing.TB) (*cli.MockUi, *NamespacePatchCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespacePatchCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespacePatchCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespacePatchCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespacePatchCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -18,6 +18,8 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
+var errNamespaceNotFound = errors.New("requested namespace does not exist")
+
 var namespacePathSchema = &framework.FieldSchema{
 	Type:        framework.TypeString,
 	Required:    false,
@@ -404,9 +406,13 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
+		if _, ok := data.Raw["custom_metadata"]; !ok {
+			return logical.ErrorResponse("request body must include custom_metadata"), logical.ErrInvalidRequest
+		}
+
 		ns, _, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, nil, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			if ns.UUID == "" {
-				return nil, fmt.Errorf("requested namespace does not exist")
+				return nil, errNamespaceNotFound
 			}
 
 			current := make(map[string]interface{})
@@ -428,6 +434,9 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return ns, nil
 		})
 		if err != nil {
+			if errors.Is(err, errNamespaceNotFound) {
+				return nil, logical.CodedError(http.StatusNotFound, "namespace not found")
+			}
 			return nil, fmt.Errorf("failed to modify namespace: %w", err)
 		}
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
+var errNamespaceNotFound = errors.New("requested namespace does not exist")
+
 var namespacePathSchema = &framework.FieldSchema{
 	Type:        framework.TypeString,
 	Required:    false,
@@ -443,9 +445,13 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return nil, errors.New("path must not contain /")
 		}
 
+		if _, ok := data.Raw["custom_metadata"]; !ok {
+			return logical.ErrorResponse("request body must include custom_metadata"), logical.ErrInvalidRequest
+		}
+
 		ns, _, err := b.Core.namespaceStore.ModifyNamespaceByPath(ctx, path, nil, func(ctx context.Context, ns *namespace.Namespace) (*namespace.Namespace, error) {
 			if ns.UUID == "" {
-				return nil, fmt.Errorf("requested namespace does not exist")
+				return nil, errNamespaceNotFound
 			}
 
 			current := make(map[string]interface{})
@@ -467,6 +473,9 @@ func (b *SystemBackend) handleNamespacesPatch() framework.OperationFunc {
 			return ns, nil
 		})
 		if err != nil {
+			if errors.Is(err, errNamespaceNotFound) {
+				return nil, logical.CodedError(http.StatusNotFound, "namespace not found")
+			}
 			return nil, fmt.Errorf("failed to modify namespace: %w", err)
 		}
 


### PR DESCRIPTION
## Description

Add "CreateNamespace", "ReadNamespace", "ListNamespaces", "PatchNamespace"
and "DeleteNamespace" helpers to the "Sys()" API client, with table-driven
unit tests for each operation.

Refactor the matching CLI commands ("namespace create", "delete", "list",
"lookup", "patch") to use the new client methods instead of raw logical
client calls.

Fix two server-side status code bugs in the PATCH endpoint:
- PATCH on a nonexistent namespace returned 500; now returns 404.
- PATCH with an empty or unrecognized body returned 500; now returns 400.

## Rationale

Resolves: #2821

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.