### PR TITLE
Do not attempt post-unseal on sealed namespaces

### DIFF
--- a/vault/namespace_store.go
+++ b/vault/namespace_store.go
@@ -1169,7 +1169,9 @@ func (ns *NamespaceStore) unsealNamespace(ctx context.Context, namespaceToUnseal
 				ns.namespacesByUUID[newNs.UUID] = newNs
 				ns.namespacesByAccessor[newNs.ID] = newNs
 
-				collected = append(collected, newNs.Clone(false))
+				if !ns.core.NamespaceSealed(newNs) {
+					collected = append(collected, newNs.Clone(false))
+				}
 
 				return nil
 			})


### PR DESCRIPTION
## Description
When we unseal namespace we load all child namespaces until we find next sealed namespace, we load it into the storage to recognize an attempt to unseal it. This fixes an attempt to run post-unseal on a namespace that was loaded to storage but is sealed (sealable child of a sealed namespace get implicitly sealed).

courtesy of @satoqz
script to reproduce on main:
```
#!/usr/bin/env sh
set -euo pipefail

ns1=$(bao namespace create -format=json -key-shares=1 -key-threshold=1 ns1 | jq -r '.key_shares.[0]')
bao namespace unseal ns1 "$ns1"
ns2=$(bao namespace create -format=json -key-shares=1 -key-threshold=1 -ns=ns1 ns2 | jq -r '.key_shares.[0]')
bao namespace unseal -ns=ns1 ns2 "$ns2"
ns3=$(bao namespace create -format=json -key-shares=1 -key-threshold=1 -ns=ns1/ns2 ns3 | jq -r '.key_shares.[0]')
bao namespace unseal -ns=ns1/ns2 ns3 "$ns3"
ns4=$(bao namespace create -format=json -key-shares=1 -key-threshold=1 -ns=ns1/ns2/ns3 ns4 | jq -r '.key_shares.[0]')
bao namespace unseal -ns=ns1/ns2/ns3 ns4 "$ns4"

bao namespace seal -ns=ns1/ns2/ns3 ns4
bao namespace seal -ns=ns1 ns2
bao namespace unseal -ns=ns1 ns2 "$ns2"
```

## Rationale
namespace sealing bugfixing

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
