### PR TITLE
GRPC Synchronization of Namespace Seal Root Keys

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -42,6 +42,7 @@ type Namespace struct {
 	UUID           string            `json:"uuid" mapstructure:"uuid"`
 	Path           string            `json:"path" mapstructure:"path"`
 	Tainted        bool              `json:"tainted" mapstructure:"tainted"`
+	ManuallySealed bool              `json:"manually_sealed" mapstructure:"manually_sealed"`
 	Locked         bool              `json:"-"`
 	UnlockKey      string            `json:"unlock_key" mapstructure:"unlock_key"`
 	CustomMetadata map[string]string `json:"custom_metadata" mapstructure:"custom_metadata"`
@@ -101,6 +102,7 @@ var (
 		UUID:           RootNamespaceUUID,
 		Path:           "",
 		Tainted:        false,
+		ManuallySealed: false,
 		Locked:         false,
 		CustomMetadata: make(map[string]string),
 	}
@@ -152,6 +154,7 @@ func (n *Namespace) Clone(withUnlock bool) *Namespace {
 		UUID:           n.UUID,
 		Path:           n.Path,
 		Tainted:        n.Tainted,
+		ManuallySealed: n.ManuallySealed,
 		Locked:         n.Locked,
 		CustomMetadata: meta,
 	}

--- a/vault/barrier/aes_gcm.go
+++ b/vault/barrier/aes_gcm.go
@@ -4,6 +4,7 @@
 package barrier
 
 import (
+	"cmp"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
@@ -13,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +22,7 @@ import (
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 )
@@ -64,6 +67,7 @@ var (
 // and integrity.
 type AESGCMBarrier struct {
 	backend    physical.Backend
+	namespace  *namespace.Namespace
 	metaPrefix string
 
 	l        sync.RWMutex
@@ -128,16 +132,20 @@ func (b *AESGCMBarrier) SetRotationConfig(ctx context.Context, rotConfig KeyRota
 
 // NewAESGCMBarrier is used to construct a new barrier that uses
 // the provided physical backend for storage.
-func NewAESGCMBarrier(storage physical.Backend, metaPrefix string) SecurityBarrier {
+func NewAESGCMBarrier(storage physical.Backend, ns *namespace.Namespace) SecurityBarrier {
 	b := &AESGCMBarrier{
 		backend:                  storage,
-		metaPrefix:               metaPrefix,
+		namespace:                cmp.Or(ns, namespace.RootNamespace),
 		sealed:                   true,
 		cache:                    make(map[uint32]cipher.AEAD),
 		currentAESGCMVersionByte: byte(AESGCMVersion2),
 		UnaccountedEncryptions:   &atomic.Int64{},
 		RemoteEncryptions:        &atomic.Int64{},
 		totalLocalEncryptions:    &atomic.Int64{},
+	}
+
+	if ns != nil && ns.UUID != namespace.RootNamespaceUUID {
+		b.metaPrefix = path.Join(NamespacePrefix, ns.UUID) + "/"
 	}
 
 	if _, ok := storage.(physical.TransactionalBackend); ok {
@@ -1280,6 +1288,10 @@ func (b *AESGCMBarrier) encryptions() int64 {
 
 func (b *AESGCMBarrier) SetReadOnly(readOnly bool) {
 	b.readOnly.Store(readOnly)
+}
+
+func (b *AESGCMBarrier) Namespace() *namespace.Namespace {
+	return b.namespace
 }
 
 func (b *TransactionalAESGCMBarrier) BeginReadOnlyTx(ctx context.Context) (logical.Transaction, error) {

--- a/vault/barrier/aes_gcm_test.go
+++ b/vault/barrier/aes_gcm_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/helper/testhelpers/corehelpers"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -22,14 +23,14 @@ var logger = logging.NewVaultLogger(log.Trace)
 func TestAESGCMBarrier_Basic(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	testBarrier(t, b)
 }
 
 func TestAESGCMBarrier_Rotate(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	testBarrier_Rotate(t, b)
 }
 
@@ -38,7 +39,7 @@ func TestAESGCMBarrier_MissingRotateConfig(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
@@ -58,8 +59,8 @@ func TestAESGCMBarrier_MissingRotateConfig(t *testing.T) {
 func TestAESGCMBarrier_Upgrade(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
-	b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b1 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
+	b2 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade(t, b1, b2)
 }
 
@@ -68,8 +69,8 @@ func TestAESGCMBarrier_Upgrade_RotateRootKey(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
-	b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b1 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
+	b2 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade_RotateRootKey(t, b1, b2)
 
 	// Test migration from legacy to new root key path. Move the existing
@@ -111,7 +112,7 @@ func TestAESGCMBarrier_Upgrade_RotateRootKey(t *testing.T) {
 func TestAESGCMBarrier_RotateRootKey(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	testBarrier_RotateRootKey(t, b)
 }
 
@@ -121,7 +122,7 @@ func TestAESGCMBarrier_Confidential(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
@@ -146,7 +147,7 @@ func TestAESGCMBarrier_Integrity(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
@@ -173,7 +174,7 @@ func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion1
 
 	// Initialize and unseal
@@ -200,7 +201,7 @@ func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion2
 
 	// Initialize and unseal
@@ -227,7 +228,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion1
 
 	// Initialize and unseal
@@ -243,7 +244,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 	require.NoError(t, b.Seal())
 
 	// Open again as version 2
-	b = NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b = NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	b.currentAESGCMVersionByte = AESGCMVersion2
 
 	// Unseal
@@ -259,7 +260,7 @@ func TestEncrypt_Unique(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	key, _ := b.GenerateKey()
 	require.NoError(t, b.Initialize(ctx, key, nil))
@@ -283,7 +284,7 @@ func TestInitialize_KeyLength(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	long := []byte("ThisKeyDoesNotHaveTheRightLength!")
 	middle := []byte("ThisIsASecretKeyAndMore")
@@ -300,7 +301,7 @@ func TestEncrypt_BarrierEncryptor(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
 
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
 	require.NoError(t, b.Initialize(ctx, key, nil))
@@ -319,7 +320,7 @@ func TestDecrypt_InvalidCipherLength(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
 
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 	key, err := b.GenerateKey()
 	require.NoError(t, err)
 
@@ -343,7 +344,7 @@ func TestDecrypt_InvalidCipherLength(t *testing.T) {
 func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
@@ -361,7 +362,7 @@ func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 
 	{
 		// Create a second barrier and rotate the keyring
-		b2 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+		b2 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 		require.NoError(t, b2.Unseal(ctx, key))
 		_, err = b2.Rotate(ctx)
 		require.NoError(t, err)
@@ -388,7 +389,7 @@ func TestAESGCMBarrier_ReloadKeyring(t *testing.T) {
 func TestBarrier_LegacyRotate(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b1 := NewAESGCMBarrier(inm, "").(*TransactionalAESGCMBarrier)
+	b1 := NewAESGCMBarrier(inm, nil).(*TransactionalAESGCMBarrier)
 
 	key, _ := b1.GenerateKey()
 
@@ -446,7 +447,7 @@ func TestBarrier_persistKeyring_Context(t *testing.T) {
 			// Set up barrier
 			backend, err := inmem.NewInmem(nil, corehelpers.NewTestLogger(t))
 			require.NoError(t, err)
-			barrier := NewAESGCMBarrier(backend, "").(*TransactionalAESGCMBarrier)
+			barrier := NewAESGCMBarrier(backend, nil).(*TransactionalAESGCMBarrier)
 			key, _ := barrier.GenerateKey()
 			require.NoError(t, barrier.Initialize(ctx, key, nil))
 			require.NoError(t, barrier.Unseal(ctx, key))
@@ -483,14 +484,14 @@ func TestBarrier_persistKeyring_Context(t *testing.T) {
 func TestAESGCMBarrier_Prefix_Basic(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 	testBarrier(t, b)
 }
 
 func TestAESGCMBarrier_Prefix_Rotate(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 	testBarrier_Rotate(t, b)
 }
 
@@ -499,7 +500,7 @@ func TestAESGCMBarrier_Prefix_MissingRotateConfig(t *testing.T) {
 
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()
@@ -519,22 +520,22 @@ func TestAESGCMBarrier_Prefix_MissingRotateConfig(t *testing.T) {
 func TestAESGCMBarrier_Prefix_Upgrade(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b1 := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
-	b2 := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b1 := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
+	b2 := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade(t, b1, b2)
 }
 
 func TestAESGCMBarrier_Prefix_Upgrade_RotateRootKey(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b1 := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
-	b2 := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b1 := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
+	b2 := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 	testBarrier_Upgrade_RotateRootKey(t, b1, b2)
 }
 
 func TestAESGCMBarrier_Prefix_RotateRootKey(t *testing.T) {
 	inm, err := inmem.NewInmem(nil, logger)
 	require.NoError(t, err)
-	b := NewAESGCMBarrier(inm, "prefix/").(*TransactionalAESGCMBarrier)
+	b := NewAESGCMBarrier(inm, &namespace.Namespace{UUID: "prefix"}).(*TransactionalAESGCMBarrier)
 	testBarrier_RotateRootKey(t, b)
 }

--- a/vault/barrier/barrier.go
+++ b/vault/barrier/barrier.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -79,6 +80,10 @@ const (
 	// SystemBarrierPrefix is the prefix used for the
 	// system logical backend.
 	SystemBarrierPrefix = "sys/"
+
+	// NamespacePrefix is the prefix to the UUID of a namespace
+	// used in the barrier view for the namespace-owned backends.
+	NamespacePrefix = "namespaces/"
 )
 
 const (
@@ -178,6 +183,9 @@ type SecurityBarrierCore interface {
 	// SetReadOnly allows marking storage as read-only; this is useful for
 	// HA mode but could be more broadly useful.
 	SetReadOnly(readOnly bool)
+
+	// Namespace returns the namespace related to this barrier.
+	Namespace() *namespace.Namespace
 }
 
 // SecurityBarrier is a critical component of Vault. It is used to wrap

--- a/vault/barrier/testing.go
+++ b/vault/barrier/testing.go
@@ -14,7 +14,7 @@ func MockBarrier(t testing.TB, logger hclog.Logger) (physical.Backend, SecurityB
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	b := NewAESGCMBarrier(inm, "")
+	b := NewAESGCMBarrier(inm, nil)
 
 	// Initialize and unseal
 	key, _ := b.GenerateKey()

--- a/vault/core.go
+++ b/vault/core.go
@@ -1073,7 +1073,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 
 	// Construct a new AES-GCM barrier
-	c.barrier = barrier.NewAESGCMBarrier(c.physical, "")
+	c.barrier = barrier.NewAESGCMBarrier(c.physical, nil)
 	c.SetupSealManager()
 
 	// We create the funcs here, then populate the given config with it so that

--- a/vault/core.go
+++ b/vault/core.go
@@ -555,7 +555,8 @@ type Core struct {
 
 	quotaManager *quotas.Manager
 
-	clusterHeartbeatInterval time.Duration
+	clusterHeartbeatInterval     time.Duration
+	clusterNamespaceSyncInterval time.Duration
 
 	// activeTime is set on active nodes indicating the time at which this node
 	// became active.
@@ -751,7 +752,8 @@ type CoreConfig struct {
 
 	ClusterNetworkLayer cluster.NetworkLayer
 
-	ClusterHeartbeatInterval time.Duration
+	ClusterHeartbeatInterval     time.Duration
+	ClusterNamespaceSyncInterval time.Duration
 
 	// number of workers to use for lease revocation in the expiration manager
 	NumExpirationWorkers int
@@ -858,6 +860,15 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		clusterHeartbeatInterval = 5 * time.Second
 	}
 
+	clusterNamespaceSyncInterval := conf.ClusterNamespaceSyncInterval
+	if clusterNamespaceSyncInterval == 0 {
+		// We don't want namespaces to take forever to unseal, but we also
+		// want to avoid spamming the leader. This seems like a reasonable
+		// middle ground. By tying it to clusterHeartbeatInterval, tests
+		// can run faster automatically.
+		clusterNamespaceSyncInterval = 3 * clusterHeartbeatInterval
+	}
+
 	if conf.NumExpirationWorkers == 0 {
 		conf.NumExpirationWorkers = numExpirationWorkersDefault
 	}
@@ -925,6 +936,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		raftJoinDoneCh:                 make(chan struct{}),
 		pendingRaftPeerChallengeKey:    make([]byte, 32),
 		clusterHeartbeatInterval:       clusterHeartbeatInterval,
+		clusterNamespaceSyncInterval:   clusterNamespaceSyncInterval,
 		numExpirationWorkers:           conf.NumExpirationWorkers,
 		raftFollowerStates:             raft.NewFollowerStates(),
 		disableAutopilot:               conf.DisableAutopilot,
@@ -3865,10 +3877,11 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 	c.rpcForwardingClient = forwarding.NewClient(
 		c,
 		forwarding.NewRequestForwardingClient(c.rpcClientConn),
-		time.NewTicker(c.clusterHeartbeatInterval),
 		dctx,
+		time.NewTicker(c.clusterHeartbeatInterval),
+		time.NewTicker(c.clusterNamespaceSyncInterval),
 	)
-	c.rpcForwardingClient.StartHeartbeat()
+	c.rpcForwardingClient.Start()
 
 	return nil
 }

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -564,7 +564,7 @@ func (im *invalidationManager) splitNamespaceFromKey(key string) (string, string
 	namespaceUUID := namespace.RootNamespaceUUID
 	namespacedKey := key
 
-	if keySuffix, ok := strings.CutPrefix(key, namespaceBarrierPrefix); ok {
+	if keySuffix, ok := strings.CutPrefix(key, barrier.NamespacePrefix); ok {
 		namespaceUUID, namespacedKey, _ = strings.Cut(keySuffix, "/")
 	}
 

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -322,7 +322,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			require.NoError(t, err)
 
 			if ns.ID != namespace.RootNamespaceID {
-				storagePath = path.Join(namespaceBarrierPrefix, ns.UUID, storagePath)
+				storagePath = path.Join(barrier.NamespacePrefix, ns.UUID, storagePath)
 			}
 
 			// 3. Invalidate Path

--- a/vault/external_tests/namespaces/sealing_test.go
+++ b/vault/external_tests/namespaces/sealing_test.go
@@ -1,0 +1,176 @@
+package namespaces
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openbao/openbao/api/v2"
+	vaulthttp "github.com/openbao/openbao/http"
+	"github.com/openbao/openbao/vault"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createSealedNs(t require.TestingT, client *api.Client, name string, config string) []string {
+	// Create a couple of sealed namespaces.
+	resp, err := client.Logical().Write("sys/namespaces/"+name, map[string]any{
+		"seal": config,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "key_shares")
+	rawShares := resp.Data["key_shares"].([]any)
+
+	var shares []string
+	for _, share := range rawShares {
+		shares = append(shares, share.(string))
+	}
+
+	return shares
+}
+
+func doUnseal(t require.TestingT, client *api.Client, name string, shares []string) {
+	unsealed := false
+	for index, share := range shares {
+		resp, err := client.Logical().Write("sys/namespaces/"+name+"/unseal", map[string]any{
+			"key": share,
+		})
+		require.NoError(t, err, "with client %v", index)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "sealed")
+		sealed := resp.Data["sealed"].(bool)
+		if !sealed {
+			unsealed = true
+		}
+	}
+
+	require.True(t, unsealed)
+}
+
+func doSeal(t require.TestingT, client *api.Client, name string) {
+	resp, err := client.Logical().Write("sys/namespaces/"+name+"/seal", nil)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+}
+
+func requireSealed(t require.TestingT, ns string, clients ...*api.Client) {
+	for index, client := range clients {
+		nsClient := client.WithNamespace(ns)
+		mounts, err := nsClient.Sys().ListMounts()
+		require.ErrorContains(t, err, "is sealed", "with client: %v", index)
+		require.Nil(t, mounts, "with client: %v", index)
+	}
+}
+
+func requireUnsealed(t require.TestingT, ns string, clients ...*api.Client) {
+	for _, client := range clients {
+		nsClient := client.WithNamespace(ns)
+		mounts, err := nsClient.Sys().ListMounts()
+		require.NoError(t, err)
+		require.NotEmpty(t, mounts)
+	}
+}
+
+func TestNamespaceClusterSealing(t *testing.T) {
+	t.Parallel()
+
+	cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+		NumCores:    3,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	client0 := cluster.Cores[0].Client
+	client1 := cluster.Cores[1].Client
+	client2 := cluster.Cores[2].Client
+	allClients := []*api.Client{client0, client1, client2}
+
+	sealConfig := `
+seal "shamir" {
+	shares = 3
+	threshold = 2
+}
+	`
+
+	// Create some sealed namespaces.
+	ns1Shares := createSealedNs(t, client0, "ns1", sealConfig)
+	require.Equal(t, 3, len(ns1Shares))
+
+	ns2Shares := createSealedNs(t, client1, "ns2", sealConfig)
+	require.Equal(t, 3, len(ns2Shares))
+
+	ns3Shares := createSealedNs(t, client2, "ns3", sealConfig)
+	require.Equal(t, 3, len(ns3Shares))
+
+	allNamespaces := map[string][]string{
+		"ns1": ns1Shares,
+		"ns2": ns2Shares,
+		"ns3": ns3Shares,
+	}
+
+	// All namespaces should be sealed.
+	for ns := range allNamespaces {
+		requireSealed(t, ns, allClients...)
+	}
+
+	// Unsealing with secondary client should result in namespace immediately
+	// being unsealed on active.
+	doUnseal(t, client1, "ns1", ns1Shares)
+	requireUnsealed(t, "ns1", client0)
+
+	// And eventually unsealed on all other nodes.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		requireUnsealed(t, "ns1", allClients...)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	// Sealing the active node and first standby node should result in the
+	// third node taking over.
+	require.NoError(t, client0.Sys().Seal())
+	require.NoError(t, client1.Sys().Seal())
+
+	// If we unseal ns2, and then step down the node, when the other nodes
+	// com back up, we should have ns1 and ns2 eventually once node 2
+	// synchronizes the state.
+	doUnseal(t, client2, "ns2", ns2Shares)
+	requireUnsealed(t, "ns2", client2)
+	require.NoError(t, client2.Sys().StepDown())
+
+	cluster.UnsealCore(t, cluster.Cores[0])
+	vault.TestWaitActive(t, cluster.Cores[0].Core)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		requireUnsealed(t, "ns1", client0)
+		requireUnsealed(t, "ns2", client0)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	// Bringing up node 1 should mean everything is available on all nodes.
+	cluster.UnsealCore(t, cluster.Cores[1])
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		requireUnsealed(t, "ns1", allClients...)
+		requireUnsealed(t, "ns2", allClients...)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	// Now unsealing ns3 should be fine.
+	doUnseal(t, client2, "ns3", ns3Shares)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for ns := range allNamespaces {
+			requireUnsealed(t, ns, allClients...)
+		}
+	}, 25*time.Second, 100*time.Millisecond)
+
+	// When we seal a namespace, it should lose all information on all
+	// nodes.
+	doSeal(t, client2, "ns1")
+	requireSealed(t, "ns1", client0)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		requireSealed(t, "ns1", allClients...)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	// Unsealing a manually sealed namespace should propagate to all nodes.
+	doUnseal(t, client1, "ns1", ns1Shares)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		requireUnsealed(t, "ns1", allClients...)
+	}, 25*time.Second, 100*time.Millisecond)
+}

--- a/vault/external_tests/storage/crosstest/cross_test.go
+++ b/vault/external_tests/storage/crosstest/cross_test.go
@@ -16,6 +16,7 @@ import (
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/physical/postgresql"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
@@ -183,7 +184,7 @@ func allLogical(t *testing.T) (map[string]logical.Storage, func()) {
 }
 
 func newAESBarrier(t *testing.T, parent physical.Backend) barrier.SecurityBarrier {
-	b := barrier.NewAESGCMBarrier(parent, "")
+	b := barrier.NewAESGCMBarrier(parent, namespace.RootNamespace)
 	key, err := b.GenerateKey()
 	require.NoError(t, err, "failed generating random key")
 

--- a/vault/forwarding/request_forwarding.go
+++ b/vault/forwarding/request_forwarding.go
@@ -40,6 +40,11 @@ type core interface {
 	clusterInfoGetter
 	GetRaftBackend() *raft.RaftBackend
 	Logger() log.Logger
+
+	NamespacesWithKeys() []string
+	NamespacesMissingKeys() []string
+	SetNamespaceKeys(context.Context, map[string][]byte) error
+	NamespaceKeys(context.Context, []string) (map[string][]byte, error)
 }
 
 type clusterPeerClusterAddrsCache interface {

--- a/vault/forwarding/request_forwarding_rpc.go
+++ b/vault/forwarding/request_forwarding_rpc.go
@@ -240,6 +240,7 @@ func (c *Client) Start() {
 				c.core.Logger().Warn("another namespace key synchronization is still running")
 				return
 			}
+			defer syncRunning.Store(false)
 
 			c.core.Logger().Info("synchronizing namespace keys with active node")
 
@@ -249,8 +250,6 @@ func (c *Client) Start() {
 			defer cancel()
 
 			c.SynchronizeKeys(ctx)
-
-			syncRunning.Store(false)
 		}
 
 		tick()
@@ -276,13 +275,13 @@ func (c *Client) SynchronizeKeys(ctx context.Context) {
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		if err := c.shipKeys(ctx); err != nil {
-			c.core.Logger().Error("got error sending keys", "error", err)
+			c.core.Logger().Error("error sending namespace keys", "error", err)
 		}
 	})
 
 	wg.Go(func() {
 		if err := c.getKeys(ctx); err != nil {
-			c.core.Logger().Error("got error receiving keys", "error", err)
+			c.core.Logger().Error("error receiving namespace keys", "error", err)
 		}
 	})
 
@@ -309,9 +308,11 @@ func (c *Client) shipKeys(ctx context.Context) error {
 		return nil
 	}
 
-	keys, getNamespaceErr := c.core.NamespaceKeys(ctx, response.Namespaces)
+	// Even if we have errs, if we have a non-empty key set, we should still
+	// attempt to send them to the active node.
+	keys, errs := c.core.NamespaceKeys(ctx, response.Namespaces)
 	if len(keys) == 0 {
-		return getNamespaceErr
+		return errs
 	}
 
 	reply := &SendNamespaceKeysRequest{}
@@ -324,10 +325,10 @@ func (c *Client) shipKeys(ctx context.Context) error {
 
 	_, err = c.SendNamespaceKeys(ctx, reply)
 	if err != nil {
-		return multierror.Append(getNamespaceErr, err)
+		return multierror.Append(errs, err)
 	}
 
-	return getNamespaceErr
+	return errs
 }
 
 func (c *Client) getKeys(ctx context.Context) error {
@@ -344,7 +345,7 @@ func (c *Client) getKeys(ctx context.Context) error {
 		return fmt.Errorf("failed getting namespace keys from active node: %w", err)
 	}
 
-	if len(keys.Keys) == 0 {
+	if keys == nil || len(keys.Keys) == 0 {
 		return nil
 	}
 

--- a/vault/forwarding/request_forwarding_rpc.go
+++ b/vault/forwarding/request_forwarding_rpc.go
@@ -242,7 +242,7 @@ func (c *Client) Start() {
 			}
 			defer syncRunning.Store(false)
 
-			c.core.Logger().Info("synchronizing namespace keys with active node")
+			c.core.Logger().Trace("synchronizing namespace keys with active node")
 
 			// We don't want to hang forever waiting to synchronize namespace
 			// seal keys with the active node. Bind it to a reasonable length.

--- a/vault/forwarding/request_forwarding_rpc.go
+++ b/vault/forwarding/request_forwarding_rpc.go
@@ -5,12 +5,17 @@ package forwarding
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"runtime/debug"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
 	"github.com/openbao/openbao/helper/forwarding"
 	"github.com/openbao/openbao/physical/raft"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -106,25 +111,76 @@ func (s *forwardedRequestRPCServer) Echo(ctx context.Context, in *EchoRequest) (
 	return reply, nil
 }
 
-type Client struct {
-	RequestForwardingClient
-	core        core
-	echoTicker  *time.Ticker
-	echoContext context.Context
+func (s *forwardedRequestRPCServer) AdvertiseNamespaceKeys(ctx context.Context, in *AdvertiseNamespaceKeysRequest) (*AdvertiseNamespaceKeysReply, error) {
+	missing := s.core.NamespacesMissingKeys()
+	ret := &AdvertiseNamespaceKeysReply{}
+	for _, uuid := range missing {
+		if slices.Contains(in.Namespaces, uuid) {
+			ret.Namespaces = append(ret.Namespaces, uuid)
+		}
+	}
+
+	return ret, nil
 }
 
-func NewClient(core core, requestForwardingClient RequestForwardingClient, echoTicker *time.Ticker, echoContext context.Context) *Client {
+func (s *forwardedRequestRPCServer) SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error) {
+	keys := make(map[string][]byte, len(in.Keys))
+
+	for _, key := range in.Keys {
+		keys[key.Uuid] = key.Key
+	}
+
+	if err := s.core.SetNamespaceKeys(ctx, keys); err != nil {
+		s.core.Logger().Error("failed to set namespace keys", "error", err)
+		return &SendNamespaceKeysReply{
+			Retry: true,
+		}, nil
+	}
+
+	return &SendNamespaceKeysReply{}, nil
+}
+
+func (s *forwardedRequestRPCServer) GetNamespaceKeys(ctx context.Context, in *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error) {
+	keys, err := s.core.NamespaceKeys(ctx, in.Namespaces)
+	if err != nil && len(keys) == 0 {
+		s.core.Logger().Error("call to get namespace keys failed", "error", err)
+		return &GetNamespaceKeysReply{}, nil
+	} else if err != nil {
+		s.core.Logger().Warn("call to get namespace keys failed, but continuing with keys", "error", err, "keys", len(keys))
+	}
+
+	resp := &GetNamespaceKeysReply{}
+	for uuid, rootKey := range keys {
+		resp.Keys = append(resp.Keys, &NamespaceKey{
+			Uuid: uuid,
+			Key:  rootKey,
+		})
+	}
+
+	return resp, nil
+}
+
+type Client struct {
+	RequestForwardingClient
+	core         core
+	taskContext  context.Context
+	echoTicker   *time.Ticker
+	nsSyncTicker *time.Ticker
+}
+
+func NewClient(core core, requestForwardingClient RequestForwardingClient, taskContext context.Context, echoTicker *time.Ticker, nsSyncTicker *time.Ticker) *Client {
 	return &Client{
 		RequestForwardingClient: requestForwardingClient,
 		core:                    core,
+		taskContext:             taskContext,
 		echoTicker:              echoTicker,
-		echoContext:             echoContext,
+		nsSyncTicker:            nsSyncTicker,
 	}
 }
 
 // NOTE: we also take advantage of gRPC's keepalive bits, but as we send data
 // with these requests it's useful to keep this as well
-func (c *Client) StartHeartbeat() {
+func (c *Client) Start() {
 	go func() {
 		clusterAddr := c.core.ClusterAddr()
 		hostname, _ := os.Hostname()
@@ -154,7 +210,7 @@ func (c *Client) StartHeartbeat() {
 			}
 			defer metrics.MeasureSinceWithLabels([]string{"ha", "rpc", "client", "echo"}, now, labels)
 
-			ctx, cancel := context.WithTimeout(c.echoContext, 2*time.Second)
+			ctx, cancel := context.WithTimeout(c.taskContext, 2*time.Second)
 			resp, err := c.Echo(ctx, req)
 			cancel()
 			if err != nil {
@@ -170,23 +226,136 @@ func (c *Client) StartHeartbeat() {
 				c.core.Logger().Debug("forwarding: unexpected echo response from active node", "message", resp.Message)
 				return
 			}
+
 			// Store the active node's replication state to display in
 			// sys/health calls
 			c.core.SetActiveNodeReplicationState(consts.ReplicationState(resp.ReplicationState))
 		}
 
+		// The ticker may fire several times before keys are synchronized,
+		// so ignore them.
+		var syncRunning atomic.Bool
+		syncKeys := func() {
+			if !syncRunning.CompareAndSwap(false, true) {
+				c.core.Logger().Warn("another namespace key synchronization is still running")
+				return
+			}
+
+			c.core.Logger().Info("synchronizing namespace keys with active node")
+
+			// We don't want to hang forever waiting to synchronize namespace
+			// seal keys with the active node. Bind it to a reasonable length.
+			ctx, cancel := context.WithTimeout(c.taskContext, 2*time.Minute)
+			defer cancel()
+
+			c.SynchronizeKeys(ctx)
+
+			syncRunning.Store(false)
+		}
+
 		tick()
+		syncKeys()
 
 		for {
 			select {
-			case <-c.echoContext.Done():
+			case <-c.taskContext.Done():
 				c.echoTicker.Stop()
 				c.core.Logger().Debug("forwarding: stopping heartbeating")
 				c.core.SetActiveNodeReplicationState(consts.ReplicationUnknown)
 				return
 			case <-c.echoTicker.C:
 				tick()
+			case <-c.nsSyncTicker.C:
+				go syncKeys()
 			}
 		}
 	}()
+}
+
+func (c *Client) SynchronizeKeys(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		if err := c.shipKeys(ctx); err != nil {
+			c.core.Logger().Error("got error sending keys", "error", err)
+		}
+	})
+
+	wg.Go(func() {
+		if err := c.getKeys(ctx); err != nil {
+			c.core.Logger().Error("got error receiving keys", "error", err)
+		}
+	})
+
+	wg.Wait()
+}
+
+func (c *Client) shipKeys(ctx context.Context) error {
+	namespaces := c.core.NamespacesWithKeys()
+	if len(namespaces) == 0 {
+		// Nothing to do.
+		return nil
+	}
+
+	advertisement := &AdvertiseNamespaceKeysRequest{
+		Namespaces: namespaces,
+	}
+
+	response, err := c.AdvertiseNamespaceKeys(ctx, advertisement)
+	if err != nil {
+		return fmt.Errorf("failed to send unsealed namespace advertisement to active node: %v", err)
+	}
+
+	if len(response.Namespaces) == 0 {
+		return nil
+	}
+
+	keys, getNamespaceErr := c.core.NamespaceKeys(ctx, response.Namespaces)
+	if len(keys) == 0 {
+		return getNamespaceErr
+	}
+
+	reply := &SendNamespaceKeysRequest{}
+	for uuid, key := range keys {
+		reply.Keys = append(reply.Keys, &NamespaceKey{
+			Uuid: uuid,
+			Key:  key,
+		})
+	}
+
+	_, err = c.SendNamespaceKeys(ctx, reply)
+	if err != nil {
+		return multierror.Append(getNamespaceErr, err)
+	}
+
+	return getNamespaceErr
+}
+
+func (c *Client) getKeys(ctx context.Context) error {
+	namespaces := c.core.NamespacesMissingKeys()
+	if len(namespaces) == 0 {
+		// No namespaces to update.
+		return nil
+	}
+
+	keys, err := c.GetNamespaceKeys(ctx, &GetNamespaceKeysRequest{
+		Namespaces: namespaces,
+	})
+	if err != nil {
+		return fmt.Errorf("failed getting namespace keys from active node: %w", err)
+	}
+
+	if len(keys.Keys) == 0 {
+		return nil
+	}
+
+	batch := make(map[string][]byte, len(keys.Keys))
+	for _, key := range keys.Keys {
+		batch[key.Uuid] = key.Key
+	}
+
+	if err := c.core.SetNamespaceKeys(ctx, batch); err != nil {
+		return fmt.Errorf("failed loading namespace keys: %w", err)
+	}
+
+	return nil
 }

--- a/vault/forwarding/request_forwarding_service.pb.go
+++ b/vault/forwarding/request_forwarding_service.pb.go
@@ -381,6 +381,330 @@ func (x *ClientKey) GetD() []byte {
 	return nil
 }
 
+type NamespaceKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uuid          string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Key           []byte                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NamespaceKey) Reset() {
+	*x = NamespaceKey{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NamespaceKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NamespaceKey) ProtoMessage() {}
+
+func (x *NamespaceKey) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NamespaceKey.ProtoReflect.Descriptor instead.
+func (*NamespaceKey) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *NamespaceKey) GetUuid() string {
+	if x != nil {
+		return x.Uuid
+	}
+	return ""
+}
+
+func (x *NamespaceKey) GetKey() []byte {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
+type AdvertiseNamespaceKeysRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespaces    []string               `protobuf:"bytes,1,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdvertiseNamespaceKeysRequest) Reset() {
+	*x = AdvertiseNamespaceKeysRequest{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdvertiseNamespaceKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdvertiseNamespaceKeysRequest) ProtoMessage() {}
+
+func (x *AdvertiseNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdvertiseNamespaceKeysRequest.ProtoReflect.Descriptor instead.
+func (*AdvertiseNamespaceKeysRequest) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *AdvertiseNamespaceKeysRequest) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+type AdvertiseNamespaceKeysReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespaces    []string               `protobuf:"bytes,1,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	Retry         bool                   `protobuf:"varint,2,opt,name=retry,proto3" json:"retry,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdvertiseNamespaceKeysReply) Reset() {
+	*x = AdvertiseNamespaceKeysReply{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdvertiseNamespaceKeysReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdvertiseNamespaceKeysReply) ProtoMessage() {}
+
+func (x *AdvertiseNamespaceKeysReply) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdvertiseNamespaceKeysReply.ProtoReflect.Descriptor instead.
+func (*AdvertiseNamespaceKeysReply) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *AdvertiseNamespaceKeysReply) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+func (x *AdvertiseNamespaceKeysReply) GetRetry() bool {
+	if x != nil {
+		return x.Retry
+	}
+	return false
+}
+
+type SendNamespaceKeysRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keys          []*NamespaceKey        `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendNamespaceKeysRequest) Reset() {
+	*x = SendNamespaceKeysRequest{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendNamespaceKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendNamespaceKeysRequest) ProtoMessage() {}
+
+func (x *SendNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendNamespaceKeysRequest.ProtoReflect.Descriptor instead.
+func (*SendNamespaceKeysRequest) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SendNamespaceKeysRequest) GetKeys() []*NamespaceKey {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type SendNamespaceKeysReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Retry         bool                   `protobuf:"varint,1,opt,name=retry,proto3" json:"retry,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendNamespaceKeysReply) Reset() {
+	*x = SendNamespaceKeysReply{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendNamespaceKeysReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendNamespaceKeysReply) ProtoMessage() {}
+
+func (x *SendNamespaceKeysReply) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendNamespaceKeysReply.ProtoReflect.Descriptor instead.
+func (*SendNamespaceKeysReply) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SendNamespaceKeysReply) GetRetry() bool {
+	if x != nil {
+		return x.Retry
+	}
+	return false
+}
+
+type GetNamespaceKeysRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespaces    []string               `protobuf:"bytes,1,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNamespaceKeysRequest) Reset() {
+	*x = GetNamespaceKeysRequest{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNamespaceKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNamespaceKeysRequest) ProtoMessage() {}
+
+func (x *GetNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNamespaceKeysRequest.ProtoReflect.Descriptor instead.
+func (*GetNamespaceKeysRequest) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetNamespaceKeysRequest) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+type GetNamespaceKeysReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keys          []*NamespaceKey        `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNamespaceKeysReply) Reset() {
+	*x = GetNamespaceKeysReply{}
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNamespaceKeysReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNamespaceKeysReply) ProtoMessage() {}
+
+func (x *GetNamespaceKeysReply) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNamespaceKeysReply.ProtoReflect.Descriptor instead.
+func (*GetNamespaceKeysReply) Descriptor() ([]byte, []int) {
+	return file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetNamespaceKeysReply) GetKeys() []*NamespaceKey {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
 var File_vault_forwarding_request_forwarding_service_proto protoreflect.FileDescriptor
 
 const file_vault_forwarding_request_forwarding_service_proto_rawDesc = "" +
@@ -419,10 +743,35 @@ const file_vault_forwarding_request_forwarding_service_proto_rawDesc = "" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\f\n" +
 	"\x01x\x18\x02 \x01(\fR\x01x\x12\f\n" +
 	"\x01y\x18\x03 \x01(\fR\x01y\x12\f\n" +
-	"\x01d\x18\x04 \x01(\fR\x01d2\x8c\x01\n" +
+	"\x01d\x18\x04 \x01(\fR\x01d\"4\n" +
+	"\fNamespaceKey\x12\x12\n" +
+	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x10\n" +
+	"\x03key\x18\x02 \x01(\fR\x03key\"?\n" +
+	"\x1dAdvertiseNamespaceKeysRequest\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\x01 \x03(\tR\n" +
+	"namespaces\"S\n" +
+	"\x1bAdvertiseNamespaceKeysReply\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\x01 \x03(\tR\n" +
+	"namespaces\x12\x14\n" +
+	"\x05retry\x18\x02 \x01(\bR\x05retry\"H\n" +
+	"\x18SendNamespaceKeysRequest\x12,\n" +
+	"\x04keys\x18\x01 \x03(\v2\x18.forwarding.NamespaceKeyR\x04keys\".\n" +
+	"\x16SendNamespaceKeysReply\x12\x14\n" +
+	"\x05retry\x18\x01 \x01(\bR\x05retry\"9\n" +
+	"\x17GetNamespaceKeysRequest\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\x01 \x03(\tR\n" +
+	"namespaces\"E\n" +
+	"\x15GetNamespaceKeysReply\x12,\n" +
+	"\x04keys\x18\x01 \x03(\v2\x18.forwarding.NamespaceKeyR\x04keys2\xbb\x03\n" +
 	"\x11RequestForwarding\x12=\n" +
 	"\x0eForwardRequest\x12\x13.forwarding.Request\x1a\x14.forwarding.Response\"\x00\x128\n" +
-	"\x04Echo\x12\x17.forwarding.EchoRequest\x1a\x15.forwarding.EchoReply\"\x00B-Z+github.com/openbao/openbao/vault/forwardingb\x06proto3"
+	"\x04Echo\x12\x17.forwarding.EchoRequest\x1a\x15.forwarding.EchoReply\"\x00\x12n\n" +
+	"\x16AdvertiseNamespaceKeys\x12).forwarding.AdvertiseNamespaceKeysRequest\x1a'.forwarding.AdvertiseNamespaceKeysReply\"\x00\x12_\n" +
+	"\x11SendNamespaceKeys\x12$.forwarding.SendNamespaceKeysRequest\x1a\".forwarding.SendNamespaceKeysReply\"\x00\x12\\\n" +
+	"\x10GetNamespaceKeys\x12#.forwarding.GetNamespaceKeysRequest\x1a!.forwarding.GetNamespaceKeysReply\"\x00B-Z+github.com/openbao/openbao/vault/forwardingb\x06proto3"
 
 var (
 	file_vault_forwarding_request_forwarding_service_proto_rawDescOnce sync.Once
@@ -436,27 +785,42 @@ func file_vault_forwarding_request_forwarding_service_proto_rawDescGZIP() []byte
 	return file_vault_forwarding_request_forwarding_service_proto_rawDescData
 }
 
-var file_vault_forwarding_request_forwarding_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_vault_forwarding_request_forwarding_service_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_vault_forwarding_request_forwarding_service_proto_goTypes = []any{
-	(*EchoRequest)(nil),         // 0: forwarding.EchoRequest
-	(*EchoReply)(nil),           // 1: forwarding.EchoReply
-	(*NodeInformation)(nil),     // 2: forwarding.NodeInformation
-	(*ClientKey)(nil),           // 3: forwarding.ClientKey
-	(*forwarding.Request)(nil),  // 4: forwarding.Request
-	(*forwarding.Response)(nil), // 5: forwarding.Response
+	(*EchoRequest)(nil),                   // 0: forwarding.EchoRequest
+	(*EchoReply)(nil),                     // 1: forwarding.EchoReply
+	(*NodeInformation)(nil),               // 2: forwarding.NodeInformation
+	(*ClientKey)(nil),                     // 3: forwarding.ClientKey
+	(*NamespaceKey)(nil),                  // 4: forwarding.NamespaceKey
+	(*AdvertiseNamespaceKeysRequest)(nil), // 5: forwarding.AdvertiseNamespaceKeysRequest
+	(*AdvertiseNamespaceKeysReply)(nil),   // 6: forwarding.AdvertiseNamespaceKeysReply
+	(*SendNamespaceKeysRequest)(nil),      // 7: forwarding.SendNamespaceKeysRequest
+	(*SendNamespaceKeysReply)(nil),        // 8: forwarding.SendNamespaceKeysReply
+	(*GetNamespaceKeysRequest)(nil),       // 9: forwarding.GetNamespaceKeysRequest
+	(*GetNamespaceKeysReply)(nil),         // 10: forwarding.GetNamespaceKeysReply
+	(*forwarding.Request)(nil),            // 11: forwarding.Request
+	(*forwarding.Response)(nil),           // 12: forwarding.Response
 }
 var file_vault_forwarding_request_forwarding_service_proto_depIDxs = []int32{
-	2, // 0: forwarding.EchoRequest.node_info:type_name -> forwarding.NodeInformation
-	2, // 1: forwarding.EchoReply.node_info:type_name -> forwarding.NodeInformation
-	4, // 2: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
-	0, // 3: forwarding.RequestForwarding.Echo:input_type -> forwarding.EchoRequest
-	5, // 4: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
-	1, // 5: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2,  // 0: forwarding.EchoRequest.node_info:type_name -> forwarding.NodeInformation
+	2,  // 1: forwarding.EchoReply.node_info:type_name -> forwarding.NodeInformation
+	4,  // 2: forwarding.SendNamespaceKeysRequest.keys:type_name -> forwarding.NamespaceKey
+	4,  // 3: forwarding.GetNamespaceKeysReply.keys:type_name -> forwarding.NamespaceKey
+	11, // 4: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
+	0,  // 5: forwarding.RequestForwarding.Echo:input_type -> forwarding.EchoRequest
+	5,  // 6: forwarding.RequestForwarding.AdvertiseNamespaceKeys:input_type -> forwarding.AdvertiseNamespaceKeysRequest
+	7,  // 7: forwarding.RequestForwarding.SendNamespaceKeys:input_type -> forwarding.SendNamespaceKeysRequest
+	9,  // 8: forwarding.RequestForwarding.GetNamespaceKeys:input_type -> forwarding.GetNamespaceKeysRequest
+	12, // 9: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
+	1,  // 10: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
+	6,  // 11: forwarding.RequestForwarding.AdvertiseNamespaceKeys:output_type -> forwarding.AdvertiseNamespaceKeysReply
+	8,  // 12: forwarding.RequestForwarding.SendNamespaceKeys:output_type -> forwarding.SendNamespaceKeysReply
+	10, // 13: forwarding.RequestForwarding.GetNamespaceKeys:output_type -> forwarding.GetNamespaceKeysReply
+	9,  // [9:14] is the sub-list for method output_type
+	4,  // [4:9] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_vault_forwarding_request_forwarding_service_proto_init() }
@@ -470,7 +834,7 @@ func file_vault_forwarding_request_forwarding_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vault_forwarding_request_forwarding_service_proto_rawDesc), len(file_vault_forwarding_request_forwarding_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/vault/forwarding/request_forwarding_service.pb.go
+++ b/vault/forwarding/request_forwarding_service.pb.go
@@ -766,9 +766,9 @@ const file_vault_forwarding_request_forwarding_service_proto_rawDesc = "" +
 	"namespaces\"E\n" +
 	"\x15GetNamespaceKeysReply\x12,\n" +
 	"\x04keys\x18\x01 \x03(\v2\x18.forwarding.NamespaceKeyR\x04keys2\xbb\x03\n" +
-	"\x11RequestForwarding\x12=\n" +
-	"\x0eForwardRequest\x12\x13.forwarding.Request\x1a\x14.forwarding.Response\"\x00\x128\n" +
-	"\x04Echo\x12\x17.forwarding.EchoRequest\x1a\x15.forwarding.EchoReply\"\x00\x12n\n" +
+	"\x11RequestForwarding\x128\n" +
+	"\x04Echo\x12\x17.forwarding.EchoRequest\x1a\x15.forwarding.EchoReply\"\x00\x12=\n" +
+	"\x0eForwardRequest\x12\x13.forwarding.Request\x1a\x14.forwarding.Response\"\x00\x12n\n" +
 	"\x16AdvertiseNamespaceKeys\x12).forwarding.AdvertiseNamespaceKeysRequest\x1a'.forwarding.AdvertiseNamespaceKeysReply\"\x00\x12_\n" +
 	"\x11SendNamespaceKeys\x12$.forwarding.SendNamespaceKeysRequest\x1a\".forwarding.SendNamespaceKeysReply\"\x00\x12\\\n" +
 	"\x10GetNamespaceKeys\x12#.forwarding.GetNamespaceKeysRequest\x1a!.forwarding.GetNamespaceKeysReply\"\x00B-Z+github.com/openbao/openbao/vault/forwardingb\x06proto3"
@@ -806,13 +806,13 @@ var file_vault_forwarding_request_forwarding_service_proto_depIDxs = []int32{
 	2,  // 1: forwarding.EchoReply.node_info:type_name -> forwarding.NodeInformation
 	4,  // 2: forwarding.SendNamespaceKeysRequest.keys:type_name -> forwarding.NamespaceKey
 	4,  // 3: forwarding.GetNamespaceKeysReply.keys:type_name -> forwarding.NamespaceKey
-	11, // 4: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
-	0,  // 5: forwarding.RequestForwarding.Echo:input_type -> forwarding.EchoRequest
+	0,  // 4: forwarding.RequestForwarding.Echo:input_type -> forwarding.EchoRequest
+	11, // 5: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
 	5,  // 6: forwarding.RequestForwarding.AdvertiseNamespaceKeys:input_type -> forwarding.AdvertiseNamespaceKeysRequest
 	7,  // 7: forwarding.RequestForwarding.SendNamespaceKeys:input_type -> forwarding.SendNamespaceKeysRequest
 	9,  // 8: forwarding.RequestForwarding.GetNamespaceKeys:input_type -> forwarding.GetNamespaceKeysRequest
-	12, // 9: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
-	1,  // 10: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
+	1,  // 9: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
+	12, // 10: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
 	6,  // 11: forwarding.RequestForwarding.AdvertiseNamespaceKeys:output_type -> forwarding.AdvertiseNamespaceKeysReply
 	8,  // 12: forwarding.RequestForwarding.SendNamespaceKeys:output_type -> forwarding.SendNamespaceKeysReply
 	10, // 13: forwarding.RequestForwarding.GetNamespaceKeys:output_type -> forwarding.GetNamespaceKeysReply

--- a/vault/forwarding/request_forwarding_service.proto
+++ b/vault/forwarding/request_forwarding_service.proto
@@ -17,7 +17,7 @@ message EchoRequest {
 	// ClusterAddrs is used to send up a list of cluster addresses to a dr
 	// primary from a dr secondary
 	repeated string cluster_addrs = 3;
-    
+
 	uint64 raft_applied_index = 4;
 	string raft_node_id = 5;
 	NodeInformation node_info = 6;
@@ -52,7 +52,49 @@ message ClientKey {
     bytes d = 4;
 }
 
+message NamespaceKey {
+    string uuid = 1;
+    bytes key = 2;
+}
+
+message AdvertiseNamespaceKeysRequest {
+    repeated string namespaces = 1;
+}
+
+message AdvertiseNamespaceKeysReply {
+    repeated string namespaces = 1;
+    bool retry = 2;
+}
+
+message SendNamespaceKeysRequest {
+    repeated NamespaceKey keys = 1;
+}
+
+message SendNamespaceKeysReply {
+    bool retry = 1;
+}
+
+message GetNamespaceKeysRequest {
+    repeated string namespaces = 1;
+}
+
+message GetNamespaceKeysReply {
+    repeated NamespaceKey keys = 1;
+}
+
 service RequestForwarding {
 	rpc ForwardRequest(forwarding.Request) returns (forwarding.Response) {}
 	rpc Echo(EchoRequest) returns (EchoReply) {}
+
+    // Namespace key sharing.
+
+    // standby->active; used when the standby was formerly the active node
+    // and a new active takes over without knowledge of past keys. This is
+    // a two-step process to avoid sending keys which the active node
+    // already knows about.
+    rpc AdvertiseNamespaceKeys(AdvertiseNamespaceKeysRequest) returns (AdvertiseNamespaceKeysReply) {};
+    rpc SendNamespaceKeys(SendNamespaceKeysRequest) returns (SendNamespaceKeysReply) {};
+
+    // active->standby; used by the standby to refresh keys.
+    rpc GetNamespaceKeys(GetNamespaceKeysRequest) returns (GetNamespaceKeysReply) {};
 }

--- a/vault/forwarding/request_forwarding_service.proto
+++ b/vault/forwarding/request_forwarding_service.proto
@@ -46,55 +46,65 @@ message NodeInformation {
 }
 
 message ClientKey {
-    string type = 1;
-    bytes x = 2;
-    bytes y = 3;
-    bytes d = 4;
+	string type = 1;
+	bytes x = 2;
+	bytes y = 3;
+	bytes d = 4;
 }
 
 message NamespaceKey {
-    string uuid = 1;
-    bytes key = 2;
+	string uuid = 1;
+	bytes key = 2;
 }
 
 message AdvertiseNamespaceKeysRequest {
-    repeated string namespaces = 1;
+	repeated string namespaces = 1;
 }
 
 message AdvertiseNamespaceKeysReply {
-    repeated string namespaces = 1;
-    bool retry = 2;
+	repeated string namespaces = 1;
+	bool retry = 2;
 }
 
 message SendNamespaceKeysRequest {
-    repeated NamespaceKey keys = 1;
+	repeated NamespaceKey keys = 1;
 }
 
 message SendNamespaceKeysReply {
-    bool retry = 1;
+	bool retry = 1;
 }
 
 message GetNamespaceKeysRequest {
-    repeated string namespaces = 1;
+	repeated string namespaces = 1;
 }
 
 message GetNamespaceKeysReply {
-    repeated NamespaceKey keys = 1;
+	repeated NamespaceKey keys = 1;
 }
 
+// RequestForwarding service is always a standby->active RPC invocation. While
+// named for legacy reasons (renaming a service is a breaking change), this
+// service handles more than just pure request forwarding.
+//
+// See also: https://medium.com/@hoangxuantoank13/grpc-non-breaking-changes-breaking-changes-and-versioning-solution-1dcb989beb16
 service RequestForwarding {
-	rpc ForwardRequest(forwarding.Request) returns (forwarding.Response) {}
+    // Service health.
+
 	rpc Echo(EchoRequest) returns (EchoReply) {}
 
-    // Namespace key sharing.
+    // Request forwarding.
 
-    // standby->active; used when the standby was formerly the active node
-    // and a new active takes over without knowledge of past keys. This is
-    // a two-step process to avoid sending keys which the active node
-    // already knows about.
-    rpc AdvertiseNamespaceKeys(AdvertiseNamespaceKeysRequest) returns (AdvertiseNamespaceKeysReply) {};
-    rpc SendNamespaceKeys(SendNamespaceKeysRequest) returns (SendNamespaceKeysReply) {};
+	rpc ForwardRequest(forwarding.Request) returns (forwarding.Response) {}
 
-    // active->standby; used by the standby to refresh keys.
-    rpc GetNamespaceKeys(GetNamespaceKeysRequest) returns (GetNamespaceKeysReply) {};
+	// Namespace key sharing.
+
+	// standby->active key sharing; used when the standby has knowledge of
+    // namespace keys that a new active node does not. This is a two-step
+	// process to avoid sending keys which the active node already knows
+    // about over the wire.
+	rpc AdvertiseNamespaceKeys(AdvertiseNamespaceKeysRequest) returns (AdvertiseNamespaceKeysReply) {};
+	rpc SendNamespaceKeys(SendNamespaceKeysRequest) returns (SendNamespaceKeysReply) {};
+
+	// active->standby key sharing; used by the standby to refresh keys.
+	rpc GetNamespaceKeys(GetNamespaceKeysRequest) returns (GetNamespaceKeysReply) {};
 }

--- a/vault/forwarding/request_forwarding_service_grpc.pb.go
+++ b/vault/forwarding/request_forwarding_service_grpc.pb.go
@@ -23,8 +23,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	RequestForwarding_ForwardRequest_FullMethodName = "/forwarding.RequestForwarding/ForwardRequest"
-	RequestForwarding_Echo_FullMethodName           = "/forwarding.RequestForwarding/Echo"
+	RequestForwarding_ForwardRequest_FullMethodName         = "/forwarding.RequestForwarding/ForwardRequest"
+	RequestForwarding_Echo_FullMethodName                   = "/forwarding.RequestForwarding/Echo"
+	RequestForwarding_AdvertiseNamespaceKeys_FullMethodName = "/forwarding.RequestForwarding/AdvertiseNamespaceKeys"
+	RequestForwarding_SendNamespaceKeys_FullMethodName      = "/forwarding.RequestForwarding/SendNamespaceKeys"
+	RequestForwarding_GetNamespaceKeys_FullMethodName       = "/forwarding.RequestForwarding/GetNamespaceKeys"
 )
 
 // RequestForwardingClient is the client API for RequestForwarding service.
@@ -33,6 +36,14 @@ const (
 type RequestForwardingClient interface {
 	ForwardRequest(ctx context.Context, in *forwarding.Request, opts ...grpc.CallOption) (*forwarding.Response, error)
 	Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoReply, error)
+	// standby->active; used when the standby was formerly the active node
+	// and a new active takes over without knowledge of past keys. This is
+	// a two-step process to avoid sending keys which the active node
+	// already knows about.
+	AdvertiseNamespaceKeys(ctx context.Context, in *AdvertiseNamespaceKeysRequest, opts ...grpc.CallOption) (*AdvertiseNamespaceKeysReply, error)
+	SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest, opts ...grpc.CallOption) (*SendNamespaceKeysReply, error)
+	// active->standby; used by the standby to refresh keys.
+	GetNamespaceKeys(ctx context.Context, in *GetNamespaceKeysRequest, opts ...grpc.CallOption) (*GetNamespaceKeysReply, error)
 }
 
 type requestForwardingClient struct {
@@ -63,12 +74,50 @@ func (c *requestForwardingClient) Echo(ctx context.Context, in *EchoRequest, opt
 	return out, nil
 }
 
+func (c *requestForwardingClient) AdvertiseNamespaceKeys(ctx context.Context, in *AdvertiseNamespaceKeysRequest, opts ...grpc.CallOption) (*AdvertiseNamespaceKeysReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdvertiseNamespaceKeysReply)
+	err := c.cc.Invoke(ctx, RequestForwarding_AdvertiseNamespaceKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *requestForwardingClient) SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest, opts ...grpc.CallOption) (*SendNamespaceKeysReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SendNamespaceKeysReply)
+	err := c.cc.Invoke(ctx, RequestForwarding_SendNamespaceKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *requestForwardingClient) GetNamespaceKeys(ctx context.Context, in *GetNamespaceKeysRequest, opts ...grpc.CallOption) (*GetNamespaceKeysReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetNamespaceKeysReply)
+	err := c.cc.Invoke(ctx, RequestForwarding_GetNamespaceKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // RequestForwardingServer is the server API for RequestForwarding service.
 // All implementations must embed UnimplementedRequestForwardingServer
 // for forward compatibility.
 type RequestForwardingServer interface {
 	ForwardRequest(context.Context, *forwarding.Request) (*forwarding.Response, error)
 	Echo(context.Context, *EchoRequest) (*EchoReply, error)
+	// standby->active; used when the standby was formerly the active node
+	// and a new active takes over without knowledge of past keys. This is
+	// a two-step process to avoid sending keys which the active node
+	// already knows about.
+	AdvertiseNamespaceKeys(context.Context, *AdvertiseNamespaceKeysRequest) (*AdvertiseNamespaceKeysReply, error)
+	SendNamespaceKeys(context.Context, *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error)
+	// active->standby; used by the standby to refresh keys.
+	GetNamespaceKeys(context.Context, *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error)
 	mustEmbedUnimplementedRequestForwardingServer()
 }
 
@@ -84,6 +133,15 @@ func (UnimplementedRequestForwardingServer) ForwardRequest(context.Context, *for
 }
 func (UnimplementedRequestForwardingServer) Echo(context.Context, *EchoRequest) (*EchoReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method Echo not implemented")
+}
+func (UnimplementedRequestForwardingServer) AdvertiseNamespaceKeys(context.Context, *AdvertiseNamespaceKeysRequest) (*AdvertiseNamespaceKeysReply, error) {
+	return nil, status.Error(codes.Unimplemented, "method AdvertiseNamespaceKeys not implemented")
+}
+func (UnimplementedRequestForwardingServer) SendNamespaceKeys(context.Context, *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error) {
+	return nil, status.Error(codes.Unimplemented, "method SendNamespaceKeys not implemented")
+}
+func (UnimplementedRequestForwardingServer) GetNamespaceKeys(context.Context, *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetNamespaceKeys not implemented")
 }
 func (UnimplementedRequestForwardingServer) mustEmbedUnimplementedRequestForwardingServer() {}
 func (UnimplementedRequestForwardingServer) testEmbeddedByValue()                           {}
@@ -142,6 +200,60 @@ func _RequestForwarding_Echo_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RequestForwarding_AdvertiseNamespaceKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AdvertiseNamespaceKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RequestForwardingServer).AdvertiseNamespaceKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RequestForwarding_AdvertiseNamespaceKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RequestForwardingServer).AdvertiseNamespaceKeys(ctx, req.(*AdvertiseNamespaceKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RequestForwarding_SendNamespaceKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SendNamespaceKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RequestForwardingServer).SendNamespaceKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RequestForwarding_SendNamespaceKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RequestForwardingServer).SendNamespaceKeys(ctx, req.(*SendNamespaceKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RequestForwarding_GetNamespaceKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetNamespaceKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RequestForwardingServer).GetNamespaceKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RequestForwarding_GetNamespaceKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RequestForwardingServer).GetNamespaceKeys(ctx, req.(*GetNamespaceKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // RequestForwarding_ServiceDesc is the grpc.ServiceDesc for RequestForwarding service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -156,6 +268,18 @@ var RequestForwarding_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Echo",
 			Handler:    _RequestForwarding_Echo_Handler,
+		},
+		{
+			MethodName: "AdvertiseNamespaceKeys",
+			Handler:    _RequestForwarding_AdvertiseNamespaceKeys_Handler,
+		},
+		{
+			MethodName: "SendNamespaceKeys",
+			Handler:    _RequestForwarding_SendNamespaceKeys_Handler,
+		},
+		{
+			MethodName: "GetNamespaceKeys",
+			Handler:    _RequestForwarding_GetNamespaceKeys_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/vault/forwarding/request_forwarding_service_grpc.pb.go
+++ b/vault/forwarding/request_forwarding_service_grpc.pb.go
@@ -23,8 +23,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	RequestForwarding_ForwardRequest_FullMethodName         = "/forwarding.RequestForwarding/ForwardRequest"
 	RequestForwarding_Echo_FullMethodName                   = "/forwarding.RequestForwarding/Echo"
+	RequestForwarding_ForwardRequest_FullMethodName         = "/forwarding.RequestForwarding/ForwardRequest"
 	RequestForwarding_AdvertiseNamespaceKeys_FullMethodName = "/forwarding.RequestForwarding/AdvertiseNamespaceKeys"
 	RequestForwarding_SendNamespaceKeys_FullMethodName      = "/forwarding.RequestForwarding/SendNamespaceKeys"
 	RequestForwarding_GetNamespaceKeys_FullMethodName       = "/forwarding.RequestForwarding/GetNamespaceKeys"
@@ -33,16 +33,22 @@ const (
 // RequestForwardingClient is the client API for RequestForwarding service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// RequestForwarding service is always a standby->active RPC invocation. While
+// named for legacy reasons (renaming a service is a breaking change), this
+// service handles more than just pure request forwarding.
+//
+// See also: https://medium.com/@hoangxuantoank13/grpc-non-breaking-changes-breaking-changes-and-versioning-solution-1dcb989beb16
 type RequestForwardingClient interface {
-	ForwardRequest(ctx context.Context, in *forwarding.Request, opts ...grpc.CallOption) (*forwarding.Response, error)
 	Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoReply, error)
-	// standby->active; used when the standby was formerly the active node
-	// and a new active takes over without knowledge of past keys. This is
-	// a two-step process to avoid sending keys which the active node
-	// already knows about.
+	ForwardRequest(ctx context.Context, in *forwarding.Request, opts ...grpc.CallOption) (*forwarding.Response, error)
+	// standby->active key sharing; used when the standby has knowledge of
+	// namespace keys that a new active node does not. This is a two-step
+	// process to avoid sending keys which the active node already knows
+	// about over the wire.
 	AdvertiseNamespaceKeys(ctx context.Context, in *AdvertiseNamespaceKeysRequest, opts ...grpc.CallOption) (*AdvertiseNamespaceKeysReply, error)
 	SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest, opts ...grpc.CallOption) (*SendNamespaceKeysReply, error)
-	// active->standby; used by the standby to refresh keys.
+	// active->standby key sharing; used by the standby to refresh keys.
 	GetNamespaceKeys(ctx context.Context, in *GetNamespaceKeysRequest, opts ...grpc.CallOption) (*GetNamespaceKeysReply, error)
 }
 
@@ -54,20 +60,20 @@ func NewRequestForwardingClient(cc grpc.ClientConnInterface) RequestForwardingCl
 	return &requestForwardingClient{cc}
 }
 
-func (c *requestForwardingClient) ForwardRequest(ctx context.Context, in *forwarding.Request, opts ...grpc.CallOption) (*forwarding.Response, error) {
+func (c *requestForwardingClient) Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(forwarding.Response)
-	err := c.cc.Invoke(ctx, RequestForwarding_ForwardRequest_FullMethodName, in, out, cOpts...)
+	out := new(EchoReply)
+	err := c.cc.Invoke(ctx, RequestForwarding_Echo_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *requestForwardingClient) Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoReply, error) {
+func (c *requestForwardingClient) ForwardRequest(ctx context.Context, in *forwarding.Request, opts ...grpc.CallOption) (*forwarding.Response, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(EchoReply)
-	err := c.cc.Invoke(ctx, RequestForwarding_Echo_FullMethodName, in, out, cOpts...)
+	out := new(forwarding.Response)
+	err := c.cc.Invoke(ctx, RequestForwarding_ForwardRequest_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -107,16 +113,22 @@ func (c *requestForwardingClient) GetNamespaceKeys(ctx context.Context, in *GetN
 // RequestForwardingServer is the server API for RequestForwarding service.
 // All implementations must embed UnimplementedRequestForwardingServer
 // for forward compatibility.
+//
+// RequestForwarding service is always a standby->active RPC invocation. While
+// named for legacy reasons (renaming a service is a breaking change), this
+// service handles more than just pure request forwarding.
+//
+// See also: https://medium.com/@hoangxuantoank13/grpc-non-breaking-changes-breaking-changes-and-versioning-solution-1dcb989beb16
 type RequestForwardingServer interface {
-	ForwardRequest(context.Context, *forwarding.Request) (*forwarding.Response, error)
 	Echo(context.Context, *EchoRequest) (*EchoReply, error)
-	// standby->active; used when the standby was formerly the active node
-	// and a new active takes over without knowledge of past keys. This is
-	// a two-step process to avoid sending keys which the active node
-	// already knows about.
+	ForwardRequest(context.Context, *forwarding.Request) (*forwarding.Response, error)
+	// standby->active key sharing; used when the standby has knowledge of
+	// namespace keys that a new active node does not. This is a two-step
+	// process to avoid sending keys which the active node already knows
+	// about over the wire.
 	AdvertiseNamespaceKeys(context.Context, *AdvertiseNamespaceKeysRequest) (*AdvertiseNamespaceKeysReply, error)
 	SendNamespaceKeys(context.Context, *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error)
-	// active->standby; used by the standby to refresh keys.
+	// active->standby key sharing; used by the standby to refresh keys.
 	GetNamespaceKeys(context.Context, *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error)
 	mustEmbedUnimplementedRequestForwardingServer()
 }
@@ -128,11 +140,11 @@ type RequestForwardingServer interface {
 // pointer dereference when methods are called.
 type UnimplementedRequestForwardingServer struct{}
 
-func (UnimplementedRequestForwardingServer) ForwardRequest(context.Context, *forwarding.Request) (*forwarding.Response, error) {
-	return nil, status.Error(codes.Unimplemented, "method ForwardRequest not implemented")
-}
 func (UnimplementedRequestForwardingServer) Echo(context.Context, *EchoRequest) (*EchoReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method Echo not implemented")
+}
+func (UnimplementedRequestForwardingServer) ForwardRequest(context.Context, *forwarding.Request) (*forwarding.Response, error) {
+	return nil, status.Error(codes.Unimplemented, "method ForwardRequest not implemented")
 }
 func (UnimplementedRequestForwardingServer) AdvertiseNamespaceKeys(context.Context, *AdvertiseNamespaceKeysRequest) (*AdvertiseNamespaceKeysReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method AdvertiseNamespaceKeys not implemented")
@@ -164,24 +176,6 @@ func RegisterRequestForwardingServer(s grpc.ServiceRegistrar, srv RequestForward
 	s.RegisterService(&RequestForwarding_ServiceDesc, srv)
 }
 
-func _RequestForwarding_ForwardRequest_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(forwarding.Request)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RequestForwardingServer).ForwardRequest(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: RequestForwarding_ForwardRequest_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RequestForwardingServer).ForwardRequest(ctx, req.(*forwarding.Request))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _RequestForwarding_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EchoRequest)
 	if err := dec(in); err != nil {
@@ -196,6 +190,24 @@ func _RequestForwarding_Echo_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RequestForwardingServer).Echo(ctx, req.(*EchoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RequestForwarding_ForwardRequest_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(forwarding.Request)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RequestForwardingServer).ForwardRequest(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RequestForwarding_ForwardRequest_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RequestForwardingServer).ForwardRequest(ctx, req.(*forwarding.Request))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -262,12 +274,12 @@ var RequestForwarding_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*RequestForwardingServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ForwardRequest",
-			Handler:    _RequestForwarding_ForwardRequest_Handler,
-		},
-		{
 			MethodName: "Echo",
 			Handler:    _RequestForwarding_Echo_Handler,
+		},
+		{
+			MethodName: "ForwardRequest",
+			Handler:    _RequestForwarding_ForwardRequest_Handler,
 		},
 		{
 			MethodName: "AdvertiseNamespaceKeys",

--- a/vault/logical_system_namespaces_seals.go
+++ b/vault/logical_system_namespaces_seals.go
@@ -96,6 +96,7 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 							Description: http.StatusText(http.StatusNoContent),
 						}},
 					},
+					ForwardPerformanceStandby: true,
 				},
 			},
 
@@ -131,6 +132,7 @@ func (b *SystemBackend) namespaceSealPaths() []*framework.Path {
 							Fields:      sealStatusSchema,
 						}},
 					},
+					ForwardPerformanceStandby: true,
 				},
 			},
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -1341,7 +1341,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: barrier.NamespacePrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table type, and 'cubbyholeNS' type with namespace not present in store",
@@ -1366,7 +1366,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: barrier.NamespacePrefix + testNamespace1.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'mount' table, and 'kv' type with nested namespace present",
@@ -1378,7 +1378,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   testNamespace2,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: barrier.NamespacePrefix + testNamespace2.UUID + "/" + backendBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type with namespace present",
@@ -1390,7 +1390,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   testNamespace1,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace1.UUID + "/" + barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: barrier.NamespacePrefix + testNamespace1.UUID + "/" + barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 		{
 			name: "entry of 'auth' table, and 'userpass' type with nested namespace present",
@@ -1402,7 +1402,7 @@ func TestCore_MountEntryView(t *testing.T) {
 				Namespace:   testNamespace2,
 			},
 
-			wantViewPrefix: namespaceBarrierPrefix + testNamespace2.UUID + "/" + barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
+			wantViewPrefix: barrier.NamespacePrefix + testNamespace2.UUID + "/" + barrier.CredentialBarrierPrefix + testMountEntryUUID + "/",
 		},
 	}
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -40,10 +40,6 @@ const (
 	// Namespace storage location.
 	namespaceStoreSubPath = "core/namespaces/"
 
-	// namespaceBarrierPrefix is the prefix to the UUID of a namespaces
-	// used in the barrier view for the namespace-owned backends.
-	namespaceBarrierPrefix = "namespaces/"
-
 	// nsDispatcherName is the name of the jobmanager instance for metrics.
 	nsDispatcherName = "namespace-deletion"
 
@@ -134,7 +130,7 @@ func NamespaceStoragePathPrefix(ns *namespace.Namespace) string {
 		return ""
 	}
 
-	return path.Join(namespaceBarrierPrefix, ns.UUID) + "/"
+	return path.Join(barrier.NamespacePrefix, ns.UUID) + "/"
 }
 
 // cancelNamespaceDeletion cancels goroutine that runs namespace deletion.
@@ -1628,7 +1624,7 @@ func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (strin
 // NamespaceByStoragePath parses an absolute storage path and returns the
 // matching namespace that the path belongs to.
 func (c *Core) NamespaceByStoragePath(ctx context.Context, path string) (*namespace.Namespace, string, error) {
-	rest, ok := strings.CutPrefix(path, namespaceBarrierPrefix)
+	rest, ok := strings.CutPrefix(path, barrier.NamespacePrefix)
 	if !ok || rest == "" {
 		return namespace.RootNamespace, path, nil
 	}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1070,7 +1070,7 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 	namespaceToSeal.ManuallySealed = true
 	nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
 	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
-		return fmt.Errorf("failed to persist namespace seal: %w", err)
+		return fmt.Errorf("failed to persist namespace: %w", err)
 	}
 
 	return errs
@@ -1123,7 +1123,7 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	namespaceToUnseal.ManuallySealed = false
 	nsCopy := namespaceToUnseal.Clone(true /* preserve unlock */)
 	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
-		return fmt.Errorf("failed to modify namespace seal: %w", err)
+		return fmt.Errorf("failed to modify namespace: %w", err)
 	}
 
 	// Unlock before calling unsealNamespace; we recurse back into the

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1111,7 +1111,7 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	}
 
 	if !namespaceToUnseal.HasParent(parent) {
-		return fmt.Errorf("given parent namespace from context is not the parent of this namespace")
+		return fmt.Errorf("namespace from context is not the parent of the target namespace to unseal")
 	}
 
 	// Now modify just this one namespace in storage to mark it unsealed,

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -242,6 +242,16 @@ func (ns *NamespaceStore) loadNamespacesLocked(ctx context.Context) error {
 		}
 		namespacesByUUID[namespace.UUID] = namespace
 		namespacesByAccessor[namespace.ID] = namespace
+
+		if namespace.ManuallySealed {
+			barrier := ns.core.sealManager.NamespaceBarrier(namespace.Path)
+			if barrier != nil && !barrier.Sealed() {
+				if err := barrier.Seal(); err != nil {
+					ns.logger.Warn("unable to seal namespace barrier", "error", err, "ns", namespace.Path, "uuid", namespace.UUID)
+				}
+			}
+		}
+
 		return nil
 	}
 
@@ -1050,6 +1060,19 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 		}
 	})
 
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get parent namespace from context: %w", err)
+	}
+
+	// Now modify just this one namespace in storage to mark it sealed,
+	// forgetting the keys from all other nodes.
+	namespaceToSeal.ManuallySealed = true
+	nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
+	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
+		return fmt.Errorf("failed to persist namespace seal: %w", err)
+	}
+
 	return errs
 }
 
@@ -1057,7 +1080,28 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key []byte) error {
 	defer metrics.MeasureSince([]string{"namespace", "unseal_namespace"}, time.Now())
 
-	namespaceToUnseal, err := ns.GetNamespaceByPath(ctx, path)
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading parent namespace from context: %w", err)
+	}
+
+	unlocker, err := ns.lockWithInvalidation(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	// We have multiple code paths we want to call unlock on.
+	var unlocked atomic.Bool
+	unlock := func() {
+		if !unlocked.CompareAndSwap(false, true) {
+			return
+		}
+
+		unlocker()
+	}
+	defer unlock()
+
+	namespaceToUnseal, err := ns.getNamespaceByPathLocked(ctx, path, false)
 	if err != nil {
 		return err
 	}
@@ -1069,6 +1113,22 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	if namespaceToUnseal.ID == namespace.RootNamespaceID {
 		return errors.New("cannot unseal root namespace with this operation")
 	}
+
+	if !namespaceToUnseal.HasParent(parent) {
+		return fmt.Errorf("given parent namespace from context is not the parent of this namespace")
+	}
+
+	// Now modify just this one namespace in storage to mark it unsealed,
+	// letting other nodes unseal it as well.
+	namespaceToUnseal.ManuallySealed = false
+	nsCopy := namespaceToUnseal.Clone(true /* preserve unlock */)
+	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
+		return fmt.Errorf("failed to modify namespace seal: %w", err)
+	}
+
+	// Unlock before calling unsealNamespace; we recurse back into the
+	// namespace store here.
+	unlock()
 
 	_, err = ns.unsealNamespace(ctx, namespaceToUnseal, key)
 	return err

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -249,7 +249,7 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 		break
 	}
 
-	keys, err = s.storage.List(ctx, path.Join(namespaceBarrierPrefix, parentNamespace.UUID, namespaceStoreSubPath)+"/")
+	keys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, parentNamespace.UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Empty(t, keys, "Expected empty namespace store on storage level")
 }
@@ -885,21 +885,21 @@ func TestNamespaceStorage(t *testing.T) {
 	require.Len(t, nsKeys, 2)
 	require.ElementsMatch(t, nsKeys, []string{namespaces[0].UUID, namespaces[1].UUID})
 
-	nsKeys, err = s.storage.List(ctx, path.Join(namespaceBarrierPrefix, namespaces[0].UUID, namespaceStoreSubPath)+"/")
+	nsKeys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, namespaces[0].UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Len(t, nsKeys, 1)
 	require.ElementsMatch(t, nsKeys, []string{namespaces[2].UUID})
 
-	nsKeys, err = s.storage.List(ctx, path.Join(namespaceBarrierPrefix, namespaces[1].UUID, namespaceStoreSubPath)+"/")
+	nsKeys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, namespaces[1].UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Len(t, nsKeys, 0)
 
-	nsKeys, err = s.storage.List(ctx, path.Join(namespaceBarrierPrefix, namespaces[2].UUID, namespaceStoreSubPath)+"/")
+	nsKeys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, namespaces[2].UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Len(t, nsKeys, 1)
 	require.ElementsMatch(t, nsKeys, []string{namespaces[3].UUID})
 
-	nsKeys, err = s.storage.List(ctx, path.Join(namespaceBarrierPrefix, namespaces[3].UUID, namespaceStoreSubPath)+"/")
+	nsKeys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, namespaces[3].UUID, namespaceStoreSubPath)+"/")
 	require.NoError(t, err)
 	require.Len(t, nsKeys, 0)
 

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/armon/go-radix"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
@@ -48,9 +49,10 @@ type SealManager struct {
 	// invalidated atomic.Bool
 
 	sealByNamespace              map[string]Seal
+	barrierByNamespace           map[string]barrier.SecurityBarrier
 	unlockInformationByNamespace map[string]*unlockInformation
 	rotationConfigByNamespace    map[string]*rotationConfig
-	barrierByNamespace           *radix.Tree
+	barrierByNamespacePath       *radix.Tree
 
 	// logger is the server logger copied over from core
 	logger hclog.Logger
@@ -60,11 +62,14 @@ type SealManager struct {
 func NewSealManager(core *Core, logger hclog.Logger) *SealManager {
 	return &SealManager{
 		core: core,
-		barrierByNamespace: radix.NewFromMap(map[string]interface{}{
+		barrierByNamespacePath: radix.NewFromMap(map[string]interface{}{
 			"": core.barrier,
 		}),
 		sealByNamespace: map[string]Seal{
 			namespace.RootNamespaceUUID: core.seal,
+		},
+		barrierByNamespace: map[string]barrier.SecurityBarrier{
+			namespace.RootNamespaceUUID: core.barrier,
 		},
 		unlockInformationByNamespace: make(map[string]*unlockInformation),
 		rotationConfigByNamespace:    make(map[string]*rotationConfig),
@@ -83,7 +88,7 @@ func (c *Core) SetupSealManager() {
 // sealAll seals barriers of all namespaces and resets seal manager state.
 func (sm *SealManager) sealAll() error {
 	var errs error
-	sm.barrierByNamespace.Walk(func(path string, b interface{}) bool {
+	sm.barrierByNamespacePath.Walk(func(path string, b interface{}) bool {
 		if b != nil {
 			errs = errors.Join(errs, b.(barrier.SecurityBarrier).Seal())
 		}
@@ -137,8 +142,10 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 		return fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	sm.barrierByNamespace.Insert(ns.Path, barrier.NewAESGCMBarrier(sm.core.physical, metaPrefix))
+	nsBarrier := barrier.NewAESGCMBarrier(sm.core.physical, metaPrefix)
+	sm.barrierByNamespacePath.Insert(ns.Path, nsBarrier)
 	sm.sealByNamespace[ns.UUID] = defaultSeal
+	sm.barrierByNamespace[ns.UUID] = nsBarrier
 
 	if writeToStorage {
 		if err := defaultSeal.SetBarrierConfig(ctx, sealConfig); err != nil {
@@ -158,10 +165,11 @@ func (sm *SealManager) RemoveNamespace(ns *namespace.Namespace) {
 		return
 	}
 
+	delete(sm.barrierByNamespace, ns.UUID)
 	delete(sm.sealByNamespace, ns.UUID)
 	delete(sm.unlockInformationByNamespace, ns.UUID)
 	delete(sm.rotationConfigByNamespace, ns.UUID)
-	sm.barrierByNamespace.Delete(ns.Path)
+	sm.barrierByNamespacePath.Delete(ns.Path)
 }
 
 // NamespaceView returns the BarrierView that applies to the given namespace.
@@ -185,7 +193,7 @@ func (sm *SealManager) NamespaceBarrierByLongestPrefix(nsPath string) barrier.Se
 // namespaceBarrierByLongestPrefix returns the barrier of a namespace matching
 // the longest prefix of the provided path, going up to the root namespace.
 func (sm *SealManager) namespaceBarrierByLongestPrefix(nsPath string) barrier.SecurityBarrier {
-	_, v, exists := sm.barrierByNamespace.LongestPrefix(nsPath)
+	_, v, exists := sm.barrierByNamespacePath.LongestPrefix(nsPath)
 	if !exists {
 		return nil
 	}
@@ -203,7 +211,7 @@ func (sm *SealManager) NamespaceBarrier(nsPath string) barrier.SecurityBarrier {
 
 // namespaceBarrier returns a namespace's barrier by namespace path.
 func (sm *SealManager) namespaceBarrier(nsPath string) barrier.SecurityBarrier {
-	v, exists := sm.barrierByNamespace.Get(nsPath)
+	v, exists := sm.barrierByNamespacePath.Get(nsPath)
 	if !exists {
 		return nil
 	}
@@ -605,4 +613,230 @@ func (sm *SealManager) InitializeBarrier(ctx context.Context, ns *namespace.Name
 	}
 
 	return sealKeyShares, nil
+}
+
+// UnsealWithRootKey is used for standby<->active key sharing, passing root
+// keys via the request forwarding mechanism.
+func (sm *SealManager) UnsealWithRootKey(ctx context.Context, ns *namespace.Namespace, rootKey []byte) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	sm.logger.Debug("namespace root key supplied")
+
+	barrier := sm.namespaceBarrier(ns.Path)
+	if barrier == nil {
+		return ErrNotSealable
+	}
+
+	// Check if already unsealed
+	if !barrier.Sealed() {
+		return nil
+	}
+
+	if err := barrier.Unseal(ctx, rootKey); err != nil {
+		return err
+	}
+
+	sm.logger.Info("unsealed namespace", "namespace", ns.Path)
+
+	return nil
+}
+
+// NamespacesWithKeys is a list of namespace UUIDs which have been unsealed.
+func (sm *SealManager) NamespacesWithKeys() []string {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+
+	var namespaces []string
+	for uuid, b := range sm.barrierByNamespace {
+		if !b.Sealed() && uuid != namespace.RootNamespaceUUID {
+			namespaces = append(namespaces, uuid)
+		}
+	}
+
+	return namespaces
+}
+
+// NamespacesWithKeys is a list of namespace UUIDs which are currently sealed.
+func (sm *SealManager) NamespacesMissingKeys() []string {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+
+	var namespaces []string
+	for uuid, b := range sm.barrierByNamespace {
+		if b.Sealed() && uuid != namespace.RootNamespaceUUID {
+			namespaces = append(namespaces, uuid)
+		}
+	}
+
+	return namespaces
+}
+
+// GetRootKey yields the underlying root key of the barrier for the given
+// namespace.
+func (sm *SealManager) GetRootKey(ctx context.Context, ns *namespace.Namespace) ([]byte, error) {
+	if ns.ID == namespace.RootNamespaceID {
+		return nil, errors.New("refusing to return root namespace's root key")
+	}
+
+	path, v, exists := sm.barrierByNamespacePath.LongestPrefix(ns.Path)
+	if !exists {
+		return nil, ErrNotInit
+	}
+
+	// namespace is not sealed?
+	if path != ns.Path {
+		return nil, nil
+	}
+
+	b := v.(barrier.SecurityBarrier)
+	keyring, err := b.Keyring()
+	if err != nil {
+		return nil, err
+	}
+
+	return keyring.RootKey(), nil
+}
+
+// NamespacesWithKeys returns the list of namespaces with keys locally known
+// by this node and are thus unsealed. This ignores non-sealed namespaces.
+func (c *Core) NamespacesWithKeys() []string {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	activeCtx := c.activeContext.Load()
+	if c.Sealed() || activeCtx.Err() != nil {
+		return nil
+	}
+
+	return c.sealManager.NamespacesWithKeys()
+}
+
+// NamespacesMissingKeys returns the list of namespaces which are currently
+// sealed and thus missing root keys.
+func (c *Core) NamespacesMissingKeys() []string {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	activeCtx := c.activeContext.Load()
+	if c.Sealed() || activeCtx.Err() != nil {
+		return nil
+	}
+
+	return c.sealManager.NamespacesMissingKeys()
+}
+
+// namespaceUnsealKeyPath contain a formatting directive to allow binding the
+// actual namespace's UUID to the AAD of the encryption context. These paths
+// should not be used by actual system paths and are synthetically used by the
+// external encryption exposed by the barrier.
+const namespaceUnsealKeyPath = "[internal]core/namespace/forwarded-root-key/%v"
+
+// SetNamespaceKeys loads keys sent via GRPC from the other node, which may
+// be an active or standby node. Keys for namespaces which are already
+// unsealed are ignored, though we try to filter these out to prevent them
+// appearing on the wire.
+//
+// Most operations use the node's active context, but we check for rpc
+// cancellation and bail early if necessary.
+func (c *Core) SetNamespaceKeys(rpcCtx context.Context, keys map[string][]byte) error {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	activeCtx := c.activeContext.Load()
+	if c.Sealed() || activeCtx.Err() != nil {
+		return errors.New("instance is sealed or context is not yet active")
+	}
+
+	// We don't want to continue past rpcCtx, but also need to be terminated
+	// by active context cancellation. Use the same trick as request
+	// handling.
+	ctx, cancel := context.WithCancel(activeCtx)
+	stop := context.AfterFunc(rpcCtx, cancel)
+	defer stop()
+
+	var err error
+	for uuid, encRootKey := range keys {
+		rootKey, decErr := c.barrier.Decrypt(ctx, fmt.Sprintf(namespaceUnsealKeyPath, uuid), encRootKey)
+		if decErr != nil {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: failed to decrypt root key: %w", uuid, decErr))
+			continue
+		}
+
+		ns, nsErr := c.namespaceStore.GetNamespace(ctx, uuid)
+		if nsErr != nil {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: %w", uuid, nsErr))
+			continue
+		}
+
+		if ns.ManuallySealed {
+			c.logger.Info("skipping unsealing namespace which has been manually sealed", "path", ns.Path, "uuid", uuid)
+			continue
+		}
+
+		// Because we have a root key here, we can't call UnsealNamespace(...)
+		// as that expects a key share.
+		if unsealErr := c.sealManager.UnsealWithRootKey(ctx, ns, rootKey); unsealErr != nil {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: %w", uuid, unsealErr))
+			continue
+		}
+
+		go func() {
+			if err := c.namespaceStore.postNamespaceUnseal(c.activeContext.Load(), ns); err != nil {
+				c.logger.Error("failed to load namespace after unseal", "error", err, "ns", uuid)
+			}
+		}()
+	}
+
+	return err
+}
+
+// NamespaceKeys returns the root keys for the given namespaces, encrypted
+// with the barrier keyring. This ensures that, as long as the root barrier
+// keyring's integrity remains, even keys over a compromised GRPC connection
+// should remain secure, though we enforce TLS for GRPC everywhere.
+func (c *Core) NamespaceKeys(rpcCtx context.Context, namespaces []string) (map[string][]byte, error) {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	activeCtx := c.activeContext.Load()
+	if c.Sealed() || activeCtx.Err() != nil {
+		return nil, errors.New("instance is sealed or context is not yet active")
+	}
+
+	// We don't want to continue past rpcCtx, but also need to be terminated
+	// by active context cancellation. Use the same trick as request
+	// handling.
+	ctx, cancel := context.WithCancel(activeCtx)
+	stop := context.AfterFunc(rpcCtx, cancel)
+	defer stop()
+
+	var err error
+	rootKeys := make(map[string][]byte, len(namespaces))
+
+	for _, uuid := range namespaces {
+		ns, nsErr := c.namespaceStore.GetNamespace(ctx, uuid)
+		if nsErr != nil {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: %w", uuid, nsErr))
+			continue
+		}
+		if ns == nil {
+			continue
+		}
+
+		rootKey, rootKeyErr := c.sealManager.GetRootKey(ctx, ns)
+		if rootKeyErr != nil && !errors.Is(rootKeyErr, barrier.ErrNamespaceSealed) {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: %w", uuid, rootKeyErr))
+			continue
+		}
+
+		encRootKey, encErr := c.barrier.Encrypt(ctx, fmt.Sprintf(namespaceUnsealKeyPath, uuid), rootKey)
+		if encErr != nil {
+			err = multierror.Append(err, fmt.Errorf("for namespace %v: failed to encrypt root key: %w", uuid, encErr))
+		}
+
+		rootKeys[uuid] = encRootKey
+	}
+
+	return rootKeys, err
 }

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -657,7 +657,7 @@ func (sm *SealManager) NamespacesWithKeys() []string {
 	return namespaces
 }
 
-// NamespacesWithKeys is a list of namespace UUIDs which are currently sealed.
+// NamespacesMissingKeys is a list of namespace UUIDs which are currently sealed.
 func (sm *SealManager) NamespacesMissingKeys() []string {
 	sm.lock.RLock()
 	defer sm.lock.RUnlock()

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -49,7 +49,6 @@ type SealManager struct {
 	// invalidated atomic.Bool
 
 	sealByNamespace              map[string]Seal
-	barrierByNamespace           map[string]barrier.SecurityBarrier
 	unlockInformationByNamespace map[string]*unlockInformation
 	rotationConfigByNamespace    map[string]*rotationConfig
 	barrierByNamespacePath       *radix.Tree
@@ -67,9 +66,6 @@ func NewSealManager(core *Core, logger hclog.Logger) *SealManager {
 		}),
 		sealByNamespace: map[string]Seal{
 			namespace.RootNamespaceUUID: core.seal,
-		},
-		barrierByNamespace: map[string]barrier.SecurityBarrier{
-			namespace.RootNamespaceUUID: core.barrier,
 		},
 		unlockInformationByNamespace: make(map[string]*unlockInformation),
 		rotationConfigByNamespace:    make(map[string]*rotationConfig),
@@ -142,10 +138,9 @@ func (sm *SealManager) SetSeal(ctx context.Context, sealConfig *SealConfig, ns *
 		return fmt.Errorf("error initializing seal: %w", err)
 	}
 
-	nsBarrier := barrier.NewAESGCMBarrier(sm.core.physical, metaPrefix)
+	nsBarrier := barrier.NewAESGCMBarrier(sm.core.physical, ns)
 	sm.barrierByNamespacePath.Insert(ns.Path, nsBarrier)
 	sm.sealByNamespace[ns.UUID] = defaultSeal
-	sm.barrierByNamespace[ns.UUID] = nsBarrier
 
 	if writeToStorage {
 		if err := defaultSeal.SetBarrierConfig(ctx, sealConfig); err != nil {
@@ -165,7 +160,6 @@ func (sm *SealManager) RemoveNamespace(ns *namespace.Namespace) {
 		return
 	}
 
-	delete(sm.barrierByNamespace, ns.UUID)
 	delete(sm.sealByNamespace, ns.UUID)
 	delete(sm.unlockInformationByNamespace, ns.UUID)
 	delete(sm.rotationConfigByNamespace, ns.UUID)
@@ -648,11 +642,21 @@ func (sm *SealManager) NamespacesWithKeys() []string {
 	defer sm.lock.RUnlock()
 
 	var namespaces []string
-	for uuid, b := range sm.barrierByNamespace {
-		if !b.Sealed() && uuid != namespace.RootNamespaceUUID {
-			namespaces = append(namespaces, uuid)
+	sm.barrierByNamespacePath.Walk(func(_ string, b interface{}) bool {
+		if b == nil {
+			return false
 		}
-	}
+
+		nsBarrier := b.(barrier.SecurityBarrier)
+		ns := nsBarrier.Namespace()
+		if nsBarrier.Sealed() || ns.UUID == namespace.RootNamespaceUUID {
+			// Skip sealed or root namespaces
+			return false
+		}
+
+		namespaces = append(namespaces, ns.UUID)
+		return false
+	})
 
 	return namespaces
 }
@@ -663,11 +667,21 @@ func (sm *SealManager) NamespacesMissingKeys() []string {
 	defer sm.lock.RUnlock()
 
 	var namespaces []string
-	for uuid, b := range sm.barrierByNamespace {
-		if b.Sealed() && uuid != namespace.RootNamespaceUUID {
-			namespaces = append(namespaces, uuid)
+	sm.barrierByNamespacePath.Walk(func(_ string, b interface{}) bool {
+		if b == nil {
+			return false
 		}
-	}
+
+		nsBarrier := b.(barrier.SecurityBarrier)
+		ns := nsBarrier.Namespace()
+		if !nsBarrier.Sealed() || ns.UUID == namespace.RootNamespaceUUID {
+			// Skip unsealed or root namespaces.
+			return false
+		}
+
+		namespaces = append(namespaces, ns.UUID)
+		return false
+	})
 
 	return namespaces
 }
@@ -675,18 +689,16 @@ func (sm *SealManager) NamespacesMissingKeys() []string {
 // GetRootKey yields the underlying root key of the barrier for the given
 // namespace.
 func (sm *SealManager) GetRootKey(ctx context.Context, ns *namespace.Namespace) ([]byte, error) {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
 	if ns.ID == namespace.RootNamespaceID {
 		return nil, errors.New("refusing to return root namespace's root key")
 	}
 
-	path, v, exists := sm.barrierByNamespacePath.LongestPrefix(ns.Path)
+	v, exists := sm.barrierByNamespacePath.Get(ns.Path)
 	if !exists {
 		return nil, ErrNotInit
-	}
-
-	// namespace is not sealed?
-	if path != ns.Path {
-		return nil, nil
 	}
 
 	b := v.(barrier.SecurityBarrier)

--- a/vault/seal_manager.go
+++ b/vault/seal_manager.go
@@ -782,7 +782,7 @@ func (c *Core) SetNamespaceKeys(rpcCtx context.Context, keys map[string][]byte) 
 		}
 
 		if ns.ManuallySealed {
-			c.logger.Info("skipping unsealing namespace which has been manually sealed", "path", ns.Path, "uuid", uuid)
+			c.logger.Debug("skipping unsealing namespace which has been manually sealed", "path", ns.Path, "uuid", uuid)
 			continue
 		}
 

--- a/vault/seal_manager_test.go
+++ b/vault/seal_manager_test.go
@@ -21,7 +21,6 @@ func TestSealManager_Reset(t *testing.T) {
 	// verify initial state of seal manager
 	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 1)
 	require.Len(t, c.sealManager.sealByNamespace, 1)
-	require.Len(t, c.sealManager.barrierByNamespace, 1)
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 
@@ -37,7 +36,6 @@ func TestSealManager_Reset(t *testing.T) {
 	}
 	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 11)
 	require.Len(t, c.sealManager.sealByNamespace, 11)
-	require.Len(t, c.sealManager.barrierByNamespace, 11)
 	// until we start unlock/rotation process for the namespace, we do not populate the map.
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
@@ -46,7 +44,6 @@ func TestSealManager_Reset(t *testing.T) {
 
 	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 11)
 	require.Len(t, c.sealManager.sealByNamespace, 11)
-	require.Len(t, c.sealManager.barrierByNamespace, 11)
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 }
@@ -147,9 +144,8 @@ func TestSealManager_InitializeBarrier(t *testing.T) {
 	_, err = c.sealManager.InitializeBarrier(ctx, flawedNS)
 	require.ErrorIs(t, err, ErrNotSealable)
 
-	nsBarrier := barrier.NewAESGCMBarrier(c.physical, NamespaceStoragePathPrefix(flawedNS))
+	nsBarrier := barrier.NewAESGCMBarrier(c.physical, flawedNS)
 	c.sealManager.barrierByNamespacePath.Insert(flawedNS.Path, nsBarrier)
-	c.sealManager.barrierByNamespace["notpresent"] = nsBarrier
 
 	// check seal config presence in storage
 	_, err = c.sealManager.InitializeBarrier(ctx, flawedNS)

--- a/vault/seal_manager_test.go
+++ b/vault/seal_manager_test.go
@@ -19,8 +19,9 @@ func TestSealManager_Reset(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 
 	// verify initial state of seal manager
-	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 1)
+	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 1)
 	require.Len(t, c.sealManager.sealByNamespace, 1)
+	require.Len(t, c.sealManager.barrierByNamespace, 1)
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 
@@ -34,16 +35,18 @@ func TestSealManager_Reset(t *testing.T) {
 		err := c.sealManager.SetSeal(namespace.RootContext(t.Context()), sealConfig, &namespace.Namespace{UUID: strconv.Itoa(i), Path: fmt.Sprintf("test%d/", i)}, false)
 		require.NoError(t, err)
 	}
-	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 11)
+	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 11)
 	require.Len(t, c.sealManager.sealByNamespace, 11)
+	require.Len(t, c.sealManager.barrierByNamespace, 11)
 	// until we start unlock/rotation process for the namespace, we do not populate the map.
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 
 	c.sealManager.Reset()
 
-	require.Len(t, c.sealManager.barrierByNamespace.ToMap(), 11)
+	require.Len(t, c.sealManager.barrierByNamespacePath.ToMap(), 11)
 	require.Len(t, c.sealManager.sealByNamespace, 11)
+	require.Len(t, c.sealManager.barrierByNamespace, 11)
 	require.Len(t, c.sealManager.unlockInformationByNamespace, 0)
 	require.Len(t, c.sealManager.rotationConfigByNamespace, 0)
 }
@@ -144,7 +147,9 @@ func TestSealManager_InitializeBarrier(t *testing.T) {
 	_, err = c.sealManager.InitializeBarrier(ctx, flawedNS)
 	require.ErrorIs(t, err, ErrNotSealable)
 
-	c.sealManager.barrierByNamespace.Insert(flawedNS.Path, barrier.NewAESGCMBarrier(c.physical, NamespaceStoragePathPrefix(flawedNS)))
+	nsBarrier := barrier.NewAESGCMBarrier(c.physical, NamespaceStoragePathPrefix(flawedNS))
+	c.sealManager.barrierByNamespacePath.Insert(flawedNS.Path, nsBarrier)
+	c.sealManager.barrierByNamespace["notpresent"] = nsBarrier
 
 	// check seal config presence in storage
 	_, err = c.sealManager.InitializeBarrier(ctx, flawedNS)


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This implements cross-cluster namespace seal synchronization, ensuring
that namespace operators only need to unseal once. This:

1. Adjusts namespace seal status changes to apply on the active node.
2. Writes namespace seal status into storage to be used as invalidation
   on manual seals/unseals. This is important for the future work on
   auto-unseal, as we need to ensure not to auto-unseal a manually
   sealed namespace (even between server restarts) and wait for manual
   recovery keys to be provided.
3. Builds a GRPC synchronization mechanism for root namespace keys;
   while the GRPC mechanism is protected, we encrypt with the root
   namespace's barrier keyring to ensure protection in transit.
   This is limited to keys which need to be synchronized and already
   synchronized keys do not re-appear on the wire.
4. Add a test validating that namespace synchronization behaves as
   expected.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Related: #1357

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
