### PR TITLE
Close the HA loop

### DIFF
--- a/changelog/3223.txt
+++ b/changelog/3223.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+core/ha: Return to read-enabled standby mode instead of read-disabled standby
+mode after stepping down from active mode when standby reads are enabled. This
+also fixes SIGHUPs crashing standby nodes if they've previously stepped down
+from active.
+```

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -655,12 +655,11 @@ func (g genericAuditor) AuditResponse(ctx context.Context, input *logical.LogInp
 }
 
 func (c *Core) ReloadAuditLogs() {
-	// Ensure we are already unsealed
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
 	ctx := c.activeContext.Load()
-	if c.Sealed() || (c.standby.Load() && !c.StandbyReadsEnabled()) || ctx.IsNil() {
+	if ctx.IsNil() || c.audit == nil {
 		return
 	}
 
@@ -739,7 +738,7 @@ func (c *Core) handleAuditLogSetup(ctx context.Context, standby bool) error {
 		}
 
 		c.logger.Info("disabling removed audit device", "path", auditMount.Path)
-		if existed, err := c.disableAudit(ctx, auditMount.Path, true); existed && err != nil {
+		if existed, err := c.disableAudit(ctx, auditMount.Path, standby); existed && err != nil {
 			return fmt.Errorf("failed to disable removed audit %v: %w", auditMount.Path, err)
 		}
 	}

--- a/vault/core.go
+++ b/vault/core.go
@@ -282,9 +282,9 @@ type Core struct {
 	sealed    atomic.Bool
 
 	standby          atomic.Bool
-	standbyDoneCh    chan struct{}
-	standbyStopCh    atomic.Value
-	standbyRestartCh atomic.Value
+	haLoopDoneCh     chan struct{}
+	haLoopStopCh     atomic.Value
+	haLoopRestartCh  atomic.Value
 	manualStepDownCh chan struct{}
 	heldHALock       physical.Lock
 
@@ -946,8 +946,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	c.standby.Store(true)
-	c.standbyStopCh.Store(make(chan struct{}, 1))
-	c.standbyRestartCh.Store(make(chan struct{}, 1))
+	c.haLoopStopCh.Store(make(chan struct{}, 1))
+	c.haLoopRestartCh.Store(make(chan struct{}, 1))
 	c.sealed.Store(true)
 	c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 0, nil)
 
@@ -1794,11 +1794,11 @@ func (c *Core) unsealInternal(ctx context.Context, rootKey []byte) error {
 		c.standby.Store(false)
 	} else {
 		// Go to standby mode, wait until we are active to unseal
-		c.standbyDoneCh = make(chan struct{})
+		c.haLoopDoneCh = make(chan struct{})
 		c.manualStepDownCh = make(chan struct{}, 1)
-		c.standbyStopCh.Store(make(chan struct{}, 1))
-		c.standbyRestartCh.Store(make(chan struct{}, 1))
-		go c.runStandby(c.standbyDoneCh, c.manualStepDownCh, c.standbyStopCh.Load().(chan struct{}), c.standbyRestartCh.Load().(chan struct{}))
+		c.haLoopStopCh.Store(make(chan struct{}, 1))
+		c.haLoopRestartCh.Store(make(chan struct{}, 1))
+		go c.runHALoop(c.haLoopDoneCh, c.manualStepDownCh, c.haLoopStopCh.Load().(chan struct{}), c.haLoopRestartCh.Load().(chan struct{}))
 	}
 
 	// Success!
@@ -2042,10 +2042,9 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 			}
 		}()
 
-		// Stop the standby before attempting to acquire the standby lock.
-		// This will prevent a race condition between runStandby and this
-		// method.
-		c.stopStandby()
+		// Stop the HA loop before attempting to acquire the state lock. This
+		// will prevent a race condition between runHALoop and this method.
+		c.stopHALoop()
 
 		// Acquire the state lock.
 		c.stateLock.Lock()
@@ -2076,18 +2075,17 @@ func (c *Core) sealInternalWithOptions(grabStateLock bool) error {
 		}
 
 		// If we are trying to acquire the lock, force it to return with nil so
-		// runStandby will exit
-		// If we are active, signal the standby goroutine to shut down and wait
-		// for completion. We have the state lock here so nothing else should
-		// be toggling standby status.
-		close(c.standbyStopCh.Load().(chan struct{}))
-		c.logger.Debug("finished triggering standbyStopCh for runStandby")
+		// runHALoop will exit. If we are active, signal the standby goroutine
+		// to shut down and wait for completion. We have the state lock here so
+		// nothing else should be toggling standby status.
+		close(c.haLoopStopCh.Load().(chan struct{}))
+		c.logger.Debug("finished triggering haLoopCh for runHALoop")
 
-		// Wait for runStandby to stop
-		<-c.standbyDoneCh
-		c.logger.Debug("runStandby done")
+		// Wait for runHALoop to stop.
+		<-c.haLoopDoneCh
+		c.logger.Debug("runHALoop done")
 
-		// Stop requests from processing
+		// Stop requests from processing.
 		activeCtxCancel()
 	}
 

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -373,21 +373,21 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	return retErr
 }
 
-func (c *Core) stopStandby() {
-	standbyStopCh := c.standbyStopCh.Load()
-	if standbyStopCh == nil {
+func (c *Core) stopHALoop() {
+	haLoopStopCh := c.haLoopStopCh.Load()
+	if haLoopStopCh == nil {
 		return
 	}
 
 	select {
-	case standbyStopCh.(chan struct{}) <- struct{}{}:
+	case haLoopStopCh.(chan struct{}) <- struct{}{}:
 	default:
-		c.logger.Warn("ignoring standby stop request: stop is already in progress")
+		c.logger.Warn("ignoring HA loop stop request: stop is already in progress")
 	}
 }
 
 func (c *Core) restart() {
-	restartCh := c.standbyRestartCh.Load()
+	restartCh := c.haLoopRestartCh.Load()
 	if restartCh == nil {
 		return
 	}
@@ -401,7 +401,7 @@ func (c *Core) restart() {
 
 func (c *Core) drainPendingRestarts() {
 	for {
-		restartCh := c.standbyRestartCh.Load()
+		restartCh := c.haLoopRestartCh.Load()
 		if restartCh == nil {
 			return
 		}
@@ -468,7 +468,7 @@ func (c *Core) runStandbyGrabStateLock(stopCh <-chan struct{}) error {
 	return nil
 }
 
-// runStandby is a long running process that manages a number of the HA
+// runHALoop is a long running process that manages a number of the HA
 // subsystems.
 // doneCh will be closed once the standby has finished operating in this
 // invocation.
@@ -482,53 +482,19 @@ func (c *Core) runStandbyGrabStateLock(stopCh <-chan struct{}) error {
 //
 // stopCh and restartCh differ in that the former is terminal and the latter is
 // re-entrant. Both can be triggered by writing to the respective channel.
-func (c *Core) runStandby(doneCh chan<- struct{}, manualStepDownCh chan struct{}, stopCh, restartCh <-chan struct{}) {
+func (c *Core) runHALoop(doneCh chan<- struct{}, manualStepDownCh chan struct{}, stopCh, restartCh <-chan struct{}) {
 	defer close(doneCh)
 	defer close(manualStepDownCh)
 
 	for restart := true; restart; {
-		restart = c.runStandbyOnce(doneCh, manualStepDownCh, stopCh, restartCh)
+		restart = c.runHALoopOnce(manualStepDownCh, stopCh, restartCh)
 	}
 
-	c.logger.Info("runStandby stopped")
+	c.logger.Info("runHALoop stopped")
 }
 
-func (c *Core) runStandbyOnce(doneCh chan<- struct{}, manualStepDownCh chan struct{}, stopCh, restartCh <-chan struct{}) bool {
-	c.logger.Info("entering standby mode")
+func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <-chan struct{}) bool {
 	restart := false
-
-	if c.StandbyReadsEnabled() {
-		c.logger.Info("enabling horizontal scalability (reads)")
-		c.barrier.SetReadOnly(true)
-
-		if err := c.runStandbyGrabStateLock(stopCh); err != nil {
-			c.logger.Error("runStandby: unable to grab state lock", "err", err)
-			return false
-		}
-
-		// wipe any existing mount tables
-		if err := c.preSeal(); err != nil {
-			c.logger.Error("pre-seal teardown failed", "error", err)
-		}
-
-		c.drainPendingRestarts()
-
-		readStandbyCtx, readStandbyCancel := context.WithCancel(namespace.RootContext(context.Background()))
-		defer readStandbyCancel()
-
-		// Unseal, holding the state lock.
-		c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
-		if err := c.postUnseal(readStandbyCtx, readStandbyCancel, readonlyUnsealStrategy{}); err != nil {
-			c.logger.Error("read-only post-unseal setup failed", "error", err)
-			if err := c.sealManager.sealAll(); err != nil {
-				c.logger.Error("failed to re-seal all barriers after post-unseal setup failed", "error", err)
-			}
-			c.logger.Warn("OpenBao is sealed")
-		}
-
-		// Yield the state lock.
-		c.stateLock.Unlock()
-	}
 
 	var g run.Group
 	{
@@ -595,7 +561,7 @@ func (c *Core) runStandbyOnce(doneCh chan<- struct{}, manualStepDownCh chan stru
 	// we'll exit from this with an error.
 	err := g.Run()
 	if err != nil {
-		c.logger.Error("unexpected error in runStandby", "error", err.Error())
+		c.logger.Error("unexpected error in runHALoop", "error", err.Error())
 	}
 
 	return restart
@@ -607,25 +573,56 @@ func (c *Core) runStandbyOnce(doneCh chan<- struct{}, manualStepDownCh chan stru
 func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 	var manualStepDown bool
 	firstIteration := true
+
+	// We pin the current standby or active context to this out-of-loop variable
+	// to ensure it gets a deferred cancel if the loop exits due to an error.
+	// This method really needs a refactor :)
+	ctxCancel := context.CancelFunc(func() {})
+	defer func() {
+		ctxCancel()
+	}()
+
 	for {
+		// Cancel any old context from the previous iteration.
+		ctxCancel()
+
 		// Check for a shutdown
 		select {
 		case <-stopCh:
-			c.logger.Debug("stop channel triggered in runStandby")
+			c.logger.Debug("stop channel triggered in runHALoop")
 			return
 		default:
-			// If we've just down, we could instantly grab the lock again. Give
-			// the other nodes a chance.
-			if manualStepDown {
-				time.Sleep(manualStepDownSleepPeriod)
-				manualStepDown = false
-			} else if !firstIteration {
-				// If we restarted the for loop due to an error, wait a second
-				// so that we don't busy loop if the error persists.
-				time.Sleep(1 * time.Second)
+		}
+
+		if !firstIteration && !manualStepDown {
+			// If we restarted the for loop due to an error, wait a second
+			// so that we don't busy loop if the error persists.
+			time.Sleep(1 * time.Second)
+		}
+
+		firstIteration = false
+
+		c.logger.Info("entering standby mode")
+
+		// Create the standby context (this becomes activeCtx on core, oh well).
+		standbyCtx, standbyCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
+		// Cancel if we exit the loop without transitioning to active.
+		ctxCancel = standbyCtxCancel
+
+		// If possible, unseal in read-only mode and start acting as a
+		// read-enabled standby.
+		if c.StandbyReadsEnabled() {
+			if stop := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh); stop {
+				return
 			}
 		}
-		firstIteration = false
+
+		// If we've just stepped down, we could instantly grab the lock
+		// again. Give the other nodes a chance.
+		if manualStepDown {
+			time.Sleep(manualStepDownSleepPeriod)
+			manualStepDown = false
+		}
 
 		// Create a lock
 		uuid, err := uuid.GenerateUUID()
@@ -667,6 +664,20 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 		// detect flapping
 		activeTime := time.Now()
 
+		// We're transitioning to active, so cancel the standby context.
+		// Spawn this in a goroutine so we can cancel the context and unblock
+		// any inflight requests that are holding the state lock.
+		go func() {
+			timer := time.NewTimer(DefaultMaxRequestDuration)
+			select {
+			case <-standbyCtx.Done():
+				timer.Stop()
+			case <-timer.C:
+				// Attempt to drain any inflight requests.
+				standbyCtxCancel()
+			}
+		}()
+
 		// Grab the statelock or stop
 		l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, stopCh)
 		go l.grab()
@@ -684,6 +695,9 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 			return
 		}
 
+		// Cancel the standby context if it hasn't already been.
+		standbyCtxCancel()
+
 		// Clear pending standby restarts, not that it matters too much.
 		c.drainPendingRestarts()
 
@@ -693,6 +707,9 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 		// Create the active context
 		activeCtx, activeCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
 		c.activeContext.Store(NewAtomicContext(activeCtx, activeCtxCancel))
+
+		// Ensure it gets cancelled eventually.
+		ctxCancel = activeCtxCancel
 
 		// Mark storage as readable again.
 		c.barrier.SetReadOnly(false)
@@ -811,15 +828,15 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 
 		// Stop Active Duty
 		{
-			// Spawn this in a go routine so we can cancel the context and
-			// unblock any inflight requests that are holding the statelock.
+			// Spawn this in a goroutine so we can cancel the context and
+			// unblock any inflight requests that are holding the state lock.
 			go func() {
 				timer := time.NewTimer(DefaultMaxRequestDuration)
 				select {
 				case <-activeCtx.Done():
 					timer.Stop()
-					// Attempt to drain any inflight requests
 				case <-timer.C:
+					// Attempt to drain any inflight requests.
 					activeCtxCancel()
 				}
 			}()
@@ -871,6 +888,35 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 			c.stateLock.Unlock()
 		}
 	}
+}
+
+// runReadEnabledStandby grabs the state lock and unseals in read-only mode. It
+// returns true if stopped or timed out.
+func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.CancelFunc, stopCh <-chan struct{}) bool {
+	c.logger.Info("enabling horizontal scalability (reads)")
+	c.barrier.SetReadOnly(true)
+
+	if err := c.runStandbyGrabStateLock(stopCh); err != nil {
+		c.logger.Error("unable to grab state lock for standby", "err", err)
+		return true
+	}
+
+	defer c.stateLock.Unlock()
+
+	// Wipe any existing state.
+	if err := c.preSeal(); err != nil {
+		c.logger.Error("pre-seal teardown failed", "error", err)
+	}
+
+	c.drainPendingRestarts()
+
+	// Unseal, holding the state lock.
+	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
+	if err := c.postUnseal(ctx, ctxCancel, readonlyUnsealStrategy{}); err != nil {
+		c.logger.Error("read-only post-unseal setup failed", "error", err)
+	}
+
+	return false
 }
 
 // grabLockOrStop returns stopped=false if the lock is acquired. Returns

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -683,7 +683,7 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool) framework.Ope
 			defer cleanup()
 
 			// Grab statelock
-			l := newLockGrabber(b.Core.stateLock.Lock, b.Core.stateLock.Unlock, b.Core.standbyStopCh.Load().(chan struct{}))
+			l := newLockGrabber(b.Core.stateLock.Lock, b.Core.stateLock.Unlock, b.Core.haLoopStopCh.Load().(chan struct{}))
 			go l.grab()
 			if stopped := l.lockOrStop(); stopped {
 				b.Core.logger.Error("not applying snapshot; shutting down")

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -642,7 +642,7 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 
 		if grabLock {
 			// Grab statelock
-			l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, c.standbyStopCh.Load().(chan struct{}))
+			l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, c.haLoopStopCh.Load().(chan struct{}))
 			go l.grab()
 			if stopped := l.lockOrStop(); stopped {
 				c.logger.Error("did not apply snapshot; vault is shutting down")


### PR DESCRIPTION
## Description

After stepping down from active (no matter the cause), read-enabled standbys wouldn't unseal back into read-enabled mode, but idle as read-disabled standbys instead. Fix this by relocating the relevant setup code into the `waitForLeadership` loop.

Also make some improvements to the transition of the standby `activeContext` to the _active_ `activeContext`, and rename `runStandby` and friends to `runHALoop` since it runs both standby mode and active mode in, well, a loop.

This also caused crashes when reloading audits via SIGHUP as this code assumed `c.audit` to exist when unsealed and in standby mode with reads supported/configured.

## Rationale

Resolves: #3207, and likely many other issues we weren't aware of yet.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
