### PR TITLE
Add example on passing nested data to CLI via stdin

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -175,6 +175,20 @@ format.
 $ bao kv put secret/password value=itsasecret
 ```
 
+### Basic maps
+
+To write data alongside a basic map, you can use the command in format as follows (this example is for a `map[string]interface {}`)
+
+```shell-session
+$ bao write auth/oidc/roles/test param1="first" - \
+  param2="second" \
+    <<EOF
+    {
+      "map_param": {"name":["value1", "value2"]}
+    }
+    EOF
+```
+
 However, some OpenBao API require more advanced structures such as maps. You can
 use stdin or file input instead.
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

I wanted to contribute an example to the documentation for writing maps as I could not find any specific example anywhere online of how to do it. I rose the question in a discussion (https://github.com/orgs/openbao/discussions/3145) and was lucky enough to get a response from a user who knew the syntax.

-->

## Rationale

<!--

As this is a contribution (addition of an example) to documentation, I figured this would be classified as a 'trivial' change and would not require an issue link.

The problem with defining a map[string]interface {} for the parameter "bound_claims" is outlined in this post by myself:
https://github.com/orgs/openbao/discussions/3145

The user DrDaveD suggested a syntax to use and when tested with my own parameters, I confirmed that it worked perfectly (allowing me to authorise users based on their group membership in Keycloak).

As this information would have been extremely helpful in my configuration of OpenBao, I decided to contribute a commit to the documentation to add it as an example.

-->

Resolves: #

## Acknowledgements

 - [#] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [#] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
