### PR TITLE
Fix invalidation entries in sealed namespaces

### DIFF
--- a/changelog/3283.txt
+++ b/changelog/3283.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/mfa: Handle invalidation for login MFA within namespaces, ensuring standby nodes respond appropriately on writes.
+```

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -35,11 +35,15 @@ func (c *Core) Invalidate(key ...string) {
 	c.invalidations.Add(key...)
 }
 
-func (c *Core) invalidateSynchronous(key string) {
+func (c *Core) invalidateSynchronous(key string) error {
 	job, _ := c.invalidations.buildInvalidateJobForKey(make(chan struct{}), context.Background(), key)
+
 	if err := job.Execute(); err != nil {
 		job.OnFailure(err)
+		return err
 	}
+
+	return nil
 }
 
 // invalidationManager is a long-lived subset of Core which is used to handle
@@ -356,6 +360,18 @@ func (ij *invalidationJob) Execute() error {
 		return nil
 	}
 
+	nsBarrier := ij.im.core.sealManager.NamespaceBarrierByLongestPrefix(ns.Path)
+	if nsBarrier.Namespace().UUID != namespace.RootNamespaceUUID && nsBarrier.Sealed() {
+		// When the parent namespace is sealed, ignore the request: this
+		// means we're unable to process the invalidation regardless of
+		// what the actual invalidated entry is. Only when this parent
+		// namespace becomes unsealed can we process changes to data within
+		// it. Notably, the namespace entry for a sealed namespace sits in
+		// the namespace above it, so it is not its own parent and thus will
+		// be correctly invalidated.
+		return nil
+	}
+
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 
 	// Lastly, create a short version of the context for plugin invalidations.
@@ -400,7 +416,7 @@ func (ij *invalidationJob) Execute() error {
 	case strings.HasPrefix(ij.key, "autopilot/") || ij.key == raftAutopilotConfigurationStoragePath:
 		// Raft context is reloaded when a standby becomes active, so it is
 		// safe to ignore changes to autopilot state.
-	case isLoginMFA(ij.key):
+	case isLoginMFA(ij.nsKey):
 		ij.fatal = true
 		return ij.loginMFAInvalidation(ctx, ns)
 	case ij.im.core.router.Invalidate(shortCtx, ij.key):

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/hashicorp/go-hclog"
 	"github.com/openbao/openbao/audit"
 	"github.com/openbao/openbao/command/server"
 	"github.com/openbao/openbao/helper/namespace"
@@ -139,7 +141,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	mountPath := "ns/my-path"
 
 	// 3. Invalidate Path
-	c.invalidateSynchronous(storagePath)
+	require.NoError(t, c.invalidateSynchronous(storagePath))
 
 	// 4. Check cache was properly invalidated
 	// 4.1 Validate custom metadata
@@ -166,7 +168,7 @@ func TestCore_Invalidate_Namespaces(t *testing.T) {
 	testCore_Invalidate_sneakValueAroundCacheDelete(t, rootCtx, c, "namespaces/"+ns.UUID)
 
 	// 6. Invalidate Path
-	c.invalidateSynchronous(storagePath)
+	require.NoError(t, c.invalidateSynchronous(storagePath))
 
 	// 7. Check cache was properly invalidated
 	// 7.1 namespace should be gone
@@ -247,7 +249,7 @@ func TestCore_Invalidate_Namespaces_NonTransactional(t *testing.T) {
 	})
 
 	// 3. Invalidate Path
-	c.invalidateSynchronous(storagePath)
+	require.NoError(t, c.invalidateSynchronous(storagePath))
 
 	// 4. Check cache was properly invalidated
 	// 4.1 Validate custom metadata
@@ -283,6 +285,16 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
 
 			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
@@ -326,7 +338,7 @@ func TestCore_Invalidate_Policy(t *testing.T) {
 			}
 
 			// 3. Invalidate Path
-			c.invalidateSynchronous(storagePath)
+			require.NoError(t, c.invalidateSynchronous(storagePath))
 
 			// 4. Check cache was properly invalidated
 			updatedPolicy, err := c.policyStore.GetPolicy(ctx, "test-policy", policy.TypeACL)
@@ -363,7 +375,7 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 
 	// 3. Invalidate Path
-	c.invalidateSynchronous("sys/quotas/rate-limit/test-quota")
+	require.NoError(t, c.invalidateSynchronous("sys/quotas/rate-limit/test-quota"))
 
 	// 4. Check cache was properly invalidated
 	req = logical.TestRequest(t, logical.ReadOperation, "sys/quotas/rate-limit/test-quota")
@@ -376,52 +388,86 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 
 func TestCore_Invalidate_LoginMFA(t *testing.T) {
 	t.Parallel()
-	c, root := testCore_Invalidate_TestCore(t, nil)
-	rootCtx := namespace.RootContext(t.Context())
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"global": func(t *testing.T, c *Core) context.Context {
+			return namespace.RootContext(t.Context())
+		},
 
-	// 1. Create a login MFA to populate the cache.
-	req := logical.TestRequest(t, logical.CreateOperation, "identity/mfa/method/totp")
-	req.ClientToken = root
-	req.Data = map[string]any{
-		"method_name": "testing",
-		"issuer":      "OpenBao",
+		"local": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "ns",
+				Path: "ns",
+			}
+			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
 	}
-	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
-	require.NotNil(t, resp)
-	require.Contains(t, resp.Data, "method_id")
-	path := resp.Data["method_id"].(string)
 
-	// 2. Manipulate Storage
-	barrierView := c.NamespaceView(namespace.RootNamespace).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
-	mfa, err := c.loginMFABackend.getMFAConfig(rootCtx, path, barrierView)
-	require.NoError(t, err)
-	require.NotNil(t, mfa)
-	require.Equal(t, mfa.Name, "testing")
+	for name, init := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c, root := testCore_Invalidate_TestCore(t, nil)
+			ctx := init(t, c)
 
-	clone, err := mfa.Clone()
-	require.NoError(t, err)
+			ns, err := namespace.FromContext(ctx)
+			require.NoError(t, err)
 
-	clone.Name = "my-custom-name"
+			// 1. Create a login MFA to populate the cache.
+			req := logical.TestRequest(t, logical.CreateOperation, "identity/mfa/method/totp")
+			req.ClientToken = root
+			req.Data = map[string]any{
+				"method_name": "testing",
+				"issuer":      "OpenBao",
+			}
+			resp := testCore_Invalidate_handleRequest(t, ctx, c, req)
+			require.NotNil(t, resp)
+			require.Contains(t, resp.Data, "method_id")
+			path := resp.Data["method_id"].(string)
 
-	fullPath := barrier.SystemBarrierPrefix + loginMFAConfigPrefix + path
-	newEntry, err := proto.Marshal(clone)
-	require.NoError(t, err)
+			// 2. Manipulate Storage
+			barrierView := c.NamespaceView(ns).SubView(barrier.SystemBarrierPrefix + loginMFAConfigPrefix)
+			mfa, err := c.loginMFABackend.getMFAConfig(ctx, path, barrierView)
+			require.NoError(t, err)
+			require.NotNil(t, mfa)
+			require.Equal(t, mfa.Name, "testing")
 
-	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, &logical.StorageEntry{
-		Key:   fullPath,
-		Value: newEntry,
-	})
+			clone, err := mfa.Clone()
+			require.NoError(t, err)
 
-	// 3. Invalidate path
-	c.invalidateSynchronous(fullPath)
+			clone.Name = "my-custom-name"
 
-	// 4. Check cache was properly invalidated
-	req = logical.TestRequest(t, logical.ReadOperation, "identity/mfa/method/totp/"+path)
-	req.ClientToken = root
+			fullPath := barrierView.Prefix() + path
+			newEntry, err := proto.Marshal(clone)
+			require.NoError(t, err)
 
-	resp = testCore_Invalidate_handleRequest(t, rootCtx, c, req)
-	require.Contains(t, resp.Data, "name")
-	require.Equal(t, "my-custom-name", resp.Data["name"])
+			writePath := strings.TrimPrefix(fullPath, c.NamespaceView(ns).Prefix())
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   writePath,
+				Value: newEntry,
+			})
+
+			// 3. Invalidate path
+			require.NoError(t, c.invalidateSynchronous(fullPath))
+
+			// 4. Check cache was properly invalidated
+			req = logical.TestRequest(t, logical.ReadOperation, "identity/mfa/method/totp/"+path)
+			req.ClientToken = root
+
+			resp = testCore_Invalidate_handleRequest(t, ctx, c, req)
+			require.Contains(t, resp.Data, "name")
+			require.Equal(t, "my-custom-name", resp.Data["name"])
+		})
+	}
 }
 
 func TestCore_Invalidate_Plugin(t *testing.T) {
@@ -435,6 +481,16 @@ func TestCore_Invalidate_Plugin(t *testing.T) {
 			ns := &namespace.Namespace{
 				ID:   "ns",
 				Path: "ns",
+			}
+			TestCoreCreateNamespaces(t, c, ns)
+
+			return fmt.Sprintf("namespaces/%s/", ns.UUID), namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) (nsPrefix string, ctx context.Context) {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
 
@@ -484,8 +540,8 @@ func TestCore_Invalidate_Plugin(t *testing.T) {
 			uuid := resp.Data["uuid"].(string)
 
 			// 4. Invalidate Paths
-			c.invalidateSynchronous(nsPrefix + "logical/" + uuid + "/foo")
-			c.invalidateSynchronous(nsPrefix + "logical/" + uuid + "/bar/bazz")
+			require.NoError(t, c.invalidateSynchronous(nsPrefix+"logical/"+uuid+"/foo"))
+			require.NoError(t, c.invalidateSynchronous(nsPrefix+"logical/"+uuid+"/bar/bazz"))
 
 			// 5. Check callback was called
 			assert.Equal(t, []string{"foo", "bar/bazz"}, invalidatedKey)
@@ -559,7 +615,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	})
 
 	// 5. call invalidate
-	c.invalidateSynchronous("core/audit")
+	require.NoError(t, c.invalidateSynchronous("core/audit"))
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		require.Equal(collect, 0, c.auditBroker.Count())
@@ -576,7 +632,7 @@ func TestCore_Invalidate_Audit(t *testing.T) {
 	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, entry)
 
 	// 8. call invalidate
-	c.invalidateSynchronous("core/audit")
+	require.NoError(t, c.invalidateSynchronous("core/audit"))
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		require.EqualValues(collect, 2, callCount.Load(), "expected audit factory to be called exactly twice")
@@ -604,6 +660,16 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "ns",
+				Path: "ns",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
 
 			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
@@ -685,7 +751,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCacheDelete(t, ctx, c, entryPath)
 
 			// 5. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -703,7 +769,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 8. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -728,7 +794,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			})
 
 			// 10. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				triggerReadCall(collect, "unsupported path")
@@ -747,7 +813,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			})
 
 			// 12. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				resp := testCore_Invalidate_handleRequest(collect, ctx, c, &logical.Request{
@@ -772,7 +838,7 @@ func TestCore_Invalidate_SecretMount(t *testing.T) {
 			})
 
 			// 14. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				require.EqualValues(collect, 3, factoryCallCount.Load(), "expected factory to be called exactly thrice")
@@ -795,6 +861,16 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
 
 			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
@@ -886,7 +962,7 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			})
 
 			// 4. call invalidate
-			c.invalidateSynchronous(view.Prefix() + coreMountConfigPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreMountConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -904,7 +980,7 @@ func TestCore_Invalidate_SecretMount_NonTransactional(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 7. call invalidate
-			c.invalidateSynchronous(view.Prefix() + coreMountConfigPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreMountConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.mountsLock.RLock()
@@ -931,6 +1007,16 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
 
 			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
@@ -1012,7 +1098,7 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCacheDelete(t, ctx, c, entryPath)
 
 			// 5. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1030,7 +1116,7 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 8. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1055,7 +1141,7 @@ func TestCore_Invalidate_AuthMount(t *testing.T) {
 			})
 
 			// 10. call invalidate
-			c.invalidateSynchronous(view.Prefix() + entryPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+entryPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				callLogin(collect, "unsupported path")
@@ -1077,6 +1163,16 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 				Path: "ns",
 			}
 			TestCoreCreateNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
 
 			return namespace.ContextWithNamespace(t.Context(), ns)
 		},
@@ -1167,7 +1263,7 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			})
 
 			// 4. call invalidate
-			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreAuthConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1185,7 +1281,7 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, storageEntry)
 
 			// 7. call invalidate
-			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreAuthConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				c.authLock.RLock()
@@ -1209,11 +1305,86 @@ func TestCore_Invalidate_AuthMount_NonTransactional(t *testing.T) {
 			})
 
 			// 9. call invalidate
-			c.invalidateSynchronous(view.Prefix() + coreAuthConfigPath)
+			require.NoError(t, c.invalidateSynchronous(view.Prefix()+coreAuthConfigPath))
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				callLogin(collect, "unsupported path")
 			}, 10*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestCore_Invalidate_SealedNamespaces(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"sealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "sealed",
+				Path: "sealed",
+			}
+			TestCoreCreateSealedNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+
+		"child": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+			child := &namespace.Namespace{
+				ID:   "child",
+				Path: "unsealed/child",
+			}
+
+			TestCoreCreateNamespaces(t, c, child)
+
+			require.NoError(t, c.namespaceStore.SealNamespace(namespace.RootContext(t.Context()), ns.Path))
+
+			return namespace.ContextWithNamespace(t.Context(), child)
+		},
+	}
+
+	for name, init := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, _ := testCore_Invalidate_TestCore(t, nil)
+			ctx := init(t, c)
+
+			ns, err := namespace.FromContext(ctx)
+			require.NoError(t, err)
+			view := c.NamespaceView(ns)
+
+			nsRootView := barrier.NewView(c.barrier, view.Prefix())
+
+			require.NoError(
+				t,
+				logical.ScanViewPaginated(
+					t.Context(),
+					nsRootView,
+					hclog.NewNullLogger(),
+					50,
+					func(page int, index int, path string) (cont bool, err error) {
+						// Bypass the security barrier and write garbage.
+						testCore_Invalidate_sneakValueAroundCache(
+							t,
+							namespace.RootContext(ctx),
+							c,
+							&logical.StorageEntry{
+								Key:   path,
+								Value: []byte("absolute-garbage"),
+							},
+						)
+
+						// Call invalidate on the full path; this should not err.
+						require.NoError(t, c.invalidateSynchronous(view.Prefix()+path))
+
+						return true, nil
+					},
+				),
+			)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Ignore all invalidations in sealed namespace storage: these will always return Vault is sealed, resulting in the core restarting. We'll correctly handle invalidations when the namespace is ultimately unsealed and there should be no loaded state for that namespace anyways.

Also fix a bug in login MFA invalidation, found while expanding test coverage to unsealed namespaces.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
