### PR TITLE
Share binary container image layer across distros

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -171,27 +171,30 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PATTERN: ${{ case(startsWith(matrix.distro.name, 'openbao-hsm'), 'openbao-hsm', 'openbao') }}_*_linux_*.tar.gz
 
-      - name: Get date
-        id: date
-        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+      - name: Get release info
+        id: info
+        run: |
+          echo "sha=$(git rev-parse "$VERSION")" >> "$GITHUB_OUTPUT"
+          echo "epoch=$(git log -1 --format=%ct "$VERSION")" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          push: true
           context: .
-          target: ${{ matrix.distro.target }}
+          push: true
           tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}
+          target: ${{ matrix.distro.target }}
           platforms: ${{ join(matrix.distro.platforms, ',') }}
+          outputs: type=registry,rewrite-timestamp=true
+          build-args: SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
           labels: |
-            org.opencontainers.image.created=${{ steps.date.outputs.date }}
             org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>
             org.opencontainers.image.url=https://github.com/openbao/openbao
             org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md
             org.opencontainers.image.source=https://github.com/openbao/openbao
             org.opencontainers.image.version=${{ env.VERSION }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.info.outputs.sha }}
             org.opencontainers.image.vendor=OpenBao
             org.opencontainers.image.licenses=MPL-2.0
             org.opencontainers.image.title=OpenBao

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# This is a helper stage that ensures the binary layer is always the same, no
+# matter which base image it is copied into:
+#
+# 1. Always use /usr/bin/bao, not /bin/bao etc.
+# 2. Apply the same file permissions across the /usr and /usr/bin directories.
+#    Specifically, UBI is missing an u+w bit on /usr/bin that Alpine and
+#    Distroless have.
+#
+# Together with SOURCE_DATE_EPOCH and rewrite-timestamp, this results in an
+# identical binary layer digest across all distributions below, i.e., a given
+# release binary is only ever pushed to a registry once, even if there is more
+# than one container image flavor packaging it.
+FROM scratch AS bin
+ARG TARGETARCH
+COPY --chmod=555 bin/${TARGETARCH}/bao /usr/bin/bao
+
 # This is {docker.io,quay.io,ghcr.io}/openbao/openbao{,-hsm}.
 FROM alpine:3.24.0 AS default
 
@@ -11,11 +27,9 @@ RUN addgroup openbao && adduser -S -G openbao openbao
 
 RUN apk add --no-cache ca-certificates libcap su-exec dumb-init tzdata gcompat
 
-# The OpenBao binary is built externally in CI and copied into the container
-# build.
-ARG TARGETARCH
-COPY bin/${TARGETARCH}/bao /bin/
-RUN ln -s /bin/bao /bin/vault
+# Copy the binary stage.
+COPY --from=bin . /
+RUN ln -s /usr/bin/bao /usr/bin/vault
 
 # /openbao/logs is made available to use as a location to store audit logs, if
 # desired; /openbao/file is made available to use as a location with the file
@@ -65,11 +79,9 @@ RUN groupadd --gid 1000 openbao && \
     adduser --uid 100 --system -g openbao openbao && \
     usermod -a -G root openbao
 
-# The OpenBao binary is built externally in CI and copied into the container
-# build.
-ARG TARGETARCH
-COPY bin/${TARGETARCH}/bao /bin/
-RUN ln -s /bin/bao /bin/vault
+# Copy the binary stage.
+COPY --from=bin . /
+RUN ln -s /usr/bin/bao /usr/bin/vault
 
 # /openbao/logs is made available to use as a location to store audit logs, if
 # desired; /openbao/file is made available to use as a location with the file
@@ -115,10 +127,8 @@ FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb0147
 
 COPY LICENSE /licenses/mozilla.txt
 
-# The OpenBao binary is built externally in CI and copied into the container
-# build.
-ARG TARGETARCH
-COPY bin/${TARGETARCH}/bao /bin/
+# Copy the binary stage.
+COPY --from=bin . /
 
 # 8200/tcp is the primary interface that applications use to interact with
 # OpenBao.
@@ -126,5 +136,5 @@ EXPOSE 8200
 
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.
-ENTRYPOINT ["/bin/bao"]
+ENTRYPOINT ["/usr/bin/bao"]
 CMD ["server", "-dev", "-dev-no-store-token"]


### PR DESCRIPTION
## Description

This ensures that each release binary is pushed to a particular container registry at most once. To do this, we need to make the binary layers added to different distributions (alpine, distroless, ubi) match bit-for-bit. A few tweaks are needed to do so:

- Ensure we always drop the binary at `/usr/bin/bao`. We previously used `/bin/bao`, but this is a symlink to `/usr/bin` on UBI and Distroless and not on Alpine, creating different layers.
- Ensure that the permissions on `/usr` and `/usr/bin` are identical across distros. Specifically, UBI does not have a user write bit set on `/usr/bin`, while Alpine and Distroless do. We can do this with the extra `bin` stage I added, while also deduplicating some code.
- Finally, ensure that `/usr` and `/usr/bin` share the same modification times across distros. There are a couple ways to attack this; I chose the overkill solution and set `SOURCE_DATE_EPOCH` together with `rewrite-timestamps=true`. This should generally help make images slightly more reproducible as a side effect.

To demo, try these:

```console
$ docker pull ghcr.io/openbao/openbao
$ docker pull ghcr.io/openbao/openbao-ubi
```

note how both download one ~70MB layer each time.

```console
$ docker pull ghcr.io/ki-reply-gmbh/openbao-nightly:2.6.0-nightly202606111626
$ docker pull ghcr.io/ki-reply-gmbh/openbao-ubi-nightly:2.6.0-nightly202606111626
```

and note how the first downloads the big layer, but the second doesn't.

## Rationale

Resolves: Someone's bandwidth/storage bill. Really just nerdsniped myself here after being disappointed that the container images shared exactly zero bits between the binary layers.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
