### PR TITLE
pki: add default values for not_after_bound and not_before_bound

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -1057,6 +1057,16 @@ func (b *backend) getRole(ctx context.Context, s logical.Storage, n string) (*ro
 		modified = true
 	}
 
+	// Update not_after_bound, not_before_bound
+	if result.NotAfterBound == "" {
+		result.NotAfterBound = PermitNotAfterBound.String()
+		modified = true
+	}
+	if result.NotBeforeBound == "" {
+		result.NotBeforeBound = PermitNotBeforeBound.String()
+		modified = true
+	}
+
 	// Ensure the role is valid after updating.
 	_, err = validateRole(b, &result, ctx, s)
 	if err != nil {
@@ -1278,7 +1288,7 @@ func validateNotAfterBound(notAfterBound string) (*logical.Response, error) {
 	default:
 		_, err = time.Parse(time.RFC3339, notAfterBound)
 		if err != nil {
-			resp = logical.ErrorResponse("Unknown value for field `not_after_bound`. Possible values are `forbid`, `ttl`, or an explicit timestamp.")
+			resp = logical.ErrorResponse("Unknown value for field `not_after_bound`. Possible values are `permit`, `ttl-limited`, `forbid`, or an explicit timestamp.")
 		}
 	}
 	return resp, err
@@ -1296,7 +1306,7 @@ func validateNoBeforeBound(notBeforebound string) (*logical.Response, error) {
 	case PermitNotBeforeBound.String():
 	// nothing to do
 	default:
-		resp = logical.ErrorResponse("Unknown value for field `not_before_bound`. Possible values are `permit` or `forbid`")
+		resp = logical.ErrorResponse("Unknown value for field `not_before_bound`. Possible values are `permit` `duration` or `forbid`")
 		err = errors.New("unknown value")
 	}
 	return resp, err

--- a/changelog/3031.txt
+++ b/changelog/3031.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: Add missing migration for `not_after_bound` and `not_before_bound` role fields.
+```


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->


When starting OpenBao with a database migrated from Vault or OpenBao versions before 2.3.x, existing PKI roles returned by OpenBao contain two fields `not_after_bound` and `not_before_bound` that are returned as empty strings.  Empty string is invalid value for these fields.

This PR implements the following defaults:

* `not_after_bound`: `permit`
* `not_before_bound`: `permit`

This PR also corrects the associated error printout.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3030

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
