### PR TITLE
Enable gocritic deferInLoop lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - cyclop
+    - gocritic
     - misspell
   settings:
     cyclop:
@@ -9,6 +10,10 @@ linters:
       # 135 -> 124
       # Highest: (*ServerCommand).Run (123) in command/server.go
       max-complexity: 124
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        - deferInLoop
 formatters:
   enable:
     - gofumpt

--- a/builtin/credential/jwt/path_oidc_test.go
+++ b/builtin/credential/jwt/path_oidc_test.go
@@ -737,7 +737,7 @@ func TestOIDC_Callback(t *testing.T) {
 			}
 
 			b, storage, s := getBackendAndServer(t, useBoundCIDRs, callbackMode)
-			defer s.server.Close()
+			t.Cleanup(s.server.Close)
 
 			clientNonce := "456"
 

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -536,6 +536,7 @@ func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendCo
 		// Poll for a PutWAL call that does not return a "read-only storage" error.
 		// This ensures the startup phases of loading WAL entries from any possible
 		// failed rotations can complete without error when deleting from storage.
+		var readonlyWALID string
 	READONLY_LOOP:
 		for {
 			select {
@@ -547,7 +548,7 @@ func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendCo
 
 			walID, err := framework.PutWAL(ctx, conf.StorageView, staticWALKey, &setCredentialsWAL{RoleName: "vault-readonlytest"})
 			if walID != "" && err == nil {
-				defer framework.DeleteWAL(ctx, conf.StorageView, walID)
+				readonlyWALID = walID
 			}
 			switch {
 			case err == nil:
@@ -558,6 +559,13 @@ func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendCo
 				b.Logger().Error("deleting nil key resulted in error", "error", err)
 				return
 			}
+		}
+		if readonlyWALID != "" {
+			defer func() {
+				if err := framework.DeleteWAL(ctx, conf.StorageView, readonlyWALID); err != nil {
+					b.Logger().Error("failed to delete read-only startup WAL", "error", err)
+				}
+			}()
 		}
 
 		// Load roles and populate queue with static accounts

--- a/builtin/logical/pki/acme_helpers_test.go
+++ b/builtin/logical/pki/acme_helpers_test.go
@@ -70,8 +70,11 @@ func doACMEForCSRWithDNS(t *testing.T, dns *dnstest.TestServer, acmeClient *acme
 				challengeBody, err := acmeClient.DNS01ChallengeRecord(challenge.Token)
 				require.NoError(t, err, "failed generating challenge response")
 
-				dns.AddRecord("_acme-challenge."+auth.Identifier.Value, "TXT", challengeBody)
-				defer dns.RemoveRecord("_acme-challenge."+auth.Identifier.Value, "TXT", challengeBody)
+				recordName := "_acme-challenge." + auth.Identifier.Value
+				dns.AddRecord(recordName, "TXT", challengeBody)
+				t.Cleanup(func() {
+					dns.RemoveRecord(recordName, "TXT", challengeBody)
+				})
 
 				require.NoError(t, err, "failed setting DNS record")
 

--- a/builtin/logical/pki/path_config_acme_test.go
+++ b/builtin/logical/pki/path_config_acme_test.go
@@ -91,17 +91,17 @@ func TestAcmeConfig(t *testing.T) {
 	testCtx := t.Context()
 
 	for _, tc := range cases {
-		deadline := time.Now().Add(1 * time.Minute)
-		subTestCtx, cancel := context.WithDeadline(testCtx, deadline)
-		defer cancel()
-
-		_, err := client.Logical().WriteWithContext(subTestCtx, "pki/roles/exists", roleConfig)
-		require.NoError(t, err)
-		_, err = client.Logical().WriteWithContext(subTestCtx, "pki/roles/good", roleConfig)
-		require.NoError(t, err)
-
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.Logical().WriteWithContext(subTestCtx, "pki/config/acme", tc.AcmeConfig)
+			deadline := time.Now().Add(1 * time.Minute)
+			subTestCtx, cancel := context.WithDeadline(testCtx, deadline)
+			defer cancel()
+
+			_, err := client.Logical().WriteWithContext(subTestCtx, "pki/roles/exists", roleConfig)
+			require.NoError(t, err)
+			_, err = client.Logical().WriteWithContext(subTestCtx, "pki/roles/good", roleConfig)
+			require.NoError(t, err)
+
+			_, err = client.Logical().WriteWithContext(subTestCtx, "pki/config/acme", tc.AcmeConfig)
 
 			if tc.validConfig {
 				require.NoError(t, err)

--- a/command/debug.go
+++ b/command/debug.go
@@ -669,9 +669,8 @@ func (c *DebugCommand) collectHostInfo(ctx context.Context) {
 			return
 		}
 		if resp != nil {
-			defer resp.Body.Close() //nolint:errcheck
-
 			secret, err := api.ParseSecret(resp.Body)
+			_ = resp.Body.Close()
 			if err != nil {
 				c.captureError("host", err)
 				return
@@ -707,10 +706,9 @@ func (c *DebugCommand) collectMetrics(ctx context.Context) {
 			continue
 		}
 		if resp != nil {
-			defer resp.Body.Close() //nolint:errcheck
-
 			metricsEntry := make(map[string]interface{})
 			err := json.NewDecoder(resp.Body).Decode(&metricsEntry)
+			_ = resp.Body.Close()
 			if err != nil {
 				c.captureError("metrics", err)
 				continue
@@ -842,9 +840,8 @@ func (c *DebugCommand) collectReplicationStatus(ctx context.Context) {
 			return
 		}
 		if resp != nil {
-			defer resp.Body.Close() //nolint:errcheck
-
 			secret, err := api.ParseSecret(resp.Body)
+			_ = resp.Body.Close()
 			if err != nil {
 				c.captureError("replication-status", err)
 				return
@@ -916,8 +913,8 @@ func (c *DebugCommand) collectInFlightRequestStatus(ctx context.Context) {
 
 		var data map[string]interface{}
 		if resp != nil {
-			defer resp.Body.Close() //nolint:errcheck
 			err = jsonutil.DecodeJSONFromReader(resp.Body, &data)
+			_ = resp.Body.Close()
 			if err != nil {
 				c.captureError("requests", err)
 				return

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -398,26 +398,26 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 		goto SEALFAIL
 	}
 
-	for _, seal := range seals {
-		// There is always one nil seal. We need to skip it so we don't start an empty Finalize-Seal-Shamir
-		// section.
-		if seal == nil {
-			continue
-		}
-		seal := seal // capture range variable
-		// Ensure that the seal finalizer is called, even if using verify-only
-		defer func(seal *vault.Seal) {
-			sealType := diagnose.CapitalizeFirstLetter((*seal).BarrierType().String())
+	// Ensure that the seal finalizers are called, even if using verify-only.
+	defer func() {
+		for i := len(seals) - 1; i >= 0; i-- {
+			seal := seals[i]
+			// There is always one nil seal. We need to skip it so we don't start an empty Finalize-Seal-Shamir
+			// section.
+			if seal == nil {
+				continue
+			}
+			sealType := diagnose.CapitalizeFirstLetter(seal.BarrierType().String())
 			finalizeSealContext, finalizeSealSpan := diagnose.StartSpan(ctx, "Finalize "+sealType+" Seal")
-			err = (*seal).Finalize(finalizeSealContext)
+			err = seal.Finalize(finalizeSealContext)
 			if err != nil {
 				diagnose.Fail(finalizeSealContext, "Error finalizing seal.")
 				diagnose.Advise(finalizeSealContext, "This likely means that the barrier is still in use; therefore, finalizing the seal timed out.")
 				finalizeSealSpan.End()
 			}
 			finalizeSealSpan.End()
-		}(&seal)
-	}
+		}
+	}()
 
 	if barrierSeal == nil {
 		diagnose.Fail(sealcontext, "Could not create barrier seal. No error was generated, but it is likely that the seal stanza is misconfigured. For guidance, see Vault's configuration documentation on the seal stanza.")

--- a/command/server.go
+++ b/command/server.go
@@ -1108,21 +1108,21 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	for _, seal := range seals {
-		// There is always one nil seal. We need to skip it so we don't start an empty Finalize-Seal-Shamir
-		// section.
-		if seal == nil {
-			continue
-		}
-		seal := seal // capture range variable
-		// Ensure that the seal finalizer is called, even if using verify-only
-		defer func(seal *vault.Seal) {
-			err = (*seal).Finalize(context.Background())
+	// Ensure that the seal finalizers are called, even if using verify-only.
+	defer func() {
+		for i := len(seals) - 1; i >= 0; i-- {
+			seal := seals[i]
+			// There is always one nil seal. We need to skip it so we don't start an empty Finalize-Seal-Shamir
+			// section.
+			if seal == nil {
+				continue
+			}
+			err = seal.Finalize(context.Background())
 			if err != nil {
 				c.UI.Error(fmt.Sprintf("Error finalizing seals: %v", err))
 			}
-		}(&seal)
-	}
+		}
+	}()
 
 	if barrierSeal == nil {
 		c.UI.Error("Could not create barrier seal! Most likely proper Seal configuration information was not set, but no error was generated.")

--- a/helper/storagepacker/storagepacker.go
+++ b/helper/storagepacker/storagepacker.go
@@ -173,8 +173,12 @@ func (s *StoragePacker) DeleteMultipleItemsWithStorage(ctx context.Context, logg
 	locks := locksutil.LocksForKeys(s.storageLocks, lockKeys)
 	for _, lock := range locks {
 		lock.Lock()
-		defer lock.Unlock()
 	}
+	defer func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}()
 
 	logger.Debug("deleting multiple items from storagepacker; caching and deleting from buckets", "total_items", len(itemIDs))
 

--- a/physical/raft/snapshot/archive_test.go
+++ b/physical/raft/snapshot/archive_test.go
@@ -74,14 +74,12 @@ func TestArchive_GoodData(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		defer func() {
-			if err := f.Close(); err != nil {
-				t.Fatalf("failed to close: %v", err)
-			}
-		}()
 
 		var metadata raft.SnapshotMeta
 		err = read(f, &metadata, io.Discard, nil)
+		if closeErr := f.Close(); closeErr != nil {
+			t.Fatalf("failed to close: %v", closeErr)
+		}
 		if err != nil {
 			t.Fatalf("case %d: should've read the snapshot, but didn't: %v", i, err)
 		}
@@ -107,14 +105,12 @@ func TestArchive_BadData(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		defer func() {
-			if err := f.Close(); err != nil {
-				t.Fatalf("failed to close: %v", err)
-			}
-		}()
 
 		var metadata raft.SnapshotMeta
 		err = read(f, &metadata, io.Discard, nil)
+		if closeErr := f.Close(); closeErr != nil {
+			t.Fatalf("failed to close: %v", closeErr)
+		}
 		if err == nil || !strings.Contains(err.Error(), c.Error) {
 			t.Fatalf("case %d (%s): %v", i, c.Name, err)
 		}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -452,6 +452,12 @@ func (c *Core) reconcileAudits(req reconcileAuditsRequests) error {
 	additions, deletions := oldTable.Delta(c.audit)
 
 	var multiErr *multierror.Error
+	var restoreReadOnlyErrs []func()
+	defer func() {
+		for i := len(restoreReadOnlyErrs) - 1; i >= 0; i-- {
+			restoreReadOnlyErrs[i]()
+		}
+	}()
 
 	for _, entry := range deletions {
 		c.removeAuditReloadFunc(entry)
@@ -479,7 +485,9 @@ func (c *Core) reconcileAudits(req reconcileAuditsRequests) error {
 				view.SetReadOnlyErr(origViewReadOnlyErr)
 			})
 		} else {
-			defer view.SetReadOnlyErr(origViewReadOnlyErr)
+			restoreReadOnlyErrs = append(restoreReadOnlyErrs, func() {
+				view.SetReadOnlyErr(origViewReadOnlyErr)
+			})
 		}
 
 		// Initialize the backend

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -229,6 +229,13 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 		},
 	}
 
+	var stopGaugeCollectors []func()
+	defer func() {
+		for i := len(stopGaugeCollectors) - 1; i >= 0; i-- {
+			stopGaugeCollectors[i]()
+		}
+	}()
+
 	// Disable collection if configured.
 	if c.MetricSink().GaugeInterval == time.Duration(0) {
 		c.logger.Info("usage gauge collection is disabled")
@@ -252,12 +259,12 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 				c.logger.Error("failed to start collector", "metric", init.MetricName, "error", err)
 			} else {
 				go proc.Run()
-				defer proc.Stop()
+				stopGaugeCollectors = append(stopGaugeCollectors, proc.Stop)
 			}
 		}
 	}
 
-	// When this returns, all the defers set up above will fire.
+	// When this returns, all collectors started above will be stopped.
 	c.metricsLoop(stopCh)
 }
 

--- a/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -185,8 +185,8 @@ func TestPostgreSQL_ParallelInit(t *testing.T) {
 	var active, sealed int
 	for i, node := range nodes {
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-		defer cancel()
 		_, err := node.APIClient().Sys().ListPoliciesWithContext(ctx)
+		cancel()
 		switch {
 		case err == nil:
 			active++


### PR DESCRIPTION
## Summary
- enable gocritic with only the deferInLoop check
- replace current defers inside loops with immediate cleanup, t.Cleanup, or one outer cleanup defer
- keep cleanup ordering for seals, audit read-only state, locks, and metric collectors

Fixes #3110

## Testing
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --config .golangci.yml --enable-only gocritic --output.text.path stdout --issues-exit-code=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run -n --config .golangci.yml --output.text.path stdout --issues-exit-code=1
- go test ./builtin/credential/jwt -run '^TestOIDC_Callback$'
- go test ./builtin/logical/pki -run '^TestAcmeConfig$'
- go test ./physical/raft/snapshot
- go test ./helper/storagepacker
- go test ./builtin/logical/database -run '^$'
- go test ./command -run '^$'
- go test ./vault -run '^$'
- go test ./vault/external_tests/postgresql_binary -run '^$'