### PR TITLE
Forward generate-root requests to active node

### DIFF
--- a/changelog/2993.txt
+++ b/changelog/2993.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Forward generate-root requests to active node, fixing failures when sending request via load balancer.
+```

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -16,6 +16,12 @@ import (
 
 func handleSysGenerateRootAttempt(core *vault.Core, generateStrategy vault.GenerateRootStrategy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		standby := core.Standby()
+		if standby {
+			respondStandby(core, w, r.URL)
+			return
+		}
+
 		switch r.Method {
 		case "GET":
 			handleSysGenerateRootAttemptGet(core, w, r, "")
@@ -145,6 +151,12 @@ func handleSysGenerateRootAttemptDelete(core *vault.Core, w http.ResponseWriter,
 
 func handleSysGenerateRootUpdate(core *vault.Core, generateStrategy vault.GenerateRootStrategy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		standby := core.Standby()
+		if standby {
+			respondStandby(core, w, r.URL)
+			return
+		}
+
 		// Parse the request
 		var req GenerateRootUpdateRequest
 		if err := parseJSONRequest(r, w, &req); err != nil {

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -16,8 +16,7 @@ import (
 
 func handleSysGenerateRootAttempt(core *vault.Core, generateStrategy vault.GenerateRootStrategy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		standby := core.Standby()
-		if standby {
+		if core.HAEnabled() && core.Standby() {
 			respondStandby(core, w, r.URL)
 			return
 		}
@@ -151,8 +150,7 @@ func handleSysGenerateRootAttemptDelete(core *vault.Core, w http.ResponseWriter,
 
 func handleSysGenerateRootUpdate(core *vault.Core, generateStrategy vault.GenerateRootStrategy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		standby := core.Standby()
-		if standby {
+		if core.HAEnabled() && core.Standby() {
 			respondStandby(core, w, r.URL)
 			return
 		}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Generating a new root token fails when a load balancer forwards the request to a standby instance.

This PR ensures that the standby instance forwards both `/v1/sys/generate-root/attempt` and `/v1/sys/generate-root/update` requests to the active node for processing.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2987

This fixes regression introduced in 9832b5c75d4aeff0aaea4a96c7815ce3b9dbe887 (#1986)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
