### PR TITLE
fix/flaky test iteration 1

### DIFF
--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -89,16 +89,20 @@ type caddyConfig struct {
 	EABKey    string
 }
 
+func generateRandomId(t *testing.T) string {
+	// Roll a random run ID for mount and hostname uniqueness.
+	runID, err := uuid.GenerateUUID()
+	require.NoError(t, err, "failed to generate a unique ID for test run")
+	runID = strings.Split(runID, "-")[0]
+	return runID
+}
+
 // SubtestACMECaddy returns an ACME test for Caddy using the provided template.
 func SubtestACMECaddy(configTemplate string, enableEAB bool) func(*testing.T, *VaultPkiCluster) {
 	return func(t *testing.T, cluster *VaultPkiCluster) {
 		ctx := t.Context()
 
-		// Roll a random run ID for mount and hostname uniqueness.
-		runID, err := uuid.GenerateUUID()
-		require.NoError(t, err, "failed to generate a unique ID for test run")
-		runID = strings.Split(runID, "-")[0]
-
+		runID := generateRandomId(t)
 		// Create the PKI mount with ACME enabled
 		pki, err := cluster.CreateAcmeMount(runID)
 		require.NoError(t, err, "failed to set up ACME mount")
@@ -265,12 +269,13 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 		sleepTimer = "120"
 	}
 
+	containerName := fmt.Sprintf("vault_pki_certbot_test_%s", runID)
+
 	t.Logf("creating on network: %v", vaultNetwork)
 	runner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
-		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
-		ImageTag:  "latest",
-		// Append runID so parallel re-runs don't collide on the container name.
-		ContainerName: fmt.Sprintf("vault_pki_certbot_test_%s", runID),
+		ImageRepo:     "docker.mirror.hashicorp.services/certbot/certbot",
+		ImageTag:      "latest",
+		ContainerName: containerName,
 		NetworkName:   vaultNetwork,
 		Entrypoint:    []string{"sleep", sleepTimer},
 		LogConsumer:   logConsumer,
@@ -294,7 +299,7 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 
 	ipAddr := networks[vaultNetwork]
 	// FIX: Unique hostname to avoid DNS record conflicts across retries.
-	hostname := fmt.Sprintf("certbot-acme-client-%s.dadgarcorp.com", runID)
+	hostname := fmt.Sprintf("certbot_acme_client_%s.dadgarcorp.com", runID)
 
 	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")
@@ -477,7 +482,7 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
 		ImageTag:  "latest",
 		// Unique container name to avoid "already in use" errors on retry.
-		ContainerName: fmt.Sprintf("vault-pki-certbot-eab-test_%s", runID),
+		ContainerName: fmt.Sprintf("vault_pki_certbot_eab_test_%s", runID),
 		NetworkName:   vaultNetwork,
 		Entrypoint:    []string{"sleep", sleepTimer},
 		LogConsumer:   logConsumer,
@@ -501,7 +506,7 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 
 	ipAddr := networks[vaultNetwork]
 	// Unique hostname to avoid DNS record conflicts on retry.
-	hostname := fmt.Sprintf("certbot-eab-acme-client-%s.dadgarcorp.com", runID)
+	hostname := fmt.Sprintf("certbot_eab_acme_client_%s.dadgarcorp.com", runID)
 
 	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")
@@ -600,11 +605,14 @@ func SubtestACMEIPAndDNS(t *testing.T, cluster *VaultPkiCluster) {
 
 	logConsumer, logStdout, logStderr := getDockerLog(t)
 
+	runID := generateRandomId(t)
+	containerName := fmt.Sprintf("vault_pki_ipsans_test_%s", runID)
+
 	// Setup an nginx container that we can have respond the queries for ips
 	runner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
 		ImageRepo:     "docker.mirror.hashicorp.services/nginx",
 		ImageTag:      "latest",
-		ContainerName: "vault_pki_ipsans_test",
+		ContainerName: containerName,
 		NetworkName:   pki.GetContainerNetworkName(),
 		LogConsumer:   logConsumer,
 		LogStdout:     logStdout,

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -477,7 +477,7 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
 		ImageTag:  "latest",
 		// Unique container name to avoid "already in use" errors on retry.
-		ContainerName: fmt.Sprintf("vault_pki_certbot_eab_test_%s", runID),
+		ContainerName: fmt.Sprintf("vault-pki-certbot-eab-test_%s", runID),
 		NetworkName:   vaultNetwork,
 		Entrypoint:    []string{"sleep", sleepTimer},
 		LogConsumer:   logConsumer,

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -24,14 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/acme"
-
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/builtin/logical/pkiext"
 	"github.com/openbao/openbao/helper/testhelpers"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	hDocker "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/acme"
 )
 
 //go:embed testdata/caddy_http.json
@@ -69,7 +68,6 @@ func Test_ACME(t *testing.T) {
 			// Trap the function to be embedded later in the run so it
 			// doesn't get clobbered on the next for iteration
 			testFunc := tc[testName]
-
 			gt.Run(testName, func(st *testing.T) {
 				st.Parallel()
 				testFunc(st, cluster)
@@ -77,8 +75,9 @@ func Test_ACME(t *testing.T) {
 		}
 	})
 
-	// Do not run these tests in parallel.
-	t.Run("step down", func(gt *testing.T) { SubtestACMEStepDownNode(gt, cluster) })
+	t.Run("step down", func(gt *testing.T) {
+		SubtestACMEStepDownNode(gt, cluster)
+	})
 }
 
 // caddyConfig contains information used to render a Caddy configuration file from a template.
@@ -244,10 +243,17 @@ func SubtestACMECaddy(configTemplate string, enableEAB bool) func(*testing.T, *V
 }
 
 func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
-	pki, err := cluster.CreateAcmeMount("pki")
+	// Use a unique mount name instead of the generic "pki" to avoid collisions
+	// if the test is retried or run alongside other tests that also claim "pki".
+	runID, err := uuid.GenerateUUID()
+	require.NoError(t, err, "failed to generate run ID")
+	runID = strings.Split(runID, "-")[0]
+	mountName := "pki-certbot-" + runID
+
+	pki, err := cluster.CreateAcmeMount(mountName)
 	require.NoError(t, err, "failed setting up acme mount")
 
-	directory := "https://" + pki.GetActiveContainerIP() + ":8200/v1/pki/acme/directory"
+	directory := "https://" + pki.GetActiveContainerIP() + ":8200/v1/" + mountName + "/acme/directory"
 	vaultNetwork := pki.GetContainerNetworkName()
 
 	logConsumer, logStdout, logStderr := getDockerLog(t)
@@ -261,9 +267,10 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 
 	t.Logf("creating on network: %v", vaultNetwork)
 	runner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
-		ImageRepo:     "docker.mirror.hashicorp.services/certbot/certbot",
-		ImageTag:      "latest",
-		ContainerName: "vault_pki_certbot_test",
+		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
+		ImageTag:  "latest",
+		//Append runID so parallel re-runs don't collide on the container name.
+		ContainerName: fmt.Sprintf("vault_pki_certbot_test_%s", runID),
 		NetworkName:   vaultNetwork,
 		Entrypoint:    []string{"sleep", sleepTimer},
 		LogConsumer:   logConsumer,
@@ -286,7 +293,8 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 	require.Contains(t, networks, vaultNetwork, "expected to contain vault network")
 
 	ipAddr := networks[vaultNetwork]
-	hostname := "certbot-acme-client.dadgarcorp.com"
+	// FIX: Unique hostname to avoid DNS record conflicts across retries.
+	hostname := fmt.Sprintf("certbot-acme-client-%s.dadgarcorp.com", runID)
 
 	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")
@@ -435,7 +443,13 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 }
 
 func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
-	mountName := "pki-certbot-eab"
+	// Generate a unique run ID so the mount name, container name, and hostname are
+	// all unique, matching the same pattern used in the other certbot subtest.
+	runID, err := uuid.GenerateUUID()
+	require.NoError(t, err, "failed to generate run ID")
+	runID = strings.Split(runID, "-")[0]
+
+	mountName := "pki-certbot-eab-" + runID
 	pki, err := cluster.CreateAcmeMount(mountName)
 	require.NoError(t, err, "failed setting up acme mount")
 
@@ -452,13 +466,20 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 
 	logConsumer, logStdout, logStderr := getDockerLog(t)
 
+	// FIX: Respect the same local/regression timeout as the standard certbot test.
+	sleepTimer := "45"
+	if testhelpers.IsLocalOrRegressionTests() {
+		sleepTimer = "120"
+	}
+
 	t.Logf("creating on network: %v", vaultNetwork)
 	runner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
-		ImageRepo:     "docker.mirror.hashicorp.services/certbot/certbot",
-		ImageTag:      "latest",
-		ContainerName: "vault_pki_certbot_eab_test",
+		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
+		ImageTag:  "latest",
+		// Unique container name to avoid "already in use" errors on retry.
+		ContainerName: fmt.Sprintf("vault_pki_certbot_eab_test_%s", runID),
 		NetworkName:   vaultNetwork,
-		Entrypoint:    []string{"sleep", "45"},
+		Entrypoint:    []string{"sleep", sleepTimer},
 		LogConsumer:   logConsumer,
 		LogStdout:     logStdout,
 		LogStderr:     logStderr,
@@ -479,7 +500,8 @@ func SubtestACMECertbotEab(t *testing.T, cluster *VaultPkiCluster) {
 	require.Contains(t, networks, vaultNetwork, "expected to contain vault network")
 
 	ipAddr := networks[vaultNetwork]
-	hostname := "certbot-eab-acme-client.dadgarcorp.com"
+	// Unique hostname to avoid DNS record conflicts on retry.
+	hostname := fmt.Sprintf("certbot-eab-acme-client-%s.dadgarcorp.com", runID)
 
 	err = pki.AddHostname(hostname, ipAddr)
 	require.NoError(t, err, "failed to update vault host files")

--- a/builtin/logical/pkiext/pkiext_binary/acme_test.go
+++ b/builtin/logical/pkiext/pkiext_binary/acme_test.go
@@ -269,7 +269,7 @@ func SubtestACMECertbot(t *testing.T, cluster *VaultPkiCluster) {
 	runner, err := hDocker.NewServiceRunner(hDocker.RunOptions{
 		ImageRepo: "docker.mirror.hashicorp.services/certbot/certbot",
 		ImageTag:  "latest",
-		//Append runID so parallel re-runs don't collide on the container name.
+		// Append runID so parallel re-runs don't collide on the container name.
 		ContainerName: fmt.Sprintf("vault_pki_certbot_test_%s", runID),
 		NetworkName:   vaultNetwork,
 		Entrypoint:    []string{"sleep", sleepTimer},

--- a/command/version_history_test.go
+++ b/command/version_history_test.go
@@ -28,23 +28,32 @@ func TestVersionHistoryCommand_TableOutput(t *testing.T) {
 	client, closer := testVaultServer(t)
 	defer closer()
 
-	ui, cmd := testVersionHistoryCommand(t)
-	cmd.client = client
+	// Use explicit stdout/stderr buffers (same pattern as JsonOutput test)
+	// to avoid data races on cli.MockUi's shared buffers
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	runOpts := &RunOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+		Client: client,
+	}
 
-	code := cmd.Run([]string{})
+	args, _, _, _, _ := setupEnv([]string{"version-history"})
+
+	code := RunCustom(args, runOpts)
 
 	if expectedCode := 0; code != expectedCode {
-		t.Fatalf("expected %d to be %d: %s", code, expectedCode, ui.ErrorWriter.String())
+		t.Fatalf("expected exit code %d, got %d: %s", expectedCode, code, stderr.String())
 	}
 
-	if errorString := ui.ErrorWriter.String(); !strings.Contains(errorString, versionTrackingWarning) {
-		t.Errorf("expected %q to contain %q", errorString, versionTrackingWarning)
+	// versionTrackingWarning is always written to stderr regardless of format.
+	if stderrStr := stderr.String(); !strings.Contains(stderrStr, versionTrackingWarning) {
+		t.Errorf("expected stderr %q to contain warning %q", stderrStr, versionTrackingWarning)
 	}
 
-	output := ui.OutputWriter.String()
-
-	if !strings.Contains(output, version.Version) {
-		t.Errorf("expected %q to contain version %q", output, version.Version)
+	// Table output goes to stdout; current binary version must appear.
+	if stdoutStr := stdout.String(); !strings.Contains(stdoutStr, version.Version) {
+		t.Errorf("expected stdout %q to contain version %q", stdoutStr, version.Version)
 	}
 }
 

--- a/command/version_history_test.go
+++ b/command/version_history_test.go
@@ -9,20 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/version"
 )
-
-func testVersionHistoryCommand(tb testing.TB) (*cli.MockUi, *VersionHistoryCommand) {
-	tb.Helper()
-
-	ui := cli.NewMockUi()
-	return ui, &VersionHistoryCommand{
-		BaseCommand: &BaseCommand{
-			UI: ui,
-		},
-	}
-}
 
 func TestVersionHistoryCommand_TableOutput(t *testing.T) {
 	client, closer := testVaultServer(t)

--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -295,11 +295,13 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 	defer cluster.Cleanup()
 
 	plugin := cluster.Plugins[0]
-	client := cluster.Cores[0].Client
-	client.SetToken(cluster.RootToken)
 
-	// Register
-	if err := client.Sys().RegisterPlugin(&api.RegisterPluginInput{
+	// Use a dedicated root client for registration/deregistration only.
+	// Never share this client with subtests, else bad things happen like race conditions :(
+	rootClient := cluster.Cores[0].Client
+	rootClient.SetToken(cluster.RootToken)
+
+	if err := rootClient.Sys().RegisterPlugin(&api.RegisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
 		Command: plugin.Name,
@@ -316,13 +318,24 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 		// loop to mount 5 auth methods that will each share a single
 		// plugin process
 		for i := range 5 {
+			i := i
 			pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
-			client := cluster.Cores[i].Client
+
+			// Clone a fresh client per subtest so parallel goroutines
+			// never race on SetToken or the shared HTTP cookie/token
+			// state inside the base client.
+			subClient, err := cluster.Cores[i].Client.Clone()
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			t.Run(pluginPath, func(t *testing.T) {
 				t.Parallel()
-				client.SetToken(cluster.RootToken)
+
+				subClient.SetToken(cluster.RootToken)
+
 				// Enable
-				if err := client.Sys().EnableAuthWithOptions(pluginPath, &api.EnableAuthOptions{
+				if err := subClient.Sys().EnableAuthWithOptions(pluginPath, &api.EnableAuthOptions{
 					Type: plugin.Name,
 				}); err != nil {
 					t.Fatal(err)
@@ -332,7 +345,7 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 				// secondary has not yet invalidated the mount from the call
 				// above.
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					_, err := client.Logical().Write("auth/"+pluginPath+"/role/role1", map[string]interface{}{
+					_, err := subClient.Logical().Write("auth/"+pluginPath+"/role/role1", map[string]interface{}{
 						"bind_secret_id": "true",
 						"period":         "300",
 					})
@@ -344,12 +357,12 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 					err    error
 				)
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					secret, err = client.Logical().Write("auth/"+pluginPath+"/role/role1/secret-id", nil)
+					secret, err = subClient.Logical().Write("auth/"+pluginPath+"/role/role1/secret-id", nil)
 					require.NoError(collect, err)
 				}, 20*time.Second, 10*time.Millisecond)
 				secretID := secret.Data["secret_id"].(string)
 
-				secret, err = client.Logical().Read("auth/" + pluginPath + "/role/role1/role-id")
+				secret, err = subClient.Logical().Read("auth/" + pluginPath + "/role/role1/role-id")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -364,46 +377,51 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, err = client.Auth().Login(t.Context(), authMethod)
+				_, err = subClient.Auth().Login(t.Context(), authMethod)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				// Renew
-				_, err = client.Auth().Token().RenewSelf(30)
+				// Renew using the token that Login placed on subClient.
+				// No SetToken call needed here — Login already set it.
+				_, err = subClient.Auth().Token().RenewSelf(30)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				// Login - expect SUCCESS
-				resp, err := client.Auth().Login(t.Context(), authMethod)
+				// Login again - expect SUCCESS
+				resp, err := subClient.Auth().Login(t.Context(), authMethod)
 				if err != nil {
 					t.Fatal(err)
 				}
 
+				// Capture the token to revoke before resetting to root.
 				revokeToken := resp.Auth.ClientToken
-				// Revoke
-				if err = client.Auth().Token().RevokeSelf(revokeToken); err != nil {
-					t.Fatal(err)
+
+				// Revoke using the freshly-obtained token explicitly
+				// rather than relying on the client's current token state.
+				if err = subClient.Auth().Token().RevokeAccessor(resp.Auth.Accessor); err != nil {
+					// Fall back to RevokeSelf with the explicit token set.
+					subClient.SetToken(revokeToken)
+					if err2 := subClient.Auth().Token().RevokeSelf(revokeToken); err2 != nil {
+						t.Fatal(err2)
+					}
 				}
 
-				// Reset root token
-				client.SetToken(cluster.RootToken)
+				// Reset to root token for the Lookup check.
+				subClient.SetToken(cluster.RootToken)
 
-				// Lookup - expect FAILURE
+				// Lookup - expect FAILURE (token was revoked)
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					_, err = client.Auth().Token().Lookup(revokeToken)
+					_, err = subClient.Auth().Token().Lookup(revokeToken)
 					require.Error(collect, err)
 				}, 20*time.Second, 10*time.Millisecond)
-
-				// Reset root token
-				client.SetToken(cluster.RootToken)
 			})
 		}
 	})
 
-	// Deregister
-	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
+	// Deregister — all subtests have finished by the time we reach here.
+	if err := rootClient.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
 		Version: plugin.Version,

--- a/vault/external_tests/standby/read_only_standby_test.go
+++ b/vault/external_tests/standby/read_only_standby_test.go
@@ -80,6 +80,8 @@ func TestReadOnlyStandby(t *testing.T) {
 
 	t.Log("revoking token")
 	require.NoError(t, primaryClient.Auth().Token().RevokeTreeWithContext(t.Context(), token.Auth.ClientToken))
-	_, err = standbyClient.KVv2("kv").Get(t.Context(), "foo")
-	require.ErrorContains(t, err, "permission denied", "token was revoked on the primary, should be declined by secondaries")
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err = standbyClient.KVv2("kv").Get(t.Context(), "foo")
+		assert.ErrorContains(collect, err, "permission denied", "token was revoked on the primary, should be declined by secondaries")
+	}, 10*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

- **fix flaky test by eventuallying**
- **parallelize to match convention, add retry logic due to async, clean buffer between iters**
- **rely on local docker even if registry fails, version pinning to ensure images always exists**

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale
- ACME tests: hardcoded mount/container/hostname names caused collisions on retry; now uses random IDs to keep runs isolated
- Version history test: replaced shared MockUi with separate stdout/stderr buffers to avoid data races
- External plugin test: parallel subtests were sharing one client and racing on SetToken; now each gets its own cloned client
- Standby test: added retry loop after token revocation since replication to standbys isn't instant

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: 
Test_ACME (builtin/logical/pkiext/pkiext_binary)
TestExternalPlugin_AuthMethod (vault/external_tests/plugin)
TestVersionHistoryCommand_TableOutput (command)


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
