### PR TITLE
Recursively load non-sealed child namespaces

### DIFF
--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -231,7 +231,9 @@ func (ns *NamespaceStore) loadNamespacesLocked(ctx context.Context) error {
 	namespacesByUUID[namespace.RootNamespaceUUID] = namespace.RootNamespace
 	namespacesByAccessor[namespace.RootNamespaceID] = namespace.RootNamespace
 
-	loadingCallback := func(namespace *namespace.Namespace) error {
+	loadNamespaceInsert := func(namespace *namespace.Namespace) error {
+		ns.logger.Info("discovered namespace", "path", namespace.Path, "uuid", namespace.UUID)
+
 		if _, ok := namespacesByUUID[namespace.UUID]; ok {
 			return fmt.Errorf("namespace with UUID %q is not unique in storage", namespace.UUID)
 		}
@@ -244,7 +246,7 @@ func (ns *NamespaceStore) loadNamespacesLocked(ctx context.Context) error {
 	}
 
 	if err := logical.WithTransaction(ctx, ns.storage, func(s logical.Storage) error {
-		return ns.loadNamespacesRecursive(ctx, s, s, loadingCallback)
+		return ns.loadNamespacesRecursive(ctx, s, s, loadNamespaceInsert)
 	}); err != nil {
 		return err
 	}
@@ -964,7 +966,7 @@ func (ns *NamespaceStore) ListNamespaces(ctx context.Context, includeParent bool
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, false)
+	unlock, err := ns.lockWithInvalidation(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -1017,6 +1019,18 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 				errs = errors.Join(errs, err)
 			}
 		}
+
+		if entry.UUID != namespaceToSeal.UUID {
+			// Remove the namespace itself from our records if it isn't the
+			// sealed namespace. We want to forget child namespaces of a
+			// namespaces which was marked sealed, but retain the pointer to
+			// the sealed namespace itself.
+			if err := ns.namespacesByPath.Delete(entry.Path); err != nil {
+				errs = errors.Join(errs, err)
+			}
+			delete(ns.namespacesByUUID, entry.UUID)
+			delete(ns.namespacesByAccessor, entry.ID)
+		}
 	})
 
 	return errs
@@ -1059,35 +1073,86 @@ func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal
 		return unsealed, nil
 	}
 
-	return unsealed, ns.postNamespaceUnseal(ctx, namespaceToUnseal)
+	var collected []*namespace.Namespace
+	collected = append(collected, namespaceToUnseal.Clone(false))
+
+	// Recurse loading all new namespaces starting at this one.
+	if err := func() error {
+		unlock, err := ns.lockWithInvalidation(ctx, true)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			if unlock != nil {
+				unlock()
+			}
+		}()
+
+		if err := ns.namespacesByPath.Insert(namespaceToUnseal); err != nil {
+			return err
+		}
+		ns.namespacesByUUID[namespaceToUnseal.UUID] = namespaceToUnseal
+		ns.namespacesByAccessor[namespaceToUnseal.ID] = namespaceToUnseal
+
+		nsStorage := ns.core.NamespaceView(namespaceToUnseal)
+		return logical.WithTransaction(ctx, nsStorage, func(s logical.Storage) error {
+			return ns.loadNamespacesRecursive(ctx, s, s, func(newNs *namespace.Namespace) error {
+				if _, ok := ns.namespacesByUUID[newNs.UUID]; ok {
+					return fmt.Errorf("namespace with UUID %q is not unique in storage", newNs.UUID)
+				}
+				if err := ns.namespacesByPath.Insert(newNs); err != nil {
+					return err
+				}
+				ns.namespacesByUUID[newNs.UUID] = newNs
+				ns.namespacesByAccessor[newNs.ID] = newNs
+
+				collected = append(collected, newNs.Clone(false))
+
+				return nil
+			})
+		})
+	}(); err != nil {
+		return unsealed, err
+	}
+
+	for index, newNs := range collected {
+		ns.logger.Info("calling post-unseal for namespace", "ns_path", newNs.Path, "ns_uuid", newNs.UUID)
+
+		if err := ns.postNamespaceUnseal(ctx, newNs); err != nil {
+			return unsealed, fmt.Errorf("failed to run namespace post-unseal [%d/%v]: %w", index, newNs.ID, err)
+		}
+	}
+
+	return unsealed, nil
 }
 
 // postNamespaceUnseal loads namespace credential and secret mounts,
 // initializes the backends and updates the router.
 func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) error {
 	if err := ns.core.loadMountsForNamespace(ctx, unsealedNamespace); err != nil {
-		return err
+		return fmt.Errorf("failed to load mounts for namespace: %w", err)
 	}
 
 	var postUnsealFuncs []func()
 	if postUnsealMountFuncs, err := ns.core.setupMountsForNamespace(ctx, unsealedNamespace); err != nil {
-		return err
+		return fmt.Errorf("failed to setup mounts for namespace: %w", err)
 	} else {
 		postUnsealFuncs = append(postUnsealFuncs, postUnsealMountFuncs...)
 	}
 
 	if err := ns.core.loadCredentialsForNamespace(ctx, unsealedNamespace); err != nil {
-		return err
+		return fmt.Errorf("failed to load credential mounts for namespace: %w", err)
 	}
 
 	if postUnsealCredFuncs, err := ns.core.setupCredentialsForNamespace(ctx, unsealedNamespace); err != nil {
-		return err
+		return fmt.Errorf("failed to setup credential mounts for namespace: %w", err)
 	} else {
 		postUnsealFuncs = append(postUnsealFuncs, postUnsealCredFuncs...)
 	}
 
 	if err := ns.core.loadIdentityStoreArtifactsForNamespace(ctx, unsealedNamespace, ns.core.Standby()); err != nil {
-		return err
+		return fmt.Errorf("failed to load identity store artifacts for namespace: %w", err)
 	}
 
 	if err := ns.core.loadLoginMFAConfigsForNamespace(ctx, unsealedNamespace); err != nil {

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -989,6 +989,12 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
 	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, ns)
 
+	ns2, _, err := c.namespaceStore.ModifyNamespaceByPath(nsCtx, "ns2/", nil, func(ctx context.Context, obj *namespace.Namespace) (*namespace.Namespace, error) {
+		return obj, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ns2)
+
 	tPolicy := `
 		name = "tPolicy"
 		path "ns1/*" {
@@ -1060,6 +1066,11 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 		enfConfigs, err := c.loginMFABackend.MfaLoginEnforcementList(nsCtx)
 		require.NoError(t, err)
 		require.Len(t, enfConfigs, 1)
+
+		// namespaces
+		childNs, err := c.namespaceStore.ListNamespaces(nsCtx, false, true)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(childNs))
 	}
 
 	checkState()


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When namespace store unseals a namespace, we need to load all information for any non-sealed child namespaces as well. This occurs in two parts:

1. Discovery
2. Loading of mounts &c for all discovered namespaces.

Notably, we also clean up unloading of namespaces, so that all sealed orphaned namespaces no longer appear in memory.


## Rationale

cc: @wslabosz-reply 

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
