### PR TITLE
identity: gracefully skip partially-created namespaces during unseal

### DIFF
--- a/changelog/3353.txt
+++ b/changelog/3353.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/namespaces: gracefully skip partially-created namespaces during unseal instead of panicking
+```

--- a/vault/identity/store_util.go
+++ b/vault/identity/store_util.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	ErrDuplicateIdentityName = errors.New("duplicate identity name")
-	ErrCycleDetectedPrefix   = "cyclic relationship detected for member group ID"
-	tmpSuffix                = ".tmp"
+	ErrDuplicateIdentityName       = errors.New("duplicate identity name")
+	ErrNamespaceNotInIdentityStore = errors.New("namespace not registered in identity store")
+	ErrCycleDetectedPrefix         = "cyclic relationship detected for member group ID"
+	tmpSuffix                      = ".tmp"
 )
 
 func (i *IdentityStore) sanitizeName(name string) string {
@@ -51,7 +52,11 @@ func (i *IdentityStore) LoadGroups(ctx context.Context, readOnly bool) error {
 	}
 
 	i.logger.Debug("identity loading groups", "namespace", ns.Path)
-	existing, err := i.GroupPacker(ctx).View().List(ctx, groupBucketsPrefix)
+	gp := i.GroupPacker(ctx)
+	if gp == nil {
+		return fmt.Errorf("%w: %s", ErrNamespaceNotInIdentityStore, ns.UUID)
+	}
+	existing, err := gp.View().List(ctx, groupBucketsPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to scan for groups: %w", err)
 	}
@@ -151,7 +156,11 @@ func (i *IdentityStore) LoadEntities(ctx context.Context, readOnly bool) error {
 	}
 
 	i.logger.Debug("loading entities", "namespace", ns.Path)
-	existing, err := i.EntityPacker(ctx).View().List(ctx, storagepacker.StoragePackerBucketsPrefix)
+	ep := i.EntityPacker(ctx)
+	if ep == nil {
+		return fmt.Errorf("%w: %s", ErrNamespaceNotInIdentityStore, ns.UUID)
+	}
+	existing, err := ep.View().List(ctx, storagepacker.StoragePackerBucketsPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to scan for entities: %w", err)
 	}

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/errwrap"
@@ -69,10 +70,24 @@ func (c *Core) loadIdentityStoreArtifactsForNamespace(ctx context.Context, ns *n
 
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 
+	warnAndSkip := func() {
+		c.logger.Warn("skipping identity store loading for namespace whose setup did not complete; "+
+			"use recovery mode to remove the corrupt entry if this persists",
+			"namespace_id", ns.ID)
+	}
+
 	if err := c.identityStore.LoadEntities(ctx, readOnly); err != nil {
+		if errors.Is(err, ident.ErrNamespaceNotInIdentityStore) {
+			warnAndSkip()
+			return nil
+		}
 		return err
 	}
 	if err := c.identityStore.LoadGroups(ctx, readOnly); err != nil {
+		if errors.Is(err, ident.ErrNamespaceNotInIdentityStore) {
+			warnAndSkip()
+			return nil
+		}
 		return err
 	}
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -2043,3 +2043,42 @@ func TestIdentityStore_UnsafeCrossNamespace(t *testing.T) {
 	err = is.SanitizeAndUpsertGroup(ns1Ctx, ns1Group, nil, nil)
 	require.NoError(t, err)
 }
+
+// TestLoadIdentityStoreArtifactsForNamespace verifies both the happy path and
+// the crash-recovery path for loadIdentityStoreArtifactsForNamespace.
+// A namespace whose setup completed normally must load without error; a
+// namespace present in storage but absent from the identity store's in-memory
+// view (setup crashed before AddNamespaceView was called) must be skipped
+// gracefully instead of causing a nil pointer dereference panic.
+func TestLoadIdentityStoreArtifactsForNamespace(t *testing.T) {
+	testCases := []struct {
+		name        string
+		ns          *namespace.Namespace
+		expectError bool
+	}{
+		{
+			name: "registered namespace loads successfully",
+			ns:   namespace.RootNamespace,
+		},
+		{
+			name: "unregistered namespace is skipped without panic",
+			ns: &namespace.Namespace{
+				ID:   "orphan1234",
+				UUID: "orphan-uuid-1234-5678-abcd-ef0123456789",
+				Path: "orphan/",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, _ := TestCoreUnsealed(t)
+			err := c.loadIdentityStoreArtifactsForNamespace(t.Context(), tc.ns, false)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

When a server crashes mid-namespace-creation, the namespace UUID is written to
storage under `core/namespaces/` but `AddNamespaceView` is never called,
leaving the identity store's in-memory `views` map with no entry for that UUID.

On the next restart, `loadIdentityStoreArtifacts` iterates all namespaces from
storage (including the orphan entry) and calls `LoadEntities` and `LoadGroups`
for each. Both functions call `EntityPacker`/`GroupPacker`, which internally
call `getNSView`. When the view is absent, these return `nil`. The immediate
call to `.View()` on the nil packer produces a nil pointer dereference panic,
making the server permanently unbootable without manual intervention.

The fix adds `ErrNamespaceNotInIdentityStore` as a typed sentinel and returns
it from `LoadEntities` and `LoadGroups` when their packer is nil, converting
the crash into a recoverable error. `loadIdentityStoreArtifactsForNamespace`
catches this error symmetrically for both load steps and skips the namespace
with a warning that references recovery mode for cleanup.

**Performance**: there is no additional storage I/O. The check relies on
`i.views.Load(ns.UUID)` — a `sync.Map` lookup that is O(1) and purely
in-memory. The `views` map is already populated during `setupMounts` as part
of the normal unseal sequence. If the view is absent, it means `setupMounts`
never completed for that namespace. There is no per-namespace storage read
added, so there is little speed impact on large deployments.

The root cause that produced the inconsistent storage state was fixed in
#2226. This PR addresses surviving that state on clusters that were affected
before the fix, or any future inconsistency of the same kind.

## Rationale

Resolves: #2921

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
