### PR TITLE
fix(website): typo in yum.repos.d path

### DIFF
--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -264,7 +264,7 @@ const RpmRepo = ({ gpgKeyName }) => {
       pipeline and have not been tampered with.
       <CodeBlock
         language="shell"
-        title="/etc/yum.repos.de/openbao.repo"
+        title="/etc/yum.repos.d/openbao.repo"
         showLineNumbers
       >
         {`[openbao]


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Correct path for `/etc/yum.repos.d` on Downloads page on website.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
