### PR TITLE
fix: apply socket_mode without requiring socket_user/socket_group

### DIFF
--- a/command/agentproxyshared/cache/listener.go
+++ b/command/agentproxyshared/cache/listener.go
@@ -48,8 +48,8 @@ func StartListener(lnConfig *configutil.Listener) (*ListenerBundle, error) {
 
 	case "unix":
 		var uConfig *listenerutil.UnixSocketsConfig
-		if lnConfig.SocketMode != "" &&
-			lnConfig.SocketUser != "" &&
+		if lnConfig.SocketMode != "" ||
+			lnConfig.SocketUser != "" ||
 			lnConfig.SocketGroup != "" {
 			uConfig = &listenerutil.UnixSocketsConfig{
 				Mode:  lnConfig.SocketMode,

--- a/command/server/listener_unix.go
+++ b/command/server/listener_unix.go
@@ -19,8 +19,8 @@ func unixListenerFactory(l *configutil.Listener, _ hclog.Logger, ui cli.Ui) (net
 	}
 
 	var cfg *listenerutil.UnixSocketsConfig
-	if l.SocketMode != "" &&
-		l.SocketUser != "" &&
+	if l.SocketMode != "" ||
+		l.SocketUser != "" ||
 		l.SocketGroup != "" {
 		cfg = &listenerutil.UnixSocketsConfig{
 			Mode:  l.SocketMode,

--- a/command/server/listener_unix_test.go
+++ b/command/server/listener_unix_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,4 +26,29 @@ func TestUnixListener(t *testing.T) {
 	}
 
 	testListenerImpl(t, ln, connFn, "", 0, "", false)
+}
+
+func TestUnixListener_SocketModeOnly(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "vault.sock")
+
+	ln, _, _, err := unixListenerFactory(&configutil.Listener{
+		Address:    sockPath,
+		SocketMode: "0600",
+	}, nil, cli.NewMockUi())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer ln.Close()
+
+	fi, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("stat failed: %s", err)
+	}
+
+	// os.FileMode includes the socket type bit; mask to permission bits only
+	got := fi.Mode().Perm()
+	want := os.FileMode(0600)
+	if got != want {
+		t.Errorf("socket mode = %04o, want %04o", got, want)
+	}
 }

--- a/command/server/listener_unix_test.go
+++ b/command/server/listener_unix_test.go
@@ -28,8 +28,9 @@ func TestUnixListener(t *testing.T) {
 	testListenerImpl(t, ln, connFn, "", 0, "", false)
 }
 
-func TestUnixListener_SocketModeOnly(t *testing.T) {
-	sockPath := filepath.Join(t.TempDir(), "vault.sock")
+func TestUnixListener_ModeOnly(t *testing.T) {
+	// Use a short filename to stay under the 104-byte sun_path limit on macOS.
+	sockPath := filepath.Join(t.TempDir(), "s.sock")
 
 	ln, _, _, err := unixListenerFactory(&configutil.Listener{
 		Address:    sockPath,


### PR DESCRIPTION
## Summary
- Fix Unix socket listener to apply `socket_mode` (chmod) even when `socket_user` and `socket_group` are not specified
- Previously, `socket_mode` was only applied inside the `if socketUser != "" || socketGroup != ""` block, requiring ownership fields to be set just to change permissions
- Apply the same fix to both server and agent/proxy listener code paths
- Shorten test socket path for macOS `sun_path` limit compatibility

Fixes #2594

## Test plan
- New test verifies socket_mode is applied when socket_user and socket_group are empty
- Existing listener tests pass unchanged