### PR TITLE
Add NVIDIA to supporters

### DIFF
--- a/website/content/ecosystem/adopters.mdx
+++ b/website/content/ecosystem/adopters.mdx
@@ -21,6 +21,11 @@ import Member from './lib/Member.tsx';
         relies on OpenBao to secure its own internal infrastructure and in
         support of customer-related 24/7 managed services.
       </Member>
+      <Member title="NVIDIA">
+        [NVIDIA Cloud Functions (NVCF)](https://github.com/NVIDIA/nvcf/)
+        relies on OpenBao as part of its internal secrets-management
+        infrastructure.
+      </Member>
     </Randomize>
   </div>
 </div>

--- a/website/content/ecosystem/lib/Member.tsx
+++ b/website/content/ecosystem/lib/Member.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import styles from "./styles.module.css";
 
 const logos = require.context(
-    "openbao-ecosystem-logos", true, /\.svg$/
+    "openbao-ecosystem-logos", true, /\.(svg|png)$/
 );
 
 import { useColorMode } from '@docusaurus/theme-common';
@@ -15,11 +15,21 @@ function getLogo(title: string, logoName: string) {
 
     const darkLogo = `./${key}/dark.svg`
     const lightLogo = `./${key}/light.svg`
+    const darkLogoPng = `./${key}/dark.png`
+    const lightLogoPng = `./${key}/light.png`
+
+    console.log(logos);
 
     if (colorMode == "dark" && logos.keys().includes(darkLogo)) {
         return logos(`${darkLogo}`).default ?? logos(`./${darkLogo}`);
     } else if (colorMode != "dark" && logos.keys().includes(lightLogo)) {
         return logos(`${lightLogo}`).default ?? logos(`./${lightLogo}`);
+    } else if (colorMode == "dark" && logos.keys().includes(darkLogoPng)) {
+        return logos(`${darkLogoPng}`).default ?? logos(`${darkLogoPng}`);
+    } else if (colorMode != "dark" && logos.keys().includes(lightLogoPng)) {
+        return logos(`${lightLogoPng}`).default ?? logos(`${lightLogoPng}`);
+    } else if (logos.keys().includes(`./${key}.png`)) {
+        return logos(`./${key}.png`).default ?? logos(`./${key}.png`);
     } else {
         return logos(`./${key}.svg`).default ?? logos(`./${key}.svg`);
     }

--- a/website/content/ecosystem/lib/Member.tsx
+++ b/website/content/ecosystem/lib/Member.tsx
@@ -18,8 +18,6 @@ function getLogo(title: string, logoName: string) {
     const darkLogoPng = `./${key}/dark.png`
     const lightLogoPng = `./${key}/light.png`
 
-    console.log(logos);
-
     if (colorMode == "dark" && logos.keys().includes(darkLogo)) {
         return logos(`${darkLogo}`).default ?? logos(`./${darkLogo}`);
     } else if (colorMode != "dark" && logos.keys().includes(lightLogo)) {

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "lodash": "^4.18.1",
-    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#2b415484bbe6d01d4664ec18a83d91ce1394e95e",
+    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#5f0dacaa5e36fcf5d8cad04e669f249242734d11",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       openbao-ecosystem-logos:
-        specifier: github:openbao/openbao-ecosystem-logos#2b415484bbe6d01d4664ec18a83d91ce1394e95e
-        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e
+        specifier: github:openbao/openbao-ecosystem-logos#5f0dacaa5e36fcf5d8cad04e669f249242734d11
+        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.6)
@@ -4755,8 +4755,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e:
-    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11:
+    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11}
     version: 0.0.0
 
   opener@1.5.2:
@@ -12571,7 +12571,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/2b415484bbe6d01d4664ec18a83d91ce1394e95e: {}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11: {}
 
   opener@1.5.2: {}
 


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Per OpenBao issue, NVIDIA would like us to use the official logo from the NVIDIA Newsroom assets page. This required adding support to the ecosystem page to use PNGs. I've also included the suggested text and the logo bump.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: https://github.com/openbao/openbao/issues/3144

fyi: @staceypotter 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
