### PR TITLE
Adds Kubermatic to the Vendors page

### DIFF
--- a/website/content/ecosystem/vendors.mdx
+++ b/website/content/ecosystem/vendors.mdx
@@ -41,6 +41,10 @@ import Member from './lib/Member.tsx';
       <Member title="Origoss Solutions" logoName="origoss-solutions">
         [Origoss Solutions](https://origoss.com/) has deep expertise in OpenBao, offering comprehensive services to implement, integrate, and operate OpenBao clusters. We provide troubleshooting and support for complex deployments, and can contribute to the OpenBao codebase when needed to address your specific requirements.
       </Member>
+
+      <Member title="Kubermatic" logoName="kubermatic">
+        [Kubermatic SecureGuard](https://www.kubermatic.com/products/kubermatic-secureguard/) (KubeSG) is a self-hosted, open-source secrets management platform built on OpenBao and the External Secrets Operator. It automates breakage-free secret rotation and delivers transparent, developer-friendly security for everything from infrastructure keys to AI tokens.
+      </Member>
     </Randomize>
   </div>
 </div>

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "lodash": "^4.18.1",
-    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#4b67bcec69b9efbe2ea7c6e297f4420ac881e16d",
+    "openbao-ecosystem-logos": "github:openbao/openbao-ecosystem-logos#91e3d9c1402b35e2b41464eb58621b652d1df874",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       openbao-ecosystem-logos:
-        specifier: github:openbao/openbao-ecosystem-logos#4b67bcec69b9efbe2ea7c6e297f4420ac881e16d
-        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d
+        specifier: github:openbao/openbao-ecosystem-logos#91e3d9c1402b35e2b41464eb58621b652d1df874
+        version: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/91e3d9c1402b35e2b41464eb58621b652d1df874
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
@@ -4761,8 +4761,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d:
-    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/91e3d9c1402b35e2b41464eb58621b652d1df874:
+    resolution: {tarball: https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/91e3d9c1402b35e2b41464eb58621b652d1df874}
     version: 0.0.0
 
   opener@1.5.2:
@@ -12816,7 +12816,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/4b67bcec69b9efbe2ea7c6e297f4420ac881e16d: {}
+  openbao-ecosystem-logos@https://codeload.github.com/openbao/openbao-ecosystem-logos/tar.gz/91e3d9c1402b35e2b41464eb58621b652d1df874: {}
 
   opener@1.5.2: {}
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

The PR adds [Kubermatic](https://www.kubermatic.com/) to the Vendors page of the website.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it. 

All Pull Requests must have an issue attached to them.

-->

Kubermatic offers [Kubermatic SecureGuard](https://www.kubermatic.com/products/kubermatic-secureguard/), which is built on OpenBao and External Secrets Operator. The change is to show that we are part of the adopters of OpenBao.

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
