### PR TITLE
Stop saving nonce on seal config storage entry after rotation

### DIFF
--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -507,7 +507,9 @@ func (c *Core) performBarrierRekey(ctx context.Context, newSealKey []byte) logic
 			return logical.CodedError(http.StatusInternalServerError, "failed to store new seal key: %v", err)
 		}
 
+		// Unset VerificationKey and Nonce as we finished rotation.
 		c.rootRotationConfig.VerificationKey = nil
+		c.rootRotationConfig.Nonce = ""
 
 		if err := c.seal.SetBarrierConfig(ctx, c.rootRotationConfig); err != nil {
 			c.logger.Error("error saving rekey seal configuration", "error", err)
@@ -698,7 +700,9 @@ func (c *Core) performRecoveryRekey(ctx context.Context, newRootKey []byte) logi
 		return logical.CodedError(http.StatusInternalServerError, "failed to set recovery key: %v", err)
 	}
 
+	// Unset VerificationKey and Nonce as we finished rotation.
 	c.recoveryRotationConfig.VerificationKey = nil
+	c.recoveryRotationConfig.Nonce = ""
 
 	if err := c.seal.SetRecoveryConfig(ctx, c.recoveryRotationConfig); err != nil {
 		c.logger.Error("error saving rekey seal configuration", "error", err)

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -221,7 +221,6 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatal("seal configuration is nil")
 	}
 
-	newConf.Nonce = rkconf.Nonce
 	if !reflect.DeepEqual(sealConf, newConf) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v\nexpType: %s\nrecovery: %t", newConf, sealConf, expType, recovery)
 	}
@@ -251,7 +250,6 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 	}
 
 	// Start another rekey, this time we require a quorum!
-
 	newConf = &SealConfig{
 		Type:            expType,
 		SecretThreshold: 1,
@@ -319,7 +317,6 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 		t.Fatalf("err: %v", err)
 	}
 
-	newConf.Nonce = rkconf.Nonce
 	if !reflect.DeepEqual(sealConf, newConf) {
 		t.Fatalf("bad: %#v", sealConf)
 	}

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -436,7 +436,9 @@ func (sm *SealManager) performRootRotation(ctx context.Context, ns *namespace.Na
 			}
 		}
 
+		// Unset VerificationKey and Nonce as we finished rotation.
 		rotationConfig.VerificationKey = nil
+		rotationConfig.Nonce = ""
 
 		if err := seal.SetBarrierConfig(ctx, rotationConfig); err != nil {
 			sm.logger.Error("error saving rotate seal configuration", "error", err)
@@ -454,7 +456,9 @@ func (sm *SealManager) performRecoveryRotation(ctx context.Context, newRootKey [
 		return logical.CodedError(http.StatusInternalServerError, "failed to set recovery key: %w", err)
 	}
 
+	// Unset VerificationKey and Nonce as we finished rotation.
 	rotationConfig.VerificationKey = nil
+	rotationConfig.Nonce = ""
 
 	if err := seal.SetRecoveryConfig(ctx, rotationConfig); err != nil {
 		sm.logger.Error("error saving rotate seal configuration", "error", err)

--- a/vault/rotate_test.go
+++ b/vault/rotate_test.go
@@ -132,8 +132,8 @@ func testUpdateRotationCommon(t *testing.T, c *Core, ns *namespace.Namespace, ke
 		SecretThreshold: 3,
 		SecretShares:    5,
 	}
-	rotationResult, hErr := c.sealManager.InitRotation(ctx, ns, newConf, recovery)
-	require.NoError(t, hErr)
+	rotationResult, err := c.sealManager.InitRotation(ctx, ns, newConf, recovery)
+	require.NoError(t, err)
 	require.Empty(t, rotationResult)
 
 	// Fetch new config with generated nonce
@@ -142,7 +142,6 @@ func testUpdateRotationCommon(t *testing.T, c *Core, ns *namespace.Namespace, ke
 
 	// Provide the root/recovery keys
 	var result *RekeyResult
-	var err error
 	for _, key := range keys {
 		result, err = c.sealManager.UpdateRotation(ctx, ns, key, rotConfig.Nonce, recovery)
 		require.NoError(t, err)
@@ -164,8 +163,6 @@ func testUpdateRotationCommon(t *testing.T, c *Core, ns *namespace.Namespace, ke
 	}
 	require.NoError(t, err)
 	require.NotNil(t, sealConf)
-
-	newConf.Nonce = rotConfig.Nonce
 	require.Equal(t, sealConf, newConf)
 
 	// At this point bail if we are rotating the barrier key with recovery
@@ -248,9 +245,10 @@ func testUpdateRotationCommon(t *testing.T, c *Core, ns *namespace.Namespace, ke
 		sealConf, err = seal.BarrierConfig(ctx)
 	}
 	require.NoError(t, err)
-
-	newConf.Nonce = rotConfig.Nonce
 	require.Equal(t, sealConf, newConf)
+
+	// verfiy nonce was removed after rotation.
+	require.Empty(t, sealConf.Nonce)
 }
 
 func TestRotateInvalid(t *testing.T) {


### PR DESCRIPTION
## Description
- unseal keys rotation won't save nonce of the operation with new (rotated to) seal config

## Rationale
fix to bug introduced with namespace sealing

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
