### PR TITLE
Update release checklist

### DIFF
--- a/website/content/community/policies/release.mdx
+++ b/website/content/community/policies/release.mdx
@@ -15,15 +15,24 @@ a better release process going forward.
 
  - [ ] Designate a release manager and assign them this issue.
  - [ ] Clone this template into a GitHub release issue.
- - [ ] Identify target release version (major, minor, or patch) and milestones
-       (alpha, beta, ...).
+ - [ ] Identify target release version (major, minor, or patch & GA or beta) and
+       milestone. Add this issue to the identified milestone.
  - [ ] Identify and communicate the release timeline.
-      - [ ] Community meeting
-      - [ ] OpenBao Core Mailing list
-      - [ ] TSC Mailing List
       - [ ] Zulip
+      - [ ] Community meeting
       - [ ] GitHub milestones
+      - [ ] Helm chart team
  - [ ] Ensure relevant features and bug fixes are present in the release.
+ - [ ] Update Go version pinning in `/.go-release` and in the the `toolchain`
+       directive in `go.mod`; go-releaser uses this version via a custom
+       (in-repo) `set-up-go` action.
+ - [ ] Update external dependencies with vulnerabilities. Major changes should
+       be done earlier in the release cycle to give the community time to find
+       any breaking issues.
+ - [ ] Update container image base layer versions.
+ - [ ] Test the release workflow by creating a nightly release. Ensure that all
+       artifacts build successfully and that required services (GitHub, OCI
+       registries) are not currently unavailable due to outages.
  - [ ] Check generated changelog via `make release-changelog` and make any
        necessary updates to entries.
  - [ ] Draft release notification announcement.
@@ -31,36 +40,14 @@ a better release process going forward.
        version numbers follow core release version numbers but patch numbers
        simply increment; there are no beta releases of API except for new
        major versions of core.
-      - [ ] When bumping API major version, ensure `api/go.mod` is first
-            updated to the new version.
- - [ ] Update first-party external dependencies to use new API modules, if
-       necessary.
-      - [ ] [`go-kms-wrapping`](https://github.com/openbao/go-kms-wrapping)
-      - [ ] Tag new `go-kms-wrapping` module versions. Only components which
-            have changed need to be tagged. Note that version numbers do not
-            follow core releases.
-      - [ ] Update SDK and main module to use new `go-kms-wrapping` version.
- - [ ] Update SDK to use the new API version, if necessary.
+      - [ ] When bumping API major version (e.g., v2 -> v3), ensure the module
+            path in `api/go.mod` is first updated to the new version.
+      - [ ] Update SDK to use the new API version, if necessary.
  - [ ] Tag new SDK version, if necessary. Minor version numbers follow core
        release version numbers but patch numbers simply increment; there are
        no beta releases of SDK except for new major versions of core.
-      - [ ] When bumping SDK major version, ensure `sdk/go.mod` is first updated
-            to the new version.
- - [ ] Update first-party external dependencies to use new API & SDK
-       modules, if necessary.
-      - [ ] [`go-secure-stdlib`](https://github.com/openbao/go-secure-stdlib)
-      - [ ] [`openbao-template`](https://github.com/openbao/openbao-template)
- - [ ] Update API, SDK, and first-party external dependencies in main
-       `go.mod`. While API and SDK always use the built-in version, the
-       first-party external modules still use the external version and thus
-       must be updated.
- - [ ] Update external dependencies with vulnerabilities. Major changes should
-       be done earlier in the release cycle to give the community time to find
-       any breaking issues.
- - [ ] Update container image base layer versions.
- - [ ] Update Go version pinning in `/.go-release` and in the the `toolchain`
-       directive in `go.mod`; go-releaser uses this version via a custom
-       (in-repo) `set-up-go` action.
+      - [ ] When bumping SDK major version (e.g., v2 -> v3), ensure the module
+            path in `sdk/go.mod` is first updated to the new version.
 
 ## Release checklist
 
@@ -74,8 +61,7 @@ a better release process going forward.
       - [ ] Update docs versions in `doc-versions.json` if necessary
  - [ ] Tag release commit (`CHANGELOG.md` change).
  - [ ] Start [release workflow](https://github.com/openbao/openbao/actions/workflows/release.yml):
-       select target tag, and set applicable pre-release/latest set
-       (pre-releases should not be marked latest on GitHub).
+       select target tag (not branch) and untick "Mark as nightly build".
  - [ ] Manually upload [GPG signing key](https://openbao.org/assets/openbao-gpg-pub-20240618.asc)
        to the release artifacts.
  - [ ] Spot-check release artifacts:
@@ -90,6 +76,7 @@ a better release process going forward.
       - [ ] GitHub Discussions
       - [ ] Link from Zulip
       - [ ] Mention in next community meeting & TSC meetings.
+ - [ ] Publish any security advisory drafts fixed in this release.
  - [ ] Close the release milestone on GitHub.
  - [ ] For large releases, work with the OpenSSF for a release blog post.
  - [ ] For new major or minor versions, create a `release/<version>` branch


### PR DESCRIPTION
## Description

Adjust the release checklist to reflect the reality of recent releases more closely.

Notable changes:

- Mention security advisories
- Notify the Helm chart team pre-release as requested by @pree
- Remove steps related to go-kms-wrapping; the main go-kms-wrapping module does not depend on SDK or API, other go-kms-wrapping modules (only used by the main module in return, not by SDK) can be tagged asynchronously unless API or SDK undergo breaking changes. Omitting this unlikely edge case declutters the pre-release steps significantly.
- Fix dependency bump ordering, dependencies should be bumped before tagging API/SDK of course.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
