### PR TITLE
Add deletion of sealed namespaces

### DIFF
--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -227,10 +227,12 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 	return result.Data, mapstructure.Decode(secret, &result)
 }
 
+// DeleteNamespace removes the namespace with the given name.
 func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceOutput, error) {
 	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
+// DeleteNamespaceWithContext removes the namespace with the given name.
 func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")

--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -227,12 +227,10 @@ func (c *Sys) PatchNamespaceWithContext(ctx context.Context, name string, i *Pat
 	return result.Data, mapstructure.Decode(secret, &result)
 }
 
-// DeleteNamespace removes the namespace with the given name.
 func (c *Sys) DeleteNamespace(name string) (*DeleteNamespaceOutput, error) {
 	return c.DeleteNamespaceWithContext(context.Background(), name)
 }
 
-// DeleteNamespaceWithContext removes the namespace with the given name.
 func (c *Sys) DeleteNamespaceWithContext(ctx context.Context, name string) (*DeleteNamespaceOutput, error) {
 	if name == "" {
 		return nil, errors.New("name must not be empty")

--- a/command/commands.go
+++ b/command/commands.go
@@ -332,6 +332,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace delete-sealed": func() (cli.Command, error) {
+			return &NamespaceDeleteSealedCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"namespace lock": func() (cli.Command, error) {
 			return &NamespaceAPILockCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -36,9 +36,13 @@ Usage: bao namespace delete [options] PATH
 
       $ bao namespace delete ns1
 
-  Delete a namespace namespace from a parent namespace (e.g. ns1/ns2/):
+  Delete a namespace from a parent namespace (e.g. ns1/ns2/):
 
       $ bao namespace delete -namespace=ns1 ns2
+
+  To delete a sealed namespace, use the delete-sealed subcommand instead:
+
+      $ bao namespace delete-sealed ns1
 
 ` + c.Flags().Help()
 
@@ -98,6 +102,6 @@ func (c *NamespaceDeleteCommand) Run(args []string) int {
 		namespacePath = namespacePath + "/"
 	}
 
-	c.UI.Output(fmt.Sprintf("Success! Namespace deleted at: %s", namespacePath))
+	c.UI.Output(fmt.Sprintf("Success! Namespace deletion scheduled: %s", namespacePath))
 	return 0
 }

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -28,9 +28,10 @@ func (c *NamespaceDeleteCommand) Help() string {
 	helpText := `
 Usage: bao namespace delete [options] PATH
 
-  Delete an existing namespace. The namespace deleted will be relative to the
-  namespace provided in either the BAO_NAMESPACE environment variable or
-  -namespace CLI flag.
+  Delete a namespace.
+
+  The namespace deleted will be relative to the namespace provided in either the
+  BAO_NAMESPACE environment variable or -namespace CLI flag.
 
   Delete a namespace (e.g. ns1/):
 
@@ -43,6 +44,9 @@ Usage: bao namespace delete [options] PATH
   To delete a sealed namespace, use the delete-sealed subcommand instead:
 
       $ bao namespace delete-sealed ns1
+
+  Note that this requires the sudo capability, and will not clean up external
+  resources via lease deletion like standard namespace deletion does.
 
 ` + c.Flags().Help()
 

--- a/command/namespace_delete_sealed.go
+++ b/command/namespace_delete_sealed.go
@@ -30,8 +30,12 @@ func (c *NamespaceDeleteSealedCommand) Help() string {
 	helpText := `
 Usage: bao namespace delete-sealed [options] PATH
 
-  Delete a sealed namespace by physically wiping its storage. Requires sudo
-  privilege on the path.
+  Delete a sealed namespace by physically wiping its storage.
+
+  Note that this requires the sudo capability, and will not clean up external
+  resources via lease deletion like standard namespace deletion does. Prefer the
+  standard 'bao namespace delete' command unless the namespace is irrecoverable
+  due to lost seal keys.
 
   The namespace deleted will be relative to the namespace provided in either
   the BAO_NAMESPACE environment variable or -namespace CLI flag.
@@ -40,7 +44,7 @@ Usage: bao namespace delete-sealed [options] PATH
 
       $ bao namespace delete-sealed ns1
 
-  Delete a sealed namespace and all its child namespaces:
+  Delete a sealed namespace and recursively wipe its child namespaces:
 
       $ bao namespace delete-sealed -force ns1
 

--- a/command/namespace_delete_sealed.go
+++ b/command/namespace_delete_sealed.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceDeleteSealedCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceDeleteSealedCommand)(nil)
+)
+
+type NamespaceDeleteSealedCommand struct {
+	*BaseCommand
+
+	flagForce bool
+}
+
+func (c *NamespaceDeleteSealedCommand) Synopsis() string {
+	return "Delete a sealed namespace"
+}
+
+func (c *NamespaceDeleteSealedCommand) Help() string {
+	helpText := `
+Usage: bao namespace delete-sealed [options] PATH
+
+  Delete a sealed namespace by physically wiping its storage. Requires sudo
+  privilege on the path.
+
+  The namespace deleted will be relative to the namespace provided in either
+  the BAO_NAMESPACE environment variable or -namespace CLI flag.
+
+  Delete a sealed namespace with no child namespaces:
+
+      $ bao namespace delete-sealed ns1
+
+  Delete a sealed namespace and all its child namespaces:
+
+      $ bao namespace delete-sealed -force ns1
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceDeleteSealedCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "force",
+		Target:  &c.flagForce,
+		Default: false,
+		Usage: "Recursively delete all child namespaces of the sealed namespace. " +
+			"Required when the namespace has children.",
+	})
+
+	return set
+}
+
+func (c *NamespaceDeleteSealedCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultNamespaces()
+}
+
+func (c *NamespaceDeleteSealedCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceDeleteSealedCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	namespacePath := strings.TrimSpace(args[0])
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	params := map[string][]string{}
+	if c.flagForce {
+		params["force"] = []string{"true"}
+	}
+
+	secret, err := client.Logical().DeleteWithData(
+		fmt.Sprintf("sys/namespaces/%s/delete-sealed", namespacePath), params,
+	)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error deleting sealed namespace: %s", err))
+		return 2
+	}
+
+	if secret == nil || secret.Data == nil {
+		if secret != nil {
+			return OutputSecret(c.UI, secret)
+		}
+		c.UI.Warn("Requested namespace does not exist")
+		return 0
+	}
+
+	if !strings.HasSuffix(namespacePath, "/") {
+		namespacePath = namespacePath + "/"
+	}
+
+	for _, w := range secret.Warnings {
+		c.UI.Warn(w)
+	}
+	c.UI.Output(fmt.Sprintf("Success! Namespace deletion scheduled: %s", namespacePath))
+	return 0
+}

--- a/command/namespace_delete_sealed_test.go
+++ b/command/namespace_delete_sealed_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testNamespaceDeleteSealedCommand(tb testing.TB) (*cli.MockUi, *NamespaceDeleteCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceDeleteCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceDeleteSealedCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testNamespaceDeleteSealedCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testNamespaceDeleteSealedCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -184,6 +184,47 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 		},
 
 		{
+			// Must be registered before the generic "namespaces/(?P<path>.+)"
+			// pattern so that the router matches this specific suffix first.
+			Pattern: "namespaces/(?P<path>[^/]+)/delete-sealed",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": namespacePathSchema,
+				"force": {
+					Type:        framework.TypeBool,
+					Description: "If true, recursively deletes all child namespaces of the sealed namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.handleNamespacesDeleteSealed(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {
+							{
+								Description: "OK",
+								Fields: map[string]*framework.FieldSchema{
+									"status": {
+										Type:        framework.TypeString,
+										Description: "Status of the deletion operation.",
+									},
+								},
+							},
+						},
+					},
+					Summary: "Delete a sealed namespace by wiping its physical storage.",
+				},
+			},
+
+			HelpSynopsis:    "Delete a sealed namespace.",
+			HelpDescription: "Physically deletes a sealed namespace by wiping its storage. Requires sudo privilege. Pass force=true to also delete child namespaces.",
+		},
+
+		{
 			Pattern: "namespaces/(?P<path>.+)",
 
 			DisplayAttrs: &framework.DisplayAttributes{
@@ -546,7 +587,7 @@ func (b *SystemBackend) handleNamespacesUnlock() framework.OperationFunc {
 	}
 }
 
-// handleNamespacesDelete handles the "/sys/namespace/<path>" endpoint to delete a namespace.
+// handleNamespacesDelete handles DELETE /sys/namespaces/<path> for unsealed namespaces.
 func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -571,6 +612,50 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 				"status": status,
 			},
 		}, nil
+	}
+}
+
+// handleNamespacesDeleteSealed handles DELETE /sys/namespaces/<path>/delete-sealed.
+// It requires sudo privilege and physically wipes the sealed namespace storage
+// through the root barrier. If the namespace has child namespaces, force=true
+// must be passed to authorize recursive deletion of the entire subtree.
+func (b *SystemBackend) handleNamespacesDeleteSealed() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+
+		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
+			return nil, errors.New("path must not contain /")
+		}
+
+		isSudo := b.System().(extendedSystemView).SudoPrivilege(ctx, req.MountPoint+req.Path, req.ClientToken)
+		if !isSudo {
+			return logical.ErrorResponse("sudo privilege is required to delete a sealed namespace"), logical.ErrPermissionDenied
+		}
+
+		force := data.Get("force").(bool)
+
+		status, err := b.Core.namespaceStore.DeleteSealedNamespace(ctx, path, force)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if status == "" {
+			resp := &logical.Response{}
+			resp.AddWarning("requested namespace does not exist")
+			return resp, nil
+		}
+
+		resp := &logical.Response{
+			Data: map[string]interface{}{
+				"status": status,
+			},
+		}
+		if force {
+			resp.AddWarning("sealed namespace tree deletion performed using sudo capabilities")
+		} else {
+			resp.AddWarning("sealed namespace deletion performed using sudo capabilities")
+		}
+		return resp, nil
 	}
 }
 

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
-var errNamespaceNotFound = errors.New("requested namespace does not exist")
-
 var namespacePathSchema = &framework.FieldSchema{
 	Type:        framework.TypeString,
 	Required:    false,
@@ -181,47 +179,6 @@ func (b *SystemBackend) namespacePaths() []*framework.Path {
 
 			HelpSynopsis:    strings.TrimSpace(sysNamespacesHelp["namespaces-unlock"][0]),
 			HelpDescription: strings.TrimSpace(sysNamespacesHelp["namespaces-unlock"][1]),
-		},
-
-		{
-			// Must be registered before the generic "namespaces/(?P<path>.+)"
-			// pattern so that the router matches this specific suffix first.
-			Pattern: "namespaces/(?P<path>[^/]+)/delete-sealed",
-
-			DisplayAttrs: &framework.DisplayAttributes{
-				OperationPrefix: "namespaces",
-			},
-
-			Fields: map[string]*framework.FieldSchema{
-				"path": namespacePathSchema,
-				"force": {
-					Type:        framework.TypeBool,
-					Description: "If true, recursively deletes all child namespaces of the sealed namespace.",
-				},
-			},
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handleNamespacesDeleteSealed(),
-					Responses: map[int][]framework.Response{
-						http.StatusOK: {
-							{
-								Description: "OK",
-								Fields: map[string]*framework.FieldSchema{
-									"status": {
-										Type:        framework.TypeString,
-										Description: "Status of the deletion operation.",
-									},
-								},
-							},
-						},
-					},
-					Summary: "Delete a sealed namespace by wiping its physical storage.",
-				},
-			},
-
-			HelpSynopsis:    "Delete a sealed namespace.",
-			HelpDescription: "Physically deletes a sealed namespace by wiping its storage. Requires sudo privilege. Pass force=true to also delete child namespaces.",
 		},
 
 		{
@@ -587,7 +544,7 @@ func (b *SystemBackend) handleNamespacesUnlock() framework.OperationFunc {
 	}
 }
 
-// handleNamespacesDelete handles DELETE /sys/namespaces/<path> for unsealed namespaces.
+// handleNamespacesDelete handles the "/sys/namespaces/<path>" endpoint to delete a namespace.
 func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -612,50 +569,6 @@ func (b *SystemBackend) handleNamespacesDelete() framework.OperationFunc {
 				"status": status,
 			},
 		}, nil
-	}
-}
-
-// handleNamespacesDeleteSealed handles DELETE /sys/namespaces/<path>/delete-sealed.
-// It requires sudo privilege and physically wipes the sealed namespace storage
-// through the root barrier. If the namespace has child namespaces, force=true
-// must be passed to authorize recursive deletion of the entire subtree.
-func (b *SystemBackend) handleNamespacesDeleteSealed() framework.OperationFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-		path := namespace.Canonicalize(data.Get("path").(string))
-
-		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
-			return nil, errors.New("path must not contain /")
-		}
-
-		isSudo := b.System().(extendedSystemView).SudoPrivilege(ctx, req.MountPoint+req.Path, req.ClientToken)
-		if !isSudo {
-			return logical.ErrorResponse("sudo privilege is required to delete a sealed namespace"), logical.ErrPermissionDenied
-		}
-
-		force := data.Get("force").(bool)
-
-		status, err := b.Core.namespaceStore.DeleteSealedNamespace(ctx, path, force)
-		if err != nil {
-			return handleError(err)
-		}
-
-		if status == "" {
-			resp := &logical.Response{}
-			resp.AddWarning("requested namespace does not exist")
-			return resp, nil
-		}
-
-		resp := &logical.Response{
-			Data: map[string]interface{}{
-				"status": status,
-			},
-		}
-		if force {
-			resp.AddWarning("sealed namespace tree deletion performed using sudo capabilities")
-		} else {
-			resp.AddWarning("sealed namespace deletion performed using sudo capabilities")
-		}
-		return resp, nil
 	}
 }
 

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -139,11 +139,50 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 			HelpSynopsis:    strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][0]),
 			HelpDescription: strings.TrimSpace(sysNamespacesSealsHelp["namespaces-seal"][1]),
 		},
+
+		{
+			Pattern: "namespaces/(?P<path>.+)/delete-sealed",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "namespaces",
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"path": namespacePathSchema,
+				"force": {
+					Type:        framework.TypeBool,
+					Description: "If true, recursively deletes all child namespaces of the sealed namespace.",
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.handleNamespacesDeleteSealed(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {
+							{
+								Description: "OK",
+								Fields: map[string]*framework.FieldSchema{
+									"status": {
+										Type:        framework.TypeString,
+										Description: "Status of the deletion operation.",
+									},
+								},
+							},
+						},
+					},
+					Summary: "Delete a sealed namespace by wiping its physical storage.",
+				},
+			},
+
+			HelpSynopsis:    "Delete a sealed namespace.",
+			HelpDescription: "Physically deletes a sealed namespace by wiping its storage. Requires sudo privilege. Pass force=true to also delete child namespaces.",
+		},
 	}
 }
 
-// handleNamespaceSealStatus handles the "/sys/namespaces/<path>/seal-status" endpoint
-// to retrieve a seal status of the namespace.
+// handleNamespaceSealStatus handles the "/sys/namespaces/<path>/seal-status"
+// endpoint to retrieve a seal status of the namespace.
 func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -179,7 +218,8 @@ func (b *SystemBackend) handleNamespaceSealStatus() framework.OperationFunc {
 	}
 }
 
-// handleNamespacesSeal handles the "/sys/namespaces/<path>/seal" endpoint to seal the namespace.
+// handleNamespacesSeal handles the "/sys/namespaces/<path>/seal" endpoint to
+// seal the namespace.
 func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -196,7 +236,8 @@ func (b *SystemBackend) handleNamespacesSeal() framework.OperationFunc {
 	}
 }
 
-// handleNamespacesUnseal handles the "/sys/namespaces/<path>/unseal" endpoint to unseal the namespace.
+// handleNamespacesUnseal handles the "/sys/namespaces/<path>/unseal" endpoint
+// to unseal the namespace.
 func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := namespace.Canonicalize(data.Get("path").(string))
@@ -265,9 +306,41 @@ func (b *SystemBackend) handleNamespacesUnseal() framework.OperationFunc {
 	}
 }
 
+// handleNamespacesDeleteSealed handles the "/sys/namespaces/<path>/delete-sealed"
+// endpoint to delete a sealed namespace.
+func (b *SystemBackend) handleNamespacesDeleteSealed() framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := namespace.Canonicalize(data.Get("path").(string))
+
+		if len(path) > 0 && strings.Contains(path[:len(path)-1], "/") {
+			return handleError(errors.New("path must not contain /"))
+		}
+
+		if !b.System().(extendedSystemView).SudoPrivilege(ctx, req.MountPoint+req.Path, req.ClientToken) {
+			return nil, logical.ErrPermissionDenied
+		}
+
+		force := data.Get("force").(bool)
+		status, err := b.Core.namespaceStore.DeleteSealedNamespace(ctx, path, force)
+		if err != nil {
+			return handleError(err)
+		}
+
+		if status == "" {
+			resp := &logical.Response{}
+			resp.AddWarning("requested namespace does not exist")
+			return resp, nil
+		}
+
+		return &logical.Response{
+			Data: map[string]any{"status": status},
+		}, nil
+	}
+}
+
 var sysNamespacesSealsHelp = map[string][2]string{
 	"namespaces-seal": {
-		"Seal, unseal and check seal status of a namespace.",
+		"Seal, unseal and delete sealable namespaces and check their seal status.",
 		`
 This path responds to the following HTTP methods.
 
@@ -279,6 +352,9 @@ This path responds to the following HTTP methods.
 
 	GET /<path>/seal-status
 		Returns the seal status of the namespace.
+
+	DELETE /<path>/delete-sealed
+		Delete a sealed namespace by wiping its storage.
 		`,
 	},
 }

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -373,14 +373,16 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 
 		// three namespaces: "foobar", "foobar/bar" and "foobar/baz"
 		req := logical.TestRequest(t, logical.DeleteOperation, "namespaces/foobar")
-		_, err := b.HandleRequest(rootCtx, req)
-		// fails as foobar contains child namespaces — 409 Conflict returned as error
+		res, err := b.HandleRequest(rootCtx, req)
+		// fails as foobar contains child namespaces
+		require.Error(t, err)
+		require.Error(t, res.Error())
 		coded, ok := err.(logical.HTTPCodedError)
 		require.True(t, ok, "expected HTTPCodedError")
 		require.Equal(t, http.StatusConflict, coded.Code())
 
 		req = logical.TestRequest(t, logical.DeleteOperation, "namespaces/baz")
-		res, err := b.HandleRequest(nestedCtx, req)
+		res, err = b.HandleRequest(nestedCtx, req)
 		require.NoError(t, err)
 		require.Equal(t, "in-progress", res.Data["status"])
 

--- a/vault/logical_system_namespaces_test.go
+++ b/vault/logical_system_namespaces_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"testing"
 	"time"
@@ -372,13 +373,14 @@ func TestNamespaceBackend_Delete(t *testing.T) {
 
 		// three namespaces: "foobar", "foobar/bar" and "foobar/baz"
 		req := logical.TestRequest(t, logical.DeleteOperation, "namespaces/foobar")
-		res, err := b.HandleRequest(rootCtx, req)
-		// fails as foobar contains child namespaces
-		require.Error(t, err)
-		require.Error(t, res.Error())
+		_, err := b.HandleRequest(rootCtx, req)
+		// fails as foobar contains child namespaces — 409 Conflict returned as error
+		coded, ok := err.(logical.HTTPCodedError)
+		require.True(t, ok, "expected HTTPCodedError")
+		require.Equal(t, http.StatusConflict, coded.Code())
 
 		req = logical.TestRequest(t, logical.DeleteOperation, "namespaces/baz")
-		res, err = b.HandleRequest(nestedCtx, req)
+		res, err := b.HandleRequest(nestedCtx, req)
 		require.NoError(t, err)
 		require.Equal(t, "in-progress", res.Data["status"])
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1029,13 +1029,7 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 			return
 		}
 
-		parentPath, _ := entry.ParentPath()
-		parent := ns.namespacesByPath.Get(parentPath)
-		if parent == nil {
-			return
-		}
-
-		errs = ns.clearNamespaceResources(namespace.ContextWithNamespace(ctx, entry), parent, entry, false)
+		errs = ns.clearNamespaceResources(namespace.ContextWithNamespace(ctx, entry), entry, false)
 
 		if barrier != nil {
 			if err := barrier.Seal(); err != nil {
@@ -1301,7 +1295,7 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 	}
 
 	if ns.core.NamespaceSealed(namespaceToDelete) {
-		return "", errors.New("cannot delete a sealed namespace")
+		return "", errors.New("namespace is sealed")
 	}
 
 	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
@@ -1323,7 +1317,14 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 	}
 
 	ns.creationDeletionMap[namespaceToDelete.UUID] = true
-	ns.deletionDispatcher.AddJob(ns.newNamespaceDeletionJob(parent, namespaceToDelete), parent.UUID)
+	ns.deletionDispatcher.AddJob(&namespaceDeletionJob{
+		store:  ns,
+		parent: parent,
+		target: namespaceToDelete,
+		cleanup: func(ctx context.Context) error {
+			return ns.clearNamespaceResources(ctx, namespaceToDelete, true)
+		},
+	}, parent.UUID)
 
 	return "in-progress", nil
 }
@@ -1388,17 +1389,19 @@ func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string
 	}
 
 	ns.creationDeletionMap[namespaceToDelete.UUID] = true
-
-	if len(children) > 0 {
-		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedRecursiveDeletionJob(parent, namespaceToDelete), parent.UUID)
-	} else {
-		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedDeletionJob(parent, namespaceToDelete), parent.UUID)
-	}
+	ns.deletionDispatcher.AddJob(&namespaceDeletionJob{
+		store:  ns,
+		parent: parent,
+		target: namespaceToDelete,
+		cleanup: func(ctx context.Context) error {
+			return ns.wipeStorageTree(ctx, namespaceToDelete)
+		},
+	}, parent.UUID)
 
 	return "in-progress", nil
 }
 
-func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, parent, entry *namespace.Namespace, updateStorage bool) error {
+func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, entry *namespace.Namespace, updateStorage bool) error {
 	// clear expirations.
 	ns.core.expiration.StopNamespace(entry)
 
@@ -1521,6 +1524,59 @@ func (ns *NamespaceStore) clearNamespacePolicies(ctx context.Context, namespace 
 			}
 		}
 	}
+	return nil
+}
+
+// wipeStorageTree recursively wipes the storage of the passed namespace and all
+// of its children via depth-first traversal.
+func (ns *NamespaceStore) wipeStorageTree(ctx context.Context, root *namespace.Namespace) error {
+	// The queue of namespaces to delete, by UUID.
+	queue := []string{root.UUID}
+	// This keeps track of namespaces that we've checked for children already.
+	checked := make(map[string]struct{})
+
+	for len(queue) != 0 {
+		uuid := queue[len(queue)-1]
+
+		view := logical.NewStorageView(
+			ns.storage,
+			path.Join(barrier.NamespacePrefix, uuid)+"/",
+		)
+
+		// Check this namespace for children if we haven't.
+		if _, ok := checked[uuid]; !ok {
+			checked[uuid] = struct{}{}
+			// Find any child namespaces.
+			if err := logical.HandleListPage(
+				ctx, view, namespaceStoreSubPath,
+				logical.DefaultScanViewPageLimit, nil,
+				func(_ int, entries []string) (bool, error) {
+					queue = append(queue, entries...)
+					return true, nil
+				},
+			); err != nil {
+				return fmt.Errorf("failed to list child namespaces for %q: %w", uuid, err)
+			}
+			continue
+		}
+
+		// Pop off the queue.
+		queue = queue[:len(queue)-1]
+		delete(checked, uuid)
+
+		// Then wipe the namespace.
+		if err := logical.ScanViewPaginated(
+			ctx, view, ns.logger,
+			logical.DefaultScanViewPageLimit,
+			func(page int, index int, path string) (bool, error) {
+				err := view.Delete(ctx, path)
+				return err == nil, err
+			},
+		); err != nil {
+			return fmt.Errorf("failed to clear namespace view: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1718,23 +1774,16 @@ func (c *Core) NamespaceByStoragePath(ctx context.Context, path string) (*namesp
 // namespaceDeletionJob is used with NamespaceStore.deletionDispatcher to
 // gradually remove items from the namespace store.
 type namespaceDeletionJob struct {
-	store  *NamespaceStore
-	parent *namespace.Namespace
-	target *namespace.Namespace
-}
-
-func (ns *NamespaceStore) newNamespaceDeletionJob(parent *namespace.Namespace, target *namespace.Namespace) fairshare.Job {
-	return &namespaceDeletionJob{
-		store:  ns,
-		parent: parent,
-		target: target,
-	}
+	store   *NamespaceStore
+	parent  *namespace.Namespace
+	target  *namespace.Namespace
+	cleanup func(ctx context.Context) error
 }
 
 func (j *namespaceDeletionJob) Execute() error {
 	// Clearing needs to happen without holding the namespace lock.
 	ctx := namespace.ContextWithNamespace(j.store.creationDeletionJobContext, j.target)
-	err := j.store.clearNamespaceResources(ctx, j.parent, j.target, true)
+	err := j.cleanup(ctx)
 
 	j.store.lock.Lock()
 	defer j.store.lock.Unlock()
@@ -1747,181 +1796,25 @@ func (j *namespaceDeletionJob) Execute() error {
 		return fmt.Errorf("failed clearing namespace resources: %w", err)
 	}
 
-	if err := j.store.namespacesByPath.Delete(j.target.Path); err != nil {
-		return fmt.Errorf("failed to delete namespace entry in namespace tree: %w", err)
-	}
-
-	delete(j.store.namespacesByUUID, j.target.UUID)
-	delete(j.store.namespacesByAccessor, j.target.ID)
-
-	j.store.core.sealManager.RemoveNamespace(j.target)
-
+	// Remove the namespace's storage entry:
 	view := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
 	if err := view.Delete(ctx, j.target.UUID); err != nil {
 		return fmt.Errorf("failed to delete namespace storage entry: %w", err)
 	}
+
+	// Finally, remove entries from memory:
+	if err := j.store.namespacesByPath.Delete(j.target.Path); err != nil {
+		return fmt.Errorf("failed to delete namespace entry in namespace tree: %w", err)
+	}
+	delete(j.store.namespacesByUUID, j.target.UUID)
+	delete(j.store.namespacesByAccessor, j.target.ID)
+	j.store.core.sealManager.RemoveNamespace(j.target)
 
 	return nil
 }
 
 func (j *namespaceDeletionJob) OnFailure(err error) {
 	j.store.logger.Error("failed to handle namespace deletion; job may be retried", "namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
-}
-
-// namespaceSealedDeletionJob removes a sealed namespace by wiping its physical
-// storage prefix directly, without requiring barrier access. Mount table
-// entries are removed from memory only; sealed barrier data is cleared in bulk.
-type namespaceSealedDeletionJob struct {
-	store  *NamespaceStore
-	parent *namespace.Namespace
-	target *namespace.Namespace
-}
-
-func (ns *NamespaceStore) newNamespaceSealedDeletionJob(parent *namespace.Namespace, target *namespace.Namespace) fairshare.Job {
-	return &namespaceSealedDeletionJob{
-		store:  ns,
-		parent: parent,
-		target: target,
-	}
-}
-
-func (j *namespaceSealedDeletionJob) Execute() error {
-	ctx := namespace.ContextWithNamespace(j.store.creationDeletionJobContext, j.target)
-
-	// Wipe the entire storage prefix for this namespace via the root barrier.
-	// The root barrier is unsealed and can delete entries without decrypting
-	// them, covering all data including leases, tokens, mounts, and policies.
-	view := NamespaceScopedView(j.store.core.barrier, j.target)
-	if err := logical.ClearViewWithLogging(j.store.creationDeletionJobContext,
-		view, j.store.logger); err != nil {
-		return fmt.Errorf("failed to wipe storage for sealed namespace: %w", err)
-	}
-
-	j.store.lock.Lock()
-	defer j.store.lock.Unlock()
-	defer delete(j.store.creationDeletionMap, j.target.UUID)
-
-	if err := j.store.namespacesByPath.Delete(j.target.Path); err != nil {
-		return fmt.Errorf("failed to delete namespace entry in namespace tree: %w", err)
-	}
-
-	delete(j.store.namespacesByUUID, j.target.UUID)
-	delete(j.store.namespacesByAccessor, j.target.ID)
-
-	j.store.core.sealManager.RemoveNamespace(j.target)
-
-	// Remove the namespace metadata entry from the parent namespace store.
-	parentView := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
-	if err := parentView.Delete(ctx, j.target.UUID); err != nil {
-		return fmt.Errorf("failed to delete namespace storage entry: %w", err)
-	}
-
-	return nil
-}
-
-func (j *namespaceSealedDeletionJob) OnFailure(err error) {
-	j.store.logger.Error("failed to handle sealed namespace deletion; job may be retried", "namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
-	// Clear the deletion marker so a subsequent DeleteNamespace call can
-	// re-dispatch a new job without requiring a server restart.
-	j.store.lock.Lock()
-	defer j.store.lock.Unlock()
-	delete(j.store.creationDeletionMap, j.target.UUID)
-}
-
-// namespaceSealedRecursiveDeletionJob removes a sealed namespace and all its
-// descendants by wiping their physical storage via the root barrier in a single
-// pass, then cleaning up in-memory state in post-order.
-type namespaceSealedRecursiveDeletionJob struct {
-	store  *NamespaceStore
-	parent *namespace.Namespace
-	target *namespace.Namespace
-}
-
-func (ns *NamespaceStore) newNamespaceSealedRecursiveDeletionJob(parent, target *namespace.Namespace) fairshare.Job {
-	return &namespaceSealedRecursiveDeletionJob{
-		store:  ns,
-		parent: parent,
-		target: target,
-	}
-}
-
-func (j *namespaceSealedRecursiveDeletionJob) Execute() error {
-	ctx := j.store.creationDeletionJobContext
-
-	// Enumerate all descendant UUIDs via physical storage scan. Each namespace
-	// owns a flat, independent storage prefix in the root barrier
-	// (namespaces/<UUID>/), so wiping the parent prefix does not cover children.
-	// The in-memory tree cannot be used here because sealed children are not
-	// loaded into memory after a restart.
-	var descendants []string
-	if err := j.collectDescendants(ctx, j.target.UUID, &descendants); err != nil {
-		return fmt.Errorf("failed to enumerate descendants of %q: %w", j.target.Path, err)
-	}
-
-	// Wipe each descendant's storage prefix, deepest first (post-order from
-	// collectDescendants), then wipe the target itself.
-	for _, uuid := range descendants {
-		childView := NamespaceScopedView(j.store.core.barrier, &namespace.Namespace{UUID: uuid})
-		if err := logical.ClearViewWithLogging(ctx, childView, j.store.logger); err != nil {
-			return fmt.Errorf("failed to wipe storage for descendant namespace %q: %w", uuid, err)
-		}
-	}
-	targetView := NamespaceScopedView(j.store.core.barrier, j.target)
-	if err := logical.ClearViewWithLogging(ctx, targetView, j.store.logger); err != nil {
-		return fmt.Errorf("failed to wipe storage for sealed namespace %q: %w", j.target.Path, err)
-	}
-
-	j.store.lock.Lock()
-	defer j.store.lock.Unlock()
-
-	// Clean up in-memory state for nodes still present in the tree (post-order).
-	// Nodes absent from memory (sealed children not reloaded after restart) have
-	// no in-memory state to remove.
-	j.store.namespacesByPath.PostOrderTraversal(j.target.Path, func(entry *namespace.Namespace) {
-		delete(j.store.creationDeletionMap, entry.UUID)
-		delete(j.store.namespacesByUUID, entry.UUID)
-		delete(j.store.namespacesByAccessor, entry.ID)
-		j.store.core.sealManager.RemoveNamespace(entry)
-		_ = j.store.namespacesByPath.Delete(entry.Path)
-	})
-
-	// Remove the target's metadata entry from the parent namespace store.
-	nsCtx := namespace.ContextWithNamespace(ctx, j.parent)
-	parentView := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
-	if err := parentView.Delete(nsCtx, j.target.UUID); err != nil {
-		return fmt.Errorf("failed to delete namespace storage entry for %q: %w", j.target.Path, err)
-	}
-
-	return nil
-}
-
-// collectDescendants recursively enumerates all descendant namespace UUIDs
-// by scanning physical storage, appending them in post-order (deepest first).
-func (j *namespaceSealedRecursiveDeletionJob) collectDescendants(ctx context.Context, nsUUID string, out *[]string) error {
-	view := NamespaceScopedView(j.store.core.barrier, &namespace.Namespace{UUID: nsUUID})
-	childUUIDs, err := view.List(ctx, namespaceStoreSubPath)
-	if err != nil {
-		return fmt.Errorf("failed to list children of namespace %q: %w", nsUUID, err)
-	}
-	for _, childUUID := range childUUIDs {
-		childUUID = strings.TrimSuffix(childUUID, "/")
-		if err := j.collectDescendants(ctx, childUUID, out); err != nil {
-			return err
-		}
-		*out = append(*out, childUUID)
-	}
-	return nil
-}
-
-func (j *namespaceSealedRecursiveDeletionJob) OnFailure(err error) {
-	j.store.logger.Error("failed to handle sealed namespace recursive deletion; job may be retried",
-		"namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
-	// Clear the deletion marker so a subsequent DeleteNamespace call can
-	// re-dispatch a new job without requiring a server restart. The physical
-	// wipe is idempotent, so re-running it on already-wiped keys is safe.
-	j.store.lock.Lock()
-	defer j.store.lock.Unlock()
-	delete(j.store.creationDeletionMap, j.target.UUID)
 }
 
 // namespaceCreationFailureJob is used with NamespaceStore.setNamespaceLocked

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1573,7 +1573,7 @@ func (ns *NamespaceStore) wipeStorageTree(ctx context.Context, root *namespace.N
 				return err == nil, err
 			},
 		); err != nil {
-			return fmt.Errorf("failed to clear namespace view: %w", err)
+			return fmt.Errorf("failed to clear namespace view for %q: %w", uuid, err)
 		}
 	}
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -57,12 +57,6 @@ const (
 		1 /* final view clearing */
 )
 
-const (
-	errMsgNamespaceHasChildren       = "namespace has child namespaces; delete children first"
-	errMsgNamespaceIsSealed          = "namespace is sealed; use DELETE .../delete-sealed to delete a sealed namespace"
-	errMsgSealedNamespaceHasChildren = "sealed namespace has child namespaces; pass force=true to delete the entire subtree, or unseal the namespace barrier and delete children individually"
-)
-
 // NamespaceStore is used to provide durable storage of namespace. It is
 // a singleton store across the Core and contains all child namespaces.
 type NamespaceStore struct {
@@ -1279,8 +1273,7 @@ func (ns *NamespaceStore) taintNamespace(ctx context.Context, parent, namespaceT
 	return ns.pushToMounts(ctx, namespaceToTaint.Clone(false))
 }
 
-// DeleteNamespace deletes an unsealed namespace. Returns a 400 CodedError if
-// the namespace is sealed; use DeleteSealedNamespace in that case.
+// DeleteNamespace deletes an unsealed namespace.
 func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "delete_namespace"}, time.Now())
 
@@ -1298,13 +1291,63 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", nil
 	}
 
+	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
+	if namespaceToDelete.Tainted && isNamespaceDeleting {
+		return "in-progress", nil
+	}
+
+	if namespaceToDelete.ID == namespace.RootNamespaceID {
+		return "", errors.New("unable to delete root namespace")
+	}
+
+	if ns.core.NamespaceSealed(namespaceToDelete) {
+		return "", errors.New("cannot delete a sealed namespace")
+	}
+
+	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
+		return "", logical.CodedError(
+			http.StatusConflict,
+			"unable to delete namespace containing child namespaces",
+		)
+	}
+
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
-	if ns.core.NamespaceSealed(namespaceToDelete) {
-		return "", logical.CodedError(http.StatusBadRequest, errMsgNamespaceIsSealed)
+	if !namespaceToDelete.Tainted {
+		if err = ns.taintNamespace(ctx, parent, namespaceToDelete); err != nil {
+			return "", err
+		}
+	}
+
+	ns.creationDeletionMap[namespaceToDelete.UUID] = true
+	ns.deletionDispatcher.AddJob(ns.newNamespaceDeletionJob(parent, namespaceToDelete), parent.UUID)
+
+	return "in-progress", nil
+}
+
+// DeleteSealedNamespace physically deletes a sealed namespace by wiping its
+// storage through the root barrier. If the namespace has child namespaces,
+// force must be true to authorize recursive deletion of the entire subtree.
+func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string, force bool) (string, error) {
+	defer metrics.MeasureSince([]string{"namespace", "delete_sealed_namespace"}, time.Now())
+
+	unlock, err := ns.lockWithInvalidation(ctx, true)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
+	namespaceToDelete, err := ns.getNamespaceByPathLocked(ctx, path, false)
+	if err != nil || namespaceToDelete == nil {
+		return "", err
+	}
+
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
@@ -1316,78 +1359,26 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", errors.New("unable to delete root namespace")
 	}
 
-	// Physical storage check (belt-and-suspenders alongside the in-memory one).
-	view := NamespaceScopedView(ns.core.barrier, namespaceToDelete)
-	childKeys, err := view.List(ctx, namespaceStoreSubPath)
-	if err != nil {
-		return "", fmt.Errorf("cannot verify child namespaces for %q: %w", namespaceToDelete.Path, err)
-	}
-	if len(childKeys) > 0 {
-		return "", logical.CodedError(http.StatusConflict, errMsgNamespaceHasChildren)
-	}
-
-	// In-memory child check.
-	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
-		return "", logical.CodedError(http.StatusConflict, errMsgNamespaceHasChildren)
-	}
-
-	if !namespaceToDelete.Tainted {
-		if err = ns.taintNamespace(ctx, parent, namespaceToDelete); err != nil {
-			return "", err
-		}
-	}
-
-	ns.creationDeletionMap[namespaceToDelete.UUID] = true
-	ns.deletionDispatcher.AddJob(ns.newNamespaceDeletionJob(parent, namespaceToDelete), parent.UUID)
-	return "in-progress", nil
-}
-
-// DeleteSealedNamespace physically deletes a sealed namespace by wiping its
-// storage through the root barrier. The caller must hold sudo privilege.
-// If the namespace has child namespaces, force must be true to authorize
-// recursive deletion of the entire subtree.
-func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string, force bool) (string, error) {
-	defer metrics.MeasureSince([]string{"namespace", "delete_sealed_namespace"}, time.Now())
-
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return "", err
-	}
-	defer unlock()
-
-	namespaceToDelete, err := ns.getNamespaceByPathLocked(ctx, path, false)
-	if err != nil {
-		return "", err
-	}
-	if namespaceToDelete == nil {
-		return "", nil
-	}
-
-	parent, err := namespace.FromContext(ctx)
-	if err != nil {
-		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
-	}
-
 	if !ns.core.NamespaceSealed(namespaceToDelete) {
-		return "", logical.CodedError(http.StatusBadRequest, "namespace is not sealed; use DELETE sys/namespaces/<path> to delete an unsealed namespace")
+		return "", errors.New("namespace is not sealed")
 	}
 
-	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
-	if namespaceToDelete.Tainted && isNamespaceDeleting {
-		return "in-progress", nil
-	}
-
-	// Physical storage check for child namespaces. Key names are visible
-	// through the root barrier even when the child barrier is sealed, and
-	// even when children are absent from the in-memory namespace tree after
-	// a restart.
+	// Physical storage check for child namespaces. Child namespaces nested
+	// below a sealed namespace are not available via in-memory lookups, but
+	// their keys in storage are visible through the root barrier.
 	view := NamespaceScopedView(ns.core.barrier, namespaceToDelete)
-	childKeys, err := view.List(ctx, namespaceStoreSubPath)
+	children, err := view.List(ctx, namespaceStoreSubPath)
 	if err != nil {
 		return "", fmt.Errorf("cannot verify child namespaces for %q: %w", namespaceToDelete.Path, err)
 	}
-	if len(childKeys) > 0 && !force {
-		return "", logical.CodedError(http.StatusConflict, errMsgSealedNamespaceHasChildren)
+
+	if len(children) > 0 && !force {
+		return "", logical.CodedError(
+			http.StatusConflict,
+			"sealed namespace has leftover child namespaces; "+
+				"pass force=true to delete the entire tree, "+
+				"or unseal the namespace and delete children individually",
+		)
 	}
 
 	if !namespaceToDelete.Tainted {
@@ -1398,11 +1389,12 @@ func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string
 
 	ns.creationDeletionMap[namespaceToDelete.UUID] = true
 
-	if len(childKeys) > 0 {
+	if len(children) > 0 {
 		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedRecursiveDeletionJob(parent, namespaceToDelete), parent.UUID)
 	} else {
 		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedDeletionJob(parent, namespaceToDelete), parent.UUID)
 	}
+
 	return "in-progress", nil
 }
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -57,6 +57,12 @@ const (
 		1 /* final view clearing */
 )
 
+const (
+	errMsgNamespaceHasChildren       = "namespace has child namespaces; delete children first"
+	errMsgNamespaceIsSealed          = "namespace is sealed; use DELETE .../delete-sealed to delete a sealed namespace"
+	errMsgSealedNamespaceHasChildren = "sealed namespace has child namespaces; pass force=true to delete the entire subtree, or unseal the namespace barrier and delete children individually"
+)
+
 // NamespaceStore is used to provide durable storage of namespace. It is
 // a singleton store across the Core and contains all child namespaces.
 type NamespaceStore struct {
@@ -1273,7 +1279,8 @@ func (ns *NamespaceStore) taintNamespace(ctx context.Context, parent, namespaceT
 	return ns.pushToMounts(ctx, namespaceToTaint.Clone(false))
 }
 
-// DeleteNamespace is used to delete the named namespace
+// DeleteNamespace deletes an unsealed namespace. Returns a 400 CodedError if
+// the namespace is sealed; use DeleteSealedNamespace in that case.
 func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "delete_namespace"}, time.Now())
 
@@ -1291,8 +1298,13 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", nil
 	}
 
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
+	}
+
 	if ns.core.NamespaceSealed(namespaceToDelete) {
-		return "", errors.New("cannot delete sealed namespace")
+		return "", logical.CodedError(http.StatusBadRequest, errMsgNamespaceIsSealed)
 	}
 
 	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
@@ -1304,13 +1316,19 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", errors.New("unable to delete root namespace")
 	}
 
-	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
-		return "", errors.New("unable to delete namespace containing child namespaces")
+	// Physical storage check (belt-and-suspenders alongside the in-memory one).
+	view := NamespaceScopedView(ns.core.barrier, namespaceToDelete)
+	childKeys, err := view.List(ctx, namespaceStoreSubPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot verify child namespaces for %q: %w", namespaceToDelete.Path, err)
+	}
+	if len(childKeys) > 0 {
+		return "", logical.CodedError(http.StatusConflict, errMsgNamespaceHasChildren)
 	}
 
-	parent, err := namespace.FromContext(ctx)
-	if err != nil {
-		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
+	// In-memory child check.
+	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
+		return "", logical.CodedError(http.StatusConflict, errMsgNamespaceHasChildren)
 	}
 
 	if !namespaceToDelete.Tainted {
@@ -1321,7 +1339,70 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 
 	ns.creationDeletionMap[namespaceToDelete.UUID] = true
 	ns.deletionDispatcher.AddJob(ns.newNamespaceDeletionJob(parent, namespaceToDelete), parent.UUID)
+	return "in-progress", nil
+}
 
+// DeleteSealedNamespace physically deletes a sealed namespace by wiping its
+// storage through the root barrier. The caller must hold sudo privilege.
+// If the namespace has child namespaces, force must be true to authorize
+// recursive deletion of the entire subtree.
+func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string, force bool) (string, error) {
+	defer metrics.MeasureSince([]string{"namespace", "delete_sealed_namespace"}, time.Now())
+
+	unlock, err := ns.lockWithInvalidation(ctx, true)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
+	namespaceToDelete, err := ns.getNamespaceByPathLocked(ctx, path, false)
+	if err != nil {
+		return "", err
+	}
+	if namespaceToDelete == nil {
+		return "", nil
+	}
+
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error loading parent namespace from context: %w", err)
+	}
+
+	if !ns.core.NamespaceSealed(namespaceToDelete) {
+		return "", logical.CodedError(http.StatusBadRequest, "namespace is not sealed; use DELETE sys/namespaces/<path> to delete an unsealed namespace")
+	}
+
+	isNamespaceDeleting := ns.creationDeletionMap[namespaceToDelete.UUID]
+	if namespaceToDelete.Tainted && isNamespaceDeleting {
+		return "in-progress", nil
+	}
+
+	// Physical storage check for child namespaces. Key names are visible
+	// through the root barrier even when the child barrier is sealed, and
+	// even when children are absent from the in-memory namespace tree after
+	// a restart.
+	view := NamespaceScopedView(ns.core.barrier, namespaceToDelete)
+	childKeys, err := view.List(ctx, namespaceStoreSubPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot verify child namespaces for %q: %w", namespaceToDelete.Path, err)
+	}
+	if len(childKeys) > 0 && !force {
+		return "", logical.CodedError(http.StatusConflict, errMsgSealedNamespaceHasChildren)
+	}
+
+	if !namespaceToDelete.Tainted {
+		if err = ns.taintNamespace(ctx, parent, namespaceToDelete); err != nil {
+			return "", err
+		}
+	}
+
+	ns.creationDeletionMap[namespaceToDelete.UUID] = true
+
+	if len(childKeys) > 0 {
+		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedRecursiveDeletionJob(parent, namespaceToDelete), parent.UUID)
+	} else {
+		ns.deletionDispatcher.AddJob(ns.newNamespaceSealedDeletionJob(parent, namespaceToDelete), parent.UUID)
+	}
 	return "in-progress", nil
 }
 
@@ -1693,6 +1774,162 @@ func (j *namespaceDeletionJob) Execute() error {
 
 func (j *namespaceDeletionJob) OnFailure(err error) {
 	j.store.logger.Error("failed to handle namespace deletion; job may be retried", "namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
+}
+
+// namespaceSealedDeletionJob removes a sealed namespace by wiping its physical
+// storage prefix directly, without requiring barrier access. Mount table
+// entries are removed from memory only; sealed barrier data is cleared in bulk.
+type namespaceSealedDeletionJob struct {
+	store  *NamespaceStore
+	parent *namespace.Namespace
+	target *namespace.Namespace
+}
+
+func (ns *NamespaceStore) newNamespaceSealedDeletionJob(parent *namespace.Namespace, target *namespace.Namespace) fairshare.Job {
+	return &namespaceSealedDeletionJob{
+		store:  ns,
+		parent: parent,
+		target: target,
+	}
+}
+
+func (j *namespaceSealedDeletionJob) Execute() error {
+	ctx := namespace.ContextWithNamespace(j.store.creationDeletionJobContext, j.target)
+
+	// Wipe the entire storage prefix for this namespace via the root barrier.
+	// The root barrier is unsealed and can delete entries without decrypting
+	// them, covering all data including leases, tokens, mounts, and policies.
+	view := NamespaceScopedView(j.store.core.barrier, j.target)
+	if err := logical.ClearViewWithLogging(j.store.creationDeletionJobContext,
+		view, j.store.logger); err != nil {
+		return fmt.Errorf("failed to wipe storage for sealed namespace: %w", err)
+	}
+
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+	defer delete(j.store.creationDeletionMap, j.target.UUID)
+
+	if err := j.store.namespacesByPath.Delete(j.target.Path); err != nil {
+		return fmt.Errorf("failed to delete namespace entry in namespace tree: %w", err)
+	}
+
+	delete(j.store.namespacesByUUID, j.target.UUID)
+	delete(j.store.namespacesByAccessor, j.target.ID)
+
+	j.store.core.sealManager.RemoveNamespace(j.target)
+
+	// Remove the namespace metadata entry from the parent namespace store.
+	parentView := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
+	if err := parentView.Delete(ctx, j.target.UUID); err != nil {
+		return fmt.Errorf("failed to delete namespace storage entry: %w", err)
+	}
+
+	return nil
+}
+
+func (j *namespaceSealedDeletionJob) OnFailure(err error) {
+	j.store.logger.Error("failed to handle sealed namespace deletion; job may be retried", "namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
+	// Clear the deletion marker so a subsequent DeleteNamespace call can
+	// re-dispatch a new job without requiring a server restart.
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+	delete(j.store.creationDeletionMap, j.target.UUID)
+}
+
+// namespaceSealedRecursiveDeletionJob removes a sealed namespace and all its
+// descendants by wiping their physical storage via the root barrier in a single
+// pass, then cleaning up in-memory state in post-order.
+type namespaceSealedRecursiveDeletionJob struct {
+	store  *NamespaceStore
+	parent *namespace.Namespace
+	target *namespace.Namespace
+}
+
+func (ns *NamespaceStore) newNamespaceSealedRecursiveDeletionJob(parent, target *namespace.Namespace) fairshare.Job {
+	return &namespaceSealedRecursiveDeletionJob{
+		store:  ns,
+		parent: parent,
+		target: target,
+	}
+}
+
+func (j *namespaceSealedRecursiveDeletionJob) Execute() error {
+	ctx := j.store.creationDeletionJobContext
+
+	// Enumerate all descendant UUIDs via physical storage scan. Each namespace
+	// owns a flat, independent storage prefix in the root barrier
+	// (namespaces/<UUID>/), so wiping the parent prefix does not cover children.
+	// The in-memory tree cannot be used here because sealed children are not
+	// loaded into memory after a restart.
+	var descendants []string
+	if err := j.collectDescendants(ctx, j.target.UUID, &descendants); err != nil {
+		return fmt.Errorf("failed to enumerate descendants of %q: %w", j.target.Path, err)
+	}
+
+	// Wipe each descendant's storage prefix, deepest first (post-order from
+	// collectDescendants), then wipe the target itself.
+	for _, uuid := range descendants {
+		childView := NamespaceScopedView(j.store.core.barrier, &namespace.Namespace{UUID: uuid})
+		if err := logical.ClearViewWithLogging(ctx, childView, j.store.logger); err != nil {
+			return fmt.Errorf("failed to wipe storage for descendant namespace %q: %w", uuid, err)
+		}
+	}
+	targetView := NamespaceScopedView(j.store.core.barrier, j.target)
+	if err := logical.ClearViewWithLogging(ctx, targetView, j.store.logger); err != nil {
+		return fmt.Errorf("failed to wipe storage for sealed namespace %q: %w", j.target.Path, err)
+	}
+
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	// Clean up in-memory state for nodes still present in the tree (post-order).
+	// Nodes absent from memory (sealed children not reloaded after restart) have
+	// no in-memory state to remove.
+	j.store.namespacesByPath.PostOrderTraversal(j.target.Path, func(entry *namespace.Namespace) {
+		delete(j.store.creationDeletionMap, entry.UUID)
+		delete(j.store.namespacesByUUID, entry.UUID)
+		delete(j.store.namespacesByAccessor, entry.ID)
+		j.store.core.sealManager.RemoveNamespace(entry)
+		_ = j.store.namespacesByPath.Delete(entry.Path)
+	})
+
+	// Remove the target's metadata entry from the parent namespace store.
+	nsCtx := namespace.ContextWithNamespace(ctx, j.parent)
+	parentView := NamespaceScopedView(j.store.storage, j.parent).SubView(namespaceStoreSubPath)
+	if err := parentView.Delete(nsCtx, j.target.UUID); err != nil {
+		return fmt.Errorf("failed to delete namespace storage entry for %q: %w", j.target.Path, err)
+	}
+
+	return nil
+}
+
+// collectDescendants recursively enumerates all descendant namespace UUIDs
+// by scanning physical storage, appending them in post-order (deepest first).
+func (j *namespaceSealedRecursiveDeletionJob) collectDescendants(ctx context.Context, nsUUID string, out *[]string) error {
+	view := NamespaceScopedView(j.store.core.barrier, &namespace.Namespace{UUID: nsUUID})
+	childUUIDs, err := view.List(ctx, namespaceStoreSubPath)
+	if err != nil {
+		return fmt.Errorf("failed to list children of namespace %q: %w", nsUUID, err)
+	}
+	for _, childUUID := range childUUIDs {
+		childUUID = strings.TrimSuffix(childUUID, "/")
+		if err := j.collectDescendants(ctx, childUUID, out); err != nil {
+			return err
+		}
+		*out = append(*out, childUUID)
+	}
+	return nil
+}
+
+func (j *namespaceSealedRecursiveDeletionJob) OnFailure(err error) {
+	j.store.logger.Error("failed to handle sealed namespace recursive deletion; job may be retried",
+		"namespace", j.target.Path, "ns_uuid", j.target.UUID, "error", err.Error())
+	// Clear the deletion marker so a subsequent DeleteNamespace call can
+	// re-dispatch a new job without requiring a server restart. The physical
+	// wipe is idempotent, so re-running it on already-wiped keys is safe.
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+	delete(j.store.creationDeletionMap, j.target.UUID)
 }
 
 // namespaceCreationFailureJob is used with NamespaceStore.setNamespaceLocked

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"path"
 	"strconv"
 	"testing"
@@ -253,6 +252,108 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	keys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, parentNamespace.UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Empty(t, keys, "Expected empty namespace store on storage level")
+}
+
+func TestNamespaceStore_DeleteSealedNamespace(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := TestCoreUnsealed(t)
+	s := c.namespaceStore
+	ctx := namespace.RootContext(t.Context())
+
+	_ = TestCoreCreateUnsealedNamespaces(
+		t, c,
+		&namespace.Namespace{Path: "a/"},
+		&namespace.Namespace{Path: "b/"},
+		&namespace.Namespace{Path: "c/"},
+		&namespace.Namespace{Path: "tree/"},
+	)
+	TestCoreCreateNamespaces(
+		t, c,
+		&namespace.Namespace{Path: "tree/a/"},
+		&namespace.Namespace{Path: "tree/b/"},
+		&namespace.Namespace{Path: "tree/a/b/"},
+	)
+
+	type test struct {
+		path  string
+		force bool
+	}
+
+	// Inputs that should all fail while namespaces are unsealed.
+	tests := map[string]test{
+		"root":       {"/", false},
+		"root+force": {"/", true},
+		"a":          {"a/", false},
+		"a+force":    {"a/", true},
+		"tree":       {"tree/", false},
+		"tree+force": {"tree/", true},
+	}
+
+	for name, tt := range tests {
+		t.Run(fmt.Sprintf("unsealed+%s", name), func(t *testing.T) {
+			_, err := s.DeleteSealedNamespace(ctx, tt.path, tt.force)
+			require.Error(t, err)
+		})
+	}
+
+	// Seal the world:
+	require.NoError(t, s.SealNamespace(ctx, "a/"))
+	require.NoError(t, s.SealNamespace(ctx, "b/"))
+	require.NoError(t, s.SealNamespace(ctx, "tree/"))
+
+	// Inputs that should all fail even after sealing the namespaces.
+	tests = map[string]test{
+		"root":       {"/", false},
+		"root+force": {"/", true},
+		"tree":       {"tree/", false},
+	}
+
+	for name, tt := range tests {
+		t.Run(fmt.Sprintf("sealed+%s", name), func(t *testing.T) {
+			_, err := s.DeleteSealedNamespace(ctx, tt.path, tt.force)
+			require.Error(t, err)
+		})
+	}
+
+	// Inputs that should all wipe namespaces down to the last bit.
+	tests = map[string]test{
+		// We have single-level "a" and "b" in this test just so one can be
+		// force deleted while the other isn't.
+		"a":          {"a/", false},
+		"b+force":    {"b/", true},
+		"tree+force": {"tree/", true},
+	}
+
+	for name, tt := range tests {
+		t.Run(fmt.Sprintf("sealed+%s", name), func(t *testing.T) {
+			status, err := s.DeleteSealedNamespace(ctx, tt.path, tt.force)
+			require.NoError(t, err)
+			require.Equal(t, "in-progress", status)
+			// Wait for the deletion to finish asynchronously.
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				status, err := s.DeleteSealedNamespace(ctx, tt.path, tt.force)
+				require.Equal(t, "", status)
+				require.NoError(t, err)
+			}, time.Second*10, time.Millisecond*10)
+		})
+	}
+
+	// Check that the namespace store no longer knows of any namespaces, except
+	// for "c/", which we never touched:
+	namespaces, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive:     true,
+		IncludeSealed: true,
+	})
+	require.Len(t, namespaces, 1)
+	require.Equal(t, namespaces[0].Path, "c/")
+	require.NoError(t, err)
+
+	// Check that namespace storage is entirely empty, except for c's UUID.
+	keys, err := c.barrier.List(ctx, barrier.NamespacePrefix)
+	require.Len(t, keys, 1)
+	require.Equal(t, keys[0], namespaces[0].UUID+"/")
+	require.NoError(t, err)
 }
 
 // TestNamespaceStore_LockNamespace tests the lock namespace method of the namespace store
@@ -1206,66 +1307,4 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 
 	// verify after unseal
 	checkState()
-}
-
-// TestNamespaceStore_DeleteSudoSealed verifies DeleteSealedNamespace behaviour:
-// child protection, force requirement, and successful deletion paths.
-func TestNamespaceStore_DeleteSudoSealed(t *testing.T) {
-	t.Parallel()
-
-	c, _, _ := TestCoreUnsealed(t)
-	s := c.namespaceStore
-	ctx := namespace.RootContext(t.Context())
-
-	// Unsealed namespace with children: DeleteNamespace is rejected.
-	parent := &namespace.Namespace{Path: "parent/"}
-	require.NoError(t, s.SetNamespace(ctx, parent))
-	child := &namespace.Namespace{Path: "parent/child/"}
-	require.NoError(t, s.SetNamespace(ctx, child))
-
-	_, err := s.DeleteNamespace(ctx, "parent")
-	coded, ok := err.(logical.HTTPCodedError)
-	require.True(t, ok, "DeleteNamespace must reject namespace with children")
-	require.Equal(t, http.StatusConflict, coded.Code(), "DeleteNamespace must reject namespace with children")
-
-	// Sealed namespace: DeleteNamespace must be rejected.
-	TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "sealed-with-child/"})
-	TestCoreCreateNamespaces(t, c, &namespace.Namespace{Path: "sealed-with-child/sealed-child/"})
-	require.NoError(t, s.SealNamespace(ctx, "sealed-with-child"))
-
-	_, err = s.DeleteNamespace(ctx, "sealed-with-child")
-	coded, ok = err.(logical.HTTPCodedError)
-	require.True(t, ok, "DeleteNamespace must reject sealed namespace")
-	require.Equal(t, http.StatusBadRequest, coded.Code(), "DeleteNamespace must reject sealed namespace")
-
-	// Sealed namespace with children: DeleteSealedNamespace without force is rejected.
-	_, err = s.DeleteSealedNamespace(ctx, "sealed-with-child", false)
-	coded, ok = err.(logical.HTTPCodedError)
-	require.True(t, ok, "force=false must be rejected when sealed namespace has children")
-	require.Equal(t, http.StatusConflict, coded.Code(), "force=false must be rejected when sealed namespace has children")
-
-	// Sealed namespace with children: force=true succeeds and eventually removes the tree.
-	status, err := s.DeleteSealedNamespace(ctx, "sealed-with-child", true)
-	require.NoError(t, err)
-	require.Equal(t, "in-progress", status)
-
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		ns, err := s.GetNamespaceByPath(ctx, "sealed-with-child/")
-		require.NoError(ct, err)
-		require.Nil(ct, ns, "sealed namespace tree must be gone after recursive deletion completes")
-	}, 5*time.Second, 10*time.Millisecond)
-
-	// Sealed childless namespace: DeleteSealedNamespace without force succeeds (no children to protect).
-	TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "sealed-solo/"})
-	require.NoError(t, s.SealNamespace(ctx, "sealed-solo"))
-
-	status, err = s.DeleteSealedNamespace(ctx, "sealed-solo", false)
-	require.NoError(t, err)
-	require.Equal(t, "in-progress", status)
-
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		ns, err := s.GetNamespaceByPath(ctx, "sealed-solo/")
-		require.NoError(ct, err)
-		require.Nil(ct, ns, "sealed namespace must be gone after deletion completes")
-	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"strconv"
 	"testing"
@@ -997,7 +998,7 @@ func TestNamespaceDeletionSealingInteraction(t *testing.T) {
 		require.NoError(t, s.SealNamespace(ctx, "ns3"))
 
 		_, err := s.DeleteNamespace(ctx, "ns3")
-		require.Error(t, err)
+		require.ErrorContains(t, err, "namespace is sealed")
 	})
 }
 
@@ -1205,4 +1206,66 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 
 	// verify after unseal
 	checkState()
+}
+
+// TestNamespaceStore_DeleteSudoSealed verifies DeleteSealedNamespace behaviour:
+// child protection, force requirement, and successful deletion paths.
+func TestNamespaceStore_DeleteSudoSealed(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := TestCoreUnsealed(t)
+	s := c.namespaceStore
+	ctx := namespace.RootContext(t.Context())
+
+	// Unsealed namespace with children: DeleteNamespace is rejected.
+	parent := &namespace.Namespace{Path: "parent/"}
+	require.NoError(t, s.SetNamespace(ctx, parent))
+	child := &namespace.Namespace{Path: "parent/child/"}
+	require.NoError(t, s.SetNamespace(ctx, child))
+
+	_, err := s.DeleteNamespace(ctx, "parent")
+	coded, ok := err.(logical.HTTPCodedError)
+	require.True(t, ok, "DeleteNamespace must reject namespace with children")
+	require.Equal(t, http.StatusConflict, coded.Code(), "DeleteNamespace must reject namespace with children")
+
+	// Sealed namespace: DeleteNamespace must be rejected.
+	TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "sealed-with-child/"})
+	TestCoreCreateNamespaces(t, c, &namespace.Namespace{Path: "sealed-with-child/sealed-child/"})
+	require.NoError(t, s.SealNamespace(ctx, "sealed-with-child"))
+
+	_, err = s.DeleteNamespace(ctx, "sealed-with-child")
+	coded, ok = err.(logical.HTTPCodedError)
+	require.True(t, ok, "DeleteNamespace must reject sealed namespace")
+	require.Equal(t, http.StatusBadRequest, coded.Code(), "DeleteNamespace must reject sealed namespace")
+
+	// Sealed namespace with children: DeleteSealedNamespace without force is rejected.
+	_, err = s.DeleteSealedNamespace(ctx, "sealed-with-child", false)
+	coded, ok = err.(logical.HTTPCodedError)
+	require.True(t, ok, "force=false must be rejected when sealed namespace has children")
+	require.Equal(t, http.StatusConflict, coded.Code(), "force=false must be rejected when sealed namespace has children")
+
+	// Sealed namespace with children: force=true succeeds and eventually removes the tree.
+	status, err := s.DeleteSealedNamespace(ctx, "sealed-with-child", true)
+	require.NoError(t, err)
+	require.Equal(t, "in-progress", status)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		ns, err := s.GetNamespaceByPath(ctx, "sealed-with-child/")
+		require.NoError(ct, err)
+		require.Nil(ct, ns, "sealed namespace tree must be gone after recursive deletion completes")
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Sealed childless namespace: DeleteSealedNamespace without force succeeds (no children to protect).
+	TestCoreCreateUnsealedNamespaces(t, c, &namespace.Namespace{Path: "sealed-solo/"})
+	require.NoError(t, s.SealNamespace(ctx, "sealed-solo"))
+
+	status, err = s.DeleteSealedNamespace(ctx, "sealed-solo", false)
+	require.NoError(t, err)
+	require.Equal(t, "in-progress", status)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		ns, err := s.GetNamespaceByPath(ctx, "sealed-solo/")
+		require.NoError(ct, err)
+		require.Nil(ct, ns, "sealed namespace must be gone after deletion completes")
+	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -706,7 +706,7 @@ func BenchmarkClearNamespaceResources(b *testing.B) {
 
 	for b.Loop() {
 		ns := randomNamespace(s)
-		err := s.clearNamespaceResources(ctx, namespace.RootNamespace, ns, true)
+		err := s.clearNamespaceResources(ctx, ns, true)
 		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
## Description

Adds support for physical deletion of sealed namespaces. Before this change, a
namespace with its own barrier could be sealed but never removed: the deletion
path required an active barrier to clean up secrets, so a sealed namespace
became permanently undeletable.

The new behavior allows an operator holding sudo privilege to delete a sealed
namespace. The deletion is dispatched as an asynchronous job that wipes the
namespace's physical storage through the root barrier, bypassing the sealed
child barrier entirely.

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
