### PR TITLE
No longer delete quotas with mount deletion on standby nodes

### DIFF
--- a/changelog/3316.txt
+++ b/changelog/3316.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sys/quotas: Fix unintentional attempts to delete quotas on standby nodes when mount is removed.
+```

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -353,7 +353,8 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	t.Parallel()
 	c, root := testCore_Invalidate_TestCore(t, nil)
 	rootCtx := namespace.RootContext(t.Context())
-	// 1. Create some qutoa to populate cache
+
+	// 1. Create quota to populate cache
 	req := logical.TestRequest(t, logical.CreateOperation, "sys/quotas/rate-limit/test-quota")
 	req.ClientToken = root
 	req.Data = map[string]any{
@@ -362,7 +363,7 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	}
 	testCore_Invalidate_handleRequest(t, rootCtx, c, req)
 
-	// 2. Manipulate Storage
+	// 2. Manipulate storage: write updated quota
 	quota, err := c.quotaManager.QuotaByName("rate-limit", "test-quota")
 	require.NoError(t, err)
 
@@ -375,14 +376,37 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
 
 	// 3. Invalidate Path
-	require.NoError(t, c.invalidateSynchronous("sys/quotas/rate-limit/test-quota"))
+	require.NoError(t, c.invalidateSynchronous(newEntry.Key))
 
-	// 4. Check cache was properly invalidated
-	req = logical.TestRequest(t, logical.ReadOperation, "sys/quotas/rate-limit/test-quota")
+	// 4. Check cache: quota updated
+	req = logical.TestRequest(t, logical.ReadOperation, newEntry.Key)
 	req.ClientToken = root
 
 	resp := testCore_Invalidate_handleRequest(t, rootCtx, c, req)
+	require.Equal(t, 1, resp.Data["interval"])
 
+	// 5. Delete quota
+	testCore_Invalidate_sneakValueAroundCacheDelete(t, rootCtx, c, newEntry.Key)
+
+	// 6. Invalidate Path
+	require.NoError(t, c.invalidateSynchronous(newEntry.Key))
+
+	// 7. Check cache: quota deleted
+	req = logical.TestRequest(t, logical.ReadOperation, newEntry.Key)
+	req.ClientToken = root
+	resp = testCore_Invalidate_handleRequest(t, rootCtx, c, req)
+
+	require.Nil(t, resp)
+
+	// 8. Manipulate quota in storage: restore quota
+	testCore_Invalidate_sneakValueAroundCache(t, rootCtx, c, newEntry)
+
+	// 9. Invalidate path
+	require.NoError(t, c.invalidateSynchronous(newEntry.Key))
+
+	// 10. Check cache: quota brought back
+	resp = testCore_Invalidate_handleRequest(t, rootCtx, c, req)
+	require.NotNil(t, resp.Data)
 	require.Equal(t, 1, resp.Data["interval"])
 }
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -2122,15 +2122,11 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 
 	actualMountEntry := c.router.MatchingMountByUUID(uuid)
 
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
 	switch {
 	case desiredMountEntry == nil && actualMountEntry != nil: // mount was deleted
 		c.logger.Debug("cache invalidation: mount was deleted", "type", table, "uuid", uuid)
 
+		var err error
 		if table == routing.CredentialTableType {
 			err = c.removeCredEntryWithLock(ctx, actualMountEntry.Path, false)
 		} else {
@@ -2144,49 +2140,42 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 		if table == routing.CredentialTableType {
 			routerPath = path.Join(routing.CredentialRoutePrefix, routerPath) + "/"
 		}
+
 		if err := c.router.Unmount(ctx, routerPath); err != nil {
 			return err
-		}
-
-		if c.quotaManager != nil {
-			if err := c.quotaManager.HandleBackendDisabling(ctx, ns.Path, actualMountEntry.APIPathNoNamespace()); err != nil {
-				c.logger.Error("failed to update quotas after disabling mount", "error", err, "namespace", ns.Path, "uuid", uuid)
-				return err
-			}
 		}
 
 	case desiredMountEntry != nil && actualMountEntry == nil: // mount was created
 		c.logger.Debug("cache invalidation: mount was created", "type", table, "uuid", uuid)
 
+		var err error
 		if table == routing.CredentialTableType {
 			err = c.enableCredentialInternalWithLock(ctx, desiredMountEntry, false)
-			if err != nil {
-				return err
-			}
 		} else {
 			c.logger.Info("calling mount internal", "path", desiredMountEntry.Path)
-			err := c.mountInternalWithLock(ctx, desiredMountEntry, false)
-			if err != nil {
-				return err
-			}
+			err = c.mountInternalWithLock(ctx, desiredMountEntry, false)
+		}
+		if err != nil {
+			return err
 		}
 
 	case desiredMountEntry != nil && actualMountEntry != nil: // mount was modified (e.g. tuned or tainted)
 		c.logger.Debug("cache invalidation: mount was modified", "type", table, "uuid", uuid)
-		routerPath := actualMountEntry.Path
-		if table == routing.CredentialTableType {
-			routerPath = path.Join(routing.CredentialRoutePrefix, routerPath) + "/"
-		}
 
 		if desiredMountEntry.Tainted != actualMountEntry.Tainted {
+			routerPath := actualMountEntry.Path
+			if table == routing.CredentialTableType {
+				routerPath = path.Join(routing.CredentialRoutePrefix, routerPath) + "/"
+			}
+
 			if desiredMountEntry.Tainted {
-				err = c.router.Taint(ctx, routerPath)
+				err := c.router.Taint(ctx, routerPath)
 				if err != nil {
 					return err
 				}
 				actualMountEntry.Tainted = true
 			} else {
-				err = c.router.Untaint(ctx, routerPath)
+				err := c.router.Untaint(ctx, routerPath)
 				if err != nil {
 					return err
 				}
@@ -2200,7 +2189,7 @@ func (c *Core) reloadMountInternalWithLock(ctx context.Context, table, uuid stri
 		}
 
 		if desiredMountEntry.Options["version"] != actualMountEntry.Options["version"] {
-			err = c.reloadBackendCommon(ctx, desiredMountEntry, table == routing.CredentialTableType)
+			err := c.reloadBackendCommon(ctx, desiredMountEntry, table == routing.CredentialTableType)
 			if err != nil {
 				return err
 			}

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -977,12 +977,12 @@ func (m *Manager) Invalidate(ctx context.Context, key string) error {
 
 		switch quota {
 		case nil:
-			// Handle quota deletion
+			m.logger.Debug("cache invalidation: quota was deleted", "name", name)
 			if err := m.DeleteQuota(ctx, qType, name); err != nil {
 				return fmt.Errorf("failed to delete invalidated quota rule: %w", err)
 			}
 		default:
-			// Handle quota update
+			m.logger.Debug("cache invalidation: quota was updated", "name", name)
 			if err := m.SetQuota(ctx, qType, quota); err != nil {
 				return fmt.Errorf("failed to update invalidated quota rule: %w", err)
 			}


### PR DESCRIPTION
## Description
With mount deletion we were removing quota entries from storage on standby nodes, this shouldn't happen as we have an event trigger (quota invalidation) on quota removal from active node. In case we had a quota assigned to the mount we deleted we were causing standby nodes crash and reload.

## Rationale
invalidation logic minor bugfix

Resolves: no issue created

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
