### PR TITLE
Document deprecation of generate-root cmd

### DIFF
--- a/command/operator_generate_root.go
+++ b/command/operator_generate_root.go
@@ -56,6 +56,10 @@ func (c *OperatorGenerateRootCommand) Help() string {
 	helpText := `
 Usage: bao operator generate-root [options] [KEY]
 
+  WARNING: this method is deprecated, please consider using:
+    $ bao auth token create
+  with an existing root token with 'sudo' permission instead.
+
   Generates a new root token by combining a quorum of share holders. One of
   the following must be provided to start the root token generation:
 
@@ -297,7 +301,7 @@ func (c *OperatorGenerateRootCommand) decode(client *api.Client, encoded, otp st
 
 	if encoded == "-" {
 		// Pull our fake stdin if needed
-		stdin := (io.Reader)(os.Stdin)
+		stdin := io.Reader(os.Stdin)
 		if c.testStdin != nil {
 			stdin = c.testStdin
 		}
@@ -379,6 +383,12 @@ func (c *OperatorGenerateRootCommand) init(client *api.Client, otp, pgpKey strin
 // provide prompts the user for the seal key and posts it to the update root
 // endpoint. If this is the last unseal, this function outputs it.
 func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, kind generateRootKind) int {
+	c.UI.Warn(wrapAtLength(
+		"This root token generation method is considered insecure and requires " +
+			"\"disable_unauthed_generate_root_endpoints\" configuration parameter set to 'true', " +
+			"consider generation of the root token through \"bao auth token create\" instead.",
+	))
+
 	f := client.Sys().GenerateRootStatus
 	switch kind {
 	case generateRootRecovery:
@@ -395,11 +405,13 @@ func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, ki
 	if !status.Started {
 		c.UI.Error(wrapAtLength(
 			"No root generation is in progress. Start a root generation by " +
-				"running \"bao operator generate-root -init\"."))
+				"running \"bao operator generate-root -init\".",
+		))
 		c.UI.Warn(wrapAtLength(fmt.Sprintf(
 			"If starting root generation using the OTP method and generating "+
 				"your own OTP, the length of the OTP string needs to be %d "+
-				"characters in length.", status.OTPLength)))
+				"characters in length.", status.OTPLength,
+		)))
 		return 1
 	}
 
@@ -410,7 +422,7 @@ func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, ki
 		nonce = c.flagNonce
 
 		// Pull our fake stdin if needed
-		stdin := (io.Reader)(os.Stdin)
+		stdin := io.Reader(os.Stdin)
 		if c.testStdin != nil {
 			stdin = c.testStdin
 		}
@@ -503,6 +515,12 @@ func (c *OperatorGenerateRootCommand) cancel(client *api.Client, kind generateRo
 
 // status is used just to fetch and dump the status
 func (c *OperatorGenerateRootCommand) status(client *api.Client, kind generateRootKind) int {
+	c.UI.Warn(wrapAtLength(
+		"This root token generation method is considered insecure and requires " +
+			"\"disable_unauthed_generate_root_endpoints\" configuration parameter set to 'true', " +
+			"consider generation of the root token through \"bao auth token create\" instead.",
+	))
+
 	f := client.Sys().GenerateRootStatus
 	switch kind {
 	case generateRootRecovery:

--- a/website/content/api-docs/system/generate-root.mdx
+++ b/website/content/api-docs/system/generate-root.mdx
@@ -1,6 +1,6 @@
 ---
 description: |-
-  The `/sys/generate-root/` endpoints are used to create a new root key for
+  The `/sys/generate-root/` endpoints are used to create a new root token for
   OpenBao.
 ---
 
@@ -17,7 +17,7 @@ do so only for the short period of time required to create a new root token.
 
 # `/sys/generate-root`
 
-The `/sys/generate-root` endpoint is used to create a new root key for OpenBao.
+The `/sys/generate-root` endpoint is used to create a new root token for OpenBao.
 
 ## Read root generation progress
 
@@ -50,9 +50,9 @@ $ curl \
 }
 ```
 
-If a root generation is started, `progress` is how many unseal keys have been
-provided for this generation attempt, where `required` must be reached to
-complete. The `nonce` for the current attempt and whether the attempt is
+If a root generation is started, `progress` tracks how many unseal keys have
+been provided for this generation attempt, where `required` must be reached
+to complete. The `nonce` for the current attempt and whether the attempt is
 complete is also displayed.
 
 If a PGP key is being used to encrypt the final root
@@ -77,7 +77,7 @@ generation attempt can take place at a time.
 
 ### Parameters
 
-- `pgp_key` `(string: <optional>)` – Specifies a base64-encoded PGP public key.
+- `pgp_key` `(string: <optional>)` - Specifies a base64-encoded PGP public key.
   The raw bytes of the token will be encrypted with this value before being
   returned to the final unseal key provider.
 
@@ -135,9 +135,9 @@ nonce must be provided with each call.
 
 ### Parameters
 
-- `key` `(string: <required>)` – Specifies a single root key share.
+- `key` `(string: <required>)` - Specifies a single root key share.
 
-- `nonce` `(string: <required>)` – Specifies the nonce of the attempt.
+- `nonce` `(string: <required>)` - Specifies the nonce of the attempt.
 
 ### Sample payload
 

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -5,6 +5,17 @@ description: |-
   quorum of share holders.
 ---
 
+:::warning
+
+Note: As of v2.5.3 usage of this command is [deprecated](../../deprecation/unauthed-generate-root.mdx)
+and will be rejected by default. Consider using [`token create`](../token/create.mdx)
+command to create new root tokens from existing tokens with `sudo` permission.
+To re-enable, see the documentation around the `disable_unauthed_generate_root_endpoints`
+[listener parameter](../../configuration/listener/unix.mdx): it is suggested to
+do so only for the short period of time required to create a new root token.
+
+:::
+
 # operator generate-root
 
 The `operator generate-root` command generates a new root token by combining a


### PR DESCRIPTION
## Description
- Adds a warning box to the `operator generate-root` cmd documentation.
- Adds a warning text to the help text of `operator generate-root` command, and warning info on the `operator generate-root -init` command output.

## Rationale
We've added same warning to the API endpoint documentation, but haven't done so in case of cmd, so this PR corrects that omit.

Resolves: #3020

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
