### PR TITLE
Add Fermilab to Ecosystem web pages

### DIFF
--- a/website/content/ecosystem/adopters.mdx
+++ b/website/content/ecosystem/adopters.mdx
@@ -21,6 +21,12 @@ import Member from './lib/Member.tsx';
         relies on OpenBao to secure its own internal infrastructure and in
         support of customer-related 24/7 managed services.
       </Member>
+      <Member title="Fermilab">
+        [Fermilab](https://fnal.gov) uses OpenBao to
+        [securely store authentication tokens](https://arxiv.org/pdf/2503.24196)
+        for scientific computing as configured through their
+        [htvault-config](https://github.com/fermitools/htvault-config) package.
+      </Member>
       <Member title="NVIDIA">
         [NVIDIA Cloud Functions (NVCF)](https://github.com/NVIDIA/nvcf/)
         relies on OpenBao as part of its internal secrets-management

--- a/website/content/ecosystem/supporters.mdx
+++ b/website/content/ecosystem/supporters.mdx
@@ -16,6 +16,12 @@ import Member from './lib/Member.tsx';
         by fostering community advocacy and growth.
       </Member>
 
+      <Member title="Fermilab">
+        [Fermilab](https://fnal.gov/)
+        participates in OpenBao development, in particular for the 
+        JWT/OIDC authentication module and for packaging of OpenBao in EPEL.
+      </Member>
+
       <Member title="GitLab">
         GitLab contributes to development and open-source community efforts of OpenBao.
       </Member>


### PR DESCRIPTION
## Description

This adds Fermilab to the Adopters, Integrators, and Supporters Ecosystem pages on the OpenBao website.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
