### PR TITLE
Do per-namespace invalidation

### DIFF
--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -935,7 +935,7 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 			}
 		}
 
-		go f.invalidateHook(keys...)
+		f.invalidateHook(keys...)
 	}
 
 	// If we advanced the latest value, update the in-memory representation too.

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -440,7 +440,28 @@ func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
 	// The namespace UUID is the final path segment; ij.nsUUID contains the
 	// parent namespace UUID.
 	childUUID := strings.TrimPrefix(ij.nsKey, namespaceStoreSubPath)
-	return ij.im.core.namespaceStore.Invalidate(ctx, ij.nsUUID, childUUID)
+
+	// Reload the namespace entry:
+	child, deleted, err := ij.im.core.namespaceStore.Invalidate(ctx, ij.nsUUID, childUUID)
+	switch {
+	case err != nil:
+		return err
+	case child == nil, ij.im.core.NamespaceSealed(child):
+		// Nothing to do.
+		return nil
+	}
+
+	ctx = namespace.ContextWithNamespace(ctx, child)
+
+	// Invalidate all policies within the namespace.
+	ij.im.core.policyStore.InvalidateNamespace(ctx, childUUID)
+
+	// Now reload all mounts within the namespace.
+	if err := ij.im.core.reloadNamespaceMounts(ctx, childUUID, deleted); err != nil {
+		return fmt.Errorf("unable to invalidate mounts in namespace %q: %w", ij.nsUUID, err)
+	}
+
+	return nil
 }
 
 func (ij *invalidationJob) policyInvalidation(ctx context.Context) error {

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -438,63 +437,10 @@ func (ij *invalidationJob) Execute() error {
 }
 
 func (ij *invalidationJob) namespaceInvalidation(ctx context.Context) error {
-	ij.im.dispacherLogger.Trace("issuing namespace invalidation")
-
-	// The namespace name is the final path segment; ij.nsUUID contains the
+	// The namespace UUID is the final path segment; ij.nsUUID contains the
 	// parent namespace UUID.
-	namespaceUUID := strings.TrimPrefix(ij.nsKey, namespaceStoreSubPath)
-
-	beforeNs, beforeErr := ij.im.core.namespaceStore.GetNamespace(ctx, namespaceUUID)
-
-	// First notify the namespace storage that our next lookup might be stale.
-	ij.im.core.namespaceStore.invalidate(ctx, ij.key)
-
-	afterNs, afterErr := ij.im.core.namespaceStore.GetNamespace(ctx, namespaceUUID)
-
-	// There are three happy paths for namespace invalidation:
-	//
-	// 1. Namespace deletion; before the namespace would be present but
-	//    afterwards it would be nil.
-	// 2. Namespace creation; before the namespace would be missing and
-	//    afterwards it will be present.
-	// 3. Namespace update; this exists in both places but we'd prefer the
-	//    updated version.
-	var preferredNs *namespace.Namespace
-	var deleted bool
-	switch {
-	case beforeErr != nil && afterErr != nil:
-		return fmt.Errorf("failed loading invalidated namespace; before=%w; after=%v", beforeErr, afterErr)
-	case beforeNs == nil && afterNs == nil:
-		return errors.New("failed loading invalidated namespace: does not exist before or after")
-	case afterNs != nil && afterErr == nil:
-		preferredNs = afterNs
-	case beforeNs != nil && beforeErr == nil:
-		preferredNs = beforeNs
-		deleted = true
-	}
-
-	nsBarrier := ij.im.core.sealManager.NamespaceBarrierByLongestPrefix(preferredNs.Path)
-	if nsBarrier.Sealed() {
-		// Namespace is sealed; nothing more we can do with it.
-		return nil
-	} else if preferredNs.ManuallySealed {
-		// Namespace was manually sealed but we're not actually sealed locally;
-		// seal it.
-		ij.im.dispacherLogger.Info("sealing manually sealed namespace", "path", preferredNs.Path, "uuid", preferredNs.UUID)
-		return ij.im.core.namespaceStore.SealNamespace(ctx, preferredNs.Path)
-	}
-
-	childCtx := namespace.ContextWithNamespace(ctx, preferredNs)
-
-	// Invalidate all policies within the namespace.
-	ij.im.core.policyStore.InvalidateNamespace(childCtx, namespaceUUID)
-
-	// Now reload all mounts within the namespace.
-	if err := ij.im.core.reloadNamespaceMounts(childCtx, namespaceUUID, deleted); err != nil {
-		return fmt.Errorf("unable to invalidate mounts in namespace %q: %w", ij.nsUUID, err)
-	}
-
-	return nil
+	childUUID := strings.TrimPrefix(ij.nsKey, namespaceStoreSubPath)
+	return ij.im.core.namespaceStore.Invalidate(ctx, ij.nsUUID, childUUID)
 }
 
 func (ij *invalidationJob) policyInvalidation(ctx context.Context) error {

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -200,11 +200,18 @@ func (im *invalidationManager) buildInvalidateJobForKey(quitCh chan struct{}, qu
 	ns, subkey := im.splitNamespaceFromKey(key)
 
 	queue := ns
-	if ns == namespace.RootNamespaceUUID {
-		if strings.HasPrefix(subkey, "core/") {
-			queue = key
-		}
-	} else if strings.HasPrefix(subkey, "core/") {
+
+	isCore := strings.HasPrefix(subkey, "core/")
+	isNamespaceStore := isCore && strings.HasPrefix(subkey, namespaceStoreSubPath)
+
+	switch {
+	case isNamespaceStore:
+		// Namespaces are laid out in a dense tree, so ordering is important.
+		// Send all namespace store updates to the same queue.
+		queue = "namespaces"
+	case queue == namespace.RootNamespaceUUID && isCore:
+		queue = key
+	case isCore:
 		queue += "-core"
 	}
 

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -349,9 +349,10 @@ func (ij *invalidationJob) Execute() error {
 		ij.fatal = true
 		return fmt.Errorf("failed to load namespace %q from store: %w", ij.nsUUID, err)
 	}
-	if ns == nil {
-		// Namespace was deleted; this is safe to ignore, because it occurs in
-		// one of two scenarios:
+	if ns == nil || ns.Tainted {
+		// Namespace was deleted or created (or is in process of being
+		// deleted/created); this is safe to ignore, because it occurs in one of
+		// two scenarios:
 		//
 		// 1. The namespace was deleted already (invalidation on
 		//    core/namespaces/<uuid> was processed first) and we're getting an

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -276,8 +276,11 @@ func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID 
 		return nil, false, nil
 	}
 
+	// Get the parent's barrier.
+	b := ns.core.sealManager.NamespaceBarrierByLongestPrefix(parent.Path)
+
 	// Try to re-read the namespace.
-	entry, err := ns.core.NamespaceView(parent).Get(ctx, namespaceStoreSubPath+childUUID)
+	entry, err := NamespaceScopedView(b, parent).Get(ctx, namespaceStoreSubPath+childUUID)
 	switch {
 	case errors.Is(err, barrier.ErrBarrierSealed):
 		// This is okay, we have nothing to do as the parent is sealed.
@@ -318,6 +321,18 @@ func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID 
 	}
 	ns.namespacesByUUID[child.UUID] = &child
 	ns.namespacesByAccessor[child.ID] = &child
+
+	if entry, err := NamespaceScopedView(b, &child).Get(ctx, barrierSealConfigPath); err != nil {
+		return nil, false, err
+	} else if entry != nil {
+		var config SealConfig
+		if err := entry.DecodeJSON(&config); err != nil {
+			return nil, false, err
+		}
+		if err := ns.core.sealManager.SetSeal(ctx, &config, &child, false); err != nil {
+			return nil, false, err
+		}
+	}
 
 	if child.ManuallySealed {
 		// Ensure this namespace is sealed locally.

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -270,9 +270,9 @@ func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID 
 	// Do we know the parent namespace at all?
 	parent, ok := ns.namespacesByUUID[parentUUID]
 	if !ok {
-		// If not, it is most likely a child namespace of a sealable namespace
-		// that we simply don't know about on this standby, in which case we
-		// shouldn't error.
+		// If not, the parent namespace is most likely itself a child namespace
+		// of a sealable namespace that isn't yet unsealed on this standby, so
+		// we're good to ignore this invalidation.
 		return nil, false, nil
 	}
 
@@ -304,6 +304,7 @@ func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID 
 		}
 		delete(ns.namespacesByUUID, child.UUID)
 		delete(ns.namespacesByAccessor, child.ID)
+		ns.core.sealManager.RemoveNamespace(child)
 		return child, true, nil
 	}
 

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -66,8 +65,7 @@ type NamespaceStore struct {
 	// This lock ensures we don't concurrently modify the store while using
 	// a namespace entry. We also store an atomic to check if we need to
 	// reload all namespaces.
-	lock        sync.RWMutex
-	invalidated atomic.Bool
+	lock sync.RWMutex
 
 	// List of all namespaces within the store. This is loaded at store
 	// initialization time and persisted throughout the lifetime of the
@@ -148,70 +146,6 @@ func (ns *NamespaceStore) CancelNamespaceDeletion() {
 
 	// Stop jobs.
 	ns.deletionDispatcher.Stop()
-}
-
-// checkInvalidation checks if the store has been marked as invalidated, and if
-// so, reloads namespaces from disk.
-// checkInvalidation returns true if it acquired a write-lock as part of the
-// store reload and is handing the lock over to the caller.
-// If checkInvalidation returns an error, it never keeps a write lock for the
-// caller, so there is no need to check the bool before propagating an error.
-func (ns *NamespaceStore) checkInvalidation(ctx context.Context) (bool, error) {
-	if ctx.Err() != nil {
-		return false, ctx.Err()
-	}
-
-	if !ns.invalidated.Load() {
-		return false, nil
-	}
-
-	ns.lock.Lock()
-
-	// Status might have changed
-	if !ns.invalidated.Load() {
-		return true, nil
-	}
-
-	if err := ns.loadNamespacesLocked(ctx); err != nil {
-		// Caller likely just wants to propagate the error,
-		// so don't keep the lock for them.
-		ns.lock.Unlock()
-		return false, fmt.Errorf("error handling invalidation: %w", err)
-	}
-
-	ns.invalidated.Store(false)
-	return true, nil
-}
-
-// lockWithInvalidation is a helper calls [checkInvalidation] and acquires the
-// desired type of lock, potentially carrying it over from [checkInvalidation].
-// This is useful for most namespace store operations that initially revalidate
-// the store and then need a lock to perform the main read and/or write
-// operation.
-//
-// lockWithInvalidation in write = false mode may actually yield a write lock if
-// one was acquired by [checkInvalidation].
-// lockWithInvalidation in write = true mode will always yield a write lock.
-//
-// The returned unlock function will be the correct one to unlock the respective
-// type of lock acquired under the hood. The caller must not call the unlock
-// function if a non-nil error is returned.
-func (ns *NamespaceStore) lockWithInvalidation(ctx context.Context, write bool) (func(), error) {
-	locked, err := ns.checkInvalidation(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	switch {
-	case locked:
-		return ns.lock.Unlock, nil
-	case write:
-		ns.lock.Lock()
-		return ns.lock.Unlock, nil
-	default:
-		ns.lock.RLock()
-		return ns.lock.RUnlock, nil
-	}
 }
 
 // loadNamespaces loads all stored namespaces from disk. It assumes the lock
@@ -329,23 +263,16 @@ func (c *Core) teardownNamespaceStore() error {
 	return nil
 }
 
-func (ns *NamespaceStore) invalidate(ctx context.Context, path string) {
-	// We want to keep invalidation proper fast (as it holds up replication),
-	// so defer invalidation to the next load.
-	//
-	// TODO(ascheel): handle individual entry invalidation correctly. We'll
-	// need to handle child namespace invalidation as well. sync.Map could be
-	// used instead in the future alongside the actual boolean.
-	ns.invalidated.Store(true)
+func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID string) error {
+	return nil
 }
 
 // SetNamespace is used to create or update a namespace.
 func (ns *NamespaceStore) SetNamespace(ctx context.Context, entry *namespace.Namespace) error {
 	defer metrics.MeasureSince([]string{"namespace", "set_namespace"}, time.Now())
 
-	if _, err := ns.lockWithInvalidation(ctx, true); err != nil {
-		return err
-	}
+	// setNamespaceLocked will unlock.
+	ns.lock.Lock()
 
 	_, err := ns.setNamespaceLocked(ctx, entry, nil)
 	return err
@@ -357,9 +284,8 @@ func (ns *NamespaceStore) SetNamespace(ctx context.Context, entry *namespace.Nam
 func (ns *NamespaceStore) SetNamespaceWithSeal(ctx context.Context, entry *namespace.Namespace, sealConfig *SealConfig) ([][]byte, error) {
 	defer metrics.MeasureSince([]string{"namespace", "set_namespace_with_seal"}, time.Now())
 
-	if _, err := ns.lockWithInvalidation(ctx, true); err != nil {
-		return nil, err
-	}
+	// setNamespaceLocked will unlock.
+	ns.lock.Lock()
 
 	return ns.setNamespaceLocked(ctx, entry, sealConfig)
 }
@@ -763,11 +689,8 @@ func (ns *NamespaceStore) pushToMounts(ctx context.Context, entry *namespace.Nam
 func (ns *NamespaceStore) GetNamespace(ctx context.Context, uuid string) (*namespace.Namespace, error) {
 	defer metrics.MeasureSince([]string{"namespace", "get_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
 
 	item, ok := ns.namespacesByUUID[uuid]
 	if !ok {
@@ -784,11 +707,8 @@ func (ns *NamespaceStore) GetNamespace(ctx context.Context, uuid string) (*names
 func (ns *NamespaceStore) GetNamespaceByAccessor(ctx context.Context, id string) (*namespace.Namespace, error) {
 	defer metrics.MeasureSince([]string{"namespace", "get_namespace_by_accessor"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
 
 	item, ok := ns.namespacesByAccessor[id]
 	if !ok {
@@ -807,11 +727,12 @@ func (ns *NamespaceStore) GetNamespaceByLongestPrefix(ctx context.Context, path 
 		ctxNs = namespace.RootNamespace
 	}
 
-	combinedPath := ctxNs.Path + path
 	ns.lock.RLock()
+	defer ns.lock.RUnlock()
+
+	combinedPath := ctxNs.Path + path
 	prefix, entry, _ := ns.namespacesByPath.LongestPrefix(combinedPath)
 	entry.Tainted = entry.Tainted || ns.creationDeletionMap[entry.UUID]
-	ns.lock.RUnlock()
 	return entry, strings.TrimPrefix(combinedPath, prefix)
 }
 
@@ -819,11 +740,8 @@ func (ns *NamespaceStore) GetNamespaceByLongestPrefix(ctx context.Context, path 
 func (ns *NamespaceStore) GetNamespaceByPath(ctx context.Context, path string) (*namespace.Namespace, error) {
 	defer metrics.MeasureSince([]string{"namespace", "get_namespace_by_path"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
 
 	return ns.getNamespaceByPathLocked(ctx, path, false)
 }
@@ -863,19 +781,16 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 		return nil, nil, logical.CodedError(http.StatusBadRequest, "refusing to modify root namespace")
 	}
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return nil, nil, err
-	}
+	ns.lock.Lock()
 
 	entry := ns.namespacesByPath.Get(path)
 	if entry != nil {
 		if entry.Tainted {
-			unlock()
+			ns.lock.Unlock()
 			return nil, nil, errors.New("namespace with that name exists and is currently tainted")
 		}
 		if value := ns.creationDeletionMap[entry.UUID]; value {
-			unlock()
+			ns.lock.Unlock()
 			return nil, nil, errors.New("namespace with that name exists and is currently being created or deleted")
 		}
 
@@ -893,7 +808,7 @@ func (ns *NamespaceStore) ModifyNamespaceByPath(ctx context.Context, path string
 		entry.UnlockKey = ""
 		entry, err = callback(ctx, entry)
 		if err != nil {
-			unlock()
+			ns.lock.Unlock()
 			return nil, nil, err
 		}
 
@@ -931,11 +846,8 @@ func (ns *NamespaceStore) ListNamespaces(ctx context.Context, opts ListNamespace
 		return nil, err
 	}
 
-	unlock, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
 
 	var namespaces []*namespace.Namespace
 
@@ -979,11 +891,8 @@ func (ns *NamespaceStore) ListNamespaces(ctx context.Context, opts ListNamespace
 func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "seal_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return err
-	}
-	defer unlock()
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
 
 	namespaceToSeal, err := ns.getNamespaceByPathLocked(ctx, path, false)
 	if err != nil {
@@ -1070,21 +979,14 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return false, fmt.Errorf("error loading parent namespace from context: %w", err)
 	}
 
-	unlocker, err := ns.lockWithInvalidation(ctx, false)
-	if err != nil {
-		return false, err
-	}
+	ns.lock.Lock()
 
-	// We have multiple code paths we want to call unlock on.
-	var unlocked atomic.Bool
-	unlock := func() {
-		if !unlocked.CompareAndSwap(false, true) {
-			return
+	unlock := true
+	defer func() {
+		if unlock {
+			ns.lock.Unlock()
 		}
-
-		unlocker()
-	}
-	defer unlock()
+	}()
 
 	namespaceToUnseal, err := ns.getNamespaceByPathLocked(ctx, path, false)
 	if err != nil {
@@ -1127,9 +1029,10 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 		return true, fmt.Errorf("failed to modify namespace: %w", err)
 	}
 
-	// Unlock before calling unsealNamespace; we recurse back into the
-	// namespace store here.
-	unlock()
+	// Unlock before calling unsealNamespace; we recurse back into the namespace
+	// store here.
+	unlock = false
+	ns.lock.Unlock()
 
 	return true, ns.unsealNamespace(ctx, namespaceToUnseal)
 }
@@ -1140,16 +1043,8 @@ func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal
 
 	// Recurse loading all new namespaces starting at this one.
 	if err := func() error {
-		unlock, err := ns.lockWithInvalidation(ctx, true)
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			if unlock != nil {
-				unlock()
-			}
-		}()
+		ns.lock.Lock()
+		defer ns.lock.Unlock()
 
 		if err := ns.namespacesByPath.Insert(namespaceToUnseal); err != nil {
 			return err
@@ -1266,11 +1161,8 @@ func (ns *NamespaceStore) taintNamespace(ctx context.Context, parent, namespaceT
 func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "delete_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return "", err
-	}
-	defer unlock()
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
 
 	namespaceToDelete, err := ns.getNamespaceByPathLocked(ctx, path, false)
 	if err != nil {
@@ -1330,11 +1222,8 @@ func (ns *NamespaceStore) DeleteNamespace(ctx context.Context, path string) (str
 func (ns *NamespaceStore) DeleteSealedNamespace(ctx context.Context, path string, force bool) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "delete_sealed_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return "", err
-	}
-	defer unlock()
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
 
 	namespaceToDelete, err := ns.getNamespaceByPathLocked(ctx, path, false)
 	if err != nil || namespaceToDelete == nil {
@@ -1635,14 +1524,12 @@ func (ns *NamespaceStore) getLockingNamespace(n *namespace.Namespace) *namespace
 func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path string) error {
 	defer metrics.MeasureSince([]string{"namespace", "unlock_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return err
-	}
+	ns.lock.Lock()
 
+	unlock := true
 	defer func() {
-		if unlock != nil {
-			unlock()
+		if unlock {
+			ns.lock.Unlock()
 		}
 	}()
 
@@ -1686,7 +1573,7 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 	parentCtx := namespace.ContextWithNamespace(ctx, parentNs)
 
 	// setNamespaceLocked now handles unlocking.
-	unlock = nil
+	unlock = false
 	if _, err = ns.setNamespaceLocked(parentCtx, namespaceToUnlock, nil); err != nil {
 		return fmt.Errorf("unable to save unlocked namespace %q", namespaceToUnlock.Path)
 	}
@@ -1697,14 +1584,12 @@ func (ns *NamespaceStore) UnlockNamespace(ctx context.Context, unlockKey, path s
 func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (string, error) {
 	defer metrics.MeasureSince([]string{"namespace", "lock_namespace"}, time.Now())
 
-	unlock, err := ns.lockWithInvalidation(ctx, true)
-	if err != nil {
-		return "", err
-	}
+	ns.lock.Lock()
 
+	unlock := true
 	defer func() {
-		if unlock != nil {
-			unlock()
+		if unlock {
+			ns.lock.Unlock()
 		}
 	}()
 
@@ -1745,7 +1630,7 @@ func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (strin
 	parentCtx := namespace.ContextWithNamespace(ctx, parentNs)
 
 	// setNamespaceLocked now handles unlocking.
-	unlock = nil
+	unlock = false
 	if _, err = ns.setNamespaceLocked(parentCtx, namespaceToLock, nil); err != nil {
 		return "", fmt.Errorf("unable to save locked namespace %q", namespaceToLock.Path)
 	}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -263,8 +263,68 @@ func (c *Core) teardownNamespaceStore() error {
 	return nil
 }
 
-func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID string) error {
-	return nil
+func (ns *NamespaceStore) Invalidate(ctx context.Context, parentUUID, childUUID string) (*namespace.Namespace, bool, error) {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	// Do we know the parent namespace at all?
+	parent, ok := ns.namespacesByUUID[parentUUID]
+	if !ok {
+		// If not, it is most likely a child namespace of a sealable namespace
+		// that we simply don't know about on this standby, in which case we
+		// shouldn't error.
+		return nil, false, nil
+	}
+
+	// Try to re-read the namespace.
+	entry, err := ns.core.NamespaceView(parent).Get(ctx, namespaceStoreSubPath+childUUID)
+	switch {
+	case errors.Is(err, barrier.ErrBarrierSealed):
+		// This is okay, we have nothing to do as the parent is sealed.
+		return nil, false, nil
+	case err != nil:
+		return nil, false, err
+	}
+
+	// The namespace was deleted.
+	if entry == nil {
+		// If we have it in memory, remove it, or do nothing.
+		child, ok := ns.namespacesByUUID[childUUID]
+		if !ok {
+			return nil, false, nil
+		}
+
+		// If there remain further child namespaces in the tree, the ordering of
+		// this invalidation did not make much sense and we'd prefer to error.
+		if err := ns.namespacesByPath.Delete(child.Path); err != nil {
+			return nil, false, err
+		}
+		delete(ns.namespacesByUUID, child.UUID)
+		delete(ns.namespacesByAccessor, child.ID)
+		return child, true, nil
+	}
+
+	// The namespace was either modified or created. Refresh our in-memory
+	// state.
+	var child namespace.Namespace
+	if err := entry.DecodeJSON(&child); err != nil {
+		return nil, false, err
+	}
+
+	child.Locked = child.UnlockKey != ""
+
+	if err := ns.namespacesByPath.Insert(&child); err != nil {
+		return nil, false, err
+	}
+	ns.namespacesByUUID[child.UUID] = &child
+	ns.namespacesByAccessor[child.ID] = &child
+
+	if child.ManuallySealed {
+		// Ensure this namespace is sealed locally.
+		return &child, false, ns.sealNamespaceLocked(ctx, &child)
+	}
+
+	return &child, false, nil
 }
 
 // SetNamespace is used to create or update a namespace.
@@ -920,16 +980,13 @@ func (ns *NamespaceStore) SealNamespace(ctx context.Context, path string) error 
 		return errors.New("namespace from context is not the parent of the target namespace to seal")
 	}
 
-	// Mark the namespace as sealed before we seal it; this ensures future
-	// loads will reflect the desired status.
-	if !ns.core.Standby() {
-		// Now modify just this one namespace in storage to mark it sealed,
-		// forgetting the keys from all other nodes.
-		namespaceToSeal.ManuallySealed = true
-		nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
-		if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
-			return fmt.Errorf("failed to persist namespace: %w", err)
-		}
+	// Mark the namespace as manually sealed before we seal it; this ensures
+	// future loads will reflect the desired status. Additionally, standbys will
+	// see this update and seal the namespace accordingly.
+	namespaceToSeal.ManuallySealed = true
+	nsCopy := namespaceToSeal.Clone(true /* preserve unlock */)
+	if err := ns.writeNamespace(ctx, ns.core.NamespaceView(parent), nsCopy); err != nil {
+		return fmt.Errorf("failed to persist namespace: %w", err)
 	}
 
 	return ns.sealNamespaceLocked(ctx, namespaceToSeal)


### PR DESCRIPTION
## Description

An attempt at https://github.com/openbao/openbao/issues/3327, which it does resolve, though I need to do more testing and see if I broke anything that previously worked.

I'm fairly certain there was a reason we didn't do it this way before, probably concerns around ordering or so. I'd like to make the case that if we arrive at a nonsensical namespace tree, we just restart core, but do per-namespace reloads otherwise.

This fixes a class of bugs and should be a good performance improvement for instances with many namespaces, too.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3327

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
