### PR TITLE
Add -dev-cross-namespace-identity flag

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -131,6 +131,7 @@ type ServerCommand struct {
 	flagDevThreeNode       bool
 	flagDevAutoSeal        bool
 	flagDevClusterJson     string
+	flagDevCrossNsIdentity bool
 	flagTestVerifyOnly     bool
 	flagTestServerConfig   bool
 	flagExitOnCoreShutdown bool
@@ -334,6 +335,13 @@ func (c *ServerCommand) Flags() *FlagSets {
 		Name:   "dev-cluster-json",
 		Target: &c.flagDevClusterJson,
 		Usage:  "File to write cluster definition to",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "dev-cross-namespace-identity",
+		Target:  &c.flagDevCrossNsIdentity,
+		Default: false,
+		Usage:   "Enable the UnsafeCrossNamespaceIdentity option",
 	})
 
 	// TODO: should the below flags be public?
@@ -2774,7 +2782,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		MetricSink:                     metricSink,
 		EnableResponseHeaderHostname:   config.EnableResponseHeaderHostname,
 		EnableResponseHeaderRaftNodeID: config.EnableResponseHeaderRaftNodeID,
-		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity,
+		UnsafeCrossNamespaceIdentity:   config.UnsafeCrossNamespaceIdentity || c.flagDevCrossNsIdentity,
 		AllowUnauthenticatedWorkflows:  config.AllowUnauthenticatedWorkflows,
 		UnsafeRelativePaths:            config.UnsafeRelativePaths,
 	}


### PR DESCRIPTION
I've created a corresponding issue (#3127), but, I already had this code lying around, and it's borderline trivial, so, thought I'd just raise a PR directly.

## Description

This enables the UnsafeCrossNamespaceIdentity option when starting a -dev server instance.

## Rationale

This makes testing out changes locally, significantly easier, and makes sharing scripts easier.

Resolves: #3127

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
