### PR TITLE
Fix namespace unsealing restart

### DIFF
--- a/vault/logical_system_namespaces_seals_test.go
+++ b/vault/logical_system_namespaces_seals_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNamespaceBackend_SealUnseal(t *testing.T) {
 	t.Parallel()
-	c, _, _ := TestCoreUnsealed(t)
+	c, rootShares, root := TestCoreUnsealed(t)
 	b := c.systemBackend
 
 	rootCtx := namespace.RootContext(context.Background())
@@ -87,7 +87,8 @@ func TestNamespaceBackend_SealUnseal(t *testing.T) {
 	})
 
 	t.Run("preserve mounts after unsealing namespaces", func(t *testing.T) {
-		keyshares := TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "foobar/"})
+		nsFoobar := &namespace.Namespace{Path: "foobar/"}
+		keyshares := TestCoreCreateUnsealedNamespaces(t, c, nsFoobar)
 		ns, err := c.namespaceStore.GetNamespaceByPath(rootCtx, "foobar")
 		require.NoError(t, err)
 		nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
@@ -179,5 +180,67 @@ func TestNamespaceBackend_SealUnseal(t *testing.T) {
 		res, err = c.router.Route(nsCtx, req)
 		require.NoError(t, err)
 		require.NotNil(t, res)
+
+		// Sealing and unsealing the root namespace should work.
+		require.NoError(t, c.Seal(root))
+
+		// Unseal the root namespace.
+		for i, key := range rootShares {
+			unseal, err := TestCoreUnseal(c, key)
+			require.NoError(t, err)
+			require.False(t, i+1 == len(rootShares) && !unseal)
+		}
+
+		// Namespace should now be sealed.
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/child")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.Error(t, err)
+		require.NotNil(t, res.Error())
+
+		// Validate that mounts are gone.
+		req = logical.TestRequest(t, logical.ReadOperation, "mounts")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.Empty(t, res.Data)
+
+		req = logical.TestRequest(t, logical.ReadOperation, "auth")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.Empty(t, res.Data)
+
+		// We should be able to unseal it.
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][0])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Data["progress"])
+		require.Equal(t, true, res.Data["sealed"])
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][1])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, 2, res.Data["progress"])
+		require.Equal(t, true, res.Data["sealed"])
+
+		req = logical.TestRequest(t, logical.UpdateOperation, "namespaces/foobar/unseal")
+		req.Data["key"] = base64.RawStdEncoding.EncodeToString(keyshares["foobar/"][2])
+		res, err = b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+
+		// progress reset
+		require.Equal(t, 0, res.Data["progress"])
+		require.Equal(t, false, res.Data["sealed"])
+
+		// Now we should be able to list mounts again.
+		req = logical.TestRequest(t, logical.ReadOperation, "mounts")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_secrets/"])
+
+		req = logical.TestRequest(t, logical.ReadOperation, "auth")
+		res, err = b.HandleRequest(nsCtx, req)
+		require.NoError(t, err)
+		require.NotNil(t, res.Data["my_approle/"])
 	})
 }

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -128,9 +128,14 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	defaultSeal.SetCore(sm.core)
 	defaultSeal.SetMetaPrefix(metaPrefix)
 
-	// At this point, the namespace's barrier is still the parent's barrier,
-	// hence we can just query that without computing the actual parent.
-	defaultSeal.SetConfigAccess(sm.namespaceBarrierByLongestPrefix(ns.Path))
+	// The configuration access should always at least use the parent's seal
+	// configuration information.
+	parent, ok := ns.ParentPath()
+	if !ok {
+		return fmt.Errorf("cannot seal the root namespace via this approach")
+	}
+	parentBarrier := sm.namespaceBarrierByLongestPrefix(parent)
+	defaultSeal.SetConfigAccess(parentBarrier)
 
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 	if err := defaultSeal.Init(ctx); err != nil {

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -117,6 +117,12 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
+	// Check if we're already present; if so, don't set any seal information
+	// as we don't want to overwrite what we have.
+	if _, ok := sm.sealByNamespace[ns.UUID]; ok {
+		return nil
+	}
+
 	if err := sealConfig.Validate(); err != nil {
 		return fmt.Errorf("invalid seal configuration: %w", err)
 	}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This fixes a bug in namespace seals which prevents us from working on HA storage backends after the server restarts or is sealed. Each individual commit has details. To reproduce:

```
$ ( ( killall bao && sleep 1 ) ; devbao node start --force --initialize --unseal --profiles secret,userpass,pki --audit --seals static:// --ui ) && . <(devbao node env prod)
$ bao namespace create -key-shares=1 -key-threshold=1 asdf
$ bao write sys/namespaces/asdf/unseal key=...
(works)
$ killall bao && sleep 2 && devbao node resume prod
$ bao write sys/namespaces/asdf/unseal key=...
(fails)
```

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Related: #1357

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
