### PR TITLE
Fix LDAP bind DN lookups in auth, secrets engine (#3306)

### DIFF
--- a/builtin/logical/openldap/client.go
+++ b/builtin/logical/openldap/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 	"github.com/hashicorp/go-hclog"
-	"github.com/openbao/openbao/sdk/v2/helper/ldaputil"
 
 	"github.com/openbao/openbao/builtin/logical/openldap/client"
 )
@@ -50,7 +49,7 @@ func (c *Client) UpdateDNPassword(conf *client.Config, dn string, newPassword st
 
 	if field == client.FieldRegistry.UserPrincipalName {
 		scope = ldap.ScopeWholeSubtree
-		bindUser := fmt.Sprintf("%s@%s", ldaputil.EscapeLDAPValue(dn), conf.UPNDomain)
+		bindUser := fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)
 		filters[field] = []string{bindUser}
 		dn = conf.UserDN
 	}

--- a/changelog/3306.txt
+++ b/changelog/3306.txt
@@ -1,0 +1,6 @@
+```release-note:security
+auth/ldap: Prevent unlikely post-bind LDAP injection via bind DN to group resolution. GHSA-6mwx-4547-5vc9.
+```
+```release-note:security
+secret/ldap: Prevent potential LDAP injection with unsanitized DNs for service accounts. GHSA-6mwx-4547-5vc9.
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -298,7 +298,7 @@ func (c *Client) GetUserDN(cfg *ConfigEntry, conn Connection, bindDN, username s
 	userDN := ""
 	if cfg.UPNDomain != "" {
 		// Find the distinguished name for the user if userPrincipalName used for login
-		filter := fmt.Sprintf("(userPrincipalName=%s@%s)", EscapeLDAPValue(username), cfg.UPNDomain)
+		filter := fmt.Sprintf("(userPrincipalName=%s@%s)", ldap.EscapeFilter(username), cfg.UPNDomain)
 		if c.Logger.IsDebug() {
 			c.Logger.Debug("searching upn", "userdn", cfg.UserDN, "filter", filter)
 		}


### PR DESCRIPTION
Prevent LDAP injection via search filters



Add changelog entry

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: GHSA-6mwx-4547-5vc9

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
