### PR TITLE
raft: disable snapshot compression

### DIFF
--- a/changelog/3061.txt
+++ b/changelog/3061.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+raft: improve snapshot duration while slightly increasing snapshot size
+```

--- a/physical/raft/snapshot/snapshot.go
+++ b/physical/raft/snapshot/snapshot.go
@@ -141,7 +141,10 @@ func Write(logger hclog.Logger, r *raft.Raft, sealer Sealer, w io.Writer) error 
 	}()
 
 	// Wrap the file writer in a gzip compressor.
-	compressor := gzip.NewWriter(w)
+	compressor, err := gzip.NewWriterLevel(w, gzip.NoCompression)
+	if err != nil {
+		return fmt.Errorf("failed to create snapshot file: %v", err)
+	}
 
 	// Write the archive.
 	if err := write(compressor, metadata, snap, sealer); err != nil {


### PR DESCRIPTION
## Description

This changes the raft snapshot process in a fully compatible way: Snapshots are still gzipped tar files, just a gzip stream without compression. I wasn't even required to touch the restore part.

## Rationale

Much faster snapshots at the expense of slightly larger files (exact numbers will vary based on the actual data and scale of a given cluster)

Resolves: #2957

We were discussing, if this should be configurable, but concluded to leave it hard-coded any add configurability on concrete request.

If you want to compress your snapshots, you can `gunzip` and `gzip` them again and the resulting file will successfully restore on an OpenBao cluster.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
