### PR TITLE
feat(doc): Mention unsafe_cross_namespace_identity in documentation

### DIFF
--- a/website/content/docs/concepts/namespaces/index.mdx
+++ b/website/content/docs/concepts/namespaces/index.mdx
@@ -84,7 +84,9 @@ Entities or groups from any namespace are not enabled by default.
 
 The configuration setting `unsafe_cross_namespace_identity` gives compatibility with Vault Enterprise's cross-namespace group membership and should not be enabled.
 
-**Warning**: There are no mitigating controls on what identities or groups another namespace can reference and allows for unconfined permission sharing.
+There are no mitigating controls on what identities or groups another namespace can reference and allows for unconfined permission sharing.
+
+:::
 
 Example:
 

--- a/website/content/docs/concepts/namespaces/index.mdx
+++ b/website/content/docs/concepts/namespaces/index.mdx
@@ -78,9 +78,13 @@ a child namespace.
 
 ### Cross-namespaces identities
 
-Entities or groups from a parent namespace are not enabled by default.
+Entities or groups from any namespace are not enabled by default.
 
-The configuration setting `unsafe_cross_namespace_identity` gives compatibility with Vault Enterprise's cross-namespace group membership and should be enabled.
+:::warning
+
+The configuration setting `unsafe_cross_namespace_identity` gives compatibility with Vault Enterprise's cross-namespace group membership and should not be enabled.
+
+**Warning**: There are no mitigating controls on what identities or groups another namespace can reference and allows for unconfined permission sharing.
 
 Example:
 
@@ -90,7 +94,7 @@ listener "tcp" {
   ...
 }
 
-# Allow child namespaces to reference parent namespaces entities or groups
+# Allow namespaces to reference other namespaces' entities or groups
 unsafe_cross_namespace_identity = true
 ```
 

--- a/website/content/docs/concepts/namespaces/index.mdx
+++ b/website/content/docs/concepts/namespaces/index.mdx
@@ -76,6 +76,24 @@ policies for a child namespace might reference entities or groups from the paren
 namespace. Parent namespaces can also **assert** policies on identities within
 a child namespace.
 
+### Cross-namespaces identities
+
+Entities or groups from a parent namespace are not enabled by default.
+
+The configuration setting `unsafe_cross_namespace_identity` gives compatibility with Vault Enterprise's cross-namespace group membership and should be enabled.
+
+Example:
+
+```hcl
+api_addr = "..."
+listener "tcp" {
+  ...
+}
+
+# Allow child namespaces to reference parent namespaces entities or groups
+unsafe_cross_namespace_identity = true
+```
+
 ## Delegation and namespace administrators
 
 OpenBao system administrators can assign administration rights to delegate


### PR DESCRIPTION
## Description

Add a mention of the `unsafe_cross_namespace_identity` configuration setting in the `namespace` documentation.

## Rationale

This follows #3291 