### PR TITLE
Drop GOOS=windows GOARCH=arm from release builds

### DIFF
--- a/changelog/3191.txt
+++ b/changelog/3191.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+packaging: Drop builds for 32-bit ARM Windows as part of its [removal from Go 1.26](https://go.dev/doc/go1.26#windows).
+```

--- a/goreleaser.other.yaml
+++ b/goreleaser.other.yaml
@@ -61,7 +61,6 @@ builds:
         goarm: "7"
       - goos: windows
         goarch: arm
-        goarm: "7"
       - goos: windows
         goarch: riscv64
     mod_timestamp: "{{ .CommitTimestamp }}"


### PR DESCRIPTION
## Description

Drop the `arm` target for `windows` (notably, not `arm64`) from release builds.

## Rationale

See https://go.dev/doc/go1.26#windows. I ran a nightly build (on my fork) for testing and Windows failed to build on main.

It deserves a changelog entry but I don't think it's worth propagating to the main deprecations page.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
