### PR TITLE
Refactor context, cancellation to be co-atomic

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -659,11 +659,12 @@ func (c *Core) ReloadAuditLogs() {
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
-	if c.Sealed() || (c.standby.Load() && !c.StandbyReadsEnabled()) || c.activeContext == nil {
+	ctx := c.activeContext.Load()
+	if c.Sealed() || (c.standby.Load() && !c.StandbyReadsEnabled()) || ctx.IsNil() {
 		return
 	}
 
-	if err := c.handleAuditLogSetup(c.activeContext, c.standby.Load()); err != nil {
+	if err := c.handleAuditLogSetup(ctx, c.standby.Load()); err != nil {
 		c.logger.Error("failed to set up audit logs on reload", "error", err)
 	}
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -199,7 +199,7 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origViewReadOnlyErr)
 	// initialize, using the core's active context.
-	err = backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+	err = backend.Initialize(c.activeContext.Load(), &logical.InitializationRequest{Storage: view})
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 		return err
 	}
 
-	revokeCtx := namespace.ContextWithNamespace(c.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
 
 	if backend != nil && c.expiration != nil && updateStorage {
 		// Revoke credentials from this path

--- a/vault/context.go
+++ b/vault/context.go
@@ -1,0 +1,75 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// atomicContext is a struct to bind together a context (interface) and its
+// cancel function in a single package to help with atomic.Pointer operations.
+// Notably from the CancelFunc docs, it is safe to call in multiple contexts
+// simultaneously and any subsequent calls will be ignored. These functions
+// are written so that if c.activeContext.Load() is called and there is no
+// active context, we should mostly behave like a cancelled context.
+type atomicContext struct {
+	ctx      context.Context
+	canceler context.CancelFunc
+}
+
+var _ context.Context = &atomicContext{}
+
+func NewAtomicContext(ctx context.Context, cancel context.CancelFunc) *atomicContext {
+	return &atomicContext{
+		ctx:      ctx,
+		canceler: cancel,
+	}
+}
+
+func (a *atomicContext) IsNil() bool {
+	return a == nil || a.ctx == nil
+}
+
+func (a *atomicContext) Canceler() context.CancelFunc {
+	if a.IsNil() || a.canceler == nil {
+		return func() {}
+	}
+
+	return a.canceler
+}
+
+func (a *atomicContext) Deadline() (time.Time, bool) {
+	if a.IsNil() {
+		return time.Time{}, false
+	}
+
+	return a.ctx.Deadline()
+}
+
+func (a *atomicContext) Done() <-chan struct{} {
+	if a.IsNil() {
+		// This must return a closed channel per documentation on Done to
+		// behave like a cancelled context.
+		ret := make(chan struct{})
+		close(ret)
+		return ret
+	}
+
+	return a.ctx.Done()
+}
+
+func (a *atomicContext) Err() error {
+	if a.IsNil() {
+		return errors.New("no active context")
+	}
+
+	return a.ctx.Err()
+}
+
+func (a *atomicContext) Value(key any) any {
+	if a.IsNil() {
+		return nil
+	}
+
+	return a.ctx.Value(key)
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -510,8 +510,7 @@ type Core struct {
 
 	// This can be used to trigger operations to stop running when Vault is
 	// going to be shut down, stepped down, or sealed
-	activeContext           context.Context
-	activeContextCancelFunc atomic.Pointer[context.CancelFunc]
+	activeContext atomic.Pointer[atomicContext]
 
 	// unsealwithStoredKeysLock is a mutex that prevents multiple processes from
 	// unsealing with stored keys are the same time.
@@ -1056,6 +1055,12 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 
+	if c.recoveryMode {
+		// When in recovery mode, assign a default context during startup.
+		ctx, cancel := context.WithCancel(context.Background())
+		c.activeContext.Store(NewAtomicContext(ctx, cancel))
+	}
+
 	// Construct a new AES-GCM barrier
 	c.barrier = barrier.NewAESGCMBarrier(c.physical, "")
 	c.SetupSealManager()
@@ -1385,7 +1390,7 @@ func (c *Core) GetContext() (context.Context, context.CancelFunc) {
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
-	return context.WithCancel(namespace.RootContext(c.activeContext))
+	return context.WithCancel(namespace.RootContext(c.activeContext.Load()))
 }
 
 // Sealed checks if the Vault is currently sealed
@@ -1973,9 +1978,9 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext, te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext.Load(), te)
 		if err == nil {
-			err = c.expiration.Revoke(c.activeContext, leaseID)
+			err = c.expiration.Revoke(c.activeContext.Load(), leaseID)
 		}
 		if err != nil {
 			c.logger.Error("token needed revocation before seal but failed to revoke", "error", err)
@@ -2026,7 +2031,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 	c.clearForwardingClients()
 	c.requestForwardingConnectionLock.Unlock()
 
-	activeCtxCancel := c.activeContextCancelFunc.Load()
+	activeCtxCancel := c.activeContext.Load().Canceler()
 	cancelCtxAndLock := func() {
 		doneCh := make(chan struct{})
 		go func() {
@@ -2034,9 +2039,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 			case <-doneCh:
 			// Attempt to drain any inflight requests
 			case <-time.After(DefaultMaxRequestDuration):
-				if activeCtxCancel != nil {
-					(*activeCtxCancel)()
-				}
+				activeCtxCancel()
 			}
 		}()
 
@@ -2050,9 +2053,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 		close(doneCh)
 
 		// Stop requests from processing
-		if activeCtxCancel != nil {
-			(*activeCtxCancel)()
-		}
+		activeCtxCancel()
 	}
 
 	// Do pre-seal teardown if HA is not enabled
@@ -2065,9 +2066,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 		c.standby.Store(true)
 
 		// Stop requests from processing
-		if activeCtxCancel != nil {
-			(*activeCtxCancel)()
-		}
+		activeCtxCancel()
 	} else {
 		// If we are keeping the lock we already have the state write lock
 		// held. Otherwise grab it here so that when stopCh is triggered we are
@@ -2088,6 +2087,9 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 		// Wait for runStandby to stop
 		<-c.standbyDoneCh
 		c.logger.Debug("runStandby done")
+
+		// Stop requests from processing
+		activeCtxCancel()
 	}
 
 	// Stop all running subsystems.
@@ -2155,7 +2157,7 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 
 	if c.autoRotateCancel == nil {
 		var autoRotateCtx context.Context
-		autoRotateCtx, c.autoRotateCancel = context.WithCancel(c.activeContext)
+		autoRotateCtx, c.autoRotateCancel = context.WithCancel(c.activeContext.Load())
 		go c.autoRotateBarrierLoop(autoRotateCtx)
 	}
 
@@ -2291,8 +2293,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	c.postUnsealFuncs = nil
 
 	// Create a new request context
-	c.activeContext = ctx
-	c.activeContextCancelFunc.Store(&ctxCancelFunc)
+	c.activeContext.Store(NewAtomicContext(ctx, ctxCancelFunc))
 
 	defer func() {
 		if retErr != nil {
@@ -2331,7 +2332,7 @@ func (c *Core) postUnseal(ctx context.Context, ctxCancelFunc context.CancelFunc,
 	// the keys used for auto unsealing ensures Vault and its data will
 	// continue to be accessible even after prior seal keys are destroyed.
 	if seal, ok := c.seal.(*autoSeal); ok {
-		if err := seal.UpgradeKeys(c.activeContext); err != nil {
+		if err := seal.UpgradeKeys(c.activeContext.Load()); err != nil {
 			c.logger.Warn("post-unseal upgrade seal keys failed", "error", err)
 		}
 
@@ -3122,7 +3123,7 @@ func (c *Core) setupCachedMFAResponseAuth() {
 	mfaQueue := c.mfaResponseAuthQueue
 	c.mfaResponseAuthQueueLock.Unlock()
 
-	ctx := c.activeContext
+	ctx := c.activeContext.Load()
 
 	go func() {
 		ticker := time.Tick(5 * time.Second)
@@ -3148,7 +3149,7 @@ func (c *Core) updateLockedUserEntries() {
 	}
 
 	var updateLockedUserEntriesCtx context.Context
-	updateLockedUserEntriesCtx, c.updateLockedUserEntriesCancel = context.WithCancel(c.activeContext)
+	updateLockedUserEntriesCtx, c.updateLockedUserEntriesCancel = context.WithCancel(c.activeContext.Load())
 
 	if err := c.runLockedUserEntryUpdates(updateLockedUserEntriesCtx); err != nil {
 		c.Logger().Error("failed to run locked user entry updates", "error", err)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -906,7 +906,7 @@ func TestCore_OneTenPlus_BatchTokens(t *testing.T) {
 		}
 	}
 
-	err := c.loadVersionHistory(c.activeContext)
+	err := c.loadVersionHistory(t.Context())
 	if err != nil {
 		t.Fatalf("failed to populate version history cache, err: %s", err.Error())
 	}
@@ -2464,7 +2464,7 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 	// Wait for postUnseal to conclude
 	require.Eventually(t, func() bool {
 		core2.stateLock.RLock()
-		c2ctx := core2.activeContext
+		c2ctx := core2.activeContext.Load()
 		core2.stateLock.RUnlock()
 
 		return c2ctx != nil

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -341,7 +341,7 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 		quitCh: make(chan struct{}),
 
 		coreStateLock: c.stateLock,
-		quitContext:   c.activeContext,
+		quitContext:   c.activeContext.Load(),
 
 		logLeaseExpirations: api.ReadBaoVariable("BAO_SKIP_LOGGING_LEASE_EXPIRATIONS") == "",
 

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -354,9 +354,9 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext, te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext.Load(), te)
 		if err == nil {
-			err = c.expiration.Revoke(c.activeContext, leaseID)
+			err = c.expiration.Revoke(c.activeContext.Load(), leaseID)
 		}
 		if err != nil {
 			c.logger.Error("token needed revocation before step-down but failed to revoke", "error", err)
@@ -692,14 +692,13 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 
 		// Create the active context
 		activeCtx, activeCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
-		c.activeContext = activeCtx
-		c.activeContextCancelFunc.Store(&activeCtxCancel)
+		c.activeContext.Store(NewAtomicContext(activeCtx, activeCtxCancel))
 
 		// Mark storage as readable again.
 		c.barrier.SetReadOnly(false)
 
 		// Perform seal migration
-		if err := c.migrateSeal(c.activeContext); err != nil {
+		if err := c.migrateSeal(activeCtx); err != nil {
 			c.logger.Error("root seal migration error", "error", err)
 			// nothing we can do about it here
 			_ = c.sealManager.sealAll()

--- a/vault/ha_test.go
+++ b/vault/ha_test.go
@@ -111,7 +111,7 @@ func testCoreRestart(t *testing.T, core int) {
 	TestWaitActive(t, c.Cores[0].Core)
 
 	c.Cores[core].stateLock.RLock()
-	activeContextDone := c.Cores[core].activeContext.Done()
+	activeContextDone := c.Cores[core].activeContext.Load().Done()
 	c.Cores[core].stateLock.RUnlock()
 
 	// trigger the restart
@@ -128,7 +128,7 @@ func testCoreRestart(t *testing.T, core int) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		c.Cores[core].stateLock.RLock()
 		defer c.Cores[core].stateLock.RUnlock()
-		require.NotNil(t, c.Cores[core].activeContext)
-		require.Nil(t, c.Cores[core].activeContext.Err())
+		require.NotNil(t, c.Cores[core].activeContext.Load())
+		require.Nil(t, c.Cores[core].activeContext.Load().Err())
 	}, 10*time.Second, 10*time.Millisecond)
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -244,7 +244,7 @@ func (b *SystemBackend) handleTidyLeases(ctx context.Context, req *logical.Reque
 	}
 
 	go func() {
-		tidyCtx := namespace.ContextWithNamespace(b.Core.activeContext, ns)
+		tidyCtx := namespace.ContextWithNamespace(b.Core.activeContext.Load(), ns)
 		err := b.Core.expiration.Tidy(tidyCtx)
 		if err != nil {
 			b.Backend.Logger().Error("failed to tidy leases", "error", err)
@@ -1370,7 +1370,7 @@ func (b *SystemBackend) handleRemount(ctx context.Context, req *logical.Request,
 // and intermittently checks to see if it is still open.
 func (b *SystemBackend) moveMount(ns *namespace.Namespace, logger log.Logger, migrationID string, entry *routing.MountEntry, fromPathDetails, toPathDetails namespace.MountPathDetails) error {
 	logger.Info("Starting to update the mount table and revoke leases")
-	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext.Load(), ns)
 
 	var err error
 	// Attempt remount
@@ -2046,7 +2046,7 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 	if err != nil {
 		return nil, err
 	}
-	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext.Load(), ns)
 	if data.Get("sync").(bool) {
 		// Invoke the expiration manager directly
 		if err := b.Core.expiration.Revoke(revokeCtx, leaseID); err != nil {
@@ -2088,7 +2088,7 @@ func (b *SystemBackend) handleRevokePrefixCommon(ctx context.Context,
 	}
 
 	// Invoke the expiration manager directly
-	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(b.Core.activeContext.Load(), ns)
 	if force {
 		err = b.Core.expiration.RevokeForce(revokeCtx, prefix)
 	} else {
@@ -4502,7 +4502,7 @@ func (b *SystemBackend) rotateBarrierKey(ctx context.Context) error {
 		// Schedule the destroy of the upgrade path
 		time.AfterFunc(b.Core.KeyRotateGracePeriod(), func() {
 			b.Backend.Logger().Debug("cleaning up upgrade keys", "waited", b.Core.KeyRotateGracePeriod())
-			if err := b.Core.barrier.DestroyUpgrade(b.Core.activeContext, newTerm); err != nil {
+			if err := b.Core.barrier.DestroyUpgrade(b.Core.activeContext.Load(), newTerm); err != nil {
 				b.Backend.Logger().Error("failed to destroy upgrade", "term", newTerm, "error", err)
 			}
 		})

--- a/vault/logical_system_rotate.go
+++ b/vault/logical_system_rotate.go
@@ -663,7 +663,7 @@ func (b *SystemBackend) handleRotateInitDelete() framework.OperationFunc {
 // handleRotateUpdate handles the POST `/sys/rotate/root/update` and `/sys/rotate/recovery/update`
 // endpoints used for providing a single root key share progressing the rotation of the key.
 func (b *SystemBackend) handleRotateUpdate() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	return func(_ context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		ikey, ok, err := data.GetOkErr("key")
 		if err != nil {
 			return handleError(err)
@@ -694,7 +694,7 @@ func (b *SystemBackend) handleRotateUpdate() framework.OperationFunc {
 			}
 		}
 
-		ctx, cancel := context.WithCancel(namespace.RootContext(b.Core.activeContext))
+		ctx, cancel := context.WithCancel(namespace.RootContext(b.Core.activeContext.Load()))
 		defer cancel()
 
 		// Use the key to make progress on rotation (rekey)
@@ -767,7 +767,7 @@ func (b *SystemBackend) handleRotateVerifyGet() framework.OperationFunc {
 // handleRotateVerifyPut handles the POST `/sys/rotate/root/verify` and `/sys/rotate/recovery/verify`
 // endpoints used to enter a single key share to progress the rotation verification operation.
 func (b *SystemBackend) handleRotateVerifyPut() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	return func(_ context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		ikey, ok, err := data.GetOkErr("key")
 		if err != nil {
 			return handleError(err)
@@ -798,7 +798,7 @@ func (b *SystemBackend) handleRotateVerifyPut() framework.OperationFunc {
 			}
 		}
 
-		ctx, cancel := context.WithCancel(namespace.RootContext(b.Core.activeContext))
+		ctx, cancel := context.WithCancel(namespace.RootContext(b.Core.activeContext.Load()))
 		defer cancel()
 
 		// Use the key to make progress on rotation (rekey) verification

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -341,7 +341,7 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origReadOnlyErr)
 	// initialize, using the core's active context.
-	err = backend.Initialize(c.activeContext, &logical.InitializationRequest{Storage: view})
+	err = backend.Initialize(c.activeContext.Load(), &logical.InitializationRequest{Storage: view})
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 		return err
 	}
 
-	revokeCtx := namespace.ContextWithNamespace(c.activeContext, ns)
+	revokeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
 	if backend != nil && c.rollback != nil {
 		// Invoke the rollback manager a final time. This is not fatal as
 		// various periodic funcs (e.g., PKI) can legitimately error; the
@@ -674,7 +674,7 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	// various periodic funcs (e.g., PKI) can legitimately error; the
 	// periodic rollback manager logs these errors rather than failing
 	// replication like returning this error would do.
-	rCtx := namespace.ContextWithNamespace(c.activeContext, ns)
+	rCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
 	if c.rollback != nil && c.router.MatchingBackend(ctx, srcRelativePath) != nil {
 		if err := c.rollback.Rollback(rCtx, srcRelativePath); err != nil {
 			c.logger.Error("ignoring rollback error during remount", "error", err, "path", src.Namespace.Path+src.MountPath)

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -110,7 +110,7 @@ func NewNamespaceStore(ctx context.Context, core *Core, logger hclog.Logger) (*N
 		creationDeletionMap:  make(map[string]bool),
 	}
 
-	ns.creationDeletionJobContext, ns.creationDeletionJobCancelFunc = context.WithCancel(core.activeContext)
+	ns.creationDeletionJobContext, ns.creationDeletionJobCancelFunc = context.WithCancel(core.activeContext.Load())
 	ns.deletionDispatcher = fairshare.NewJobManager(nsDispatcherName, nsMaxWorkers, ns.logger, core.metricSink)
 	ns.deletionDispatcher.Start()
 

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -212,11 +212,12 @@ func (c *Core) ReloadPlugins() {
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
-	if c.Sealed() || (c.standby.Load() && !c.StandbyReadsEnabled()) || c.activeContext == nil {
+	ctx := c.activeContext.Load()
+	if c.Sealed() || (c.standby.Load() && !c.StandbyReadsEnabled()) || ctx.IsNil() {
 		return
 	}
 
-	if err := c.registerDeclarativePlugins(c.activeContext, c.Standby()); err != nil {
+	if err := c.registerDeclarativePlugins(ctx, c.Standby()); err != nil {
 		c.logger.Error("failed to set up plugins on reload", "error", err)
 	}
 }

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -189,7 +189,7 @@ func (c *Core) setupRaftActiveNode(ctx context.Context) error {
 		c.logger.Error("failed to load autopilot config from storage when setting up cluster; continuing since autopilot falls back to default config", "error", err)
 	}
 
-	raftBackend.SetupAutopilot(c.activeContext, autopilotConfig, c.raftFollowerStates, c.disableAutopilot)
+	raftBackend.SetupAutopilot(c.activeContext.Load(), autopilotConfig, c.raftFollowerStates, c.disableAutopilot)
 
 	// Reload the raft TLS keys to ensure we are using the latest version.
 	if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -584,7 +584,7 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 		return nil, consts.ErrSealed
 	}
 
-	if c.activeContext == nil || c.activeContext.Err() != nil {
+	if c.activeContext.Load().Err() != nil {
 		if c.standby.Load() {
 			return nil, logical.ErrPerfStandbyPleaseForward
 		}
@@ -595,7 +595,7 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	// so we have a clean context with few values in it, and the http request
 	// context so that if the remote peer closes the connection, we can
 	// properly stop this request.
-	ctx, cancel := context.WithCancel(c.activeContext)
+	ctx, cancel := context.WithCancel(c.activeContext.Load())
 	defer cancel()
 
 	stop := context.AfterFunc(httpCtx, cancel)
@@ -1169,7 +1169,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 			// valid request (this is the token's final use). We pass the ID in
 			// directly just to be safe in case something else modifies te later.
 			defer func(id string) {
-				nsActiveCtx := namespace.ContextWithNamespace(c.activeContext, ns)
+				nsActiveCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
 				leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(nsActiveCtx, te)
 				if err == nil {
 					err = c.expiration.LazyRevoke(ctx, leaseID)

--- a/vault/rollback.go
+++ b/vault/rollback.go
@@ -402,7 +402,7 @@ func (c *Core) startRollback() error {
 	}
 	rollbackLogger := c.baseLogger.Named("rollback")
 	c.AddLogger(rollbackLogger)
-	c.rollback = NewRollbackManager(c.activeContext, rollbackLogger, backendsFunc, c.router, c)
+	c.rollback = NewRollbackManager(c.activeContext.Load(), rollbackLogger, backendsFunc, c.router, c)
 	c.rollback.Start()
 	return nil
 }

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -476,7 +476,7 @@ func (d *autoSeal) StartHealthCheck() {
 	healthCheck := time.NewTicker(sealHealthTestIntervalNominal)
 	d.healthCheckStop = make(chan struct{})
 	healthCheckStop := d.healthCheckStop
-	ctx := d.core.activeContext
+	ctx := d.core.activeContext.Load()
 
 	go func() {
 		lastTestOk := true

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -638,7 +638,7 @@ func (sm *SealManager) RotateBarrierKey(ctx context.Context, ns *namespace.Names
 		// Schedule the destroy of the upgrade path
 		time.AfterFunc(sm.core.KeyRotateGracePeriod(), func() {
 			sm.logger.Debug("cleaning up upgrade keys", "waited", sm.core.KeyRotateGracePeriod())
-			if err := b.DestroyUpgrade(sm.core.activeContext, newTerm); err != nil {
+			if err := b.DestroyUpgrade(sm.core.activeContext.Load(), newTerm); err != nil {
 				sm.logger.Error("failed to destroy upgrade", "term", newTerm, "error", err, "namespace", ns.Path)
 			}
 		})

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -783,8 +783,6 @@ func (c *Core) CreateToken(ctx context.Context, entry *logical.TokenEntry, persi
 type TokenStore struct {
 	*framework.Backend
 
-	activeContext context.Context
-
 	core *Core
 
 	batchTokenEncryptor barrier.Encryptor
@@ -823,7 +821,6 @@ type TokenStore struct {
 func NewTokenStore(ctx context.Context, logger log.Logger, core *Core, config *logical.BackendConfig) (*TokenStore, error) {
 	// Initialize the store
 	t := &TokenStore{
-		activeContext:         ctx,
 		core:                  core,
 		batchTokenEncryptor:   core.barrier,
 		cubbyholeDestroyer:    destroyCubbyhole,
@@ -832,7 +829,7 @@ func NewTokenStore(ctx context.Context, logger log.Logger, core *Core, config *l
 		tokensPendingDeletion: &sync.Map{},
 		saltLock:              sync.RWMutex{},
 		tidyLock:              sync.Mutex{},
-		quitContext:           core.activeContext,
+		quitContext:           core.activeContext.Load(),
 		salts:                 make(map[string]*salt.Salt),
 	}
 

--- a/vault/version_store_test.go
+++ b/vault/version_store_test.go
@@ -51,7 +51,7 @@ func TestVersionStore_GetOldestVersion(t *testing.T) {
 		}
 	}
 
-	err := c.loadVersionHistory(c.activeContext)
+	err := c.loadVersionHistory(t.Context())
 	if err != nil {
 		t.Fatalf("failed to populate version history cache, err: %s", err.Error())
 	}
@@ -90,7 +90,7 @@ func TestVersionStore_GetNewestVersion(t *testing.T) {
 		}
 	}
 
-	err := c.loadVersionHistory(c.activeContext)
+	err := c.loadVersionHistory(t.Context())
 	if err != nil {
 		t.Fatalf("failed to populate version history cache, err: %s", err.Error())
 	}
@@ -131,7 +131,7 @@ func TestVersionStore_SelfHealUTC(t *testing.T) {
 		}
 	}
 
-	err = c.loadVersionHistory(c.activeContext)
+	err = c.loadVersionHistory(t.Context())
 	if err != nil {
 		t.Fatalf("failed to load version timestamps, err: %s", err.Error())
 	}


### PR DESCRIPTION
## Description


Context cancellation is bound to the particular context which needs to be cancelled; while the active context itself is mostly maintained within the bounds of the state lock, the cancellation needs to be accessible without grabbing the lock (for when we need to cancel long-running in-flight requests which are actively using the context).

However, there are re-entrant paths where we may or may not come in from a state-lock held flow, especially as we get more cross-boundary refactors.

By binding active context and its cancellation together, we can ensure co-atomic updates to both. Note that calling context cancellation multiple times is generally considered safe.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This is a precursor to #3027 and its related proof of concept. I think the change is good to do anyways and hence opening as a separate refactor.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
