### PR TITLE
Fix context for container cleanup

### DIFF
--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -279,10 +279,26 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 
 	cleanup := func() {
 		for range 10 {
-			_, err := d.DockerAPI.ContainerRemove(ctx, result.Container.ID, client.ContainerRemoveOptions{Force: true})
-			if err == nil || errdefs.IsNotFound(err) {
+			if func() bool {
+				// Container removal may take a little bit, but do not
+				// prematurely time out because our parent context was
+				// cancelled on us.
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				// We don't necessarily have anywhere to surface this error
+				// so swallow it.
+				_, err := d.DockerAPI.ContainerRemove(cleanupCtx, result.Container.ID, client.ContainerRemoveOptions{Force: true})
+				if err == nil || errdefs.IsNotFound(err) {
+					return true
+				}
+
+				return false
+			}() {
+				// OK to return early
 				return
 			}
+
 			time.Sleep(1 * time.Second)
 		}
 	}


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When cleaning up container creation, we default to using the creation's context. However, when that errs or times out, we don't even call the cleanup API at all. This converts cleanup to using fresh, 10 second limited contexts for each cleanup call if we're using a cancelled context. This should ensure fewer outstanding containers lying around after test execution.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
