### PR TITLE
Fix panic due to unlock of unlocked mutex in Transit (#3309)

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -142,6 +142,14 @@ func GetCacheSizeFromStorage(ctx context.Context, s logical.Storage) (int, error
 
 // Update cache size and get policy
 func (b *backend) GetPolicy(ctx context.Context, polReq keysutil.PolicyRequest, rand io.Reader) (retP *keysutil.Policy, retUpserted bool, retErr error) {
+	return b.getPolicy(ctx, polReq, rand, false /* not exclusive */)
+}
+
+func (b *backend) GetPolicyExclusive(ctx context.Context, polReq keysutil.PolicyRequest, rand io.Reader) (retP *keysutil.Policy, retUpserted bool, retErr error) {
+	return b.getPolicy(ctx, polReq, rand, true /* exclusive */)
+}
+
+func (b *backend) getPolicy(ctx context.Context, polReq keysutil.PolicyRequest, rand io.Reader, exclusive bool) (retP *keysutil.Policy, retUpserted bool, retErr error) {
 	// Acquire read lock to read cacheSizeChanged
 	b.configMutex.RLock()
 	if b.lm.GetUseCache() && b.cacheSizeChanged {
@@ -167,7 +175,7 @@ func (b *backend) GetPolicy(ctx context.Context, polReq keysutil.PolicyRequest, 
 	} else {
 		b.configMutex.RUnlock()
 	}
-	p, _, err := b.lm.GetPolicy(ctx, polReq, rand)
+	p, _, err := b.lm.GetPolicyWithLockType(ctx, polReq, rand, exclusive)
 	if err != nil {
 		return p, false, err
 	}
@@ -237,7 +245,7 @@ func (b *backend) autoRotateKeys(ctx context.Context, req *logical.Request) erro
 	var errs *multierror.Error
 
 	for _, key := range keys {
-		p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+		p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 			Storage: req.Storage,
 			Name:    key,
 		}, b.GetRandomReader())
@@ -262,9 +270,6 @@ func (b *backend) autoRotateKeys(ctx context.Context, req *logical.Request) erro
 
 // rotateIfRequired rotates a key if it is due for autorotation.
 func (b *backend) rotateIfRequired(ctx context.Context, req *logical.Request, key string, p *keysutil.Policy) error {
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
-	}
 	defer p.Unlock()
 
 	// If the key is imported, it can only be rotated from within Vault if allowed.

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -1715,10 +1715,9 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 					t.Fatal("expected non-nil policy")
 				}
 				p.AutoRotatePeriod = time.Nanosecond
-				err = p.Persist(context.Background(), storage)
-				if err != nil {
-					t.Fatal(err)
-				}
+				err = p.Persist(t.Context(), storage)
+				require.NoError(t, err)
+				p.Unlock()
 
 				// Run the rotation check and validate the state of key rotations
 				b.checkAutoRotateAfter = time.Now()

--- a/builtin/logical/transit/path_byok.go
+++ b/builtin/logical/transit/path_byok.go
@@ -81,9 +81,6 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 	if dstP == nil {
 		return nil, errors.New("no such destination key to export to")
 	}
-	if !b.System().CachingDisabled() {
-		dstP.Lock(false)
-	}
 	defer dstP.Unlock()
 
 	if dstP.SoftDeleted {
@@ -99,9 +96,6 @@ func (b *backend) pathPolicyBYOKExportRead(ctx context.Context, req *logical.Req
 	}
 	if srcP == nil {
 		return nil, errors.New("no such source key for export")
-	}
-	if !b.System().CachingDisabled() {
-		srcP.Lock(false)
 	}
 	defer srcP.Unlock()
 

--- a/builtin/logical/transit/path_certificates.go
+++ b/builtin/logical/transit/path_certificates.go
@@ -94,9 +94,6 @@ func (b *backend) pathCreateCSRWrite(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse("key with provided name '%s' not found", name), logical.ErrInvalidRequest
 	}
 
-	if !b.System().CachingDisabled() {
-		policy.Lock(false)
-	}
 	defer policy.Unlock()
 
 	// check if key supports signing
@@ -163,7 +160,7 @@ func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Req
 
 	name := data.Get("name").(string)
 
-	policy, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+	policy, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
 	}, b.GetRandomReader())
@@ -174,9 +171,6 @@ func (b *backend) pathImportCertChainWrite(ctx context.Context, req *logical.Req
 		return logical.ErrorResponse("key with provided name '%s' not found", name), logical.ErrInvalidRequest
 	}
 
-	if !b.System().CachingDisabled() {
-		policy.Lock(true)
-	}
 	defer policy.Unlock()
 
 	// check if transit key supports signing

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -117,9 +117,6 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	newKey := make([]byte, 32)

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -163,9 +163,6 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	successesInBatch := false

--- a/builtin/logical/transit/path_derive_key.go
+++ b/builtin/logical/transit/path_derive_key.go
@@ -137,9 +137,6 @@ func (b *backend) pathPolicyDeriveKeyWrite(ctx context.Context, req *logical.Req
 	if p == nil {
 		return logical.ErrorResponse("specified base key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	if !p.Type.KeyAgreementSupported() {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -288,7 +288,7 @@ func (b *backend) pathEncryptExistenceCheck(ctx context.Context, req *logical.Re
 	if err != nil {
 		return false, err
 	}
-	if p != nil && b.System().CachingDisabled() {
+	if p != nil {
 		p.Unlock()
 	}
 
@@ -417,9 +417,6 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	}
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -112,9 +112,6 @@ func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request
 	if p == nil {
 		return nil, nil
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	if !p.Exportable && exportType != exportTypePublicKey && exportType != exportTypeCertificateChain {

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -135,9 +135,6 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	switch {
@@ -255,9 +252,6 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 	}
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_hmac_test.go
+++ b/builtin/logical/transit/path_hmac_test.go
@@ -59,6 +59,7 @@ func TestTransit_HMAC(t *testing.T) {
 		if err = p.Persist(context.Background(), storage); err != nil {
 			t.Fatal(err)
 		}
+		p.Unlock()
 
 		req.Path = "hmac/" + c.name
 		req.Data = map[string]interface{}{
@@ -248,6 +249,7 @@ func TestTransit_batchHMAC(t *testing.T) {
 	if err = p.Persist(context.Background(), storage); err != nil {
 		t.Fatal(err)
 	}
+	p.Unlock()
 
 	req.Path = "hmac/foo"
 	batchInput := []batchRequestHMACItem{

--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -230,9 +230,7 @@ func (b *backend) pathImportWrite(ctx context.Context, req *logical.Request, d *
 	}
 
 	if p != nil {
-		if b.System().CachingDisabled() {
-			p.Unlock()
-		}
+		p.Unlock()
 		return nil, errors.New("the import path cannot be used with an existing key; use import-version to rotate an existing imported key")
 	}
 
@@ -271,24 +269,22 @@ func (b *backend) pathImportVersionWrite(ctx context.Context, req *logical.Reque
 		Upsert:       false,
 		IsPrivateKey: isCiphertextSet,
 	}
-	p, _, err := b.GetPolicy(ctx, polReq, b.GetRandomReader())
+	p, _, err := b.GetPolicyExclusive(ctx, polReq, b.GetRandomReader())
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return nil, fmt.Errorf("no key found with name %s; to import a new key, use the import/ endpoint", name)
 	}
+
+	defer p.Unlock()
+
 	if !p.Imported {
 		return nil, errors.New("the import_version endpoint can only be used with an imported key")
 	}
 	if p.ConvergentEncryption {
 		return nil, errors.New("import_version cannot be used on keys with convergent encryption enabled")
 	}
-
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
-	}
-	defer p.Unlock()
 
 	key, resp, err := b.extractKeyFromFields(ctx, req, d, p.Type, isCiphertextSet)
 	if err != nil {

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -313,9 +313,6 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	if p == nil {
 		return nil, errors.New("error generating key: returned policy was nil")
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	resp, err := b.formatKeyPolicy(p, nil)
@@ -348,9 +345,6 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 	}
 	if p == nil {
 		return nil, nil
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
 	}
 	defer p.Unlock()
 
@@ -527,7 +521,7 @@ func (b *backend) pathPolicySoftDelete(ctx context.Context, req *logical.Request
 
 	name := d.Get("name").(string)
 
-	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+	p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
 	}, b.GetRandomReader())
@@ -536,9 +530,6 @@ func (b *backend) pathPolicySoftDelete(ctx context.Context, req *logical.Request
 	}
 	if p == nil {
 		return nil, nil
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
 	}
 	defer p.Unlock()
 
@@ -574,7 +565,7 @@ func (b *backend) pathPolicySoftDeleteRestore(ctx context.Context, req *logical.
 
 	name := d.Get("name").(string)
 
-	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+	p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
 	}, b.GetRandomReader())
@@ -583,9 +574,6 @@ func (b *backend) pathPolicySoftDeleteRestore(ctx context.Context, req *logical.
 	}
 	if p == nil {
 		return nil, nil
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_keys_config.go
+++ b/builtin/logical/transit/path_keys_config.go
@@ -88,7 +88,7 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 	name := d.Get("name").(string)
 
 	// Check if the policy already exists before we lock everything
-	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+	p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
 	}, b.GetRandomReader())
@@ -99,9 +99,6 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(
 				fmt.Sprintf("no existing key named %s could be found", name)),
 			logical.ErrInvalidRequest
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -437,3 +437,51 @@ func validateOpsFail(t *testing.T, b *backend, s logical.Storage, encrypt bool, 
 
 	// Soft deleted keys remain updatable.
 }
+
+func TestCreateDerivedKey(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	for _, algo := range []string{
+		"aes128-gcm96", "aes256-gcm96", "chacha20-poly1305",
+		"xchacha20-poly1305", "ed25519",
+	} {
+		req := &logical.Request{
+			Path:      "keys/" + algo,
+			Operation: logical.UpdateOperation,
+			Storage:   s,
+			Data: map[string]interface{}{
+				"type":    algo,
+				"derived": true,
+			},
+		}
+		if algo == "hmac" {
+			req.Data["key_size"] = 32
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		require.NoError(t, err, algo)
+		require.NotNil(t, resp, algo)
+	}
+
+	for _, algo := range []string{
+		"hmac", "rsa-2048", "rsa-3072", "rsa-4096", "ecdsa-p256",
+		"ecdsa-p384", "ecdsa-p521",
+	} {
+		req := &logical.Request{
+			Path:      "keys/" + algo,
+			Operation: logical.UpdateOperation,
+			Storage:   s,
+			Data: map[string]interface{}{
+				"type":    algo,
+				"derived": true,
+			},
+		}
+		if algo == "hmac" {
+			req.Data["key_size"] = 32
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		require.Error(t, err, algo)
+		require.Nil(t, resp, algo)
+	}
+}

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -128,9 +128,6 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	for i, item := range batchInputItems {

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -49,7 +49,7 @@ func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *
 	name := d.Get("name").(string)
 
 	// Get the policy
-	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+	p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
 	}, b.GetRandomReader())
@@ -58,9 +58,6 @@ func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *
 	}
 	if p == nil {
 		return logical.ErrorResponse("key not found"), logical.ErrInvalidRequest
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(true)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -368,9 +368,6 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 	if p == nil {
 		return logical.ErrorResponse("signing key not found"), logical.ErrInvalidRequest
 	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
-	}
 	defer p.Unlock()
 
 	if !p.Type.SigningSupported() {
@@ -603,9 +600,6 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 	}
 	if p == nil {
 		return logical.ErrorResponse("signature verification key not found"), logical.ErrInvalidRequest
-	}
-	if !b.System().CachingDisabled() {
-		p.Lock(false)
 	}
 	defer p.Unlock()
 

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -160,6 +160,7 @@ func testTransit_SignVerify_ECDSA(t *testing.T, bits int) {
 	req.Data = map[string]interface{}{
 		"input": "dGhlIHF1aWNrIGJyb3duIGZveA==",
 	}
+	p.Unlock()
 
 	signRequest := func(req *logical.Request, errExpected bool, postpath string) string {
 		t.Helper()
@@ -619,7 +620,9 @@ func TestTransit_SignVerify_ED25519(t *testing.T) {
 	if err = fooP.Persist(context.Background(), storage); err != nil {
 		t.Fatal(err)
 	}
-	err = barP.Rotate(context.Background(), storage, b.GetRandomReader())
+	fooP.Unlock()
+
+	err = barP.Rotate(t.Context(), storage, b.GetRandomReader())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,6 +634,7 @@ func TestTransit_SignVerify_ED25519(t *testing.T) {
 	if err = barP.Persist(context.Background(), storage); err != nil {
 		t.Fatal(err)
 	}
+	barP.Unlock()
 
 	req.Data = map[string]interface{}{
 		"input":   "dGhlIHF1aWNrIGJyb3duIGZveA==",

--- a/builtin/logical/transit/path_trim.go
+++ b/builtin/logical/transit/path_trim.go
@@ -58,7 +58,7 @@ func (b *backend) pathTrimUpdate() framework.OperationFunc {
 
 		name := d.Get("name").(string)
 
-		p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+		p, _, err := b.GetPolicyExclusive(ctx, keysutil.PolicyRequest{
 			Storage: req.Storage,
 			Name:    name,
 		}, b.GetRandomReader())
@@ -67,9 +67,6 @@ func (b *backend) pathTrimUpdate() framework.OperationFunc {
 		}
 		if p == nil {
 			return logical.ErrorResponse("invalid key name"), logical.ErrInvalidRequest
-		}
-		if !b.System().CachingDisabled() {
-			p.Lock(true)
 		}
 		defer p.Unlock()
 

--- a/builtin/logical/transit/path_trim_test.go
+++ b/builtin/logical/transit/path_trim_test.go
@@ -46,6 +46,7 @@ func TestTransit_Trim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	p.Unlock()
 
 	// Archive: 0, 1
 	archive, err := p.LoadArchive(namespace.RootContext(nil), storage)

--- a/builtin/logical/transit/path_wrapping_key.go
+++ b/builtin/logical/transit/path_wrapping_key.go
@@ -85,9 +85,7 @@ func (b *backend) getWrappingKey(ctx context.Context, storage logical.Storage) (
 	if p == nil {
 		return nil, errors.New("error retrieving wrapping key: returned policy was nil")
 	}
-	if b.System().CachingDisabled() {
-		p.Unlock()
-	}
+	defer p.Unlock()
 
 	return p, nil
 }

--- a/changelog/3309.txt
+++ b/changelog/3309.txt
@@ -1,0 +1,6 @@
+```release-note:security
+secrets/transit: Prevent server crash due to unlock of unlocked mutex for RSA keys created with `derived=true`. GHSA-8w8f-r2xv-4q4j.
+```
+```release-notes:change
+sdk/keysutil: Ensure mutex received is always locked regardless of cache state, simplifying caller locking behavior.
+```

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -277,9 +277,22 @@ func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage
 	return backup, nil
 }
 
-// When the function returns, if caching was disabled, the Policy's lock must
-// be unlocked when the caller is done (and it should not be re-locked).
+// The Policy's lock must be unlocked when the caller is done (and it should
+// not be re-locked). This will usually be a read lock but may be exclusive
+// in certain circumstances, such as when upserted.
 func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io.Reader) (retP *Policy, retUpserted bool, retErr error) {
+	return lm.GetPolicyWithLockType(ctx, req, rand, false /* not exclusive */)
+}
+
+// The Policy's lock must be unlocked when the caller is done (and it should
+// not be re-locked). This will definitely be an exclusive lock.
+func (lm *LockManager) GetPolicyExclusive(ctx context.Context, req PolicyRequest, rand io.Reader) (retP *Policy, retUpserted bool, retErr error) {
+	return lm.GetPolicyWithLockType(ctx, req, rand, true /* exclusive */)
+}
+
+// The Policy must be unlocked when done. See note about GetPolicy for when
+// exclusive=false.
+func (lm *LockManager) GetPolicyWithLockType(ctx context.Context, req PolicyRequest, rand io.Reader, exclusive bool) (retP *Policy, retUpserted bool, retErr error) {
 	var p *Policy
 	var err error
 	var ok bool
@@ -294,6 +307,7 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 		if atomic.LoadUint32(&p.deleted) == 1 {
 			return nil, false, nil
 		}
+		p.Lock(exclusive)
 		return p, false, nil
 	}
 
@@ -305,20 +319,19 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 
 	// If we are using the cache, defer the lock unlock; otherwise we will
 	// return from here with the lock still held.
-	cleanup := func() {
+	defer func() {
 		switch {
-		// If using the cache we always unlock, the caller locks the policy
-		// themselves
-		case lm.useCache:
-			lock.Unlock()
-
-		// If not using the cache, if we aren't returning a policy the caller
-		// doesn't have a lock, so we must unlock
 		case retP == nil:
+			// If not using the cache and if we aren't returning a policy, the
+			// caller doesn't have a lock reference, so we must unlock.
+			lock.Unlock()
+		case lm.useCache:
+			// If using the cache, we always unlock the global lock, but before
+			// doing so, we acquire a lock on the policy itself.
+			retP.Lock(exclusive)
 			lock.Unlock()
 		}
-	}
-	defer cleanup()
+	}()
 
 	// Check the cache again
 	if lm.useCache {
@@ -371,7 +384,6 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 
 		case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 			if req.Derived || req.Convergent {
-				cleanup()
 				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 		case KeyType_HMAC:

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -95,9 +95,7 @@ func testKeyUpgradeCommon(t *testing.T, lm *LockManager) {
 	if !upserted {
 		t.Fatal("expected an upsert")
 	}
-	if !lm.useCache {
-		p.Unlock()
-	}
+	defer p.Unlock()
 
 	testBytes := make([]byte, len(p.Keys["1"].Key))
 	copy(testBytes, p.Keys["1"].Key)
@@ -144,9 +142,7 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	if p == nil {
 		t.Fatal("nil policy")
 	}
-	if !lm.useCache {
-		p.Unlock()
-	}
+	p.Unlock()
 
 	// Store the initial key in the archive
 	keysArchive := []KeyEntry{{}, p.Keys["1"]}
@@ -201,9 +197,7 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	if p == nil {
 		t.Fatal("nil policy")
 	}
-	if !lm.useCache {
-		p.Unlock()
-	}
+	p.Unlock()
 
 	checkKeys(t, ctx, p, storage, keysArchive, "upgrade", 10, 10, 10)
 
@@ -241,9 +235,7 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	if p == nil {
 		t.Fatal("policy nil after bad delete")
 	}
-	if !lm.useCache {
-		p.Unlock()
-	}
+	p.Unlock()
 
 	// Now do it properly
 	p.DeletionAllowed = true


### PR DESCRIPTION
Fix locking in keysutil policy creation

In my refactor in 5d130d52d56e60670bb089a7c6366d890691d391 to fix other locking issues in Transit, I ended up keeping the named function for the defer, which lead to a double unlock on the one missed error path. Convert this to a regular defer pattern.



Ensure always a locked policy from keysutil

When using LockManager, ensure that we always get given a locked policy with proper lock ordering internally to ensure no other callers win the update before we have had a chance to modify the policy with our exclusive lock if created.

This introduces new variants of GetPolicy which are then used by Transit.



Add changelog entries

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: GHSA-8w8f-r2xv-4q4j

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
