### PR TITLE
Add per-ns encryption key and seal status endpoints

### DIFF
--- a/command/operator_key_status.go
+++ b/command/operator_key_status.go
@@ -21,15 +21,15 @@ type OperatorKeyStatusCommand struct {
 }
 
 func (c *OperatorKeyStatusCommand) Synopsis() string {
-	return "Provides information about the active encryption key"
+	return "Provides information about specific namespace barrier encryption key"
 }
 
 func (c *OperatorKeyStatusCommand) Help() string {
 	helpText := `
 Usage: bao operator key-status [options]
 
-  Provides information about the active encryption key. Specifically,
-  the current key term and the key installation time.
+  Provides information about specific namespace barrier encryption key.
+  Specifically the current key term, installation time and encryption count.
 
 ` + c.Flags().Help()
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3075,22 +3075,31 @@ func (b *SystemBackend) handleConfigUIHeadersDelete(ctx context.Context, req *lo
 	return nil, nil
 }
 
-// handleKeyStatus returns status information about the backend key
+// handleKeyStatus handles the "/sys/key-status" endpoint
+// to return status information about the (namespace scoped) backend key.
 func (b *SystemBackend) handleKeyStatus(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	// Get the key info
-	info, err := b.Core.barrier.ActiveKeyInfo()
+	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return handleError(err)
 	}
 
-	resp := &logical.Response{
+	barrier := b.Core.sealManager.NamespaceBarrier(ns.Path)
+	if barrier == nil {
+		return handleError(ErrNotSealable)
+	}
+
+	info, err := barrier.ActiveKeyInfo()
+	if err != nil {
+		return handleError(err)
+	}
+
+	return &logical.Response{
 		Data: map[string]interface{}{
 			"term":         info.Term,
 			"install_time": info.InstallTime.Format(time.RFC3339Nano),
 			"encryptions":  info.Encryptions,
 		},
-	}
-	return resp, nil
+	}, nil
 }
 
 func (b *SystemBackend) handleWrappingWrap(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -5260,9 +5269,9 @@ Enable a new audit backend or disable an existing backend.
 	},
 
 	"key-status": {
-		"Provides information about the backend encryption key.",
+		"Provides information about the specific namespace barrier encryption key.",
 		`
-		Provides the current backend encryption key term and installation time.
+		Provides the current encryption key term, installation time and encryption count.
 		`,
 	},
 

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -52,9 +52,36 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 
 	return []*framework.Path{
 		{
+			Pattern: "namespaces/(?P<path>.+)/seal-status",
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+				OperationSuffix: "seal",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": namespacePathSchema,
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Summary:  "Check the seal status of an OpenBao namespace.",
+					Callback: b.handleNamespaceSealStatus(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: http.StatusText(http.StatusOK),
+							Fields:      sealStatusSchema,
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
+			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
+		},
+		{
 			Pattern: "namespaces/(?P<path>.+)/seal",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "namespaces",
+				OperationVerb:   "seal",
 			},
 			Fields: map[string]*framework.FieldSchema{
 				"path": namespacePathSchema,
@@ -80,6 +107,7 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 			Pattern: "namespaces/(?P<path>.+)/unseal",
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "namespaces",
+				OperationVerb:   "unseal",
 			},
 			Fields: map[string]*framework.FieldSchema{
 				"path": namespacePathSchema,
@@ -109,6 +137,43 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
 			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
 		},
+	}
+}
+
+// handleNamespaceSealStatus handles the "/sys/namespaces/<path>/seal-status" endpoint
+// to retrieve a seal status of the namespace.
+func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
+			return nil, errors.New("path must not contain /")
+		}
+
+		ns, err := b.Core.namespaceStore.GetNamespaceByPath(ctx, path)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if ns == nil {
+			return nil, fmt.Errorf("namespace %q doesn't exist", path)
+		}
+
+		status, err := b.Core.sealManager.SealStatus(ctx, ns)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"type":        status.Type,
+				"initialized": status.Initialized,
+				"sealed":      status.Sealed,
+				"t":           status.T,
+				"n":           status.N,
+				"progress":    status.Progress,
+				"nonce":       status.Nonce,
+			},
+		}, nil
 	}
 }
 
@@ -212,9 +277,6 @@ This path responds to the following HTTP methods.
 
 	GET /<path>/seal-status
 		Returns the seal status of the namespace.
-
-	GET /<path>/key-status
-		Provides the namespace current backend encryption key term and installation time.
 		`,
 	},
 }

--- a/vault/logical_system_namespaces_seals_test.go
+++ b/vault/logical_system_namespaces_seals_test.go
@@ -13,6 +13,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNamespaceBackend_SealStatus(t *testing.T) {
+	t.Parallel()
+	c, _, _ := TestCoreUnsealed(t)
+	b := c.systemBackend
+	rootCtx := namespace.RootContext(context.Background())
+
+	t.Run("returns error on non-sealable namespace", func(t *testing.T) {
+		testCreateNamespace(t, rootCtx, b, "foo", nil)
+
+		req := logical.TestRequest(t, logical.ReadOperation, "namespaces/foo/seal-status")
+		resp, err := b.HandleRequest(rootCtx, req)
+		require.Error(t, err)
+		require.ErrorContains(t, resp.Error(), ErrNotSealable.Error())
+	})
+
+	t.Run("can read seal status", func(t *testing.T) {
+		TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "bar/"})
+
+		req := logical.TestRequest(t, logical.ReadOperation, "namespaces/bar/seal-status")
+		res, err := b.HandleRequest(rootCtx, req)
+		require.NoError(t, err)
+		require.Equal(t, "shamir", res.Data["type"])
+		require.Equal(t, false, res.Data["sealed"])
+		require.Equal(t, 3, res.Data["t"])
+		require.Equal(t, 3, res.Data["n"])
+		require.Equal(t, 0, res.Data["progress"])
+	})
+}
+
 func TestNamespaceBackend_SealUnseal(t *testing.T) {
 	t.Parallel()
 	c, rootShares, root := TestCoreUnsealed(t)

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1654,16 +1654,35 @@ func (b *SystemBackend) auditPaths() []*framework.Path {
 func (b *SystemBackend) sealPaths() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: "key-status$",
+			Pattern: "key-status",
 
 			DisplayAttrs: &framework.DisplayAttributes{
-				OperationPrefix: "encryption-key",
 				OperationVerb:   "status",
+				OperationSuffix: "encryption-key",
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
+					Summary:  "Provides information about the backend encryption key.",
 					Callback: b.handleKeyStatus,
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Fields: map[string]*framework.FieldSchema{
+								"term": {
+									Type:     framework.TypeInt,
+									Required: true,
+								},
+								"install_time": {
+									Type:     framework.TypeTime,
+									Required: true,
+								},
+								"encryptions": {
+									Type:     framework.TypeInt64,
+									Required: true,
+								},
+							},
+						}},
+					},
 				},
 			},
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3383,22 +3383,44 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 	}
 }
 
-func TestSystemBackend_keyStatus(t *testing.T) {
-	b := testSystemBackend(t)
-	req := logical.TestRequest(t, logical.ReadOperation, "key-status")
-	resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+func TestSystemBackend_KeyStatus(t *testing.T) {
+	t.Parallel()
+	c, _, _ := TestCoreUnsealed(t)
+	b := c.systemBackend
+	rootCtx := namespace.RootContext(t.Context())
 
-	exp := map[string]interface{}{
-		"term": 1,
-	}
-	delete(resp.Data, "install_time")
-	delete(resp.Data, "encryptions")
-	if !reflect.DeepEqual(resp.Data, exp) {
-		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)
-	}
+	t.Run("returns key info for root namespace", func(t *testing.T) {
+		req := logical.TestRequest(t, logical.ReadOperation, "key-status")
+		resp, err := b.HandleRequest(rootCtx, req)
+
+		require.NoError(t, err)
+		require.Equal(t, resp.Data["term"], 1)
+		require.NotEmpty(t, resp.Data["encryptions"])
+		require.NotEmpty(t, resp.Data["install_time"])
+	})
+
+	t.Run("returns error for non-sealable namespace", func(t *testing.T) {
+		ns := testCreateNamespace(t, rootCtx, b, "foo", nil)
+		nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
+		req := logical.TestRequest(t, logical.ReadOperation, "key-status")
+		resp, err := b.HandleRequest(nsCtx, req)
+
+		require.Error(t, err)
+		require.ErrorContains(t, resp.Error(), ErrNotSealable.Error())
+	})
+
+	t.Run("returns key info for sealable namespace", func(t *testing.T) {
+		ns := &namespace.Namespace{Path: "bar/"}
+		_ = TestCoreCreateUnsealedNamespaces(t, c, ns)
+		req := logical.TestRequest(t, logical.ReadOperation, "key-status")
+		nsCtx := namespace.ContextWithNamespace(rootCtx, ns)
+		resp, err := b.HandleRequest(nsCtx, req)
+
+		require.NoError(t, err)
+		require.Equal(t, resp.Data["term"], 1)
+		require.NotEmpty(t, resp.Data["encryptions"])
+		require.NotEmpty(t, resp.Data["install_time"])
+	})
 }
 
 func TestSystemBackend_deprecatedRotateConfig(t *testing.T) {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -94,7 +94,6 @@ func init() {
 		"internal/counters/activity/monthly",
 		"internal/counters/config",
 		"internal/inspect/router",
-		"key-status",
 		"loggers",
 		"metrics",
 		"mfa/method",

--- a/website/content/api-docs/system/key-status.mdx
+++ b/website/content/api-docs/system/key-status.mdx
@@ -1,18 +1,18 @@
 ---
 description: |-
-  The `/sys/key-status` endpoint is used to query info about the current
-  encryption key of OpenBao.
+  The `/sys/key-status` endpoint is used to query info about the
+  encryption key of specific namespace barrier.
 ---
 
 # `/sys/key-status`
 
-The `/sys/key-status` endpoint is used to query info about the current
-encryption key of OpenBao.
+The `/sys/key-status` endpoint is used to query info about the
+active encryption key of specific namespace barrier.
 
 ## Get encryption key status
 
-This endpoint returns information about the current encryption key used by
-OpenBao.
+This endpoint returns information about the active encryption
+key of specific namespace barrier.
 
 | Method | Path              |
 | :----- | :---------------- |
@@ -23,6 +23,7 @@ OpenBao.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
+    --header "X-Vault-Namespace: ..." \
     --request GET \
     http://127.0.0.1:8200/v1/sys/key-status
 
@@ -44,6 +45,6 @@ number of encryptions made by the key including those on other cluster
 nodes. 
 
 Note that the estimated encryption count is aggregated from secondary
-OpenBao nodes to the primary but not in the other direction.  Thus the
+OpenBao nodes to the primary but not in the other direction. Thus the
 count only accurately reflects the cluster-wide estimate when queried
 on the primary.

--- a/website/content/docs/commands/operator/index.mdx
+++ b/website/content/docs/commands/operator/index.mdx
@@ -54,7 +54,7 @@ Usage: bao operator <subcommand> [options] [args]
 Subcommands:
     generate-root    Generates a new root token
     init             Initializes a server
-    key-status       Provides information about the active encryption key
+    key-status       Provides information about specific namespace barrier active encryption key
     rekey            Generates new unseal keys (deprecated)
     rotate-keys      Generates new unseal keys
     rotate           Rotates the underlying encryption key

--- a/website/content/docs/commands/operator/key-status.mdx
+++ b/website/content/docs/commands/operator/key-status.mdx
@@ -1,14 +1,15 @@
 ---
 sidebar_label: key-status
 description: |-
-  The "operator key-status" provides information about the active encryption
-  key.
+  The "operator key-status" provides information about specific
+  namespace barrier active encryption key.
 ---
 
 # operator key-status
 
-The `operator key-status` provides information about the active encryption key.
-Specifically, the current key term and the key installation time.
+The `operator key-status` provides information about specific 
+namespace barrier active encryption key. Specifically
+the current key term, installation time and encryption count.
 
 ## Examples
 
@@ -19,6 +20,15 @@ $ bao operator key-status
 Key Term          2
 Install Time      01 Jan 17 12:30 UTC
 Encryption Count  4494
+```
+
+you can also specify namespace:
+
+```shell-session
+$ bao operator -ns=teamA key-status
+Key Term          1
+Install Time      01 Jan 17 12:30 UTC
+Encryption Count  3333
 ```
 
 ## Usage

--- a/website/content/partials/api/restricted-endpoints.mdx
+++ b/website/content/partials/api/restricted-endpoints.mdx
@@ -27,7 +27,6 @@ API path | Root | Child
 `sys/internal/counters/activity/monthly` | YES | NO
 `sys/internal/counters/config` | YES | NO
 `sys/internal/inspect/router` | YES | NO
-`sys/key-status` | YES | NO
 `sys/loggers` | YES | NO
 `sys/metrics` | YES | NO
 `sys/mfa/method` | YES | NO


### PR DESCRIPTION
## Description
- added `"namespaces/(?P<path>.+)/seal-status"` endpoint handler (seal status read)
- adjusted `/key-status` endpoint code, references and documentation, highlighting the namespace specification attribute
- removed `/key-status` endpoint from the restricted sys apis list 

## Rationale
Seal status added on `/namespaces` prefix path due to required "offline" nature of the endpoint (we have to allow read of the status when namespace is sealed). Key-status read is only available when barrier is unsealed, hence existing flow is adjusted to allow for namespace specification.

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
