### PR TITLE
Add patch support to OpenAPI schema

### DIFF
--- a/changelog/3289.txt
+++ b/changelog/3289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+openapi: Add missing support for reporting PATCH support on endpoints.
+```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -118,6 +118,7 @@ type OASPathItem struct {
 
 	Get    *OASOperation `json:"get,omitempty"`
 	Post   *OASOperation `json:"post,omitempty"`
+	Patch  *OASOperation `json:"patch,omitempty"`
 	Delete *OASOperation `json:"delete,omitempty"`
 }
 
@@ -346,8 +347,8 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 			op.Deprecated = props.Deprecated
 			op.OperationID = operationID
 
-			// Add any fields not present in the path as body parameters for POST.
-			if opType == logical.CreateOperation || opType == logical.UpdateOperation {
+			// Add any fields not present in the path as body parameters for POST or PATCH.
+			if opType == logical.CreateOperation || opType == logical.UpdateOperation || opType == logical.PatchOperation {
 				s := &OASSchema{
 					Type:       "object",
 					Properties: make(map[string]*OASSchema),
@@ -581,6 +582,8 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 				pi.Get = op
 			case logical.DeleteOperation:
 				pi.Delete = op
+			case logical.PatchOperation:
+				pi.Patch = op
 			}
 		}
 
@@ -1129,7 +1132,7 @@ func (d *OASDocument) CreateOperationIDs(context string) {
 
 	for _, path := range paths {
 		pi := d.Paths[path]
-		for _, method := range []string{"get", "post", "delete"} {
+		for _, method := range []string{"get", "post", "delete", "patch"} {
 			var oasOperation *OASOperation
 			switch method {
 			case "get":
@@ -1138,6 +1141,8 @@ func (d *OASDocument) CreateOperationIDs(context string) {
 				oasOperation = pi.Post
 			case "delete":
 				oasOperation = pi.Delete
+			case "patch":
+				oasOperation = pi.Patch
 			}
 
 			if oasOperation == nil {

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -437,6 +437,10 @@ func TestOpenAPI_Paths(t *testing.T) {
 					Summary:     "Update Summary",
 					Description: "Update Description",
 				},
+				logical.PatchOperation: &PathOperation{
+					Summary:     "Patch Summary",
+					Description: "Patch Description",
+				},
 				logical.CreateOperation: &PathOperation{
 					Summary:     "Create Summary",
 					Description: "Create Description",

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -81,12 +81,85 @@
             "description": "OK"
           }
         }
+      },
+      "patch": {
+        "operationId": "kv-patch-foo-id",
+        "tags": [
+          "secrets"
+        ],
+        "summary": "Patch Summary",
+        "description": "Patch Description",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KvPatchFooIdRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
   "components": {
     "schemas": {
       "KvWriteFooIdRequest": {
+        "type": "object",
+        "required": [
+          "age"
+        ],
+        "properties": {
+          "flavors": {
+            "type": "array",
+            "description": "the flavors",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer",
+            "description": "the age",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "x-vault-displayAttrs": {
+              "name": "Age",
+              "sensitive": true,
+              "group": "Some Group",
+              "value": 7
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "the name",
+            "default": "Larry",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "x-abc-token": {
+            "type": "string",
+            "description": "a header value",
+            "enum": [
+              "a",
+              "b",
+              "c"
+            ]
+          },
+          "maximum": {
+            "type": "integer",
+            "description": "a maximum value",
+            "format": "int64"
+          }
+        }
+      },
+      "KvPatchFooIdRequest": {
         "type": "object",
         "required": [
           "age"


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This adds the missing support for PATCH operations to the OpenAPI schema. 

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
