### PR TITLE
Handle invalidation of LoginMFA keys

### DIFF
--- a/changelog/3083.txt
+++ b/changelog/3083.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/mfa: Handle invalidation for login MFA, ensuring standby nodes respond appropriately on writes.
+```

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -257,6 +257,11 @@ func isMissedMountKey(key string) bool {
 		strings.HasPrefix(key, auditBarrierPrefix)
 }
 
+func isLoginMFA(key string) bool {
+	return strings.HasPrefix(key, barrier.SystemBarrierPrefix+loginMFAConfigPrefix) ||
+		strings.HasPrefix(key, barrier.SystemBarrierPrefix+mfaLoginEnforcementPrefix)
+}
+
 func (ij *invalidationJob) Execute() error {
 	ij.im.dispacherLogger.Trace("processing invalidation", "key", ij.key)
 	defer ij.im.dispacherLogger.Trace("concluding processing of invalidation", "key", ij.key)
@@ -393,6 +398,9 @@ func (ij *invalidationJob) Execute() error {
 	case strings.HasPrefix(ij.key, "autopilot/") || ij.key == raftAutopilotConfigurationStoragePath:
 		// Raft context is reloaded when a standby becomes active, so it is
 		// safe to ignore changes to autopilot state.
+	case isLoginMFA(ij.key):
+		ij.fatal = true
+		return ij.loginMFAInvalidation(ctx, ns)
 	case ij.im.core.router.Invalidate(shortCtx, ij.key):
 		// if router.Invalidate returns true, a matching plugin was found and
 		// the invalidation is therefore dispatched.
@@ -491,6 +499,14 @@ func (ij *invalidationJob) legacyMountInvalidation(ctx context.Context) error {
 func (ij *invalidationJob) transactionalMountInvalidation(ctx context.Context) error {
 	if err := ij.im.core.reloadMount(ctx, ij.nsKey); err != nil {
 		return fmt.Errorf("unable to invalidate mount for key %q in namespace %q: %w", ij.nsKey, ij.nsUUID, err)
+	}
+
+	return nil
+}
+
+func (ij *invalidationJob) loginMFAInvalidation(ctx context.Context, ns *namespace.Namespace) error {
+	if err := ij.im.core.loginMFABackend.invalidate(ctx, ns, ij.nsKey); err != nil {
+		return fmt.Errorf("unable to invalidate login MFA config for key %q in namespace %q: %w", ij.nsKey, ij.nsUUID, err)
 	}
 
 	return nil

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+	"github.com/openbao/openbao/vault/barrier"
 	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/quotas"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func testCore_Invalidate_TestCore(t *testing.T, config *CoreConfig) (*Core, string) {
@@ -370,6 +372,56 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
 	require.Equal(t, 1, resp.Data["interval"])
+}
+
+func TestCore_Invalidate_LoginMFA(t *testing.T) {
+	t.Parallel()
+	c, root := testCore_Invalidate_TestCore(t, nil)
+	rootCtx := namespace.RootContext(t.Context())
+
+	// 1. Create a login MFA to populate the cache.
+	req := logical.TestRequest(t, logical.CreateOperation, "identity/mfa/method/totp")
+	req.ClientToken = root
+	req.Data = map[string]any{
+		"method_name": "testing",
+		"issuer":      "OpenBao",
+	}
+	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "method_id")
+	path := resp.Data["method_id"].(string)
+
+	// 2. Manipulate Storage
+	barrierView := NamespaceScopedView(c.barrier, namespace.RootNamespace).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	mfa, err := c.loginMFABackend.getMFAConfig(rootCtx, path, barrierView)
+	require.NoError(t, err)
+	require.NotNil(t, mfa)
+	require.Equal(t, mfa.Name, "testing")
+
+	clone, err := mfa.Clone()
+	require.NoError(t, err)
+
+	clone.Name = "my-custom-name"
+
+	fullPath := barrier.SystemBarrierPrefix + loginMFAConfigPrefix + path
+	newEntry, err := proto.Marshal(clone)
+	require.NoError(t, err)
+
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, &logical.StorageEntry{
+		Key:   fullPath,
+		Value: newEntry,
+	})
+
+	// 3. Invalidate path
+	c.invalidateSynchronous(fullPath)
+
+	// 4. Check cache was properly invalidated
+	req = logical.TestRequest(t, logical.ReadOperation, "identity/mfa/method/totp/"+path)
+	req.ClientToken = root
+
+	resp = testCore_Invalidate_handleRequest(t, rootCtx, c, req)
+	require.Contains(t, resp.Data, "name")
+	require.Equal(t, "my-custom-name", resp.Data["name"])
 }
 
 func TestCore_Invalidate_Plugin(t *testing.T) {

--- a/vault/identity/store.go
+++ b/vault/identity/store.go
@@ -1127,6 +1127,8 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 		}
 		txn.Commit()
 		return
+	default:
+		i.logger.Trace("unknown path to invalidate in identity engine", "key", key)
 	}
 }
 

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -174,6 +174,32 @@ func (b *LoginMFABackend) ResetLoginMFAMemDB() error {
 	return nil
 }
 
+func (b *LoginMFABackend) invalidate(ctx context.Context, ns *namespace.Namespace, path string) error {
+	switch {
+	case strings.HasPrefix(path, barrier.SystemBarrierPrefix+loginMFAConfigPrefix):
+		key, _ := strings.CutPrefix(path, barrier.SystemBarrierPrefix+loginMFAConfigPrefix)
+		barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+
+		return b.loadMFAMethodConfig(ctx, ns, barrierView, key)
+	case strings.HasPrefix(path, barrier.SystemBarrierPrefix+mfaLoginEnforcementPrefix):
+		key, _ := strings.CutPrefix(path, barrier.SystemBarrierPrefix+mfaLoginEnforcementPrefix)
+		barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+
+		mConfig, err := b.loadMFAEnforcementConfig(ctx, ns, barrierView, key)
+		if err != nil {
+			return err
+		}
+
+		if mConfig == nil {
+			return nil
+		}
+
+		return b.loginMFAMethodExistenceCheck(mConfig)
+	default:
+		return fmt.Errorf("unknown path to invalidate: %v", path)
+	}
+}
+
 // loadMFAMethodConfigs loads MFA method configs for login MFA
 func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespace.Namespace) error {
 	b.mfaLogger.Trace("loading login MFA configurations")
@@ -185,27 +211,35 @@ func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespac
 	b.mfaLogger.Trace("methods collected", "num_existing", len(existing))
 
 	for _, key := range existing {
-		b.mfaLogger.Trace("loading method", "method", key)
-
-		// Read the config from storage
-		mConfig, err := b.getMFAConfig(ctx, key, barrierView)
-		if err != nil {
-			return err
-		}
-
-		if mConfig == nil {
-			b.mfaLogger.Trace("failed to find the config related to a method", "namespace", ns.Path, "prefix", loginMFAConfigPrefix, "method", key)
-			continue
-		}
-
-		// Load the config in MemDB
-		err = b.MemDBUpsertMFAConfig(ctx, mConfig)
-		if err != nil {
-			return fmt.Errorf("failed to load configuration ID %s prefix %s in MemDB: %w", mConfig.ID, loginMFAConfigPrefix, err)
+		if err := b.loadMFAMethodConfig(ctx, ns, barrierView, key); err != nil {
+			return fmt.Errorf("failed to load MFA method config %v: %w", key, err)
 		}
 	}
 
 	b.mfaLogger.Trace("configurations restored", "namespace", ns.Path, "prefix", loginMFAConfigPrefix)
+
+	return nil
+}
+
+func (b *LoginMFABackend) loadMFAMethodConfig(ctx context.Context, ns *namespace.Namespace, barrierView barrier.View, key string) error {
+	b.mfaLogger.Trace("loading method", "method", key)
+
+	// Read the config from storage
+	mConfig, err := b.getMFAConfig(ctx, key, barrierView)
+	if err != nil {
+		return err
+	}
+
+	if mConfig == nil {
+		b.mfaLogger.Trace("failed to find the config related to a method", "namespace", ns.Path, "prefix", loginMFAConfigPrefix, "method", key)
+		return nil
+	}
+
+	// Load the config in MemDB
+	err = b.MemDBUpsertMFAConfig(ctx, mConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration ID %s prefix %s in MemDB: %w", mConfig.ID, loginMFAConfigPrefix, err)
+	}
 
 	return nil
 }
@@ -222,31 +256,42 @@ func (b *LoginMFABackend) loadMFAEnforcementConfigs(ctx context.Context, ns *nam
 
 	eConfigs := make([]*mfa.MFAEnforcementConfig, 0)
 	for _, key := range existing {
-		b.mfaLogger.Trace("loading enforcement", "config", key)
-
-		// Read the config from storage
-		mConfig, err := b.getMFALoginEnforcementConfig(ctx, key, barrierView)
+		mConfig, err := b.loadMFAEnforcementConfig(ctx, ns, barrierView, key)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error loading login MFA enforcement config %v: %w", key, err)
 		}
 
-		if mConfig == nil {
-			b.mfaLogger.Trace("failed to find an enforcement config", "namespace", ns.Path, "prefix", mfaLoginEnforcementPrefix, "config", key)
-			continue
+		if mConfig != nil {
+			eConfigs = append(eConfigs, mConfig)
 		}
-
-		// Load the config in MemDB
-		err = b.MemDBUpsertMFALoginEnforcementConfig(ctx, mConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load enforcement configuration ID %s with prefix %s in MemDB: %w", mConfig.ID, mfaLoginEnforcementPrefix, err)
-		}
-
-		eConfigs = append(eConfigs, mConfig)
 	}
 
 	b.mfaLogger.Trace("enforcement configurations restored", "namespace", ns.Path, "prefix", mfaLoginEnforcementPrefix)
 
 	return eConfigs, nil
+}
+
+func (b *LoginMFABackend) loadMFAEnforcementConfig(ctx context.Context, ns *namespace.Namespace, barrierView barrier.View, key string) (*mfa.MFAEnforcementConfig, error) {
+	b.mfaLogger.Trace("loading enforcement", "config", key)
+
+	// Read the config from storage
+	mConfig, err := b.getMFALoginEnforcementConfig(ctx, key, barrierView)
+	if err != nil {
+		return nil, err
+	}
+
+	if mConfig == nil {
+		b.mfaLogger.Trace("failed to find an enforcement config", "namespace", ns.Path, "prefix", mfaLoginEnforcementPrefix, "config", key)
+		return nil, nil
+	}
+
+	// Load the config in MemDB
+	err = b.MemDBUpsertMFALoginEnforcementConfig(ctx, mConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load enforcement configuration ID %s with prefix %s in MemDB: %w", mConfig.ID, mfaLoginEnforcementPrefix, err)
+	}
+
+	return mConfig, nil
 }
 
 func (b *LoginMFABackend) loginMFAMethodExistenceCheck(eConfig *mfa.MFAEnforcementConfig) error {


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Notably, LoginMFA did not currently contain code for invalidation in OpenBao. This meant standbys had stale entries on API responses. As token-based login is only processed by the active node, this wouldn't have had much effect otherwise.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2879

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
