### PR TITLE
Disallow non-auth plugins from creating tokens (#3087)

### DIFF
--- a/changelog/3087.txt
+++ b/changelog/3087.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Disallow logical secret engines from creating authentication tokens.
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1387,7 +1387,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	// other request this is an internal error.
 	if resp != nil && resp.Auth != nil {
 		if !strings.HasPrefix(req.Path, "auth/token/") {
-			c.logger.Error("unexpected Auth response for non-token backend", "request_path", req.Path)
+			c.logger.Error("unexpected auth response for non-token backend", "request_path", req.Path)
 			retErr = multierror.Append(retErr, ErrInternalError)
 			return nil, auth, retErr
 		}
@@ -1665,8 +1665,17 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		retErr = multierror.Append(retErr, ErrInternalError)
 		return retResp, retAuth, retErr
 	}
+
 	// If the response generated an authentication, then generate the token
 	if resp != nil && resp.Auth != nil && req.Path != "sys/mfa/validate" {
+		// When the request path is part of a logical backend (and not a
+		// credential backend), reject the token creation.
+		if !strings.HasPrefix(req.Path, "auth/") {
+			c.logger.Error("unexpected auth response for logical secret backend", "request_path", req.Path)
+			retErr = multierror.Append(retErr, ErrInternalError)
+			return nil, nil, retErr
+		}
+
 		// Check for request role in context to role based quotas
 		var role string
 		reqRole := ctx.Value(logical.CtxKeyRequestRole{})

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -759,4 +760,46 @@ func TestRequestHandling_RelativePathAllowed(t *testing.T) {
 	// While other places still disallow the relative paths (e.g., storage
 	// view), we know that we made it farther.
 	require.ErrorContains(t, err, "read failed")
+}
+
+func TestRequestHandling_DisallowLogicalTokenCreation(t *testing.T) {
+	t.Parallel()
+
+	core, _, _ := TestCoreUnsealed(t)
+
+	if err := core.loadMounts(namespace.RootContext(t.Context()), false); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	core.logicalBackends["test"] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		b := &NoopBackend{
+			Login: []string{"login"},
+			Response: &logical.Response{
+				Auth: &logical.Auth{},
+			},
+		}
+		if err := b.Setup(ctx, conf); err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	meUUID, _ := uuid.GenerateUUID()
+	err := core.mount(namespace.RootContext(t.Context()), &MountEntry{
+		Table: mountTableType,
+		UUID:  meUUID,
+		Path:  "test",
+		Type:  "test",
+	})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Path:      "test/login",
+		Operation: logical.ReadOperation,
+	}
+	resp, err := core.HandleRequest(namespace.RootContext(t.Context()), req)
+	if resp != nil {
+		require.Nil(t, resp.Auth)
+	}
+	require.Error(t, err, ErrInternalError)
 }


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/3087 (with conflicts)

There was a conflict in `vault/request_handling_test.go` cause by refactoring code into sub-packages.