### PR TITLE
Prevent errors from creating orphaned tokens (#3150)

### DIFF
--- a/builtin/credential/kerberos/path_login.go
+++ b/builtin/credential/kerberos/path_login.go
@@ -66,7 +66,6 @@ func parseKeytab(b64EncodedKt string) (*keytab.Keytab, error) {
 
 func (b *backend) pathLoginGet(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	return &logical.Response{
-		Auth: &logical.Auth{},
 		Headers: map[string][]string{
 			"www-authenticate": {"Negotiate"},
 		},

--- a/changelog/3150.txt
+++ b/changelog/3150.txt
@@ -1,0 +1,6 @@
+```release-note:security
+core: Prevent hidden default token issuance from auth plugin endpoints returning both a `logical.Auth{}` response object and an error. GHSA-7j6w-vvw2-5f9c / CVE-2026-46405.
+```
+```release-note:bug
+auth/kerberos: Do not return `logical.Auth{}` response during initial negotiation at the same time as an error.
+```

--- a/tools/semgrep/ci/non-nil-err-auth-response.yml
+++ b/tools/semgrep/ci/non-nil-err-auth-response.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: non-nil-err-auth-response
+    patterns:
+      - pattern-either:
+          - pattern: |
+              return &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }, err
+          - pattern: |
+              return &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }, logical.CodedError(...)
+          - pattern: |
+              return &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }, fmt.Errorf(...)
+          - pattern: |
+              return &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }, errors.New(...)
+          - pattern: |
+              $FOO = &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }
+              ...
+              return $FOO, err
+          - pattern: |
+              $FOO = &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }
+              ...
+              return $FOO, logical.CodedError(...)
+          - pattern: |
+              $FOO = &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }
+              ...
+              return $FOO, fmt.Errorf(...)
+          - pattern: |
+              $FOO = &logical.Response{
+                Auth: &logical.Auth{ ... },
+                ...
+              }
+              ...
+              return $FOO, errors.New(...)
+    message: a non-nil error should not include an auth response
+    languages:
+      - go
+    severity: ERROR

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1384,7 +1384,11 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	}
 
 	// Only the token store is allowed to return an auth block, for any
-	// other request this is an internal error.
+	// other request this is an internal error. When the request fails,
+	// do not generate a token even if the backend returned an auth block.
+	if resp != nil && resp.Auth != nil && routeErr != nil {
+		resp.Auth = nil
+	}
 	if resp != nil && resp.Auth != nil {
 		if !strings.HasPrefix(req.Path, "auth/token/") {
 			c.logger.Error("unexpected auth response for non-token backend", "request_path", req.Path)
@@ -1667,6 +1671,10 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	}
 
 	// If the response generated an authentication, then generate the token
+	// only if it did not also err as the err would shadow the token.
+	if resp != nil && resp.Auth != nil && routeErr != nil {
+		resp.Auth = nil
+	}
 	if resp != nil && resp.Auth != nil && req.Path != "sys/mfa/validate" {
 		// When the request path is part of a logical backend (and not a
 		// credential backend), reject the token creation.

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -833,7 +833,7 @@ func TestRequestHandling_DisallowAuthErrorTokenCreation(t *testing.T) {
 	}
 
 	core.credentialBackends["test"] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-		b := &backendTest.Noop{
+		b := &NoopBackend{
 			Login:       []string{"login"},
 			BackendType: logical.TypeCredential,
 			RequestHandler: func(ctx context.Context, req *logical.Request) (*logical.Response, error) {

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -816,6 +817,54 @@ func TestRequestHandling_DisallowLogicalTokenCreation(t *testing.T) {
 		Operation: logical.ReadOperation,
 	}
 	resp, err := core.HandleRequest(namespace.RootContext(t.Context()), req)
+	if resp != nil {
+		require.Nil(t, resp.Auth)
+	}
+	require.Error(t, err, ErrInternalError)
+}
+
+func TestRequestHandling_DisallowAuthErrorTokenCreation(t *testing.T) {
+	t.Parallel()
+
+	core, _, root := TestCoreUnsealed(t)
+
+	if err := core.loadMounts(namespace.RootContext(t.Context()), false); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	core.credentialBackends["test"] = func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		b := &backendTest.Noop{
+			Login:       []string{"login"},
+			BackendType: logical.TypeCredential,
+			RequestHandler: func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+				return &logical.Response{
+					Auth: &logical.Auth{},
+				}, errors.New("erring for test")
+			},
+		}
+		if err := b.Setup(ctx, conf); err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	req := &logical.Request{
+		Path:        "sys/auth/test",
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"type": "test",
+		},
+	}
+	resp, err := core.HandleRequest(namespace.RootContext(t.Context()), req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	req = &logical.Request{
+		Path:      "auth/test/login",
+		Operation: logical.ReadOperation,
+	}
+	resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
 	if resp != nil {
 		require.Nil(t, resp.Auth)
 	}


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

The Kerberos authentication method is the only auth method that potentially returns an (empty) Auth block at the same time as a non-nil err. This resulted in token generation, albeit without returning the OpenBao token to the user, limiting the impact of this significantly.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: CVE-2026-46405
Resolves: GHSA-7j6w-vvw2-5f9c

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
