### PR TITLE
Add script to backport dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,27 +303,6 @@ sync-deps:
 ci-sync-deps: sync-deps
 	git diff --quiet || (echo -e "\n\nModified files:" && git status --short && echo -e "\n\nRun 'make sync-deps' locally and commit the changes.\n" && exit 1)
 
-.PHONY: bump-critical
-bump-critical:
-	go get github.com/golang-jwt/jwt/v4@latest
-	go get github.com/golang-jwt/jwt/v5@latest
-	go get github.com/ProtonMail/go-crypto@latest
-	go get github.com/go-jose/go-jose/v4@latest
-	go get github.com/caddyserver/certmagic@latest
-	go get github.com/mholt/acmez/v3@latest
-	go get github.com/google/cel-go@latest
-	go get github.com/jackc/pgx/v5@latest
-	go get github.com/hashicorp/cap@latest
-	go get github.com/hashicorp/raft@latest
-	go get github.com/tink-crypto/tink-go/v2@latest
-	go get github.com/pquerna/otp@latest
-	go get go.etcd.io/bbolt@latest
-	go get google.golang.org/grpc@latest
-	grep -o 'golang.org/x/[^ ]*' ./go.mod  | xargs -I{} go get '{}@latest'
-	grep -o 'github.com/hashicorp/go-secure-stdlib/[^ ]*' ./go.mod  | xargs -I{} go get '{}@latest'
-	grep -o 'github.com/openbao/go-kms-wrapping/[^ ]*' ./go.mod  | xargs -I{} go get '{}@latest'
-	make sync-deps
-
 .PHONY: tag-api
 tag-api:
 	@:$(if $(THIS_RELEASE),,$(error please set the THIS_RELEASE environment variable for API tagging))

--- a/scripts/backport-deps.sh
+++ b/scripts/backport-deps.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+release_dir="$1"
+modules=$(find . -name go.mod)
+
+curl -sSL https://vuln.go.dev/index/modules.json > /tmp/vuln-go-dev-modules.json
+
+function clean_version() { echo "$@" | sed 's/^v//g' | sed 's/-.*$//g' | sed 's/+.*$//g'; }
+
+# Helpers from https://gist.github.com/jonlabelle/6691d740f404b9736116c22195a8d706
+function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+while read -r go_mod; do
+	grep '^	' "$go_mod" | while read -r line; do
+		pkg="$(awk '{print $1}' <<< "$line")"
+		current_version="$(awk '{print $2}' <<< "$line")"
+		update_version="$(awk '{print $2}' <<< "$line")"
+		release_version="$(grep "^	${pkg} " "$release_dir/$go_mod" | awk '{print $2}')"
+
+	  if [ "$release_version" == "" ]; then
+		  continue
+	  fi
+
+	  if [ "$update_version" == "$release_version" ]; then
+		  continue
+	  fi
+
+	  update_version="$(clean_version "$update_version")"
+	  release_version="$(clean_version "$release_version")"
+
+	  if version_gt "$release_version" "$update_version"; then
+		  if ! [[  "$pkg" == "github.com/openbao/openbao"* ]]; then
+			  echo "Dependency $pkg is newer on release branch than main"
+		  fi
+		  continue
+	  fi
+
+	  entry="$(jq '.[] | select(.path == "'"$pkg"'")' < /tmp/vuln-go-dev-modules.json)"
+	  vuln_count="$(jq '.vulns | length' <<< "$entry")"
+
+	  if (( vuln_count == 0 )); then
+		  continue
+	  fi
+
+	  echo "Checking vulnerabilities for $pkg..."
+
+	  update=false
+
+	  if [ "$update_version" == "0.0.0" ]; then
+		  update=true
+	  fi
+
+	  for vuln_index in $(seq 0 "$(( vuln_count - 1 ))"); do
+		  vuln_info="$(jq '.vulns['"$vuln_index"']' <<< "$entry")"
+		  vuln_id="$(jq -r '.id' <<< "$vuln_info")"
+
+		  if ! [[ "$vuln_info" == *fixed* ]]; then
+			  echo "-> Skipping $vuln_id as it is not fixed"
+			  continue
+		  fi
+
+		  fixed_mod_version="$(jq -r '.fixed' <<< "$vuln_info")"
+		  fixed_version="$(clean_version "$fixed_mod_version")"
+
+		  if version_gt "$fixed_version" "$release_version" && version_ge "$update_version" "$fixed_version"; then
+			  update="true"
+			  break
+		  elif ! version_ge "$update_version" "$fixed_version"; then
+			  echo "-> !!! Update $pkg on main to $fixed_mod_version first !!!"
+		  fi
+	  done
+
+	  if [ "$update" == "true" ]; then
+		  echo "-> Updating on release branch to $current_version"
+		  (
+			  cd "$release_dir" || exit 1
+			  dir="$(dirname "$go_mod")"
+			  cd "$dir" || exit 1
+
+			  echo "[$PWD] " go get "$pkg@$current_version"
+			  go get "$pkg@$current_version"
+		  ) || exit 1
+	  fi
+	done
+done <<< "$modules"
+
+(
+	cd "$release_dir" || exit 1
+	make sync-deps
+) || exit 1

--- a/scripts/backport-deps.sh
+++ b/scripts/backport-deps.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+if [[ -z "$1" ]]; then
+	echo "Usage: $0 /path/to/release/branch/checkout" 1>&2
+	exit 1
+fi
+
+release_dir="$1"
+modules=$(find . -name go.mod)
+
+MODULE_JSON="$(curl -sSL https://vuln.go.dev/index/modules.json)"
+
+function clean_version() { echo "$@" | sed 's/^v//g' | sed 's/-.*$//g' | sed 's/+.*$//g'; }
+
+# Helpers from https://gist.github.com/jonlabelle/6691d740f404b9736116c22195a8d706
+function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+while read -r go_mod; do
+	modules_count="$(go mod edit -json "$go_mod" | jq -r '.Require | length')"
+	for module_index in $(seq 0 "$(( modules_count - 1 ))"); do
+		pkg="$(go mod edit -json "$go_mod" | jq -r '.Require['"$module_index"'].Path')"
+		current_version="$(go mod edit -json "$go_mod" | jq -r '.Require['"$module_index"'].Version')"
+		update_version="$current_version"
+		release_version="$(go mod edit -json "$release_dir/$go_mod" | jq -r '.Require[] | select(.Path == "'"$pkg"'") | .Version')"
+
+	  if [[ "$release_version" == "" ]]; then
+		  continue
+	  fi
+
+	  if [[ "$update_version" == "$release_version" ]]; then
+		  continue
+	  fi
+
+	  update_version="$(clean_version "$update_version")"
+	  release_version="$(clean_version "$release_version")"
+
+	  if version_gt "$release_version" "$update_version"; then
+		  if ! [[  "$pkg" == "github.com/openbao/openbao"* ]]; then
+			  echo "Dependency $pkg is newer on release branch than main"
+		  fi
+		  continue
+	  fi
+
+	  entry="$(jq -r '.[] | select(.path == "'"$pkg"'")' <<< "$MODULE_JSON")"
+	  vuln_count="$(jq -r '.vulns | length' <<< "$entry")"
+
+	  if (( vuln_count == 0 )); then
+		  continue
+	  fi
+
+	  echo "Checking vulnerabilities for $pkg..."
+
+	  update=false
+
+	  if [[ "$update_version" == "0.0.0" ]]; then
+		  update=true
+	  fi
+
+	  for vuln_index in $(seq 0 "$(( vuln_count - 1 ))"); do
+		  vuln_info="$(jq -r '.vulns['"$vuln_index"']' <<< "$entry")"
+		  vuln_id="$(jq -r '.id' <<< "$vuln_info")"
+
+		  if ! [[ "$vuln_info" == *fixed* ]]; then
+			  echo "-> Skipping $vuln_id as it is not fixed"
+			  continue
+		  fi
+
+		  fixed_mod_version="$(jq -r '.fixed' <<< "$vuln_info")"
+		  fixed_version="$(clean_version "$fixed_mod_version")"
+
+		  if version_gt "$fixed_version" "$release_version" && version_ge "$update_version" "$fixed_version"; then
+			  update="true"
+			  break
+		  elif ! version_ge "$update_version" "$fixed_version"; then
+			  echo "-> !!! Update $pkg on main to $fixed_mod_version first !!!"
+		  fi
+	  done
+
+	  if [[ "$update" == "true" ]]; then
+		  echo "-> Updating on release branch to $current_version"
+		  (
+			  cd "$release_dir" || exit 1
+			  dir="$(dirname "$go_mod")"
+			  cd "$dir" || exit 1
+
+			  echo "[$PWD] " go get "$pkg@$current_version"
+			  go get "$pkg@$current_version"
+		  ) || exit 1
+	  fi
+	done
+done <<< "$modules"
+
+(
+	cd "$release_dir" || exit 1
+	make sync-deps
+) || exit 1


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->


This hack allows us to check the govulndb for dependencies which are newer in main than in a release branch tree, updating the dependency to the version in main only if the package has seen vulnerabilities.

Needs curl, jq.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Last release, we had discussions that `bump-critical` should not be used as @dependabot is the preferred tool. However, dependabot doesn't currently execute on release branches (nor would we want to backport everything is part of the argument against `bump-critical`), thus this attempts to form a compromise.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
