### PR TITLE
tests: use alpine instead of ubuntu for TLS listener test container

### DIFF
--- a/vault/external_tests/tlslistener_binary/tls_test.go
+++ b/vault/external_tests/tlslistener_binary/tls_test.go
@@ -281,9 +281,9 @@ func validateTLS(t *testing.T, ctx context.Context, root string, networkName str
 	// in a certificate with the container network's IP address rather than
 	// localhost.
 	containerfile := `
-FROM ubuntu:latest
+FROM alpine:latest
 
-RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y curl
+RUN apk add --no-cache curl
 
 COPY root.pem /root.pem
 `


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

The `vault/external_tests/tlslistener_binary/tls_test.go:validateTLS()` helper builds a container image based on `ubuntu:latest` and runs `apt update && apt install -y curl` during the build process.

Downloading ubuntu and running apt frequently exceeds the timeout, resulting in flaky tests (`TestTLSListener_*` #2581).

This PR implements a minimal workaround by simply replacing the Ubuntu base image with Alpine, which hopefully reduces the container build time enough to pass the test.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3039

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
