### PR TITLE
Add authenticated root token generation endpoints

### DIFF
--- a/changelog/3041.txt
+++ b/changelog/3041.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**Authenticated root generation**: 
+  Introduced authenticated `/sys/generate-root-token` endpoints in replacement of deprecated unauthenticated ones.
+```

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -54,7 +54,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Get the generation configuration
-	generationConfig, err := core.GenerateRootConfiguration()
+	generationConfig, err := core.GenerateRootConfiguration(ctx)
 	switch {
 	// we return the progress as 0 in this case, root generation has not started
 	case errors.Is(err, vault.ErrNoRootGeneration):
@@ -64,7 +64,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Get the progress
-	progress, err := core.GenerateRootProgress()
+	progress, err := core.GenerateRootProgress(ctx)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
@@ -95,7 +95,9 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 }
 
 func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r *http.Request, generateStrategy vault.GenerateRootStrategy) {
-	// Parse the request
+	ctx, cancel := core.GetContext()
+	defer cancel()
+
 	var req GenerateRootInitRequest
 	if err := parseJSONRequest(r, w, &req); err != nil && err != io.EOF {
 		respondError(w, http.StatusBadRequest, err)
@@ -121,7 +123,7 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 	}
 
 	// Attemptialize the generation
-	if err := core.GenerateRootInit(req.OTP, req.PGPKey, generateStrategy); err != nil {
+	if err := core.GenerateRootInit(ctx, req.OTP, req.PGPKey, generateStrategy); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -135,7 +137,10 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 }
 
 func handleSysGenerateRootAttemptDelete(core *vault.Core, w http.ResponseWriter, r *http.Request) {
-	err := core.GenerateRootCancel()
+	ctx, cancel := core.GetContext()
+	defer cancel()
+
+	err := core.GenerateRootCancel(ctx)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return

--- a/vault/core.go
+++ b/vault/core.go
@@ -295,11 +295,10 @@ type Core struct {
 	// conditions.
 	shutdownDoneCh *atomic.Value
 
-	// generateRootProgress holds the shares until we reach enough
-	// to verify the root key
-	generateRootConfig   *GenerateRootConfig
-	generateRootProgress [][]byte
-	generateRootLock     sync.Mutex
+	// namespaceRootGens holds the shares for each namespace
+	// until we reach enough to verify the root key.
+	namespaceRootGens    map[string]*rootTokenGeneration
+	namespaceRootGenLock sync.RWMutex
 
 	// These variables holds the config and shares we have until we reach
 	// enough to verify the appropriate root key. Note that the same lock is
@@ -945,6 +944,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		unsafeCrossNamespaceIdentity:   conf.UnsafeCrossNamespaceIdentity,
 		allowUnauthedWorkflows:         conf.AllowUnauthenticatedWorkflows,
 		unsafeRelativePaths:            conf.UnsafeRelativePaths,
+		namespaceRootGens:              make(map[string]*rootTokenGeneration),
 	}
 
 	c.standby.Store(true)

--- a/vault/generate_root.go
+++ b/vault/generate_root.go
@@ -11,11 +11,17 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/pgpkeys"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 )
+
+type rootTokenGeneration struct {
+	Config   *GenerateRootConfig
+	Progress [][]byte
+}
 
 // GenerateStandardRootTokenStrategy is the strategy used to
 // generate a typical root token.
@@ -37,15 +43,12 @@ type GenerateRootStrategy interface {
 type generateStandardRootToken struct{}
 
 func (g generateStandardRootToken) authenticate(ctx context.Context, c *Core, combinedKey []byte) error {
-	rootKey, err := c.sealManager.unsealKeyToRootKey(ctx, c.seal, combinedKey, true, false)
+	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to authenticate: %w", err)
-	}
-	if err := c.barrier.VerifyRoot(rootKey); err != nil {
-		return fmt.Errorf("root key verification failed: %w", err)
+		return err
 	}
 
-	return nil
+	return c.sealManager.AuthenticateRootKey(ctx, ns, combinedKey)
 }
 
 func (g generateStandardRootToken) generate(ctx context.Context, c *Core) (string, func(), error) {
@@ -66,8 +69,7 @@ func (g generateStandardRootToken) generate(ctx context.Context, c *Core) (strin
 	return te.ExternalID, cleanupFunc, nil
 }
 
-// GenerateRootConfig holds the configuration for a root generation
-// command.
+// GenerateRootConfig holds the configuration for a root token generation.
 type GenerateRootConfig struct {
 	Nonce          string
 	PGPKey         string
@@ -76,8 +78,7 @@ type GenerateRootConfig struct {
 	Strategy       GenerateRootStrategy
 }
 
-// GenerateRootResult holds the result of a root generation update
-// command
+// GenerateRootResult holds the result of a root token generation update.
 type GenerateRootResult struct {
 	Progress       int
 	Required       int
@@ -85,55 +86,103 @@ type GenerateRootResult struct {
 	PGPFingerprint string
 }
 
-// GenerateRootProgress is used to return the root generation progress (num shares)
-func (c *Core) GenerateRootProgress() (int, error) {
+// lockRootGeneration is used to lock the stateLock of the Core,
+// check the seal, standby and recoveryMode statuses, and return
+// back an unlock func.
+func (c *Core) lockRootGeneration() (func(), error) {
 	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
+
 	if c.Sealed() && !c.recoveryMode {
-		return 0, consts.ErrSealed
-	}
-	if c.standby.Load() && !c.recoveryMode {
-		return 0, consts.ErrStandby
-	}
-
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	return len(c.generateRootProgress), nil
-}
-
-// GenerateRootConfiguration is used to read the root generation configuration
-// It stubbornly refuses to return the OTP if one is there.
-func (c *Core) GenerateRootConfiguration() (*GenerateRootConfig, error) {
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrSealed
 	}
 	if c.standby.Load() && !c.recoveryMode {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrStandby
 	}
+	if !c.barrier.Sealed() && c.recoveryMode {
+		c.stateLock.RUnlock()
+		return nil, errors.New("attempted to generate recovery operation token when already unsealed")
+	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
+	return c.stateLock.RUnlock, nil
+}
 
-	if c.generateRootConfig == nil {
+// GenerateRootProgress is used to return the root token generation progress.
+func (c *Core) GenerateRootProgress(ctx context.Context) (int, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	c.namespaceRootGenLock.RLock()
+	defer c.namespaceRootGenLock.RUnlock()
+
+	if c.namespaceRootGens[ns.UUID] == nil {
+		return 0, nil
+	}
+
+	return len(c.namespaceRootGens[ns.UUID].Progress), nil
+}
+
+// GenerateRootConfiguration is used to read the root generation configuration.
+// It stubbornly refuses to return the OTP if one is there.
+func (c *Core) GenerateRootConfiguration(ctx context.Context) (*GenerateRootConfig, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.namespaceRootGenLock.RLock()
+	defer c.namespaceRootGenLock.RUnlock()
+
+	namespaceRootGen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
 		return nil, ErrNoRootGeneration
 	}
 
-	config := *c.generateRootConfig
+	config := *namespaceRootGen.Config
 	config.OTP = ""
 	config.Strategy = nil
 
 	return &config, nil
 }
 
-// GenerateRootInit is used to initialize the root generation settings
-func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrategy) error {
+// GenerateRootInit is used to initialize the root generation attempt.
+func (c *Core) GenerateRootInit(ctx context.Context, otp, pgpKey string, strategy GenerateRootStrategy) error {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	var fingerprint string
 	switch {
 	case len(otp) > 0:
-		expectedLength := TokenLength
+		var expectedLength int
+		if ns.UUID == namespace.RootNamespaceUUID {
+			expectedLength = TokenLength
+		} else {
+			expectedLength = NSTokenLength
+		}
+
 		if c.DisableSSCTokens() {
 			expectedLength += OldTokenPrefixLength
 		} else {
@@ -158,35 +207,27 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 		return errors.New("otp or pgp_key parameter must be provided")
 	}
 
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return consts.ErrSealed
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
+
+	gen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
+		gen = &rootTokenGeneration{}
+		c.namespaceRootGens[ns.UUID] = gen
 	}
 
-	if !c.barrier.Sealed() && c.recoveryMode {
-		return errors.New("attempt to generate recovery operation token when already unsealed")
-	}
-	if c.standby.Load() && !c.recoveryMode {
-		return consts.ErrStandby
+	// Prevent multiple concurrent root generations per namespace.
+	if gen.Config != nil {
+		return errors.New("root generation already in progress for this namespace")
 	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	// Prevent multiple concurrent root generations
-	if c.generateRootConfig != nil {
-		return errors.New("root generation already in progress")
-	}
-
-	// Copy the configuration
-	generationNonce, err := uuid.GenerateUUID()
+	nonce, err := uuid.GenerateUUID()
 	if err != nil {
 		return err
 	}
 
-	c.generateRootConfig = &GenerateRootConfig{
-		Nonce:          generationNonce,
+	gen.Config = &GenerateRootConfig{
+		Nonce:          nonce,
 		OTP:            otp,
 		PGPKey:         pgpKey,
 		PGPFingerprint: fingerprint,
@@ -196,21 +237,37 @@ func (c *Core) GenerateRootInit(otp, pgpKey string, strategy GenerateRootStrateg
 	if c.logger.IsInfo() {
 		switch strategy.(type) {
 		case generateStandardRootToken:
-			c.logger.Info("root generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("root generation initialized", "nonce", gen.Config.Nonce)
 		case *generateRecoveryToken:
-			c.logger.Info("recovery operation token generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("recovery operation token generation initialized", "nonce", gen.Config.Nonce)
 		default:
-			c.logger.Info("dr operation token generation initialized", "nonce", c.generateRootConfig.Nonce)
+			c.logger.Info("dr operation token generation initialized", "nonce", gen.Config.Nonce)
 		}
 	}
 
 	return nil
 }
 
-// GenerateRootUpdate is used to provide a new key part
+// GenerateRootUpdate is used to provide a new key part to progress root generation.
 func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string, strategy GenerateRootStrategy) (*GenerateRootResult, error) {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	barrier := c.sealManager.NamespaceBarrier(ns.Path)
+	if barrier == nil {
+		return nil, ErrNotSealable
+	}
+
 	// Verify the key length
-	min, max := c.barrier.KeyLength()
+	min, max := barrier.KeyLength()
 	max += shamir.ShareOverhead
 	if len(key) < min {
 		return nil, &ErrInvalidKey{fmt.Sprintf("key is shorter than minimum %d bytes", min)}
@@ -219,13 +276,17 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, &ErrInvalidKey{fmt.Sprintf("key is longer than maximum %d bytes", max)}
 	}
 
+	seal := c.sealManager.NamespaceSeal(ns.UUID)
+	if seal == nil {
+		return nil, ErrNotSealable
+	}
+
 	// Get the seal configuration
 	var config *SealConfig
-	var err error
-	if c.seal.RecoveryKeySupported() {
-		config, err = c.seal.RecoveryConfig(ctx)
+	if seal.RecoveryKeySupported() {
+		config, err = seal.RecoveryConfig(ctx)
 	} else {
-		config, err = c.seal.BarrierConfig(ctx)
+		config, err = seal.BarrierConfig(ctx)
 	}
 
 	if err != nil {
@@ -237,47 +298,32 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, ErrNotInit
 	}
 
-	// Ensure we are already unsealed
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return nil, consts.ErrSealed
-	}
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
 
-	if !c.barrier.Sealed() && c.recoveryMode {
-		return nil, errors.New("attempt to generate recovery operation token when already unsealed")
-	}
-
-	if c.standby.Load() && !c.recoveryMode {
-		return nil, consts.ErrStandby
-	}
-
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
-
-	// Ensure a generateRoot is in progress
-	if c.generateRootConfig == nil {
+	gen, exists := c.namespaceRootGens[ns.UUID]
+	if !exists {
 		return nil, ErrNoRootGeneration
 	}
 
-	if nonce != c.generateRootConfig.Nonce {
-		return nil, fmt.Errorf("incorrect nonce supplied; nonce for this root generation operation is %q", c.generateRootConfig.Nonce)
+	if nonce != gen.Config.Nonce {
+		return nil, fmt.Errorf("incorrect nonce supplied; nonce for this root generation operation is %q", gen.Config.Nonce)
 	}
 
-	if strategy != c.generateRootConfig.Strategy {
+	if strategy != gen.Config.Strategy {
 		return nil, errors.New("incorrect strategy supplied; a generate root operation of another type is already in progress")
 	}
 
 	// Check if we already have this piece
-	for _, existing := range c.generateRootProgress {
+	for _, existing := range gen.Progress {
 		if bytes.Equal(existing, key) {
 			return nil, errors.New("given key has already been provided during this generation operation")
 		}
 	}
 
 	// Store this key
-	c.generateRootProgress = append(c.generateRootProgress, key)
-	progress := len(c.generateRootProgress)
+	gen.Progress = append(gen.Progress, key)
+	progress := len(gen.Progress)
 
 	// Check if we don't have enough keys to unlock
 	if progress < config.SecretThreshold {
@@ -287,18 +333,18 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return &GenerateRootResult{
 			Progress:       progress,
 			Required:       config.SecretThreshold,
-			PGPFingerprint: c.generateRootConfig.PGPFingerprint,
+			PGPFingerprint: gen.Config.PGPFingerprint,
 		}, nil
 	}
 
 	// Combine the key parts
 	var combinedKey []byte
 	if config.SecretThreshold == 1 {
-		combinedKey = c.generateRootProgress[0]
-		c.generateRootProgress = nil
+		combinedKey = gen.Progress[0]
+		gen.Progress = nil
 	} else {
-		combinedKey, err = shamir.Combine(c.generateRootProgress)
-		c.generateRootProgress = nil
+		combinedKey, err = shamir.Combine(gen.Progress)
+		gen.Progress = nil
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute root key: %w", err)
 		}
@@ -318,11 +364,11 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 	var encodedToken string
 
 	switch {
-	case len(c.generateRootConfig.OTP) > 0:
-		encodedToken, err = roottoken.EncodeToken(token, c.generateRootConfig.OTP)
-	case len(c.generateRootConfig.PGPKey) > 0:
+	case len(gen.Config.OTP) > 0:
+		encodedToken, err = roottoken.EncodeToken(token, gen.Config.OTP)
+	case len(gen.Config.PGPKey) > 0:
 		var tokenBytesArr [][]byte
-		_, tokenBytesArr, err = pgpkeys.EncryptShares([][]byte{[]byte(token)}, []string{c.generateRootConfig.PGPKey})
+		_, tokenBytesArr, err = pgpkeys.EncryptShares([][]byte{[]byte(token)}, []string{gen.Config.PGPKey})
 		encodedToken = base64.StdEncoding.EncodeToString(tokenBytesArr[0])
 	default:
 		err = errors.New("unreachable condition")
@@ -337,39 +383,39 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		Progress:       progress,
 		Required:       config.SecretThreshold,
 		EncodedToken:   encodedToken,
-		PGPFingerprint: c.generateRootConfig.PGPFingerprint,
+		PGPFingerprint: gen.Config.PGPFingerprint,
 	}
 
 	switch strategy.(type) {
 	case generateStandardRootToken:
-		c.logger.Info("root generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("root generation finished", "nonce", gen.Config.Nonce)
 	case *generateRecoveryToken:
-		c.logger.Info("recovery operation token generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("recovery operation token generation finished", "nonce", gen.Config.Nonce)
 	default:
-		c.logger.Info("dr operation token generation finished", "nonce", c.generateRootConfig.Nonce)
+		c.logger.Info("dr operation token generation finished", "nonce", gen.Config.Nonce)
 	}
 
-	c.generateRootProgress = nil
-	c.generateRootConfig = nil
+	delete(c.namespaceRootGens, ns.UUID)
 	return results, nil
 }
 
 // GenerateRootCancel is used to cancel an in-progress root generation
-func (c *Core) GenerateRootCancel() error {
-	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
-	if c.Sealed() && !c.recoveryMode {
-		return consts.ErrSealed
+func (c *Core) GenerateRootCancel(ctx context.Context) error {
+	unlock, err := c.lockRootGeneration()
+	if err != nil {
+		return err
 	}
-	if c.standby.Load() && !c.recoveryMode {
-		return consts.ErrStandby
+	defer unlock()
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	c.generateRootLock.Lock()
-	defer c.generateRootLock.Unlock()
+	c.namespaceRootGenLock.Lock()
+	defer c.namespaceRootGenLock.Unlock()
 
 	// Clear any progress or config
-	c.generateRootConfig = nil
-	c.generateRootProgress = nil
+	delete(c.namespaceRootGens, ns.UUID)
 	return nil
 }

--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -16,296 +16,249 @@ import (
 
 func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Lifecycle_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Lifecycle_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Lifecycle_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, keys [][]byte) {
+func testCore_GenerateRoot_Lifecycle_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
 	// Verify update not allowed
-	if _, err := c.GenerateRootUpdate(namespace.RootContext(t.Context()), keys[0], "", GenerateStandardRootTokenStrategy); err == nil {
-		t.Fatal("no root generation in progress")
-	}
+	_, err := c.GenerateRootUpdate(ctx, keys[0], "", GenerateStandardRootTokenStrategy)
+	require.Error(t, err)
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	// Cancel should be idempotent
-	err = c.GenerateRootCancel()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootCancel(ctx))
 
 	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
 
 	// Start a root generation
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Should get config
-	conf, err = c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if conf == nil {
-		t.Fatalf("expected conf != nil")
-	}
+	conf, err = c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conf)
 
 	// Cancel should be clear
-	err = c.GenerateRootCancel()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, c.GenerateRootCancel(ctx))
 
 	// Should be no config
-	conf, err = c.GenerateRootConfiguration()
+	conf, err = c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 }
 
 func TestCore_GenerateRoot_Init(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Init_Common(t, c)
+	ns := &namespace.Namespace{Path: "test1/"}
+	TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Init_Common(t, c, namespace.RootNamespace)
 
 	bc := &SealConfig{SecretShares: 5, SecretThreshold: 3}
 	rc := &SealConfig{SecretShares: 5, SecretThreshold: 3}
 	c, _, _, _ = TestCoreUnsealedWithConfigs(t, bc, rc)
-	testCore_GenerateRoot_Init_Common(t, c)
+	testCore_GenerateRoot_Init_Common(t, c, namespace.RootNamespace)
+
+	testCore_GenerateRoot_Init_Common(t, c, ns)
 }
 
-func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core) {
-	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
-	}
+func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core, ns *namespace.Namespace) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	tokenLength := TokenLength
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
+
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Second should fail
-	err = c.GenerateRootInit("", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy)
-	if err == nil {
-		t.Fatal("should fail")
-	}
+	require.Error(t, c.GenerateRootInit(ctx, "", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy))
 }
 
 func TestCore_GenerateRoot_InvalidRootNonce(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	// Pass in root keys as they'll be invalid
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	// incrementing root keys will make them invalid
 	rootKeys[0][0]++
-	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, rootKeys)
+	keysPerNamespace[ns.Path][0][0]++
+
+	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_InvalidRootNonce_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, keys [][]byte) {
-	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
-	}
+func testCore_GenerateRoot_InvalidRootNonce_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	tokenLength := TokenLength
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
+
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rgconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rgconf == nil {
-		t.Fatal("bad: no rotate config received")
-	}
+	rgconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rgconf)
 
-	// Provide the nonce (invalid)
-	_, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), keys[0], "abcd", GenerateStandardRootTokenStrategy)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	// Provide the invalid nonce
+	_, err = c.GenerateRootUpdate(ctx, keys[0], "abcd", GenerateStandardRootTokenStrategy)
+	require.Error(t, err)
 
-	// Provide the root (invalid)
+	// Provide the invalid root key
 	for _, key := range keys {
-		_, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
+		_, err = c.GenerateRootUpdate(ctx, key, rgconf.Nonce, GenerateStandardRootTokenStrategy)
 	}
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 }
 
 func TestCore_GenerateRoot_Update_OTP(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_OTP_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Update_OTP_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Update_OTP_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byte) {
+func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
 	tokenLength := TokenLength
-	otp, err := base62.Random(TokenPrefixLength + tokenLength)
-	if err != nil {
-		t.Fatal(err)
+	if ns.UUID != namespace.RootNamespaceUUID {
+		tokenLength = NSTokenLength
 	}
+	otp, err := base62.Random(TokenPrefixLength + tokenLength)
+	require.NoError(t, err)
 
 	// Start a root generation
-	err = c.GenerateRootInit(otp, "", GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.GenerateRootInit(ctx, otp, "", GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rkconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rkconf == nil {
-		t.Fatal("bad: no root generation config received")
-	}
+	rkconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rkconf)
 
 	// Provide the keys
 	var result *GenerateRootResult
 	for _, key := range keys {
-		result, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		result, err = c.GenerateRootUpdate(ctx, key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
+		require.NoError(t, err)
 		if result.EncodedToken != "" {
 			break
 		}
 	}
-	if result == nil {
-		t.Fatal("Bad, result is nil")
-	}
+	require.NotNil(t, result)
 
 	encodedToken := result.EncodedToken
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	tokenBytes, err := base64.RawStdEncoding.DecodeString(encodedToken)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	tokenBytes, err = xor.XORBytes(tokenBytes, []byte(otp))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	token := string(tokenBytes)
 
 	// Ensure that the token is a root token
-	te, err := c.tokenStore.Lookup(namespace.RootContext(t.Context()), token)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if te == nil {
-		t.Fatal("token was nil")
-	}
-	if te.ID != token || te.Parent != "" ||
-		len(te.Policies) != 1 || te.Policies[0] != "root" {
-		t.Fatalf("bad: %#v", *te)
-	}
+	te, err := c.tokenStore.Lookup(ctx, token)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	require.False(t, te.ID != token || te.Parent != "" ||
+		len(te.Policies) != 1 || te.Policies[0] != "root")
 }
 
 func TestCore_GenerateRoot_Update_PGP(t *testing.T) {
 	c, rootKeys, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_PGP_Common(t, c, rootKeys)
+	ns := &namespace.Namespace{Path: "test1/"}
+	keysPerNamespace := TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+	testCore_GenerateRoot_Update_PGP_Common(t, c, namespace.RootNamespace, rootKeys)
+	testCore_GenerateRoot_Update_PGP_Common(t, c, ns, keysPerNamespace[ns.Path])
 }
 
-func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, keys [][]byte) {
-	// Start a root generation
-	err := c.GenerateRootInit("", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+func testCore_GenerateRoot_Update_PGP_Common(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
+	require.NoError(t, c.GenerateRootInit(ctx, "", pgpkeys.TestPubKey1, GenerateStandardRootTokenStrategy))
 
 	// Fetch new config with generated nonce
-	rkconf, err := c.GenerateRootConfiguration()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if rkconf == nil {
-		t.Fatal("bad: no root generation config received")
-	}
+	rkconf, err := c.GenerateRootConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rkconf)
 
 	// Provide the keys
 	var result *GenerateRootResult
 	for _, key := range keys {
-		result, err = c.GenerateRootUpdate(namespace.RootContext(t.Context()), key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		result, err = c.GenerateRootUpdate(ctx, key, rkconf.Nonce, GenerateStandardRootTokenStrategy)
+		require.NoError(t, err)
 		if result.EncodedToken != "" {
 			break
 		}
 	}
-	if result == nil {
-		t.Fatal("Bad, result is nil")
-	}
+	require.NotNil(t, result)
 
 	encodedToken := result.EncodedToken
 
 	// Should be no progress
-	num, err := c.GenerateRootProgress()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if num != 0 {
-		t.Fatalf("bad: %d", num)
-	}
+	num, err := c.GenerateRootProgress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, num)
 
 	// Should be no config
-	conf, err := c.GenerateRootConfiguration()
+	conf, err := c.GenerateRootConfiguration(ctx)
 	require.Error(t, err)
 	require.Nil(t, conf)
 
 	ptBuf, err := pgpkeys.DecryptBytes(encodedToken, pgpkeys.TestPrivKey1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ptBuf == nil {
-		t.Fatal("Got nil plaintext key")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, ptBuf)
 
 	token := ptBuf.String()
 
 	// Ensure that the token is a root token
-	te, err := c.tokenStore.Lookup(namespace.RootContext(t.Context()), token)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if te == nil {
-		t.Fatal("token was nil")
-	}
-	if te.ID != token || te.Parent != "" ||
-		len(te.Policies) != 1 || te.Policies[0] != "root" {
-		t.Fatalf("bad: %#v", *te)
-	}
+	te, err := c.tokenStore.Lookup(ctx, token)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	require.False(t, te.ID != token || te.Parent != "" ||
+		len(te.Policies) != 1 || te.Policies[0] != "root")
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -44,7 +44,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/pluginutil"
-	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
 	"github.com/openbao/openbao/sdk/v2/helper/wrapping"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault/policy"
@@ -103,8 +102,6 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"unseal",
 				"leader",
 				"health",
-				"generate-root/attempt",
-				"generate-root/update",
 				"decode-token",
 				"mfa/validate",
 
@@ -118,6 +115,13 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"rekey-recovery-key/init",
 				"rekey-recovery-key/update",
 				"rekey-recovery-key/verify",
+
+				// These endpoints are unauthenticated only with the
+				// "disable_unauthed_generate_root_endpoints" listener property explicitly
+				// set to false. Note that they are not routable through the normal
+				// SystemBackend calls but are instead specially handled by http.
+				"generate-root/attempt",
+				"generate-root/update",
 			},
 
 			LocalStorage: []string{
@@ -130,6 +134,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	b.Paths = append(b.Paths, b.configPaths()...)
 	b.Paths = append(b.Paths, b.rekeyPaths()...)
 	b.Paths = append(b.Paths, b.rotatePaths()...)
+	b.Paths = append(b.Paths, b.generateRootPaths()...)
 	b.Paths = append(b.Paths, b.sealPaths()...)
 	b.Paths = append(b.Paths, b.statusPaths()...)
 	b.Paths = append(b.Paths, b.pluginsCatalogListPaths()...)
@@ -850,22 +855,6 @@ func (b *SystemBackend) handleRekeyDeleteRecovery(ctx context.Context, req *logi
 	return b.handleRekeyDelete(ctx, req, data, true)
 }
 
-func (b *SystemBackend) handleGenerateRootDecodeTokenUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	encodedToken := data.Get("encoded_token").(string)
-	otp := data.Get("otp").(string)
-
-	if encodedToken == "" || otp == "" {
-		return handleError(errors.New("provided encoded_token or otp is empty"))
-	}
-
-	token, err := roottoken.DecodeToken(encodedToken, otp, len(otp))
-	if err != nil {
-		return handleError(err)
-	}
-
-	return &logical.Response{Data: map[string]interface{}{"token": token}}, nil
-}
-
 func (b *SystemBackend) mountInfo(ctx context.Context, entry *routing.MountEntry) map[string]interface{} {
 	info := map[string]interface{}{
 		"type":                    entry.Type,
@@ -977,14 +966,16 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 	err := expandStringValsWithCommas(configMap)
 	if err != nil {
 		return logical.ErrorResponse(
-				"unable to parse given auth config information"),
+				"unable to parse given auth config information",
+			),
 			logical.ErrInvalidRequest
 	}
 	if len(configMap) != 0 {
 		err := mapstructure.Decode(configMap, &apiConfig)
 		if err != nil {
 			return logical.ErrorResponse(
-					"unable to convert given mount config information"),
+					"unable to convert given mount config information",
+				),
 				logical.ErrInvalidRequest
 		}
 	}
@@ -1020,14 +1011,16 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 
 	if config.DefaultLeaseTTL > b.Core.maxLeaseTTL && config.MaxLeaseTTL == 0 {
 		return logical.ErrorResponse(
-				"given default lease TTL greater than system max lease TTL of %d", int(b.Core.maxLeaseTTL.Seconds())),
+				"given default lease TTL greater than system max lease TTL of %d", int(b.Core.maxLeaseTTL.Seconds()),
+			),
 			logical.ErrInvalidRequest
 	}
 
 	switch logicalType {
 	case "":
 		return logical.ErrorResponse(
-				"backend type must be specified as a string"),
+				"backend type must be specified as a string",
+			),
 			logical.ErrInvalidRequest
 	case "plugin":
 		// Only set plugin-name if mount is of type plugin, with apiConfig.PluginName
@@ -1039,7 +1032,8 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 			logicalType = pluginName
 		default:
 			return logical.ErrorResponse(
-					"plugin_name must be provided for plugin backend"),
+					"plugin_name must be provided for plugin backend",
+				),
 				logical.ErrInvalidRequest
 		}
 	}
@@ -1274,7 +1268,8 @@ func (b *SystemBackend) handleRemount(ctx context.Context, req *logical.Request,
 	toPath := data.Get("to").(string)
 	if fromPath == "" || toPath == "" {
 		return logical.ErrorResponse(
-				"both 'from' and 'to' path must be specified as a string"),
+				"both 'from' and 'to' path must be specified as a string",
+			),
 			logical.ErrInvalidRequest
 	}
 
@@ -1409,7 +1404,8 @@ func (b *SystemBackend) handleAuthTuneRead(ctx context.Context, req *logical.Req
 	path := data.Get("path").(string)
 	if path == "" {
 		return logical.ErrorResponse(
-				"path must be specified as a string"),
+				"path must be specified as a string",
+			),
 			logical.ErrInvalidRequest
 	}
 	return b.handleTuneReadCommon(ctx, "auth/"+path)
@@ -1419,7 +1415,8 @@ func (b *SystemBackend) handleRemountStatusCheck(ctx context.Context, req *logic
 	migrationID := data.Get("migration_id").(string)
 	if migrationID == "" {
 		return logical.ErrorResponse(
-				"migrationID must be specified"),
+				"migrationID must be specified",
+			),
 			logical.ErrInvalidRequest
 	}
 
@@ -1441,7 +1438,8 @@ func (b *SystemBackend) handleMountTuneRead(ctx context.Context, req *logical.Re
 	path := data.Get("path").(string)
 	if path == "" {
 		return logical.ErrorResponse(
-				"path must be specified as a string"),
+				"path must be specified as a string",
+			),
 			logical.ErrInvalidRequest
 	}
 
@@ -1669,7 +1667,8 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 			err := mapstructure.Decode(userLockoutConfigMap, &apiUserLockoutConfig)
 			if err != nil {
 				return logical.ErrorResponse(
-						"unable to convert given user lockout config information"),
+						"unable to convert given user lockout config information",
+					),
 					logical.ErrInvalidRequest
 			}
 
@@ -1920,14 +1919,16 @@ func (b *SystemBackend) handleUnlockUser(ctx context.Context, req *logical.Reque
 	mountAccessor := data.Get("mount_accessor").(string)
 	if mountAccessor == "" {
 		return logical.ErrorResponse(
-				"missing mount_accessor"),
+				"missing mount_accessor",
+			),
 			logical.ErrInvalidRequest
 	}
 
 	aliasName := data.Get("alias_identifier").(string)
 	if aliasName == "" {
 		return logical.ErrorResponse(
-				"missing alias_identifier"),
+				"missing alias_identifier",
+			),
 			logical.ErrInvalidRequest
 	}
 
@@ -2206,14 +2207,16 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 	err := expandStringValsWithCommas(configMap)
 	if err != nil {
 		return logical.ErrorResponse(
-				"unable to parse given auth config information"),
+				"unable to parse given auth config information",
+			),
 			logical.ErrInvalidRequest
 	}
 	if len(configMap) != 0 {
 		err := mapstructure.Decode(configMap, &apiConfig)
 		if err != nil {
 			return logical.ErrorResponse(
-					"unable to convert given auth config information"),
+					"unable to convert given auth config information",
+				),
 				logical.ErrInvalidRequest
 		}
 	}
@@ -2249,7 +2252,8 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 
 	if config.DefaultLeaseTTL > b.Core.maxLeaseTTL && config.MaxLeaseTTL == 0 {
 		return logical.ErrorResponse(
-				"given default lease TTL greater than system max lease TTL of %d", int(b.Core.maxLeaseTTL.Seconds())),
+				"given default lease TTL greater than system max lease TTL of %d", int(b.Core.maxLeaseTTL.Seconds()),
+			),
 			logical.ErrInvalidRequest
 	}
 
@@ -2269,7 +2273,8 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 	switch logicalType {
 	case "":
 		return logical.ErrorResponse(
-				"backend type must be specified as a string"),
+				"backend type must be specified as a string",
+			),
 			logical.ErrInvalidRequest
 	case "plugin":
 		// Only set plugin name if mount is of type plugin, with apiConfig.PluginName
@@ -2281,7 +2286,8 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 			logicalType = pluginName
 		default:
 			return logical.ErrorResponse(
-					"plugin_name must be provided for plugin backend"),
+					"plugin_name must be provided for plugin backend",
+				),
 				logical.ErrInvalidRequest
 		}
 	}
@@ -4829,27 +4835,7 @@ This path responds to the following HTTP methods.
 		Returns health information about OpenBao.
 		`,
 	},
-	"generate-root": {
-		"Reads, generates, or deletes a root token regeneration process.",
-		`
-This path responds to multiple HTTP methods which change the behavior. Those
-HTTP methods are listed below.
 
-    GET /attempt
-        Reads the configuration and progress of the current root generation
-        attempt.
-
-    POST /attempt
-        Initializes a new root generation attempt. Only a single root generation
-        attempt can take place at a time. One (and only one) of otp or pgp_key
-        are required.
-
-    DELETE /attempt
-        Cancels any in-progress root generation attempt. This clears any
-        progress made. This must be called to change the OTP or PGP key being
-        used.
-		`,
-	},
 	"seal-status": {
 		"Returns the seal status of the OpenBao instance.",
 		`

--- a/vault/logical_system_generate_root.go
+++ b/vault/logical_system_generate_root.go
@@ -1,0 +1,461 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-secure-stdlib/base62"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
+	"github.com/openbao/openbao/sdk/v2/logical"
+)
+
+func (b *SystemBackend) generateRootPaths() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "generate-root-token/attempt",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationVerb:   "generate",
+				OperationSuffix: "root-token",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"otp": {
+					Type:        framework.TypeString,
+					Required:    false,
+					Description: "One-time password for encoding the root token.",
+				},
+				"pgp_key": {
+					Type:        framework.TypeString,
+					Required:    false,
+					Description: "PGP key for encrypting the root token.",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Summary:  "Read the status of root token generation.",
+					Callback: b.handleGenerateRootStatus(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"started": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"complete": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"progress": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"required": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"otp": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"otp_length": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"nonce": {
+									Type: framework.TypeString,
+								},
+								"pgp_fingerprint": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:     "Initialize root token generation.",
+					Description: "Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.",
+					Callback:    b.handleGenerateRootInit(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"started": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"complete": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"progress": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"required": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"otp": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"otp_length": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"nonce": {
+									Type: framework.TypeString,
+								},
+								"pgp_fingerprint": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Summary:  "Cancel root token generation.",
+					Callback: b.handleGenerateRootCancel(),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{
+							Description: http.StatusText(http.StatusNoContent),
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(generateRootSysHelp["generate-root-token"][0]),
+			HelpDescription: strings.TrimSpace(generateRootSysHelp["generate-root-token"][1]),
+		},
+		{
+			Pattern: "generate-root-token/update",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationVerb:   "update-generation-attempt",
+				OperationSuffix: "root-token",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"key": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Unseal key share.",
+				},
+				"nonce": {
+					Type:        framework.TypeString,
+					Required:    true,
+					Description: "Nonce for the generation operation.",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Summary:     "Provide an unseal key share for root token generation.",
+					Description: "If the threshold number of unseal key shares is reached, OpenBao will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.",
+					Callback:    b.handleGenerateRootUpdate(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields: map[string]*framework.FieldSchema{
+								"started": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"complete": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"progress": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"required": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"nonce": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"encoded_token": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"pgp_fingerprint": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(generateRootSysHelp["generate-root-token"][0]),
+			HelpDescription: strings.TrimSpace(generateRootSysHelp["generate-root-token"][1]),
+		},
+		{
+			Pattern: "decode-token",
+			Fields: map[string]*framework.FieldSchema{
+				"encoded_token": {
+					Type:        framework.TypeString,
+					Description: "Specifies the encoded token (result from generate-root-token call).",
+				},
+				"otp": {
+					Type:        framework.TypeString,
+					Description: "Specifies the otp code used for decoding.",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.handleGenerateRootDecodeTokenUpdate,
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb:   "decode",
+						OperationSuffix: "root-token",
+					},
+					Summary: "Decodes the encoded token with the otp.",
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(generateRootSysHelp["decode-token"][0]),
+			HelpDescription: strings.TrimSpace(generateRootSysHelp["decode-token"][1]),
+		},
+	}
+}
+
+func (b *SystemBackend) handleGenerateRootInit() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		otp := data.Get("otp").(string)
+		pgpKey := data.Get("pgp_key").(string)
+
+		var genned bool
+		switch {
+		case len(otp) > 0, len(pgpKey) > 0:
+		default:
+			genned = true
+			ns, err := namespace.FromContext(ctx)
+			if err != nil {
+				return handleError(err)
+			}
+
+			baseLen := TokenLength
+			if ns.UUID != namespace.RootNamespaceUUID {
+				baseLen = NSTokenLength
+			}
+
+			if b.Core.DisableSSCTokens() {
+				otp, err = base62.Random(baseLen + OldTokenPrefixLength)
+			} else {
+				otp, err = base62.Random(baseLen + TokenPrefixLength)
+			}
+			if err != nil {
+				return handleError(err)
+			}
+		}
+
+		if err := b.Core.GenerateRootInit(ctx, otp, pgpKey, GenerateStandardRootTokenStrategy); err != nil {
+			return handleError(err)
+		}
+
+		if genned {
+			return b.generateRootStatus(ctx, otp)
+		}
+
+		return b.generateRootStatus(ctx, "")
+	}
+}
+
+func (b *SystemBackend) handleGenerateRootStatus() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		return b.generateRootStatus(ctx, "")
+	}
+}
+
+func (b *SystemBackend) handleGenerateRootUpdate() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		nonce := ""
+		key := ""
+
+		if dataNonce, ok := data.GetOk("nonce"); ok {
+			nonce = dataNonce.(string)
+		}
+		if dataKey, ok := data.GetOk("key"); ok {
+			key = dataKey.(string)
+		}
+
+		if nonce == "" {
+			return logical.ErrorResponse("nonce is required"), logical.ErrInvalidRequest
+		}
+		if key == "" {
+			return logical.ErrorResponse("key is required"), logical.ErrInvalidRequest
+		}
+
+		key = strings.TrimSpace(key)
+		decodedKey, err := hex.DecodeString(key)
+		if err != nil {
+			decodedKey, err = base64.StdEncoding.DecodeString(key)
+			if err != nil {
+				return nil, fmt.Errorf("'key' must be a valid hex or base64 string")
+			}
+		}
+
+		result, err := b.Core.GenerateRootUpdate(ctx, decodedKey, nonce, GenerateStandardRootTokenStrategy)
+		if err != nil {
+			return nil, err
+		}
+
+		return &logical.Response{Data: map[string]interface{}{
+			"started":         true,
+			"complete":        result.Progress == result.Required,
+			"progress":        result.Progress,
+			"required":        result.Required,
+			"nonce":           nonce,
+			"encoded_token":   result.EncodedToken,
+			"pgp_fingerprint": result.PGPFingerprint,
+		}}, nil
+	}
+}
+
+func (b *SystemBackend) handleGenerateRootCancel() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		if err := b.Core.GenerateRootCancel(ctx); err != nil {
+			return handleError(err)
+		}
+
+		return nil, nil
+	}
+}
+
+func (b *SystemBackend) handleGenerateRootDecodeTokenUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	encodedToken := data.Get("encoded_token").(string)
+	otp := data.Get("otp").(string)
+
+	if encodedToken == "" || otp == "" {
+		return handleError(errors.New("provided 'encoded_token' or 'otp' is empty"))
+	}
+
+	token, err := roottoken.DecodeToken(encodedToken, otp, len(otp))
+	if err != nil {
+		return handleError(err)
+	}
+
+	return &logical.Response{Data: map[string]interface{}{"token": token}}, nil
+}
+
+func (b *SystemBackend) generateRootStatus(ctx context.Context, otp string) (*logical.Response, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return handleError(err)
+	}
+
+	seal := b.Core.sealManager.NamespaceSeal(ns.UUID)
+	if seal == nil {
+		return handleError(ErrNotSealable)
+	}
+
+	sealConfig, err := seal.BarrierConfig(ctx)
+	if err != nil {
+		return handleError(err)
+	}
+	if sealConfig == nil {
+		return handleError(ErrNotInit)
+	}
+
+	if seal.RecoveryKeySupported() {
+		sealConfig, err = seal.RecoveryConfig(ctx)
+		if err != nil {
+			return handleError(err)
+		}
+	}
+
+	generationConfig, err := b.Core.GenerateRootConfiguration(ctx)
+	switch {
+	// Return the progress as 0 in this case, root generation has not started.
+	case errors.Is(err, ErrNoRootGeneration):
+	case err != nil:
+		return handleError(err)
+	}
+
+	progress, err := b.Core.GenerateRootProgress(ctx)
+	if err != nil {
+		return handleError(err)
+	}
+
+	var baseLength int
+	if ns.ID == namespace.RootNamespaceID {
+		baseLength = TokenLength
+	} else {
+		baseLength = NSTokenLength
+	}
+
+	var otpLength int
+	if b.Core.DisableSSCTokens() {
+		otpLength = baseLength + OldTokenPrefixLength
+	} else {
+		otpLength = baseLength + TokenPrefixLength
+	}
+
+	response := map[string]interface{}{
+		"started":    false,
+		"complete":   false,
+		"progress":   progress,
+		"required":   sealConfig.SecretThreshold,
+		"otp":        otp,
+		"otp_length": otpLength,
+	}
+
+	if generationConfig != nil {
+		response["nonce"] = generationConfig.Nonce
+		response["started"] = true
+		response["pgp_fingerprint"] = generationConfig.PGPFingerprint
+	}
+
+	return &logical.Response{Data: response}, nil
+}
+
+var generateRootSysHelp = map[string][2]string{
+	"generate-root-token": {
+		"Reads status, initializes, or cancels a root token generation process.",
+		`
+This path responds to multiple HTTP methods which change the behavior. Those
+HTTP methods are listed below.
+
+    GET /attempt
+        Reads the configuration and progress of the current root generation
+        attempt.
+
+    POST /attempt
+        Initializes a new root generation attempt. Only a single root generation
+        attempt can take place at a time. One (and only one) of otp or pgp_key
+        are required.
+
+    DELETE /attempt
+        Cancels any in-progress root generation attempt. This clears any
+        progress made. This must be called to change the OTP or PGP key being
+        used.
+		`,
+	},
+	"decode-token": {
+		"Decodes encoded root token generated through `sys/generate-root-token` or unauthenticated `sys/generate-root` endpoint",
+		`
+This path responds to the following HTTP methods.
+
+	POST
+		Decode provided token using provided otp.
+		`,
+	},
+}

--- a/vault/logical_system_generate_root_test.go
+++ b/vault/logical_system_generate_root_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/pgpkeys"
+	"github.com/openbao/openbao/sdk/v2/helper/testhelpers/schema"
+	"github.com/openbao/openbao/sdk/v2/helper/xor"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRoot_Failure(t *testing.T) {
+	t.Parallel()
+	c, rootKey, _ := TestCoreUnsealed(t)
+	ns := &namespace.Namespace{Path: "test/"}
+	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, ns)
+	testGenerateRoot_Failure(t, c, namespace.RootNamespace, rootKey)
+	testGenerateRoot_Failure(t, c, ns, nsKeys["test/"])
+}
+
+func testGenerateRoot_Failure(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	req := logical.TestRequest(t, logical.UpdateOperation, "generate-root-token/attempt")
+	req.Data["otp"] = "wrong length"
+	_, err := c.systemBackend.HandleRequest(ctx, req)
+	require.Error(t, err)
+
+	req.Data["otp"] = ""
+	res, err := c.systemBackend.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Data)
+
+	nonce := res.Data["nonce"].(string)
+
+	req = logical.TestRequest(t, logical.UpdateOperation, "generate-root-token/update")
+	_, err = c.systemBackend.HandleRequest(ctx, req)
+	require.Error(t, err)
+
+	req.Data["nonce"] = nonce
+	_, err = c.systemBackend.HandleRequest(ctx, req)
+	require.Error(t, err)
+
+	req.Data["key"] = "invalid-key"
+	_, err = c.systemBackend.HandleRequest(ctx, req)
+	require.Error(t, err)
+
+	// make the key a valid hex.
+	req.Data["key"] = hex.EncodeToString(keys[0])[:1]
+	_, err = c.systemBackend.HandleRequest(ctx, req)
+	require.Error(t, err)
+
+	req.Data["key"] = hex.EncodeToString(keys[0])
+	res, err = c.systemBackend.HandleRequest(ctx, req)
+	require.NoError(t, err)
+
+	expected := map[string]interface{}{
+		"started":         true,
+		"complete":        false,
+		"progress":        1,
+		"required":        3,
+		"nonce":           nonce,
+		"encoded_token":   "",
+		"pgp_fingerprint": "",
+	}
+	require.Equal(t, expected, res.Data)
+}
+
+func TestGenerateRootAttempt(t *testing.T) {
+	t.Parallel()
+	c, rootKeys, _ := TestCoreUnsealed(t)
+	ns := &namespace.Namespace{Path: "test/"}
+	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, ns)
+	testGenerateRootAttempt(t, c, namespace.RootNamespace, "", rootKeys)
+	testGenerateRootAttempt(t, c, namespace.RootNamespace, pgpkeys.TestPubKey1, rootKeys)
+	testGenerateRootAttempt(t, c, ns, "", nsKeys["test/"])
+	testGenerateRootAttempt(t, c, ns, pgpkeys.TestPubKey1, nsKeys["test/"])
+}
+
+func testGenerateRootAttempt(t *testing.T, c *Core, ns *namespace.Namespace, pgp string, keys [][]byte) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	expected := map[string]interface{}{
+		"started":         true,
+		"complete":        false,
+		"progress":        0,
+		"required":        3,
+		"otp":             "",
+		"otp_length":      28,
+		"pgp_fingerprint": "",
+	}
+
+	if ns.UUID != namespace.RootNamespaceUUID {
+		expected["otp_length"] = 35
+	}
+
+	initReq := logical.TestRequest(t, logical.UpdateOperation, "generate-root-token/attempt")
+	if pgp != "" {
+		initReq.Data["pgp_key"] = pgp
+		expected["pgp_fingerprint"] = "816938b8a29146fbe245dd29e7cbaf8e011db793"
+	}
+
+	res, err := c.systemBackend.HandleRequest(ctx, initReq)
+	require.NoError(t, err)
+
+	// copy nonce and otp
+	expected["nonce"] = res.Data["nonce"]
+	expected["otp"] = res.Data["otp"]
+	require.Equal(t, expected, res.Data)
+
+	// clear root generation attempt
+	req := logical.TestRequest(t, logical.DeleteOperation, "generate-root-token/attempt")
+	res, err = c.systemBackend.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	// check that the attempt has been cancelled
+	req = logical.TestRequest(t, logical.ReadOperation, "generate-root-token/attempt")
+	res, err = c.systemBackend.HandleRequest(ctx, req)
+	require.NoError(t, err)
+
+	uninitExp := map[string]interface{}{
+		"started":    false,
+		"complete":   false,
+		"progress":   0,
+		"required":   3,
+		"otp":        "",
+		"otp_length": expected["otp_length"],
+	}
+	require.Equal(t, uninitExp, res.Data)
+
+	// again initialize the attempt
+	res, err = c.systemBackend.HandleRequest(ctx, initReq)
+	require.NoError(t, err)
+
+	// copy nonce and otp
+	otp := res.Data["otp"].(string)
+	nonce := res.Data["nonce"].(string)
+	expected["nonce"] = nonce
+	expected["otp"] = otp
+	require.Equal(t, expected, res.Data)
+
+	delete(expected, "otp")
+	delete(expected, "otp_length")
+	expected["encoded_token"] = ""
+
+	for i, key := range keys {
+		req := logical.TestRequest(t, logical.UpdateOperation, "generate-root-token/update")
+		req.Data["nonce"] = nonce
+		req.Data["key"] = hex.EncodeToString(key)
+
+		res, err = c.systemBackend.HandleRequest(ctx, req)
+		require.NoError(t, err)
+
+		expected["progress"] = i + 1
+		if pgp != "" {
+			expected["pgp_fingerprint"] = "816938b8a29146fbe245dd29e7cbaf8e011db793"
+		}
+		if i+1 == len(keys) {
+			expected["complete"] = true
+			expected["encoded_token"] = res.Data["encoded_token"]
+		}
+		require.Equal(t, expected, res.Data)
+	}
+
+	var newRootToken string
+	if pgp != "" {
+		decodedTokenBuf, err := pgpkeys.DecryptBytes(expected["encoded_token"].(string), pgpkeys.TestPrivKey1)
+		require.NoError(t, err)
+		require.NotNil(t, decodedTokenBuf)
+		newRootToken = decodedTokenBuf.String()
+	} else {
+		tokenBytes, err := base64.RawStdEncoding.DecodeString(expected["encoded_token"].(string))
+		require.NoError(t, err)
+
+		tokenBytes, err = xor.XORBytes(tokenBytes, []byte(otp))
+		require.NoError(t, err)
+		newRootToken = string(tokenBytes)
+	}
+
+	var meta map[string]string
+	expected = map[string]interface{}{
+		"id":               newRootToken,
+		"display_name":     "root",
+		"meta":             meta,
+		"num_uses":         0,
+		"policies":         []string{"root"},
+		"orphan":           true,
+		"creation_ttl":     int64(0),
+		"ttl":              int64(0),
+		"path":             "auth/token/root",
+		"explicit_max_ttl": int64(0),
+		"expire_time":      nil,
+		"entity_id":        "",
+		"type":             "service",
+	}
+
+	if ns.UUID != namespace.RootNamespaceUUID {
+		expected["display_name"] = fmt.Sprintf("%s_root", ns.ID)
+		expected["namespace_path"] = ns.Path
+		expected["path"] = fmt.Sprintf("namespaces/%s/%s", ns.UUID, expected["path"])
+	}
+
+	req = logical.TestRequest(t, logical.ReadOperation, "auth/token/lookup-self")
+	req.ClientToken = newRootToken
+	res, err = c.HandleRequest(ctx, req)
+	require.NoError(t, err)
+
+	expected["creation_time"] = res.Data["creation_time"]
+	expected["accessor"] = res.Data["accessor"]
+
+	require.Equal(t, expected, res.Data)
+}
+
+// TestSystemBackend_decodeToken ensures the correct decoding of the encoded token.
+// It also ensures that the API fails if there is some payload missing.
+func TestSystemBackend_decodeToken(t *testing.T) {
+	encodedToken := "Bxg9JQQqOCNKBRICNwMIRzo2J3cWCBRi"
+	otp := "3JhHkONiyiaNYj14nnD9xZQS"
+	tokenExpected := "4RUmoevJ3lsLni9sTXcNnRE1"
+
+	_, b, _ := testCoreSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.UpdateOperation, "decode-token")
+	req.Data["encoded_token"] = encodedToken
+	req.Data["otp"] = otp
+
+	resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
+	require.NoError(t, err)
+
+	schema.ValidateResponse(
+		t,
+		schema.GetResponseSchema(t, b.(*SystemBackend).Route(req.Path), req.Operation),
+		resp,
+		true,
+	)
+
+	token, ok := resp.Data["token"]
+	require.True(t, ok)
+	require.Equal(t, tokenExpected, token.(string))
+
+	datas := []map[string]interface{}{
+		nil,
+		{"encoded_token": encodedToken},
+		{"otp": otp},
+	}
+	for _, data := range datas {
+		req.Data = data
+		resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
+		require.Error(t, err)
+		schema.ValidateResponse(
+			t,
+			schema.GetResponseSchema(t, b.(*SystemBackend).Route(req.Path), req.Operation),
+			resp,
+			true,
+		)
+	}
+}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -399,8 +399,8 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["generate-root"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["generate-root"][1]),
+			HelpSynopsis:    strings.TrimSpace(generateRootSysHelp["generate-root-token"][0]),
+			HelpDescription: strings.TrimSpace(generateRootSysHelp["generate-root-token"][1]),
 		},
 		{
 			Pattern: "generate-root/update$",
@@ -472,33 +472,8 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 				},
 			},
 
-			HelpSynopsis:    strings.TrimSpace(sysHelp["generate-root"][0]),
-			HelpDescription: strings.TrimSpace(sysHelp["generate-root"][1]),
-		},
-		{
-			Pattern: "decode-token$",
-			Fields: map[string]*framework.FieldSchema{
-				"encoded_token": {
-					Type:        framework.TypeString,
-					Description: "Specifies the encoded token (result from generate-root).",
-				},
-				"otp": {
-					Type:        framework.TypeString,
-					Description: "Specifies the otp code for decode.",
-				},
-			},
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handleGenerateRootDecodeTokenUpdate,
-					DisplayAttrs: &framework.DisplayAttributes{
-						OperationVerb: "decode",
-					},
-					Summary: "Decodes the encoded token with the otp.",
-					Responses: map[int][]framework.Response{
-						http.StatusOK: {{Description: "OK"}},
-					},
-				},
-			},
+			HelpSynopsis:    strings.TrimSpace(generateRootSysHelp["generate-root-token"][0]),
+			HelpDescription: strings.TrimSpace(generateRootSysHelp["generate-root-token"][1]),
 		},
 
 		{

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2631,60 +2631,6 @@ func TestSystemBackend_enableAudit(t *testing.T) {
 	}
 }
 
-// TestSystemBackend_decodeToken ensures the correct decoding of the encoded token.
-// It also ensures that the API fails if there is some payload missing.
-func TestSystemBackend_decodeToken(t *testing.T) {
-	encodedToken := "Bxg9JQQqOCNKBRICNwMIRzo2J3cWCBRi"
-	otp := "3JhHkONiyiaNYj14nnD9xZQS"
-	tokenExpected := "4RUmoevJ3lsLni9sTXcNnRE1"
-
-	_, b, _ := testCoreSystemBackend(t)
-
-	req := logical.TestRequest(t, logical.UpdateOperation, "decode-token")
-	req.Data["encoded_token"] = encodedToken
-	req.Data["otp"] = otp
-
-	resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	schema.ValidateResponse(
-		t,
-		schema.GetResponseSchema(t, b.(*SystemBackend).Route(req.Path), req.Operation),
-		resp,
-		true,
-	)
-
-	token, ok := resp.Data["token"]
-	if !ok {
-		t.Fatalf("did not get token back in response, response was %#v", resp.Data)
-	}
-
-	if token.(string) != tokenExpected {
-		t.Fatalf("bad token back: %s", token.(string))
-	}
-
-	datas := []map[string]interface{}{
-		nil,
-		{"encoded_token": encodedToken},
-		{"otp": otp},
-	}
-	for _, data := range datas {
-		req.Data = data
-		resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
-		if err == nil {
-			t.Fatal("no error despite missing payload")
-		}
-		schema.ValidateResponse(
-			t,
-			schema.GetResponseSchema(t, b.(*SystemBackend).Route(req.Path), req.Operation),
-			resp,
-			true,
-		)
-	}
-}
-
 func TestSystemBackend_auditHash(t *testing.T) {
 	b := testSystemBackendUnsafeAuditCreation(t)
 
@@ -4233,7 +4179,7 @@ func TestSystemBackend_InternalUIMounts(t *testing.T) {
 		},
 	}
 	if diff := deep.Equal(resp.Data, exp); diff != nil {
-		t.Logf("resp.Data[secret][sys/] = %#v", ((resp.Data["secret"]).(map[string]interface{}))["sys/"])
+		t.Logf("resp.Data[secret][sys/] = %#v", resp.Data["secret"].(map[string]interface{})["sys/"])
 		t.Fatal(diff)
 	}
 
@@ -4709,7 +4655,8 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 					"length = 20\n" +
 						"rule \"charset\" {\n" +
 						"	charset=\"abcdefghij\"\n" +
-						"}"),
+						"}",
+				),
 			}),
 
 			storage: new(logical.InmemStorage),
@@ -4897,7 +4844,8 @@ func TestHandlePoliciesPasswordDelete(t *testing.T) {
 				"name": "testpolicy",
 			}),
 
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("testpolicy"),
 					Value: toJson(t,
@@ -4977,7 +4925,8 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 			},
 		},
 		"one policy": {
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("testpolicy"),
 					Value: toJson(t,
@@ -4997,7 +4946,8 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 			},
 		},
 		"two policies": {
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("testpolicy"),
 					Value: toJson(t,
@@ -5030,7 +4980,8 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 			},
 		},
 		"policy with /": {
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("testpolicy/testpolicy1"),
 					Value: toJson(t,
@@ -5050,7 +5001,8 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 			},
 		},
 		"list path/to/policy": {
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("path/to/policy"),
 					Value: toJson(t,
@@ -5070,7 +5022,8 @@ func TestHandlePoliciesPasswordList(t *testing.T) {
 			},
 		},
 		"policy ending with /": {
-			storage: makeStorage(t,
+			storage: makeStorage(
+				t,
 				&logical.StorageEntry{
 					Key: getPasswordPolicyKey("path/to/policy/"),
 					Value: toJson(t,

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -83,7 +83,6 @@ func init() {
 		"config/reload",
 		"config/state",
 		"config/ui",
-		"decode-token",
 		"generate-recovery-token",
 		"generate-root",
 		"health",

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -477,8 +477,14 @@ func (sm *SealManager) unsealKeyToRootKey(ctx context.Context, seal Seal, combin
 	switch seal.BarrierType() {
 	case vaultseal.WrapperTypeShamir:
 		if useTestSeal {
+			ns, err := namespace.FromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+
 			testseal := NewDefaultSeal(vaultseal.NewAccess(vaultseal.NewShamirWrapper()))
 			testseal.SetCore(sm.core)
+			testseal.SetMetaPrefix(NamespaceStoragePathPrefix(ns))
 			cfg, err := seal.BarrierConfig(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to setup test barrier config: %w", err)
@@ -531,7 +537,7 @@ func (sm *SealManager) AuthenticateRootKey(ctx context.Context, ns *namespace.Na
 		return ErrNotSealable
 	}
 
-	rootKey, err := sm.unsealKeyToRootKey(ctx, seal, combinedKey, false, false)
+	rootKey, err := sm.unsealKeyToRootKey(ctx, seal, combinedKey, true, false)
 	if err != nil {
 		return fmt.Errorf("unable to authenticate: %w", err)
 	}


### PR DESCRIPTION
based on #2925, requires a rebase after a merge.

## Description
Introduced authenticated `sys/generate-root-token` endpoints allowing for per-namespace root token creation.

Changes originally sourced from [commit](https://github.com/openbao/openbao/commit/ba8ef86fc34c74a2281bb33980414e4e71f101ea) created by @rencooo

## Rationale
Root token generation for a namespace will enable specific namespace operators to setup the namespace before usage without requiring "higher-order" operator. Also introduction of authenticated endpoints aims at filling the gap after the deprecation of the unauthenticated ones.

Resolves: no issue, a follow-up to #2912

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
