### PR TITLE
Stop reporting ha status on namespace seal output

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -280,15 +280,14 @@ func (t TableFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) 
 		return t.OutputList(ui, nil, data)
 	case map[string]interface{}:
 		return t.OutputMap(ui, data)
-	case SealStatusOutput:
+	case api.SealStatusResponse, SealStatusOutput:
 		return t.OutputSealStatusStruct(ui, data)
 	default:
 		return errors.New("cannot use the table formatter for this type")
 	}
 }
 
-func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, data interface{}) error {
-	status := data.(SealStatusOutput)
+func (t TableFormatter) formatSealStatusStruct(status api.SealStatusResponse) []string {
 	var sealPrefix string
 
 	out := []string{}
@@ -309,6 +308,19 @@ func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, data interface{}) erro
 		out = append(out, fmt.Sprintf("Unseal Progress | %d/%d", status.Progress, status.T))
 		out = append(out, fmt.Sprintf("Unseal Nonce | %s", status.Nonce))
 	}
+	return out
+}
+
+func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, data interface{}) error {
+	status, ok := data.(SealStatusOutput)
+	if !ok {
+		ui.Output(tableOutput(t.formatSealStatusStruct(data.(api.SealStatusResponse)), &columnize.Config{
+			Delim: "|",
+		}))
+		return nil
+	}
+
+	out := t.formatSealStatusStruct(status.SealStatusResponse)
 
 	if status.Migration {
 		out = append(out, fmt.Sprintf("Seal Migration in Progress | %t", status.Migration))

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -97,12 +96,12 @@ func TestStatusFormat(t *testing.T) {
 	ui := mockUi{t: t, outputData: &output}
 	os.Setenv(EnvVaultFormat, "table")
 
-	statusHA := getMockStatusData(false)
-	statusOmitEmpty := getMockStatusData(true)
+	statusRoot := getMockStatusData(true)
+	statusNonRoot := getMockStatusData(false)
 
 	// Testing that HA fields are formatted properly for table.
-	// All fields (including new HA fields) are expected
-	if err := outputWithFormat(ui, nil, statusHA); err != 0 {
+	// All fields are expected for root namespace.
+	if err := outputWithFormat(ui, nil, statusRoot); err != 0 {
 		t.Fatal(err)
 	}
 
@@ -127,46 +126,37 @@ Raft Committed Index          3
 Raft Applied Index            4`
 
 	if expectedOutputString != output {
-		fmt.Printf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
+		t.Logf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
 		t.Fatal("format output for status does not match expected format. Check print statements above.")
 	}
 
-	// Testing that omitEmpty fields are omitted from status
-	// no HA fields are expected, except HA Enabled
-	if err := outputWithFormat(ui, nil, statusOmitEmpty); err != 0 {
+	// Testing that subset of field are rendered for namespace status.
+	if err := outputWithFormat(ui, nil, statusNonRoot); err != 0 {
 		t.Fatal(err)
 	}
 
-	expectedOutputString = `Key                           Value
----                           -----
-Seal Type                     type
-Recovery Seal Type            type
-Initialized                   true
-Sealed                        true
-Total Recovery Shares         2
-Threshold                     1
-Unseal Progress               3/1
-Unseal Nonce                  nonce
-Seal Migration in Progress    true
-Version                       version
-Commit Date                   commit date
-Storage Type                  type
-HA Enabled                    false`
+	expectedOutputString = `Key                Value
+---                -----
+Seal Type          type
+Initialized        true
+Sealed             true
+Total Shares       2
+Threshold          1
+Unseal Progress    3/1
+Unseal Nonce       nonce`
 
 	if expectedOutputString != output {
-		fmt.Printf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
+		t.Logf("%s\n%+v\n %s\n%+v\n", "output found was: ", output, "versus", expectedOutputString)
 		t.Fatal("format output for status does not match expected format. Check print statements above.")
 	}
 }
 
 // getMockStatusData outputs a SealStatusOutput struct from format.go to be used
-// for testing. The emptyfields parameter specifies whether the struct will be
-// initialized with all the omitempty fields as empty or not.
-func getMockStatusData(emptyFields bool) SealStatusOutput {
-	var status SealStatusOutput
-	var sealStatusResponseMock api.SealStatusResponse
-	if !emptyFields {
-		sealStatusResponseMock = api.SealStatusResponse{
+// for testing. The root parameter specifies whether the struct is seal status
+// output of whole instance (root) or another namespace.
+func getMockStatusData(root bool) any {
+	if root {
+		sealStatusResponseMock := api.SealStatusResponse{
 			Type:             "type",
 			RecoverySealType: "type",
 			Initialized:      true,
@@ -185,7 +175,7 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 		}
 
 		// must initialize this struct without explicit field names due to embedding
-		status = SealStatusOutput{
+		return SealStatusOutput{
 			sealStatusResponseMock,
 			true,                     // HAEnabled
 			true,                     // IsSelf
@@ -196,37 +186,16 @@ func getMockStatusData(emptyFields bool) SealStatusOutput {
 			4,                        // RaftAppliedIndex
 		}
 	} else {
-		sealStatusResponseMock = api.SealStatusResponse{
-			Type:             "type",
-			RecoverySealType: "type",
-			Initialized:      true,
-			Sealed:           true,
-			T:                1,
-			N:                2,
-			Progress:         3,
-			Nonce:            "nonce",
-			Version:          "version",
-			CommitDate:       "commit date",
-			Migration:        true,
-			ClusterName:      "",
-			ClusterID:        "",
-			RecoverySeal:     true,
-			StorageType:      "type",
-		}
-
-		// must initialize this struct without explicit field names due to embedding
-		status = SealStatusOutput{
-			sealStatusResponseMock,
-			false,             // HAEnabled
-			false,             // IsSelf
-			time.Time{}.UTC(), // ActiveTime
-			"",                // LeaderAddress
-			"",                // LeaderClusterAddress
-			0,                 // RaftCommittedIndex
-			0,                 // RaftAppliedIndex
+		return api.SealStatusResponse{
+			Type:        "type",
+			Initialized: true,
+			Sealed:      true,
+			T:           1,
+			N:           2,
+			Progress:    3,
+			Nonce:       "nonce",
 		}
 	}
-	return status
 }
 
 func Test_Format_Parsing(t *testing.T) {

--- a/command/namespace_seal_status.go
+++ b/command/namespace_seal_status.go
@@ -89,7 +89,7 @@ func (c *NamespaceSealStatusCommand) Run(args []string) int {
 		return 2
 	}
 
-	return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+	return OutputData(c.UI, api.SealStatusResponse{
 		Type:        status.Type,
 		Initialized: status.Initialized,
 		Sealed:      status.Sealed,
@@ -97,5 +97,5 @@ func (c *NamespaceSealStatusCommand) Run(args []string) int {
 		N:           status.N,
 		Progress:    status.Progress,
 		Nonce:       status.Nonce,
-	}})
+	})
 }

--- a/command/namespace_unseal.go
+++ b/command/namespace_unseal.go
@@ -129,7 +129,7 @@ func (c *NamespaceUnsealCommand) Run(args []string) int {
 			c.UI.Error(fmt.Sprintf("Error resetting unseal process: %s", err))
 			return 2
 		}
-		return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+		return OutputData(c.UI, api.SealStatusResponse{
 			Type:        status.Type,
 			Initialized: status.Initialized,
 			Sealed:      status.Sealed,
@@ -137,7 +137,7 @@ func (c *NamespaceUnsealCommand) Run(args []string) int {
 			N:           status.N,
 			Progress:    status.Progress,
 			Nonce:       status.Nonce,
-		}})
+		})
 	}
 
 	if unsealKey == "" {
@@ -180,7 +180,7 @@ func (c *NamespaceUnsealCommand) Run(args []string) int {
 		return 2
 	}
 
-	return OutputData(c.UI, SealStatusOutput{SealStatusResponse: api.SealStatusResponse{
+	return OutputData(c.UI, api.SealStatusResponse{
 		Type:        status.Type,
 		Initialized: status.Initialized,
 		Sealed:      status.Sealed,
@@ -188,5 +188,5 @@ func (c *NamespaceUnsealCommand) Run(args []string) int {
 		N:           status.N,
 		Progress:    status.Progress,
 		Nonce:       status.Nonce,
-	}})
+	})
 }


### PR DESCRIPTION
## Description
- `bao namespace seal-status` and `bao namespace unseal` now won't respond with `HA Status` info
- adjusted specific test case

## Rationale

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
