### PR TITLE
Add RFC on CEL for certificate auth

### DIFF
--- a/website/content/community/rfcs/cel-cert-auth.mdx
+++ b/website/content/community/rfcs/cel-cert-auth.mdx
@@ -1,0 +1,156 @@
+---
+sidebar_label: CEL for Cert Auth
+description: |-
+  An OpenBao RFC for enabling CEL roles in the Certificate Auth method.
+---
+
+# RFC: CEL Expression Support for Certificate Authentication
+
+## Summary
+
+This feature offers support for [Common Expression Language
+(CEL)](https://github.com/google/cel-spec) in OpenBao's certificate-based auth
+engine to create a flexible framework for validating extensions and dynamically
+assigning token policies. CEL will allow administrators to define fine-grained
+rules for cert validation and dynamic policy assignment, extending the more
+static assignment of role- and identity-based policies.
+
+Cert Auth CEL support is implemented as a new type of CEL role and follows the
+[general plan for CEL support](cel-best-practices.mdx) in OpenBao.
+
+## Problem Statement
+
+OpenBao's X.509 certificate-based auth engine currently assemble token
+policies from leaf certificates presented by the user combined with
+static information set by the operator. However, operators cannot enforce
+complex constraints, such as validating combinations of extensions or
+dynamically assigning token policies based on extension or subject values.
+
+## User-facing description
+
+**_Administrators_** can define CEL roles under a new endpoint,
+`auth/cert/cel/roles/:name`, to be executed during authentication. CEL roles
+should evaluate all incoming certificate fields and generate `logical.Auth{}`
+instances having appropriate token policies. In defining a CEL program, the
+administrator takes on all validation responsibility shy of cryptographic
+verification. This means they must avoid granting policies, entities, or
+aliases based on unvalidated attributes.
+
+**_Users_** authenticating with X.509 certificates will have their certs
+validated through the CEL indicated role. If successful, they receive a token
+with policies and other attributes.
+
+For example:
+
+- A CEL role validates that the cert contains specific expressions like:
+  `"cn=admin" in cert.subject && matches(cert.extensions[1.5.3.2], [0-9]+)"`.
+- If validation passes, the CEL program assigns the token policies `admin` and
+  `team-12345` (using `cert.extensions[1.5.3.2]` to form the policy name).
+
+This could be codified in the following CEL program:
+
+```json
+("admin" in cert.subject &&
+ matches(cert.extensions[1.5.3.2], [0-9]+)) ?
+pb.Auth{ policies: ["admin", "team-" + string(cert.extensions[1.5.3.2])] } :
+false
+```
+
+## Technical Description
+
+### CEL in Auth Engines
+
+CEL roles integrate with OpenBao's Auth engine to dynamically evaluate
+expressions. Instead of using static role-to-policy assignment with
+`allowed_*_names`, CEL programs validate expressions and return a `logical.Auth{}`
+instance containing dynamically assigned token policies.
+
+**Workflow:**
+
+1. A user authenticates with an X.509 certificate.
+2. The incoming certificate fields are passed to the CEL role for validation.
+3. If the CEL policy evaluates successfully:
+    - A `logical.Auth{}` instance is returned.
+    - Token policies are assigned dynamically based on the CEL program logic.
+4. If validation fails, `false` or `string` (error message) is returned and
+   token is not generated.
+
+### **API Endpoints**
+
+| Use                          | Method   | Path                             |
+|------------------------------|----------|----------------------------------|
+| List CEL roles               | `LIST`   | `auth/cert/cel/roles`            |
+| Retrieve a specific CEL role | `GET`    | `auth/cert/cel/role/:name`       |
+| Create a CEL role            | `POST`   | `auth/cert/cel/role/:name`       |
+| Update a CEL role            | `PATCH`  | `auth/cert/cel/role/:name`       |
+| Delete a CEL role            | `DELETE` | `auth/cert/cel/role/:name`       |
+| Login with CEL role          | `POST`   | `auth/cert/cel/login name=:name` |
+
+### CEL Role Format
+
+A CEL role is defined as a JSON object with the following fields:
+```json
+{
+  "name": "string",
+  "cel_program": {
+    "variables": [
+      {
+        "name": "string",
+        "expression": "string"
+      }
+    ],
+    "expression": "string",
+  },
+  "certificate": "string",
+  "ocsp_ca_certificates": "string",
+  "ocsp_server_override": "string",
+  "ocsp_fail_open": "bool",
+  "ocsp_query_all_servers": "bool",
+}
+```
+
+The following parameters are supplied by the CEL policy engine and may be
+used in the expression:
+
+- `chain` `([]CertTemplate: required)` - encoded representation of the matching
+  X.509 certificate chain presented on issuance. See implementation in
+  [CEL for PKI](cel-pki.mdx) for more information.
+
+### CEL Reply Format (CEL role to Auth Engine)
+
+The CEL role engine evaluates the cert and returns a `logical.Auth{}` object
+or error that determines the authenticated user's token and policies.
+
+The CEL expression itself may return one of the following:
+- `pb.Auth` `(protobuf Auth: optional)` - A `logical.Auth` instance containing
+  the following fields:
+    - `policies` `([]string: required)`  - List of token policies assigned
+      to the user.
+    - `lease_duration` `(int: required)` - Duration (in seconds) for which the
+      token is valid.
+    - `renewable` `(bool: required)` - whether the token is renewable.
+- `bool` `(false: optional)` - A boolean false value indicates failed
+  authorization.
+- `string` `(error: optional)` - A detailed error when the program fails.
+
+## Rationale and alternatives
+
+[Unlike JWT](/api-docs/auth/jwt/#acl-policy-templating-examples), cert auth
+currently has no format for dynamic templating of policies. While easier with
+JWTs as many claims are simple strings, certificate extensions are often
+custom ASN.1 structures which are unlikely to be parseable in `text/template`.
+
+Some form CEL or regex evaluation could be added to existing role instead
+of creating a new type of role, though this deviates from the pattern
+established elsewhere.
+
+Alternatively, a web hook approach like [Vault's
+CIEPS](https://developer.hashicorp.com/vault/docs/secrets/pki/cieps) could
+be used to achieve similar flexibility. However, the performance implications
+and system brittleness make this an unattractive alternative.
+
+## Downsides
+
+Additional complexity of a new type; not backwards compatible with Vault for
+operators or application developers as the role name is required in CEL auth
+unlike normal roles which support defaults.

--- a/website/content/community/rfcs/cel-jwt.mdx
+++ b/website/content/community/rfcs/cel-jwt.mdx
@@ -1,10 +1,16 @@
+---
+sidebar_label: CEL for JWT Auth
+description: |-
+  An OpenBao RFC for enabling CEL roles in the JWT auth method.
+---
+
 # RFC: CEL Expression Support for JWT Authentication
 
 ## Summary
 
 This feature offers support for [Common Expression Language (CEL)](https://github.com/google/cel-spec) in OpenBao's jwt-based auth engines (oidc, jwt) to create a flexible framework for validating claims and dynamically assigning token policies. CEL will allow administrators to define fine-grained rules for claim validation and dynamic policy assignment, extending the more static assignment of role- and identity-based policies.
 
-JWT CEL support is implemented as a new type of CEL role and follows the [general plan for CEL support](https://github.com/openbao/openbao/blob/main/website/content/community/rfcs/cel-best-practices.mdx) in OpenBao.
+JWT CEL support is implemented as a new type of CEL role and follows the [general plan for CEL support](cel-best-practices.mdx) in OpenBao.
 
 ---
 
@@ -34,7 +40,7 @@ This could be codified in the following CEL program:
 
 ## Technical Description
 
-### CEL in Vault Auth Engines (OIDC, JWT)
+### CEL in Auth Engines (OIDC, JWT)
 
 CEL roles integrate with OpenBao's Auth engine (OIDC and JWT) to dynamically evaluate claims. Instead of using static role-to-policy assignment with `bound_claim`, CEL programs validate claims and return a `logical.Auth` instance containing dynamically assigned token policies.
 

--- a/website/content/community/rfcs/index.mdx
+++ b/website/content/community/rfcs/index.mdx
@@ -33,6 +33,9 @@ Steering Committee.
  - [GRPC-Based Invalidation](grpc-invalidation.mdx), for providing read
    scalability on non-Raft HA storage backends which expose an underlying
    index consistent between different nodes.
+ - [CEL for Cert Auth](cel-cert-auth.mdx), enabling CEL roles in the x.509
+   certificate authentication method for greater auth flexibility, supporting
+   SPIFFE attribute validation.
 
 ## Landed
 

--- a/website/sidebarsCommunity.ts
+++ b/website/sidebarsCommunity.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/grpc-invalidation",
                 "rfcs/control-groups",
                 "rfcs/pqc",
+                "rfcs/cel-cert-auth",
             ],
         },
         {


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This adds an RFC aligned with our [existing proposals](https://openbao.org/community/rfcs/cel-best-practices/) around CEL support
for the Certificate Authentication method. This would unblock use of
Cert Auth for SPIFFE and other use cases.
    

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: https://github.com/openbao/openbao/pull/2679

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

---

cc: @andens @suprjinx @fatima2003