### PR TITLE
Fix up LICENSE_DEPENDENCIES.tpl for go-licenses/v2

### DIFF
--- a/LICENSE_DEPENDENCIES.tpl
+++ b/LICENSE_DEPENDENCIES.tpl
@@ -5,14 +5,16 @@ license terms. These dependencies are managed via the `go.mod` and
 `go.sum` files, and included in the source tarball.
 
 The dependencies and their licenses are as follows:
-
-{{ range . }}
+{{- range . }}
 
 ## {{ .Name }}
 
 **License:** {{ .LicenseName }}
 
+{{- if ne .LicensePath "Unknown" }}
+
 ```
 {{ .LicenseText }}
 ```
-{{ end }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Description

Update `LICENSE_DEPENDENCIES.tpl` to be compatible with the upgrade of `github.com/google/go-licenses` to v2.

## Rationale

When go-licenses fails to detect a license, `.LicenseText` would previously return an empty string. In v2, it instead attempts to read `"Unknown"` as a literal file path, which fails.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
