### PR TITLE
Fix release workflow prerelease detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
             dist/*
         env:
           VERSION: ${{ needs.setup.outputs.version }}
-          PRERELEASE: ${{ inputs.nightly || contains(steps.version.outputs.version, '-') }}
+          PRERELEASE: ${{ inputs.nightly || contains(needs.setup.outputs.version, '-') }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload GPG signing key


### PR DESCRIPTION
## Description

I ran a test non-nightly pre-release in a fork repo and noticed this evaluated to the wrong value (and doesn't even error...)

## Rationale

Not critical since it creates a draft release, and the `prerelease` flag is purely cosmetic as far as I can tell. But it's nice to have the right value filled into the draft.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
