### PR TITLE
Add node existence check before attempting promotion or demotion in raft cluster

### DIFF
--- a/changelog/3350.txt
+++ b/changelog/3350.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/raft: Added existence verification of the raft node before attempting to promote or demote.
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1249,15 +1250,15 @@ func (b *RaftBackend) PromotePeer(ctx context.Context, peerID string) error {
 		return fmt.Errorf("failed to get Raft peers: %s", err)
 	}
 
-	found := false
-	addr := ""
-	for _, peer := range peers {
-		if peer.ID == peerID {
-			addr = peer.Address
-			found = true
-			break
+	var addr string
+	found := slices.ContainsFunc(peers, func(p Peer) bool {
+		if p.ID == peerID {
+			addr = p.Address
+			return true
 		}
-	}
+		return false
+	})
+
 	if !found {
 		return fmt.Errorf("server %s not found in raft configuration", peerID)
 	}
@@ -1296,15 +1297,7 @@ func (b *RaftBackend) DemotePeer(ctx context.Context, peerID string) error {
 		return fmt.Errorf("failed to get Raft peers: %s", err)
 	}
 
-	found := false
-	for _, peer := range peers {
-		if peer.ID == peerID {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !slices.ContainsFunc(peers, func(p Peer) bool { return p.ID == peerID }) {
 		return fmt.Errorf("server %s not found in raft configuration", peerID)
 	}
 

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1244,28 +1244,25 @@ func (b *RaftBackend) PromotePeer(ctx context.Context, peerID string) error {
 		return err
 	}
 
+	peers, err := b.Peers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Raft peers: %s", err)
+	}
+
+	found := false
+	addr := ""
+	for _, peer := range peers {
+		if peer.ID == peerID {
+			addr = peer.Address
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("server %s not found in raft configuration", peerID)
+	}
+
 	if b.disableAutopilot {
-		if b.raft == nil {
-			return errors.New("raft storage is not initialized")
-		}
-		peers, err := b.Peers(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get Raft peers: %s", err)
-		}
-
-		found := false
-		addr := ""
-		for _, peer := range peers {
-			if peer.ID == peerID {
-				addr = peer.Address
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("server %s not found in raft configuration", peerID)
-		}
-
 		future := b.raft.AddVoter(raft.ServerID(peerID), raft.ServerAddress(addr), 0, 0)
 		if err := future.Error(); err != nil {
 			return fmt.Errorf("failed to promote non-voter to voter: %s", err)
@@ -1294,34 +1291,30 @@ func (b *RaftBackend) DemotePeer(ctx context.Context, peerID string) error {
 		return err
 	}
 
-	if b.disableAutopilot {
-		if b.raft == nil {
-			return errors.New("raft storage is not initialized")
-		}
+	peers, err := b.Peers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Raft peers: %s", err)
+	}
 
+	found := false
+	for _, peer := range peers {
+		if peer.ID == peerID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("server %s not found in raft configuration", peerID)
+	}
+
+	if b.disableAutopilot {
 		// refuse to demote current leader to not trigger a leader election
 		// when the leader is demoted. This is not necessary if autopilot is enabled,
 		// as it will handle this case for us and only demote the leader after a
 		// leader election
 		if strings.EqualFold(peerID, b.localID) {
 			return errors.New("refusing to demote current leader")
-		}
-
-		peers, err := b.Peers(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get Raft peers: %s", err)
-		}
-
-		found := false
-		for _, peer := range peers {
-			if peer.ID == peerID {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return fmt.Errorf("server %s not found in raft configuration", peerID)
 		}
 
 		future := b.raft.DemoteVoter(raft.ServerID(peerID), 0, 0)


### PR DESCRIPTION
## Description
This PR adds existence check of a node before attempting demotion or promotion while running raft autopilot.

before:
```
$ bao operator raft promote test 
Error promoting server: Error making API request.

URL: PUT http://127.0.0.1:8300/v1/sys/storage/raft/promote
Code: 500. Errors:

* 1 error occurred:
	* server is not a non-voter


$ bao operator raft demote test
Server demoted successfully!
```
after:
```
$ bao operator raft promote test
Error promoting server: Error making API request.

URL: PUT http://127.0.0.1:8300/v1/sys/storage/raft/promote
Code: 500. Errors:

* 1 error occurred:
	* server test not found in raft configuration


$ bao operator raft demote test
Error promoting server: Error making API request.

URL: PUT http://127.0.0.1:8300/v1/sys/storage/raft/demote
Code: 500. Errors:

* 1 error occurred:
	* server test not found in raft configuration
```

## Rationale
Before you could add a non-existing server ID to the list of the cluster non-voters, which wasn't ideal.

Resolves: #3085 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
