### PR TITLE
Fix init dev core flake

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1131,7 +1131,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
 	if c.flagDevThreeNode {
-		return c.enableThreeNodeDevCluster(&coreConfig, info, infoKeys, c.flagDevListenAddr, api.ReadBaoVariable("BAO_DEV_TEMP_DIR"))
+		return c.enableThreeNodeDevCluster(&coreConfig, info, infoKeys, api.ReadBaoVariable("BAO_DEV_TEMP_DIR"))
 	}
 
 	if allowPendingRemoval := api.ReadBaoVariable(consts.EnvVaultAllowPendingRemovalMounts); allowPendingRemoval != "" {
@@ -2002,7 +2002,7 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 	return init, nil
 }
 
-func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info map[string]string, infoKeys []string, devListenAddress, tempDir string) int {
+func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info map[string]string, infoKeys []string, tempDir string) int {
 	conf, opts := teststorage.ClusterSetup(base, &vault.TestClusterOptions{
 		HandlerFunc:       vaulthttp.Handler,
 		BaseListenAddress: c.flagDevListenAddr,
@@ -2861,100 +2861,101 @@ func initDevCore(c *ServerCommand, coreConfig *vault.CoreConfig, config *server.
 
 		var qw *quiescenceSink
 		var qwo sync.Once
-		qw = &quiescenceSink{
-			t: time.AfterFunc(100*time.Millisecond, func() {
-				qwo.Do(func() {
-					c.logger.DeregisterSink(qw)
 
-					// Print the big dev mode warning!
-					c.UI.Warn("")
-					c.UI.Warn(wrapAtLength(
-						"WARNING! dev mode is enabled! In this mode, OpenBao runs entirely " +
-							"in-memory and starts unsealed with a single unseal key. The root " +
-							"token is already authenticated to the CLI, so you can immediately " +
-							"begin using OpenBao.",
-					))
-					c.UI.Warn("")
-					c.UI.Warn("You may need to set the following environment variables:")
-					c.UI.Warn("")
+		qw = &quiescenceSink{}
+		qw.t = time.AfterFunc(100*time.Millisecond, func() {
+			qwo.Do(func() {
+				c.logger.DeregisterSink(qw)
 
-					protocol := "http://"
-					if c.flagDevTLS {
-						protocol = "https://"
-					}
+				// Print the big dev mode warning!
+				c.UI.Warn("")
+				c.UI.Warn(wrapAtLength(
+					"WARNING! dev mode is enabled! In this mode, OpenBao runs entirely " +
+						"in-memory and starts unsealed with a single unseal key. The root " +
+						"token is already authenticated to the CLI, so you can immediately " +
+						"begin using OpenBao.",
+				))
+				c.UI.Warn("")
+				c.UI.Warn("You may need to set the following environment variables:")
+				c.UI.Warn("")
 
-					endpointURL := protocol + config.Listeners[0].Address
+				protocol := "http://"
+				if c.flagDevTLS {
+					protocol = "https://"
+				}
+
+				endpointURL := protocol + config.Listeners[0].Address
+				if runtime.GOOS == "windows" {
+					c.UI.Warn("PowerShell:")
+					c.UI.Warn(fmt.Sprintf("    $env:BAO_ADDR=\"%s\"", endpointURL))
+					c.UI.Warn("cmd.exe:")
+					c.UI.Warn(fmt.Sprintf("    set BAO_ADDR=%s", endpointURL))
+				} else {
+					c.UI.Warn(fmt.Sprintf("    $ export BAO_ADDR='%s'", endpointURL))
+				}
+
+				if c.flagDevTLS {
 					if runtime.GOOS == "windows" {
 						c.UI.Warn("PowerShell:")
-						c.UI.Warn(fmt.Sprintf("    $env:BAO_ADDR=\"%s\"", endpointURL))
+						c.UI.Warn(fmt.Sprintf("    $env:BAO_CACERT=\"%s/vault-ca.pem\"", certDir))
 						c.UI.Warn("cmd.exe:")
-						c.UI.Warn(fmt.Sprintf("    set BAO_ADDR=%s", endpointURL))
+						c.UI.Warn(fmt.Sprintf("    set BAO_CACERT=%s/vault-ca.pem", certDir))
 					} else {
-						c.UI.Warn(fmt.Sprintf("    $ export BAO_ADDR='%s'", endpointURL))
+						c.UI.Warn(fmt.Sprintf("    $ export BAO_CACERT='%s/vault-ca.pem'", certDir))
 					}
+					c.UI.Warn("")
+				}
 
-					if c.flagDevTLS {
-						if runtime.GOOS == "windows" {
-							c.UI.Warn("PowerShell:")
-							c.UI.Warn(fmt.Sprintf("    $env:BAO_CACERT=\"%s/vault-ca.pem\"", certDir))
-							c.UI.Warn("cmd.exe:")
-							c.UI.Warn(fmt.Sprintf("    set BAO_CACERT=%s/vault-ca.pem", certDir))
-						} else {
-							c.UI.Warn(fmt.Sprintf("    $ export BAO_CACERT='%s/vault-ca.pem'", certDir))
-						}
-						c.UI.Warn("")
-					}
-
-					if len(init.SecretShares) > 0 {
-						c.UI.Warn("")
-						c.UI.Warn(wrapAtLength(
-							"The unseal key and root token are displayed below in case you want " +
-								"to seal/unseal the Vault or re-authenticate.",
-						))
-						c.UI.Warn("")
-						c.UI.Warn(fmt.Sprintf("Unseal Key: %s", base64.StdEncoding.EncodeToString(init.SecretShares[0])))
-					}
-
-					if len(init.RecoveryShares) > 0 {
-						c.UI.Warn("")
-						c.UI.Warn(wrapAtLength(
-							"The recovery key and root token are displayed below in case you want " +
-								"to seal/unseal the Vault or re-authenticate.",
-						))
-						c.UI.Warn("")
-						c.UI.Warn(fmt.Sprintf("Recovery Key: %s", base64.StdEncoding.EncodeToString(init.RecoveryShares[0])))
-					}
-
-					c.UI.Warn(fmt.Sprintf("Root Token: %s", init.RootToken))
-
-					if len(plugins) > 0 {
-						c.UI.Warn("")
-						c.UI.Warn(wrapAtLength(
-							"The following dev plugins are registered in the catalog:",
-						))
-						for _, p := range plugins {
-							c.UI.Warn(fmt.Sprintf("    - %s", p))
-						}
-					}
-
-					if len(pluginsNotLoaded) > 0 {
-						c.UI.Warn("")
-						c.UI.Warn(wrapAtLength(
-							"The following dev plugins FAILED to be registered in the catalog due to unknown type:",
-						))
-						for _, p := range pluginsNotLoaded {
-							c.UI.Warn(fmt.Sprintf("    - %s", p))
-						}
-					}
-
+				if len(init.SecretShares) > 0 {
 					c.UI.Warn("")
 					c.UI.Warn(wrapAtLength(
-						"Development mode should NOT be used in production installations!",
+						"The unseal key and root token are displayed below in case you want " +
+							"to seal/unseal the Vault or re-authenticate.",
 					))
 					c.UI.Warn("")
-				})
-			}),
-		}
+					c.UI.Warn(fmt.Sprintf("Unseal Key: %s", base64.StdEncoding.EncodeToString(init.SecretShares[0])))
+				}
+
+				if len(init.RecoveryShares) > 0 {
+					c.UI.Warn("")
+					c.UI.Warn(wrapAtLength(
+						"The recovery key and root token are displayed below in case you want " +
+							"to seal/unseal the Vault or re-authenticate.",
+					))
+					c.UI.Warn("")
+					c.UI.Warn(fmt.Sprintf("Recovery Key: %s", base64.StdEncoding.EncodeToString(init.RecoveryShares[0])))
+				}
+
+				c.UI.Warn(fmt.Sprintf("Root Token: %s", init.RootToken))
+
+				if len(plugins) > 0 {
+					c.UI.Warn("")
+					c.UI.Warn(wrapAtLength(
+						"The following dev plugins are registered in the catalog:",
+					))
+					for _, p := range plugins {
+						c.UI.Warn(fmt.Sprintf("    - %s", p))
+					}
+				}
+
+				if len(pluginsNotLoaded) > 0 {
+					c.UI.Warn("")
+					c.UI.Warn(wrapAtLength(
+						"The following dev plugins FAILED to be registered in the catalog due to unknown type:",
+					))
+					for _, p := range pluginsNotLoaded {
+						c.UI.Warn(fmt.Sprintf("    - %s", p))
+					}
+				}
+
+				c.UI.Warn("")
+				c.UI.Warn(wrapAtLength(
+					"Development mode should NOT be used in production installations!",
+				))
+				c.UI.Warn("")
+			})
+		})
+
 		c.logger.RegisterSink(qw)
 	}
 	return nil

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -197,8 +197,6 @@ func TestServer_ReloadListener(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		name     string
 		contents string
@@ -287,8 +285,6 @@ func TestServer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			ui, cmd := testServerCommand(t)
 
 			f, err := os.CreateTemp(t.TempDir(), "")

--- a/vault/external_tests/standby/read_only_standby_test.go
+++ b/vault/external_tests/standby/read_only_standby_test.go
@@ -56,10 +56,12 @@ func TestReadOnlyStandby(t *testing.T) {
 		expectedValue := fmt.Sprintf("expected value #%d", i)
 
 		t.Logf("writing expected value on node %d", i)
-		_, err := core.Client.KVv2("kv").Put(t.Context(), "foo", map[string]any{
-			"bar": expectedValue,
-		})
-		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := core.Client.KVv2("kv").Put(t.Context(), "foo", map[string]any{
+				"bar": expectedValue,
+			})
+			require.NoError(collect, err)
+		}, 10*time.Second, 100*time.Millisecond)
 
 		t.Logf("validating expected value on primary %d", i)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {


### PR DESCRIPTION
## Description
- fixes `TestServer_DevTLS` sometimes reporting `DATA RACE` due to concurrent reads inside the `time.AfterFunc` callback of `quiescenceSink` struct
- removes `t.Parallel()` from `command/TestServer` due to valid concurrency issue (multiple goroutines want to update same metrics)
- gofumpt run over the file
- adjustment in `TestReadOnlyStandby` test sometimes failing with:
`* Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly.`

## Rationale
making ci more resilient

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
