### PR TITLE
Create documentation for sealable namespaces

### DIFF
--- a/command/namespace.go
+++ b/command/namespace.go
@@ -24,8 +24,6 @@ func (c *NamespaceCommand) Help() string {
 Usage: bao namespace <subcommand> [options] [args]
 
   This command groups subcommands for interacting with OpenBao namespaces.
-  These subcommands operate in the context of the namespace that the
-  currently logged in token belongs to.
 
   List enabled child namespaces:
 

--- a/command/operator_generate_root.go
+++ b/command/operator_generate_root.go
@@ -56,10 +56,6 @@ func (c *OperatorGenerateRootCommand) Help() string {
 	helpText := `
 Usage: bao operator generate-root [options] [KEY]
 
-  WARNING: this method is deprecated, please consider using:
-    $ bao auth token create
-  with an existing root token with 'sudo' permission instead.
-
   Generates a new root token by combining a quorum of share holders. One of
   the following must be provided to start the root token generation:
 
@@ -383,12 +379,6 @@ func (c *OperatorGenerateRootCommand) init(client *api.Client, otp, pgpKey strin
 // provide prompts the user for the seal key and posts it to the update root
 // endpoint. If this is the last unseal, this function outputs it.
 func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, kind generateRootKind) int {
-	c.UI.Warn(wrapAtLength(
-		"This root token generation method is considered insecure and requires " +
-			"\"disable_unauthed_generate_root_endpoints\" configuration parameter set to 'true', " +
-			"consider generation of the root token through \"bao auth token create\" instead.",
-	))
-
 	f := client.Sys().GenerateRootStatus
 	switch kind {
 	case generateRootRecovery:
@@ -515,12 +505,6 @@ func (c *OperatorGenerateRootCommand) cancel(client *api.Client, kind generateRo
 
 // status is used just to fetch and dump the status
 func (c *OperatorGenerateRootCommand) status(client *api.Client, kind generateRootKind) int {
-	c.UI.Warn(wrapAtLength(
-		"This root token generation method is considered insecure and requires " +
-			"\"disable_unauthed_generate_root_endpoints\" configuration parameter set to 'true', " +
-			"consider generation of the root token through \"bao auth token create\" instead.",
-	))
-
 	f := client.Sys().GenerateRootStatus
 	switch kind {
 	case generateRootRecovery:

--- a/website/content/api-docs/system/generate-root-token.mdx
+++ b/website/content/api-docs/system/generate-root-token.mdx
@@ -1,16 +1,23 @@
 ---
 description: |-
   The `/sys/generate-root-token/` endpoints are used to create a new root token for
-  OpenBao.
+  OpenBao's root namespace or a sealable namespace.
 ---
 
 # `/sys/generate-root-token`
 
 The `/sys/generate-root-token` endpoint is used to create a new root token for OpenBao.
 
-## Read root generation progress
+:::info
 
-This endpoint reads the configuration and process of the current root generation
+These endpoints are available in both the root namespace and sealable namespaces
+and work with the respective set of key shares.
+
+:::
+
+## Read root token generation progress
+
+This endpoint reads the configuration and process of the current root token generation
 attempt.
 
 | Method | Path                               |
@@ -38,7 +45,7 @@ $ curl \
 }
 ```
 
-If a root generation is started, `progress` tracks how many unseal keys have
+If a root token generation is started, `progress` tracks how many unseal keys have
 been provided for this generation attempt, where `required` must be reached
 to complete. The `nonce` for the current attempt and whether the attempt is
 complete is also displayed.
@@ -56,8 +63,8 @@ key, encoded as base64.
 
 ## Start root token generation
 
-This endpoint initializes a new root generation attempt. Only a single root
-generation attempt can take place at a time.
+This endpoint initializes a new root token generation attempt. Only a single
+root token generation attempt can take place at a time.
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
@@ -91,10 +98,10 @@ $ curl \
 }
 ```
 
-## Cancel root generation
+## Cancel root token generation
 
-This endpoint cancels any in-progress root generation attempt. This clears any
-progress made. This must be called to change the OTP or PGP key being used.
+This endpoint cancels any in-progress root token generation attempt. This clears
+any progress made. This must be called to change the OTP or PGP key being used.
 
 | Method   | Path                               |
 | :------- | :--------------------------------- |
@@ -108,11 +115,11 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/generate-root-token/attempt
 ```
 
-## Provide key share to generate root
+## Provide key share to generate root token
 
-This endpoint is used to enter a single root key share to progress the root
+This endpoint is used to enter a single root key share to progress the root token
 generation attempt. If the threshold number of root key shares is reached,
-OpenBao will complete the root generation and issue the new token. Otherwise,
+OpenBao will complete the root key generation and issue the new token. Otherwise,
 this API must be called multiple times until that threshold is met. The attempt
 nonce must be provided with each call.
 

--- a/website/content/api-docs/system/generate-root.mdx
+++ b/website/content/api-docs/system/generate-root.mdx
@@ -1,4 +1,5 @@
 ---
+sidebar_label: /sys/generate-root
 description: |-
   The `/sys/generate-root/` endpoints are used to create a new root token for
   OpenBao.
@@ -7,8 +8,10 @@ description: |-
 :::warning
 
 Note: As of v2.5.3 usage of these endpoints is [deprecated](/community/deprecation/unauthed-generate-root/)
-and will be disabled by default. Consider using [`auth/token/create`](../auth/token.mdx)
-to create new root tokens from existing tokens with `sudo` permission.
+and will be disabled by default. Consider using
+[`auth/token/create`](../auth/token.mdx) to create new root tokens from existing
+tokens or the new authenticated
+[`sys/generate-root-token`](./generate-root-token.mdx) endpoint.
 To re-enable, see the documentation around the `disable_unauthed_generate_root_endpoints`
 [listener parameter](/docs/configuration/listener/unix/): it is suggested to
 do so only for the short period of time required to create a new root token.

--- a/website/content/api-docs/system/namespaces.mdx
+++ b/website/content/api-docs/system/namespaces.mdx
@@ -62,6 +62,7 @@ This endpoint creates a namespace at the given path.
   will be created.
 - `custom_metadata` `(map<string|string>: nil)` - A map of arbitrary string to string valued user-provided metadata meant
   to describe the namespace.
+- `seal` `(string: "")` - An optional seal config document (JSON or HCL) to create a sealable namespace
 
 ### Sample payload
 
@@ -70,7 +71,8 @@ This endpoint creates a namespace at the given path.
   "custom_metadata": {
     "foo": "abc",
     "bar": "123"
-  }
+  },
+  "seal": "seal \"shamir\" {\n    shares = 5\n    threshold = 3\n}"
 }
 ```
 
@@ -166,3 +168,90 @@ $ curl \
 }
 ```
 
+## Read namespace seal status (sealable namespaces only)
+
+This endpoint gets the seal status for the given sealable namespace path.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `GET`  | `/sys/namespaces/:path/seal-status` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/namespaces/ns1/seal-status
+```
+
+### Sample response
+
+```json
+{
+  "initialized": true,
+  "n": 5,
+  "nonce": "",
+  "progress": 0,
+  "sealed": false,
+  "t": 3,
+  "type": "shamir"
+}
+```
+
+## Unseal a namespace (sealable namespaces only)
+
+This endpoint unseals the given sealable namespace.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `PUT`  | `/sys/namespaces/:path/unseal` |
+
+### Sample payload
+
+```json
+{
+  "key": "...",
+  "reset": false,
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/namespaces/ns1/unseal
+```
+
+### Sample response
+
+```json
+{
+  "initialized": true,
+  "n": 5,
+  "nonce": "",
+  "progress": 1,
+  "sealed": true,
+  "t": 3,
+  "type": "shamir"
+}
+```
+
+## Seal a namespace (sealable namespaces only)
+
+This endpoint seals the given sealable namespace.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `PUT`  | `/sys/namespaces/:path/seal` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request PUT \
+    http://127.0.0.1:8200/v1/sys/namespaces/ns1/seal
+```

--- a/website/content/api-docs/system/namespaces.mdx
+++ b/website/content/api-docs/system/namespaces.mdx
@@ -139,6 +139,36 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/namespaces/ns1
 ```
 
+## Delete sealed namespace
+
+:::info
+
+Note that this requires the sudo capability and will not clean up external
+resources via lease deletion like standard namespace deletion does. Prefer the
+standard `DELETE /sys/namespaces/:path` endpoint unless the namespace is
+irrecoverable due to lost seal keys.
+
+:::
+
+This endpoint deletes a sealed namespace at the specified path.
+
+| Method   | Path                    |
+| :------- | :---------------------- |
+| `DELETE` | `/sys/namespaces/:path/delete-sealed` |
+
+### Parameters
+
+- `force` `(bool: false)` - if set to true, will also recursively delete any child namespaces.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request DELETE \
+    http://127.0.0.1:8200/v1/sys/namespaces/ns1/delete-sealed?force=true
+```
+
 ## Read namespace information
 
 This endpoint gets the metadata for the given namespace path.

--- a/website/content/api-docs/system/remount.mdx
+++ b/website/content/api-docs/system/remount.mdx
@@ -1,4 +1,5 @@
 ---
+sidebar_label: /sys/remount
 description: >-
   The '/sys/remount' endpoint is used remount a mounted backend to a new
   endpoint.

--- a/website/content/api-docs/system/rotate/index.mdx
+++ b/website/content/api-docs/system/rotate/index.mdx
@@ -6,6 +6,13 @@ description: >-
 
 # `/sys/rotate`
 
+:::info
+
+These endpoints are available in both the root namespace and sealable namespaces
+and operate on the respective set of keys.
+
+:::
+
 ### Encryption key rotation
 
 The `/sys/rotate/keyring` endpoint is used to rotate the encryption key. It is

--- a/website/content/docs/commands/namespace.mdx
+++ b/website/content/docs/commands/namespace.mdx
@@ -123,8 +123,6 @@ $ bao namespace seal-status
 Usage: bao namespace <subcommand> [options] [args]
 
   This command groups subcommands for interacting with OpenBao namespaces.
-  These subcommands operate in the context of the namespace that the
-  currently logged in token belongs to.
 
 Subcommands:
     create         Create a new namespace

--- a/website/content/docs/commands/namespace.mdx
+++ b/website/content/docs/commands/namespace.mdx
@@ -57,6 +57,18 @@ Delete the namespace at path `ns1/`:
 $ bao namespace delete ns1/
 ```
 
+Delete a sealed namespace with no child namespaces (requires sudo):
+
+```shell-session
+$ bao namespace delete-sealed ns1
+```
+
+Delete a sealed namespace and recursively wipe its child namespaces (requires sudo):
+
+```shell-session
+$ bao namespace delete-sealed -force ns1
+```
+
 Lookup the namespace information at path `ns1/`:
 
 ```shell-session
@@ -117,6 +129,7 @@ Usage: bao namespace <subcommand> [options] [args]
 Subcommands:
     create         Create a new namespace
     delete         Delete an existing namespace
+    delete-sealed  Delete a sealed namespace
     list           List child namespaces
     lock           Lock the API for particular namespaces
     lookup         Look up an existing namespace

--- a/website/content/docs/commands/namespace.mdx
+++ b/website/content/docs/commands/namespace.mdx
@@ -87,24 +87,45 @@ Unlock the API for a descendant namespace at path `current/namespacens1/`:
 $ bao namespace unlock -unlock-key <unlock key> ns1/
 ```
 
+Seal the namespace:  
+
+```shell-session
+$ bao namespace seal
+```
+
+Unseal the namespace:
+
+```shell-session
+$ bao namespace unseal
+```
+
+Retrieve the namespace seal status:
+
+```shell-session
+$ bao namespace seal-status
+```
+
 ## Usage
 
 ```text
 Usage: bao namespace <subcommand> [options] [args]
 
-  This command groups subcommands for interacting with Vault namespaces.
-  These set of subcommands operate on the context of the namespace that the
-  current logged in token belongs to.
+  This command groups subcommands for interacting with OpenBao namespaces.
+  These subcommands operate in the context of the namespace that the
+  currently logged in token belongs to.
 
 Subcommands:
-    create    Create a new namespace
-    delete    Delete an existing namespace
-    list      List child namespaces
-    lock      Lock the API for particular namespaces
-    lookup    Look up an existing namespace
-    patch     Patch an existing namespace
-    scan      List all (child) namespaces recursively
-    unlock    Unlock the API for particular namespaces
+    create         Create a new namespace
+    delete         Delete an existing namespace
+    list           List child namespaces
+    lock           Lock the API for particular namespaces
+    lookup         Look up an existing namespace
+    patch          Patch an existing namespace
+    scan           List all (child) namespaces recursively
+    seal           Seals the namespace
+    seal-status    Prints the namespace seal status
+    unlock         Unlock the API for particular namespaces
+    unseal         Unseals the namespace
 ```
 
 For more information, examples, and usage about a subcommand, click on the name

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -5,14 +5,12 @@ description: |-
   quorum of share holders.
 ---
 
-:::warning
+:::info
 
-Note: As of v2.5.3 usage of this command is [deprecated](/community/deprecation/unauthed-generate-root)
-and will be rejected by default. Consider using [`token create`](../token/create.mdx)
-command to create new root tokens from existing tokens with `sudo` permission.
-To re-enable, see the documentation around the `disable_unauthed_generate_root_endpoints`
-[listener parameter](../../configuration/listener/unix.mdx): it is suggested to
-do so only for the short period of time required to create a new root token.
+Note: As of v2.6.0, this command uses the new and authenticated
+`/sys/generate-root-token` endpoint instead of the deprecated and
+unauthenticated `/sys/generate-root` endpoint. It now also supports generating
+root tokens for sealable namespaces.
 
 :::
 

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -55,6 +55,12 @@ Enter an unseal key to progress root token generation:
 $ bao operator generate-root -otp="..."
 ```
 
+Start root token generation for a sealable namespace:
+
+```shell-session
+$ bao operator generate-root -ns=tenants/my-tenant -init
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of
@@ -97,3 +103,5 @@ flags](../index.mdx) included on all commands.
 - `-dr-token` `(bool: false)` - Generate DR operational token
 
 - `-recovery-token` `(bool: false)` - Generate recovery operational token
+
+- `-namespace` `(string: "")` - Sealable namespace to generate the root token for. Defaults to the root namespace.

--- a/website/content/docs/commands/operator/key-status.mdx
+++ b/website/content/docs/commands/operator/key-status.mdx
@@ -22,7 +22,7 @@ Install Time      01 Jan 17 12:30 UTC
 Encryption Count  4494
 ```
 
-you can also specify namespace:
+you can also specify a sealable namespace:
 
 ```shell-session
 $ bao operator -ns=teamA key-status
@@ -41,3 +41,7 @@ flags](../index.mdx) included on all commands.
 - `-format` `(string: "table")` - Print the output in the given format. Valid
   formats are "table", "json", or "yaml". This can also be specified via the
   `BAO_FORMAT` environment variable.
+
+### Command options
+
+- `-namespace` `(string: "")` - Sealable namespace to get the key status for. Defaults to the root namespace.

--- a/website/content/docs/commands/operator/rotate-keys.mdx
+++ b/website/content/docs/commands/operator/rotate-keys.mdx
@@ -105,6 +105,12 @@ Perform the verification of the rotation using the verification nonce:
 $ bao operator rotate-keys -verify -nonce="..."
 ```
 
+Perform a rotation on a sealable namespace:
+
+```shell-session
+$ bao operator rotate-keys -ns=tenants/my-tenant -init
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of
@@ -150,6 +156,8 @@ flags](../index.mdx) included on all commands.
 - `-verify` `(bool: false)` - Indicate during the phase `-init` that the
   verification process is activated for the rotation. Along with `-nonce` option
   it indicates that the nonce given is for the verification process.
+
+- `-namespace` `(string: "")` - Sealable namespace to rotate the unseal key for. Defaults to the root namespace.
 
 ### Backup options
 

--- a/website/content/docs/commands/operator/rotate.mdx
+++ b/website/content/docs/commands/operator/rotate.mdx
@@ -28,6 +28,17 @@ Key Term        3
 Install Time    01 May 17 10:30 UTC
 ```
 
+Rotate a sealable namespace's encryption key:
+
+```shell-session
+$ bao operator rotate -ns=tenants/my-tenant
+Success! Rotated key
+
+Key Term            2
+Install Time        10 Jun 26 08:37 UTC
+Encryption Count    0
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of
@@ -38,3 +49,7 @@ flags](../index.mdx) included on all commands.
 - `-format` `(string: "table")` - Print the output in the given format. Valid
   formats are "table", "json", or "yaml". This can also be specified via the
   `BAO_FORMAT` environment variable.
+
+### Command options
+
+- `-namespace` `(string: "")` - Sealable namespace to rotate the key for. Defaults to the root namespace.

--- a/website/content/docs/concepts/namespaces/index.mdx
+++ b/website/content/docs/concepts/namespaces/index.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Namespaces
+sidebar_label: Overview
 description: >-
   OpenBao Namespaces enable secure multi-tenancy and self-management of
   instances.

--- a/website/content/docs/concepts/namespaces/sealable-namespaces.mdx
+++ b/website/content/docs/concepts/namespaces/sealable-namespaces.mdx
@@ -1,0 +1,89 @@
+---
+description: >-
+  Learn about OpenBao's advanced Namespace isolation
+---
+
+# Sealable Namespaces
+
+:::info
+
+This page describes the concept of sealable namespaces. For a getting started
+guide, see the [Sealable Namespace Guide](../../guides/sealable-namespaces.mdx).
+
+:::
+
+## Overview
+
+Sealable namespaces extend OpenBao's multi-tenancy model by giving tenants
+cryptographic control over their own namespace. When a namespace is created with
+sealing enabled, it gets its own encryption keys, separate from the global
+OpenBao seal. A tenant can independently seal and unseal their namespace without
+affecting any other tenants and without involving the platform operator.
+
+This is distinct from the existing namespace lock/unlock mechanism. Sealing is a
+cryptographic operation: a sealed namespace discards its in-memory keys, making
+the data physically inaccessible until the namespace is explicitly unsealed
+again. Locking only blocks requests at the API layer.
+
+Child-namespaces of sealable namespaces can either be normal namespaces (which
+are encrypted with the nearest sealable parent namespace's keys) or sealable
+namespaces (which again get their own encryption keys). There is no multi-layer
+encryption: data from a namespace is encrypted exactly once, so there is no
+additional performance penalty to using sealable namespaces.
+
+## Use Cases
+
+Sealable namespaces are useful when:
+
+- **Tenant data sovereignty is required**. Each sealable namespace has its own
+  encryption keys. The platform operator's root key cannot decrypt a sealed
+  namespace's data. Tenants control their own keys entirely.
+- **Independent availability control is needed**. A tenant can seal their
+  namespace to make it inaccessible without affecting other tenants. If a
+  namespace's keys are suspected to be compromised, that namespace can be sealed
+  and rekeyed in isolation.
+- **Breach containment**. If a namespace's encryption key is leaked, only that
+  namespace is affected. Other tenants' data remains protected by their own
+  keys.
+
+Sealable namespaces are an optional feature. A namespace that is not itself
+sealable, and has no sealable ancestor in its namespace hierarchy, behaves
+exactly as all pre-v2.6 namespaces: it is protected by the global OpenBao seal.
+
+## How Sealable Namespaces Work
+
+A sealable namespace has its own keyring and root key that are used to encrypt
+data. This means:
+
+- The global operator cannot read namespace data without the tenant's key
+- Even if the global root key is available, a sealed namespace's data remains
+  inaccessible
+- In a single-node cluster: A server restart seals all namespaces; each must be unsealed independently
+  after OpenBao is unsealed. Parent namespaces must be unsealed before child
+  namespaces can be unsealed.
+- In a multi-node cluster: Seal status of all namespaces is maintained across
+  the active cluster when a single node is restarted. After restarting and
+  completing the main unseal procedure, the node will try to unseal namespaces
+  through syncing with the other nodes.
+
+:::warning
+
+**Important**: OpenBao must be globally unsealed before any namespace can be
+unsealed.
+
+:::
+
+### Comparison With Namespace Locking
+
+|                            | Namespace Lock | Namespace Seal |
+| ---------------------------| -------------- | -------------- |
+| Blocks API requests        | Yes            | Yes            |
+| Discards in-memory keys    | No             | Yes            |
+| Per-tenant encryption keys | No             | Yes            |
+
+Both features can be used together. To temporarily block API requests to a namespace, use namespace locking. Use sealable namespaces if you need a stronger tenant data sovereignty.
+
+## Seal Methods
+
+Sealable namespaces currently only support Shamir seals. Auto-unsealing support is
+planned, but not yet implemented. Contributions towards this are welcome.

--- a/website/content/docs/guides/sealable-namespaces.mdx
+++ b/website/content/docs/guides/sealable-namespaces.mdx
@@ -203,3 +203,58 @@ Key Term            2
 Install Time        10 Jun 26 08:37 UTC
 Encryption Count    0
 ```
+
+## Generate a Sealable Namespace Root Token
+
+You can use the `bao operator generate-root` command to generate a namespace-scoped root token for a sealable namespace.
+
+```shell-session
+$ bao operator generate-root -ns=tenants/my-tenant -init
+A One-Time-Password has been generated for you and is shown in the OTP field.
+You will need this value to decode the resulting root token, so keep it safe.
+Nonce         ad287b9e-cb19-613b-3720-84b5ac4ac1ef
+Started       true
+Progress      0/3
+Complete      false
+OTP           zs6S1qnRj6meHCEUsyFv7AclrDpI4jHbQ
+OTP Length    33
+```
+
+You will then have to provide the appropriate number of seal shares to finish the root token generation.
+
+```shell-session
+$ bao operator generate-root -ns=tenants/my-tenant
+Operation nonce: ad287b9e-cb19-613b-3720-84b5ac4ac1ef
+Unseal Key (will be hidden): 
+Nonce            ad287b9e-cb19-613b-3720-84b5ac4ac1ef
+Started          true
+Progress         3/3
+Complete         true
+Encoded Token    CV1XEQdDCApdBi88eDF9YRYgfhBeESQjFgdeLXEBBywf
+```
+
+See the documentation of [`operator generate-root`](../../commands/operator/generate-root) for more infos on this and how to decode the returned token.
+
+Check out the generated token using `bao token lookup`:
+
+```shell-session
+$ bao token lookup
+Key                 Value
+---                 -----
+accessor            W4gespQDyq6NDI2flWOxiPR7.dEkONN
+creation_time       1781095090
+creation_ttl        0s
+display_name        dEkONN_root
+entity_id           n/a
+expire_time         <nil>
+explicit_max_ttl    0s
+id                  s.aB62fX70BY0r84eY8fiPGOdC.dEkONN
+meta                <nil>
+namespace_path      tenants/my-tenant/
+num_uses            0
+orphan              true
+path                namespaces/62a3560f-bb0c-1436-ff45-9f1f8192cafd/auth/token/root
+policies            [root]
+ttl                 0s
+type                service
+```

--- a/website/content/docs/guides/sealable-namespaces.mdx
+++ b/website/content/docs/guides/sealable-namespaces.mdx
@@ -120,6 +120,43 @@ HA Enabled         false
 
 Retrieving the seal status of a non-sealable namespace will result in an error.
 
+## Deleting a Sealable Namespace
+
+If a sealable namespace is unsealed and empty, it can be deleted with the normal `bao namespace delete` command:
+
+```shell-session
+$ bao namespace delete -ns=tenants my-tenant
+Success! Namespace deleted at: tenants/my-tenant/
+```
+
+If a namespace is sealed and does not contain child namespaces, it can be
+deleted with `bao namespace delete-sealed`:
+
+```shell-session
+$ bao namespace delete-sealed -ns=tenants my-tenant
+Success! Namespace deletion scheduled: tenants/my-tenant/
+```
+
+Sealed namespaces that are not empty can be deleted by passing the `-force`
+flag. This will delete any data in that namespace and any child-namespaces that
+might exist.
+
+```shell-session
+$ bao namespace delete-sealed -ns=tenants -force my-tenant
+Success! Namespace deletion scheduled: tenants/my-tenant/
+```
+
+:::info
+
+Note that `bao namespace delete-sealed` requires the sudo capability, and will
+not clean up external resources via lease deletion like standard namespace
+deletion does.
+
+Prefer the standard `bao namespace delete` command unless the namespace is
+irrecoverable due to lost seal keys.
+
+:::
+
 ## Rotate Unseal Keys
 
 To start generating a new set of unseal keys for a sealable namespace, use the

--- a/website/content/docs/guides/sealable-namespaces.mdx
+++ b/website/content/docs/guides/sealable-namespaces.mdx
@@ -1,0 +1,205 @@
+---
+sidebar_label: Sealable Namespace Guide
+description: >-
+  This page contains a guide to get started with sealable namespaces in OpenBao
+---
+
+# Getting Started with Sealable Namespaces
+
+:::info
+
+For understanding the concept of sealable namespaces, check out the [Sealable Namespaces](../../concepts/namespaces/sealable-namespaces) concept page.
+
+If you are working with the API instead of the CLI, you can add `-output-curl-string` to any of these commands to find the correct path and header values or check the API docs.
+
+:::
+
+## Creating a Namespace
+
+You can create a sealable namespace `my-tenant` under an existing namespace `tenants` with a Shamir seal like this:
+
+```shell-session
+$ bao namespace create -ns=tenants -key-shares=5 -key-threshold=3 my-tenant
+Unseal Key 1: 639c362ebf75b0ebfdc0f62b6e40da5a3471d6f9ad9223c968a62ba369b8f453ab
+Unseal Key 2: cee185da54cce9d4cd87154d4a228edfd61473b497a599208c3686b9377c1f13b4
+Unseal Key 3: 6280d458eac88def949b197bcda005d1b639ed18c55ef6699b1db3ba1556c54d96
+Unseal Key 4: fe223cc4d2d10322a2955175af11fe23b007338bb9ca8a1ddab005ff6ba59d4b90
+Unseal Key 5: 6024203476e44f811c6720b938d478f7ebb05c776cd756cc942b0e5652accb2594
+
+Namespace initialized with 5 key shares and a key threshold of 3. Please
+securely distribute the key shares printed above. When the namespace is
+re-sealed, you must supply at least 3 of these keys to unseal it.
+
+Key                Value
+---                -----
+custom_metadata    map[]
+id                 dEkONN
+locked             false
+path               tenants/my-tenant/
+tainted            false
+uuid               62a3560f-bb0c-1436-ff45-9f1f8192cafd
+```
+
+:::info
+
+**Note**: You'll always need to specify the parent namespace with the `-ns`
+flag, since the namespace itself might not be able to accept requests when in a
+sealed state.
+
+:::
+
+Just like `bao operator init`, you can specify a list of PGP or Keybase keys to
+encrypt the key shares with. See [`operator
+init`](../../commands/operator/init#examples) docs for more details.
+
+
+:::warning
+
+**Important**: Migrating an existing non-sealable namespace to a sealable one or vice versa is currently not supported.
+
+:::
+
+## Unsealing a Namespace
+
+A newly created sealable namespace is sealed. To unseal a Shamir-sealed namespace, use the command `bao namespace unseal`:
+
+```shell-session
+$ bao namespace unseal -ns=tenants my-tenant
+Unseal Key (will be hidden): 
+Key                Value
+---                -----
+Seal Type          shamir
+Initialized        true
+Sealed             true
+Total Shares       5
+Threshold          3
+Unseal Progress    1/3
+Unseal Nonce       0f975b9c-5644-6763-e4dc-73e7094ac136
+HA Enabled         false
+```
+
+Cancelling an in-progress unsealing procedure can be done by passing the `-reset` flag to the `namespace unseal` command.
+
+Unlike the global OpenBao seal, namespaces do not have to be unsealed per node,
+but just once per cluster.
+
+## Sealing a Namespace
+
+To seal a sealable namespace, use the command `bao namespace seal`:
+
+```shell-session
+$ bao namespace seal -ns=tenants my-tenant
+Success! Namespace "my-tenant" is sealed.
+```
+
+Sealing a namespace:
+- immediately discards the in-memory namespace keys
+- causes all subsequent requests to that namespace to fail until it is unsealed again
+- if an unseal is in progress, sealing resets the process. Key holders will need to re-enter their shares
+- sealing a namespace that is already sealed has no effect (and will not reset the unseal progress)
+
+If a parent namespace is sealed, all child namespaces with their own seal configurations are also sealed.
+
+## Seal Status
+
+To retrieve the seal status of a namespace, you can use the command `bao namespace seal-status`:
+
+```shell-session
+$ bao namespace seal-status -ns=tenants my-tenant
+Key                Value
+---                -----
+Seal Type          shamir
+Initialized        true
+Sealed             true
+Total Shares       5
+Threshold          3
+Unseal Progress    1/3
+Unseal Nonce       0f975b9c-5644-6763-e4dc-73e7094ac136
+HA Enabled         false
+```
+
+Retrieving the seal status of a non-sealable namespace will result in an error.
+
+## Rotate Unseal Keys
+
+To start generating a new set of unseal keys for a sealable namespace, use the
+`bao operator rotate-keys` command with the `-ns` flag. 
+
+```shell-session
+$ bao operator rotate-keys -ns=tenants/my-tenant -init
+WARNING! If you lose the keys after they are returned, there is no recovery.
+Consider canceling this operation and re-initializing with the -pgp-keys flag
+to protect the returned unseal keys along with -backup to allow recovery of
+the encrypted keys in case of emergency. You can delete the stored keys later
+using the -delete flag.
+
+Key                      Value
+---                      -----
+Nonce                    393bcb43-93b0-bd74-393e-19fa7a929cee
+Started                  true
+Progress                 0/3
+New Shares               5
+New Threshold            3
+Verification Required    false
+```
+
+:::info
+
+**Note**: Unlike the `bao namespace` commands, the `bao operator` commands require
+specifying the **target namespace** via the `-ns` flag.
+
+:::
+
+You can optionally provide the `-key-shares` and `-key-threshold` flags to
+change the number of shares and threshold.
+
+Then you will have to provide a quorum of the old key shares to finish the key
+rotation procedure using the same command without the `-init` flag:
+
+```shell-session
+$ bao operator rotate-keys -ns=tenants/my-tenant
+rotation nonce: 393bcb43-93b0-bd74-393e-19fa7a929cee
+Unseal Key (will be hidden): 
+
+Key 1: PBkUn7edaxLU1RoWhQ2V1WB/d+fDqD7vbTGdZn3RvlJL
+Key 2: Kevv2P/y8quC2Z+fC0U+NFDv2QgHk8wz+xQWcR3kbHSn
+Key 3: zCgyQ4nR65veU2N5w3KkJOI8LsIkDyCUlMn98bY6bvQn
+Key 4: ivlPCrBJtMKGN66m6FTQVu+yW22WjE304Zz02tEyNF0o
+Key 5: hFZUpb3i6L8m+aYcISaUVkF0FVFfKa4FMIo/oLifU9Ym
+
+Operation nonce: 393bcb43-93b0-bd74-393e-19fa7a929cee
+
+OpenBao unseal keys rotated to 5 key shares and a key threshold of 3. Please
+securely distribute the key shares printed above. When OpenBao is re-sealed,
+restarted, or stopped, you must supply at least 3 of these keys to unseal it
+before it can start servicing requests.
+```
+
+You can cancel the rotation procedure at any time using the `-cancel` flag.
+
+For more details see the documentation for the [`operator
+rotate-keys`](../../commands/operator/rotate-keys#examples) command.
+
+## Keyring Rotation
+
+To rotate the data encryption keys of a namespace, you can use the existing `bao
+operator rotate` command, while specifying the namespace with the `-ns` flag.
+This requires the namespace to be unsealed.
+
+```shell-session
+$ bao operator rotate -ns=tenants/my-tenant
+Success! Rotated key
+
+Key Term            2
+Install Time        10 Jun 26 08:37 UTC
+Encryption Count    0
+```
+
+You can always check the current status of the namespace keyring by using the `bao operator key-status` command:
+
+```shell-session
+$ bao operator key-status -ns=tenants/my-tenant
+Key Term            2
+Install Time        10 Jun 26 08:37 UTC
+Encryption Count    0
+```

--- a/website/content/partials/api/restricted-endpoints.mdx
+++ b/website/content/partials/api/restricted-endpoints.mdx
@@ -42,11 +42,6 @@ API path | Root | Child
 `sys/replication/recover` | YES | NO
 `sys/replication/reindex` | YES | NO
 `sys/replication/status` | YES | NO
-`sys/rotate` | YES | NO
-`sys/rotate/config` | YES | NO
-`sys/rotate/keyring` | YES | NO
-`sys/rotate/keyring/config` | YES | NO
-`sys/rotate/root` | YES | NO
 `sys/seal` | YES | NO
 `sys/sealwrap/rewrap` | YES | NO
 `sys/step-down` | YES | NO

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -74,7 +74,12 @@ const sidebars: SidebarsConfig = {
                         "concepts/integrated-storage/autopilot",
                     ],
                 },
-                "concepts/namespaces/index",
+                {
+                    "Namespaces": [
+                        "concepts/namespaces/index",
+                        "concepts/namespaces/sealable-namespaces",
+                    ]
+                },
                 "concepts/pgp-gpg-keybase",
                 "concepts/recovery-mode",
                 "concepts/resource-quotas",
@@ -85,6 +90,7 @@ const sidebars: SidebarsConfig = {
             ],
             Guides: [
                 "guides/migration",
+                "guides/sealable-namespaces",
                 {
                     Unsealing: [
                         {

--- a/website/sidebarsApi.ts
+++ b/website/sidebarsApi.ts
@@ -96,7 +96,7 @@ const sidebars: SidebarsConfig = {
         "system/init",
         "system/internal-counters",
         {
-          "sys/internal/inspect": [
+          "/sys/internal/inspect": [
             "system/inspect/index",
             "system/inspect/request",
             "system/inspect/router",
@@ -129,7 +129,7 @@ const sidebars: SidebarsConfig = {
         "system/rekey-recovery-key",
         "system/remount",
         {
-          "sys/rotate": [
+          "/sys/rotate": [
             "system/rotate/index",
             "system/rotate/keyring",
             "system/rotate/keyring-config",
@@ -144,7 +144,7 @@ const sidebars: SidebarsConfig = {
         "system/seal-status",
         "system/step-down",
         {
-          "sys/storage": [
+          "/sys/storage": [
             "system/storage/index",
             "system/storage/raft",
             "system/storage/raftautopilot",


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Adds documentation:
- concept docs for sealable namespaces
- getting started guide for sealable namespaces
- command documentation for new namespace commands
- usage examples of operator commands for sealable namespaces
- API docs for sealable namespace operations

Reverts parts of #3033 to undeprecate the `operator generate-root` command, which now uses the new `/sys/generate-root-token` endpoint and can be used for sealable namespaces too.

~Missing from the docs for now is the deletion of sealed namespaces, which is currently being worked on in #3188. We can add docs on that after the PR is merged.~

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Part of: #1357

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
