### PR TITLE
Fix cache invalidation memory leak

### DIFF
--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -159,19 +159,21 @@ func (im *invalidationManager) processPendingQueue(quitCh chan struct{}, quitCon
 			case <-im.pendingNotify:
 			}
 
-			defer metrics.MeasureSince([]string{dispatcherName, "enqueue-pending"}, time.Now())
+			func() {
+				defer metrics.MeasureSince([]string{dispatcherName, "enqueue-pending"}, time.Now())
 
-			im.pendingLock.Lock()
-			pending := im.pending
-			im.pending = nil
-			im.pendingLock.Unlock()
+				im.pendingLock.Lock()
+				pending := im.pending
+				im.pending = nil
+				im.pendingLock.Unlock()
 
-			im.core.metricSink.SetGauge([]string{dispatcherName, "pending-dequeue-size"}, float32(len(pending)))
+				im.core.metricSink.SetGauge([]string{dispatcherName, "pending-dequeue-size"}, float32(len(pending)))
 
-			for _, key := range pending {
-				job, queue := im.buildInvalidateJobForKey(quitCh, quitContext, key)
-				im.dispatcher.AddJob(job, queue)
-			}
+				for _, key := range pending {
+					job, queue := im.buildInvalidateJobForKey(quitCh, quitContext, key)
+					im.dispatcher.AddJob(job, queue)
+				}
+			}()
 		}
 	}()
 }


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

When processing the pending invalidation queue, we emit a deferred metric, enqueue-pending, meant to record the time it takes to convert all pending invalidations to proper invalidation jobs. This metric was not wrapped in its own function closure, resulting in memory growth as long as the active/standby node relationship was stable. Restarting the node is sufficient to fix memory usage related to this function.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3086

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
