### PR TITLE
Fix flake in TestNamespaceClusterSealing

### DIFF
--- a/vault/external_tests/namespaces/sealing_test.go
+++ b/vault/external_tests/namespaces/sealing_test.go
@@ -110,9 +110,12 @@ seal "shamir" {
 		"ns3": ns3Shares,
 	}
 
-	// All namespaces should be sealed.
+	// All namespaces should be sealed; this is wrapped in an eventually as
+	// the namespaces can take a minute to be created on the standby nodes.
 	for ns := range allNamespaces {
-		requireSealed(t, ns, allClients...)
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			requireSealed(t, ns, allClients...)
+		}, 25*time.Second, 100*time.Millisecond)
 	}
 
 	// Unsealing with secondary client should result in namespace immediately


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Invalidation across clusters is variable timing, so we should wrap this in an eventually block. 

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
