### PR TITLE
Fix unseal CLI test failures

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -395,11 +395,12 @@ func testVaultServerWithNamespace(tb testing.TB, name string, sealed bool) (*api
 
 	client, _, closer := testVaultServerUnseal(tb)
 	data := map[string]any{
-		"seal": map[string]any{
-			"type":             "shamir",
-			"secret_shares":    3,
-			"secret_threshold": 2,
-		},
+		"seal": `
+seal "shamir" {
+	shares = 3
+	threshold = 2
+}
+`,
 	}
 	resp, err := client.Logical().Write("/sys/namespaces/"+name, data)
 	require.NoError(tb, err)


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

In reviewing #2900 and #2972, I had incorrectly assumed #2972 was a second patch series based on top of #2900 and handled the HCL-based namespace seal configuration. This was wrong and is causing test failures.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Main should be green and apparently I shouldn't be reviewing PRs at 40k feet on international flights. :airplane: :laughing: 

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
