### PR TITLE
fix(command): revoke self-init root token

### DIFF
--- a/changelog/3346.txt
+++ b/changelog/3346.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Revoke the transient root token after declarative self-initialization, including failure paths.
+```

--- a/command/self_init_root_token_test.go
+++ b/command/self_init_root_token_test.go
@@ -1,0 +1,220 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/command/server"
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/helper/testhelpers/teststorage"
+	vaulthttp "github.com/openbao/openbao/http"
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/vault"
+	"github.com/openbao/openbao/vault/seal"
+	"github.com/stretchr/testify/require"
+)
+
+const testSelfInitProofToken = "self-init-proof-reader"
+
+func TestSelfInitRevokesRootToken(t *testing.T) {
+	tests := []struct {
+		name             string
+		disableSSCTokens bool
+		explicitRevoke   bool
+		failAfterCapture bool
+		wantErr          bool
+	}{
+		{
+			name:             "success",
+			disableSSCTokens: true,
+		},
+		{
+			name: "ssc_tokens",
+		},
+		{
+			name:             "explicit_revoke_self",
+			disableSSCTokens: true,
+			explicitRevoke:   true,
+		},
+		{
+			name:             "failure_after_capture",
+			disableSSCTokens: true,
+			failAfterCapture: true,
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, core, cleanup := testSelfInitCore(t, tt.disableSSCTokens)
+			t.Cleanup(cleanup)
+
+			config := testSelfInitRootTokenConfig(t, tt.explicitRevoke, tt.failAfterCapture)
+			err := cmd.Initialize(core, config)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			rootToken := testSelfInitCapturedRootToken(t, core)
+			entry, err := core.LookupToken(namespace.RootContext(context.Background()), rootToken)
+			require.NoError(t, err)
+			require.Nil(t, entry)
+		})
+	}
+}
+
+func testSelfInitCore(t *testing.T, disableSSCTokens bool) (*ServerCommand, *vault.Core, func()) {
+	t.Helper()
+
+	testSeal, _ := seal.NewTestSeal(nil)
+	autoSeal, err := vault.NewAutoSeal(testSeal)
+	require.NoError(t, err)
+
+	logger := log.NewInterceptLogger(&log.LoggerOptions{Level: log.Debug})
+	conf, opts := teststorage.ClusterSetup(&vault.CoreConfig{
+		DisableCache:       true,
+		DisableSSCTokens:   disableSSCTokens,
+		Logger:             logger,
+		Seal:               autoSeal,
+		CredentialBackends: defaultVaultCredentialBackends,
+		AuditBackends:      defaultVaultAuditBackends,
+		LogicalBackends:    defaultVaultLogicalBackends,
+	}, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+		Logger:      logger,
+		NumCores:    1,
+		SkipInit:    true,
+	}, nil)
+
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+
+	cmd := &ServerCommand{
+		BaseCommand: &BaseCommand{
+			UI: cli.NewMockUi(),
+		},
+		ShutdownCh: MakeShutdownCh(),
+		SighupCh:   MakeSighupCh(),
+		SigUSR2Ch:  MakeSigUSR2Ch(),
+		logger:     logger,
+	}
+
+	return cmd, cluster.Cores[0].Core, cluster.Cleanup
+}
+
+func testSelfInitRootTokenConfig(t *testing.T, explicitRevoke, failAfterCapture bool) *server.Config {
+	t.Helper()
+
+	var revokeSelf string
+	if explicitRevoke {
+		revokeSelf = `
+  request "revoke-self" {
+    operation = "update"
+    path      = "auth/token/revoke-self"
+  }
+`
+	}
+
+	var fail string
+	if failAfterCapture {
+		fail = `
+  request "fail-duplicate-mount" {
+    operation = "update"
+    path      = "sys/mounts/secret"
+    data = {
+      type = "kv"
+    }
+  }
+`
+	}
+
+	config, err := server.ParseConfig(fmt.Sprintf(`
+initialize "proof" {
+  request "mount-kv" {
+    operation = "update"
+    path      = "sys/mounts/secret"
+    data = {
+      type = "kv"
+      options = {
+        version = "2"
+      }
+    }
+  }
+
+  request "add-proof-reader-policy" {
+    operation = "update"
+    path      = "sys/policies/acl/proof-reader"
+    data = {
+      policy = <<-EOF
+        path "secret/data/root-token-proof" {
+          capabilities = ["read"]
+        }
+      EOF
+    }
+  }
+
+  request "create-proof-token" {
+    operation = "update"
+    path      = "auth/token/create"
+    data = {
+      id                = %q
+      policies          = ["proof-reader"]
+      no_parent         = true
+      no_default_policy = true
+    }
+  }
+
+  request "lookup-self" {
+    operation = "read"
+    path      = "auth/token/lookup-self"
+  }
+
+  request "capture-root-token" {
+    operation = "update"
+    path      = "secret/data/root-token-proof"
+    data = {
+      data = {
+        token = {
+          eval_source     = "response"
+          eval_type       = "string"
+          initialize_name = "proof"
+          response_name   = "lookup-self"
+          field_selector  = ["data", "id"]
+        }
+      }
+    }
+  }
+%s%s
+}
+`, testSelfInitProofToken, revokeSelf, fail), "self-init-root-token-test")
+	require.NoError(t, err)
+
+	return config
+}
+
+func testSelfInitCapturedRootToken(t *testing.T, core *vault.Core) string {
+	t.Helper()
+
+	ctx := namespace.RootContext(context.Background())
+	resp, err := core.HandleRequest(ctx, &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "secret/data/root-token-proof",
+		ClientToken: testSelfInitProofToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError(), resp.Error())
+
+	data, ok := resp.Data["data"].(map[string]interface{})
+	require.True(t, ok)
+	token, ok := data["token"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, token)
+
+	return token
+}

--- a/command/server.go
+++ b/command/server.go
@@ -1738,7 +1738,7 @@ func (c *ServerCommand) waitForLeader(core *vault.Core) (bool, error) {
 // Initialize performs declarative self-initialization of a production-mode
 // OpenBao core. This will exit early if there is no configuration for this
 // or if the core is already initialized.
-func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) error {
+func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) (retErr error) {
 	// Skip initialize for dev server as it is handled in initDevCore
 	if len(config.Initialization) == 0 || c.flagDev {
 		return nil
@@ -1780,6 +1780,36 @@ func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) erro
 		}
 		return fmt.Errorf("self-initialization failed: %w", err)
 	}
+	defer func() {
+		req := &logical.Request{
+			ID:          "self-init-revoke-root",
+			Operation:   logical.UpdateOperation,
+			ClientToken: init.RootToken,
+			Path:        "auth/token/revoke-self",
+		}
+		alreadyRevoked := func() bool {
+			entry, lookupErr := core.LookupToken(ctx, init.RootToken)
+			if lookupErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("failed to confirm self-init root token revocation: %w", lookupErr))
+				return false
+			}
+			return entry == nil
+		}
+		resp, err := core.HandleRequest(ctx, req)
+		if err != nil {
+			if alreadyRevoked() {
+				return
+			}
+			retErr = errors.Join(retErr, fmt.Errorf("failed to revoke self-init root token: %w", err))
+			return
+		}
+		if resp != nil && resp.IsError() {
+			if alreadyRevoked() {
+				return
+			}
+			retErr = errors.Join(retErr, fmt.Errorf("failed to revoke self-init root token: %s", resp.Error()))
+		}
+	}()
 
 	// Wait for leadership; if we don't get the leadership status, it means
 	// that someone has brought up more than one node at a time and we've


### PR DESCRIPTION
## Description
This PR updates declarative self-initialization so the transient root token created during `core.Initialize` is revoked after self-init finishes.

The cleanup is deferred immediately after successful initialization, so it runs on both successful and failed self-init paths. Revocation is performed through the normal token handler path using `auth/token/revoke-self`.

## Rationale

Declarative self-init needs a temporary root token to perform first-boot configuration. That token should not remain usable after self-init has completed or failed.

This was reported and discussed with maintainers before opening this PR publicly and was classified as a normal bug rather than a security advisory.

Resolves: #3345

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.