### PR TITLE
Add Nitrokey as an integrator

### DIFF
--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -45,6 +45,10 @@ import Member from './lib/Member.tsx';
   <Member title="DuoKey" logoName="duokey">
     [DuoKey](https://www.duokey.com/) provides a [Software Defined HSM and KMS integrating with OpenBao](https://duokey.com/en/products/vault). Using Multi-Party Computation, keys are never reconstructed and cryptographic operations never expose key material or plaintext, enabling HSM-grade protection and cloud-native scalability.
   </Member>
+
+  <Member title="Nitrokey" logoName="nitrokey">
+    [Nitrokey](https://www.nitrokey.com/) provides Open Source security hardware. Nitrokey's [NetHSM](https://www.nitrokey.com/products/nethsm) offers a secure and highly available key storage, which protects your OpenBao secrets with hardware backed sealing.
+  </Member>
 </Randomize>
 </div>
 </div>

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "lodash": "^4.18.1",
-    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#879411a1d50129b5678f4fa89cf5228c65f8eb32",
+    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#2b415484bbe6d01d4664ec18a83d91ce1394e95e",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       openbao-ecosystem-logos:
-        specifier: github:openbao/openbao-ecosystem-logos#879411a1d50129b5678f4fa89cf5228c65f8eb32
-        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/879411a1d50129b5678f4fa89cf5228c65f8eb32
+        specifier: github:openbao/openbao-ecosystem-logos#2b415484bbe6d01d4664ec18a83d91ce1394e95e
+        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.6)
@@ -4755,8 +4755,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/879411a1d50129b5678f4fa89cf5228c65f8eb32:
-    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/879411a1d50129b5678f4fa89cf5228c65f8eb32}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e:
+    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e}
     version: 0.0.0
 
   opener@1.5.2:
@@ -12571,7 +12571,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/879411a1d50129b5678f4fa89cf5228c65f8eb32: {}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e: {}
 
   opener@1.5.2: {}
 


### PR DESCRIPTION
## Description

Adds Nitrokey to the ecosystem integrators page.

## Rationale

Nitrokey NetHSM integration with OpenBao auto-unseal is documented here > #3004 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.