### PR TITLE
docs: prefer BAO env var prefixes in website docs

### DIFF
--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -259,7 +259,7 @@ The user lockout feature is enabled by default. The default values for "lockout 
 "lockout duration" is 15 minutes, "lockout counter reset" is 15 minutes.
 
 The user lockout feature can be disabled as follows:
-- It can be disabled globally using environment variable `VAULT_DISABLE_USER_LOCKOUT`.
+- It can be disabled globally using environment variable `BAO_DISABLE_USER_LOCKOUT`.
 - It can be disabled for all supported auth methods (ldap, userpass and approle) or a specific supported auth method using the `disable_lockout`
   parameter within `user_lockout` stanza in configuration file.
   Please see [user lockout configuration](../configuration/user-lockout.mdx#user_lockout-stanza) for more details.

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -300,7 +300,7 @@ The user lockout feature is enabled by default. The default values for "lockout 
 "lockout duration" is 15 minutes, "lockout counter reset" is 15 minutes.
 
 The user lockout feature can be disabled as follows:
-- It can be disabled globally using environment variable `VAULT_DISABLE_USER_LOCKOUT`.
+- It can be disabled globally using environment variable `BAO_DISABLE_USER_LOCKOUT`.
 - It can be disabled for all supported auth methods (ldap, userpass and approle) or a specific supported auth method using the `disable_lockout`
   parameter within `user_lockout` stanza in configuration file.
   Please see [user lockout configuration](../configuration/user-lockout.mdx#user_lockout-stanza) for more details.

--- a/website/content/docs/auth/userpass.mdx
+++ b/website/content/docs/auth/userpass.mdx
@@ -102,7 +102,7 @@ The user lockout feature is enabled by default. The default values for "lockout 
 "lockout duration" is 15 minutes, "lockout counter reset" is 15 minutes.
 
 The user lockout feature can be disabled as follows:
-- It can be disabled globally using environment variable `VAULT_DISABLE_USER_LOCKOUT`.
+- It can be disabled globally using environment variable `BAO_DISABLE_USER_LOCKOUT`.
 - It can be disabled for all supported auth methods (ldap, userpass and approle) or a specific supported auth method using the `disable_lockout`
   parameter within `user_lockout` stanza in configuration file.
   Please see [user lockout configuration](../configuration/user-lockout.mdx#user_lockout-stanza) for more details.

--- a/website/content/docs/concepts/user-lockout.mdx
+++ b/website/content/docs/concepts/user-lockout.mdx
@@ -21,7 +21,7 @@ The user lockout feature is enabled by default. The default values for "lockout 
 "lockout duration" is 15 minutes, "lockout counter reset" is 15 minutes.
 
 The user lockout feature can be disabled as follows:
-- It can be disabled globally using environment variable `VAULT_DISABLE_USER_LOCKOUT`.
+- It can be disabled globally using environment variable `BAO_DISABLE_USER_LOCKOUT`.
 - It can be disabled for all supported auth methods (ldap, userpass and approle) or a specific supported auth method using the `disable_lockout`
   parameter within the `user_lockout` stanza in the configuration file.
   Please see [user lockout configuration](../configuration/user-lockout.mdx#user_lockout-stanza) for more details.
@@ -43,7 +43,7 @@ Configuration for "all" auth methods in config file >> Default values.
 
 The precedence for user lockout disable is as follows:
 
-Disable using environment variable VAULT_DISABLE_USER_LOCKOUT >>
+Disable using environment variable BAO_DISABLE_USER_LOCKOUT >>
 Configuration for an auth mount using tune >> Configuration for an auth method in config file >>
 Configuration for "all" auth methods in config file >> Default values.
 

--- a/website/content/docs/configuration/user-lockout.mdx
+++ b/website/content/docs/configuration/user-lockout.mdx
@@ -20,7 +20,7 @@ The user lockout feature is enabled by default. The default values for "lockout 
 "lockout duration" is 15 minutes, "lockout counter reset" is 15 minutes.
 
 The user lockout feature can be disabled as follows:
-- It can be disabled globally using environment variable `VAULT_DISABLE_USER_LOCKOUT`.
+- It can be disabled globally using environment variable `BAO_DISABLE_USER_LOCKOUT`.
 - It can be disabled for all supported auth methods (ldap, userpass and approle) or a specific supported auth method using the `disable_lockout`
   parameter within `user_lockout` stanza in configuration file.
   Please see [user lockout configuration](user-lockout.mdx#user_lockout-stanza) for more details.

--- a/website/content/partials/plugin-file-permissions-check.mdx
+++ b/website/content/partials/plugin-file-permissions-check.mdx
@@ -1,4 +1,4 @@
-Enabling the file permissions check via the environment variable `VAULT_ENABLE_FILE_PERMISSIONS_CHECK`
+Enabling the file permissions check via the environment variable `BAO_ENABLE_FILE_PERMISSIONS_CHECK`
 allows OpenBao to check if the config directory and files are owned by the user running OpenBao.
 It also checks if there are no write or execute permissions for group or others.
 OpenBao allows operators to specify the user and permissions of the plugin directory and binaries

--- a/website/content/partials/raft-large-snapshots.mdx
+++ b/website/content/partials/raft-large-snapshots.mdx
@@ -2,5 +2,5 @@
 
 Taking and restoring Raft snapshots can exceed OpenBao's default and recommended
 timeout settings. The
-[`VAULT_CLIENT_TIMEOUT`](/docs/commands#vault_client_timeout) environment variable can
+[`BAO_CLIENT_TIMEOUT`](/docs/commands#bao_client_timeout) environment variable can
 be used to allow for more time to take or restore a snapshot.


### PR DESCRIPTION
## Summary

- replace a small set of website docs references from `VAULT_` env vars to the preferred `BAO_` names
- update the client timeout anchor to the existing `BAO_CLIENT_TIMEOUT` command docs section
- keep this scoped to variables that are read through `ReadBaoVariable` and already have `BAO_` constants in code

Refs #2793.

## Validation

- `git diff --check`
- `rg -n "VAULT_CLIENT_TIMEOUT|VAULT_ENABLE_FILE_PERMISSIONS_CHECK|VAULT_DISABLE_USER_LOCKOUT|vault_client_timeout" <edited files>`