### PR TITLE
Reload vault stanza TLS config on SIGHUP

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -463,6 +463,13 @@ func (c *Config) ConfigureTLS(t *TLSConfig) error {
 	return c.configureTLS(t)
 }
 
+// ConfigureTLS invokes config.ConfigureTLS. This exposes the ability to reload
+// TLS configuration without recreating the client, which is useful for rotating
+// short-lived TLS credentials.
+func (c *Client) ConfigureTLS(t *TLSConfig) error {
+	return c.config.ConfigureTLS(t)
+}
+
 // ReadEnvironment reads configuration information from the environment. If
 // there is an error, no configuration value is updated. This is a no-op if
 // DisableEnvironment is set.

--- a/api/client.go
+++ b/api/client.go
@@ -467,6 +467,9 @@ func (c *Config) ConfigureTLS(t *TLSConfig) error {
 // TLS configuration without recreating the client, which is useful for rotating
 // short-lived TLS credentials.
 func (c *Client) ConfigureTLS(t *TLSConfig) error {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
+
 	return c.config.ConfigureTLS(t)
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -621,6 +621,90 @@ func TestConfigureTLS(t *testing.T) {
 	}
 }
 
+func TestClientConfigureTLS(t *testing.T) {
+	cwd, _ := os.Getwd()
+	caCertPath := cwd + "/test-fixtures/keys/cert.pem"
+
+	tests := []struct {
+		name      string
+		tlsConfig *TLSConfig
+		wantErr   assert.ErrorAssertionFunc
+		assert    func(t *testing.T, c *Config)
+	}{
+		{
+			name:      "updates RootCAs on existing client",
+			tlsConfig: &TLSConfig{CACert: caCertPath},
+			assert: func(t *testing.T, c *Config) {
+				tr := c.HttpClient.Transport.(*http.Transport)
+				require.NotNil(t, tr.TLSClientConfig.RootCAs,
+					"RootCAs should be set after ConfigureTLS")
+			},
+		},
+		{
+			name:      "invalid CA cert returns error",
+			tlsConfig: &TLSConfig{CACert: "/nonexistent/ca.pem"},
+			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
+				return assert.ErrorContains(t, err, "Error loading CA File")
+			},
+		},
+		{
+			name:      "updates InsecureSkipVerify",
+			tlsConfig: &TLSConfig{Insecure: true},
+			assert: func(t *testing.T, c *Config) {
+				tr := c.HttpClient.Transport.(*http.Transport)
+				assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := DefaultConfig()
+			client, err := NewClient(config)
+			require.NoError(t, err)
+
+			err = client.ConfigureTLS(tc.tlsConfig)
+			if tc.wantErr != nil {
+				tc.wantErr(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.assert != nil {
+				tc.assert(t, config)
+			}
+		})
+	}
+}
+
+// TestClientConfigureTLS_Reload verifies that calling ConfigureTLS a second
+// time re-reads certificates from disk and updates the transport's RootCAs,
+// simulating a CA rotation.
+func TestClientConfigureTLS_Reload(t *testing.T) {
+	cwd, _ := os.Getwd()
+	caCertPath := cwd + "/test-fixtures/keys/cert.pem"
+
+	config := DefaultConfig()
+	err := config.ConfigureTLS(&TLSConfig{CACert: caCertPath})
+	require.NoError(t, err)
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+
+	tr := config.HttpClient.Transport.(*http.Transport)
+	firstRootCAs := tr.TLSClientConfig.RootCAs
+	require.NotNil(t, firstRootCAs)
+
+	// Second call re-reads the same file from disk, proving the pool is replaced.
+	err = client.ConfigureTLS(&TLSConfig{CACert: caCertPath})
+	require.NoError(t, err)
+
+	secondRootCAs := tr.TLSClientConfig.RootCAs
+	require.NotNil(t, secondRootCAs)
+	assert.True(t, secondRootCAs.Equal(firstRootCAs),
+		"pools loaded from the same file should be equal")
+}
+
 func TestClientEnvNamespace(t *testing.T) {
 	var seenNamespace string
 	handler := func(w http.ResponseWriter, req *http.Request) {

--- a/changelog/3038.txt
+++ b/changelog/3038.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: SIGHUP reloads the client TLS configuration
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -1129,6 +1129,7 @@ func (c *AgentCommand) loadConfig(paths []string) (*agentConfig.Config, error) {
 // Currently only reloading the following are supported:
 // * log level
 // * TLS certs for listeners
+// * TLS config for the upstream vault connection (ca_cert, ca_path, client_cert, client_key)
 func (c *AgentCommand) reloadConfig(paths []string) error {
 	// Notify systemd that the server is reloading
 	c.notifySystemd(systemd.SdNotifyReloading)
@@ -1156,6 +1157,12 @@ func (c *AgentCommand) reloadConfig(paths []string) error {
 		errors = multierror.Append(errors, err)
 	}
 
+	// Update upstream vault connection TLS
+	err = c.reloadVaultTLS()
+	if err != nil {
+		errors = multierror.Append(errors, err)
+	}
+
 	return errors
 }
 
@@ -1172,11 +1179,11 @@ func (c *AgentCommand) reloadLogLevel() error {
 	return nil
 }
 
-// reloadCerts will attempt to reload certificates using a reload func which
-// was provided when the listeners were configured, only funcs that were appended
-// to the AgentCommand slice will be invoked.
-// This function returns a multierror type so that every func can report an error
-// if it encounters one.
+// reloadCerts reloads TLS certificates for the agent's own listeners (inbound
+// connections to the agent's API/cache proxy). These reload funcs are registered
+// during listener configuration and re-read the listener cert/key from disk.
+// This does NOT affect the outbound connection to the OpenBao server — see
+// reloadVaultTLS for that.
 func (c *AgentCommand) reloadCerts() error {
 	var errors error
 
@@ -1194,6 +1201,30 @@ func (c *AgentCommand) reloadCerts() error {
 	}
 
 	return errors
+}
+
+// reloadVaultTLS re-reads the vault stanza TLS configuration (ca_cert, ca_path,
+// client_cert, client_key) from disk and updates the API client's HTTP transport
+// used for outbound connections to the OpenBao server. This allows the agent to
+// pick up rotated CA bundles without a restart.
+// This is distinct from reloadCerts which handles the agent's own listener TLS.
+func (c *AgentCommand) reloadVaultTLS() error {
+	if c.config.Vault == nil {
+		return nil
+	}
+	v := c.config.Vault
+	if v.CACert == "" && v.CAPath == "" && v.ClientCert == "" && v.ClientKey == "" {
+		return nil
+	}
+	c.logger.Info("reloading vault stanza TLS configuration")
+	return c.client.ConfigureTLS(&api.TLSConfig{
+		CACert:        v.CACert,
+		CAPath:        v.CAPath,
+		ClientCert:    v.ClientCert,
+		ClientKey:     v.ClientKey,
+		TLSServerName: v.TLSServerName,
+		Insecure:      v.TLSSkipVerify,
+	})
 }
 
 // outputErrors will take an error or multierror and handle outputting each to the UI

--- a/command/agent.go
+++ b/command/agent.go
@@ -1179,11 +1179,13 @@ func (c *AgentCommand) reloadLogLevel() error {
 	return nil
 }
 
-// reloadCerts reloads TLS certificates for the agent's own listeners (inbound
-// connections to the agent's API/cache proxy). These reload funcs are registered
-// during listener configuration and re-read the listener cert/key from disk.
+// reloadCerts will attempt to reload certificates using a reload func which
+// was provided when the listeners were configured, only funcs that were appended
+// to the AgentCommand slice will be invoked.
+// This function returns a multierror type so that every func can report an error
+// if it encounters one.
 // This does NOT affect the outbound connection to the OpenBao server — see
-// reloadVaultTLS for that.
+// reloadVaultTLS for that functionality.
 func (c *AgentCommand) reloadCerts() error {
 	var errors error
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Implements hot-reloading of client TLS certificates and bundles when SIGHUP is received.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: https://github.com/openbao/openbao/issues/1557

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
