### PR TITLE
Make `SystemBackend` a singleton

### DIFF
--- a/changelog/3007.txt
+++ b/changelog/3007.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: `SystemBackend` is now a singleton shared across all namespaces, reducing idle memory usage of the OpenBao instance.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -1247,7 +1247,12 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 		b := NewSystemBackend(c, sysBackendLogger)
 		return b, b.Setup(ctx, config)
 	}
-	logicalBackends[routing.MountTypeNSSystem] = logicalBackends[routing.MountTypeSystem]
+	logicalBackends[routing.MountTypeNSSystem] = func(ctx context.Context, bc *logical.BackendConfig) (logical.Backend, error) {
+		if c.systemBackend != nil {
+			return c.systemBackend, nil
+		}
+		return nil, errors.New("system backend does not exist")
+	}
 
 	// Identity
 	logicalBackends[routing.MountTypeIdentity] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {


### PR DESCRIPTION
## Description
This PR makes `SystemBackend` a singleton rather than creating one instance per created namespace.

## Rationale
by account of @satoqz report
> the memory usage of an idle bao server -dev with 1000 empty namespaces drops from 1.3 GB to 900 MB on my system.

this means it's a substantial memory optimization without any fallbacks.

Note: #1809 was proposing the reverse, so making `SystemBackend` per namespace rather than singleton (which was the reverse of the current state), this was motivated by future enhancements we could implement:
- simplifying locks over mounts, policy store
- making expiration manager per namespace
and possibly others, but this would require a more through refactor which a plan for should be formulated beforehand, hence we opt for low-hanging fruit here.


patch used in the PR prepared fully by @satoqz

Resolves: #1809

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
