### PR TITLE
Add Utimaco to the ecosystem page

### DIFF
--- a/website/content/ecosystem/integrators.mdx
+++ b/website/content/ecosystem/integrators.mdx
@@ -49,6 +49,10 @@ import Member from './lib/Member.tsx';
   <Member title="Nitrokey" logoName="nitrokey">
     [Nitrokey](https://www.nitrokey.com/) provides Open Source security hardware. Nitrokey's [NetHSM](https://www.nitrokey.com/products/nethsm) offers a secure and highly available key storage, which protects your OpenBao secrets with hardware backed sealing.
   </Member>
+
+  <Member title="Utimaco" logoName="utimaco">
+    [Utimaco](https://utimaco.com/) is a global platform provider of trusted Cybersecurity and Data Protection solutions, and develops leading on-premises and cloud-based hardware security modules, solutions for key management and data protection which integrate with OpenBao.
+  </Member>
 </Randomize>
 </div>
 </div>

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "lodash": "^4.18.1",
-    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#5f0dacaa5e36fcf5d8cad04e669f249242734d11",
+    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#4b67bcec69b9efbe2ea7c6e297f4420ac881e16d",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       openbao-ecosystem-logos:
-        specifier: github:openbao/openbao-ecosystem-logos#5f0dacaa5e36fcf5d8cad04e669f249242734d11
-        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11
+        specifier: github:openbao/openbao-ecosystem-logos#4b67bcec69b9efbe2ea7c6e297f4420ac881e16d
+        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.6)
@@ -4755,8 +4755,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11:
-    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d:
+    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d}
     version: 0.0.0
 
   opener@1.5.2:
@@ -12571,7 +12571,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/5f0dacaa5e36fcf5d8cad04e669f249242734d11: {}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d: {}
 
   opener@1.5.2: {}
 


### PR DESCRIPTION
## Description

Adds Utimaco to the integrators section on behalf and request of the Utimaco team.

## Rationale

The Utimaco HSM products officially integrate with OpenBao, e.g. via PKCS#11.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
