### PR TITLE
Switch to automatic nonce generation

### DIFF
--- a/changelog/3290.txt
+++ b/changelog/3290.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Switch to cipher.NewGCMWithRandomNonce for fewer nonce generation calls.
+```

--- a/helper/dhutil/dhutil.go
+++ b/helper/dhutil/dhutil.go
@@ -113,20 +113,14 @@ func EncryptAES(key, plaintext, aad []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
-	nonce := make([]byte, 12)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, nil, err
-	}
-
-	aesgcm, err := cipher.NewGCM(block)
+	aesgcm, err := cipher.NewGCMWithRandomNonce(block)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ciphertext := aesgcm.Seal(nil, nonce, plaintext, aad)
+	ciphertext := aesgcm.Seal(nil, nil, plaintext, aad)
 
-	return ciphertext, nonce, nil
+	return ciphertext[12:], ciphertext[0:12], nil
 }
 
 // Use AES256-GCM to decrypt some ciphertext with a provided key and nonce. The

--- a/helper/dhutil/dhutil_test.go
+++ b/helper/dhutil/dhutil_test.go
@@ -2,3 +2,26 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package dhutil
+
+import (
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+
+	ciphertext, nonce, err := EncryptAES(key, key, key)
+	require.NoError(t, err)
+	require.NotEmpty(t, ciphertext)
+	require.NotEmpty(t, nonce)
+
+	plaintext, err := DecryptAES(key, ciphertext, nonce, key)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, key)
+}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1914,6 +1914,7 @@ func (p *Policy) SymmetricEncryptRaw(ver int, encKey, plaintext []byte, opts Sym
 	var aead cipher.AEAD
 	var err error
 	nonce := opts.Nonce
+	sealCreatesNonce := false
 
 	switch p.Type {
 	case KeyType_AES128_GCM96, KeyType_AES256_GCM96:
@@ -1923,13 +1924,24 @@ func (p *Policy) SymmetricEncryptRaw(ver int, encKey, plaintext []byte, opts Sym
 			return nil, errutil.InternalError{Err: err.Error()}
 		}
 
-		// Setup the GCM AEAD
-		gcm, err := cipher.NewGCM(aesCipher)
-		if err != nil {
-			return nil, errutil.InternalError{Err: err.Error()}
-		}
+		// Setup the GCM AEAD: use FIPS compatible by default but fall back
+		// for convergent encryption.
+		if opts.Convergent {
+			gcm, err := cipher.NewGCM(aesCipher)
+			if err != nil {
+				return nil, errutil.InternalError{Err: err.Error()}
+			}
 
-		aead = gcm
+			aead = gcm
+		} else {
+			gcm, err := cipher.NewGCMWithRandomNonce(aesCipher)
+			if err != nil {
+				return nil, errutil.InternalError{Err: err.Error()}
+			}
+
+			aead = gcm
+			sealCreatesNonce = true
+		}
 
 	case KeyType_ChaCha20_Poly1305:
 		cha, err := chacha20poly1305.New(encKey)
@@ -1965,7 +1977,7 @@ func (p *Policy) SymmetricEncryptRaw(ver int, encKey, plaintext []byte, opts Sym
 		default:
 			return nil, errutil.InternalError{Err: fmt.Sprintf("unhandled convergent version %d", convergentVersion)}
 		}
-	} else if len(nonce) == 0 {
+	} else if len(nonce) == 0 && !sealCreatesNonce {
 		// Compute random nonce
 		nonce, err = uuid.GenerateRandomBytes(aead.NonceSize())
 		if err != nil {
@@ -1979,7 +1991,7 @@ func (p *Policy) SymmetricEncryptRaw(ver int, encKey, plaintext []byte, opts Sym
 	ciphertext := aead.Seal(nil, nonce, plaintext, opts.AdditionalData)
 
 	// Place the encrypted data after the nonce
-	if !opts.Convergent || p.convergentVersion(ver) > 1 {
+	if (!opts.Convergent || p.convergentVersion(ver) > 1) && len(nonce) > 0 {
 		ciphertext = append(nonce, ciphertext...)
 	}
 	return ciphertext, nil

--- a/vault/barrier/aes_gcm.go
+++ b/vault/barrier/aes_gcm.go
@@ -998,7 +998,7 @@ func (b *AESGCMBarrier) aeadFromKey(key []byte) (cipher.AEAD, error) {
 	}
 
 	// Create the GCM mode AEAD
-	gcm, err := cipher.NewGCM(aesCipher)
+	gcm, err := cipher.NewGCMWithRandomNonce(aesCipher)
 	if err != nil {
 		return nil, errors.New("failed to initialize GCM mode")
 	}
@@ -1025,26 +1025,16 @@ func (b *AESGCMBarrier) encrypt(path string, term uint32, gcm cipher.AEAD, plain
 	// Set the version byte
 	out[4] = b.currentAESGCMVersionByte
 
-	// Generate a random nonce
-	nonce := out[5 : 5+gcm.NonceSize()]
-	n, err := rand.Read(nonce)
-	if err != nil {
-		return nil, err
-	}
-	if n != len(nonce) {
-		return nil, errors.New("unable to read enough random bytes to fill gcm nonce")
-	}
-
 	// Seal the output
 	switch b.currentAESGCMVersionByte {
 	case AESGCMVersion1:
-		out = gcm.Seal(out, nonce, plain, nil)
+		out = gcm.Seal(out, nil, plain, nil)
 	case AESGCMVersion2:
 		aad := []byte(nil)
 		if path != "" {
 			aad = []byte(path)
 		}
-		out = gcm.Seal(out, nonce, plain, aad)
+		out = gcm.Seal(out, nil, plain, aad)
 	default:
 		panic("Unknown AESGCM version")
 	}

--- a/vault/barrier/aes_gcm.go
+++ b/vault/barrier/aes_gcm.go
@@ -1007,16 +1007,16 @@ func (b *AESGCMBarrier) aeadFromKey(key []byte) (cipher.AEAD, error) {
 
 // encrypt is used to encrypt a value
 func (b *AESGCMBarrier) encrypt(path string, term uint32, gcm cipher.AEAD, plain []byte) ([]byte, error) {
-	// Allocate the output buffer with room for tern, version byte,
+	// Allocate the output buffer with room for term, version byte,
 	// nonce, GCM tag and the plaintext
 
-	extra := termSize + 1 + gcm.NonceSize() + gcm.Overhead()
+	extra := termSize + 1 + gcm.Overhead()
 	if len(plain) > math.MaxInt-extra {
 		return nil, ErrPlaintextTooLarge
 	}
 
 	capacity := len(plain) + extra
-	size := termSize + 1 + gcm.NonceSize()
+	size := termSize + 1
 	out := make([]byte, size, capacity)
 
 	// Set the key term
@@ -1053,24 +1053,23 @@ func termLabel(term uint32) []metrics.Label {
 
 // decrypt is used to decrypt a value using the keyring
 func (b *AESGCMBarrier) decrypt(path string, gcm cipher.AEAD, cipher []byte) ([]byte, error) {
-	if len(cipher) < 5+gcm.NonceSize() {
+	if len(cipher) <= 5 {
 		return nil, errors.New("invalid cipher length")
 	}
-	// Capture the parts
-	nonce := cipher[5 : 5+gcm.NonceSize()]
-	raw := cipher[5+gcm.NonceSize():]
-	out := make([]byte, 0, len(raw)-gcm.NonceSize())
+
+	raw := cipher[5:]
+	var out []byte
 
 	// Attempt to open
 	switch cipher[4] {
 	case AESGCMVersion1:
-		return gcm.Open(out, nonce, raw, nil)
+		return gcm.Open(out, nil, raw, nil)
 	case AESGCMVersion2:
 		aad := []byte(nil)
 		if path != "" {
 			aad = []byte(path)
 		}
-		return gcm.Open(out, nonce, raw, aad)
+		return gcm.Open(out, nil, raw, aad)
 	default:
 		return nil, errors.New("version bytes mis-match")
 	}


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Addresses barrier encryption, dhutil, and transit use of random nonces with the Go standard library helper. 

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->
This shifts nonce generation to the crypto library, putting it inside the FIPS boundary and letting us run further with FIPS mode.

See also: https://github.com/openbao/go-kms-wrapping/pull/45

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
