### PR TITLE
Add Liquid Reply to Supporters

### DIFF
--- a/website/content/ecosystem/supporters.mdx
+++ b/website/content/ecosystem/supporters.mdx
@@ -8,32 +8,41 @@ import Randomize from './lib/Randomize.tsx';
 import Member from './lib/Member.tsx';
 
 <div className="container">
-<div className="row">
-<Randomize>
-  <Member title="Adfinis">
-    [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
-    commits to OpenBao through core contributions, open source leadership, and
-    by fostering community advocacy and growth.
-  </Member>
-  <Member title="GitLab">
-    GitLab contributes to development and open-source community efforts of OpenBao.
-  </Member>
-  <Member title="SAP">
-    Several Developers from/on behalf of 
-    [SAP SE](https://www.sap.com/)
-    work full time on OpenBao (project funded by  
-    [European Union - NextGenerationEU](https://commission.europa.eu/strategy-and-policy/recovery-plan-europe_en)).
-  </Member>
-  <Member title="Proton">
-    Proton sponsors its collaboration suite (email and calendar) for OpenBao maintainers.
-  </Member>
-  <Member title="Blendbyte">
-    Blendbyte sponsors OpenBao's RPM & DEB package repository hosted on pkgs.openbao.org.
-  </Member>
-  <Member title="ControlPlane">
-    [ControlPlane](https://control-plane.io/enterprise-for-openbao/) contributes to development and
-    [open-source community leadership](https://control-plane.io/posts/why-we-support-openbao/) efforts of OpenBao.
-  </Member>
-</Randomize>
-</div>
+  <div className="row">
+    <Randomize>
+      <Member title="Adfinis">
+        [Adfinis](https://www.adfinis.com/en/partners-and-products/openbao?mtm_campaign=openbao&mtm_kwd=global&mtm_source=openbao&mtm_medium=website)
+        commits to OpenBao through core contributions, open source leadership, and
+        by fostering community advocacy and growth.
+      </Member>
+
+      <Member title="GitLab">
+        GitLab contributes to development and open-source community efforts of OpenBao.
+      </Member>
+
+      <Member title="SAP">
+        Several Developers from/on behalf of 
+        [SAP SE](https://www.sap.com/)
+        work full time on OpenBao (project funded by  
+        [European Union - NextGenerationEU](https://commission.europa.eu/strategy-and-policy/recovery-plan-europe_en)).
+      </Member>
+
+      <Member title="Proton">
+        Proton sponsors its collaboration suite (email and calendar) for OpenBao maintainers.
+      </Member>
+
+      <Member title="Blendbyte">
+        Blendbyte sponsors OpenBao's RPM & DEB package repository hosted on pkgs.openbao.org.
+      </Member>
+
+      <Member title="ControlPlane">
+        [ControlPlane](https://control-plane.io/enterprise-for-openbao/) contributes to development and
+        [open-source community leadership](https://control-plane.io/posts/why-we-support-openbao/) efforts of OpenBao.
+      </Member>
+      
+      <Member title="Liquid Reply" logoname="liquidreply">
+        [Liquid Reply](https://liquidreply.net/en/) commits to OpenBao through core contributions, and by fostering community advocacy and growth.
+      </Member>
+    </Randomize>
+  </div>
 </div>


### PR DESCRIPTION
require rebase after #2994 merge

## Description
Adding Liquid Reply to Supporters page from ecosystem.

## Rationale
ecosystem page addition

Resolves: #2989

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
