### PR TITLE
Add lease restoration to sealed namespaces

### DIFF
--- a/helper/namespace/namespace.go
+++ b/helper/namespace/namespace.go
@@ -201,6 +201,13 @@ func (n *Namespace) ValidateUUID(candidate string) error {
 	return nil
 }
 
+// MatchesID returns true if the given accessor/lease ID matches the current
+// namespace.
+func (n *Namespace) MatchesID(id string) bool {
+	_, nsId := SplitIDFromString(id)
+	return nsId == n.ID || (nsId == "" && n.ID == RootNamespaceID)
+}
+
 // ContextWithNamespace adds the given namespace to the given context
 func ContextWithNamespace(ctx context.Context, ns *Namespace) context.Context {
 	return context.WithValue(ctx, contextNamespace, ns)

--- a/helper/namespace/namespace_test.go
+++ b/helper/namespace/namespace_test.go
@@ -135,6 +135,16 @@ func TestSplitIDFromString(t *testing.T) {
 		if pre != c.prefix || id != c.id {
 			t.Fatalf("bad test case %d: %s != %s, %s != %s", i, pre, c.prefix, id, c.id)
 		}
+
+		if c.id == "" {
+			require.True(t, RootNamespace.MatchesID(c.input), "input: %v", c.input)
+		} else {
+			ns := &Namespace{
+				ID: c.id,
+			}
+			require.True(t, ns.MatchesID(c.input), "input: %v", c.input)
+			require.False(t, RootNamespace.MatchesID(c.input), "input: %v", c.input)
+		}
 	}
 }
 

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -466,16 +466,26 @@ func (m *ExpirationManager) collectLeases() (map[*namespace.Namespace][]string, 
 			continue
 		}
 
-		view := m.leaseView(namespace)
-		keys, err := logical.CollectKeys(m.quitContext, view)
+		keys, err := m.collectNamespaceLeases(namespace)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to scan for leases: %w", err)
+			return nil, 0, err
 		}
+
 		existing[namespace] = keys
 		leaseCount += len(keys)
 	}
 
 	return existing, leaseCount, nil
+}
+
+func (m *ExpirationManager) collectNamespaceLeases(ns *namespace.Namespace) ([]string, error) {
+	view := m.leaseView(ns)
+	keys, err := logical.CollectKeys(m.quitContext, view)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan for leases: %w", err)
+	}
+
+	return keys, nil
 }
 
 // lockLease takes out a lock for a given lease ID
@@ -679,8 +689,31 @@ func (m *ExpirationManager) Tidy(ctx context.Context) error {
 }
 
 // Restore is used to recover the lease states when starting.
+//
 // This is used after starting the vault.
-func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
+func (m *ExpirationManager) Restore(errorFunc func()) error {
+	return m.restore(m.collectLeases, errorFunc)
+}
+
+// Restore is used to restore the leases belonging to a particular namespace
+// when it unseals.
+func (m *ExpirationManager) RestoreNamespace(ns *namespace.Namespace, errorFunc func()) error {
+	m.restoreMode.Store(true)
+	m.restoreLocks = locksutil.CreateLocks()
+
+	return m.restore(func() (map[*namespace.Namespace][]string, int, error) {
+		leases, err := m.collectNamespaceLeases(ns)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return map[*namespace.Namespace][]string{
+			ns.Clone(false): leases,
+		}, len(leases), nil
+	}, errorFunc)
+}
+
+func (m *ExpirationManager) restore(collect func() (map[*namespace.Namespace][]string, int, error), errorFunc func()) (retErr error) {
 	defer func() {
 		// Turn off restore mode. We can do this safely without the lock because
 		// if restore mode finished successfully, restore mode was already
@@ -708,11 +741,11 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 
 	// Accumulate existing leases
 	m.logger.Debug("collecting leases")
-	existing, leaseCount, err := m.collectLeases()
+	existing, leaseCount, err := collect()
 	if err != nil {
 		return err
 	}
-	m.logger.Debug("leases collected", "num_existing", leaseCount)
+	m.logger.Debug("leases collected", "num_existing", leaseCount, "namespaces", len(existing))
 
 	// Make the channels used for the worker pool
 	type lease struct {
@@ -897,6 +930,55 @@ func (m *ExpirationManager) Stop() error {
 	m.emptyUniquePolicies.Stop()
 
 	return nil
+}
+
+// StopNamespace removes all information related to a namespace without
+// affecting other namespaces.
+func (m *ExpirationManager) StopNamespace(ns *namespace.Namespace) {
+	m.pendingLock.Lock()
+	defer m.pendingLock.Unlock()
+
+	leaseIds := make(map[string]struct{})
+
+	m.irrevocable.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			m.irrevocable.Delete(key)
+			m.pending.Delete(key)
+			m.nonexpiring.Delete(key)
+			m.lockPerLease.Delete(key)
+			m.irrevocableLeaseCount -= 1
+			leaseIds[key] = struct{}{}
+		}
+		return true
+	})
+
+	m.pending.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			m.pending.Delete(key)
+			m.nonexpiring.Delete(key)
+			m.lockPerLease.Delete(key)
+			leaseIds[key] = struct{}{}
+		}
+		return true
+	})
+
+	m.nonexpiring.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			m.nonexpiring.Delete(key)
+			m.lockPerLease.Delete(key)
+			leaseIds[key] = struct{}{}
+		}
+		return true
+	})
+
+	m.lockPerLease.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			m.lockPerLease.Delete(key)
+		}
+		return true
+	})
+
+	m.leaseCount -= len(leaseIds)
 }
 
 // Revoke is used to revoke a secret named by the given LeaseID

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1159,6 +1159,17 @@ func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNames
 		return err
 	}
 
+	// load expirations
+	if err := ns.core.expiration.RestoreNamespace(unsealedNamespace, func() {
+		go func() {
+			if err := ns.SealNamespace(ns.core.activeContext.Load(), unsealedNamespace.Path); err != nil {
+				ns.logger.Error("failed to re-seal namespace after erring loading leases", "err", err)
+			}
+		}()
+	}); err != nil {
+		return err
+	}
+
 	// now we run the collected post unseal functions to finalize unsealing
 	ns.core.runPostUnsealFuncs(postUnsealFuncs)
 	return nil
@@ -1248,6 +1259,9 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 }
 
 func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, parent, entry *namespace.Namespace, updateStorage bool) error {
+	// clear expirations.
+	ns.core.expiration.StopNamespace(entry)
+
 	// clear ACL policies
 	if err := ns.clearNamespacePolicies(nsCtx, entry, updateStorage); err != nil {
 		return err

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -490,6 +490,8 @@ func TestNamespaceHierarchy(t *testing.T) {
 }
 
 func TestNamespaceTree(t *testing.T) {
+	t.Parallel()
+
 	rootNs := namespace.RootNamespace
 	tree := newNamespaceTree(rootNs)
 
@@ -728,6 +730,8 @@ func BenchmarkNamespace_Set(b *testing.B) {
 
 // TestNamespaces_ResolveNamespaceFromRequest verifies namespace resolution logic from request.
 func TestNamespaces_ResolveNamespaceFromRequest(t *testing.T) {
+	t.Parallel()
+
 	core, _, _ := TestCoreUnsealed(t)
 	nsStore := core.namespaceStore
 
@@ -841,6 +845,8 @@ func TestNamespaces_ResolveNamespaceFromRequest(t *testing.T) {
 }
 
 func TestNamespaceStorage(t *testing.T) {
+	t.Parallel()
+
 	c, keys, root := TestCoreUnsealed(t)
 	s := c.namespaceStore
 
@@ -898,6 +904,8 @@ func TestNamespaceStorage(t *testing.T) {
 }
 
 func TestNamespaceDeletionSealingInteraction(t *testing.T) {
+	t.Parallel()
+
 	c, keys, _ := TestCoreUnsealed(t)
 	s := c.namespaceStore
 	ctx := namespace.RootContext(t.Context())
@@ -974,7 +982,9 @@ func TestNamespaceDeletionSealingInteraction(t *testing.T) {
 }
 
 func TestNamespaceSealResourcesLifecycle(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	t.Parallel()
+
+	c, _, rootToken := TestCoreUnsealed(t)
 	c.credentialBackends["approle"] = credAppRole.Factory
 	c.logicalBackends["noop"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		return &be.Noop{
@@ -1038,6 +1048,47 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 	require.NoError(t, c.loginMFABackend.PutMFALoginEnforcementConfig(nsCtx, eConfig, ns))
 	require.NoError(t, c.loginMFABackend.MemDBUpsertMFALoginEnforcementConfig(nsCtx, eConfig))
 
+	resp, err := c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing/role-id",
+		Operation:   logical.ReadOperation,
+		ClientToken: rootToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "role_id")
+	roleId := resp.Data["role_id"].(string)
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing/secret-id",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "secret_id")
+	secretId := resp.Data["secret_id"].(string)
+
+	authResp, err := c.HandleRequest(nsCtx, &logical.Request{
+		Path:      "auth/approle/login",
+		Operation: logical.CreateOperation,
+		Data: map[string]any{
+			"role_id":   roleId,
+			"secret_id": secretId,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, authResp)
+
+	t.Logf("\n\nauth: %#v\n\n", authResp)
+
 	checkState := func() {
 		// policies
 		policies, err := c.policyStore.ListPolicies(nsCtx, policy.TypeACL, false)
@@ -1057,7 +1108,7 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 		// identity
 		counts, err := c.identityStore.CountEntitiesByNamespace(nsCtx)
 		require.NoError(t, err)
-		require.Equal(t, 1, counts[ns.ID])
+		require.Equal(t, 2, counts[ns.ID])
 
 		// mfa
 		mfaMethods, err := c.loginMFABackend.MfaMethodList(nsCtx, "")
@@ -1071,6 +1122,20 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 		childNs, err := c.namespaceStore.ListNamespaces(nsCtx, false, true)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(childNs))
+
+		// leases
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			found := false
+			c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+				key := keyRaw.(string)
+				if ns.MatchesID(key) {
+					found = true
+				}
+
+				return true
+			})
+			require.True(collect, found)
+		}, time.Second, 100*time.Millisecond)
 	}
 
 	checkState()


### PR DESCRIPTION
This allows expiration manager to restore leases for a specified namespace, temporarily entering restore mode again.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
