### PR TITLE
Add ControlPlane to TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | Michael Hofer    | michael.hofer@adfinis.com    | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Chair        |
 | Maw Wildpaner    | maw@gitlab.com               |                                            | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
 | Klaus Kiefer     | klaus.kiefer@sap.com         | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
-| Alex Scheel      | alexander.m.scheel@gmail.com | [@cipherboy](https://github.com/cipherboy) |                                                 | Individual           | Member       |
+| Alex Scheel      | alex.scheel@control-plane.io | [@cipherboy](https://github.com/cipherboy) | Eugene Davis (eugene.davis@control-plane.io)    | ControlPlane         | Member       |
 
 To view the process for joining the TSC, see [GOVERNANCE.md](GOVERNANCE.md) in
 the root of this repository. That document is considered part of this document.


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This was voted on at the April TSC meeting, though I've waited until we've confirmed our second member internally.

See also: https://docs.google.com/document/d/1oNqm4GXCsIZbcNHsIqft4kgciRcuwS9rrIRGXlMz1yg/edit?tab=t.j9lcyrvl3939#heading=h.k0ultsb9fi3u


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

---

fyi @karras 