### PR TITLE
Skip namespace reloads on sealed namespaces

### DIFF
--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -379,29 +379,28 @@ func (ij *invalidationJob) Execute() error {
 	defer shortCancel()
 
 	// Now handle the actual event.
-	key := ij.nsKey
 	switch {
-	case strings.HasPrefix(key, namespaceStoreSubPath):
+	case strings.HasPrefix(ij.nsKey, namespaceStoreSubPath):
 		ij.fatal = true
 		return ij.namespaceInvalidation(ctx)
-	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+policy.ACLSubPath):
+	case strings.HasPrefix(ij.nsKey, barrier.SystemBarrierPrefix+policy.ACLSubPath):
 		// Policy invalidation is not fatal as it contains a LRU cache: we
 		// know removal is strict and it is only potentially preloading an
 		// entry which may err.
 		return ij.policyInvalidation(ctx)
-	case strings.HasPrefix(key, barrier.SystemBarrierPrefix+quotas.StoragePrefix):
+	case strings.HasPrefix(ij.nsKey, barrier.SystemBarrierPrefix+quotas.StoragePrefix):
 		ij.fatal = true
 		return ij.quotaInvalidation(ctx)
-	case key == coreAuditConfigPath || key == coreLocalAuditConfigPath:
+	case ij.nsKey == coreAuditConfigPath || ij.nsKey == coreLocalAuditConfigPath:
 		ij.fatal = true
 		return ij.auditInvalidation(ctx)
-	case isLegacyMountPath(key):
+	case isLegacyMountPath(ij.nsKey):
 		ij.fatal = true
 		return ij.legacyMountInvalidation(ctx)
-	case isTransactionalMountPath(key):
+	case isTransactionalMountPath(ij.nsKey):
 		ij.fatal = true
 		return ij.transactionalMountInvalidation(ctx)
-	case isKeyringPath(key):
+	case isKeyringPath(ij.nsKey):
 		// The HA subsystem handles keyring rotations via the
 		// periodicCheckKeyUpgrades(...) actor.
 	case strings.HasPrefix(ij.key, coreLeaderPrefix):
@@ -432,7 +431,7 @@ func (ij *invalidationJob) Execute() error {
 		//
 		// This is true in reverse for deletions.
 	default:
-		ij.im.dispacherLogger.Warn("no mechanism to invalidate cache for specified key", "key", key)
+		ij.im.dispacherLogger.Warn("no mechanism to invalidate cache for specified key", "key", ij.nsKey, "full_key", ij.key)
 	}
 
 	return nil
@@ -472,6 +471,17 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 	case beforeNs != nil && beforeErr == nil:
 		preferredNs = beforeNs
 		deleted = true
+	}
+
+	nsBarrier := ij.im.core.sealManager.NamespaceBarrierByLongestPrefix(preferredNs.Path)
+	if nsBarrier.Sealed() {
+		// Namespace is sealed; nothing more we can do with it.
+		return nil
+	} else if preferredNs.ManuallySealed {
+		// Namespace was manually sealed but we're not actually sealed locally;
+		// seal it.
+		ij.im.dispacherLogger.Info("sealing manually sealed namespace", "path", preferredNs.Path, "uuid", preferredNs.UUID)
+		return ij.im.core.namespaceStore.SealNamespace(ctx, preferredNs.Path)
 	}
 
 	childCtx := namespace.ContextWithNamespace(ctx, preferredNs)

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -1385,6 +1385,24 @@ func TestCore_Invalidate_SealedNamespaces(t *testing.T) {
 					},
 				),
 			)
+
+			// Try invalidating the namespace entry itself.
+			parentPath, ok := ns.ParentPath()
+			require.True(t, ok, "expected namespace to have parent")
+
+			parentNs, err := c.namespaceStore.GetNamespaceByPath(namespace.RootContext(t.Context()), parentPath)
+			require.NoError(t, err)
+			require.NotNil(t, parentNs)
+
+			childNsPath := path.Join(namespaceStoreSubPath, ns.UUID)
+			if parentNs.UUID != namespace.RootNamespaceUUID {
+				childNsPath = path.Join(barrier.NamespacePrefix, parentNs.UUID, childNsPath)
+			}
+
+			// Call invalidate on the full path; this should not err. We've
+			// not made any updates but we're more interested in downstream
+			// effects.
+			require.NoError(t, c.invalidateSynchronous(childNsPath))
 		})
 	}
 }

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -238,16 +238,6 @@ func (ns *NamespaceStore) loadNamespacesLocked(ctx context.Context) error {
 		}
 		namespacesByUUID[namespace.UUID] = namespace
 		namespacesByAccessor[namespace.ID] = namespace
-
-		if namespace.ManuallySealed {
-			barrier := ns.core.sealManager.NamespaceBarrier(namespace.Path)
-			if barrier != nil && !barrier.Sealed() {
-				if err := barrier.Seal(); err != nil {
-					ns.logger.Warn("unable to seal namespace barrier", "error", err, "ns", namespace.Path, "uuid", namespace.UUID)
-				}
-			}
-		}
-
 		return nil
 	}
 
@@ -1012,6 +1002,27 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("unable to seal tainted namespace")
 	}
 
+	parent, err := namespace.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get parent namespace from context: %w", err)
+	}
+
+	if !namespaceToSeal.HasParent(parent) {
+		return errors.New("namespace from context is not the parent of the target namespace to seal")
+	}
+
+	// Mark the namespace as sealed before we seal it; this ensures future
+	// loads will reflect the desired status.
+	if !ns.core.Standby() {
+		// Now modify just this one namespace in storage to mark it sealed,
+		// forgetting the keys from all other nodes.
+		namespaceToSeal.ManuallySealed = true
+		nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
+		if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
+			return fmt.Errorf("failed to persist namespace: %w", err)
+		}
+	}
+
 	return ns.sealNamespaceLocked(ctx, namespaceToSeal)
 }
 
@@ -1046,19 +1057,6 @@ func (ns *NamespaceStore) sealNamespaceLocked(ctx context.Context, namespaceToSe
 			delete(ns.namespacesByAccessor, entry.ID)
 		}
 	})
-
-	parent, err := namespace.FromContext(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get parent namespace from context: %w", err)
-	}
-
-	// Now modify just this one namespace in storage to mark it sealed,
-	// forgetting the keys from all other nodes.
-	namespaceToSeal.ManuallySealed = true
-	nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
-	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
-		return fmt.Errorf("failed to persist namespace: %w", err)
-	}
 
 	return errs
 }


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

On standby nodes, we'll attempt to reload the entire namespace's contents if the namespace object itself changed. This is necessary because the mount table will include cached namespace representations, so it is important to update these. In doing so, we'd err on sealed child namespaces, bypassing our earlier barrier check. This updates namespace reloading logic, also handling manually sealed namespaces explicitly during target namespace invalidation.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
