### PR TITLE
Fix storage list in remount operation

### DIFF
--- a/vault/mount.go
+++ b/vault/mount.go
@@ -765,7 +765,7 @@ func (c *Core) moveStorage(ctx context.Context, src namespace.MountPathDetails, 
 		key, keys = keys[0], keys[1:]
 		entryKey := path.Join(prefix, me.UUID, key)
 		if strings.HasSuffix(key, "/") {
-			nestedKeys, err := srcBarrier.List(ctx, entryKey)
+			nestedKeys, err := srcBarrier.List(ctx, entryKey+"/")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
- remount operation `moveStorage` now correctly lists storage entries

## Rationale
fix to bug introduced with namespace sealing

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
