### PR TITLE
Fix `/v1/sys/` forwarding regressions for standby instances

### DIFF
--- a/changelog/3006.txt
+++ b/changelog/3006.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Forward generate-root, step-down and rekey requests to active node to resolve inconsistent standby behavior.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -52,6 +52,7 @@ import (
 	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
+	"github.com/openbao/openbao/sdk/v2/helper/pointerutil"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -1304,6 +1305,12 @@ func (c *ServerCommand) Run(args []string) int {
 	core.SetClusterListenerAddrs(clusterAddrs)
 	core.SetClusterHandler(vaulthttp.Handler.Handler(&vault.HandlerProperties{
 		Core: core,
+		// The cluster handler allows all endpoints to support forwarding.
+		// The decision to disable unauthed endpoints is made by external-facing listeners, so this is safe.
+		ListenerConfig: &configutil.Listener{
+			DisableUnauthedGenerateRootEndpoints: pointerutil.BoolPtr(false),
+			DisableUnauthedRekeyEndpoints:        pointerutil.BoolPtr(false),
+		},
 	}))
 
 	// Attempt unsealing in a background goroutine. This is needed for when a

--- a/http/forwarding_test.go
+++ b/http/forwarding_test.go
@@ -21,14 +21,18 @@ import (
 	"golang.org/x/net/http2"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/openbao/openbao/api/v2"
 	credCert "github.com/openbao/openbao/builtin/credential/cert"
 	"github.com/openbao/openbao/builtin/logical/transit"
+	"github.com/openbao/openbao/helper/configutil"
 	"github.com/openbao/openbao/helper/testhelpers"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/keysutil"
+	"github.com/openbao/openbao/sdk/v2/helper/pointerutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTP_Fallback_Bad_Address(t *testing.T) {
@@ -615,4 +619,77 @@ func TestHTTP_Forwarding_LocalOnly(t *testing.T) {
 
 	testLocalOnly(cores[1].Client)
 	testLocalOnly(cores[2].Client)
+}
+
+func TestHTTP_Forwarding_StandbySystemEndpoints(t *testing.T) {
+	cluster := vault.NewTestCluster(t, &vault.CoreConfig{}, &vault.TestClusterOptions{
+		HandlerFunc: Handler,
+		DefaultHandlerProperties: vault.HandlerProperties{
+			ListenerConfig: &configutil.Listener{
+				DisableUnauthedGenerateRootEndpoints: pointerutil.BoolPtr(false),
+				DisableUnauthedRekeyEndpoints:        pointerutil.BoolPtr(false),
+			},
+		},
+		NumCores: 2,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
+
+	// Get a client that sends request to a standby.
+	standbyClient := func() *api.Client {
+		standbys := testhelpers.DeriveStandbyCores(t, cluster)
+		require.NotEmpty(t, standbys, "expected at least one standby core")
+		return standbys[0].Client
+	}
+
+	// Test that generate-root forwards to active.
+	otp, err := base62.Random(vault.TokenPrefixLength + vault.TokenLength)
+	require.NoError(t, err)
+	generateRootResponse, err := standbyClient().Sys().GenerateRootInit(otp, "")
+	require.NoError(t, err, "expected no error when request is successfully forwarded to active")
+	require.NotNil(t, generateRootResponse)
+	for _, k := range cluster.BarrierKeys {
+		generateRootResponse, err = standbyClient().Sys().GenerateRootUpdate(base64.StdEncoding.EncodeToString(k), generateRootResponse.Nonce)
+		require.NoError(t, err, "expected no error when request is successfully forwarded to active")
+	}
+	require.True(t, generateRootResponse.Complete)
+
+	// Test that rekey/init forwards to active.
+	//nolint:staticcheck // endpoint already marked as deprecated
+	rekeyInitResponse, err := standbyClient().Sys().RekeyInit(&api.RekeyInitRequest{
+		SecretShares:        1,
+		SecretThreshold:     1,
+		RequireVerification: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rekeyInitResponse)
+	require.True(t, rekeyInitResponse.Started)
+
+	// Test that rekey/update forwards to active.
+	var rekeyUpdateResponse *api.RekeyUpdateResponse
+	for _, k := range cluster.BarrierKeys {
+		//nolint:staticcheck // endpoint already marked as deprecated
+		rekeyUpdateResponse, err = standbyClient().Sys().RekeyUpdate(base64.StdEncoding.EncodeToString(k), rekeyInitResponse.Nonce)
+		require.NoError(t, err)
+	}
+	require.True(t, rekeyUpdateResponse.Complete)
+
+	// Test that rekey/verify forwards to active.
+	var rekeyVerifyResponse *api.RekeyVerificationUpdateResponse
+	for _, k := range rekeyUpdateResponse.Keys {
+		//nolint:staticcheck // endpoint already marked as deprecated
+		rekeyVerifyResponse, err = standbyClient().Sys().RekeyVerificationUpdate(k, rekeyUpdateResponse.VerificationNonce)
+		require.NoError(t, err)
+	}
+	require.True(t, rekeyVerifyResponse.Complete)
+
+	// Test that step-down forwards to active.
+	activeBeforeStepDown := testhelpers.DeriveActiveCore(t, cluster)
+	err = standbyClient().Sys().StepDown()
+	require.NoError(t, err)
+	testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
+	activeAfterStepDown := testhelpers.DeriveActiveCore(t, cluster)
+	require.NotEqual(t, activeBeforeStepDown.NodeID, activeAfterStepDown.NodeID, "expected different active after step-down")
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -168,7 +168,7 @@ func handler(props *vault.HandlerProperties) http.Handler {
 		mux.Handle("/v1/sys/init", handleSysInit(core))
 		mux.Handle("/v1/sys/seal-status", handleSysSealStatus(core))
 		mux.Handle("/v1/sys/seal", handleSysSeal(core))
-		mux.Handle("/v1/sys/step-down", handleSysStepDown(core))
+		mux.Handle("/v1/sys/step-down", handleForwardIfStandby(core, handleSysStepDown(core)))
 		mux.Handle("/v1/sys/unseal", handleSysUnseal(core))
 		mux.Handle("/v1/sys/leader", handleSysLeader(core))
 		mux.Handle("/v1/sys/health", handleSysHealth(core))
@@ -177,25 +177,25 @@ func handler(props *vault.HandlerProperties) http.Handler {
 		// Register without unauthenticated generate root, if necessary.
 		if props.ListenerConfig != nil && props.ListenerConfig.DisableUnauthedGenerateRootEndpoints != nil && !*props.ListenerConfig.DisableUnauthedGenerateRootEndpoints {
 			mux.Handle("/v1/sys/generate-root/attempt",
-				handleAuditNonLogical(core, handleSysGenerateRootAttempt(core, vault.GenerateStandardRootTokenStrategy)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysGenerateRootAttempt(core, vault.GenerateStandardRootTokenStrategy))))
 			mux.Handle("/v1/sys/generate-root/update",
-				handleAuditNonLogical(core, handleSysGenerateRootUpdate(core, vault.GenerateStandardRootTokenStrategy)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysGenerateRootUpdate(core, vault.GenerateStandardRootTokenStrategy))))
 		}
 
 		// Register without unauthenticated rekey, if necessary.
 		if props.ListenerConfig != nil && props.ListenerConfig.DisableUnauthedRekeyEndpoints != nil && !*props.ListenerConfig.DisableUnauthedRekeyEndpoints {
 			mux.Handle("/v1/sys/rekey/init",
-				handleAuditNonLogical(core, handleSysRekeyInit(core, false)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyInit(core, false))))
 			mux.Handle("/v1/sys/rekey/update",
-				handleAuditNonLogical(core, handleSysRekeyUpdate(core, false)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyUpdate(core, false))))
 			mux.Handle("/v1/sys/rekey/verify",
-				handleAuditNonLogical(core, handleSysRekeyVerify(core, false)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyVerify(core, false))))
 			mux.Handle("/v1/sys/rekey-recovery-key/init",
-				handleAuditNonLogical(core, handleSysRekeyInit(core, true)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyInit(core, true))))
 			mux.Handle("/v1/sys/rekey-recovery-key/update",
-				handleAuditNonLogical(core, handleSysRekeyUpdate(core, true)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyUpdate(core, true))))
 			mux.Handle("/v1/sys/rekey-recovery-key/verify",
-				handleAuditNonLogical(core, handleSysRekeyVerify(core, true)))
+				handleForwardIfStandby(core, handleAuditNonLogical(core, handleSysRekeyVerify(core, true))))
 		}
 
 		mux.Handle("/v1/sys/storage/raft/bootstrap", handleSysRaftBootstrap(core))
@@ -1294,4 +1294,14 @@ func respondOIDCPermissionDenied(w http.ResponseWriter) {
 
 	enc := json.NewEncoder(w)
 	enc.Encode(oidcResponse)
+}
+
+func handleForwardIfStandby(core *vault.Core, handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if core.HAEnabled() && core.Standby() {
+			forwardRequest(core, w, r)
+		} else {
+			handler.ServeHTTP(w, r)
+		}
+	})
 }

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -16,12 +16,6 @@ import (
 
 func handleSysRekeyInit(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		standby := core.Standby()
-		if standby {
-			respondStandby(core, w, r.URL)
-			return
-		}
-
 		ctx, cancel := core.GetContext()
 		defer cancel()
 
@@ -143,12 +137,6 @@ func handleSysRekeyInitDelete(ctx context.Context, core *vault.Core, recovery bo
 
 func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		standby := core.Standby()
-		if standby {
-			respondStandby(core, w, r.URL)
-			return
-		}
-
 		// Parse the request
 		var req RekeyUpdateRequest
 		if err := parseJSONRequest(r, w, &req); err != nil {
@@ -216,12 +204,6 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 
 func handleSysRekeyVerify(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		standby := core.Standby()
-		if standby {
-			respondStandby(core, w, r.URL)
-			return
-		}
-
 		ctx, cancel := core.GetContext()
 		defer cancel()
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This PR ensures the following endpoints are correctly forwarded to the active instance:

* `/v1/sys/step-down`
* `/v1/sys/generate-root/{attempt,update}`
* `/v1/sys/rekey-*/{init,update,verify}`

It resolves these issues when sending requests to a standby instance:

1. Generating a new root token failed with a `400` error `Vault is in standby mode`.
2. Requesting a step-down returned `Success! Stepped down` without taking action.
3. Re-keying returned a `307` `Temporary Redirect` instead of utilizing request forwarding through the cluster listener.



<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale


Resolves: #2987

This fixes regression https://github.com/openbao/openbao/issues/2987#issuecomment-4338816221 introduced in 9832b5c75d4aeff0aaea4a96c7815ce3b9dbe887 (#1986)


<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
