### PR TITLE
Gracefully revert partial namespace unseal

### DIFF
--- a/changelog/3330.txt
+++ b/changelog/3330.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+namespaces: seal namespace back on failed postNamespaceUnseal to avoid dirty partial state
+```

--- a/changelog/3330.txt
+++ b/changelog/3330.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-namespaces: seal namespace back on failed postNamespaceUnseal to avoid dirty partial state
-```

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1134,7 +1134,17 @@ func (ns *NamespaceStore) UnsealNamespace(ctx context.Context, path string, key 
 	return true, ns.unsealNamespace(ctx, namespaceToUnseal)
 }
 
-func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal *namespace.Namespace) error {
+func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal *namespace.Namespace) (err error) {
+	defer func() {
+		if err != nil {
+			// If any step fails, the namespace is sealed back to avoid a dirty
+			// partial state.
+			if err := ns.SealNamespace(ns.core.activeContext.Load(), namespaceToUnseal.Path); err != nil {
+				ns.logger.Error("failed to re-seal namespace after failed unseal", "namespace", namespaceToUnseal.Path)
+			}
+		}
+	}()
+
 	var collected []*namespace.Namespace
 	collected = append(collected, namespaceToUnseal.Clone(false))
 
@@ -1191,16 +1201,7 @@ func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal
 
 // postNamespaceUnseal loads namespace credential and secret mounts,
 // initializes the backends and updates the router.
-// If any step fails the namespace is sealed back to avoid a dirty partial state.
-func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) (retErr error) {
-	defer func() {
-		if retErr != nil {
-			if err := ns.SealNamespace(ns.core.activeContext.Load(), unsealedNamespace.Path); err != nil {
-				ns.logger.Error("failed to re-seal namespace after failed unseal", "namespace", unsealedNamespace.Path)
-			}
-		}
-	}()
-
+func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) error {
 	if err := ns.core.loadMountsForNamespace(ctx, unsealedNamespace); err != nil {
 		return fmt.Errorf("failed to load mounts for namespace: %w", err)
 	}

--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1191,7 +1191,16 @@ func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal
 
 // postNamespaceUnseal loads namespace credential and secret mounts,
 // initializes the backends and updates the router.
-func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) error {
+// If any step fails the namespace is sealed back to avoid a dirty partial state.
+func (ns *NamespaceStore) postNamespaceUnseal(ctx context.Context, unsealedNamespace *namespace.Namespace) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			if err := ns.SealNamespace(ns.core.activeContext.Load(), unsealedNamespace.Path); err != nil {
+				ns.logger.Error("failed to re-seal namespace after failed unseal", "namespace", unsealedNamespace.Path)
+			}
+		}
+	}()
+
 	if err := ns.core.loadMountsForNamespace(ctx, unsealedNamespace); err != nil {
 		return fmt.Errorf("failed to load mounts for namespace: %w", err)
 	}

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -2134,3 +2134,75 @@ func TestNamespaceSealedLeaseTokenRevoke(t *testing.T) {
 		require.Error(collect, err, "resp: %v", resp)
 	}, 25*time.Second, 10*time.Millisecond)
 }
+
+// TestNamespaceStore_UnsealRollbackOnFailure verifies that if postNamespaceUnseal
+// fails partway through, the namespace is sealed back to a known clean state
+// rather than being left in a dirty partially-initialized state.
+func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
+	// corruptEntry overwrites the first entry under prefix with invalid JSON.
+	// Transactional backends store individual entries at prefix/<uuid>;
+	// legacy backends store a single combined entry at prefix directly.
+	corruptEntry := func(t *testing.T, ctx context.Context, view logical.Storage, prefix string) {
+		t.Helper()
+		uuids, err := view.List(ctx, prefix+"/")
+		require.NoError(t, err)
+		key := prefix
+		if len(uuids) > 0 {
+			key = prefix + "/" + uuids[0]
+		}
+		require.NoError(t, view.Put(ctx, &logical.StorageEntry{
+			Key:   key,
+			Value: []byte("{not valid json}"),
+		}))
+	}
+
+	testCases := []struct {
+		name    string
+		corrupt func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace)
+	}{
+		{
+			name: "corrupt mount table causes rollback",
+			corrupt: func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace) {
+				corruptEntry(t, ctx, c.NamespaceView(nsEntry), coreMountConfigPath)
+			},
+		},
+		{
+			name: "corrupt auth table causes rollback",
+			corrupt: func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace) {
+				corruptEntry(t, ctx, c.NamespaceView(nsEntry), coreAuthConfigPath)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, _ := TestCoreUnsealed(t)
+			s := c.namespaceStore
+			ctx := namespace.RootContext(t.Context())
+
+			ns := &namespace.Namespace{Path: "rollback-test/"}
+			keyShares := TestCoreCreateUnsealedNamespaces(t, c, ns)
+			require.False(t, c.NamespaceSealed(ns))
+
+			nsEntry, err := s.GetNamespaceByPath(ctx, "rollback-test/")
+			require.NoError(t, err)
+			require.NotNil(t, nsEntry)
+
+			tc.corrupt(t, ctx, c, nsEntry)
+
+			require.NoError(t, s.SealNamespace(ctx, "rollback-test"))
+			require.True(t, c.NamespaceSealed(nsEntry))
+
+			keys := keyShares["rollback-test/"]
+			var unsealErr error
+			for _, key := range keys {
+				_, unsealErr = s.UnsealNamespace(ctx, "rollback-test", key)
+				if unsealErr != nil {
+					break
+				}
+			}
+			require.Error(t, unsealErr)
+			require.True(t, c.NamespaceSealed(nsEntry), "namespace must be sealed back after failed postNamespaceUnseal")
+		})
+	}
+}

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -2139,38 +2139,39 @@ func TestNamespaceSealedLeaseTokenRevoke(t *testing.T) {
 // fails partway through, the namespace is sealed back to a known clean state
 // rather than being left in a dirty partially-initialized state.
 func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
-	// corruptEntry overwrites the first entry under prefix with invalid JSON.
-	// Transactional backends store individual entries at prefix/<uuid>;
-	// legacy backends store a single combined entry at prefix directly.
-	corruptEntry := func(t *testing.T, ctx context.Context, view logical.Storage, prefix string) {
+	// corruptEntry overwrites the first transactional entry under prefix with invalid JSON.
+	corruptEntry := func(t *testing.T, view logical.Storage, prefix string) {
 		t.Helper()
-		uuids, err := view.List(ctx, prefix+"/")
+		uuids, err := view.List(t.Context(), prefix+"/")
 		require.NoError(t, err)
-		key := prefix
-		if len(uuids) > 0 {
-			key = prefix + "/" + uuids[0]
-		}
-		require.NoError(t, view.Put(ctx, &logical.StorageEntry{
-			Key:   key,
+		require.NotEmpty(t, uuids, "expected at least one transactional mount entry under %s", prefix)
+		require.NoError(t, view.Put(t.Context(), &logical.StorageEntry{
+			Key:   prefix + "/" + uuids[0],
 			Value: []byte("{not valid json}"),
 		}))
 	}
 
 	testCases := []struct {
-		name    string
-		corrupt func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace)
+		name        string
+		corrupt     func(t *testing.T, c *Core, nsEntry *namespace.Namespace)
+		expectError bool
 	}{
 		{
+			name: "no corruption: unseal succeeds",
+		},
+		{
 			name: "corrupt mount table causes rollback",
-			corrupt: func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace) {
-				corruptEntry(t, ctx, c.NamespaceView(nsEntry), coreMountConfigPath)
+			corrupt: func(t *testing.T, c *Core, nsEntry *namespace.Namespace) {
+				corruptEntry(t, c.NamespaceView(nsEntry), coreMountConfigPath)
 			},
+			expectError: true,
 		},
 		{
 			name: "corrupt auth table causes rollback",
-			corrupt: func(t *testing.T, ctx context.Context, c *Core, nsEntry *namespace.Namespace) {
-				corruptEntry(t, ctx, c.NamespaceView(nsEntry), coreAuthConfigPath)
+			corrupt: func(t *testing.T, c *Core, nsEntry *namespace.Namespace) {
+				corruptEntry(t, c.NamespaceView(nsEntry), coreAuthConfigPath)
 			},
+			expectError: true,
 		},
 	}
 
@@ -2188,7 +2189,9 @@ func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, nsEntry)
 
-			tc.corrupt(t, ctx, c, nsEntry)
+			if tc.corrupt != nil {
+				tc.corrupt(t, c, nsEntry)
+			}
 
 			require.NoError(t, s.SealNamespace(ctx, "rollback-test"))
 			require.True(t, c.NamespaceSealed(nsEntry))
@@ -2196,13 +2199,20 @@ func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
 			keys := keyShares["rollback-test/"]
 			var unsealErr error
 			for _, key := range keys {
-				_, unsealErr = s.UnsealNamespace(ctx, "rollback-test", key)
-				if unsealErr != nil {
+				var unsealed bool
+				unsealed, unsealErr = s.UnsealNamespace(ctx, "rollback-test", key)
+				if unsealErr != nil || unsealed {
 					break
 				}
 			}
-			require.Error(t, unsealErr)
-			require.True(t, c.NamespaceSealed(nsEntry), "namespace must be sealed back after failed postNamespaceUnseal")
+
+			if tc.expectError {
+				require.Error(t, unsealErr)
+				require.True(t, c.NamespaceSealed(nsEntry), "namespace must be sealed back after failed postNamespaceUnseal")
+			} else {
+				require.NoError(t, unsealErr)
+				require.False(t, c.NamespaceSealed(nsEntry), "namespace must be unsealed after successful postNamespaceUnseal")
+			}
 		})
 	}
 }

--- a/vault/namespace_store_test.go
+++ b/vault/namespace_store_test.go
@@ -2135,9 +2135,9 @@ func TestNamespaceSealedLeaseTokenRevoke(t *testing.T) {
 	}, 25*time.Second, 10*time.Millisecond)
 }
 
-// TestNamespaceStore_UnsealRollbackOnFailure verifies that if postNamespaceUnseal
-// fails partway through, the namespace is sealed back to a known clean state
-// rather than being left in a dirty partially-initialized state.
+// TestNamespaceStore_UnsealRollbackOnFailure verifies that if unsealing a
+// namespace fails partway through, the namespace is sealed back to a known
+// clean state rather than being left in a dirty partially-initialized state.
 func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
 	// corruptEntry overwrites the first transactional entry under prefix with invalid JSON.
 	corruptEntry := func(t *testing.T, view logical.Storage, prefix string) {
@@ -2185,16 +2185,12 @@ func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
 			keyShares := TestCoreCreateUnsealedNamespaces(t, c, ns)
 			require.False(t, c.NamespaceSealed(ns))
 
-			nsEntry, err := s.GetNamespaceByPath(ctx, "rollback-test/")
-			require.NoError(t, err)
-			require.NotNil(t, nsEntry)
-
 			if tc.corrupt != nil {
-				tc.corrupt(t, c, nsEntry)
+				tc.corrupt(t, c, ns)
 			}
 
 			require.NoError(t, s.SealNamespace(ctx, "rollback-test"))
-			require.True(t, c.NamespaceSealed(nsEntry))
+			require.True(t, c.NamespaceSealed(ns))
 
 			keys := keyShares["rollback-test/"]
 			var unsealErr error
@@ -2208,10 +2204,10 @@ func TestNamespaceStore_UnsealRollbackOnFailure(t *testing.T) {
 
 			if tc.expectError {
 				require.Error(t, unsealErr)
-				require.True(t, c.NamespaceSealed(nsEntry), "namespace must be sealed back after failed postNamespaceUnseal")
+				require.True(t, c.NamespaceSealed(ns), "namespace must be sealed back after failed unseal")
 			} else {
 				require.NoError(t, unsealErr)
-				require.False(t, c.NamespaceSealed(nsEntry), "namespace must be unsealed after successful postNamespaceUnseal")
+				require.False(t, c.NamespaceSealed(ns), "namespace must be unsealed after successful unseal")
 			}
 		})
 	}


### PR DESCRIPTION
## Description

If any step of `postNamespaceUnseal` fails (e.g., corrupt mount table, failed credential loading), the namespace was left in a partially-initialized state: its barrier was unsealed, but mounts, credentials, or identity artifacts were not fully loaded. This made the namespace neither correctly sealed nor correctly operational.

This PR applies the same rollback pattern used by `postUnseal` for the root namespace.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
