### PR TITLE
website: show all blog-posts in the sidebar

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -114,6 +114,8 @@ const config: Config = {
           blogTitle: "OpenBao Blog",
           blogDescription:
             "Official blog of the Bao Evangelism Taskforce (BET)",
+          blogSidebarCount: 'ALL',
+          blogSidebarTitle: 'All posts',
           path: "content/blog",
         },
         theme: {


### PR DESCRIPTION
## Description

This configures the sidebar of our [blog](https://openbao.org/blog/) to display all blog post not just the 5 most recent ones.

As recommended [here](https://docusaurus.io/docs/3.9.2/blog#blog-sidebar) it also overwrites the title (

## Rationale

Discussed on Zulip: https://linuxfoundation.zulipchat.com/#narrow/channel/529890-openssf-openbao-discussion/topic/blog.3A.20posts.20list.20truncated.20to.205/with/585421449


**Philipp Stehle (@phil9909)**: 

> I think it's wired that the list of our blog posts (the sidebar here: https://openbao.org/blog/) is truncated to 5 most recent items.
> This [can be configured](https://docusaurus.io/docs/blog#blog-sidebar).
> I think I get the idea: blog-post are not "ever green" like documentation (should) be, therefore might contain outdated information, so making them less discoverable seems justified.
> Still, I don't like it. And if we have out-dated information in a blog post, we can always add a note like "this is supported starting with v3.2.0", without destroying the original content.
> I guess what I most dislike about this is, that there is no indication that it has been truncated. When I myself first looked at the blog, it just though "oh, that's it".
> WDYT?
>
> ---
> 
> I guess in 2026 most people won't care about e.g. the [December OpenBao RFC Update](https://openbao.org/blog/rfcs-dec-2024/) (December 11, 2024), but the even older [My First Week as an OpenBao Mentee!](https://openbao.org/blog/my-first-week-openbao-mentee/) might still be interesting for some

**Alex Scheel (@cipherboy):**

>  @phil9909 Yeah, I'm fine to bump the sidebar count, we're (ControlPlane) looking to do more blog posts in the near-ish future and I'm hoping for a few more community contributions there as well. 
> I wish there was some way to link the archive?

> I only know about it since I stumbled upon it once: https://openbao.org/blog/archive/


**Jonas Köhnen (@satoqz)**:
> Does setting this to "ALL" result in a sidebar that shows all headings but keep the main content on several pages so they're not all loaded at once? In that case I'm in favor of setting "ALL".


Fun fact: The Docusaurus team also uses `ALL` for their own blog: https://github.com/facebook/docusaurus/blob/094248992c5b5e99c8dc8ab3f77d564192736a29/website/docusaurus.config.ts#L568 seems like the don't like their own default, but they can't change it, because it would be breaking :man_shrugging: 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
