### PR TITLE
Fix source tarball release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,12 @@ jobs:
         with:
           package_json_file: ui/package.json
 
+      - name: Set up UI cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: http/web_ui/
+          key: ${{ github.ref }}-ui
+
       - name: Make LICENSE_NODE_MODULES.txt
         run: |
           pnpm install
@@ -244,15 +250,22 @@ jobs:
 
       - name: Make SPDX_NODE_MODULES.txt
         run: |
-          jq -r .license ui/node_modules/*/package.json | \
-            grep -v url | \
-            sed 's/.*"type": "//;s/",//' | \
-            grep -v { | grep -v } | grep -v ^null$ | \
-            awk '{if ((($2 == "OR") || ($2 == "AND")) && (substr($1, 0, 1) != "(")) { print "(" $0 ")"} else {print $0}}' | \
-            sort -u > SPDX_NODE_MODULES.txt
+          pnpm licenses list --prod --json \
+            | jq -r '. | keys[]' \
+            | awk '{if ((($2 == "OR") || ($2 == "AND")) && (substr($1, 0, 1) != "(")) { print "(" $0 ")"} else {print $0}}' \
+            | sort -u \
+            > ../SPDX_NODE_MODULES.txt
+        working-directory: ui
 
       - name: Make VERSION_NODE_MODULES.txt
-        run: jq -r '"\(.name) \(.version)"' ui/node_modules/*/package.json > VERSION_NODE_MODULES.txt
+        run: |
+          # Note: Also use 'pnpm licenses list' instead of 'pnpm list' just for
+          # version listing as this yields a flat list, while 'pnpm list' lists
+          # a tree that is harder to traverse.
+          pnpm licenses list --prod --json \
+            | jq -r 'to_entries[] | .value[] | .name as $name | .versions[] | "\($name) \(.)"' \
+            > ../VERSION_NODE_MODULES.txt
+        working-directory: ui
 
       - name: Make LICENSE_DEPENDENCIES.md
         run: |


### PR DESCRIPTION
## Description

PNPM only links direct dependencies to the top-level of `node_modules/`, so we must use a deeper traversal.

Also add the UI cache step to the dist tarball job so it includes the built UI. I had thought of this, but it must've silently disappeared in some refactor.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3351

@DrDaveD there are some new licenses that appear but those seem to legitimately stem from UI dependency upgrades that happened with v2.6.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
