### PR TITLE
Fix audit logs dropping custom headers when using inline auth

### DIFF
--- a/changelog/3076.txt
+++ b/changelog/3076.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/auth: fix audit logs dropping custom headers when using inline auth
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -457,7 +457,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 		delete(req.Headers, consts.InlineAuthPathHeaderName)
 		delete(req.Headers, consts.InlineAuthOperationHeaderName)
 		for header := range req.Headers {
-			if !strings.HasPrefix(header, consts.InlineAuthParameterHeaderPrefix) {
+			if strings.HasPrefix(header, consts.InlineAuthParameterHeaderPrefix) {
 				delete(req.Headers, header)
 			}
 		}


### PR DESCRIPTION
## Description

When attempting to remove all auth-related headers for inline auth, we should be checking and removing all headers with the inline auth prefix instead of removing all headers without the inline auth prefix.

## Rationale

Allows custom headers added by clients to be correctly logged by the audit log.

Resolves: #3074 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
