### PR TITLE
Add Host header to logical.Request headers

### DIFF
--- a/changelog/3325.txt
+++ b/changelog/3325.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+http: Ensure that `passthrough_request_headers` can pass the `Host` header to plugins.
+```

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -118,6 +118,38 @@ func TestHandler_parseMFAHandler(t *testing.T) {
 	}
 }
 
+type nilResponseWriter struct{}
+
+func (w *nilResponseWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (w *nilResponseWriter) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (w *nilResponseWriter) WriteHeader(statusCode int) {}
+
+func TestHandler_HostHeader(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "http://domain.example/v1/path", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	r.Header.Add("user-agent", "Test")
+	req, status, err := buildLogicalRequestNoAuth(&nilResponseWriter{}, r)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if status != 0 {
+		t.Fatalf("status: %d", status)
+	}
+
+	require.Subset(t, req.Headers, http.Header{
+		http.CanonicalHeaderKey("user-agent"): {"Test"},
+		http.CanonicalHeaderKey("host"):       {"domain.example"},
+	})
+}
+
 func TestHandler_cors(t *testing.T) {
 	core, _, _ := vault.TestCoreUnsealed(t)
 	ln, addr := TestServer(t, core)

--- a/http/logical.go
+++ b/http/logical.go
@@ -185,13 +185,19 @@ func buildLogicalRequestNoAuth(w http.ResponseWriter, r *http.Request) (*logical
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to generate identifier for the request: %w", err)
 	}
 
+	// The http package removes the Host header when deserializing
+	// the http request.  This adds it back in so it is available
+	// in the logical request.
+	reqHeader := r.Header.Clone()
+	reqHeader.Add("Host", r.Host)
+
 	req := &logical.Request{
 		ID:         requestId,
 		Operation:  op,
 		Path:       path,
 		Data:       data,
 		Connection: getConnection(r),
-		Headers:    r.Header.Clone(),
+		Headers:    reqHeader,
 	}
 
 	if passHTTPReq {


### PR DESCRIPTION
## Description

This pull request adds the Host header value back to the header collection before passing it to a `logical.Request`, as `http.Server` removes this value from the `http.Request` header collection when adding it to the `Request.Host` field.

## Rationale

Code that interacts with a `logical.Request` can access the original HTTP headers passed in the request by accessing the `Headers` collection of the `logical.Request`.  If the code is part of a plugin, it requires that `--passthrough-request-header` to be specified.  However, because the Host header is removed by `http.Server` when assigned to the `http.Request.Host`, this is not passed to the `logical.Request` when simply copying the header collection as is.  By adding the host header back to the collection, it becomes available to any code that needs to access it.

Resolves: #3254 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
