### PR TITLE
Switch /bin/bash hashbangs for /usr/bin/env bash

### DIFF
--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-#  This script validates if the git diff contains only docs/ui changes
+#!/usr/bin/env bash
+# This script validates if the git diff contains only docs/ui changes
 
 event_type=$1 # GH event type (pull_request)
 ref_name=$2 # branch reference that triggered the workflow

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 

--- a/scripts/nightly_tag.sh
+++ b/scripts/nightly_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script will print the appropriate nightly tag version for the current
 # branch to standard out

--- a/scripts/sync-deps-gkw.sh
+++ b/scripts/sync-deps-gkw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 modules=$(find "$GO_KMS_WRAPPING" -name go.mod)
 

--- a/scripts/sync-deps.sh
+++ b/scripts/sync-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 modules=$(find . -mindepth 2 -name go.mod)
 


### PR DESCRIPTION
## Description

Replace

```sh
#!/bin/bash
```

with

```sh
#!/usr/bin/env bash
```

across all developer-facing scripts that are meant to be portable and not tied to e.g., one particular Linux distribution.

## Rationale

This results in the script being executed by the first `bash` executable in `$PATH` opposed to the executable at `/bin/bash`, yielding several advantages:

- Some systems do not have an executable at `/bin/bash` (though they may have it elsewhere) and thus will fail to execute the script. `/bin/bash` is not a POSIX-standardized path, while `/bin/sh` and `/usr/bin/env` are.
- Systems that do have `/bin/bash` usually place a stable Bash version at this path intended for use by the operating system or packages installed by the associated package manager. There is no reason to re-use this path for portable development scripts as it unnecessarily complicates working with different Bash versions present on a system. 
  For example, `/bin/bash` tends to be very old, particularly on macOS:

  ```console
  $ /bin/bash --version
  GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)
  Copyright (C) 2007 Free Software Foundation, Inc.
  
  $ bash --version
  GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin24.6.0)
  Copyright (C) 2025 Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
  
  This is free software; you are free to change and redistribute it.
  There is NO WARRANTY, to the extent permitted by law.
  
  $ which bash
  /opt/homebrew/bin/bash
  ```

  In this case, `/bin/bash` is two major versions behind the first `bash` in my `$PATH`, which is not Apple's Bash, but Homebrew's. This should be a very common case for developers on macOS.

I'm ultimately flagging this because `readarray` as introduced in https://github.com/openbao/openbao/pull/3148 was not available in `/bin/bash` on my system, but was available via first `bash` in `$PATH`.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

