### PR TITLE
Disallow non-auth plugins from creating tokens

### DIFF
--- a/changelog/3087.txt
+++ b/changelog/3087.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Disallow logical secret engines from creating authentication tokens.
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1393,7 +1393,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	// other request this is an internal error.
 	if resp != nil && resp.Auth != nil {
 		if !strings.HasPrefix(req.Path, "auth/token/") {
-			c.logger.Error("unexpected Auth response for non-token backend", "request_path", req.Path)
+			c.logger.Error("unexpected auth response for non-token backend", "request_path", req.Path)
 			retErr = multierror.Append(retErr, ErrInternalError)
 			return nil, auth, retErr
 		}
@@ -1671,8 +1671,17 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		retErr = multierror.Append(retErr, ErrInternalError)
 		return retResp, retAuth, retErr
 	}
+
 	// If the response generated an authentication, then generate the token
 	if resp != nil && resp.Auth != nil && req.Path != "sys/mfa/validate" {
+		// When the request path is part of a logical backend (and not a
+		// credential backend), reject the token creation.
+		if !strings.HasPrefix(req.Path, "auth/") {
+			c.logger.Error("unexpected auth response for logical secret backend", "request_path", req.Path)
+			retErr = multierror.Append(retErr, ErrInternalError)
+			return nil, nil, retErr
+		}
+
 		// Check for request role in context to role based quotas
 		var role string
 		reqRole := ctx.Value(logical.CtxKeyRequestRole{})

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	credUserpass "github.com/openbao/openbao/builtin/credential/userpass"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	backendTest "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/stretchr/testify/require"
 )
@@ -783,4 +785,46 @@ func TestRequestHandling_RelativePathAllowed(t *testing.T) {
 	// While other places still disallow the relative paths (e.g., storage
 	// view), we know that we made it farther.
 	require.ErrorContains(t, err, "read failed")
+}
+
+func TestRequestHandling_DisallowLogicalTokenCreation(t *testing.T) {
+	t.Parallel()
+
+	core, _, _ := TestCoreUnsealed(t)
+
+	if err := core.loadMounts(namespace.RootContext(t.Context()), false); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	core.logicalBackends["test"] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		b := &backendTest.Noop{
+			Login: []string{"login"},
+			Response: &logical.Response{
+				Auth: &logical.Auth{},
+			},
+		}
+		if err := b.Setup(ctx, conf); err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	meUUID, _ := uuid.GenerateUUID()
+	err := core.mount(namespace.RootContext(t.Context()), &routing.MountEntry{
+		Table: routing.MountTableType,
+		UUID:  meUUID,
+		Path:  "test",
+		Type:  "test",
+	})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Path:      "test/login",
+		Operation: logical.ReadOperation,
+	}
+	resp, err := core.HandleRequest(namespace.RootContext(t.Context()), req)
+	if resp != nil {
+		require.Nil(t, resp.Auth)
+	}
+	require.Error(t, err, ErrInternalError)
 }


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

While strictly outside of our security model as plugins are assumed to be trusted, it is unusual that logical secret engines can create tokens by returning a `logical.Auth{}` response, even though they wouldn't be mounted as an auth engine (under `auth/`). This held because of a common path handler for unauthenticated requests (`handleLoginRequest(...)`), which was assumed to be used for login requests initially, before secrets engines had a reason to expose non-sensitive data (such as PKI CAs) over these paths.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

There was already a similar guard for authenticated paths in `handleRequest(...)`, restricting this to the `auth/token` backend; to me, it was an oversight that a it wasn't also present in `handleLoginRequest(...)`

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
