### PR TITLE
Trigger mount reload on remounting

### DIFF
--- a/changelog/3212.txt
+++ b/changelog/3212.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+command: Fix `bao auth move` not prepending `auth/` resulting in possible secret mount remount.
+```
+```release-note:bug
+core: Fix mount remount operations not reloading mount entries on standby nodes on invalidation.
+```

--- a/internal/command/auth_move.go
+++ b/internal/command/auth_move.go
@@ -85,8 +85,8 @@ func (c *AuthMoveCommand) Run(args []string) int {
 	}
 
 	// Grab the source and destination
-	source := ensureTrailingSlash(args[0])
-	destination := ensureTrailingSlash(args[1])
+	source := fmt.Sprintf("auth/%s", ensureTrailingSlash(args[0]))
+	destination := fmt.Sprintf("auth/%s", ensureTrailingSlash(args[1]))
 
 	client, err := c.Client()
 	if err != nil {

--- a/internal/command/auth_move_test.go
+++ b/internal/command/auth_move_test.go
@@ -46,7 +46,7 @@ func TestAuthMoveCommand_Run(t *testing.T) {
 		{
 			"non_existent",
 			[]string{"not_real", "over_here"},
-			"Error moving auth method not_real/ to over_here/",
+			"Error moving auth method auth/not_real/ to auth/over_here/",
 			2,
 		},
 	}
@@ -93,7 +93,7 @@ func TestAuthMoveCommand_Run(t *testing.T) {
 		}
 
 		code := cmd.Run([]string{
-			"auth/my-auth/", "auth/my-auth-2/",
+			"my-auth/", "my-auth-2/",
 		})
 		if exp := 0; code != exp {
 			t.Errorf("expected %d to be %d", code, exp)
@@ -125,7 +125,7 @@ func TestAuthMoveCommand_Run(t *testing.T) {
 		cmd.client = client
 
 		code := cmd.Run([]string{
-			"auth/my-auth/", "auth/my-auth-2/",
+			"my-auth/", "my-auth-2/",
 		})
 		if exp := 2; code != exp {
 			t.Errorf("expected %d to be %d", code, exp)

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -322,7 +322,6 @@ func (c *Core) removeCredEntry(ctx context.Context, path string, updateStorage b
 }
 
 func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateStorage bool) error {
-	// Taint the entry from the auth table
 	newTable := c.auth.ShallowClone()
 	entry, err := newTable.Remove(ctx, path)
 	if err != nil {
@@ -345,7 +344,7 @@ func (c *Core) removeCredEntryWithLock(ctx context.Context, path string, updateS
 	return nil
 }
 
-func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPathDetails, updateStorage bool) error {
+func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPathDetails) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -385,7 +384,7 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	}
 
 	// Mark the entry as tainted
-	if err := c.taintCredEntry(ctx, src.Namespace.ID, src.MountPath, updateStorage); err != nil {
+	if err := c.taintCredEntry(ctx, src.Namespace.ID, src.MountPath, true); err != nil {
 		return err
 	}
 
@@ -408,18 +407,16 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 		return fmt.Errorf("path in use at %q", match)
 	}
 
-	mountEntry.Tainted = false
 	mountEntry.NamespaceID = dst.Namespace.ID
 	mountEntry.Namespace = dst.Namespace
 	srcPath := mountEntry.Path
 	mountEntry.Path = strings.TrimPrefix(dst.MountPath, routing.CredentialRoutePrefix)
 
-	// Update the mount table
+	// Update the auth table
 	if err := c.persistAuth(ctx, c.NamespaceView(mountEntry.Namespace), c.auth, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.Namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
-		mountEntry.Tainted = true
 		c.authLock.Unlock()
 		return fmt.Errorf("failed to update auth table with error %w", err)
 	}
@@ -450,12 +447,13 @@ func (c *Core) remountCredential(ctx context.Context, src, dst namespace.MountPa
 	}
 	c.authLock.Unlock()
 
-	// Un-taint the new path in the router
-	if err := c.router.Untaint(ctx, dstRelativePath); err != nil {
+	// Mark the entry as untainted.
+	if err := c.untaintCredEntry(ctx, dst.Namespace.ID, dst.MountPath, true); err != nil {
 		return err
 	}
 
-	return nil
+	// Un-taint the new path in the router.
+	return c.router.Untaint(ctx, dstRelativePath)
 }
 
 // taintCredEntry is used to mark an entry in the auth table as tainted
@@ -463,20 +461,39 @@ func (c *Core) taintCredEntry(ctx context.Context, nsID, path string, updateStor
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 
-	// Taint the entry from the auth table
-	// We do this on the original since setting the taint operates
-	// on the entries which a shallow clone shares anyways
-	entry := c.auth.SetTaint(nsID, strings.TrimPrefix(path, routing.CredentialRoutePrefix))
-
-	// Ensure there was a match
+	// As modifying the taint of an entry affects shallow clones,
+	// we simply use the original.
+	entry := c.auth.Taint(nsID, strings.TrimPrefix(path, routing.CredentialRoutePrefix))
 	if entry == nil {
-		return fmt.Errorf("no matching backend for path %q namespaceID %q", path, nsID)
+		return logical.CodedError(500, "failed to taint entry in auth table")
 	}
 
 	if updateStorage {
-		// Update the auth table
 		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace), c.auth, &entry.Local, entry.UUID); err != nil {
-			return fmt.Errorf("failed to update auth table: %w", err)
+			return logical.CodedError(500, "failed to taint entry in auth table: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// untaintCredEntry is used to mark an entry in the auth table as untainted.
+func (c *Core) untaintCredEntry(ctx context.Context, nsID, path string, updateStorage bool) error {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+
+	// As modifying the taint of an entry affects shallow clones,
+	// we simply use the original
+	entry := c.auth.Untaint(nsID, strings.TrimPrefix(path, routing.CredentialRoutePrefix))
+	if entry == nil {
+		c.logger.Error("nil entry found untainting entry in auth table", "path", path)
+		return logical.CodedError(500, "failed to untaint entry in auth table")
+	}
+
+	if updateStorage {
+		if err := c.persistAuth(ctx, c.NamespaceView(entry.Namespace), c.auth, &entry.Local, entry.UUID); err != nil {
+			c.logger.Error("failed to untaint entry in auth table", "error", err)
+			return logical.CodedError(500, "failed to untaint entry in auth table: %v", err)
 		}
 	}
 

--- a/internal/vault/auth_test.go
+++ b/internal/vault/auth_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -16,11 +17,13 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/v2/internal/builtin/credential/userpass"
 	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/v2/internal/helper/versions"
 	be "github.com/openbao/openbao/v2/internal/vault/backend"
+	"github.com/openbao/openbao/v2/internal/vault/barrier"
 	"github.com/openbao/openbao/v2/internal/vault/routing"
 )
 
@@ -705,10 +708,10 @@ func TestCore_CredentialInitialize(t *testing.T) {
 	}
 }
 
-func remountCredentialFromRoot(ctx context.Context, c *Core, src, dst string, updateStorage bool) error {
+func remountCredentialFromRoot(ctx context.Context, c *Core, src, dst string) error {
 	srcPathDetails := c.splitNamespaceAndMountFromPath("", src)
 	dstPathDetails := c.splitNamespaceAndMountFromPath("", dst)
-	return c.remountCredential(namespace.RootContext(ctx), srcPathDetails, dstPathDetails, updateStorage)
+	return c.remountCredential(namespace.RootContext(ctx), srcPathDetails, dstPathDetails)
 }
 
 func TestCore_RemountCredential(t *testing.T) {
@@ -734,7 +737,7 @@ func TestCore_RemountCredential(t *testing.T) {
 		t.Fatalf("missing mount, match: %q", match)
 	}
 
-	err = remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/bar", true)
+	err = remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/bar")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -812,7 +815,7 @@ func TestCore_RemountCredential_Cleanup(t *testing.T) {
 	}
 
 	// Disable should cleanup
-	err = remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/bar", true)
+	err = remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/bar")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -837,7 +840,8 @@ func TestCore_RemountCredential_Cleanup(t *testing.T) {
 }
 
 func TestCore_RemountCredential_Namespaces(t *testing.T) {
-	c, keys, _ := TestCoreUnsealed(t)
+	require.NoError(t, be.AddTestCredentialBackend("userpass", userpass.Factory))
+	c, keys, rootToken := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "ns/"}
 	unsealable1 := &namespace.Namespace{Path: "ns/unsealable1/"}
 	unsealable2 := &namespace.Namespace{Path: "ns/unsealable2/"}
@@ -850,11 +854,19 @@ func TestCore_RemountCredential_Namespaces(t *testing.T) {
 	me := &routing.MountEntry{
 		Table: routing.CredentialTableType,
 		Path:  "foo",
-		Type:  "noop",
+		Type:  "userpass",
 	}
 
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 	require.NoError(t, c.enableCredential(namespace.ContextWithNamespace(ctx, unsealable1), me))
+
+	// Write data to userpass mount
+	req := logical.TestRequest(t, logical.CreateOperation, "unsealable1/auth/foo/users/user")
+	req.ClientToken = rootToken
+	req.Data = map[string]any{"password": "pass"}
+	resp, err := c.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Error())
 
 	tests := []struct {
 		name string
@@ -923,7 +935,7 @@ func TestCore_RemountCredential_Namespaces(t *testing.T) {
 			match := c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
 			require.Equalf(t, tt.src.Namespace.Path+tt.src.MountPath, match, "missing mount, match: %q", match)
 
-			require.NoError(t, c.remountCredential(ctx, tt.src, tt.dst, true))
+			require.NoError(t, c.remountCredential(ctx, tt.src, tt.dst))
 
 			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
 			require.Equalf(t, "", match, "auth method still at old location, match: %q", match)
@@ -951,13 +963,27 @@ func TestCore_RemountCredential_Namespaces(t *testing.T) {
 
 			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
 			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "auth method not at new location after unseal, match: %q", match)
+
+			// Read written auth user
+			req := logical.TestRequest(t, logical.ReadOperation, path.Join(tt.dst.MountPath, "users", "user"))
+			req.ClientToken = rootToken
+			resp, err := c.HandleRequest(dstCtx, req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.Data)
+
+			// Verify storage entries have moved
+			view := c.NamespaceView(tt.dst.Namespace)
+			creds, err := view.List(ctx, path.Join(barrier.CredentialBarrierPrefix, me.UUID)+"/")
+			require.NoError(t, err)
+			require.Len(t, creds, 1)
+			require.Equal(t, "user/", creds[0])
 		})
 	}
 }
 
 func TestCore_RemountCredential_InvalidSource(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := remountCredentialFromRoot(t.Context(), c, "foo", "auth/bar", true)
+	err := remountCredentialFromRoot(t.Context(), c, "foo", "auth/bar")
 	if err.Error() != `cannot remount non-auth mount "foo/"` {
 		t.Fatalf("err: %v", err)
 	}
@@ -965,7 +991,7 @@ func TestCore_RemountCredential_InvalidSource(t *testing.T) {
 
 func TestCore_RemountCredential_InvalidDestination(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := remountCredentialFromRoot(t.Context(), c, "auth/foo", "bar", true)
+	err := remountCredentialFromRoot(t.Context(), c, "auth/foo", "bar")
 	if err.Error() != `cannot remount auth mount to non-auth mount "bar/"` {
 		t.Fatalf("err: %v", err)
 	}
@@ -973,7 +999,7 @@ func TestCore_RemountCredential_InvalidDestination(t *testing.T) {
 
 func TestCore_RemountCredential_ProtectedSource(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := remountCredentialFromRoot(t.Context(), c, "auth/token", "auth/bar", true)
+	err := remountCredentialFromRoot(t.Context(), c, "auth/token", "auth/bar")
 	if err.Error() != `cannot remount "auth/token/"` {
 		t.Fatalf("err: %v", err)
 	}
@@ -981,7 +1007,7 @@ func TestCore_RemountCredential_ProtectedSource(t *testing.T) {
 
 func TestCore_RemountCredential_ProtectedDestination(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/token", true)
+	err := remountCredentialFromRoot(t.Context(), c, "auth/foo", "auth/token")
 	if err.Error() != `cannot remount to "auth/token/"` {
 		t.Fatalf("err: %v", err)
 	}

--- a/internal/vault/invalidation_test.go
+++ b/internal/vault/invalidation_test.go
@@ -822,14 +822,14 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			uuid := resp.Data["uuid"].(string)
 			entryPath := path.Join(coreMountConfigPath, uuid)
 
-			triggerReadCall := func(collect require.TestingT, expectedErrors ...string) {
+			triggerReadCall := func(collect require.TestingT, path string, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
 					ClientToken: root,
-					Path:        "my-kv-mount",
+					Path:        path,
 				}, expectedErrors...)
 			}
-			triggerReadCall(t)
+			triggerReadCall(t, "my-kv-mount")
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			ns, err := namespace.FromContext(ctx)
@@ -856,7 +856,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 
 			// 6. verify 404
-			triggerReadCall(t, "unsupported path")
+			triggerReadCall(t, "my-kv-mount", "unsupported path")
 
 			// 7. Manipulate mount table in storage: restore mount
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
@@ -869,15 +869,26 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 				defer c.mountsLock.RUnlock()
 				require.Equal(collect, mountTableCount+1, len(c.mounts.Entries), "expected mount table to grew by one")
 				require.EqualValues(collect, 2, factoryCallCount.Load(), "expected factory to be called exactly twice")
-				triggerReadCall(collect)
+				triggerReadCall(collect, "my-kv-mount")
 			}, 10*time.Second, 10*time.Millisecond)
 			require.EqualValues(t, 2, readCallCount.Load(), "expected two read calls")
 
-			// 9. Manipulate mount table in storage: taint mount
+			// 9. Remount secret mount
+			require.NoError(t, c.remountSecretsEngine(ctx, c.splitNamespaceAndMountFromPath(ns.Path, "my-kv-mount"), c.splitNamespaceAndMountFromPath(ns.Path, "new-kv-mount")))
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				triggerReadCall(t, "my-kv-mount", "unsupported path")
+				triggerReadCall(t, "new-kv-mount")
+			}, 10*time.Second, 10*time.Millisecond)
+
+			// 10. Manipulate mount table in storage: taint mount
+			storageEntry, err = view.Get(ctx, entryPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", view.Prefix()+entryPath)
+
 			mountEntry := new(routing.MountEntry)
 			require.NoError(t, jsonutil.DecodeJSON(storageEntry.Value, mountEntry))
 			mountEntry.Tainted = true
-
 			updatedData, err := jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
@@ -886,14 +897,14 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 				Value: updatedData,
 			})
 
-			// 10. call invalidate
+			// 11. call invalidate
 			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				triggerReadCall(collect, "unsupported path")
+				triggerReadCall(collect, "new-kv-mount", "unsupported path")
 			}, 10*time.Second, 10*time.Millisecond)
 
-			// 11. Manipulate mount table in storage: untaint and allow header
+			// 12. Manipulate mount table in storage: untaint and allow header
 			mountEntry.Tainted = false
 			mountEntry.Config.AllowedResponseHeaders = []string{"Test-Header"}
 
@@ -905,21 +916,21 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 				Value: updatedData,
 			})
 
-			// 12. call invalidate
+			// 13. call invalidate
 			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				resp := testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
 					ClientToken: root,
-					Path:        "my-kv-mount",
+					Path:        "new-kv-mount",
 				})
 				require.Equal(collect, map[string][]string{
 					"Test-Header": {"test-value"},
 				}, resp.Headers)
 			}, 10*time.Second, 10*time.Millisecond)
 
-			// 13. Manipulate mount table in storage: change kv version
+			// 14. Manipulate mount table in storage: change kv version
 			mountEntry.Options["version"] = "2"
 
 			updatedData, err = jsonutil.EncodeJSON(mountEntry)
@@ -930,12 +941,12 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 				Value: updatedData,
 			})
 
-			// 14. call invalidate
+			// 15. call invalidate
 			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				require.EqualValues(collect, 3, factoryCallCount.Load(), "expected factory to be called exactly thrice")
-				triggerReadCall(collect)
+				require.EqualValues(collect, 3, factoryCallCount.Load(), "expected factory to be called exactly 3 times")
+				triggerReadCall(collect, "new-kv-mount")
 			}, 10*time.Second, 10*time.Millisecond)
 		})
 	}
@@ -1021,14 +1032,14 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.mounts.Entries), "expected mount table to grew by one")
 
-			triggerReadCall := func(collect require.TestingT, expectedErrors ...string) {
+			triggerReadCall := func(collect require.TestingT, path string, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
 					ClientToken: root,
-					Path:        "my-kv-mount",
+					Path:        path,
 				}, expectedErrors...)
 			}
-			triggerReadCall(t)
+			triggerReadCall(t, "my-kv-mount")
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			ns, err := namespace.FromContext(ctx)
@@ -1067,7 +1078,7 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 
 			// 5. verify 404
-			triggerReadCall(t, "unsupported path")
+			triggerReadCall(t, "my-kv-mount", "unsupported path")
 
 			// 6. Manipulate mount table in storage: restore mount
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
@@ -1080,9 +1091,35 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 				defer c.mountsLock.RUnlock()
 				require.Equal(collect, mountTableCount+1, len(c.mounts.Entries), "expected mount table to grew by one")
 				require.EqualValues(collect, 2, factoryCallCount.Load(), "expected factory to be called exactly twice")
-				triggerReadCall(collect)
+				triggerReadCall(collect, "my-kv-mount")
 			}, 10*time.Second, 10*time.Millisecond)
 			require.EqualValues(t, 2, readCallCount.Load(), "expected two read calls")
+
+			// 8. Remount secret mount
+			require.NoError(t, c.remountSecretsEngine(ctx, c.splitNamespaceAndMountFromPath(ns.Path, "my-kv-mount"), c.splitNamespaceAndMountFromPath(ns.Path, "new-kv-mount")))
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				triggerReadCall(t, "my-kv-mount", "unsupported path")
+				triggerReadCall(t, "new-kv-mount")
+			}, 10*time.Second, 10*time.Millisecond)
+
+			// 9. Manipulate mount table in storage: taint mount
+			mountTable.Entries[len(mountTable.Entries)-1].Tainted = true
+
+			updatedData, err = jsonutil.EncodeJSON(mountTable)
+			require.NoError(t, err)
+
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   coreMountConfigPath,
+				Value: updatedData,
+			})
+
+			// 10. call invalidate
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreMountConfigPath))
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				triggerReadCall(collect, "new-kv-mount", "unsupported path")
+			}, 10*time.Second, 10*time.Millisecond)
 		})
 	}
 }
@@ -1169,14 +1206,14 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			uuid := resp.Data["uuid"].(string)
 			entryPath := path.Join(coreAuthConfigPath, uuid)
 
-			callLogin := func(collect require.TestingT, expectedErrors ...string) {
+			callLogin := func(collect require.TestingT, path string, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
 					ClientToken: root,
-					Path:        "auth/my-auth",
+					Path:        fmt.Sprintf("auth/%s", path),
 				}, expectedErrors...)
 			}
-			callLogin(t)
+			callLogin(t, "my-auth")
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			ns, err := namespace.FromContext(ctx)
@@ -1203,7 +1240,7 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 
 			// 6. verify 404
-			callLogin(t, "unsupported path")
+			callLogin(t, "my-auth", "unsupported path")
 
 			// 7. Manipulate mount table in storage: restore mount
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
@@ -1216,15 +1253,26 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 				defer c.authLock.RUnlock()
 				require.Equal(collect, mountTableCount+1, len(c.auth.Entries), "expected mount table to grew by one")
 				require.EqualValues(collect, 2, factoryCallCount.Load(), "expected factory to be called exactly twice")
-				callLogin(collect)
+				callLogin(collect, "my-auth")
 			}, 10*time.Second, 10*time.Millisecond)
 			require.EqualValues(t, 2, readCallCount.Load(), "expected two read calls")
 
-			// 9. Manipulate mount table in storage: taint mount
+			// 9. Remount credential mount
+			require.NoError(t, c.remountCredential(ctx, c.splitNamespaceAndMountFromPath(ns.Path, "auth/my-auth"), c.splitNamespaceAndMountFromPath(ns.Path, "auth/new-auth")))
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				callLogin(t, "my-auth", "unsupported path")
+				callLogin(t, "new-auth")
+			}, 10*time.Second, 10*time.Millisecond)
+
+			// 10. Manipulate mount table in storage: taint mount
+			storageEntry, err = view.Get(ctx, entryPath)
+			require.NoError(t, err)
+			require.NotNil(t, storageEntry, "expected mount entry to be written at %s", view.Prefix()+entryPath)
+
 			mountEntry := new(routing.MountEntry)
 			require.NoError(t, jsonutil.DecodeJSON(storageEntry.Value, mountEntry))
 			mountEntry.Tainted = true
-
 			updatedData, err := jsonutil.EncodeJSON(mountEntry)
 			require.NoError(t, err)
 
@@ -1233,11 +1281,11 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 				Value: updatedData,
 			})
 
-			// 10. call invalidate
+			// 11. call invalidate
 			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				callLogin(collect, "unsupported path")
+				callLogin(collect, "new-auth", "unsupported path")
 			}, 10*time.Second, 10*time.Millisecond)
 		})
 	}
@@ -1322,14 +1370,14 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 			require.Equal(t, mountTableCount+1, len(c.auth.Entries), "expected mount table to grew by one")
 
-			callLogin := func(collect require.TestingT, expectedErrors ...string) {
+			callLogin := func(collect require.TestingT, path string, expectedErrors ...string) {
 				testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
 					Operation:   logical.ReadOperation,
 					ClientToken: root,
-					Path:        "auth/my-auth",
+					Path:        fmt.Sprintf("auth/%s", path),
 				}, expectedErrors...)
 			}
-			callLogin(t)
+			callLogin(t, "my-auth")
 			require.EqualValues(t, 1, readCallCount.Load(), "expected one read call")
 
 			ns, err := namespace.FromContext(ctx)
@@ -1368,7 +1416,7 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			require.EqualValues(t, 1, factoryCallCount.Load(), "expected factory to be called exactly once")
 
 			// 5. verify 404
-			callLogin(t, "unsupported path")
+			callLogin(t, "my-auth", "unsupported path")
 
 			// 6. Manipulate mount table in storage: restore mount
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
@@ -1381,12 +1429,19 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 				defer c.authLock.RUnlock()
 				require.Equal(collect, mountTableCount+1, len(c.auth.Entries), "expected mount table to grew by one")
 				require.EqualValues(collect, 2, factoryCallCount.Load(), "expected factory to be called exactly twice")
-				callLogin(collect)
+				callLogin(collect, "my-auth")
 			}, 10*time.Second, 10*time.Millisecond)
 			require.EqualValues(t, 2, readCallCount.Load(), "expected two read calls")
 
-			// 8. Manipulate mount table in storage: taint mount
-			require.NoError(t, jsonutil.DecodeJSON(storageEntry.Value, mountTable))
+			// 8. Remount credential mount
+			require.NoError(t, c.remountCredential(ctx, c.splitNamespaceAndMountFromPath(ns.Path, "auth/my-auth"), c.splitNamespaceAndMountFromPath(ns.Path, "auth/new-auth")))
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				callLogin(t, "my-auth", "unsupported path")
+				callLogin(t, "new-auth")
+			}, 10*time.Second, 10*time.Millisecond)
+
+			// 9. Manipulate mount table in storage: taint mount
 			mountTable.Entries[len(mountTable.Entries)-1].Tainted = true
 
 			updatedData, err = jsonutil.EncodeJSON(mountTable)
@@ -1397,11 +1452,11 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 				Value: updatedData,
 			})
 
-			// 9. call invalidate
+			// 10. call invalidate
 			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreAuthConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				callLogin(collect, "unsupported path")
+				callLogin(collect, "new-auth", "unsupported path")
 			}, 10*time.Second, 10*time.Millisecond)
 		})
 	}

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -1381,9 +1381,9 @@ func (b *SystemBackend) moveMount(ns *namespace.Namespace, logger log.Logger, mi
 	// Attempt remount
 	switch entry.Table {
 	case routing.CredentialTableType:
-		err = b.Core.remountCredential(revokeCtx, fromPathDetails, toPathDetails, true)
+		err = b.Core.remountCredential(revokeCtx, fromPathDetails, toPathDetails)
 	case routing.MountTableType:
-		err = b.Core.remountSecretsEngine(revokeCtx, fromPathDetails, toPathDetails, true)
+		err = b.Core.remountSecretsEngine(revokeCtx, fromPathDetails, toPathDetails)
 	default:
 		return fmt.Errorf("cannot remount mount of table %q", entry.Table)
 	}

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -409,11 +409,7 @@ func (c *Core) unmount(ctx context.Context, path string) error {
 	}
 
 	// Unmount mount internally
-	if err := c.unmountInternal(ctx, path, true); err != nil {
-		return err
-	}
-
-	return nil
+	return c.unmountInternal(ctx, path, true)
 }
 
 func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage bool) error {
@@ -439,7 +435,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 	backend := c.router.MatchingBackend(ctx, path)
 
 	// Mark the entry as tainted
-	if err := c.taintMountEntry(ctx, ns.ID, path, updateStorage, true); err != nil {
+	if err := c.taintMountEntry(ctx, ns.ID, path, updateStorage); err != nil {
 		c.logger.Error("failed to taint mount entry for path being unmounted", "error", err, "namespace", ns.Path, "path", path)
 		return err
 	}
@@ -545,24 +541,46 @@ func (c *Core) removeMountEntryWithLock(ctx context.Context, path string, update
 	return nil
 }
 
-// taintMountEntry is used to mark an entry in the mount table as tainted
-func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, updateStorage, unmounting bool) error {
+// taintMountEntry is used to mark an entry in the mount table as tainted.
+func (c *Core) taintMountEntry(ctx context.Context, nsID, mountPath string, updateStorage bool) error {
+	c.mountsLock.Lock()
+	defer c.mountsLock.Unlock()
+
+	// As modifying the taint of an entry affects shallow clones,
+	// we simply use the original.
+	entry := c.mounts.Taint(nsID, mountPath)
+	if entry == nil {
+		c.logger.Error("nil entry found tainting entry in mount table", "path", mountPath)
+		return logical.CodedError(500, "failed to taint entry in mount table")
+	}
+
+	if updateStorage {
+		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace), c.mounts, &entry.Local, entry.UUID); err != nil {
+			c.logger.Error("failed to taint entry in mount table", "error", err)
+			return logical.CodedError(500, "failed to taint entry in mount table: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// untaintMountEntry is used to mark an entry in the mount table as untainted.
+func (c *Core) untaintMountEntry(ctx context.Context, nsID, mountPath string, updateStorage bool) error {
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
 
 	// As modifying the taint of an entry affects shallow clones,
 	// we simply use the original
-	entry := c.mounts.SetTaint(nsID, mountPath)
+	entry := c.mounts.Untaint(nsID, mountPath)
 	if entry == nil {
-		c.logger.Error("nil entry found tainting entry in mounts table", "path", mountPath)
-		return logical.CodedError(500, "failed to taint entry in mounts table")
+		c.logger.Error("nil entry found untainting entry in mount table", "path", mountPath)
+		return logical.CodedError(500, "failed to untaint entry in mount table")
 	}
 
 	if updateStorage {
-		// Update the mount table
 		if err := c.persistMounts(ctx, c.NamespaceView(entry.Namespace), c.mounts, &entry.Local, entry.UUID); err != nil {
-			c.logger.Error("failed to taint entry in mounts table", "error", err)
-			return logical.CodedError(500, "failed to taint entry in mounts table: %v", err)
+			c.logger.Error("failed to untaint entry in mount table", "error", err)
+			return logical.CodedError(500, "failed to untaint entry in mount table: %v", err)
 		}
 	}
 
@@ -614,7 +632,7 @@ func (c *Core) handleDeprecatedMountEntry(ctx context.Context, entry *routing.Mo
 	return nil, nil
 }
 
-func (c *Core) remountSecretsEngineCurrentNamespace(ctx context.Context, src, dst string, updateStorage bool) error {
+func (c *Core) remountSecretsEngineCurrentNamespace(ctx context.Context, src, dst string) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -622,11 +640,11 @@ func (c *Core) remountSecretsEngineCurrentNamespace(ctx context.Context, src, ds
 
 	srcPathDetails := c.splitNamespaceAndMountFromPath(ns.Path, src)
 	dstPathDetails := c.splitNamespaceAndMountFromPath(ns.Path, dst)
-	return c.remountSecretsEngine(ctx, srcPathDetails, dstPathDetails, updateStorage)
+	return c.remountSecretsEngine(ctx, srcPathDetails, dstPathDetails)
 }
 
 // remountSecretsEngine is used to remount a path at a new mount point.
-func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.MountPathDetails, updateStorage bool) error {
+func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.MountPathDetails) error {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return err
@@ -657,7 +675,7 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	}
 
 	// Mark the entry as tainted
-	if err := c.taintMountEntry(ctx, src.Namespace.ID, src.MountPath, updateStorage, false); err != nil {
+	if err := c.taintMountEntry(ctx, src.Namespace.ID, src.MountPath, true); err != nil {
 		return err
 	}
 
@@ -670,9 +688,8 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	// various periodic funcs (e.g., PKI) can legitimately error; the
 	// periodic rollback manager logs these errors rather than failing
 	// replication like returning this error would do.
-	rCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
 	if c.rollback != nil && c.router.MatchingBackend(ctx, srcRelativePath) != nil {
-		if err := c.rollback.Rollback(rCtx, srcRelativePath); err != nil {
+		if err := c.rollback.Rollback(ctx, srcRelativePath); err != nil {
 			c.logger.Error("ignoring rollback error during remount", "error", err, "path", src.Namespace.Path+src.MountPath)
 			err = nil //nolint:ineffassign // we explicitly ignore the error
 		}
@@ -690,23 +707,16 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 		return fmt.Errorf("path in use at %q", match)
 	}
 
-	mountEntry.Tainted = false
 	mountEntry.NamespaceID = dst.Namespace.ID
 	mountEntry.Namespace = dst.Namespace
 	srcPath := mountEntry.Path
 	mountEntry.Path = dst.MountPath
-
-	dstBarrierView, err := c.mountEntryView(mountEntry)
-	if err != nil {
-		return err
-	}
 
 	// Update the mount table
 	if err := c.persistMounts(ctx, c.NamespaceView(mountEntry.Namespace), c.mounts, &mountEntry.Local, mountEntry.UUID); err != nil {
 		mountEntry.Namespace = src.Namespace
 		mountEntry.NamespaceID = src.Namespace.ID
 		mountEntry.Path = srcPath
-		mountEntry.Tainted = true
 		c.mountsLock.Unlock()
 		return fmt.Errorf("failed to update mount table with error %+v", err)
 	}
@@ -717,6 +727,11 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 			c.mountsLock.Unlock()
 			return err
 		}
+	}
+
+	dstBarrierView, err := c.mountEntryView(mountEntry)
+	if err != nil {
+		return err
 	}
 
 	// Remount the backend
@@ -731,12 +746,13 @@ func (c *Core) remountSecretsEngine(ctx context.Context, src, dst namespace.Moun
 	}
 	c.mountsLock.Unlock()
 
-	// Un-taint the path
-	if err := c.router.Untaint(ctx, dstRelativePath); err != nil {
+	// Mark the entry as untainted.
+	if err := c.untaintMountEntry(ctx, dst.Namespace.ID, dst.MountPath, true); err != nil {
 		return err
 	}
 
-	return nil
+	// Un-taint the new path in the router.
+	return c.router.Untaint(ctx, dstRelativePath)
 }
 
 // moveMountStorage moves storage entries of a mount mountEntry to its new destination.
@@ -2162,6 +2178,24 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 	case desiredMountEntry != nil && actualMountEntry != nil: // mount was modified (e.g. tuned or tainted)
 		c.logger.Debug("cache invalidation: mount was modified", "type", table, "uuid", uuid)
 
+		if desiredMountEntry.Path != actualMountEntry.Path { // mount was moved
+			// Taint the mount entry as it's gonna be removed on active node
+			// as last part of storage move.
+			if err := c.taintMountEntry(ctx, actualMountEntry.Namespace.ID, actualMountEntry.Path, false); err != nil {
+				return err
+			}
+
+			// pre-emptiveely taint router path to new location of mount entry
+			routerPath := desiredMountEntry.Path
+			if table == routing.CredentialTableType {
+				routerPath = path.Join(routing.CredentialRoutePrefix, routerPath) + "/"
+			}
+
+			if err := c.router.Taint(ctx, routerPath); err != nil {
+				return err
+			}
+		}
+
 		if desiredMountEntry.Tainted != actualMountEntry.Tainted {
 			routerPath := actualMountEntry.Path
 			if table == routing.CredentialTableType {
@@ -2169,14 +2203,12 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 			}
 
 			if desiredMountEntry.Tainted {
-				err := c.router.Taint(ctx, routerPath)
-				if err != nil {
+				if err := c.router.Taint(ctx, routerPath); err != nil {
 					return err
 				}
 				actualMountEntry.Tainted = true
 			} else {
-				err := c.router.Untaint(ctx, routerPath)
-				if err != nil {
+				if err := c.router.Untaint(ctx, routerPath); err != nil {
 					return err
 				}
 				actualMountEntry.Tainted = false
@@ -2189,10 +2221,7 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 		}
 
 		if desiredMountEntry.Options["version"] != actualMountEntry.Options["version"] {
-			err := c.reloadBackendCommon(ctx, desiredMountEntry, table == routing.CredentialTableType)
-			if err != nil {
-				return err
-			}
+			return c.reloadBackendCommon(ctx, desiredMountEntry, table == routing.CredentialTableType)
 		}
 	}
 

--- a/internal/vault/mount_test.go
+++ b/internal/vault/mount_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"path"
 	"reflect"
 	"strings"
 	"testing"
@@ -619,12 +620,20 @@ func testCore_Unmount_Cleanup(t *testing.T, causeFailure bool) {
 
 func TestCore_Remount(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
-	err := c.remountSecretsEngineCurrentNamespace(namespace.RootContext(t.Context()), "secret", "foo", true)
+	ctx := namespace.RootContext(t.Context())
+
+	// Verify it's forbidden to remount protected mounts.
+	err := c.remountSecretsEngineCurrentNamespace(ctx, "sys", "foo")
+	if err.Error() != `cannot remount "sys/"` {
+		t.Fatalf("err: %v", err)
+	}
+
+	err = c.remountSecretsEngineCurrentNamespace(ctx, "secret", "foo")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	match := c.router.MatchingMount(namespace.RootContext(t.Context()), "foo/bar")
+	match := c.router.MatchingMount(ctx, "foo/bar")
 	if match != "foo/" {
 		t.Fatal("failed remount")
 	}
@@ -640,7 +649,7 @@ func TestCore_Remount(t *testing.T) {
 		}
 	}
 
-	match = c.router.MatchingMount(namespace.RootContext(t.Context()), "foo/bar")
+	match = c.router.MatchingMount(ctx, "foo/bar")
 	if match != "foo/" {
 		t.Fatal("failed remount")
 	}
@@ -704,7 +713,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 	}
 
 	// Remount, this should cleanup
-	if err := c.remountSecretsEngineCurrentNamespace(namespace.RootContext(t.Context()), "test/", "new/", true); err != nil {
+	if err := c.remountSecretsEngineCurrentNamespace(namespace.RootContext(t.Context()), "test/", "new/"); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -731,16 +740,8 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 	}
 }
 
-func TestCore_Remount_Protected(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
-	err := c.remountSecretsEngineCurrentNamespace(namespace.RootContext(t.Context()), "sys", "foo", true)
-	if err.Error() != `cannot remount "sys/"` {
-		t.Fatalf("err: %v", err)
-	}
-}
-
 func TestCore_RemountMount_Namespaces(t *testing.T) {
-	c, keys, _ := TestCoreUnsealed(t)
+	c, keys, rootToken := TestCoreUnsealed(t)
 	ns := &namespace.Namespace{Path: "ns/"}
 	unsealable1 := &namespace.Namespace{Path: "ns/unsealable1/"}
 	unsealable2 := &namespace.Namespace{Path: "ns/unsealable2/"}
@@ -757,8 +758,15 @@ func TestCore_RemountMount_Namespaces(t *testing.T) {
 	}
 
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
-	err := c.mount(namespace.ContextWithNamespace(ctx, unsealable1), me)
+	require.NoError(t, c.mount(namespace.ContextWithNamespace(ctx, unsealable1), me))
+
+	// Write data to kv mount
+	req := logical.TestRequest(t, logical.CreateOperation, "unsealable1/foo/secret")
+	req.ClientToken = rootToken
+	req.Data = map[string]any{"foo": "bar"}
+	resp, err := c.HandleRequest(ctx, req)
 	require.NoError(t, err)
+	require.NoError(t, resp.Error())
 
 	table := []struct {
 		name string
@@ -826,7 +834,7 @@ func TestCore_RemountMount_Namespaces(t *testing.T) {
 			match := c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
 			require.Equalf(t, tt.src.Namespace.Path+tt.src.MountPath, match, "missing mount, match: %q", match)
 
-			err := c.remountSecretsEngine(ctx, tt.src, tt.dst, true)
+			err := c.remountSecretsEngine(ctx, tt.src, tt.dst)
 			require.NoError(t, err)
 
 			match = c.router.MatchingMount(srcCtx, tt.src.MountPath+"foobar")
@@ -855,6 +863,20 @@ func TestCore_RemountMount_Namespaces(t *testing.T) {
 
 			match = c.router.MatchingMount(dstCtx, tt.dst.MountPath+"baz")
 			require.Equalf(t, tt.dst.Namespace.Path+tt.dst.MountPath, match, "mount not at new location after unseal, match: %q", match)
+
+			// Read written secret
+			req := logical.TestRequest(t, logical.ReadOperation, path.Join(tt.dst.MountPath, "secret"))
+			req.ClientToken = rootToken
+			resp, err := c.HandleRequest(dstCtx, req)
+			require.NoError(t, err)
+			require.Equal(t, "bar", resp.Data["foo"])
+
+			// Verify storage entries have moved
+			view := c.NamespaceView(tt.dst.Namespace)
+			secrets, err := view.List(ctx, path.Join(backendBarrierPrefix, me.UUID)+"/")
+			require.NoError(t, err)
+			require.Len(t, secrets, 1)
+			require.Equal(t, "secret", secrets[0])
 		})
 	}
 }

--- a/internal/vault/routing/mount_table.go
+++ b/internal/vault/routing/mount_table.go
@@ -65,13 +65,27 @@ func (old *MountTable) Delta(new *MountTable) (additions []*MountEntry, deletion
 	return additions, deletions
 }
 
-// SetTaint is used to set the taint on given mount entry
+// Taint is used to set the taint on given mount entry
 // using provided path and nsID. Returns back tainted
 // entry or nil if not found.
-func (t *MountTable) SetTaint(nsID, path string) *MountEntry {
+func (t *MountTable) Taint(nsID, path string) *MountEntry {
 	for _, entry := range t.Entries {
 		if entry.Path == path && entry.Namespace.ID == nsID {
 			entry.Tainted = true
+			return entry
+		}
+	}
+
+	return nil
+}
+
+// Untaint is used to untaint given mount entry
+// using provided path and nsID. Returns back
+// entry or nil if not found.
+func (t *MountTable) Untaint(nsID, path string) *MountEntry {
+	for _, entry := range t.Entries {
+		if entry.Path == path && entry.Namespace.ID == nsID {
+			entry.Tainted = false
 			return entry
 		}
 	}


### PR DESCRIPTION
## Description
- adds invalidation logic for a mount remount operation - essentially mount tune of a `path` field.
- adds `auth/` prefix to `bao auth move` command, previously could lead to incorrect remounts

## Rationale
without this change remounting a mount while running a read-only standby nodes would require the restart of said nodes to reflect the change in path of the mount

Resolves: #3139

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
