### PR TITLE
Propagate JSON parse errors consistently

### DIFF
--- a/changelog/3240.txt
+++ b/changelog/3240.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+http: Always include full JSON parse and complexity errors in the response instead of hiding it behind a constant error message.
+```

--- a/http/handler.go
+++ b/http/handler.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"maps"
 	"mime"
@@ -858,33 +857,6 @@ func parseQuery(values url.Values) map[string]interface{} {
 		return data
 	}
 	return nil
-}
-
-func parseJSONRequest(r *http.Request, w http.ResponseWriter, out interface{}) error {
-	ctx := r.Context()
-
-	// Enforce limits on JSON complexity.
-	_, _, err := EnforceJSONComplexityLimits(ctx, r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to limit JSON input: %w", err)
-	}
-
-	// Reset to the beginning.
-	if err := resetBody(r); err != nil {
-		return fmt.Errorf("failed to reset body: %w", err)
-	}
-
-	err = jsonutil.DecodeJSONFromReader(r.Body, out)
-	if err != nil && err != io.EOF {
-		return fmt.Errorf("failed to parse JSON input: %w", err)
-	}
-
-	// Reset to the beginning again.
-	if err := resetBody(r); err != nil {
-		return fmt.Errorf("failed to reset body: %w", err)
-	}
-
-	return err
 }
 
 // parseFormRequest parses values from a form POST.

--- a/http/json.go
+++ b/http/json.go
@@ -7,13 +7,48 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
+
+	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 )
 
 var (
-	ErrJSONExceededMemory  = errors.New("input JSON exceeded maximum estimated memory limits")
-	ErrJSONExceededStrings = errors.New("input JSON exceeded maximum number of strings")
+	ErrJSONExceededMemory  = errors.New("exceeded maximum estimated memory limits")
+	ErrJSONExceededStrings = errors.New("exceeded maximum number of strings")
 )
+
+func parseJSONRequest(r *http.Request, out any) error {
+	ctx := r.Context()
+
+	// Enforce limits on JSON complexity.
+	if _, _, err := EnforceJSONComplexityLimits(ctx, r.Body); err != nil {
+		switch {
+		case errors.Is(err, ErrJSONExceededMemory), errors.Is(err, ErrJSONExceededStrings):
+			return fmt.Errorf("refused JSON input due to high complexity: %w", err)
+		default:
+			return fmt.Errorf("failed to decode JSON input: %w", err)
+		}
+	}
+
+	// Reset to the beginning.
+	if err := resetBody(r); err != nil {
+		return fmt.Errorf("failed to reset body: %w", err)
+	}
+
+	// Actually decode.
+	if err := jsonutil.DecodeJSONFromReader(r.Body, out); err != nil {
+		return fmt.Errorf("failed to decode JSON input: %w", err)
+	}
+
+	// Reset to the beginning again.
+	if err := resetBody(r); err != nil {
+		return fmt.Errorf("failed to reset body: %w", err)
+	}
+
+	return nil
+}
 
 type ctxKeyMaxRequestJsonMemory struct{}
 

--- a/http/json_test.go
+++ b/http/json_test.go
@@ -83,7 +83,7 @@ func TestSafeJSONReader(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, "POST", "/v1/sys/testing", body)
 		require.NoError(t, err)
 
-		err = parseJSONRequest(req, nil, &out)
+		err = parseJSONRequest(req, &out)
 		require.NoError(t, err)
 
 		// Decreasing memory by one, if allowed, should cause a failure. This
@@ -97,7 +97,7 @@ func TestSafeJSONReader(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, "POST", "/v1/sys/testing", bytes.NewBufferString(test))
 			require.NoError(t, err)
 
-			err = parseJSONRequest(req, nil, &out)
+			err = parseJSONRequest(req, &out)
 			require.Error(t, err)
 			require.ErrorContains(t, err, ErrJSONExceededMemory.Error())
 		}
@@ -113,7 +113,7 @@ func TestSafeJSONReader(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, "POST", "/v1/sys/testing", bytes.NewBufferString(test))
 			require.NoError(t, err)
 
-			err = parseJSONRequest(req, nil, &out)
+			err = parseJSONRequest(req, &out)
 			require.Error(t, err)
 			require.ErrorContains(t, err, ErrJSONExceededStrings.Error())
 		}

--- a/http/logical.go
+++ b/http/logical.go
@@ -133,15 +133,8 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 
 				data = formData
 			} else {
-				err = parseJSONRequest(r, w, &data)
-				if err == io.EOF {
-					data = nil
-					err = nil
-				}
-				if err != nil {
-					status := http.StatusBadRequest
-					logical.AdjustErrorStatusCode(&status, err)
-					return nil, status, errors.New("error parsing JSON")
+				if err := parseJSONRequest(r, &data); err != nil && !errors.Is(err, io.EOF) {
+					return nil, http.StatusBadRequest, err
 				}
 			}
 		}
@@ -161,17 +154,8 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 			return nil, http.StatusUnsupportedMediaType, fmt.Errorf("PATCH requires Content-Type of %s, provided %s", MergePatchContentTypeHeader, contentType)
 		}
 
-		err = parseJSONRequest(r, w, &data)
-
-		if err == io.EOF {
-			data = nil
-			err = nil
-		}
-
-		if err != nil {
-			status := http.StatusBadRequest
-			logical.AdjustErrorStatusCode(&status, err)
-			return nil, status, errors.New("error parsing JSON")
+		if err := parseJSONRequest(r, &data); err != nil && !errors.Is(err, io.EOF) {
+			return nil, http.StatusBadRequest, err
 		}
 
 	case "LIST":

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -99,7 +99,7 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 	defer cancel()
 
 	var req GenerateRootInitRequest
-	if err := parseJSONRequest(r, w, &req); err != nil && err != io.EOF {
+	if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -152,7 +152,7 @@ func handleSysGenerateRootUpdate(core *vault.Core, generateStrategy vault.Genera
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the request
 		var req GenerateRootUpdateRequest
-		if err := parseJSONRequest(r, w, &req); err != nil {
+		if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +47,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 
 	// Parse the request
 	var req InitRequest
-	if err := parseJSONRequest(r, w, &req); err != nil {
+	if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -49,7 +49,7 @@ func handleSysRaftJoin(core *vault.Core) http.Handler {
 func handleSysRaftJoinPost(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req JoinRequest
-	if err := parseJSONRequest(r, w, &req); err != nil && err != io.EOF {
+	if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/openbao/openbao/helper/pgpkeys"
@@ -96,7 +97,7 @@ func handleSysRekeyInitGet(ctx context.Context, core *vault.Core, recovery bool,
 func handleSysRekeyInitPut(ctx context.Context, core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req RekeyRequest
-	if err := parseJSONRequest(r, w, &req); err != nil {
+	if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -139,7 +140,7 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the request
 		var req RekeyUpdateRequest
-		if err := parseJSONRequest(r, w, &req); err != nil {
+		if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}
@@ -276,7 +277,7 @@ func handleSysRekeyVerifyDelete(ctx context.Context, core *vault.Core, recovery 
 func handleSysRekeyVerifyPut(_ context.Context, core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req RekeyVerificationUpdateRequest
-	if err := parseJSONRequest(r, w, &req); err != nil {
+	if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/hashicorp/errwrap"
@@ -88,7 +89,7 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 
 		// Parse the request
 		var req UnsealRequest
-		if err := parseJSONRequest(r, w, &req); err != nil {
+		if err := parseJSONRequest(r, &req); err != nil && !errors.Is(err, io.EOF) {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}


### PR DESCRIPTION
## Description

Always propagate the full error to the response, like was already the case for several one-off endpoints (`http/sys_*.go` and friends) but not for "logical" requests. See discussion in https://github.com/openbao/openbao/issues/2996.

Also clean up error wrapping to the point that we don't include duplicate information, such as "error parsing JSON: failed to parse JSON: ...".

## Rationale

Resolves: https://github.com/openbao/openbao/issues/2996

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
