### PR TITLE
Add manual trigger to docs/ui/codecheck workflows

### DIFF
--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - release/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-lint

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "website/**"
+  workflow_dispatch:
 
 jobs:
   check-links:

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - release/**
+  workflow_dispatch:
 
 jobs:
   test-ui:


### PR DESCRIPTION
## Rationale

Go CI already has one, but it's missing on other workflows. This makes it easy to run CI against a private or not yet PR'd branch.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
