### PR TITLE
Ensure workflows do not escape namespace hierarchy

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -591,20 +591,19 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	stop := context.AfterFunc(httpCtx, cancel)
 	defer stop()
 
+	nsHeader := namespace.HeaderFromContext(httpCtx)
 	contextNS, err := namespace.FromContext(httpCtx)
 	haveContextNS := err == nil
 
-	if haveContextNS {
+	if haveContextNS && nsHeader == "" {
 		// If we have a namespace in context, prepend its path to the request
-		// path before namespace resolution. We prepend to request path instead
-		// of prepending to header to guarantee that the header is always
-		// interpreted as an absolute path.
+		// path before namespace resolution unless a header is defined, which
+		// would set a new absolute path to join the request path to.
 		req.Path = contextNS.Path + req.Path
 	}
 
 	// Resolve the namespace for this request from header & path.
 	var ns *namespace.Namespace
-	nsHeader := namespace.HeaderFromContext(httpCtx)
 	ns, req.Path = c.namespaceStore.ResolveNamespaceFromRequest(nsHeader, req.Path)
 	if ns == nil {
 		return nil, logical.CodedError(http.StatusNotFound, "namespace not found")

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -47,7 +47,6 @@ import (
 )
 
 const (
-	replTimeout                           = 1 * time.Second
 	EnvVaultDisableLocalAuthMountEntities = "BAO_DISABLE_LOCAL_AUTH_MOUNT_ENTITIES"
 
 	// coreLockedUsersPath is a base path to store locked users
@@ -592,18 +591,37 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	stop := context.AfterFunc(httpCtx, cancel)
 	defer stop()
 
-	// A namespace was manually passed to HandleRequest, as can be the case with:
-	// 1. Synthesized logical requests not originating from an HTTP request
-	// 2. Tests
-	ns, err := namespace.FromContext(httpCtx)
-	var nsHeader string
-	if err != nil {
-		// If the above is not the case, resolve the namespace from header & request path.
-		nsHeader = namespace.HeaderFromContext(httpCtx)
-		ns, req.Path = c.namespaceStore.ResolveNamespaceFromRequest(nsHeader, req.Path)
-		if ns == nil {
-			return nil, logical.CodedError(http.StatusNotFound, "namespace not found")
-		}
+	contextNS, err := namespace.FromContext(httpCtx)
+	haveContextNS := err == nil
+
+	if haveContextNS {
+		// If we have a namespace in context, prepend its path to the request
+		// path before namespace resolution. We prepend to request path instead
+		// of prepending to header to guarantee that the header is always
+		// interpreted as an absolute path.
+		req.Path = contextNS.Path + req.Path
+	}
+
+	// Resolve the namespace for this request from header & path.
+	var ns *namespace.Namespace
+	nsHeader := namespace.HeaderFromContext(httpCtx)
+	ns, req.Path = c.namespaceStore.ResolveNamespaceFromRequest(nsHeader, req.Path)
+	if ns == nil {
+		return nil, logical.CodedError(http.StatusNotFound, "namespace not found")
+	}
+
+	if haveContextNS && !ns.HasParent(contextNS) {
+		// If we were externally passed a namespace via context previously (as
+		// is the case for some tests and synthetic requests sent within
+		// core), ensure that the namespace resolved above does not escape the
+		// context's namespace. This is important e.g. for the workflow store,
+		// where we'd like subsequent requests to not escape the namespace that
+		// the workflow is hosted in.
+		return nil, logical.CodedError(
+			http.StatusBadRequest,
+			"subsequent request to namespace %q cannot escape namespace %q",
+			ns.Path, contextNS.Path,
+		)
 	}
 
 	if ns.ID != namespace.RootNamespaceID {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -595,11 +595,13 @@ func (c *Core) switchedLockHandleRequest(httpCtx context.Context, req *logical.R
 	contextNS, err := namespace.FromContext(httpCtx)
 	haveContextNS := err == nil
 
-	if haveContextNS && nsHeader == "" {
-		// If we have a namespace in context, prepend its path to the request
-		// path before namespace resolution unless a header is defined, which
-		// would set a new absolute path to join the request path to.
-		req.Path = contextNS.Path + req.Path
+	if haveContextNS {
+		// If we have a namespace in context, prepend its path to namespace
+		// header. As a result, the namespace header is relative when a
+		// namespace is in context (e.g., if this call originates from the
+		// workflow store), but absolute otherwise. A canonicalized namespace
+		// path ends in a '/', so a basic concatenation is fine.
+		nsHeader = contextNS.Path + nsHeader
 	}
 
 	// Resolve the namespace for this request from header & path.

--- a/vault/workflow_store.go
+++ b/vault/workflow_store.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	urlpath "path"
 	"path/filepath"
 	"strings"
 
@@ -292,11 +291,6 @@ func (ws *WorkflowStore) List(ctx context.Context, prefix string, recursive bool
 }
 
 func (ws *WorkflowStore) Execute(ctx context.Context, reqId string, path string, unauthed bool, trace bool, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to find namespace in context: %w", err)
-	}
-
 	// Reject trace requests when unauthenticated.
 	if unauthed && trace {
 		return nil, logical.ErrPermissionDenied
@@ -375,17 +369,13 @@ func (ws *WorkflowStore) Execute(ctx context.Context, reqId string, path string,
 		// this policy can only access requests under its own namespace and
 		// forbid requests to parent namespaces.
 		profiles.WithRequestHandler(func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
-			// When a namespace header exists in the synthetic request, we
-			// have to inject it into the namespace header, ensuring we set
-			// the prefix accordingly.
+			// When a namespace header exists in the synthetic request, we have
+			// to inject it into the namespace header.
 			if values, ok := req.Headers[consts.NamespaceHeaderName]; ok {
 				if len(values) > 1 {
 					return nil, fmt.Errorf("have %q values for %q header; expected only 1", len(values), consts.NamespaceHeaderName)
 				}
-
-				nsHeader := namespace.HeaderFromContext(ctx)
-				nsHeader = urlpath.Join(nsHeader, values[0])
-				ctx = namespace.ContextWithNamespaceHeader(ctx, nsHeader)
+				ctx = namespace.ContextWithNamespaceHeader(ctx, values[0])
 			}
 
 			// We guarantee we come in from the profile system, which means
@@ -398,24 +388,18 @@ func (ws *WorkflowStore) Execute(ctx context.Context, reqId string, path string,
 		return nil, fmt.Errorf("failed building profile engine: %w", err)
 	}
 
-	// HandleRequest will force all requests with a given namespace to be
-	// routed to the namespace in the context, even if the request path has
-	// a different namespace.
-	noNsCtx := namespace.ContextWithNamespace(ctx, nil)
-	noNsCtx = namespace.ContextWithNamespaceHeader(noNsCtx, ns.Path)
-
 	if trace {
-		result := engine.Debug(noNsCtx)
+		result := engine.Debug(ctx)
 		return &logical.Response{
 			Data: result,
 		}, nil
 	}
 
 	if output != nil {
-		return engine.EvaluateResponse(noNsCtx)
+		return engine.EvaluateResponse(ctx)
 	}
 
-	if err := engine.Evaluate(noNsCtx); err != nil {
+	if err := engine.Evaluate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to evaluate workflow: %w", err)
 	}
 


### PR DESCRIPTION
## Description

This seeks to address two related issues in workflow execution namespace routing.

1. Workflow execution could escape boundary of the namespace the execution was originally called from via path traversal in the 'X-Vault-Namespace' header. We don't want to allow this; requests generated by a workflow should not unexpectedly leave the hierarchy of the workflow's namespace. Making requests to the same namespace and any of its children is fine.

2. Any time we set X-Vault-Namespace, it should be the start of an absolute path. It is always interpreted this way for requests arriving externally, it should not suddenly become a path relative to the workflow's hosting namespace when set in a profile.

We can enforce this property more globally in request handling, depending on whether we get a namespace passed in `httpCtx`. If so, we can compare it against the namespace otherwise resolved from header + path.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
