### PR TITLE
Disable UI CI on push to main

### DIFF
--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -13,6 +13,8 @@ on:
     branches:
       - main
       - release/**
+    paths:
+      - "ui/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Disable running UI tests on all pushes to main, unless they modify `ui/**` paths, matching the existing configuration for pull requests.

## Rationale

The UI tests are full of flakes, nobody is fixing them, and current configuration does nothing but spin cycles and cause a bloodbath when merging the 99% of unrelated changes to main.

I like green checkmark[^1], I like seeing when I legitimately don't have green checkmark, or at least that I don't have green checkmark because a Go test is flaky so I can rerun and record in https://github.com/openbao/openbao/issues/2581 to then at least theorize about why I don't have green checkmark.

[^1]: ✅ (a green checkmark, just so we can remind ourselves of what that even looks like)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
