### PR TITLE
[codex] Validate raft promote and demote server IDs

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1277,6 +1277,10 @@ func (b *RaftBackend) PromotePeer(ctx context.Context, peerID string) error {
 		return ErrRaftAutopilotNotInitialized
 	}
 
+	if !autopilotStateHasServer(b.autopilot.GetState(), peerID) {
+		return fmt.Errorf("server %s not found in raft autopilot state", peerID)
+	}
+
 	if !b.delegate.IsNonVoter(raft.ServerID(peerID)) {
 		return errors.New("server is not a non-voter")
 	}
@@ -1335,6 +1339,10 @@ func (b *RaftBackend) DemotePeer(ctx context.Context, peerID string) error {
 		return ErrRaftAutopilotNotInitialized
 	}
 
+	if !autopilotStateHasServer(b.autopilot.GetState(), peerID) {
+		return fmt.Errorf("server %s not found in raft autopilot state", peerID)
+	}
+
 	b.logger.Trace("demoting voter to non-voter", "id", peerID)
 
 	if b.delegate.IsNonVoter(raft.ServerID(peerID)) {
@@ -1342,6 +1350,14 @@ func (b *RaftBackend) DemotePeer(ctx context.Context, peerID string) error {
 	}
 
 	return b.delegate.AddNonVoter(raft.ServerID(peerID))
+}
+
+func autopilotStateHasServer(state *autopilot.State, peerID string) bool {
+	if state == nil {
+		return false
+	}
+	_, ok := state.Servers[raft.ServerID(peerID)]
+	return ok
 }
 
 // GetConfigurationOffline is used to read the stale, last known raft

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -117,6 +118,49 @@ func TestRaft_Backend(t *testing.T) {
 	b := GetRaft(t, true, true)
 
 	physical.ExerciseBackend(t, b)
+}
+
+func TestAutopilotStateHasServer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		state  *autopilot.State
+		peerID string
+		want   bool
+	}{
+		"nil state": {
+			peerID: "node1",
+			want:   false,
+		},
+		"missing server": {
+			state: &autopilot.State{
+				Servers: map[raft.ServerID]*autopilot.ServerState{
+					raft.ServerID("node1"): {},
+				},
+			},
+			peerID: "node2",
+			want:   false,
+		},
+		"present server": {
+			state: &autopilot.State{
+				Servers: map[raft.ServerID]*autopilot.ServerState{
+					raft.ServerID("node1"): {},
+				},
+			},
+			peerID: "node1",
+			want:   true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := autopilotStateHasServer(tt.state, tt.peerID); got != tt.want {
+				t.Fatalf("autopilotStateHasServer() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestRaft_TransactionalBackend(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject raft promote/demote requests for server IDs that are absent from Autopilot state
- prevent arbitrary IDs such as `?` from being persisted as permanent non-voters
- add unit coverage for nil, missing, and present Autopilot state lookups

Fixes #3085

## Validation

- go test ./physical/raft -run TestAutopilotStateHasServer -count=1
- git diff --check