### PR TITLE
Forward bootstrap challenge/answer requests to active node

### DIFF
--- a/changelog/2976.txt
+++ b/changelog/2976.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: Forward bootstrap challenge/answer requests to active node, fixing raft join failures via load balancer.
+```

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -56,8 +56,9 @@ func (b *SystemBackend) raftStoragePaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handleRaftBootstrapAnswerWrite(),
-					Summary:  "Accepts an answer from the peer to be joined to the raft cluster.",
+					Callback:                  b.handleRaftBootstrapAnswerWrite(),
+					Summary:                   "Accepts an answer from the peer to be joined to the raft cluster.",
+					ForwardPerformanceStandby: true,
 				},
 			},
 
@@ -75,8 +76,9 @@ func (b *SystemBackend) raftStoragePaths() []*framework.Path {
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handleRaftBootstrapChallengeWrite(),
-					Summary:  "Creates a challenge for the new peer to be joined to the raft cluster.",
+					Callback:                  b.handleRaftBootstrapChallengeWrite(),
+					Summary:                   "Creates a challenge for the new peer to be joined to the raft cluster.",
+					ForwardPerformanceStandby: true,
 				},
 			},
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Raft join fails randomly when a joining node connects the cluster through a Kubernetes service or any other load balancer. For example the `challenge` request may be sent to the active node but the `answer` is routed to a standby. This creates a mismatch, as the challenge is derived from the active node's key but the answer is validated against a standby node's key.

This PR ensures that both requests are forwarded to the active node for processing.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale





<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This fixes regression introduced by handling read requests locally on standby nodes https://github.com/openbao/openbao/commit/9832b5c75d4aeff0aaea4a96c7815ce3b9dbe887 (https://github.com/openbao/openbao/pull/1986).

Resolves: #2975

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
