### PR TITLE
Docs: Document bound_service_account_namespace_selector usage.

### DIFF
--- a/changelog/3214.txt
+++ b/changelog/3214.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-auth/kubernetes: document bound_service_account_namespace_selector usage
-```

--- a/changelog/3214.txt
+++ b/changelog/3214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/kubernetes: document bound_service_account_namespace_selector usage
+```

--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -129,6 +129,10 @@ entities attempting to login.
   names able to access this role. If set to "\*" all names are allowed.
 - `bound_service_account_namespaces` `(array: <required>)` - List of namespaces
   allowed to access this role. If set to "\*" all namespaces are allowed.
+- `bound_service_account_namespace_selector` `(string: "")` - A label selector for Kubernetes namespaces 
+  which are allowed to access this role. Accepts either a JSON or YAML object. To use label selectors, OpenBao
+  must have read permission for namespaces in the Kubernetes cluster. If set with `bound_service_account_namespaces`, the 
+  conditions are `OR`ed.
 - `audience` `(string: "")` <a name="audience"></a> - Optional Audience claim to verify in the JWT.
 - `alias_name_source` `(string: "serviceaccount_uid")` - Configures how identity aliases are generated.
   Valid choices are: `serviceaccount_uid`, `serviceaccount_name`


### PR DESCRIPTION
## Description

This PR documents bound_service_account_namespace_selector feature in OpanBao. 

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3214#event-26202102569

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
