### PR TITLE
Scorecard action runner revert

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:


### PR DESCRIPTION
## Description
Changed runner from `ubuntu-slim` to `ubuntu-latest` (partial revert of #2933)

## Rationale
ubuntu-slim runner doesn't allow for pulling docker images like done in `scorecard.yml` action,
shown by failure like [this](https://github.com/openbao/openbao/actions/runs/25306677606/job/74184073672)

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
