### PR TITLE
api: Add methods to list and scan keys to the KVv1 and KVv2 client

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -21,9 +21,9 @@ var ErrSecretNotFound = errors.New("secret not found")
 // The Raw field can be inspected for information about the lease,
 // and passed to a LifetimeWatcher object for periodic renewal.
 type KVSecret struct {
-	Data            map[string]interface{}
+	Data            map[string]any
 	VersionMetadata *KVVersionMetadata
-	CustomMetadata  map[string]interface{}
+	CustomMetadata  map[string]any
 	Raw             *Secret
 }
 

--- a/api/kv.go
+++ b/api/kv.go
@@ -39,7 +39,7 @@ type KVSecret struct {
 // The Raw field can be used to access e.g. the request id.
 type KVList struct {
 	Keys     []string
-	Metadata map[string]KVMetadata
+	Metadata map[string]*KVMetadata
 	Raw      *Secret
 }
 

--- a/api/kv.go
+++ b/api/kv.go
@@ -27,6 +27,22 @@ type KVSecret struct {
 	Raw             *Secret
 }
 
+// A KVList is a list of secrets returned by OpenBao's KV secrets engine.
+//
+// Keys contains a list of sub-keys of the path, while metadata contains the
+// metadata for every sub-key as a map.
+// The Metadata field for a KV v1 list response will always be nil, as metadata
+// is only supported starting in KV v2. For KV v2 the Metadata will only be
+// available if requested explicitly (i.e. via `ListWithDetails` or
+// `ScanWithDetails`).
+//
+// The Raw field can be used to access e.g. the request id.
+type KVList struct {
+	Keys     []string
+	Metadata map[string]KVMetadata
+	Raw      *Secret
+}
+
 // KVv1 is used to return a client for reads and writes against
 // a KV v1 secrets engine in Vault.
 //

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -31,11 +31,11 @@ func TestExtractVersionMetadata(t *testing.T) {
 		{
 			name: "a secret",
 			input: &Secret{
-				Data: map[string]interface{}{
-					"data": map[string]interface{}{
+				Data: map[string]any{
+					"data": map[string]any{
 						"password": "Hashi123",
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"version":         10,
 						"created_time":    inputCreatedTimeStr,
 						"deletion_time":   "",
@@ -54,11 +54,11 @@ func TestExtractVersionMetadata(t *testing.T) {
 		{
 			name: "a secret that has been deleted",
 			input: &Secret{
-				Data: map[string]interface{}{
-					"data": map[string]interface{}{
+				Data: map[string]any{
+					"data": map[string]any{
 						"password": "Hashi123",
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"version":         10,
 						"created_time":    inputCreatedTimeStr,
 						"deletion_time":   inputDeletionTimeStr,
@@ -77,7 +77,7 @@ func TestExtractVersionMetadata(t *testing.T) {
 		{
 			name: "a response from a Write operation",
 			input: &Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"version":         10,
 					"created_time":    inputCreatedTimeStr,
 					"deletion_time":   "",
@@ -121,11 +121,11 @@ func TestExtractDataAndVersionMetadata(t *testing.T) {
 	}
 
 	readResp := &Secret{
-		Data: map[string]interface{}{
-			"data": map[string]interface{}{
+		Data: map[string]any{
+			"data": map[string]any{
 				"password": "Hashi123",
 			},
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"version":         10,
 				"created_time":    inputCreatedTimeStr,
 				"deletion_time":   "",
@@ -136,9 +136,9 @@ func TestExtractDataAndVersionMetadata(t *testing.T) {
 	}
 
 	readRespDeleted := &Secret{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"data": nil,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"version":         10,
 				"created_time":    inputCreatedTimeStr,
 				"deletion_time":   inputDeletionTimeStr,
@@ -157,7 +157,7 @@ func TestExtractDataAndVersionMetadata(t *testing.T) {
 			name:  "a response from a Read operation",
 			input: readResp,
 			expected: &KVSecret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"password": "Hashi123",
 				},
 				VersionMetadata: &KVVersionMetadata{
@@ -223,24 +223,24 @@ func TestExtractFullMetadata(t *testing.T) {
 	}
 
 	metadataResp := &Secret{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"cas_required":    true,
 			"created_time":    inputCreatedTimeStr,
 			"current_version": 2,
-			"custom_metadata": map[string]interface{}{
+			"custom_metadata": map[string]any{
 				"org": "eng",
 			},
 			"delete_version_after": "200s",
 			"max_versions":         3,
 			"oldest_version":       1,
 			"updated_time":         inputUpdatedTimeStr,
-			"versions": map[string]interface{}{
-				"2": map[string]interface{}{
+			"versions": map[string]any{
+				"2": map[string]any{
 					"created_time":  inputUpdatedTimeStr,
 					"deletion_time": "",
 					"destroyed":     false,
 				},
-				"1": map[string]interface{}{
+				"1": map[string]any{
 					"created_time":  inputCreatedTimeStr,
 					"deletion_time": inputDeletedTimeStr,
 					"destroyed":     false,
@@ -261,7 +261,7 @@ func TestExtractFullMetadata(t *testing.T) {
 				CASRequired:    true,
 				CreatedTime:    expectedCreatedTimeParsed,
 				CurrentVersion: 2,
-				CustomMetadata: map[string]interface{}{
+				CustomMetadata: map[string]any{
 					"org": "eng",
 				},
 				DeleteVersionAfter: time.Duration(200 * time.Second),
@@ -300,83 +300,83 @@ func TestExtractCustomMetadata(t *testing.T) {
 	testCases := []struct {
 		name         string
 		inputAPIResp *Secret
-		expected     map[string]interface{}
+		expected     map[string]any
 	}{
 		{
 			name: "a read response with some custom metadata",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"custom_metadata": map[string]interface{}{"org": "eng"},
+				Data: map[string]any{
+					"metadata": map[string]any{
+						"custom_metadata": map[string]any{"org": "eng"},
 					},
 				},
 			},
-			expected: map[string]interface{}{"org": "eng"},
+			expected: map[string]any{"org": "eng"},
 		},
 		{
 			name: "a write response with some (pre-existing) custom metadata",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"custom_metadata": map[string]interface{}{"org": "eng"},
+				Data: map[string]any{
+					"custom_metadata": map[string]any{"org": "eng"},
 				},
 			},
-			expected: map[string]interface{}{"org": "eng"},
+			expected: map[string]any{"org": "eng"},
 		},
 		{
 			name: "a read response with no custom metadata from a pre-1.9 Vault server",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"metadata": map[string]interface{}{},
+				Data: map[string]any{
+					"metadata": map[string]any{},
 				},
 			},
-			expected: map[string]interface{}(nil),
+			expected: map[string]any(nil),
 		},
 		{
 			name: "a write response with no custom metadata from a pre-1.9 Vault server",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 			},
-			expected: map[string]interface{}(nil),
+			expected: map[string]any(nil),
 		},
 		{
 			name: "a read response with no custom metadata from a post-1.9 Vault server",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Data: map[string]any{
+					"metadata": map[string]any{
 						"custom_metadata": nil,
 					},
 				},
 			},
-			expected: map[string]interface{}(nil),
+			expected: map[string]any(nil),
 		},
 		{
 			name: "a write response with no custom metadata from a post-1.9 Vault server",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"custom_metadata": nil,
 				},
 			},
-			expected: map[string]interface{}(nil),
+			expected: map[string]any(nil),
 		},
 		{
 			name: "a read response where custom metadata was deleted",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"custom_metadata": map[string]interface{}{},
+				Data: map[string]any{
+					"metadata": map[string]any{
+						"custom_metadata": map[string]any{},
 					},
 				},
 			},
-			expected: map[string]interface{}{},
+			expected: map[string]any{},
 		},
 		{
 			name: "a write response where custom metadata was deleted",
 			inputAPIResp: &Secret{
-				Data: map[string]interface{}{
-					"custom_metadata": map[string]interface{}{},
+				Data: map[string]any{
+					"custom_metadata": map[string]any{},
 				},
 			},
-			expected: map[string]interface{}{},
+			expected: map[string]any{},
 		},
 	}
 

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -33,7 +33,7 @@ func TestExtractVersionMetadata(t *testing.T) {
 			input: &Secret{
 				Data: map[string]any{
 					"data": map[string]any{
-						"password": "Hashi123",
+						"password": "password123",
 					},
 					"metadata": map[string]any{
 						"version":         10,
@@ -56,7 +56,7 @@ func TestExtractVersionMetadata(t *testing.T) {
 			input: &Secret{
 				Data: map[string]any{
 					"data": map[string]any{
-						"password": "Hashi123",
+						"password": "password123",
 					},
 					"metadata": map[string]any{
 						"version":         10,
@@ -123,7 +123,7 @@ func TestExtractDataAndVersionMetadata(t *testing.T) {
 	readResp := &Secret{
 		Data: map[string]any{
 			"data": map[string]any{
-				"password": "Hashi123",
+				"password": "password123",
 			},
 			"metadata": map[string]any{
 				"version":         10,
@@ -158,7 +158,7 @@ func TestExtractDataAndVersionMetadata(t *testing.T) {
 			input: readResp,
 			expected: &KVSecret{
 				Data: map[string]any{
-					"password": "Hashi123",
+					"password": "password123",
 				},
 				VersionMetadata: &KVVersionMetadata{
 					Version:      10,

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -222,36 +222,34 @@ func TestExtractFullMetadata(t *testing.T) {
 		t.Fatalf("unable to parse expected deletion time: %v", err)
 	}
 
-	metadataResp := &Secret{
-		Data: map[string]any{
-			"cas_required":    true,
-			"created_time":    inputCreatedTimeStr,
-			"current_version": 2,
-			"custom_metadata": map[string]any{
-				"org": "eng",
+	metadataResp := map[string]any{
+		"cas_required":    true,
+		"created_time":    inputCreatedTimeStr,
+		"current_version": 2,
+		"custom_metadata": map[string]any{
+			"org": "eng",
+		},
+		"delete_version_after": "200s",
+		"max_versions":         3,
+		"oldest_version":       1,
+		"updated_time":         inputUpdatedTimeStr,
+		"versions": map[string]any{
+			"2": map[string]any{
+				"created_time":  inputUpdatedTimeStr,
+				"deletion_time": "",
+				"destroyed":     false,
 			},
-			"delete_version_after": "200s",
-			"max_versions":         3,
-			"oldest_version":       1,
-			"updated_time":         inputUpdatedTimeStr,
-			"versions": map[string]any{
-				"2": map[string]any{
-					"created_time":  inputUpdatedTimeStr,
-					"deletion_time": "",
-					"destroyed":     false,
-				},
-				"1": map[string]any{
-					"created_time":  inputCreatedTimeStr,
-					"deletion_time": inputDeletedTimeStr,
-					"destroyed":     false,
-				},
+			"1": map[string]any{
+				"created_time":  inputCreatedTimeStr,
+				"deletion_time": inputDeletedTimeStr,
+				"destroyed":     false,
 			},
 		},
 	}
 
 	testCases := []struct {
 		name     string
-		input    *Secret
+		input    map[string]any
 		expected *KVMetadata
 	}{
 		{

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -396,7 +396,7 @@ func TestExtractExtractKeyList(t *testing.T) {
 		name            string
 		input           *Secret
 		expectedKeys    []string
-		expectedDetails map[string]KVMetadata
+		expectedDetails map[string]*KVMetadata
 		expectedError   error
 	}{{
 		name: "happy case: empty data",
@@ -427,7 +427,7 @@ func TestExtractExtractKeyList(t *testing.T) {
 			},
 		},
 		expectedKeys: []string{"a", "b"},
-		expectedDetails: map[string]KVMetadata{
+		expectedDetails: map[string]*KVMetadata{
 			"a": {
 				CurrentVersion: 42,
 			},

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -4,9 +4,13 @@
 package api
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractVersionMetadata(t *testing.T) {
@@ -384,5 +388,105 @@ func TestExtractCustomMetadata(t *testing.T) {
 		if !reflect.DeepEqual(cm, tc.expected) {
 			t.Fatalf("%s: got\n%#v\nexpected\n%#v\n", tc.name, cm, tc.expected)
 		}
+	}
+}
+
+func TestExtractExtractKeyList(t *testing.T) {
+	testCases := []struct {
+		name            string
+		input           *Secret
+		expectedKeys    []string
+		expectedDetails map[string]KVMetadata
+		expectedError   error
+	}{{
+		name: "happy case: empty data",
+		input: &Secret{
+			Data: map[string]any{},
+		},
+	}, {
+		name: "happy case: only keys",
+		input: &Secret{
+			Data: map[string]any{
+				"keys": []any{"a", "b", "c"},
+			},
+		},
+		expectedKeys: []string{"a", "b", "c"},
+	}, {
+		name: "happy case: with details",
+		input: &Secret{
+			Data: map[string]any{
+				"keys": []any{"a", "b"},
+				"key_info": map[string]any{
+					"a": map[string]any{
+						"current_version": 42,
+					},
+					"b": map[string]any{
+						"current_version": 1337,
+					},
+				},
+			},
+		},
+		expectedKeys: []string{"a", "b"},
+		expectedDetails: map[string]KVMetadata{
+			"a": {
+				CurrentVersion: 42,
+			},
+			"b": {
+				CurrentVersion: 1337,
+			},
+		},
+	}, {
+		name: "error: invalid data keys",
+		input: &Secret{
+			Data: map[string]any{
+				"keys": "this should be an array",
+			},
+		},
+		expectedError: errors.New(`invalid response from server: expected "keys" to be of type []any but got string`),
+	}, {
+		name: "error: invalid data single key",
+		input: &Secret{
+			Data: map[string]any{
+				"keys": []any{"1", "2", 3},
+			},
+		},
+		expectedError: errors.New(`invalid response from server: expected every key to be of type string but got int`),
+	}, {
+		name: "error: invalid key_info",
+		input: &Secret{
+			Data: map[string]any{
+				"keys":     []any{"a", "b", "c"},
+				"key_info": "this should be a map",
+			},
+		},
+		expectedError: errors.New(`invalid response from server: expected "key_info" to be of type map[string]any but got string`),
+	}, {
+		name: "error: invalid key_info entry",
+		input: &Secret{
+			Data: map[string]any{
+				"keys": []any{"a", "b", "c"},
+				"key_info": map[string]any{
+					"a": "invalid",
+				},
+			},
+		},
+		expectedError: errors.New(`invalid response from server: expected all "key_info" entries to be of type map[string]any but got string`),
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			list, err := extractKeyList(tc.input)
+
+			if tc.expectedError == nil {
+				require.NoError(t, err)
+				require.NotNil(t, list)
+				assert.Equal(t, tc.expectedKeys, list.Keys)
+				assert.Equal(t, tc.expectedDetails, list.Metadata)
+				assert.Equal(t, tc.input, list.Raw)
+			} else {
+				assert.Equal(t, tc.expectedError, err)
+				assert.Nil(t, list)
+			}
+		})
 	}
 }

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -36,7 +36,7 @@ func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 // KV v1 secrets engine.
 //
 // If the secret already exists, it will be overwritten.
-func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
+func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]any) error {
 	pathToWriteTo := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
 
 	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -58,3 +58,28 @@ func (kv *KVv1) Delete(ctx context.Context, secretPath string) error {
 
 	return nil
 }
+
+// List returns the list of available keys at the specified location.
+func (kv *KVv1) List(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ListWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}
+
+// Scan returns the list of available keys at the specified location, recursing
+// into sub-folders.
+func (kv *KVv1) Scan(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ScanWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}

--- a/api/kv_v1.go
+++ b/api/kv_v1.go
@@ -32,7 +32,7 @@ func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
 	}, nil
 }
 
-// Put inserts a key-value secret (e.g. {"password": "Hashi123"}) into the
+// Put inserts a key-value secret (e.g. {"password": "password123"}) into the
 // KV v1 secrets engine.
 //
 // If the secret already exists, it will be overwritten.

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -176,7 +176,7 @@ func (kv *KVv2) GetVersionsAsList(ctx context.Context, secretPath string) ([]KVV
 		return nil, fmt.Errorf("%w: no metadata at %s", ErrSecretNotFound, pathToRead)
 	}
 
-	md, err := extractFullMetadata(secret)
+	md, err := extractFullMetadata(secret.Data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract metadata from secret to determine versions: %w", err)
 	}
@@ -203,7 +203,7 @@ func (kv *KVv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata
 		return nil, fmt.Errorf("%w: no metadata at %s", ErrSecretNotFound, pathToRead)
 	}
 
-	md, err := extractFullMetadata(secret)
+	md, err := extractFullMetadata(secret.Data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract metadata from secret: %w", err)
 	}
@@ -581,14 +581,14 @@ func extractVersionMetadata(secret *Secret) (*KVVersionMetadata, error) {
 	return metadata, nil
 }
 
-func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
+func extractFullMetadata(data map[string]any) (*KVMetadata, error) {
 	var metadata *KVMetadata
 
-	if secret.Data == nil {
+	if data == nil {
 		return nil, nil
 	}
 
-	if versions, ok := secret.Data["versions"]; ok {
+	if versions, ok := data["versions"]; ok {
 		versionsMap := versions.(map[string]any)
 		if len(versionsMap) > 0 {
 			for version, metadata := range versionsMap {
@@ -606,7 +606,7 @@ func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
 				versionsMap[version] = metadataMap // save the updated copy of the metadata map
 			}
 		}
-		secret.Data["versions"] = versionsMap // save the updated copy of the versions map
+		data["versions"] = versionsMap // save the updated copy of the versions map
 	}
 
 	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -620,7 +620,7 @@ func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
 		return nil, fmt.Errorf("error setting up decoder for API response: %w", err)
 	}
 
-	err = d.Decode(secret.Data)
+	err = d.Decode(data)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding metadata from API response into KVMetadata: %w", err)
 	}

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -23,14 +23,14 @@ type KVv2 struct {
 
 // KVMetadata is the full metadata for a given KV v2 secret.
 type KVMetadata struct {
-	CASRequired        bool                   `mapstructure:"cas_required"`
-	CreatedTime        time.Time              `mapstructure:"created_time"`
-	CurrentVersion     int                    `mapstructure:"current_version"`
-	CustomMetadata     map[string]interface{} `mapstructure:"custom_metadata"`
-	DeleteVersionAfter time.Duration          `mapstructure:"delete_version_after"`
-	MaxVersions        int                    `mapstructure:"max_versions"`
-	OldestVersion      int                    `mapstructure:"oldest_version"`
-	UpdatedTime        time.Time              `mapstructure:"updated_time"`
+	CASRequired        bool           `mapstructure:"cas_required"`
+	CreatedTime        time.Time      `mapstructure:"created_time"`
+	CurrentVersion     int            `mapstructure:"current_version"`
+	CustomMetadata     map[string]any `mapstructure:"custom_metadata"`
+	DeleteVersionAfter time.Duration  `mapstructure:"delete_version_after"`
+	MaxVersions        int            `mapstructure:"max_versions"`
+	OldestVersion      int            `mapstructure:"oldest_version"`
+	UpdatedTime        time.Time      `mapstructure:"updated_time"`
 	// Keys are stringified ints, e.g. "3". To get a sorted slice of version metadata, use GetVersionsAsList.
 	Versions map[string]KVVersionMetadata `mapstructure:"versions"`
 	Raw      *Secret
@@ -43,7 +43,7 @@ type KVMetadata struct {
 // struct will be reset to their zero value.
 type KVMetadataPutInput struct {
 	CASRequired        bool
-	CustomMetadata     map[string]interface{}
+	CustomMetadata     map[string]any
 	DeleteVersionAfter time.Duration
 	MaxVersions        int
 }
@@ -60,7 +60,7 @@ type KVMetadataPutInput struct {
 // custom metadata.
 type KVMetadataPatchInput struct {
 	CASRequired        *bool
-	CustomMetadata     map[string]interface{}
+	CustomMetadata     map[string]any
 	DeleteVersionAfter *time.Duration
 	MaxVersions        *int
 }
@@ -74,7 +74,7 @@ type KVVersionMetadata struct {
 }
 
 // Currently supported options: WithOption, WithCheckAndSet, WithMethod
-type KVOption func() (key string, value interface{})
+type KVOption func() (key string, value any)
 
 const (
 	KVOptionCheckAndSet    = "cas"
@@ -85,8 +85,8 @@ const (
 
 // WithOption can optionally be passed to provide generic options for a
 // KV request. Valid keys and values depend on the type of request.
-func WithOption(key string, value interface{}) KVOption {
-	return func() (string, interface{}) {
+func WithOption(key string, value any) KVOption {
+	return func() (string, any) {
 		return key, value
 	}
 }
@@ -217,10 +217,10 @@ func (kv *KVv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata
 // If the secret already exists, a new version will be created
 // and the previous version can be accessed with the GetVersion method.
 // GetMetadata can provide a list of available versions.
-func (kv *KVv2) Put(ctx context.Context, secretPath string, data map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+func (kv *KVv2) Put(ctx context.Context, secretPath string, data map[string]any, opts ...KVOption) (*KVSecret, error) {
 	pathToWriteTo := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
 
-	wrappedData := map[string]interface{}{
+	wrappedData := map[string]any{
 		"data": data,
 	}
 
@@ -228,7 +228,7 @@ func (kv *KVv2) Put(ctx context.Context, secretPath string, data map[string]inte
 	// We leave this as an optional arg so that most users
 	// can just pass plain key-value secret data without
 	// having to remember to put the extra layer "data" in there.
-	options := make(map[string]interface{})
+	options := make(map[string]any)
 	for _, opt := range opts {
 		k, v := opt()
 		options[k] = v
@@ -279,7 +279,7 @@ func (kv *KVv2) PutMetadata(ctx context.Context, secretPath string, metadata KVM
 	)
 
 	// convert values to a map we can pass to Logical
-	metadataMap := make(map[string]interface{})
+	metadataMap := make(map[string]any)
 	metadataMap[maxVersionsKey] = metadata.MaxVersions
 	metadataMap[deleteVersionAfterKey] = metadata.DeleteVersionAfter.String()
 	metadataMap[casRequiredKey] = metadata.CASRequired
@@ -302,7 +302,7 @@ func (kv *KVv2) PutMetadata(ctx context.Context, secretPath string, metadata KVM
 // only be able to use the old "rw" (read-then-write) style of partial update,
 // whereas newer Vault servers can use the default value of "patch" if the
 // client token's policy has the "patch" capability.
-func (kv *KVv2) Patch(ctx context.Context, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+func (kv *KVv2) Patch(ctx context.Context, secretPath string, newData map[string]any, opts ...KVOption) (*KVSecret, error) {
 	// determine patch method
 	var patchMethod string
 	var ok bool
@@ -386,7 +386,7 @@ func (kv *KVv2) DeleteVersions(ctx context.Context, secretPath string, versions 
 	for _, version := range versions {
 		versionsToDelete = append(versionsToDelete, strconv.Itoa(version))
 	}
-	versionsMap := map[string]interface{}{
+	versionsMap := map[string]any{
 		"versions": versionsToDelete,
 	}
 	_, err := kv.c.Logical().WriteWithContext(ctx, pathToDelete, versionsMap)
@@ -417,7 +417,7 @@ func (kv *KVv2) DeleteMetadata(ctx context.Context, secretPath string) error {
 func (kv *KVv2) Undelete(ctx context.Context, secretPath string, versions []int) error {
 	pathToUndelete := fmt.Sprintf("%s/undelete/%s", kv.mountPath, secretPath)
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"versions": versions,
 	}
 
@@ -437,7 +437,7 @@ func (kv *KVv2) Undelete(ctx context.Context, secretPath string, versions []int)
 func (kv *KVv2) Destroy(ctx context.Context, secretPath string, versions []int) error {
 	pathToDestroy := fmt.Sprintf("%s/destroy/%s", kv.mountPath, secretPath)
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"versions": versions,
 	}
 
@@ -489,19 +489,19 @@ func (kv *KVv2) Rollback(ctx context.Context, secretPath string, toVersion int) 
 	return kvs, nil
 }
 
-func extractCustomMetadata(secret *Secret) map[string]interface{} {
+func extractCustomMetadata(secret *Secret) map[string]any {
 	// Logical Writes return the metadata directly, Reads return it nested inside the "metadata" key
 	customMetadataInterface, ok := secret.Data["custom_metadata"]
 	if !ok {
 		metadataInterface := secret.Data["metadata"]
-		metadataMap, ok := metadataInterface.(map[string]interface{})
+		metadataMap, ok := metadataInterface.(map[string]any)
 		if !ok {
 			return nil
 		}
 		customMetadataInterface = metadataMap["custom_metadata"]
 	}
 
-	cm, ok := customMetadataInterface.(map[string]interface{})
+	cm, ok := customMetadataInterface.(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -513,7 +513,7 @@ func extractDataAndVersionMetadata(secret *Secret) (*KVSecret, error) {
 	// A nil map is a valid value for data: secret.Data will be nil when this
 	// version of the secret has been deleted, but the metadata is still
 	// available.
-	var data map[string]interface{}
+	var data map[string]any
 	if secret.Data != nil {
 		dataInterface, ok := secret.Data["data"]
 		if !ok {
@@ -521,7 +521,7 @@ func extractDataAndVersionMetadata(secret *Secret) (*KVSecret, error) {
 		}
 
 		if dataInterface != nil {
-			data, ok = dataInterface.(map[string]interface{})
+			data, ok = dataInterface.(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("unexpected type for 'data' element: %T (%#v)", data, data)
 			}
@@ -548,10 +548,10 @@ func extractVersionMetadata(secret *Secret) (*KVVersionMetadata, error) {
 	}
 
 	// Logical Writes return the metadata directly, Reads return it nested inside the "metadata" key
-	var metadataMap map[string]interface{}
+	var metadataMap map[string]any
 	metadataInterface, ok := secret.Data["metadata"]
 	if ok {
-		metadataMap, ok = metadataInterface.(map[string]interface{})
+		metadataMap, ok = metadataInterface.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("unexpected type for 'metadata' element: %T (%#v)", metadataInterface, metadataInterface)
 		}
@@ -589,10 +589,10 @@ func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
 	}
 
 	if versions, ok := secret.Data["versions"]; ok {
-		versionsMap := versions.(map[string]interface{})
+		versionsMap := versions.(map[string]any)
 		if len(versionsMap) > 0 {
 			for version, metadata := range versionsMap {
-				metadataMap := metadata.(map[string]interface{})
+				metadataMap := metadata.(map[string]any)
 				// deletion_time usually comes in as an empty string which can't be
 				// processed as time.RFC3339, so we reset it to a convertible value
 				if metadataMap["deletion_time"] == "" {
@@ -656,15 +656,15 @@ func validateRollbackVersion(rollbackVersion *KVSecret) error {
 	return nil
 }
 
-func mergePatch(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+func mergePatch(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]any, opts ...KVOption) (*KVSecret, error) {
 	pathToMergePatch := fmt.Sprintf("%s/data/%s", mountPath, secretPath)
 
 	// take any other additional options provided
 	// and pass them along to the patch request
-	wrappedData := map[string]interface{}{
+	wrappedData := map[string]any{
 		"data": newData,
 	}
-	options := make(map[string]interface{})
+	options := make(map[string]any)
 	for _, opt := range opts {
 		k, v := opt()
 		options[k] = v
@@ -715,7 +715,7 @@ func mergePatch(ctx context.Context, client *Client, mountPath string, secretPat
 	return kvSecret, nil
 }
 
-func readThenWrite(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]interface{}) (*KVSecret, error) {
+func readThenWrite(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]any) (*KVSecret, error) {
 	// First, read the secret.
 	existingVersion, err := client.KVv2(mountPath).Get(ctx, secretPath)
 	if err != nil {
@@ -744,8 +744,8 @@ func readThenWrite(ctx context.Context, client *Client, mountPath string, secret
 	return updatedSecret, nil
 }
 
-func toMetadataMap(patchInput KVMetadataPatchInput) (map[string]interface{}, error) {
-	metadataMap := make(map[string]interface{})
+func toMetadataMap(patchInput KVMetadataPatchInput) (map[string]any, error) {
+	metadataMap := make(map[string]any)
 
 	const (
 		casRequiredKey        = "cas_required"

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -211,7 +211,7 @@ func (kv *KVv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata
 	return md, nil
 }
 
-// Put inserts a key-value secret (e.g. {"password": "Hashi123"})
+// Put inserts a key-value secret (e.g. {"password": "password123"})
 // into the KV v2 secrets engine.
 //
 // If the secret already exists, a new version will be created

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -489,6 +489,57 @@ func (kv *KVv2) Rollback(ctx context.Context, secretPath string, toVersion int) 
 	return kvs, nil
 }
 
+// List returns the list of available keys at the specified location.
+func (kv *KVv2) List(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ListWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}
+
+// Scan returns the list of available keys at the specified location, recursing
+// into sub-folders.
+func (kv *KVv2) Scan(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ScanWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}
+
+// List returns the list of available keys and their metadata at the specified
+// location.
+func (kv *KVv2) ListWithDetails(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/detailed-metadata/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ListWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}
+
+// Scan returns the list of available keys and their metadata at the specified
+// location, recursing into sub-folders.
+func (kv *KVv2) ScanWithDetails(ctx context.Context, secretPath string) (*KVList, error) {
+	pathToList := fmt.Sprintf("%s/detailed-metadata/%s", kv.mountPath, secretPath)
+
+	resp, err := kv.c.Logical().ScanWithContext(ctx, pathToList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing secrets at %s: %w", pathToList, err)
+	}
+
+	return extractKeyList(resp)
+}
+
 func extractCustomMetadata(secret *Secret) map[string]any {
 	// Logical Writes return the metadata directly, Reads return it nested inside the "metadata" key
 	customMetadataInterface, ok := secret.Data["custom_metadata"]
@@ -777,4 +828,60 @@ func toMetadataMap(patchInput KVMetadataPatchInput) (map[string]any, error) {
 	}
 
 	return metadataMap, nil
+}
+
+func extractKeyList(resp *Secret) (*KVList, error) {
+	result := KVList{
+		Raw: resp,
+	}
+
+	if resp == nil {
+		return nil, nil
+	}
+
+	keysUntyped, ok := resp.Data["keys"]
+	if !ok {
+		return &result, nil
+	}
+
+	keysAny, ok := keysUntyped.([]any)
+	if !ok {
+		return nil, fmt.Errorf(`invalid response from server: expected "keys" to be of type []any but got %T`, keysUntyped)
+	}
+
+	result.Keys = make([]string, 0, len(keysAny))
+	for _, key := range keysAny {
+		keyString, ok := key.(string)
+		if !ok {
+			return nil, fmt.Errorf(`invalid response from server: expected every key to be of type string but got %T`, key)
+		}
+
+		result.Keys = append(result.Keys, keyString)
+	}
+
+	keysInfoUntyped, ok := resp.Data["key_info"]
+	if !ok {
+		return &result, nil
+	}
+
+	keyInfo, ok := keysInfoUntyped.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf(`invalid response from server: expected "key_info" to be of type map[string]any but got %T`, keysInfoUntyped)
+	}
+
+	result.Metadata = make(map[string]KVMetadata, len(keyInfo))
+	for key, value := range keyInfo {
+		valueAsMap, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf(`invalid response from server: expected all "key_info" entries to be of type map[string]any but got %T`, value)
+		}
+
+		valueAsStruct, err := extractFullMetadata(valueAsMap)
+		if err != nil {
+			return nil, err
+		}
+		result.Metadata[key] = *valueAsStruct
+	}
+
+	return &result, nil
 }

--- a/api/kv_v2.go
+++ b/api/kv_v2.go
@@ -869,7 +869,7 @@ func extractKeyList(resp *Secret) (*KVList, error) {
 		return nil, fmt.Errorf(`invalid response from server: expected "key_info" to be of type map[string]any but got %T`, keysInfoUntyped)
 	}
 
-	result.Metadata = make(map[string]KVMetadata, len(keyInfo))
+	result.Metadata = make(map[string]*KVMetadata, len(keyInfo))
 	for key, value := range keyInfo {
 		valueAsMap, ok := value.(map[string]any)
 		if !ok {
@@ -880,7 +880,7 @@ func extractKeyList(resp *Secret) (*KVList, error) {
 		if err != nil {
 			return nil, err
 		}
-		result.Metadata[key] = *valueAsStruct
+		result.Metadata[key] = valueAsStruct
 	}
 
 	return &result, nil

--- a/changelog/3220.txt
+++ b/changelog/3220.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-api: Add methods to list and scan keys to the KVv1 and KVv2 client
+api: Add methods to list and scan keys to the KVv1 and KVv2 client.
 ```

--- a/changelog/3220.txt
+++ b/changelog/3220.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Add methods to list and scan keys to the KVv1 and KVv2 client
+```


### PR DESCRIPTION

## Description

Add the following methods to the API:

- `KVv1.List`
- `KVv1.Scan`
- `KVv2.List`
- `KVv2.ListWithDetails`
- `KVv2.Scan`
- `KVv2.ScanWithDetails`

+ some minor refactorings

## Rationale

Makes the API client more useful.

BTW: the datatypes returned by our high level `List` APIs are rather inconsistent:

- Some like [`Sys.ListAuth`](https://pkg.go.dev/github.com/openbao/openbao/api/v2#Sys.ListAuth) return a `map[string]something`
- Some like [`Sys.ListPlugins`](https://pkg.go.dev/github.com/openbao/openbao/api/v2#Sys.ListPlugins) return a struct `ListSomethingResponse`
- Some like [`Sys.ListPolicies`](https://pkg.go.dev/github.com/openbao/openbao/api/v2#Sys.ListPolicies) return a `[]string`

IMHO the struct is the best approach here, because it can be extended in a compatible way. Happy to here other opinions.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
