### PR TITLE
Replace os.MkdirTemp to t.TempDir in tests

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -527,14 +527,7 @@ func TestAgent_Template_UserAgent(t *testing.T) {
 
 	roleIDPath, secretIDPath := setupAppRoleAndKVMounts(t, serverClient)
 
-	// make a temp directory to hold renders. Each test will create a temp dir
-	// inside this one
-	tmpDirRoot := t.TempDir()
-	// create temp dir for this test run
-	tmpDir, err := os.MkdirTemp(tmpDirRoot, "TestAgent_Template_UserAgent")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := t.TempDir()
 
 	// make some template files
 	var templatePaths []string
@@ -693,10 +686,6 @@ func TestAgent_Template_Basic(t *testing.T) {
 
 	roleIDPath, secretIDPath := setupAppRoleAndKVMounts(t, serverClient)
 
-	// make a temp directory to hold renders. Each test will create a temp dir
-	// inside this one
-	tmpDirRoot := t.TempDir()
-
 	// start test cases here
 	testCases := map[string]struct {
 		templateCount int
@@ -721,10 +710,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 	for tcname, tc := range testCases {
 		t.Run(tcname, func(t *testing.T) {
 			// create temp dir for this test run
-			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcname)
-			if err != nil {
-				t.Fatal(err)
-			}
+			tmpDir := t.TempDir()
 
 			// make some template files
 			var templatePaths []string
@@ -1160,15 +1146,7 @@ func TestAgent_Template_ExitCounter(t *testing.T) {
 
 	roleIDPath, secretIDPath := setupAppRoleAndKVMounts(t, serverClient)
 
-	// make a temp directory to hold renders. Each test will create a temp dir
-	// inside this one
-	tmpDirRoot := t.TempDir()
-
-	// create temp dir for this test run
-	tmpDir, err := os.MkdirTemp(tmpDirRoot, "agent-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := t.TempDir()
 
 	// Create a config file
 	config := `
@@ -1460,10 +1438,6 @@ func TestAgent_Template_Retry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make a temp directory to hold renders. Each test will create a temp dir
-	// inside this one
-	tmpDirRoot := t.TempDir()
-
 	intRef := func(i int) *int {
 		return &i
 	}
@@ -1505,11 +1479,7 @@ func TestAgent_Template_Retry(t *testing.T) {
 			// perspective) attempt, it will succeed.
 			h.failCount = 6
 
-			// create temp dir for this test run
-			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcname)
-			if err != nil {
-				t.Fatal(err)
-			}
+			tmpDir := t.TempDir()
 
 			// make some template files
 			templatePath := filepath.Join(tmpDir, "render_0.tmpl")
@@ -2291,10 +2261,6 @@ func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make a temp directory to hold renders. Each test will create a temp dir
-	// inside this one
-	tmpDirRoot := t.TempDir()
-
 	// Note that missing key is different from a non-existent secret. A missing
 	// key (2xx response with missing keys in the response map) can still yield
 	// a successful render unless error_on_missing_key is specified, whereas a
@@ -2392,11 +2358,7 @@ func TestAgent_TemplateConfig_ExitOnRetryFailure(t *testing.T) {
 
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			// create temp dir for this test run
-			tmpDir, err := os.MkdirTemp(tmpDirRoot, tcName)
-			if err != nil {
-				t.Fatal(err)
-			}
+			tmpDir := t.TempDir()
 
 			listenAddr := generateListenerAddress(t)
 			listenConfig := fmt.Sprintf(`

--- a/command/agentproxyshared/auth/jwt/jwt_test.go
+++ b/command/agentproxyshared/auth/jwt/jwt_test.go
@@ -23,14 +23,9 @@ func TestIngressToken(t *testing.T) {
 		symlinked = "symlinked"
 	)
 
-	rootDir := t.TempDir()
-
 	setupTestDir := func() string {
-		testDir, err := os.MkdirTemp(rootDir, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = os.WriteFile(path.Join(testDir, file), []byte("test"), 0o644)
+		testDir := t.TempDir()
+		err := os.WriteFile(path.Join(testDir, file), []byte("test"), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/physical/raft/fsm_test.go
+++ b/physical/raft/fsm_test.go
@@ -6,7 +6,6 @@ package raft
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -20,11 +19,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func getFSM(t testing.TB) (*FSM, string) {
-	raftDir, err := os.MkdirTemp("", "vault-raft-")
-	if err != nil {
-		t.Fatal(err)
-	}
+func getFSM(t testing.TB) *FSM {
+	raftDir := t.TempDir()
 	t.Logf("raft dir: %s", raftDir)
 
 	logger := hclog.New(&hclog.LoggerOptions{
@@ -37,13 +33,12 @@ func getFSM(t testing.TB) (*FSM, string) {
 		t.Fatal(err)
 	}
 
-	return fsm, raftDir
+	return fsm
 }
 
 func TestFSM_Batching(t *testing.T) {
 	t.Parallel()
-	fsm, dir := getFSM(t)
-	defer func() { _ = os.RemoveAll(dir) }()
+	fsm := getFSM(t)
 
 	var index uint64
 	var term uint64 = 1
@@ -145,8 +140,7 @@ func TestFSM_Batching(t *testing.T) {
 
 func TestFSM_List(t *testing.T) {
 	t.Parallel()
-	fsm, dir := getFSM(t)
-	defer func() { _ = os.RemoveAll(dir) }()
+	fsm := getFSM(t)
 
 	ctx := t.Context()
 	count := 100

--- a/vault/external_tests/plugin/plugin_test.go
+++ b/vault/external_tests/plugin/plugin_test.go
@@ -593,11 +593,7 @@ func testSystemBackendMock(t *testing.T, numCores, numMounts int, backendType lo
 		},
 	}
 
-	// Create a tempdir, cluster.Cleanup will clean up this directory
-	tempDir, err := os.MkdirTemp("", "vault-test-cluster")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
 
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
 		HandlerFunc:        vaulthttp.Handler,
@@ -667,11 +663,7 @@ func testSystemBackend_SingleCluster_Env(t *testing.T, env []string) *vault.Test
 			"test": plugin.Factory,
 		},
 	}
-	// Create a tempdir, cluster.Cleanup will clean up this directory
-	tempDir, err := os.MkdirTemp("", "vault-test-cluster")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
 
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
 		HandlerFunc:        vaulthttp.Handler,

--- a/vault/plugin_catalog_oci_test.go
+++ b/vault/plugin_catalog_oci_test.go
@@ -98,11 +98,7 @@ func TestExtractPluginFromImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a temporary directory for the test
-			tempDir, err := os.MkdirTemp("", "oci-plugin-test")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			defer os.RemoveAll(tempDir) //nolint:errcheck
+			tempDir := t.TempDir()
 
 			// Create the test OCI image
 			img := createTestOCIImage(t, tt.binaryName, tt.binaryContent)
@@ -114,7 +110,7 @@ func TestExtractPluginFromImage(t *testing.T) {
 
 			// Test the extraction
 			targetPath := filepath.Join(tempDir, "extracted-plugin")
-			err = downloader.ExtractPluginFromImage(img, targetPath, tt.targetBinary, logger)
+			err := downloader.ExtractPluginFromImage(img, targetPath, tt.targetBinary, logger)
 
 			if tt.expectError {
 				if err == nil {
@@ -370,11 +366,7 @@ func TestReconcileOCIPlugins(t *testing.T) {
 // TestPluginCacheStructure tests the new hidden cache structure and symlink functionality
 func TestPluginCacheStructure(t *testing.T) {
 	// Create a temporary directory for plugins
-	tempDir, err := os.MkdirTemp("", "oci-cache-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := t.TempDir()
 
 	// Test plugin configuration
 	pluginConfig := &server.PluginConfig{
@@ -392,7 +384,7 @@ func TestPluginCacheStructure(t *testing.T) {
 	cachedPluginPath := filepath.Join(cacheDir, pluginConfig.BinaryName)
 
 	// Create the cache directory
-	err = os.MkdirAll(cacheDir, 0o755)
+	err := os.MkdirAll(cacheDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to create cache directory: %v", err)
 	}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Replaces some `os.MkdirTemp()` calls with `t.TempDir()`. There seemed to be some structuring in the tests where there was a root folder and other tempdirs inside that parent folder. These were replaced by just calling`TempDir` at least in those tests the directory structure didn't seem to matter. I didn't replace the calls in every single spot since some tests dependent on the structure that the `TempDir` function cannot guarantee.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Go's testing package contains a more ergonomic `t.TempDir()` method which makes tests cleaner and shorter. Therefore, that should be preferred over using `os.MkdirTemp()`.

Resolves: #2869 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
