### PR TITLE
Handle login mfa configs lifecycle on namespace (un)seal

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -41,7 +41,6 @@ import (
 	"github.com/openbao/openbao/command/server"
 	fwd "github.com/openbao/openbao/helper/forwarding"
 	"github.com/openbao/openbao/helper/identity"
-	"github.com/openbao/openbao/helper/identity/mfa"
 	"github.com/openbao/openbao/helper/locking"
 	"github.com/openbao/openbao/helper/metricsutil"
 	"github.com/openbao/openbao/helper/namespace"
@@ -1103,9 +1102,9 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	// MFA method
-	c.loginMFABackend = NewLoginMFABackend(c, conf.Logger)
-	if c.loginMFABackend.mfaLogger != nil {
-		c.AddLogger(c.loginMFABackend.mfaLogger)
+	c.loginMFABackend, err = NewLoginMFABackend(c, conf.Logger)
+	if err != nil {
+		return nil, err
 	}
 
 	// Logical backends
@@ -3078,27 +3077,32 @@ func (c *Core) isPrimary() bool {
 }
 
 func (c *Core) loadLoginMFAConfigs(ctx context.Context) error {
-	eConfigs := make([]*mfa.MFAEnforcementConfig, 0)
-	allNamespaces, err := c.ListNamespaces(ctx)
+	namespaces, err := c.ListNamespaces(ctx)
 	if err != nil {
 		return err
 	}
 
-	for _, ns := range allNamespaces {
-		err := c.loginMFABackend.loadMFAMethodConfigs(ctx, ns)
-		if err != nil {
-			return fmt.Errorf("error loading MFA method Config, namespace %s, error: %w", ns.Path, err)
+	for _, ns := range namespaces {
+		if err := c.loadLoginMFAConfigsForNamespace(ctx, ns); err != nil {
+			return err
 		}
-
-		loadedConfigs, err := c.loginMFABackend.loadMFAEnforcementConfigs(ctx, ns)
-		if err != nil {
-			return fmt.Errorf("error loading MFA enforcement Config, namespace %s, error: %w", ns.Path, err)
-		}
-
-		eConfigs = append(eConfigs, loadedConfigs...)
 	}
 
-	for _, conf := range eConfigs {
+	return nil
+}
+
+func (c *Core) loadLoginMFAConfigsForNamespace(ctx context.Context, ns *namespace.Namespace) error {
+	err := c.loginMFABackend.loadMFAMethodConfigs(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("error loading MFA method Config, namespace %s, error: %w", ns.Path, err)
+	}
+
+	loadedConfigs, err := c.loginMFABackend.loadMFAEnforcementConfigs(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("error loading MFA enforcement Config, namespace %s, error: %w", ns.Path, err)
+	}
+
+	for _, conf := range loadedConfigs {
 		if err := c.loginMFABackend.loginMFAMethodExistenceCheck(conf); err != nil {
 			c.loginMFABackend.mfaLogger.Error("failed to find all MFA methods that exist in MFA enforcement configs", "configID", conf.ID, "namespaceID", conf.NamespaceID, "error", err.Error())
 		}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -686,7 +686,7 @@ func TestCore_LoadLoginMFAConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	eConfig := &mfa.MFAEnforcementConfig{Name: "eConfig", NamespaceID: ns1.ID, ID: "eConfigID"}
-	err = c.loginMFABackend.PutMFALoginEnforcementConfig(ctx, eConfig)
+	err = c.loginMFABackend.PutMFALoginEnforcementConfig(ctx, eConfig, ns1)
 	require.NoError(t, err)
 
 	// check for errors when loading

--- a/vault/identity/mfa.go
+++ b/vault/identity/mfa.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -49,22 +51,22 @@ func (i *IdentityStore) handleMFAMethodListPingID(ctx context.Context, req *logi
 	return i.handleMFAMethodList(ctx, req, d, MfaMethodTypePingID)
 }
 
-func (i *IdentityStore) handleMFAMethodListGlobal(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	keys, configInfo, err := i.mfaBackend.MfaMethodList(ctx, "")
+func (i *IdentityStore) handleMFAMethodListGlobal(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	configInfo, err := i.mfaBackend.MfaMethodList(ctx, "")
 	if err != nil {
 		return nil, err
 	}
 
-	return logical.ListResponseWithInfo(keys, configInfo), nil
+	return logical.ListResponseWithInfo(slices.Collect(maps.Keys(configInfo)), configInfo), nil
 }
 
-func (i *IdentityStore) handleMFAMethodList(ctx context.Context, req *logical.Request, d *framework.FieldData, methodType string) (*logical.Response, error) {
-	keys, configInfo, err := i.mfaBackend.MfaMethodList(ctx, methodType)
+func (i *IdentityStore) handleMFAMethodList(ctx context.Context, _ *logical.Request, _ *framework.FieldData, methodType string) (*logical.Response, error) {
+	configInfo, err := i.mfaBackend.MfaMethodList(ctx, methodType)
 	if err != nil {
 		return nil, err
 	}
 
-	return logical.ListResponseWithInfo(keys, configInfo), nil
+	return logical.ListResponseWithInfo(slices.Collect(maps.Keys(configInfo)), configInfo), nil
 }
 
 func (i *IdentityStore) handleMFAMethodTOTPRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -98,7 +100,7 @@ func (i *IdentityStore) handleMFAMethodReadCommon(ctx context.Context, req *logi
 		return nil, err
 	}
 
-	respData, err := i.mfaBackend.MfaConfigReadByMethodID(methodID)
+	respData, err := i.mfaBackend.ReadMFAConfigByMethodID(methodID)
 	if err != nil {
 		return nil, err
 	}
@@ -130,21 +132,28 @@ func (i *IdentityStore) handleMFAMethodReadCommon(ctx context.Context, req *logi
 type MFABackend interface {
 	Lock()
 	Unlock()
+	HandleMFAGenerateTOTP(context.Context, *mfa.Config, string) (*logical.Response, error)
+	ValidateAuthEntriesForAccessorOrType(context.Context, *namespace.Namespace, func(entry *routing.MountEntry) bool) (bool, error)
+	CleanupNamespace(context.Context, *namespace.Namespace, bool) error
+
+	// Login Method Configs CRUD
+	PutMFAConfigByID(context.Context, *mfa.Config) error
+	ReadMFAConfigByMethodID(string) (map[string]any, error)
+	DeleteMFAConfigByMethodID(context.Context, string, string, string) error
+	MfaMethodList(context.Context, string) (map[string]any, error)
+
+	// Login Enforcement Configs CRUD
+	PutMFALoginEnforcementConfig(context.Context, *mfa.MFAEnforcementConfig, *namespace.Namespace) error
+	ReadMFALoginEnforcementConfigByNameAndNamespace(string, *namespace.Namespace) (map[string]interface{}, error)
+	DeleteMFALoginEnforcementConfigByNameAndNamespace(context.Context, string, *namespace.Namespace) error
+	MfaLoginEnforcementList(context.Context) (map[string]any, error)
+
+	// MemDB methods
+	MemDBUpsertMFAConfig(context.Context, *mfa.Config) error
 	MemDBMFAConfigByID(string) (*mfa.Config, error)
 	MemDBMFAConfigByName(context.Context, string) (*mfa.Config, error)
-	PutMFAConfigByID(context.Context, *mfa.Config) error
-	MemDBUpsertMFAConfig(context.Context, *mfa.Config) error
-	MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (*mfa.MFAEnforcementConfig, error)
-	MemDBUpsertMFALoginEnforcementConfig(ctx context.Context, eConfig *mfa.MFAEnforcementConfig) error
-	MfaMethodList(ctx context.Context, s string) ([]string, map[string]any, error)
-	MfaConfigReadByMethodID(methodID string) (map[string]any, error)
-	DeleteMFAConfigByMethodID(context.Context, string, string, string) error
-	HandleMFAGenerateTOTP(context.Context, *mfa.Config, string) (*logical.Response, error)
-	MfaLoginEnforcementList(context.Context) ([]string, map[string]any, error)
-	MfaLoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (map[string]interface{}, error)
-	ValidateAuthEntriesForAccessorOrType(ctx context.Context, ns *namespace.Namespace, validFunc func(entry *routing.MountEntry) bool) (bool, error)
-	PutMFALoginEnforcementConfig(ctx context.Context, eConfig *mfa.MFAEnforcementConfig) error
-	DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx context.Context, name, namespaceId string) error
+	MemDBMFALoginEnforcementConfigByNameAndNamespace(string, string) (*mfa.MFAEnforcementConfig, error)
+	MemDBUpsertMFALoginEnforcementConfig(context.Context, *mfa.MFAEnforcementConfig) error
 }
 
 func (i *IdentityStore) handleMFAMethodUpdateCommon(ctx context.Context, req *logical.Request, d *framework.FieldData, methodType string) (*logical.Response, error) {
@@ -181,6 +190,7 @@ func (i *IdentityStore) handleMFAMethodUpdateCommon(ctx context.Context, req *lo
 		if err != nil {
 			return nil, err
 		}
+
 		if namedMfaConfig != nil {
 			if mConfig == nil {
 				mConfig = namedMfaConfig
@@ -204,20 +214,14 @@ func (i *IdentityStore) handleMFAMethodUpdateCommon(ctx context.Context, req *lo
 		}
 	}
 
-	// Updating the method config name
+	// Upserting method config name
 	if methodName != "" {
 		mConfig.Name = methodName
 	}
 
-	mfaNs, err := i.namespacer.NamespaceByID(ctx, mConfig.NamespaceID)
-	if err != nil {
-		return nil, err
-	}
-
-	// this logic assumes that the config namespace and the current
-	// namespace should be the same. Note an ancestor of mfaNs is not allowed
-	// to create/update methodID
-	if ns.ID != mfaNs.ID {
+	// Disallow updates of configs in different namespace
+	// than provided in request context.
+	if ns.ID != mConfig.NamespaceID {
 		return logical.ErrorResponse("request namespace does not match method namespace"), nil
 	}
 
@@ -274,10 +278,10 @@ func (i *IdentityStore) handleMFAMethodUpdateCommon(ctx context.Context, req *lo
 				"method_id": mConfig.ID,
 			},
 		}, nil
-	} else {
-		//nolint:nilnil
-		return nil, nil
 	}
+
+	//nolint:nilnil
+	return nil, nil
 }
 
 func (i *IdentityStore) handleMFAMethodTOTPUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -465,21 +469,26 @@ func (i *IdentityStore) handleLoginMFAAdminDestroyUpdate(ctx context.Context, re
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	keys, configInfo, err := i.mfaBackend.MfaLoginEnforcementList(ctx)
+	configInfo, err := i.mfaBackend.MfaLoginEnforcementList(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return logical.ListResponseWithInfo(keys, configInfo), nil
+	return logical.ListResponseWithInfo(slices.Collect(maps.Keys(configInfo)), configInfo), nil
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	respData, err := i.mfaBackend.MfaLoginEnforcementConfigByNameAndNamespace(name, ns.ID)
+
+	name, ok := d.GetOk("name")
+	if !ok || name == "" {
+		return logical.ErrorResponse("missing login enforcement config name"), nil
+	}
+
+	respData, err := i.mfaBackend.ReadMFALoginEnforcementConfigByNameAndNamespace(name.(string), ns)
 	if err != nil {
 		return nil, err
 	}
@@ -500,24 +509,21 @@ func (i *IdentityStore) handleMFALoginEnforcementRead(ctx context.Context, req *
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	var err error
-	var eConfig *mfa.MFAEnforcementConfig
-
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	name := d.Get("name").(string)
-	if name == "" {
-		return logical.ErrorResponse("missing enforcement name"), nil
+	name, ok := d.GetOk("name")
+	if !ok || name == "" {
+		return logical.ErrorResponse("missing login enforcement config name"), nil
 	}
 
 	b := i.mfaBackend
 	b.Lock()
 	defer b.Unlock()
 
-	eConfig, err = b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, ns.ID)
+	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name.(string), ns.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +534,7 @@ func (i *IdentityStore) handleMFALoginEnforcementUpdate(ctx context.Context, req
 			return nil, fmt.Errorf("failed to generate an identifier for MFA login enforcement config: %w", err)
 		}
 		eConfig = &mfa.MFAEnforcementConfig{
-			Name:        name,
+			Name:        name.(string),
 			NamespaceID: ns.ID,
 			ID:          configID,
 		}
@@ -541,7 +547,7 @@ func (i *IdentityStore) handleMFALoginEnforcementUpdate(ctx context.Context, req
 
 	for _, mmid := range mfaMethodIds.([]string) {
 		// make sure this method id actually exists
-		config, err := b.MfaConfigReadByMethodID(mmid)
+		config, err := b.ReadMFAConfigByMethodID(mmid)
 		if err != nil {
 			return nil, err
 		}
@@ -630,7 +636,7 @@ func (i *IdentityStore) handleMFALoginEnforcementUpdate(ctx context.Context, req
 	}
 
 	// Store the config
-	err = b.PutMFALoginEnforcementConfig(ctx, eConfig)
+	err = b.PutMFALoginEnforcementConfig(ctx, eConfig, ns)
 	if err != nil {
 		return nil, err
 	}
@@ -640,12 +646,17 @@ func (i *IdentityStore) handleMFALoginEnforcementUpdate(ctx context.Context, req
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return nil, i.mfaBackend.DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx, name, ns.ID)
+
+	name, ok := d.GetOk("name")
+	if !ok || name == "" {
+		return logical.ErrorResponse("missing login enforcement config name"), nil
+	}
+
+	return nil, i.mfaBackend.DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx, name.(string), ns)
 }
 
 func parseTOTPConfig(mConfig *mfa.Config, d *framework.FieldData) error {

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -48,10 +48,11 @@ const (
 	memDBMFALoginEnforcementsTable = "login_enforcements"
 	mfaTOTPKeysPrefix              = barrier.SystemBarrierPrefix + "mfa/totpkeys/"
 
+	baseLoginMFAPrefix = "login-mfa/"
 	// loginMFAConfigPrefix is the storage prefix for persisting login MFA method
 	// configs
-	loginMFAConfigPrefix      = "login-mfa/method/"
-	mfaLoginEnforcementPrefix = "login-mfa/enforcement/"
+	loginMFAConfigPrefix      = baseLoginMFAPrefix + "method/"
+	mfaLoginEnforcementPrefix = baseLoginMFAPrefix + "enforcement/"
 )
 
 var ErrBadMFACredentials = errors.New("MFA credentials not supplied or incorrect")
@@ -124,21 +125,34 @@ func loginMFASchemaFuncs() []func() *memdb.TableSchema {
 	}
 }
 
-func NewLoginMFABackend(core *Core, logger hclog.Logger) *LoginMFABackend {
-	b := NewMFABackend(core, logger, ident.MemDBLoginMFAConfigsTable, loginMFASchemaFuncs())
-	return &LoginMFABackend{b}
+func NewLoginMFABackend(core *Core, logger hclog.Logger) (*LoginMFABackend, error) {
+	b, err := NewMFABackend(core, logger, ident.MemDBLoginMFAConfigsTable, loginMFASchemaFuncs())
+	if err != nil {
+		return nil, err
+	}
+
+	return &LoginMFABackend{b}, nil
 }
 
-func NewMFABackend(core *Core, logger hclog.Logger, prefix string, schemaFuncs []func() *memdb.TableSchema) *MFABackend {
-	db, _ := SetupMFAMemDB(schemaFuncs)
+func NewMFABackend(core *Core, logger hclog.Logger, prefix string, schemaFuncs []func() *memdb.TableSchema) (*MFABackend, error) {
+	db, err := SetupMFAMemDB(schemaFuncs)
+	if err != nil {
+		return nil, err
+	}
+
+	mfaLogger := logger.Named("mfa")
+	if logger != nil {
+		core.AddLogger(mfaLogger)
+	}
+
 	return &MFABackend{
 		RWMutex:     &sync.RWMutex{},
 		Core:        core,
 		db:          db,
-		mfaLogger:   logger.Named("mfa"),
+		mfaLogger:   mfaLogger,
 		namespacer:  core,
 		methodTable: prefix,
-	}
+	}, nil
 }
 
 func SetupMFAMemDB(schemaFuncs []func() *memdb.TableSchema) (*memdb.MemDB, error) {
@@ -149,41 +163,30 @@ func SetupMFAMemDB(schemaFuncs []func() *memdb.TableSchema) (*memdb.MemDB, error
 	for _, schemaFunc := range schemaFuncs {
 		schema := schemaFunc()
 		if _, ok := mfaSchemas.Tables[schema.Name]; ok {
-			panic(fmt.Sprintf("duplicate table name: %s", schema.Name))
+			return nil, fmt.Errorf("duplicate table name: %s", schema.Name)
 		}
 		mfaSchemas.Tables[schema.Name] = schema
 	}
 
-	db, err := memdb.NewMemDB(mfaSchemas)
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
+	return memdb.NewMemDB(mfaSchemas)
 }
 
 func (b *LoginMFABackend) ResetLoginMFAMemDB() error {
 	var err error
-
-	db, err := SetupMFAMemDB(loginMFASchemaFuncs())
-	if err != nil {
-		return err
-	}
-
-	b.db = db
-
-	return nil
+	b.db, err = SetupMFAMemDB(loginMFASchemaFuncs())
+	return err
 }
 
 func (b *LoginMFABackend) invalidate(ctx context.Context, ns *namespace.Namespace, path string) error {
 	switch {
 	case strings.HasPrefix(path, barrier.SystemBarrierPrefix+loginMFAConfigPrefix):
 		key, _ := strings.CutPrefix(path, barrier.SystemBarrierPrefix+loginMFAConfigPrefix)
-		barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+		barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
 
 		return b.loadMFAMethodConfig(ctx, ns, barrierView, key)
 	case strings.HasPrefix(path, barrier.SystemBarrierPrefix+mfaLoginEnforcementPrefix):
 		key, _ := strings.CutPrefix(path, barrier.SystemBarrierPrefix+mfaLoginEnforcementPrefix)
-		barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+		barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + mfaLoginEnforcementPrefix)
 
 		mConfig, err := b.loadMFAEnforcementConfig(ctx, ns, barrierView, key)
 		if err != nil {
@@ -203,7 +206,7 @@ func (b *LoginMFABackend) invalidate(ctx context.Context, ns *namespace.Namespac
 // loadMFAMethodConfigs loads MFA method configs for login MFA
 func (b *LoginMFABackend) loadMFAMethodConfigs(ctx context.Context, ns *namespace.Namespace) error {
 	b.mfaLogger.Trace("loading login MFA configurations")
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
 	existing, err := barrierView.List(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to list MFA configurations for namespace %s and prefix %s: %w", ns.Path, loginMFAConfigPrefix, err)
@@ -247,7 +250,7 @@ func (b *LoginMFABackend) loadMFAMethodConfig(ctx context.Context, ns *namespace
 // loadMFAEnforcementConfigs loads MFA method configs for login MFA
 func (b *LoginMFABackend) loadMFAEnforcementConfigs(ctx context.Context, ns *namespace.Namespace) ([]*mfa.MFAEnforcementConfig, error) {
 	b.mfaLogger.Trace("loading login MFA enforcement configurations")
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
+	barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + mfaLoginEnforcementPrefix)
 	existing, err := barrierView.List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list MFA enforcement configurations for namespace %s with prefix %s: %w", ns.Path, mfaLoginEnforcementPrefix, err)
@@ -503,12 +506,11 @@ func (c *Core) PersistTOTPKey(ctx context.Context, methodID, entityID, key strin
 		return err
 	}
 
-	view := NamespaceScopedView(c.barrier, ns).SubView(mfaTOTPKeysPrefix).SubView(methodID + "/")
-	err = view.Put(ctx, &logical.StorageEntry{
+	view := c.NamespaceView(ns).SubView(mfaTOTPKeysPrefix + methodID + "/")
+	return view.Put(ctx, &logical.StorageEntry{
 		Key:   entityID,
 		Value: val,
 	})
-	return err
 }
 
 func (c *Core) fetchTOTPKey(ctx context.Context, methodID, entityID string) (string, error) {
@@ -517,7 +519,7 @@ func (c *Core) fetchTOTPKey(ctx context.Context, methodID, entityID string) (str
 		return "", err
 	}
 
-	view := NamespaceScopedView(c.barrier, ns).SubView(mfaTOTPKeysPrefix).SubView(methodID + "/")
+	view := c.NamespaceView(ns).SubView(mfaTOTPKeysPrefix + methodID + "/")
 	entry, err := view.Get(ctx, entityID)
 	if err != nil {
 		return "", err
@@ -635,7 +637,7 @@ func (b *MFABackend) HandleMFAGenerateTOTP(ctx context.Context, mConfig *mfa.Con
 	}, nil
 }
 
-func (b *LoginMFABackend) MfaConfigReadByMethodID(id string) (map[string]interface{}, error) {
+func (b *LoginMFABackend) ReadMFAConfigByMethodID(id string) (map[string]interface{}, error) {
 	mConfig, err := b.MemDBMFAConfigByID(id)
 	if err != nil {
 		return nil, err
@@ -647,10 +649,10 @@ func (b *LoginMFABackend) MfaConfigReadByMethodID(id string) (map[string]interfa
 	return b.mfaConfigToMap(mConfig)
 }
 
-func (b *LoginMFABackend) MfaMethodList(ctx context.Context, methodType string) ([]string, map[string]interface{}, error) {
+func (b *LoginMFABackend) MfaMethodList(ctx context.Context, methodType string) (map[string]interface{}, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	ws := memdb.NewWatchSet()
@@ -662,26 +664,24 @@ func (b *LoginMFABackend) MfaMethodList(ctx context.Context, methodType string) 
 		// get all the configs
 		iter, err = txn.Get(b.methodTable, "id")
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch iterator for login mfa method configs in memdb: %w", err)
+			return nil, fmt.Errorf("failed to fetch iterator for login mfa method configs in memdb: %w", err)
 		}
 	default:
 		// get all the configs for the given type
 		iter, err = txn.Get(b.methodTable, "type", methodType)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch iterator for login mfa method configs in memdb: %w", err)
+			return nil, fmt.Errorf("failed to fetch iterator for login mfa method configs in memdb: %w", err)
 		}
 	}
 
 	ws.Add(iter.WatchCh())
-
-	var keys []string
 	configInfo := map[string]interface{}{}
 
 	for {
 		// check for timeouts
 		select {
 		case <-ctx.Done():
-			return keys, configInfo, nil
+			return configInfo, nil
 		default:
 		}
 
@@ -694,7 +694,7 @@ func (b *LoginMFABackend) MfaMethodList(ctx context.Context, methodType string) 
 		// return this config if it's in the same ns as the request ns OR it's in a parent ns of the request ns
 		mfaNs, err := b.namespacer.NamespaceByID(ctx, config.NamespaceID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch namespace: %w", err)
+			return nil, fmt.Errorf("failed to fetch namespace: %w", err)
 		}
 
 		// the namespaces have to match, or the config namespace needs to be a parent of the request namespace
@@ -702,21 +702,20 @@ func (b *LoginMFABackend) MfaMethodList(ctx context.Context, methodType string) 
 			continue
 		}
 
-		keys = append(keys, config.ID)
 		configInfoEntry, err := b.mfaConfigToMap(config)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert config to map: %w", err)
+			return nil, fmt.Errorf("failed to convert config to map: %w", err)
 		}
 		configInfo[config.ID] = configInfoEntry
 	}
 
-	return keys, configInfo, nil
+	return configInfo, nil
 }
 
-func (b *LoginMFABackend) MfaLoginEnforcementList(ctx context.Context) ([]string, map[string]interface{}, error) {
+func (b *LoginMFABackend) MfaLoginEnforcementList(ctx context.Context) (map[string]interface{}, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	ws := memdb.NewWatchSet()
@@ -725,19 +724,17 @@ func (b *LoginMFABackend) MfaLoginEnforcementList(ctx context.Context) ([]string
 	// get all the login enforcements in our namespace
 	iter, err := txn.Get(memDBMFALoginEnforcementsTable, "namespace", ns.ID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch iterator for login enforcement configs in memdb: %w", err)
+		return nil, fmt.Errorf("failed to fetch iterator for login enforcement configs in memdb: %w", err)
 	}
 
 	ws.Add(iter.WatchCh())
-
-	var keys []string
 	enforcementInfo := map[string]interface{}{}
 
 	for {
 		// check for timeouts
 		select {
 		case <-ctx.Done():
-			return keys, enforcementInfo, nil
+			return enforcementInfo, nil
 		default:
 		}
 
@@ -746,46 +743,33 @@ func (b *LoginMFABackend) MfaLoginEnforcementList(ctx context.Context) ([]string
 			break
 		}
 		config := raw.(*mfa.MFAEnforcementConfig)
-		keys = append(keys, config.Name)
-		configInfoEntry, err := b.mfaLoginEnforcementConfigToMap(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert enforcement to map: %w", err)
-		}
-		enforcementInfo[config.Name] = configInfoEntry
+		enforcementInfo[config.Name] = b.mfaLoginEnforcementConfigToMap(config, ns)
 	}
 
-	return keys, enforcementInfo, nil
+	return enforcementInfo, nil
 }
 
-func (b *LoginMFABackend) MfaLoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (map[string]interface{}, error) {
-	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId)
-	if err != nil {
+func (b *LoginMFABackend) ReadMFALoginEnforcementConfigByNameAndNamespace(name string, ns *namespace.Namespace) (map[string]interface{}, error) {
+	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, ns.ID)
+	if err != nil || eConfig == nil {
 		return nil, err
 	}
-	if eConfig == nil {
-		return nil, nil
-	}
-	return b.mfaLoginEnforcementConfigToMap(eConfig)
+
+	return b.mfaLoginEnforcementConfigToMap(eConfig, ns), nil
 }
 
-func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforcementConfig) (map[string]interface{}, error) {
-	resp := make(map[string]interface{})
-	resp["name"] = eConfig.Name
-	ns, err := b.namespacer.NamespaceByID(context.Background(), eConfig.NamespaceID)
-	if err != nil {
-		return nil, err
+func (b *LoginMFABackend) mfaLoginEnforcementConfigToMap(eConfig *mfa.MFAEnforcementConfig, ns *namespace.Namespace) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                    eConfig.ID,
+		"name":                  eConfig.Name,
+		"namespace_path":        ns.Path,
+		"namespace_id":          eConfig.NamespaceID,
+		"mfa_method_ids":        append([]string{}, eConfig.MFAMethodIDs...),
+		"auth_method_accessors": append([]string{}, eConfig.AuthMethodAccessors...),
+		"auth_method_types":     append([]string{}, eConfig.AuthMethodTypes...),
+		"identity_group_ids":    append([]string{}, eConfig.IdentityGroupIds...),
+		"identity_entity_ids":   append([]string{}, eConfig.IdentityEntityIDs...),
 	}
-	if ns != nil {
-		resp["namespace_path"] = ns.Path
-	}
-	resp["namespace_id"] = eConfig.NamespaceID
-	resp["mfa_method_ids"] = append([]string{}, eConfig.MFAMethodIDs...)
-	resp["auth_method_accessors"] = append([]string{}, eConfig.AuthMethodAccessors...)
-	resp["auth_method_types"] = append([]string{}, eConfig.AuthMethodTypes...)
-	resp["identity_group_ids"] = append([]string{}, eConfig.IdentityGroupIds...)
-	resp["identity_entity_ids"] = append([]string{}, eConfig.IdentityEntityIDs...)
-	resp["id"] = eConfig.ID
-	return resp, nil
 }
 
 func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}, error) {
@@ -838,9 +822,8 @@ func (b *MFABackend) mfaConfigToMap(mConfig *mfa.Config) (map[string]interface{}
 	if err != nil {
 		return nil, err
 	}
-	if ns != nil {
-		respData["namespace_path"] = ns.Path
-	}
+
+	respData["namespace_path"] = ns.Path
 
 	return respData, nil
 }
@@ -1860,10 +1843,6 @@ func (b *LoginMFABackend) MemDBMFAConfigByName(ctx context.Context, name string)
 }
 
 func (b *LoginMFABackend) MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (*mfa.MFAEnforcementConfig, error) {
-	if name == "" {
-		return nil, errors.New("missing config name")
-	}
-
 	txn := b.db.Txn(false)
 	defer txn.Abort()
 
@@ -1897,69 +1876,25 @@ func (b *LoginMFABackend) MemDBMFALoginEnforcementConfigIterator() (memdb.Result
 	return it, nil
 }
 
-func (b *LoginMFABackend) DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx context.Context, name, namespaceId string) error {
-	var err error
-
-	if name == "" {
-		return errors.New("missing config name")
-	}
-
+func (b *LoginMFABackend) DeleteMFALoginEnforcementConfigByNameAndNamespace(ctx context.Context, name string, ns *namespace.Namespace) error {
 	b.Lock()
 	defer b.Unlock()
 
-	// delete the config from storage
-	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId)
+	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, ns.ID)
 	if err != nil {
 		return err
 	}
 
 	if eConfig == nil {
 		return nil
-	}
-
-	ns, err := b.namespacer.NamespaceByID(ctx, eConfig.NamespaceID)
-	if err != nil {
-		return err
-	}
-
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
-	err = barrierView.Delete(ctx, eConfig.ID)
-	if err != nil {
-		return err
 	}
 
 	// create a memdb transaction to delete config
 	txn := b.db.Txn(true)
 	defer txn.Abort()
 
-	err = txn.Delete(memDBMFALoginEnforcementsTable, eConfig)
-	if err != nil {
+	if err = txn.Delete(memDBMFALoginEnforcementsTable, eConfig); err != nil {
 		return fmt.Errorf("failed to delete MFA login enforcement config from memdb: %w", err)
-	}
-
-	txn.Commit()
-	return nil
-}
-
-func (b *LoginMFABackend) MemDBDeleteMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId, tableName string) error {
-	if name == "" || namespaceId == "" {
-		return nil
-	}
-
-	txn := b.db.Txn(true)
-	defer txn.Abort()
-
-	eConfig, err := b.MemDBMFALoginEnforcementConfigByNameAndNamespace(name, namespaceId)
-	if err != nil {
-		return err
-	}
-	if eConfig == nil {
-		return nil
-	}
-
-	err = txn.Delete(memDBMFALoginEnforcementsTable, eConfig)
-	if err != nil {
-		return err
 	}
 
 	txn.Commit()
@@ -1994,7 +1929,7 @@ func (b *LoginMFABackend) DeleteMFAConfigByMethodID(ctx context.Context, configI
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
 	err = barrierView.Delete(ctx, configID)
 	if err != nil {
 		return err
@@ -2031,7 +1966,7 @@ func (b *LoginMFABackend) DeleteMFAConfigByMethodID(ctx context.Context, configI
 
 	if mConfig.Type == "totp" && mConfig.ID != "" {
 		// This is best effort; if they end up hanging around it's okay, they're encrypted anyways
-		viewToClear := NamespaceScopedView(b.Core.barrier, ns).SubView(mfaTOTPKeysPrefix).SubView(mConfig.ID + "/")
+		viewToClear := b.Core.NamespaceView(ns).SubView(mfaTOTPKeysPrefix + mConfig.ID + "/")
 		if err := logical.ClearView(ctx, viewToClear); err != nil {
 			b.mfaLogger.Warn("unable to clear TOTP keys", "method", mConfig.Name, "error", err)
 		}
@@ -2098,7 +2033,7 @@ func (b *LoginMFABackend) PutMFAConfigByID(ctx context.Context, mConfig *mfa.Con
 		return err
 	}
 
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(loginMFAConfigPrefix)
+	barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
 	marshaledEntry, err := proto.Marshal(mConfig)
 	if err != nil {
 		return err
@@ -2148,21 +2083,43 @@ func (b *LoginMFABackend) getMFALoginEnforcementConfig(ctx context.Context, path
 	return &mConfig, nil
 }
 
-func (b *LoginMFABackend) PutMFALoginEnforcementConfig(ctx context.Context, eConfig *mfa.MFAEnforcementConfig) error {
+func (b *LoginMFABackend) PutMFALoginEnforcementConfig(ctx context.Context, eConfig *mfa.MFAEnforcementConfig, ns *namespace.Namespace) error {
 	marshaledEntry, err := proto.Marshal(eConfig)
 	if err != nil {
 		return err
 	}
 
-	ns, err := b.namespacer.NamespaceByID(ctx, eConfig.NamespaceID)
-	if err != nil {
-		return err
-	}
-
-	barrierView := NamespaceScopedView(b.Core.barrier, ns).SubView(barrier.SystemBarrierPrefix).SubView(mfaLoginEnforcementPrefix)
-
+	barrierView := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + mfaLoginEnforcementPrefix)
 	return barrierView.Put(ctx, &logical.StorageEntry{
 		Key:   eConfig.ID,
 		Value: marshaledEntry,
 	})
+}
+
+func (b *LoginMFABackend) CleanupNamespace(ctx context.Context, ns *namespace.Namespace, updateStorage bool) error {
+	b.Lock()
+	defer b.Unlock()
+
+	txn := b.db.Txn(true)
+	defer txn.Abort()
+
+	_, err := txn.DeleteAll(memDBMFALoginEnforcementsTable, "namespace", ns.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete MFA login enforcement configs from memdb: %w", err)
+	}
+
+	_, err = txn.DeleteAll(b.methodTable, "namespace_id", ns.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete MFA configs from memdb: %w", err)
+	}
+
+	if updateStorage {
+		view := b.Core.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + baseLoginMFAPrefix)
+		if err = logical.ClearViewWithLogging(ctx, view, b.mfaLogger); err != nil {
+			return err
+		}
+	}
+
+	txn.Commit()
+	return nil
 }

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1090,6 +1090,10 @@ func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNames
 		return err
 	}
 
+	if err := ns.core.loadLoginMFAConfigsForNamespace(ctx, unsealedNamespace); err != nil {
+		return err
+	}
+
 	// now we run the collected post unseal functions to finalize unsealing
 	ns.core.runPostUnsealFuncs(postUnsealFuncs)
 	return nil
@@ -1238,6 +1242,11 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, parent,
 	// clear identity store
 	if err := ns.core.identityStore.RemoveNamespaceView(entry); err != nil {
 		return fmt.Errorf("failed to clean identity store: %w", err)
+	}
+
+	// clear login mfa
+	if err := ns.core.loginMFABackend.CleanupNamespace(nsCtx, entry, updateStorage); err != nil {
+		return fmt.Errorf("failed to cleanup mfa login configs: %w", err)
 	}
 
 	if updateStorage {

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -10,10 +10,12 @@ import (
 
 	credAppRole "github.com/openbao/openbao/builtin/credential/approle"
 	"github.com/openbao/openbao/helper/benchhelpers"
+	"github.com/openbao/openbao/helper/identity/mfa"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	be "github.com/openbao/openbao/vault/backend"
 	"github.com/openbao/openbao/vault/barrier"
+	ident "github.com/openbao/openbao/vault/identity"
 	"github.com/openbao/openbao/vault/policy"
 	"github.com/openbao/openbao/vault/routing"
 	"github.com/openbao/openbao/vault/seal"
@@ -1020,6 +1022,16 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, entity)
 
+	mConfig := &mfa.Config{Name: "mConfig", NamespaceID: ns.ID, ID: "mConfigID", Type: ident.MfaMethodTypeTOTP, Config: &mfa.Config_TOTPConfig{
+		TOTPConfig: &mfa.TOTPConfig{},
+	}}
+	require.NoError(t, c.loginMFABackend.PutMFAConfigByID(nsCtx, mConfig))
+	require.NoError(t, c.loginMFABackend.MemDBUpsertMFAConfig(nsCtx, mConfig))
+
+	eConfig := &mfa.MFAEnforcementConfig{Name: "eConfig", NamespaceID: ns.ID, ID: "eConfigID"}
+	require.NoError(t, c.loginMFABackend.PutMFALoginEnforcementConfig(nsCtx, eConfig, ns))
+	require.NoError(t, c.loginMFABackend.MemDBUpsertMFALoginEnforcementConfig(nsCtx, eConfig))
+
 	checkState := func() {
 		// policies
 		policies, err := c.policyStore.ListPolicies(nsCtx, policy.TypeACL, false)
@@ -1040,6 +1052,14 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 		counts, err := c.identityStore.CountEntitiesByNamespace(nsCtx)
 		require.NoError(t, err)
 		require.Equal(t, 1, counts[ns.ID])
+
+		// mfa
+		mfaMethods, err := c.loginMFABackend.MfaMethodList(nsCtx, "")
+		require.NoError(t, err)
+		require.Len(t, mfaMethods, 1)
+		enfConfigs, err := c.loginMFABackend.MfaLoginEnforcementList(nsCtx)
+		require.NoError(t, err)
+		require.Len(t, enfConfigs, 1)
 	}
 
 	checkState()
@@ -1066,6 +1086,14 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 	counts, err := c.identityStore.CountEntitiesByNamespace(nsCtx)
 	require.NoError(t, err)
 	require.Equal(t, 0, counts[ns.ID])
+
+	mfaMethods, err := c.loginMFABackend.MfaMethodList(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, mfaMethods, 0)
+
+	mfaEnfConfigs, err := c.loginMFABackend.MfaLoginEnforcementList(nsCtx)
+	require.NoError(t, err)
+	require.Len(t, mfaEnfConfigs, 0)
 
 	for _, key := range nsKeys[ns.Path] {
 		unsealed, err := TestNamespaceUnseal(c, ns, key)


### PR DESCRIPTION
## Description
@cipherboy correctly pointed out that we retain the login mfa configs for sealed namespaces in memory, this PR:
- adjusted `loginMFABackend` constructor
- introduced login mfa configs load on namespace unseal
- introduced login mfa cleanup on namespace seal
- adjusted `*LoginMFABackend` code

## Rationale
we should remove all unnecessary memory on namespace seal, this aims at fixing one of the gaps.

### Implements parts of: #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
