### PR TITLE
Refactor ListNamespaces

### DIFF
--- a/command/namespace_scan.go
+++ b/command/namespace_scan.go
@@ -103,23 +103,14 @@ func (c *NamespaceScanCommand) Run(args []string) int {
 		}
 	}
 
-	if secret == nil {
+	if secret == nil || !ok {
 		c.UI.Error("No namespaces found")
 		return 2
 	}
 
 	// There could be e.g. warnings
-	if secret.Data == nil {
+	if secret.Data == nil || (secret.WrapInfo != nil && secret.WrapInfo.TTL != 0) {
 		return OutputSecret(c.UI, secret)
-	}
-
-	if secret.WrapInfo != nil && secret.WrapInfo.TTL != 0 {
-		return OutputSecret(c.UI, secret)
-	}
-
-	if !ok {
-		c.UI.Error("No entries found")
-		return 2
 	}
 
 	if c.flagDetailed && Format(c.UI) != "table" {

--- a/command/namespace_scan_test.go
+++ b/command/namespace_scan_test.go
@@ -33,7 +33,7 @@ func TestNamespaceScanCommand_Run(t *testing.T) {
 		{
 			"no_entries",
 			[]string{},
-			"No entries found",
+			"No namespaces found",
 			2,
 		},
 		{

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -351,8 +351,10 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 		},
 	}
 
+	ctx := namespace.RootContext(t.Context())
+
 	// Both should set up successfully
-	err := c.setupCredentials(t.Context())
+	err := c.setupCredentials(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +362,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 		t.Fatalf("expected two entries, got %d", len(c.auth.Entries))
 	}
 
-	localEntries, err := c.barrier.List(t.Context(), coreLocalAuthConfigPath+"/")
+	localEntries, err := c.barrier.List(ctx, coreLocalAuthConfigPath+"/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,11 +371,11 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 	}
 
 	c.auth.Entries[1].Local = true
-	if err := c.persistAuth(t.Context(), c.barrier, c.auth, nil, ""); err != nil {
+	if err := c.persistAuth(ctx, c.barrier, c.auth, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	localEntries, err = c.barrier.List(t.Context(), coreLocalAuthConfigPath+"/")
+	localEntries, err = c.barrier.List(ctx, coreLocalAuthConfigPath+"/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +383,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 		t.Fatalf("expected one entry in local auth table, got %#v", localEntries)
 	}
 	for _, localEntry := range localEntries {
-		rawLocal, err := c.barrier.Get(t.Context(), coreLocalAuthConfigPath+"/"+localEntry)
+		rawLocal, err := c.barrier.Get(ctx, coreLocalAuthConfigPath+"/"+localEntry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -399,7 +401,7 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 	}
 
 	oldCredential := c.auth
-	if err := c.loadCredentials(t.Context(), false); err != nil {
+	if err := c.loadCredentials(ctx, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -406,6 +406,8 @@ func (c *Core) entityGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLab
 		return []metricsutil.GaugeLabelValues{}, errors.New("nil identity store")
 	}
 
+	ctx = namespace.RootContext(ctx)
+
 	byNamespace, err := identityStore.CountEntitiesByNamespace(ctx)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
@@ -436,6 +438,8 @@ func (c *Core) entityGaugeCollectorByMount(ctx context.Context) ([]metricsutil.G
 	if identityStore == nil {
 		return []metricsutil.GaugeLabelValues{}, errors.New("nil identity store")
 	}
+
+	ctx = namespace.RootContext(ctx)
 
 	byAccessor, err := identityStore.CountEntitiesByMountAccessor(ctx)
 	if err != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3958,7 +3958,7 @@ func (b *SystemBackend) pathInternalUINamespacesRead(ctx context.Context, req *l
 		return nil, err
 	}
 
-	list, err := b.Core.namespaceStore.ListNamespaces(ctx, false, false)
+	list, err := b.Core.namespaceStore.ListNamespaces(ctx, ListNamespaceOpts{IncludeSealed: true})
 	if err != nil {
 		return nil, errors.New("failed to list namespaces")
 	}

--- a/vault/logical_system_namespaces.go
+++ b/vault/logical_system_namespaces.go
@@ -273,7 +273,9 @@ func (b *SystemBackend) handleNamespacesList() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, false, false)
+		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, ListNamespaceOpts{
+			IncludeSealed: true,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +299,10 @@ func (b *SystemBackend) handleNamespacesScan() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, false, true)
+		entries, err := b.Core.namespaceStore.ListNamespaces(ctx, ListNamespaceOpts{
+			Recursive:     true,
+			IncludeSealed: true,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/vault/logical_system_user_lockout.go
+++ b/vault/logical_system_user_lockout.go
@@ -102,7 +102,7 @@ func (b *SystemBackend) getLockedUsersResponses(ctx context.Context, mountAccess
 
 	// no mount_accessor is provided in request, get information
 	// for current namespace and all unsealed child namespaces
-	nsList, err := b.Core.namespaceStore.ListAllNamespaces(ctx, true, false)
+	nsList, err := b.Core.ListNamespaces(ctx)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -299,8 +299,10 @@ func TestCore_Mount_Local(t *testing.T) {
 		},
 	}
 
+	ctx := namespace.RootContext(t.Context())
+
 	// Both should set up successfully
-	err := c.setupMounts(namespace.RootContext(t.Context()))
+	err := c.setupMounts(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +310,7 @@ func TestCore_Mount_Local(t *testing.T) {
 		t.Fatalf("expected two entries, got %d", len(c.mounts.Entries))
 	}
 
-	localEntries, err := c.barrier.List(t.Context(), coreLocalMountConfigPath+"/")
+	localEntries, err := c.barrier.List(ctx, coreLocalMountConfigPath+"/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +318,7 @@ func TestCore_Mount_Local(t *testing.T) {
 		t.Fatalf("expected one entry in local mount table, got %#v", localEntries)
 	}
 	for _, localEntry := range localEntries {
-		rawLocal, err := c.barrier.Get(t.Context(), coreLocalMountConfigPath+"/"+localEntry)
+		rawLocal, err := c.barrier.Get(ctx, coreLocalMountConfigPath+"/"+localEntry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -335,7 +337,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	c.mounts.Entries[1].Local = true
-	if err := c.persistMounts(t.Context(), c.barrier, c.mounts, nil, ""); err != nil {
+	if err := c.persistMounts(ctx, c.barrier, c.mounts, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -343,7 +345,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	// table, the table initially when core unseals contains cubbyhole as per
 	// above, but then we overwrite it with our own table with one local entry,
 	// so we should now only expect the noop2 entry
-	localEntries, err = c.barrier.List(t.Context(), coreLocalMountConfigPath+"/")
+	localEntries, err = c.barrier.List(ctx, coreLocalMountConfigPath+"/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +353,7 @@ func TestCore_Mount_Local(t *testing.T) {
 		t.Fatalf("expected one entry in local mount table, got %#v", localEntries)
 	}
 	for _, localEntry := range localEntries {
-		rawLocal, err := c.barrier.Get(t.Context(), coreLocalMountConfigPath+"/"+localEntry)
+		rawLocal, err := c.barrier.Get(ctx, coreLocalMountConfigPath+"/"+localEntry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -369,7 +371,7 @@ func TestCore_Mount_Local(t *testing.T) {
 	}
 
 	oldMounts := c.mounts
-	if err := c.loadMounts(t.Context(), false); err != nil {
+	if err := c.loadMounts(ctx, false); err != nil {
 		t.Fatal(err)
 	}
 	compEntries := c.mounts.Entries[:0]
@@ -954,17 +956,19 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		t.Fatal("bad: values here should be different")
 	}
 
+	ctx := namespace.RootContext(t.Context())
+
 	// Remove any transactional storage entries: we want to replace the mount
 	// table with a pre-transactional variant to force upgrades to be run.
 	if _, ok := c.barrier.(logical.TransactionalStorage); ok && testType != "audits" {
-		postTxnEntries, err := c.barrier.List(t.Context(), path+"/")
+		postTxnEntries, err := c.barrier.List(ctx, path+"/")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		for _, txnEntry := range postTxnEntries {
 			t.Logf("removing entry: %v", path+"/"+txnEntry)
-			if err := c.barrier.Delete(t.Context(), path+"/"+txnEntry); err != nil {
+			if err := c.barrier.Delete(ctx, path+"/"+txnEntry); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -975,7 +979,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		Key:   path,
 		Value: raw,
 	}
-	if err := c.barrier.Put(t.Context(), entry); err != nil {
+	if err := c.barrier.Put(ctx, entry); err != nil {
 		t.Fatal(err)
 	}
 
@@ -984,15 +988,15 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	// It should load successfully and be upgraded and persisted
 	switch testType {
 	case "mounts":
-		err = c.loadMounts(t.Context(), false)
+		err = c.loadMounts(ctx, false)
 		persistFunc = c.persistMounts
 		mt = c.mounts
 	case "credentials":
-		err = c.loadCredentials(t.Context(), false)
+		err = c.loadCredentials(ctx, false)
 		persistFunc = c.persistAuth
 		mt = c.auth
 	case "audits":
-		err = c.loadAudits(t.Context(), false)
+		err = c.loadAudits(ctx, false)
 		persistFunc = func(ctx context.Context, barrier logical.Storage, mt *routing.MountTable, b *bool, mount string) error {
 			if b == nil {
 				b = new(bool)
@@ -1010,14 +1014,14 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	var actual []byte
 	if _, ok := c.barrier.(logical.TransactionalStorage); ok && testType != "audits" {
 		// Assume we got the outer, implicit type correct.
-		postTxnEntries, err := c.barrier.List(t.Context(), path+"/")
+		postTxnEntries, err := c.barrier.List(ctx, path+"/")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		mapEntries := make(map[string]string)
 		for _, txnEntry := range postTxnEntries {
-			entry, err = c.barrier.Get(t.Context(), path+"/"+txnEntry)
+			entry, err = c.barrier.Get(ctx, path+"/"+txnEntry)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1045,7 +1049,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 		actual = []byte(`{"type":"` + mt.Type + `","entries":[` + entries + `]}`)
 
 		// Read the old mount table entry and ensure it was deleted.
-		entry, err = c.barrier.Get(t.Context(), path)
+		entry, err = c.barrier.Get(ctx, path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1053,7 +1057,7 @@ func testCore_MountTable_UpgradeToTyped_Common(
 			t.Fatalf("expected empty entry at non-transactional mount table path: %v\n\tentry: %#v", path, string(entry.Value))
 		}
 	} else {
-		entry, err = c.barrier.Get(t.Context(), path)
+		entry, err = c.barrier.Get(ctx, path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1090,19 +1094,19 @@ func testCore_MountTable_UpgradeToTyped_Common(
 	// Now try saving invalid versions
 	origTableType := mt.Type
 	mt.Type = "foo"
-	if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err == nil {
+	if err := persistFunc(ctx, c.barrier, mt, nil, ""); err == nil {
 		t.Fatal("expected error")
 	}
 
 	if len(mt.Entries) > 0 {
 		mt.Type = origTableType
 		mt.Entries[0].Table = "bar"
-		if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err == nil {
+		if err := persistFunc(ctx, c.barrier, mt, nil, ""); err == nil {
 			t.Fatal("expected error")
 		}
 
 		mt.Entries[0].Table = mt.Type
-		if err := persistFunc(t.Context(), c.barrier, mt, nil, ""); err != nil {
+		if err := persistFunc(ctx, c.barrier, mt, nil, ""); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/vault/namespace_oss.go
+++ b/vault/namespace_oss.go
@@ -16,5 +16,8 @@ func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Names
 
 // ListNamespaces returns back a list of all namespaces including root.
 func (c *Core) ListNamespaces(ctx context.Context) ([]*namespace.Namespace, error) {
-	return c.namespaceStore.ListAllNamespaces(ctx, true, false)
+	return c.namespaceStore.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive:     true,
+		IncludeParent: true,
+	})
 }

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -915,37 +915,20 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 	return entry.Clone(false), nsKeyShares, nil
 }
 
-// ListAllNamespaces lists all available namespaces. includeRoot and includeSealed
-// flags control whether the result slice contains root and sealed namespaces
-// respectively.
-func (ns *NamespaceStore) ListAllNamespaces(ctx context.Context, includeRoot, includeSealed bool) ([]*namespace.Namespace, error) {
-	defer metrics.MeasureSince([]string{"namespace", "list_all_namespaces"}, time.Now())
-
-	unlock, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-
-	namespaces := make([]*namespace.Namespace, 0, len(ns.namespacesByUUID))
-	for _, entry := range ns.namespacesByUUID {
-		switch {
-		case !includeRoot && entry.ID == namespace.RootNamespaceID,
-			!includeSealed && ns.core.NamespaceSealed(entry):
-			continue
-		default:
-			namespaces = append(namespaces, entry.Clone(false))
-		}
-	}
-
-	return namespaces, nil
+// ListNamespaceOpts is passed to [NamespaceStore.ListNamespaces].
+type ListNamespaceOpts struct {
+	// Whether to list recursively, or at the current level only.
+	Recursive bool
+	// Whether to include the parent namespace that we're listing at.
+	IncludeParent bool
+	// Whether to include sealed namespaces.
+	IncludeSealed bool
 }
 
-// ListNamespaces is used to list namespaces below a parent namespace.
-// Optionally it can include the parent namespace itself and/or include all
-// descendants of the child namespaces.
-func (ns *NamespaceStore) ListNamespaces(ctx context.Context, includeParent bool, recursive bool) ([]*namespace.Namespace, error) {
-	defer metrics.MeasureSince([]string{"namespace", "list_namespace_entries"}, time.Now())
+// ListNamespaces is used to list namespaces below a parent namespace. Precise
+// listing behavior can be tuned via the passed [ListNamespaceOpts].
+func (ns *NamespaceStore) ListNamespaces(ctx context.Context, opts ListNamespaceOpts) ([]*namespace.Namespace, error) {
+	defer metrics.MeasureSince([]string{"namespace", "list_namespaces"}, time.Now())
 
 	parent, err := namespace.FromContext(ctx)
 	if err != nil {
@@ -958,7 +941,41 @@ func (ns *NamespaceStore) ListNamespaces(ctx context.Context, includeParent bool
 	}
 	defer unlock()
 
-	return ns.namespacesByPath.List(parent.Path, includeParent, recursive, ns.creationDeletionMap)
+	var namespaces []*namespace.Namespace
+
+	// This enqueues a namespace to be returned.
+	push := func(entry *namespace.Namespace) {
+		if !opts.IncludeSealed && ns.core.NamespaceSealed(entry) {
+			return
+		}
+		entry = entry.Clone(false)
+		entry.Tainted = entry.Tainted || ns.creationDeletionMap[entry.UUID]
+		namespaces = append(namespaces, entry)
+	}
+
+	// Fast-path avoid tree traversal in case we're listing recursively starting
+	// from the root namespace.
+	if parent.ID == namespace.RootNamespaceID && opts.Recursive {
+		namespaces = make([]*namespace.Namespace, 0, len(ns.namespacesByAccessor))
+		for id, entry := range ns.namespacesByAccessor {
+			if opts.IncludeParent || id != parent.ID {
+				push(entry)
+			}
+		}
+		return namespaces, nil
+	}
+
+	if opts.IncludeParent {
+		push(parent)
+	}
+
+	// Defer to the namespace tree for any queries that are not easily handled
+	// by the flat lookup maps.
+	if err := ns.namespacesByPath.Walk(parent.Path, opts.Recursive, push); err != nil {
+		return nil, err
+	}
+
+	return namespaces, nil
 }
 
 // SealNamespace acquires a read lock, and seals provided namespace,
@@ -1220,14 +1237,8 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 		return "", errors.New("unable to delete root namespace")
 	}
 
-	// checking whether namespace has child namespaces
-	childNS, err := ns.namespacesByPath.List(namespaceToDelete.Path, false, false, map[string]bool{})
-	if err != nil {
-		return "", err
-	}
-
-	if len(childNS) > 0 {
-		return "", fmt.Errorf("cannot delete namespace (%q) containing child namespaces", namespaceToDelete.Path)
+	if !ns.namespacesByPath.IsLeaf(namespaceToDelete.Path) {
+		return "", errors.New("unable to delete namespace containing child namespaces")
 	}
 
 	parent, err := namespace.FromContext(ctx)

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -32,7 +32,10 @@ func TestNamespaceStore(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaces(ctx, false, true)
+	ns, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive:     true,
+		IncludeSealed: true,
+	})
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -53,7 +56,9 @@ func TestNamespaceStore(t *testing.T) {
 	itemPath := item.Path
 
 	// We should now have one item.
-	ns, err = s.ListAllNamespaces(ctx, false, true)
+	ns, err = s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive: true,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
 	require.Equal(t, ns[0].UUID, item.UUID)
@@ -95,7 +100,9 @@ func TestNamespaceStore(t *testing.T) {
 	s = c.namespaceStore
 
 	// We should still have one item.
-	ns, err = s.ListAllNamespaces(ctx, false, true)
+	ns, err = s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive: true,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, ns)
 	require.Equal(t, ns[0].UUID, itemUUID)
@@ -108,7 +115,7 @@ func TestNamespaceStore(t *testing.T) {
 	// Wait until deletion has finished.
 	maxRetries := 50
 	for range maxRetries {
-		ns, err = s.ListAllNamespaces(ctx, false, true)
+		ns, err = s.ListNamespaces(ctx, ListNamespaceOpts{})
 		require.NoError(t, err)
 		if len(ns) > 0 {
 			time.Sleep(1 * time.Millisecond)
@@ -118,7 +125,9 @@ func TestNamespaceStore(t *testing.T) {
 	}
 
 	// Store should be empty.
-	ns, err = s.ListAllNamespaces(ctx, false, true)
+	ns, err = s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive: true,
+	})
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -139,7 +148,9 @@ func TestNamespaceStore(t *testing.T) {
 	// however, the s.SetNamespace function is still using the previous namespace.
 	s = c.namespaceStore
 
-	ns, err = s.ListAllNamespaces(ctx, false, true)
+	ns, err = s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive: true,
+	})
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -189,7 +200,10 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	}
 
 	// verify namespace deletion
-	nsList, err := s.ListAllNamespaces(ctx, false, true)
+	nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive:     true,
+		IncludeSealed: true,
+	})
 	require.NoError(t, err)
 	require.Empty(t, nsList)
 
@@ -317,13 +331,10 @@ func TestNamespaceStore_LockNamespace(t *testing.T) {
 	require.Empty(t, ret.UnlockKey)
 
 	// Verify that listing does not return locks.
-	all, err := c.namespaceStore.ListAllNamespaces(ctx, true, true)
-	require.NoError(t, err)
-	for index, ns := range all {
-		require.Empty(t, ns.UnlockKey, "namespace: %v / index: %v", ns, index)
-	}
-
-	all, err = c.namespaceStore.ListNamespaces(ctx, true, true)
+	all, err := c.namespaceStore.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive:     true,
+		IncludeParent: true,
+	})
 	require.NoError(t, err)
 	for index, ns := range all {
 		require.Empty(t, ns.UnlockKey, "namespace: %v / index: %v", ns, index)
@@ -413,7 +424,9 @@ func TestNamespaceHierarchy(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
 
 	// Initial store should be empty.
-	ns, err := s.ListAllNamespaces(ctx, false, true)
+	ns, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+		Recursive: true,
+	})
 	require.NoError(t, err)
 	require.Empty(t, ns)
 
@@ -446,7 +459,9 @@ func TestNamespaceHierarchy(t *testing.T) {
 
 	t.Run("ListNamespaces", func(t *testing.T) {
 		t.Run("no root namespace", func(t *testing.T) {
-			nsList, err := s.ListAllNamespaces(ctx, false, true)
+			nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+				Recursive: true,
+			})
 			require.NoError(t, err)
 			containsRoot := false
 			for _, nss := range nsList {
@@ -455,11 +470,14 @@ func TestNamespaceHierarchy(t *testing.T) {
 					break
 				}
 			}
-			require.Falsef(t, containsRoot, "ListAllNamespaces must not contain root namespace")
-			require.Equal(t, len(namespaces), len(nsList), "ListAllNamespaces must return all namespaces, excluding root")
+			require.Falsef(t, containsRoot, "must not contain root namespace")
+			require.Equal(t, len(namespaces), len(nsList), "must return all namespaces, excluding root")
 		})
 		t.Run("with root namespace", func(t *testing.T) {
-			nsList, err := s.ListAllNamespaces(ctx, true, true)
+			nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+				IncludeParent: true,
+				Recursive:     true,
+			})
 			require.NoError(t, err)
 			containsRoot := false
 			for _, nss := range nsList {
@@ -468,21 +486,23 @@ func TestNamespaceHierarchy(t *testing.T) {
 					break
 				}
 			}
-			require.Truef(t, containsRoot, "ListAllNamespaces must contain root namespace")
-			require.Equal(t, len(namespaces)+1, len(nsList), "ListAllNamespaces must return all namespaces")
+			require.Truef(t, containsRoot, "must contain root namespace")
+			require.Equal(t, len(namespaces)+1, len(nsList), "must return all namespaces")
 		})
 		t.Run("list child namespaces", func(t *testing.T) {
 			ctx := namespace.ContextWithNamespace(ctx, namespaces[0].Namespace)
-			nsList, err := s.ListNamespaces(ctx, false, false)
+			nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+				IncludeParent: true,
+			})
 			require.NoError(t, err)
 			for _, nss := range nsList {
 				t.Logf("> ID  : %s\n", nss.ID)
 				t.Logf("> Path: %s\n", nss.Path)
 			}
-			require.Equal(t, 1, len(nsList))
+			require.Equal(t, 2, len(nsList))
 
 			ctx = namespace.ContextWithNamespace(ctx, namespaces[1].Namespace)
-			nsList, err = s.ListNamespaces(ctx, false, false)
+			nsList, err = s.ListNamespaces(ctx, ListNamespaceOpts{})
 			require.NoError(t, err)
 			require.Equal(t, 0, len(nsList))
 		})
@@ -546,13 +566,17 @@ func TestNamespaceTree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, beforeSize-1, tree.size)
 
-	entries, err := tree.List("", false, false, map[string]bool{})
-	require.NoError(t, err)
-	require.Equal(t, 2, len(entries))
+	count := 0
+	require.NoError(t, tree.Walk("", false, func(n *namespace.Namespace) {
+		count++
+	}))
+	require.Equal(t, 2, count)
 
-	entries, err = tree.List("", true, true, map[string]bool{})
-	require.NoError(t, err)
-	require.Equal(t, tree.size, len(entries))
+	count = 0
+	require.NoError(t, tree.Walk("", true, func(n *namespace.Namespace) {
+		count++
+	}))
+	require.Equal(t, tree.size, count+1)
 
 	entry := tree.Get("ns1/")
 	require.NotNil(t, entry)
@@ -607,21 +631,21 @@ func BenchmarkNamespaceStore(b *testing.B) {
 	b.Run("GetNamespace", func(b *testing.B) {
 		for b.Loop() {
 			uuid := randomNamespace(s).UUID
-			s.GetNamespace(ctx, uuid)
+			_, _ = s.GetNamespace(ctx, uuid)
 		}
 	})
 
 	b.Run("GetNamespaceByAccessor", func(b *testing.B) {
 		for b.Loop() {
 			accessor := randomNamespace(s).ID
-			s.GetNamespaceByAccessor(ctx, accessor)
+			_, _ = s.GetNamespaceByAccessor(ctx, accessor)
 		}
 	})
 
 	b.Run("GetNamespaceByPath", func(b *testing.B) {
 		for b.Loop() {
 			path := randomNamespace(s).Path
-			s.GetNamespaceByPath(ctx, path)
+			_, _ = s.GetNamespaceByPath(ctx, path)
 		}
 	})
 
@@ -632,17 +656,11 @@ func BenchmarkNamespaceStore(b *testing.B) {
 		}
 	})
 
-	b.Run("ListAllNamespaces", func(b *testing.B) {
-		for b.Loop() {
-			_, _ = s.ListAllNamespaces(ctx, false, true)
-		}
-	})
-
 	b.Run("ListNamespaces non-recursive", func(b *testing.B) {
 		for b.Loop() {
 			parent := randomNamespace(s)
 			ctx = namespace.ContextWithNamespace(ctx, parent)
-			s.ListNamespaces(ctx, false, false)
+			_, _ = s.ListNamespaces(ctx, ListNamespaceOpts{})
 		}
 	})
 
@@ -650,14 +668,16 @@ func BenchmarkNamespaceStore(b *testing.B) {
 		for b.Loop() {
 			parent := randomNamespace(s)
 			ctx = namespace.ContextWithNamespace(ctx, parent)
-			s.ListNamespaces(ctx, false, true)
+			_, _ = s.ListNamespaces(ctx, ListNamespaceOpts{
+				Recursive: true,
+			})
 		}
 	})
 
 	b.Run("ResolveNamespaceFromRequest", func(b *testing.B) {
 		for b.Loop() {
 			ns := randomNamespace(s)
-			c.ResolveNamespaceFromRequest(ns.Path, "/sys/namespaces")
+			_, _ = c.ResolveNamespaceFromRequest(ns.Path, "/sys/namespaces")
 		}
 	})
 }
@@ -1068,7 +1088,9 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 		require.Len(t, enfConfigs, 1)
 
 		// namespaces
-		childNs, err := c.namespaceStore.ListNamespaces(nsCtx, false, true)
+		childNs, err := c.namespaceStore.ListNamespaces(nsCtx, ListNamespaceOpts{
+			Recursive: true,
+		})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(childNs))
 	}

--- a/vault/namespace_store_tree.go
+++ b/vault/namespace_store_tree.go
@@ -17,7 +17,6 @@ type namespaceTree struct {
 }
 
 type namespaceNode struct {
-	parent   *namespaceNode
 	children map[string]*namespaceNode
 	entry    *namespace.Namespace
 }
@@ -54,7 +53,7 @@ func (nt *namespaceTree) nodeAt(path string) *namespaceNode {
 	return node
 }
 
-// Get returns the namespace at a given path
+// Get returns the namespace at a given path.
 func (nt *namespaceTree) Get(path string) *namespace.Namespace {
 	node := nt.nodeAt(path)
 	if node == nil {
@@ -62,6 +61,17 @@ func (nt *namespaceTree) Get(path string) *namespace.Namespace {
 	}
 
 	return node.entry
+}
+
+// IsLeaf returns true if the given path represents a leaf node, i.e., a
+// namespace with no children.
+func (nt *namespaceTree) IsLeaf(path string) bool {
+	node := nt.nodeAt(path)
+	if node == nil {
+		return false
+	}
+
+	return len(node.children) == 0
 }
 
 // LongestPrefix finds the longest prefix of path that leads to a namespace. It
@@ -113,6 +123,9 @@ func (nt *namespaceTree) PostOrderTraversal(path string, op func(namespace *name
 	}
 }
 
+// WalkPath calls predicate by walking towards the given namespace, starting
+// from the root, until the predicate returns true or the namespace was reached
+// or not found.
 func (nt *namespaceTree) WalkPath(path string, predicate func(namespace *namespace.Namespace) bool) {
 	path = namespace.Canonicalize(path)
 	var segments []string
@@ -133,45 +146,34 @@ func (nt *namespaceTree) WalkPath(path string, predicate func(namespace *namespa
 	}
 }
 
-// List lists child Namespace entries at a given path, optionally including the
-// namespace at the given path, optionally recursing down into all child
-// namespaces.
-func (nt *namespaceTree) List(path string, includeParent bool, recursive bool, tainted map[string]bool) ([]*namespace.Namespace, error) {
+// Walk walks the tree starting at path and calls callback on each encountered
+// child namespace. An error is returned if the initial path does not exist.
+func (nt *namespaceTree) Walk(
+	path string,
+	recursive bool,
+	callback func(*namespace.Namespace),
+) error {
 	node := nt.nodeAt(path)
 	if node == nil {
-		return nil, fmt.Errorf("unknown path: %s", namespace.Canonicalize(path))
+		return fmt.Errorf("unknown path: %s", namespace.Canonicalize(path))
 	}
 
-	var nodes []*namespaceNode
-	nodes = append(nodes, node)
-
-	var entries []*namespace.Namespace
-	if includeParent {
-		entries = make([]*namespace.Namespace, 0, len(node.children)+1)
-
-		entry := node.entry.Clone(false)
-		if value := tainted[entry.UUID]; value {
-			entry.Tainted = value
-		}
-
-		entries = append(entries, entry)
+	queue := make([]*namespaceNode, 0, len(node.children))
+	for _, child := range node.children {
+		queue = append(queue, child)
 	}
-	for idx := 0; idx < len(nodes); idx++ {
-		node = nodes[idx]
-		for _, child := range node.children {
-			entry := child.entry.Clone(false)
-			if value := tainted[entry.UUID]; value {
-				entry.Tainted = value
-			}
 
-			entries = append(entries, entry)
-			if recursive {
-				nodes = append(nodes, child)
+	for len(queue) > 0 {
+		node, queue = queue[0], queue[1:]
+		callback(node.entry)
+		if recursive {
+			for _, child := range node.children {
+				queue = append(queue, child)
 			}
 		}
 	}
 
-	return entries, nil
+	return nil
 }
 
 // Insert adds or updates the namespace with the given entry. It refuses to add
@@ -192,7 +194,6 @@ func (nt *namespaceTree) Insert(entry *namespace.Namespace) error {
 				return errors.New("can't insert namespace with missing parent")
 			}
 			node.children[segment] = &namespaceNode{
-				parent:   node,
 				children: make(map[string]*namespaceNode),
 				entry:    entry,
 			}
@@ -215,23 +216,27 @@ func (nt *namespaceTree) Delete(path string) error {
 	if path == "" {
 		return errors.New("can't delete root namespace")
 	}
+
 	segments := strings.SplitAfter(path, "/")
 	segments = segments[:len(segments)-1]
+
 	node := nt.root
+	var parent *namespaceNode
+
 	for _, segment := range segments {
 		n, ok := node.children[segment]
 		if !ok {
 			return nil
 		}
 
-		node = n
+		node, parent = n, node
 	}
 
 	if len(node.children) > 0 {
 		return errors.New("can't delete namespace with children")
 	}
 
-	delete(node.parent.children, segments[len(segments)-1])
+	delete(parent.children, segments[len(segments)-1])
 	nt.size -= 1
 
 	return nil

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3863,7 +3863,8 @@ func (ts *TokenStore) gaugeCollector(ctx context.Context) ([]metricsutil.GaugeLa
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, true)
+	ctx = namespace.RootContext(ctx)
+	allNamespaces, err := ts.core.ListNamespaces(ctx)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -3922,7 +3923,8 @@ func (ts *TokenStore) gaugeCollectorByPolicy(ctx context.Context) ([]metricsutil
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, true)
+	ctx = namespace.RootContext(ctx)
+	allNamespaces, err := ts.core.ListNamespaces(ctx)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -3984,7 +3986,8 @@ func (ts *TokenStore) gaugeCollectorByTtl(ctx context.Context) ([]metricsutil.Ga
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, true)
+	ctx = namespace.RootContext(ctx)
+	allNamespaces, err := ts.core.ListNamespaces(ctx)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -4055,8 +4058,8 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 		return []metricsutil.GaugeLabelValues{}, errors.New("expiration manager is nil")
 	}
 
-	rootContext := namespace.RootContext(ctx)
-	allNamespaces, err := ts.core.namespaceStore.ListAllNamespaces(ctx, true, true)
+	ctx = namespace.RootContext(ctx)
+	allNamespaces, err := ts.core.ListNamespaces(ctx)
 	if err != nil {
 		return []metricsutil.GaugeLabelValues{}, err
 	}
@@ -4068,11 +4071,10 @@ func (ts *TokenStore) gaugeCollectorByMethod(ctx context.Context) ([]metricsutil
 	prefixTree := radix.New()
 
 	pathToPrefix := func(nsID string, path string) string {
-		ns, err := ts.core.NamespaceByID(rootContext, nsID)
+		ns, err := ts.core.NamespaceByID(ctx, nsID)
 		if ns == nil || err != nil {
 			return "unknown"
 		}
-		ctx := namespace.ContextWithNamespace(rootContext, ns)
 
 		key := ns.Path + path
 		_, method, ok := prefixTree.LongestPrefix(key)


### PR DESCRIPTION
## Description

Collapse `ListNamespaces` and `ListAllNamespaces` into a single `ListNamespaces` that takes a `ListNamespaceOptions` that customizes the behavior.

The boolean parameters these took were quite difficult to keep track of, and behavior started to diverge w.r.t setting the tainted field based on `creationDeletionMap`, and filtering sealed namespaces which `ListNamespaces` never did, even though it would be the correct thing to do in most cases.

## Rationale

Makes code easier to read, and makes it harder to get the selection of namespaces to list wrong.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
