### PR TITLE
Ensure lease timers are canceled, locks persist

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -699,6 +699,11 @@ func (m *ExpirationManager) Restore(errorFunc func()) error {
 // Restore is used to restore the leases belonging to a particular namespace
 // when it unseals.
 func (m *ExpirationManager) RestoreNamespace(ns *namespace.Namespace, errorFunc func()) error {
+	if m.core.Standby() {
+		m.logger.Info("skipping namespace lease restoration - standby")
+		return nil
+	}
+
 	m.restoreMode.Store(true)
 	return m.restore(func() (map[*namespace.Namespace][]string, int, error) {
 		leases, err := m.collectNamespaceLeases(ns)

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -358,8 +358,9 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 	if shouldProcessExp {
 		// active nodes start by running in restore mode by default
 		exp.restoreMode.Store(true)
-		exp.restoreLocks = locksutil.CreateLocks()
 	}
+
+	exp.restoreLocks = locksutil.CreateLocks()
 
 	exp.expireFunc.Store(&e)
 	if exp.revokeRetryBase == 0 {
@@ -699,8 +700,6 @@ func (m *ExpirationManager) Restore(errorFunc func()) error {
 // when it unseals.
 func (m *ExpirationManager) RestoreNamespace(ns *namespace.Namespace, errorFunc func()) error {
 	m.restoreMode.Store(true)
-	m.restoreLocks = locksutil.CreateLocks()
-
 	return m.restore(func() (map[*namespace.Namespace][]string, int, error) {
 		leases, err := m.collectNamespaceLeases(ns)
 		if err != nil {
@@ -852,7 +851,6 @@ LOOP:
 		m.restoreLoaded.Delete(k)
 		return true
 	})
-	m.restoreLocks = nil
 	m.restoreModeLock.Unlock()
 
 	m.logger.Info("lease restore complete")
@@ -940,32 +938,45 @@ func (m *ExpirationManager) StopNamespace(ns *namespace.Namespace) {
 
 	leaseIds := make(map[string]struct{})
 
+	// irrevocable holds an in-memory copy of a lease; safe to delete.
 	m.irrevocable.Range(func(keyRaw any, _ any) bool {
 		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
 			m.irrevocable.Delete(key)
-			m.pending.Delete(key)
-			m.nonexpiring.Delete(key)
-			m.lockPerLease.Delete(key)
 			m.irrevocableLeaseCount -= 1
 			leaseIds[key] = struct{}{}
 		}
 		return true
 	})
 
-	m.pending.Range(func(keyRaw any, _ any) bool {
+	// pending holds a pendingInfo object; cancel the associated timer so
+	// we don't spam failures to revoke.
+	m.pending.Range(func(keyRaw any, infoRaw any) bool {
 		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			info, ok := infoRaw.(pendingInfo)
+			if !ok {
+				return true
+			}
+
+			// Cancel the timer so it doesn't fire again.
+			info.timer.Stop()
 			m.pending.Delete(key)
-			m.nonexpiring.Delete(key)
-			m.lockPerLease.Delete(key)
 			leaseIds[key] = struct{}{}
 		}
 		return true
 	})
 
-	m.nonexpiring.Range(func(keyRaw any, _ any) bool {
+	// nonexpiring holds a pendingInfo object; cancel the associated timer so
+	// we don't spam failures to revoke.
+	m.nonexpiring.Range(func(keyRaw any, infoRaw any) bool {
 		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			info, ok := infoRaw.(pendingInfo)
+			if !ok {
+				return true
+			}
+
+			// Cancel the timer so it doesn't fire again.
+			info.timer.Stop()
 			m.nonexpiring.Delete(key)
-			m.lockPerLease.Delete(key)
 			leaseIds[key] = struct{}{}
 		}
 		return true
@@ -973,7 +984,7 @@ func (m *ExpirationManager) StopNamespace(ns *namespace.Namespace) {
 
 	m.lockPerLease.Range(func(keyRaw any, _ any) bool {
 		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
-			m.lockPerLease.Delete(key)
+			m.deleteLockForLease(key)
 		}
 		return true
 	})

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -133,7 +133,7 @@ type ExpirationManager struct {
 
 	tidyLock atomic.Bool
 
-	restoreMode        atomic.Bool
+	restoreMode        atomic.Int64
 	restoreModeLock    sync.RWMutex
 	restoreRequestLock sync.RWMutex
 	restoreLocks       []*locksutil.LockEntry
@@ -335,6 +335,8 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 		logger:      logger,
 		pendingLock: &locking.SyncRWMutex{},
 
+		restoreLocks: locksutil.CreateLocks(),
+
 		uniquePolicies:      make(map[string][]string),
 		emptyUniquePolicies: time.NewTicker(7 * 24 * time.Hour),
 
@@ -357,10 +359,8 @@ func NewExpirationManager(c *Core, e ExpireLeaseStrategy, logger log.Logger, det
 	// active node
 	if shouldProcessExp {
 		// active nodes start by running in restore mode by default
-		exp.restoreMode.Store(true)
+		exp.restoreMode.Add(1)
 	}
-
-	exp.restoreLocks = locksutil.CreateLocks()
 
 	exp.expireFunc.Store(&e)
 	if exp.revokeRetryBase == 0 {
@@ -501,7 +501,7 @@ func (m *ExpirationManager) unlockLease(leaseID string) {
 
 // inRestoreMode returns if we are currently in restore mode
 func (m *ExpirationManager) inRestoreMode() bool {
-	return m.restoreMode.Load()
+	return m.restoreMode.Load() > 0
 }
 
 // invalidate will be used in the future for implementing read replica nodes
@@ -693,7 +693,7 @@ func (m *ExpirationManager) Tidy(ctx context.Context) error {
 //
 // This is used after starting the vault.
 func (m *ExpirationManager) Restore(errorFunc func()) error {
-	return m.restore(m.collectLeases, errorFunc)
+	return m.restore(m.collectLeases, nil /* global */, errorFunc)
 }
 
 // Restore is used to restore the leases belonging to a particular namespace
@@ -704,7 +704,7 @@ func (m *ExpirationManager) RestoreNamespace(ns *namespace.Namespace, errorFunc 
 		return nil
 	}
 
-	m.restoreMode.Store(true)
+	m.restoreMode.Add(1)
 	return m.restore(func() (map[*namespace.Namespace][]string, int, error) {
 		leases, err := m.collectNamespaceLeases(ns)
 		if err != nil {
@@ -714,16 +714,16 @@ func (m *ExpirationManager) RestoreNamespace(ns *namespace.Namespace, errorFunc 
 		return map[*namespace.Namespace][]string{
 			ns.Clone(false): leases,
 		}, len(leases), nil
-	}, errorFunc)
+	}, ns, errorFunc)
 }
 
-func (m *ExpirationManager) restore(collect func() (map[*namespace.Namespace][]string, int, error), errorFunc func()) (retErr error) {
+func (m *ExpirationManager) restore(collect func() (map[*namespace.Namespace][]string, int, error), restoreNs *namespace.Namespace, errorFunc func()) (retErr error) {
 	defer func() {
 		// Turn off restore mode. We can do this safely without the lock because
 		// if restore mode finished successfully, restore mode was already
 		// disabled with the lock. In an error state, this will allow the
 		// Stop() function to shut everything down.
-		m.restoreMode.Store(false)
+		m.restoreMode.Add(-1)
 
 		switch {
 		case retErr == nil:
@@ -851,9 +851,10 @@ LOOP:
 	}
 
 	m.restoreModeLock.Lock()
-	m.restoreMode.Store(false)
-	m.restoreLoaded.Range(func(k, v interface{}) bool {
-		m.restoreLoaded.Delete(k)
+	m.restoreLoaded.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && (restoreNs == nil || restoreNs.MatchesID(key)) {
+			m.restoreLoaded.Delete(key)
+		}
 		return true
 	})
 	m.restoreModeLock.Unlock()
@@ -990,6 +991,13 @@ func (m *ExpirationManager) StopNamespace(ns *namespace.Namespace) {
 	m.lockPerLease.Range(func(keyRaw any, _ any) bool {
 		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
 			m.deleteLockForLease(key)
+		}
+		return true
+	})
+
+	m.restoreLoaded.Range(func(keyRaw any, _ any) bool {
+		if key, ok := keyRaw.(string); ok && ns.MatchesID(key) {
+			m.restoreLoaded.Delete(key)
 		}
 		return true
 	})

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1205,4 +1206,829 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 
 	// verify after unseal
 	checkState()
+}
+
+func TestNamespaceSealManyLeases(t *testing.T) {
+	t.Parallel()
+
+	c, _, rootToken := TestCoreUnsealed(t)
+	c.credentialBackends["approle"] = credAppRole.Factory
+	c.logicalBackends["noop"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		return &be.Noop{
+			RequestHandler: func(context.Context, *logical.Request) (*logical.Response, error) {
+				return &logical.Response{
+					Secret: &logical.Secret{
+						LeaseOptions: logical.LeaseOptions{
+							TTL:       512 * time.Second,
+							Renewable: true,
+						},
+					},
+				}, nil
+			},
+			DefaultLeaseTTL: 512 * time.Second,
+			MaxLeaseTTL:     512 * time.Second,
+			BackendType:     logical.TypeLogical,
+		}, nil
+	}
+
+	s := c.namespaceStore
+	ctx := namespace.RootContext(t.Context())
+
+	nsCount := 8
+	childNsNames := []string{"foo", "bar"}
+	tokenCounts := 64
+
+	var listNs []*namespace.Namespace
+	namespaces := make(map[string]*namespace.Namespace)
+	nsContexts := make(map[string]context.Context)
+	for i := range nsCount {
+		name := fmt.Sprintf("ns%v/", i)
+		namespaces[name] = &namespace.Namespace{Path: name}
+		nsContexts[name] = namespace.ContextWithNamespace(ctx, namespaces[name])
+		listNs = append(listNs, namespaces[name])
+	}
+
+	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, listNs...)
+
+	for parent := range nsCount {
+		parentName := fmt.Sprintf("ns%v/", parent)
+		parentCtx := nsContexts[parentName]
+		for child := range childNsNames {
+			childName := fmt.Sprintf("child-%v/", child)
+			childPath := parentName + childName
+
+			childNs, _, err := c.namespaceStore.ModifyNamespaceByPath(parentCtx, childName, nil, func(ctx context.Context, obj *namespace.Namespace) (*namespace.Namespace, error) {
+				return obj, nil
+			})
+			require.NoError(t, err)
+			require.NotNil(t, childNs)
+
+			namespaces[childPath] = childNs
+			nsContexts[childPath] = namespace.ContextWithNamespace(ctx, childNs)
+		}
+	}
+
+	var wg sync.WaitGroup
+	var leases sync.Map
+	var rootLeases sync.Map
+	var tokens sync.Map
+
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		tPolicy := `
+		name = "tpolicy"
+		path "*" {
+			policy = "sudo"
+		}
+	`
+		p, err := policy.ParseACLPolicy(ns, tPolicy)
+		require.NoError(t, err)
+		require.NoError(t, c.policyStore.SetPolicy(nsCtx, p, nil))
+
+		approleMe := &routing.MountEntry{
+			Table: routing.CredentialTableType,
+			Path:  "approle/",
+			Type:  "approle",
+		}
+		require.NoError(t, c.enableCredential(nsCtx, approleMe), "enabling for namespace: %v", path)
+
+		require.NoError(t, c.mount(nsCtx, &routing.MountEntry{
+			Table: routing.MountTableType,
+			Path:  "foo",
+			Type:  "noop",
+		}), "enabling for namespace: %v", path)
+
+		resp, err := c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing",
+			Operation:   logical.CreateOperation,
+			ClientToken: rootToken,
+			Data: map[string]any{
+				"token_policies": []string{"tpolicy"},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp)
+
+		resp, err = c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing/role-id",
+			Operation:   logical.ReadOperation,
+			ClientToken: rootToken,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "role_id")
+		roleId := resp.Data["role_id"].(string)
+
+		resp, err = c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing/secret-id",
+			Operation:   logical.CreateOperation,
+			ClientToken: rootToken,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "secret_id")
+		secretId := resp.Data["secret_id"].(string)
+
+		for i := range tokenCounts {
+			wg.Go(func() {
+				authResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:      "auth/approle/login",
+					Operation: logical.CreateOperation,
+					Data: map[string]any{
+						"role_id":   roleId,
+						"secret_id": secretId,
+					},
+				})
+				require.NoError(t, err, "failed to fetch approle token: %v", i)
+				require.NotNil(t, authResp, "failed to fetch approle token: %v", i)
+				require.NotNil(t, authResp.Auth, "failed to fetch approle token: %v", i)
+				require.NotEmpty(t, authResp.Auth.ClientToken, "failed to fetch approle token: %v", i)
+				require.Contains(t, authResp.Auth.Policies, "tpolicy")
+
+				secretResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "foo/create",
+					Operation:   logical.CreateOperation,
+					ClientToken: authResp.Auth.ClientToken,
+				})
+				require.NoError(t, err, "failed to fetch secret lease with token: %v", i)
+				require.NotNil(t, secretResp, "failed to fetch secret lease with token: %v", i)
+				require.NotNil(t, secretResp.Secret, "failed to fetch secret lease with token: %v", i)
+				require.NotEmpty(t, secretResp.Secret.LeaseID, "failed to fetch secret lease with token: %v", i)
+
+				tokens.Store(authResp.Auth.ClientToken, secretResp.Secret.LeaseID)
+				leases.Store(secretResp.Secret.LeaseID, secretResp)
+			})
+		}
+
+		for i := range tokenCounts {
+			wg.Go(func() {
+				secretResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "foo/create",
+					Operation:   logical.CreateOperation,
+					ClientToken: rootToken,
+				})
+				require.NoError(t, err, "failed to fetch secret lease: %v", i)
+				require.NotNil(t, secretResp, "failed to fetch secret lease: %v", i)
+				require.NotNil(t, secretResp.Secret, "failed to fetch secret lease: %v", i)
+				require.NotEmpty(t, secretResp.Secret.LeaseID, "failed to fetch secret lease: %v", i)
+
+				leases.Store(secretResp.Secret.LeaseID, secretResp)
+				rootLeases.Store(secretResp.Secret.LeaseID, secretResp)
+			})
+		}
+	}
+
+	wg.Wait()
+
+	checkState := func() {
+		for path, nsCtx := range nsContexts {
+			ns := namespaces[path]
+
+			// auth mounts
+			authMounts, err := c.auth.FindAllNamespaceMounts(nsCtx)
+			require.NoError(t, err, "for namespace: %v", path)
+			require.Len(t, authMounts, 2, "for namespace: %v", path)
+
+			// mounts
+			mounts, err := c.mounts.FindAllNamespaceMounts(nsCtx)
+			require.NoError(t, err, "for namespace: %v", path)
+			require.Len(t, mounts, 4, "for namespace: %v", path)
+
+			// leases
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				count := 0
+				c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+					key := keyRaw.(string)
+					if ns.MatchesID(key) {
+						count += 1
+					}
+
+					return true
+				})
+				require.GreaterOrEqual(collect, count, 2*tokenCounts)
+
+				leases.Range(func(leaseIdRaw any, _ any) bool {
+					leaseId := leaseIdRaw.(string)
+					if !ns.MatchesID(leaseId) {
+						return true
+					}
+
+					found := false
+					c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+						key := keyRaw.(string)
+						found = found || key == leaseId
+						return true
+					})
+					require.True(collect, found, "did not find expected lease: %v", leaseId)
+					return true
+				})
+			}, time.Second, 100*time.Millisecond)
+
+		}
+	}
+
+	checkState()
+
+	// verify after seal
+	for path := range nsKeys {
+		require.NoError(t, s.SealNamespace(ctx, path))
+	}
+
+	for path, keys := range nsKeys {
+		wg.Go(func() {
+			ns := namespaces[path]
+			for _, key := range keys {
+				unsealed, err := TestNamespaceUnseal(c, ns, key)
+				require.NoError(t, err)
+				if unsealed {
+					break
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+
+	for path := range nsKeys {
+		ns := namespaces[path]
+		require.False(t, c.NamespaceSealed(ns))
+	}
+
+	// verify after unseal
+	checkState()
+
+	t.Logf("Revoking root-owned leases...")
+
+	// now renew and then revoke all root-owned leases
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		rootLeases.Range(func(leaseIdRaw any, _ any) bool {
+			leaseId := leaseIdRaw.(string)
+			if !ns.MatchesID(leaseId) {
+				return true
+			}
+
+			resp, err := c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "sys/leases/renew",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"lease_id": leaseId,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			resp, err = c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "sys/leases/revoke",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"lease_id": leaseId,
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, resp)
+
+			return true
+		})
+	}
+
+	// now renew and then revoke all tokens and verify that the lease also
+	// got revoked
+	t.Logf("Revoking tokens...")
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		tokens.Range(func(tokenIdRaw any, leaseIdRaw any) bool {
+			tokenId := tokenIdRaw.(string)
+			tokenLeaseId := leaseIdRaw.(string)
+			if !ns.MatchesID(tokenId) {
+				return true
+			}
+
+			resp, err := c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "auth/token/renew",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"token": tokenId,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			resp, err = c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "auth/token/revoke",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"token": tokenId,
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, resp)
+
+			// Try to look up the lease; this will be asynchronously deleted.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				resp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "sys/leases/lookup",
+					Operation:   logical.CreateOperation,
+					ClientToken: rootToken,
+					Data: map[string]any{
+						"lease_id": tokenLeaseId,
+					},
+				})
+				require.Error(collect, err, "resp: %v", resp)
+			}, 25*time.Second, 10*time.Millisecond)
+
+			return true
+		})
+	}
+}
+
+func TestNamespaceManyLeases(t *testing.T) {
+	t.Parallel()
+
+	c, sealKeys, rootToken := TestCoreUnsealed(t)
+	c.credentialBackends["approle"] = credAppRole.Factory
+	c.logicalBackends["noop"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		return &be.Noop{
+			RequestHandler: func(context.Context, *logical.Request) (*logical.Response, error) {
+				return &logical.Response{
+					Secret: &logical.Secret{
+						LeaseOptions: logical.LeaseOptions{
+							TTL:       512 * time.Second,
+							Renewable: true,
+						},
+					},
+				}, nil
+			},
+			DefaultLeaseTTL: 512 * time.Second,
+			MaxLeaseTTL:     512 * time.Second,
+			BackendType:     logical.TypeLogical,
+		}, nil
+	}
+
+	ctx := namespace.RootContext(t.Context())
+
+	nsCount := 8
+	childNsNames := []string{"foo", "bar"}
+	tokenCounts := 64
+
+	var listNs []*namespace.Namespace
+	namespaces := make(map[string]*namespace.Namespace)
+	nsContexts := make(map[string]context.Context)
+	for i := range nsCount {
+		name := fmt.Sprintf("ns%v/", i)
+		namespaces[name] = &namespace.Namespace{Path: name}
+		nsContexts[name] = namespace.ContextWithNamespace(ctx, namespaces[name])
+		listNs = append(listNs, namespaces[name])
+	}
+
+	TestCoreCreateNamespaces(t, c, listNs...)
+
+	for parent := range nsCount {
+		parentName := fmt.Sprintf("ns%v/", parent)
+		parentCtx := nsContexts[parentName]
+		for child := range childNsNames {
+			childName := fmt.Sprintf("child-%v/", child)
+			childPath := parentName + childName
+
+			childNs, _, err := c.namespaceStore.ModifyNamespaceByPath(parentCtx, childName, nil, func(ctx context.Context, obj *namespace.Namespace) (*namespace.Namespace, error) {
+				return obj, nil
+			})
+			require.NoError(t, err)
+			require.NotNil(t, childNs)
+
+			namespaces[childPath] = childNs
+			nsContexts[childPath] = namespace.ContextWithNamespace(ctx, childNs)
+		}
+	}
+
+	var wg sync.WaitGroup
+	var leases sync.Map
+	var rootLeases sync.Map
+	var tokens sync.Map
+
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		tPolicy := `
+		name = "tpolicy"
+		path "*" {
+			policy = "sudo"
+		}
+	`
+		p, err := policy.ParseACLPolicy(ns, tPolicy)
+		require.NoError(t, err)
+		require.NoError(t, c.policyStore.SetPolicy(nsCtx, p, nil))
+
+		approleMe := &routing.MountEntry{
+			Table: routing.CredentialTableType,
+			Path:  "approle/",
+			Type:  "approle",
+		}
+		require.NoError(t, c.enableCredential(nsCtx, approleMe), "enabling for namespace: %v", path)
+
+		require.NoError(t, c.mount(nsCtx, &routing.MountEntry{
+			Table: routing.MountTableType,
+			Path:  "foo",
+			Type:  "noop",
+		}), "enabling for namespace: %v", path)
+
+		resp, err := c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing",
+			Operation:   logical.CreateOperation,
+			ClientToken: rootToken,
+			Data: map[string]any{
+				"token_policies": []string{"tpolicy"},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp)
+
+		resp, err = c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing/role-id",
+			Operation:   logical.ReadOperation,
+			ClientToken: rootToken,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "role_id")
+		roleId := resp.Data["role_id"].(string)
+
+		resp, err = c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "auth/approle/role/testing/secret-id",
+			Operation:   logical.CreateOperation,
+			ClientToken: rootToken,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "secret_id")
+		secretId := resp.Data["secret_id"].(string)
+
+		for i := range tokenCounts {
+			wg.Go(func() {
+				authResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:      "auth/approle/login",
+					Operation: logical.CreateOperation,
+					Data: map[string]any{
+						"role_id":   roleId,
+						"secret_id": secretId,
+					},
+				})
+				require.NoError(t, err, "failed to fetch approle token: %v", i)
+				require.NotNil(t, authResp, "failed to fetch approle token: %v", i)
+				require.NotNil(t, authResp.Auth, "failed to fetch approle token: %v", i)
+				require.NotEmpty(t, authResp.Auth.ClientToken, "failed to fetch approle token: %v", i)
+				require.Contains(t, authResp.Auth.Policies, "tpolicy")
+
+				secretResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "foo/create",
+					Operation:   logical.CreateOperation,
+					ClientToken: authResp.Auth.ClientToken,
+				})
+				require.NoError(t, err, "failed to fetch secret lease with token: %v", i)
+				require.NotNil(t, secretResp, "failed to fetch secret lease with token: %v", i)
+				require.NotNil(t, secretResp.Secret, "failed to fetch secret lease with token: %v", i)
+				require.NotEmpty(t, secretResp.Secret.LeaseID, "failed to fetch secret lease with token: %v", i)
+
+				tokens.Store(authResp.Auth.ClientToken, secretResp.Secret.LeaseID)
+				leases.Store(secretResp.Secret.LeaseID, secretResp)
+			})
+		}
+
+		for i := range tokenCounts {
+			wg.Go(func() {
+				secretResp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "foo/create",
+					Operation:   logical.CreateOperation,
+					ClientToken: rootToken,
+				})
+				require.NoError(t, err, "failed to fetch secret lease: %v", i)
+				require.NotNil(t, secretResp, "failed to fetch secret lease: %v", i)
+				require.NotNil(t, secretResp.Secret, "failed to fetch secret lease: %v", i)
+				require.NotEmpty(t, secretResp.Secret.LeaseID, "failed to fetch secret lease: %v", i)
+
+				leases.Store(secretResp.Secret.LeaseID, secretResp)
+				rootLeases.Store(secretResp.Secret.LeaseID, secretResp)
+			})
+		}
+	}
+
+	wg.Wait()
+
+	checkState := func() {
+		for path, nsCtx := range nsContexts {
+			ns := namespaces[path]
+
+			// auth mounts
+			authMounts, err := c.auth.FindAllNamespaceMounts(nsCtx)
+			require.NoError(t, err, "for namespace: %v", path)
+			require.Len(t, authMounts, 2, "for namespace: %v", path)
+
+			// mounts
+			mounts, err := c.mounts.FindAllNamespaceMounts(nsCtx)
+			require.NoError(t, err, "for namespace: %v", path)
+			require.Len(t, mounts, 4, "for namespace: %v", path)
+
+			// leases
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				count := 0
+				c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+					key := keyRaw.(string)
+					if ns.MatchesID(key) {
+						count += 1
+					}
+
+					return true
+				})
+				require.GreaterOrEqual(collect, count, 2*tokenCounts)
+
+				leases.Range(func(leaseIdRaw any, _ any) bool {
+					leaseId := leaseIdRaw.(string)
+					if !ns.MatchesID(leaseId) {
+						return true
+					}
+
+					found := false
+					c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+						key := keyRaw.(string)
+						found = found || key == leaseId
+						return true
+					})
+					require.True(collect, found, "did not find expected lease: %v", leaseId)
+					return true
+				})
+			}, time.Second, 100*time.Millisecond)
+
+		}
+	}
+
+	checkState()
+
+	// verify after seal
+	require.NoError(t, TestCoreSeal(c))
+	for _, key := range sealKeys {
+		_, err := TestCoreUnseal(c, key)
+		require.NoError(t, err)
+	}
+	require.NotNil(t, sealKeys)
+
+	// verify after unseal
+	checkState()
+
+	t.Logf("Revoking root-owned leases...")
+
+	// now renew and then revoke all root-owned leases
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		rootLeases.Range(func(leaseIdRaw any, _ any) bool {
+			leaseId := leaseIdRaw.(string)
+			if !ns.MatchesID(leaseId) {
+				return true
+			}
+
+			resp, err := c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "sys/leases/renew",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"lease_id": leaseId,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			resp, err = c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "sys/leases/revoke",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"lease_id": leaseId,
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, resp)
+
+			return true
+		})
+	}
+
+	// now renew and then revoke all tokens and verify that the lease also
+	// got revoked
+	t.Logf("Revoking tokens...")
+	for path, nsCtx := range nsContexts {
+		ns := namespaces[path]
+
+		tokens.Range(func(tokenIdRaw any, leaseIdRaw any) bool {
+			tokenId := tokenIdRaw.(string)
+			tokenLeaseId := leaseIdRaw.(string)
+			if !ns.MatchesID(tokenId) {
+				return true
+			}
+
+			resp, err := c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "auth/token/renew",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"token": tokenId,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			resp, err = c.HandleRequest(nsCtx, &logical.Request{
+				Path:        "auth/token/revoke",
+				Operation:   logical.CreateOperation,
+				ClientToken: rootToken,
+				Data: map[string]any{
+					"token": tokenId,
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, resp)
+
+			// Try to look up the lease.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				resp, err := c.HandleRequest(nsCtx, &logical.Request{
+					Path:        "sys/leases/lookup",
+					Operation:   logical.CreateOperation,
+					ClientToken: rootToken,
+					Data: map[string]any{
+						"lease_id": tokenLeaseId,
+					},
+				})
+				require.Error(collect, err, "resp: %v", resp)
+			}, 50*time.Second, 10*time.Millisecond)
+
+			return true
+		})
+	}
+}
+
+func TestNamespaceSealedLeaseTokenRevoke(t *testing.T) {
+	t.Parallel()
+
+	c, sealKeys, rootToken := TestCoreUnsealed(t)
+	c.credentialBackends["approle"] = credAppRole.Factory
+	c.logicalBackends["noop"] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
+		return &be.Noop{
+			// This is safe as this is not multi-threaded.
+			Response: &logical.Response{
+				Secret: &logical.Secret{
+					LeaseOptions: logical.LeaseOptions{
+						TTL:       512 * time.Second,
+						Renewable: true,
+					},
+				},
+			},
+			DefaultLeaseTTL: 512 * time.Second,
+			MaxLeaseTTL:     512 * time.Second,
+			BackendType:     logical.TypeLogical,
+		}, nil
+	}
+
+	ctx := namespace.RootContext(t.Context())
+
+	ns := &namespace.Namespace{Path: "ns1/"}
+	nsCtx := namespace.ContextWithNamespace(ctx, ns)
+	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, ns)
+	require.NotEmpty(t, nsKeys)
+
+	tPolicy := `
+		name = "tpolicy"
+		path "*" {
+			policy = "sudo"
+		}
+	`
+	p, err := policy.ParseACLPolicy(ns, tPolicy)
+	require.NoError(t, err)
+	require.NoError(t, c.policyStore.SetPolicy(nsCtx, p, nil))
+
+	approleMe := &routing.MountEntry{
+		Table: routing.CredentialTableType,
+		Path:  "approle/",
+		Type:  "approle",
+	}
+	require.NoError(t, c.enableCredential(nsCtx, approleMe), "enabling for namespace: %v", ns.Path)
+
+	require.NoError(t, c.mount(nsCtx, &routing.MountEntry{
+		Table: routing.MountTableType,
+		Path:  "foo",
+		Type:  "noop",
+	}), "enabling for namespace: %v", ns.Path)
+
+	resp, err := c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+		Data: map[string]any{
+			"token_policies": []string{"tpolicy"},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing/role-id",
+		Operation:   logical.ReadOperation,
+		ClientToken: rootToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "role_id")
+	roleId := resp.Data["role_id"].(string)
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/approle/role/testing/secret-id",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "secret_id")
+	secretId := resp.Data["secret_id"].(string)
+
+	authResp, err := c.HandleRequest(nsCtx, &logical.Request{
+		Path:      "auth/approle/login",
+		Operation: logical.CreateOperation,
+		Data: map[string]any{
+			"role_id":   roleId,
+			"secret_id": secretId,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, authResp)
+	require.NotNil(t, authResp.Auth)
+	require.NotEmpty(t, authResp.Auth.ClientToken)
+	require.Contains(t, authResp.Auth.Policies, "tpolicy")
+
+	secretResp, err := c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "foo/create",
+		Operation:   logical.CreateOperation,
+		ClientToken: authResp.Auth.ClientToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, secretResp)
+	require.NotNil(t, secretResp.Secret)
+	require.NotEmpty(t, secretResp.Secret.LeaseID)
+
+	// verify after seal
+	require.NoError(t, TestCoreSeal(c))
+	for _, key := range sealKeys {
+		_, err := TestCoreUnseal(c, key)
+		require.NoError(t, err)
+	}
+	require.NotNil(t, sealKeys)
+
+	for _, key := range nsKeys["ns1/"] {
+		unsealed, err := TestNamespaceUnseal(c, ns, key)
+		require.NoError(t, err)
+		if unsealed {
+			break
+		}
+	}
+
+	t.Logf("Revoking tokens...")
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/token/renew",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+		Data: map[string]any{
+			"token": authResp.Auth.ClientToken,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	resp, err = c.HandleRequest(nsCtx, &logical.Request{
+		Path:        "auth/token/revoke",
+		Operation:   logical.CreateOperation,
+		ClientToken: rootToken,
+		Data: map[string]any{
+			"token": authResp.Auth.ClientToken,
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Try to look up the lease.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp, err := c.HandleRequest(nsCtx, &logical.Request{
+			Path:        "sys/leases/lookup",
+			Operation:   logical.CreateOperation,
+			ClientToken: rootToken,
+			Data: map[string]any{
+				"lease_id": secretResp.Secret.LeaseID,
+			},
+		})
+		require.Error(collect, err, "resp: %v", resp)
+	}, 25*time.Second, 10*time.Millisecond)
 }

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -1308,7 +1308,7 @@ func TestTokenStore_CreateLookup_ExpirationInRestoreMode(t *testing.T) {
 
 	// Reset expiration manager to restore mode
 	ts.expiration.restoreModeLock.Lock()
-	ts.expiration.restoreMode.Store(true)
+	ts.expiration.restoreMode.Add(1)
 	ts.expiration.restoreLocks = locksutil.CreateLocks()
 	ts.expiration.restoreModeLock.Unlock()
 


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->


This ensures timers on lease tracking are cancelled when the namespace is sealed, preventing additional log messages. This also persists restoration locks; as there are a fixed number, they won't incur too much overhead relative to other places where these locks are already being used.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: https://github.com/openbao/openbao/pull/3257

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
