### PR TITLE
pki: allow user to define acme challenge ports and host

### DIFF
--- a/changelog/3034.txt
+++ b/changelog/3034.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+pki: Add optional ACME client port and host configuration to support non-privileged operation when a load balancer forwards challenges from ports 80 and 443.
+```

--- a/internal/helper/configutil/listener.go
+++ b/internal/helper/configutil/listener.go
@@ -100,6 +100,9 @@ type Listener struct {
 	TLSACMEDisableHttpChallengeRaw any      `hcl:"tls_acme_disable_http_challenge"`
 	TLSACMEDisableAlpnChallenge    bool     `hcl:"-"`
 	TLSACMEDisableAlpnChallengeRaw any      `hcl:"tls_acme_disable_alpn_challenge"`
+	TLSACMEHttpChallengePort       int      `hcl:"tls_acme_http_challenge_port"`
+	TLSACMEAlpnChallengePort       int      `hcl:"tls_acme_alpn_challenge_port"`
+	TLSACMEChallengeHost           string   `hcl:"tls_acme_challenge_host"`
 
 	HTTPReadTimeout          time.Duration `hcl:"-"`
 	HTTPReadTimeoutRaw       any           `hcl:"http_read_timeout"`
@@ -216,6 +219,11 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 			return multierror.Prefix(err, fmt.Sprintf("listeners.%d:", i))
 		} else {
 			l.ClusterAddress = rendered
+		}
+		if rendered, err := ParseSingleIPTemplate(l.TLSACMEChallengeHost); err != nil {
+			return multierror.Prefix(err, fmt.Sprintf("listeners.%d:", i))
+		} else {
+			l.TLSACMEChallengeHost = rendered
 		}
 
 		// Hacky way, for now, to get the values we want for sanitizing

--- a/internal/helper/listenerutil/tls_acme.go
+++ b/internal/helper/listenerutil/tls_acme.go
@@ -131,6 +131,9 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 		Logger:                  zapLogger,
 		DisableHTTPChallenge:    l.TLSACMEDisableHttpChallenge,
 		DisableTLSALPNChallenge: l.TLSACMEDisableAlpnChallenge,
+		AltHTTPPort:             l.TLSACMEHttpChallengePort,
+		AltTLSALPNPort:          l.TLSACMEAlpnChallengePort,
+		ListenHost:              l.TLSACMEChallengeHost,
 	}
 
 	if l.TLSACMECARoot != "" {

--- a/internal/vault/external_tests/tlslistener_binary/tls_test.go
+++ b/internal/vault/external_tests/tlslistener_binary/tls_test.go
@@ -299,10 +299,11 @@ func TestTLSListener_NonPrivileged(t *testing.T) {
 	dns.AddRecord("openbao.dadgarcorp.com", "A", cluster.ClusterNodes[node].ContainerGatewayIP)
 	dns.PushConfig()
 
-	client.Logical().Write("pki/config/acme", map[string]interface{}{
+	_, err = client.Logical().Write("pki/config/acme", map[string]interface{}{
 		"enabled":      true,
 		"dns_resolver": dns.GetRemoteAddr(),
 	})
+	require.NoError(t, err)
 
 	// Validate ACME cert acquisition works.
 	validateTLS(t, ctx, root, cluster.ClusterNodes[node].ContainerNetworkName, "openbao.dadgarcorp.com:443", dns.GetRemoteAddr(), false)

--- a/internal/vault/external_tests/tlslistener_binary/tls_test.go
+++ b/internal/vault/external_tests/tlslistener_binary/tls_test.go
@@ -234,6 +234,80 @@ func TestTLSListener_ALPN(t *testing.T) {
 	validateTLS(t, ctx, root, cluster.ClusterNodes[node].ContainerNetworkName, "invalid.dadgarcorp.com:443", dns.GetRemoteAddr(), true)
 }
 
+func TestTLSListener_NonPrivileged(t *testing.T) {
+	binary := api.ReadBaoVariable("BAO_BINARY")
+	if binary == "" {
+		t.Skip("only running docker test when $BAO_BINARY present")
+	}
+
+	opts := &docker.DockerClusterOptions{
+		ImageRepo:    "quay.io/openbao/openbao",
+		ImageTag:     "latest",
+		VaultBinary:  binary,
+		Root:         false,
+		Entrypoint:   entrypointPath(t),
+		PublishPorts: map[uint16]uint16{443: 8443},
+		ClusterOptions: testcluster.ClusterOptions{
+			NumCores: 1,
+			VaultNodeConfig: &testcluster.VaultNodeConfig{
+				LogLevel: "TRACE",
+				AdditionalListeners: []interface{}{
+					map[string]interface{}{
+						"tcp": map[string]interface{}{
+							"address":     "127.0.0.1:8300", // TCP listener that acts as ACME server.
+							"tls_disable": true,
+						},
+					},
+					map[string]interface{}{
+						"tcp": map[string]interface{}{
+							"address":                         "0.0.0.0:8443", // Non-privileged TCP listener that receives ACME challenge.
+							"tls_acme_cache_path":             "/tmp",
+							"tls_acme_ca_directory":           "http://127.0.0.1:8300/v1/pki/acme/directory",
+							"tls_acme_disable_http_challenge": true,
+							"tls_acme_domains":                []string{"openbao.dadgarcorp.com"},
+
+							// CertMagic's listener is set to dummy non-privileged port to avoid root.
+							"tls_acme_alpn_challenge_port": 8222,
+							"tls_acme_challenge_host":      "127.0.0.1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster := docker.NewTestDockerCluster(t, opts)
+	defer cluster.Cleanup()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	node, err := testcluster.WaitForActiveNode(ctx, cluster)
+	require.NoError(t, err, "failed to get active node")
+	require.NotNil(t, node)
+
+	client := cluster.ClusterNodes[node].APIClient()
+	require.NotNil(t, client)
+
+	// Configure PKI mount for self-hosting ACME.
+	root := setupPki(t, client, ":8300")
+
+	dns := dnstest.SetupResolverOnNetwork(t, "dadgarcorp.com", cluster.ClusterNodes[node].ContainerNetworkName)
+	defer dns.Cleanup()
+
+	// Point the domain at the gateway IP so the ACME server connects through Docker's port mapping (host:443 -> container:8443).
+	dns.AddRecord("openbao.dadgarcorp.com", "A", cluster.ClusterNodes[node].ContainerGatewayIP)
+	dns.PushConfig()
+
+	client.Logical().Write("pki/config/acme", map[string]interface{}{
+		"enabled":      true,
+		"dns_resolver": dns.GetRemoteAddr(),
+	})
+
+	// Validate ACME cert acquisition works.
+	validateTLS(t, ctx, root, cluster.ClusterNodes[node].ContainerNetworkName, "openbao.dadgarcorp.com:443", dns.GetRemoteAddr(), false)
+}
+
 func setupPki(t *testing.T, client *api.Client, acmePort string) string {
 	err := client.Sys().Mount("pki", &api.MountInput{
 		Type: "pki",

--- a/internal/vault/external_tests/tlslistener_binary/tls_test.go
+++ b/internal/vault/external_tests/tlslistener_binary/tls_test.go
@@ -251,15 +251,15 @@ func TestTLSListener_NonPrivileged(t *testing.T) {
 			NumCores: 1,
 			VaultNodeConfig: &testcluster.VaultNodeConfig{
 				LogLevel: "TRACE",
-				AdditionalListeners: []interface{}{
-					map[string]interface{}{
-						"tcp": map[string]interface{}{
+				AdditionalListeners: []any{
+					map[string]any{
+						"tcp": map[string]any{
 							"address":     "127.0.0.1:8300", // TCP listener that acts as ACME server.
 							"tls_disable": true,
 						},
 					},
-					map[string]interface{}{
-						"tcp": map[string]interface{}{
+					map[string]any{
+						"tcp": map[string]any{
 							"address":                         "0.0.0.0:8443", // Non-privileged TCP listener that receives ACME challenge.
 							"tls_acme_cache_path":             "/tmp",
 							"tls_acme_ca_directory":           "http://127.0.0.1:8300/v1/pki/acme/directory",
@@ -299,7 +299,7 @@ func TestTLSListener_NonPrivileged(t *testing.T) {
 	dns.AddRecord("openbao.dadgarcorp.com", "A", cluster.ClusterNodes[node].ContainerGatewayIP)
 	dns.PushConfig()
 
-	_, err = client.Logical().Write("pki/config/acme", map[string]interface{}{
+	_, err = client.Logical().Write("pki/config/acme", map[string]any{
 		"enabled":      true,
 		"dns_resolver": dns.GetRemoteAddr(),
 	})

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -65,7 +65,8 @@ type RunOptions struct {
 	// WriteInto is provided instead of Runner.CopyTo(...) so that it executes
 	// before the container starts, providing an opportunity to provision
 	// initial data. Map of destination -> contents.
-	WriteInto map[string]BuildContext
+	WriteInto    map[string]BuildContext
+	PublishPorts map[uint16]uint16
 }
 
 func NewDockerAPI() (*client.Client, error) {
@@ -477,6 +478,13 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 	}
 	if len(d.RunOptions.Capabilities) > 0 {
 		hostConfig.CapAdd = d.RunOptions.Capabilities
+	}
+	if len(d.RunOptions.PublishPorts) > 0 {
+		hostConfig.PortBindings = make(network.PortMap)
+		for hostPort, containerPort := range d.RunOptions.PublishPorts {
+			port, _ := network.PortFrom(containerPort, network.TCP)
+			hostConfig.PortBindings[port] = []network.PortBinding{{HostPort: strconv.Itoa(int(hostPort))}}
+		}
 	}
 
 	netConfig := &network.NetworkingConfig{}

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -480,6 +480,7 @@ type DockerClusterNode struct {
 	RealAPIAddr          string
 	ContainerNetworkName string
 	ContainerIPAddress   string
+	ContainerGatewayIP   string
 	ImageRepo            string
 	ImageTag             string
 	DataVolumeName       string
@@ -789,6 +790,7 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 		VolumeNameToMountPoint: map[string]string{
 			n.DataVolumeName: "/openbao/file",
 		},
+		PublishPorts: opts.PublishPorts,
 	})
 	if err != nil {
 		return err
@@ -839,6 +841,7 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 	}
 	n.ContainerNetworkName = netName
 	n.ContainerIPAddress = svc.Container.NetworkSettings.Networks[netName].IPAddress.String()
+	n.ContainerGatewayIP = svc.Container.NetworkSettings.Networks[netName].Gateway.String()
 	n.RealAPIAddr = "https://" + n.ContainerIPAddress + ":8200"
 	n.cleanupContainer = svc.Cleanup
 
@@ -1029,6 +1032,7 @@ type DockerClusterOptions struct {
 	Entrypoint         string
 	HADisabled         bool
 	SkipStorageCleanup bool
+	PublishPorts       map[uint16]uint16 // Host port -> container port.
 }
 
 func DefaultOptions(t *testing.T) *DockerClusterOptions {

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -327,6 +327,17 @@ in the root of the TCP listener configuration.
   the ALPN challenge type cannot work for some reason (e.g., a load balancer
   sitting in front of OpenBao).
 
+- `tls_acme_http_challenge_port` `(int: 80)` - Specifies an optional port to use for HTTP challenges
+  instead of the default. Useful when running behind a load balancer that forwards
+  port 80 to a different port.
+
+- `tls_acme_alpn_challenge_port` `(int: 443)` - Specifies an optional port to use for TLS-ALPN challenges
+  instead of the default. Useful when running behind a load balancer that forwards
+  port 443 to a different port.
+
+- `tls_acme_challenge_host` `(string: "")` - Specifies an optional host to listen on for ACME challenges.
+  Useful when wanting to limit the ACME challenge listener to a specific interface.
+
 ### `telemetry` parameters
 
 - `unauthenticated_metrics_access` `(bool: false)` - If set to true, allows


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This PR adds new optional configuration options for ACME client. Admins can now specify which ports and host the ACME listener uses:


- `tls_acme_http_challenge_port` `(int: 80)` - Specifies an optional port to use for HTTP challenges instead of the default. Useful when running behind a load balancer that forwards  port 80 to a different port.
- `tls_acme_alpn_challenge_port` `(int: 443)` - Specifies an optional port to use for TLS-ALPN challenges  instead of the default. Useful when running behind a load balancer that forwards port 443 to a different port.
- `tls_acme_challenge_host` `(string: "")` - Specifies an optional host to listen on for ACME challenges. Useful when wanting to limit the ACME challenge listener to a specific interface.

> [!NOTE]
> The server must still connect to privileged ports as required by the specification. This change allows the client to run on an unprivileged port when a load balancer or proxy forwards traffic from a privileged port.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

This allows OpenBao to run without root privileges or `CAP_NET_BIND_SERVICE`.

Background:

When OpenBao runs behind a load balancer, the load balancer can listen on ports 80 and 443 for ACME challenges, while OpenBao itself listens on unprivileged ports. Currently, CertMagic always tries to bind to the privileged ports. If it can't bind due to `permission denied`, it fails completely.

The original intention was to allow administrators to run OpenBao with ACME client without requiring elevated privileges (#857):

> if a load balancer or firewall port redirection is used, the challenges will be exposed on all ports and root permissions can be dropped.

Unfortunately, this only works if port 443 is already in use when CertMagic attempts to set up its listener. CertMagic gracefully ignores an `address already in use` error, which can be demonstrated by reserving `:443` with another process. In that case, the challenge is served via port `:8200` successfully. 

However, CertMagic does not ignore error `permission denied` ([link](https://github.com/caddyserver/certmagic/blob/c7496f1a6a93025c528b03cde701bf06394440fd/solvers.go#L748-L752)). This logic is hardcoded, and there does not seem to be any way to disable the CertMagic listener in favor of users own challenge handling via `tls.Config.NextProtos`. CertMagic assumes the user's own listener **must** be running on the same port, which is why it only ignores the `address already in use` error. 

If user wants to run behind proxy on non-privieleged port, the supported solution is to configure CertMagic's `AltTLSALPNPort` (or/and `AltHTTPPort`).


<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: Discussion: [TLS-ALPN-01 without requiring binding to privileged port (443)](https://github.com/orgs/openbao/discussions/3025)


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
