### PR TITLE
Fix audit logs dropping custom headers when using inline auth (#3076)

### DIFF
--- a/changelog/3076.txt
+++ b/changelog/3076.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/auth: fix audit logs dropping custom headers when using inline auth
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -458,7 +458,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 		delete(req.Headers, consts.InlineAuthPathHeaderName)
 		delete(req.Headers, consts.InlineAuthOperationHeaderName)
 		for header := range req.Headers {
-			if !strings.HasPrefix(header, consts.InlineAuthParameterHeaderPrefix) {
+			if strings.HasPrefix(header, consts.InlineAuthParameterHeaderPrefix) {
 				delete(req.Headers, header)
 			}
 		}


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/3076 (clean cherry-pick)
