### PR TITLE
Add initial publiccode.yml to list OpenBao in regional OSS catalogs

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -23,13 +23,14 @@ description:
   en:
     shortDescription: OpenBao is an open source, community-driven secrets
       manager and fork of Vault managed by the Linux Foundation's OpenSSF.
-    longDescription: OpenBao is an identity-based secrets and encryption
-    management system. A secret is anything that you want to tightly control
-    access to, such as API tokens, encryption keys, passwords, and
-    certificates. OpenBao provides encryption services that are gated by
-    authentication and authorization methods. Using OpenBao's UI, CLI, or HTTP
-    API, access to secrets and other sensitive data can be securely stored and
-    managed, tightly controlled (restricted), and auditable.
+    longDescription: >-
+      OpenBao is an identity-based secrets and encryption
+      management system. A secret is anything that you want to tightly control
+      access to, such as API tokens, encryption keys, passwords, and
+      certificates. OpenBao provides encryption services that are gated by
+      authentication and authorization methods. Using OpenBao's UI, CLI, or
+      HTTP API, access to secrets and other sensitive data can be securely
+      stored and managed, tightly controlled (restricted), and auditable.
     documentation: https://openbao.org/docs/
     apiDocumentation: https://openbao.org/api-docs/
     features:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,53 @@
+publiccodeYmlVersion: 0.5.0
+name: OpenBao
+url: https://github.com/openbao/openbao
+platforms:
+  - web
+categories:
+  - it-security
+  - identity-management
+organisation:
+  name: Open Source Security Foundation (OpenSSF)
+  uri: https://openssf.org/
+usedBy:
+  - Developers
+  - IT Technicians
+  - IT Administrators
+  - Systems Engineers
+  - DevOps Engineers
+  - Security Specialists
+roadmap: https://github.com/openbao/openbao/issues/1974
+developmentStatus: stable
+softwareType: standalone/web
+description:
+  en:
+    shortDescription: OpenBao is an open source, community-driven secrets
+      manager and fork of Vault managed by the Linux Foundation's OpenSSF.
+    longDescription: OpenBao is an identity-based secrets and encryption
+    management system. A secret is anything that you want to tightly control
+    access to, such as API tokens, encryption keys, passwords, and
+    certificates. OpenBao provides encryption services that are gated by
+    authentication and authorization methods. Using OpenBao's UI, CLI, or HTTP
+    API, access to secrets and other sensitive data can be securely stored and
+    managed, tightly controlled (restricted), and auditable.
+    documentation: https://openbao.org/docs/
+    apiDocumentation: https://openbao.org/api-docs/
+    features:
+      - Secure Secret Storage
+      - Dynamic Secrets
+      - Data Encryption
+      - Leasing and Renewal
+      - Revocation
+legal:
+  license: MPL-2.0
+maintenance:
+  type: community
+  contacts:
+    - name: OpenBao Community
+      email: openbao@lists.openssf.org
+    - name: OpenBao Security
+      email: openbao-security@lists.openssf.org
+localisation:
+  localisationReady: false
+  availableLanguages:
+    - en


### PR DESCRIPTION
## Description

Adds an initial publiccode.yml definition to the root of the repository. I've leveraged the web editor to fill out mainly the mandatory but also a few optional fields while avoiding hard coding versions which only result in more release checklist items:

* https://publiccode-editor.developers.italia.it/

## Rationale

With it, we should get listed in various government-affiliated OSS catalogs, hopefully raising awareness for the project.

Resolves: #2997

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
