### PR TITLE
Add CLI command for retrieving namespace seal status

### DIFF
--- a/api/sys_namespaces.go
+++ b/api/sys_namespaces.go
@@ -293,3 +293,29 @@ func (c *Sys) ReadNamespaceWithContext(ctx context.Context, name string) (*ReadN
 	}
 	return result.Data, nil
 }
+
+// NamespaceSealStatus returns information about the seal status of the namespace with the given name.
+func (c *Sys) NamespaceSealStatus(name string) (*NamespaceSealStatusOutput, error) {
+	return c.NamespaceSealStatusWithContext(context.Background(), name)
+}
+
+// NamespaceSealStatusWithContext returns information about the seal status of the namespace with the given name.
+func (c *Sys) NamespaceSealStatusWithContext(ctx context.Context, name string) (*NamespaceSealStatusOutput, error) {
+	if name == "" || name == "/" {
+		return nil, errors.New("name must not be empty")
+	}
+
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	secret, err := c.c.Logical().ReadWithContext(ctx, "sys/namespaces/"+name+"/seal-status")
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Data *NamespaceSealStatusOutput
+	}
+
+	return result.Data, mapstructure.Decode(secret, &result)
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -352,6 +352,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"namespace seal-status": func() (cli.Command, error) {
+			return &NamespaceSealStatusCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"operator": func() (cli.Command, error) {
 			return &OperatorCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/namespace_seal_status.go
+++ b/command/namespace_seal_status.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceSealCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceSealCommand)(nil)
+)
+
+type NamespaceSealStatusCommand struct {
+	*BaseCommand
+}
+
+func (c *NamespaceSealStatusCommand) Synopsis() string {
+	return "Prints the namespace seal status"
+}
+
+func (c *NamespaceSealStatusCommand) Help() string {
+	helpText := `
+Usage: bao namespace seal-status [options] PATH
+
+  This command reports whether the namespace is sealed and provides related
+  seal information. A sealed namespace does not respond to operations until it
+  is unsealed. If a namespace is not sealable, this command returns an error.
+
+  Retrieve the namespace seal status:
+
+      $ bao namespace seal-status ns1
+
+  Retrieve the seal status of a nested namespace:
+
+      $ bao namespace seal-status -ns ns1 ns2
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NamespaceSealStatusCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP)
+}
+
+func (c *NamespaceSealStatusCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultNamespaces()
+}
+
+func (c *NamespaceSealStatusCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *NamespaceSealStatusCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	namespacePath := strings.TrimSpace(args[0])
+	status, err := client.Sys().NamespaceSealStatus(namespacePath)
+	if err != nil || status == nil {
+		c.UI.Error(fmt.Sprintf("Error reading seal status: %s", err))
+		return 2
+	}
+
+	return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+		Type:        status.Type,
+		Initialized: status.Initialized,
+		Sealed:      status.Sealed,
+		T:           status.T,
+		N:           status.N,
+		Progress:    status.Progress,
+		Nonce:       status.Nonce,
+	}})
+}

--- a/command/namespace_seal_status_test.go
+++ b/command/namespace_seal_status_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func testNamespaceSealStatusCommand(tb testing.TB) (*cli.MockUi, *NamespaceSealStatusCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &NamespaceSealStatusCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestNamespaceSealStatusCommand_Run(t *testing.T) {
+	t.Parallel()
+	nsName := "ns"
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			name: "not enough arguments provided",
+			args: []string{},
+			out:  "Not enough arguments",
+			code: 1,
+		},
+		{
+			name: "too many arguments provided",
+			args: []string{"foo", "bar", "baz"},
+			out:  "Too many arguments",
+			code: 1,
+		},
+	}
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, _, closer := testVaultServerWithNamespace(t, nsName, true)
+				defer closer()
+
+				ui, cmd := testNamespaceSealStatusCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				require.Equalf(t, tc.code, code, "expected %d to be %d", code, tc.code)
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				require.Containsf(t, combined, tc.out, "expected %q to contain %q", combined, tc.out)
+			})
+		}
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		client, unsealShares, closer := testVaultServerWithNamespace(t, nsName, true)
+		defer closer()
+
+		ui, cmd := testNamespaceSealStatusCommand(t)
+		cmd.client = client
+
+		// Reset and check output
+		code := cmd.Run([]string{nsName})
+		require.Equalf(t, 0, code, "expected %d to be 0: %s", code, ui.ErrorWriter.String())
+
+		for _, key := range unsealShares {
+			ui, cmd := testNamespaceUnsealCommand(t)
+			cmd.client = client
+			cmd.testOutput = io.Discard
+
+			// Reset and check output
+			code := cmd.Run([]string{nsName, key})
+			require.Equalf(t, 0, code, "expected %d to be 0: %s", code, ui.ErrorWriter.String())
+		}
+
+		ui, cmd = testNamespaceSealStatusCommand(t)
+		cmd.client = client
+
+		// Reset and check output
+		code = cmd.Run([]string{nsName})
+		require.Equalf(t, 0, code, "expected %d to be 0: %s", code, ui.ErrorWriter.String())
+	})
+}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Adds API methods and the CLI command for retrieving namespace seal status.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Part of #1357 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
