### PR TITLE
fix two-phase MFA failure on standby node

### DIFF
--- a/changelog/3246.txt
+++ b/changelog/3246.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/mfa: Correctly forward two-phase MFA validations on standby nodes
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -3331,6 +3331,9 @@ func (c *Core) runLockedUserEntryUpdatesForMountAccessor(ctx context.Context, vi
 // PopMFAResponseAuthByID pops an item from the mfaResponseAuthQueue by ID
 // it returns the cached auth response or an error
 func (c *Core) PopMFAResponseAuthByID(reqID string) (*MFACachedAuthResponse, error) {
+	if c.standby.Load() {
+		return nil, logical.ErrReadOnly
+	}
 	c.mfaResponseAuthQueueLock.Lock()
 	defer c.mfaResponseAuthQueueLock.Unlock()
 	return c.mfaResponseAuthQueue.PopByKey(reqID)
@@ -3339,6 +3342,9 @@ func (c *Core) PopMFAResponseAuthByID(reqID string) (*MFACachedAuthResponse, err
 // SaveMFAResponseAuth pushes an MFACachedAuthResponse to the mfaResponseAuthQueue.
 // it returns an error in case of failure
 func (c *Core) SaveMFAResponseAuth(respAuth *MFACachedAuthResponse) error {
+	if c.standby.Load() {
+		return logical.ErrReadOnly
+	}
 	c.mfaResponseAuthQueueLock.Lock()
 	defer c.mfaResponseAuthQueueLock.Unlock()
 	return c.mfaResponseAuthQueue.Push(respAuth)

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -385,8 +385,11 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	doTwoPhaseLogin(t, userClient2, enginePath2, methodID, testuser2, entityID2)
 
 	// let's see if user1 is able to login after 5 seconds
-	time.Sleep(5 * time.Second)
+	time.Sleep(time.Duration(waitPeriod) * time.Second)
 	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, testuser1, entityID1)
+
+	// check two phase login on standbys (depends on the time.Sleep above to get a fresh TOTP code)
+	doTwoPhaseLogin(t, cluster.Cores[1].Client, enginePath2, methodID, testuser2, entityID2)
 
 	// Destroy the secret so that the token can self generate
 	_, err = client.Logical().WriteWithContext(t.Context(), "identity/mfa/method/totp/admin-destroy", map[string]interface{}{


### PR DESCRIPTION
## Description

Make sure mfa validation requests are forwarded

## Rationale

mfa validations are kept in memory only and can only be process by the primary.

Resolves: https://github.com/openbao/openbao/issues/3208

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
