### PR TITLE
Document rate limit quota inheritance

### DIFF
--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -35,6 +35,19 @@ the mount to restrict more specific API paths.
   requests to that mount that are made with the specified role. The request will fail if
   the auth mount does not have a concept of roles, or `path` is not an auth mount.
 
+### Namespace inheritance
+
+Rate limit quotas use the most specific matching quota for a request. A quota
+created in a namespace with `inheritable` set to `true` can apply to child
+namespaces only when the child namespace does not have a more specific
+namespace, mount, full API path, or role-based quota. If multiple parent
+namespaces have inheritable quotas, OpenBao uses the closest matching parent
+namespace quota.
+
+The `inheritable` flag is valid only for namespace quotas. Mount, full API path,
+and role-based quotas are not inherited by child namespaces. Root namespace
+quotas are inheritable by default when `inheritable` is omitted.
+
 ### Sample payload
 
 ```json

--- a/website/content/docs/concepts/resource-quotas.mdx
+++ b/website/content/docs/concepts/resource-quotas.mdx
@@ -40,6 +40,12 @@ Additionally, quotas defined with a `role` to limit login requests made using
 that role on the specified auth mount will take precedence over all other quotas.
 In other words, the most specific quota rule will be applied.
 
+Namespace quotas can also be marked as `inheritable`. When enabled, a child
+namespace can fall back to the closest inheritable quota from one of its parent
+namespaces if it does not have a more specific namespace, mount, full API path,
+or role-based quota. Quotas defined on mounts, full API paths, or roles are not
+inherited. Root namespace quotas are inheritable by default.
+
 A rate limit can be created with an optional `block_interval`, such that when set
 to a non-zero value, any client that hits a rate limit threshold will be blocked
 from all subsequent requests for a duration of `block_interval` seconds.


### PR DESCRIPTION
## Summary
- clarify how the rate limit quota inheritable flag is resolved across namespaces
- explain that inherited quotas only apply when no more specific namespace, mount, path, or role quota matches
- note that root namespace quotas default to inheritable when the flag is omitted

Fixes #2543

## Testing
- pnpm lint website/content/api-docs/system/rate-limit-quotas.mdx website/content/docs/concepts/resource-quotas.mdx
- git diff --check