### PR TITLE
fix: nil-guard d.autopilot before calling GetState

### DIFF
--- a/changelog/3054.txt
+++ b/changelog/3054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/raft: wait for shutdown to avoid panic
+```

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -356,14 +356,23 @@ func (b *RaftBackend) startFollowerHeartbeatTracker() {
 // on the active node.
 func (b *RaftBackend) StopAutopilot() {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	if b.autopilot == nil {
+		b.l.Unlock()
 		return
 	}
-	b.autopilot.Stop()
+	doneCh := b.autopilot.Stop()
+	b.l.Unlock()
+
+	// Wait for autopilot goroutines to exit before clearing the pointer.
+	// b.l must not be held here: delegate callbacks (e.g. KnownServers) call
+	// b.l.RLock() and would deadlock.
+	<-doneCh
+
+	b.l.Lock()
 	b.autopilot = nil
 	b.followerHeartbeatTicker.Stop()
+	b.l.Unlock()
 }
 
 // AutopilotState represents the health information retrieved from autopilot.

--- a/physical/raft/raft_autopilot_delegate.go
+++ b/physical/raft/raft_autopilot_delegate.go
@@ -138,7 +138,12 @@ func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 		return nil
 	}
 
-	apServerStates := d.autopilot.GetState().Servers
+	var apServerStates map[raft.ServerID]*autopilot.ServerState
+	if d.autopilot != nil {
+		if state := d.autopilot.GetState(); state != nil {
+			apServerStates = state.Servers
+		}
+	}
 	servers := future.Configuration().Servers
 	serverIDs := make([]string, 0, len(servers))
 	for _, server := range servers {


### PR DESCRIPTION
## Description

Running 2.5.2 in production, some of my replicas are crashing occasionally, generating this stack trace:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x2dd5ecd]

goroutine 38596 [running]:
sync/atomic.(*Int32).Add(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/sync/atomic/type.go:94
sync.(*RWMutex).RLock(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/sync/rwmutex.go:72
github.com/hashicorp/raft-autopilot.(*Autopilot).GetState(0xc001694620?)
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/autopilot.go:225 +0x2d
github.com/openbao/openbao/physical/raft.(*Delegate).KnownServers(0xc0014e6c00)
	/home/runner/work/openbao/openbao/physical/raft/raft_autopilot_delegate.go:141 +0xe5
github.com/hashicorp/raft-autopilot.(*Autopilot).gatherNextStateInputs(0xc001250d80, {0x5da8888, 0xc0014d71d0})
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/state.go:118 +0x254
github.com/hashicorp/raft-autopilot.(*Autopilot).nextState(0xc001250d80, {0x5da8888?, 0xc0014d71d0?})
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/state.go:188 +0x25
github.com/hashicorp/raft-autopilot.(*Autopilot).updateState(0xc001250d80, {0x5da8888?, 0xc0014d71d0?})
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/state.go:406 +0x3b
github.com/hashicorp/raft-autopilot.(*Autopilot).runStateUpdater(0xc001250d80, {0x5da8888, 0xc0014d71d0}, 0xc00135e850)
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/run.go:193 +0xf9
created by github.com/hashicorp/raft-autopilot.(*Autopilot).beginExecution in goroutine 38531
	/home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.3.0/run.go:124 +0x11c
```

Looking into it, it seems to me to be caused by a missing nil-guard, having seen a few of them elsewhere.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3053

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
