### PR TITLE
improve scripts/nightly_tag.sh

### DIFF
--- a/scripts/nightly_tag.sh
+++ b/scripts/nightly_tag.sh
@@ -1,42 +1,72 @@
 #!/bin/bash
 
-# This script assumes a strictly linear release version. We assume that,
-# while the latest tag may not be on the main branch, we can find it across
-# release branches and that incrementing its minor version will be greater
-# than any subsequent released patch versions.
+# This script will print the appropriate nightly tag version for the current
+# branch to standard out
+#
+# - When running on a release branch, only tags on that branch will be
+#   considered, defaulting patch to 0, if none is found, bumping patch by one
+#   otherwise.
+#
+# - When running on main (or any other branch) all tags will be, bumping the
+#   minor version by one.
+#
+# If the latest version was a pre-release (v2.0.0-beta) bumping will be skipped
 
-candidates=("$(git describe --tags --exclude "api/*" --exclude "sdk/*" --abbrev=0 upstream/main)")
-for branch in $(git branch --all | grep 'remotes/upstream/release/[0-9]*\.[0-9]*\.x$' | sed 's#.*remotes/##g'); do
-    candidates+=("$(git describe --tags --exclude "api/*" --exclude "sdk/*" --abbrev=0 "$branch")")
-done
+bump="minor"
 
-latest="${candidates[0]}"
-latest_timestamp="$(git show --no-patch --format=%ct "${candidates[0]}")"
+current_branch=$(git branch --show-current)
+if [ "$(dirname "$current_branch")" == "release" ] ; then
+    bump="patch"
+    major_minor="$(basename "$current_branch" .x)" # turn e.g. 'release/2.5.x' into '2.5'
 
-for candidate in "${candidates[@]}"; do
-    timestamp="$(git show --no-patch --format=%ct "$candidate")"
-    if [ $(( timestamp > latest_timestamp )) == 1 ]; then
-        latest="$candidate"
-		latest_timestamp="$timestamp"
+    latest=$(git describe --tags --match "v${major_minor}.*" --abbrev=0 --always "$current_branch")
+
+    if [ "${latest:0:1}" != "v" ] ; then # if the release branch is new, we will get a commit sha instead (starts with 0-9 or a-f)
+        bump="none"
+        latest="v${major_minor}.0"
     fi
-done
+else
+    readarray -t branches < <(git branch --all | grep 'remotes/upstream/release/[0-9]*\.[0-9]*\.x$' | sed 's#.*remotes/##g')
+    branches+=("$current_branch")
 
-echo "Latest tag: $latest @ $latest_timestamp" 1>&2
+    latest=$(
+        git describe --tags --match "v*" --abbrev=0 "${branches[@]}" \
+        | sort --version-sort --reverse \
+        | head -n 1
+     )
+fi
+
+echo "Latest tag: $latest" 1>&2
 
 base_version="$(sed 's/-.*//g' <<< "$latest")"
-major_version="$(sed 's/\..*//g' <<< "$latest")"
-minor_version="$(sed 's/^v[0-9]*\.\([0-9]*\)\..*/\1/g' <<< "$latest")"
-patch_version="$(sed 's/^v[0-9]*\.[0-9]*\.\([0-9]*\)$/\1/g' <<< "$latest")"
+major_version="$(sed 's/\..*//g' <<< "$base_version")"
+minor_version="$(sed 's/^v[0-9]*\.\([0-9]*\)\..*/\1/g' <<< "$base_version")"
+patch_version="$(sed 's/^v[0-9]*\.[0-9]*\.\([0-9]*\)$/\1/g' <<< "$base_version")"
+
+if [ "$base_version" != "$latest" ] ; then
+    # if the latest version was a beta, don't bump
+    bump="none"
+fi
 
 echo "base: $base_version" 1>&2
 echo "major: $major_version" 1>&2
 echo "minor: $minor_version" 1>&2
 echo "patch: $patch_version" 1>&2
+echo "bumping $bump" 1>&2
 
-nightly_timestamp="$(git show --no-patch --format=%ct)"
-nightly_minor=$(( minor_version + 1 ))
-nightly_version="${major_version}.${nightly_minor}.0-nightly${nightly_timestamp}"
+nightly_timestamp="$(TZ=UTC0 git show --no-patch --format=%cd --date=format-local:%Y%m%d%H%M)"
 
-echo "New minor version: $nightly_minor" 1>&2
+case $bump in
+    minor)
+        minor_version=$(( minor_version + 1 ))
+        patch_version=0
+        ;;
+    patch)
+        patch_version=$(( patch_version + 1 ))
+        ;;
+esac
+
+nightly_version="${major_version}.${minor_version}.${patch_version}-nightly${nightly_timestamp}"
+
 echo "Nightly version: $nightly_version" 1>&2
 echo "$nightly_version"


### PR DESCRIPTION
## Description

A few changes how `scripts/nightly_tag.sh` works:

- When we trigger for a release branch, only tags from that branch will be considered and the patch version instead of minor will be bumped (producing a `v2.5.4-nightly...` instead of `v2.6.0-nightly...` when running for `release/v2.5.x`
- Instead of sorting tags by timestamp use `sort --version-sort` for the main branch, this is simpler and will continue to work, if we start doing LTS releases.
- Use a somewhat human readable date format instead of unix timestamps (`v2.6.0-nightly1779192198` vs `v2.6.0-nightly202605191203`)
- If the latest version was a pre-release (i.e. contains a hyphen): don't bump. We e.g. created [v2.6.0-nightly1769702161](https://github.com/openbao/openbao-nightly/releases/tag/v2.6.0-nightly1769702161) before we released v2.5.0

## Rationale

Makes the nightly tags more meaningful

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
