### PR TITLE
Add workflow store logger to core loggers

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2277,7 +2277,7 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, c *Core, standby
 		return err
 	}
 
-	c.setupWorkflowStore(ctx)
+	c.setupWorkflowStore()
 
 	return nil
 }

--- a/vault/workflow_store.go
+++ b/vault/workflow_store.go
@@ -107,6 +107,7 @@ type WorkflowStore struct {
 
 func NewWorkflowStore(c *Core) *WorkflowStore {
 	logger := c.baseLogger.Named("workflow")
+	c.AddLogger(logger)
 	return &WorkflowStore{
 		core:        c,
 		modifyLocks: locksutil.CreateLocks(),
@@ -114,7 +115,7 @@ func NewWorkflowStore(c *Core) *WorkflowStore {
 	}
 }
 
-func (c *Core) setupWorkflowStore(ctx context.Context) {
+func (c *Core) setupWorkflowStore() {
 	c.workflowStore = NewWorkflowStore(c)
 }
 


### PR DESCRIPTION
## Description
`(*Core)` manages a list of all loggers to do bulk operations like (and probably only) set log level through API operation, workflow store logger wasn't on that list, so this fixes that by adding it.

## Rationale
minor fix

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
