### PR TITLE
raft: truncate raft log based on number of entries in log

### DIFF
--- a/changelog/3381.txt
+++ b/changelog/3381.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Fix raft log growing indefinitely if fewer than snapshot_threshold entries are written before next restart.
+```

--- a/internal/physical/raft/chunking_test.go
+++ b/internal/physical/raft/chunking_test.go
@@ -29,10 +29,6 @@ func TestRaft_Chunking_Lifecycle(t *testing.T) {
 
 	b := GetRaft(t, true, false)
 
-	t.Log("applying configuration")
-
-	b.applyConfigSettings(raft.DefaultConfig())
-
 	t.Log("chunking")
 
 	buf := []byte("let's see how this goes, shall we?")
@@ -112,10 +108,6 @@ func TestFSM_Chunking_TermChange(t *testing.T) {
 	assert := assert.New(t)
 
 	b := GetRaft(t, true, false)
-
-	t.Log("applying configuration")
-
-	b.applyConfigSettings(raft.DefaultConfig())
 
 	t.Log("chunking")
 

--- a/internal/physical/raft/raft.go
+++ b/internal/physical/raft/raft.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -127,6 +128,21 @@ type RaftBackend struct {
 	// stableStore is used by the raft library to store additional metadata in
 	// durable storage.
 	stableStore raft.StableStore
+
+	// snapshotThreshold defines the minimum number of log entries between log truncation operations.
+	snapshotThreshold uint64
+
+	// trailingLogs defines how many log entries are left in the log store after log truncation.
+	trailingLogs uint64
+
+	// snapshotInterval defines how often to check if log truncation is needed.
+	snapshotInterval time.Duration
+
+	// logTruncationStopCh is closed to stop the log truncation worker.
+	logTruncationStopCh chan struct{}
+
+	// logTruncationDoneCh is closed when the log truncation worker has exited.
+	logTruncationDoneCh chan struct{}
 
 	// bootstrapConfig is only set when this node needs to be bootstrapped upon
 	// startup.
@@ -817,33 +833,48 @@ func (b *RaftBackend) applyConfigSettings(config *raft.Config) error {
 	config.HeartbeatTimeout *= time.Duration(multiplier)
 	config.LeaderLeaseTimeout *= time.Duration(multiplier)
 
+	b.snapshotThreshold = config.SnapshotThreshold
+	b.trailingLogs = config.TrailingLogs
+	b.snapshotInterval = config.SnapshotInterval
+
+	// Disable hashicorp/raft's snapshot-driven log truncation.
+	// It counts entries since the last snapshot to decide when to truncate, but
+	// BoltSnapshotStore.List() must report a snapshot at the last applied index,
+	// otherwise Raft replays the log at startup. This resets the counter and
+	// prevents truncation from triggering if fewer than snapshot_threshold
+	// entries are written before next restart.
+	config.SnapshotThreshold = math.MaxUint64
+	config.SnapshotInterval = math.MaxInt64 / 2
+	config.TrailingLogs = math.MaxUint64
+
 	snapThresholdRaw, ok := b.conf["snapshot_threshold"]
 	if ok {
-		var err error
 		snapThreshold, err := strconv.Atoi(snapThresholdRaw)
 		if err != nil {
 			return err
 		}
-		config.SnapshotThreshold = uint64(snapThreshold)
+		b.snapshotThreshold = uint64(snapThreshold)
 	}
 
 	trailingLogsRaw, ok := b.conf["trailing_logs"]
 	if ok {
-		var err error
 		trailingLogs, err := strconv.Atoi(trailingLogsRaw)
 		if err != nil {
 			return err
 		}
-		config.TrailingLogs = uint64(trailingLogs)
+		b.trailingLogs = uint64(trailingLogs)
 	}
+
 	snapshotIntervalRaw, ok := b.conf["snapshot_interval"]
 	if ok {
-		var err error
 		snapshotInterval, err := parseutil.ParseDurationSecond(snapshotIntervalRaw)
 		if err != nil {
 			return err
 		}
-		config.SnapshotInterval = snapshotInterval
+		if snapshotInterval < 5*time.Millisecond {
+			return fmt.Errorf("snapshot_interval is too low")
+		}
+		b.snapshotInterval = snapshotInterval
 	}
 
 	config.NoSnapshotRestoreOnStart = true
@@ -1140,6 +1171,11 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 		}
 	}
 
+	// Start background log truncation worker.
+	b.logTruncationStopCh = make(chan struct{})
+	b.logTruncationDoneCh = make(chan struct{})
+	go b.startLogTruncationWorker()
+
 	b.logger.Trace("finished setting up raft cluster")
 	return nil
 }
@@ -1165,6 +1201,13 @@ func (b *RaftBackend) TeardownCluster(clusterListener cluster.ClusterHook) error
 	// If we're tearing down, then we need to recreate the raftInitCh
 	b.raftInitCh = make(chan struct{})
 	b.l.Unlock()
+
+	// Stop the truncation worker and wait for any unfinished delete operations to finish.
+	if b.logTruncationStopCh != nil {
+		close(b.logTruncationStopCh)
+		<-b.logTruncationDoneCh
+		b.logTruncationStopCh = nil
+	}
 
 	if future != nil {
 		return future.Error()
@@ -1844,6 +1887,52 @@ func (b *RaftBackend) applyLog(ctx context.Context, command *LogData) error {
 	}
 
 	return nil
+}
+
+// startLogTruncationWorker runs the background log truncation loop.
+func (b *RaftBackend) startLogTruncationWorker() {
+	defer close(b.logTruncationDoneCh)
+
+	// Truncate logs at startup to remove entries that exceeded the threshold before previous shutdown.
+	b.truncateLog()
+
+	for {
+		extra := time.Duration(rand.Int63()) % b.snapshotInterval
+		timer := time.NewTimer(b.snapshotInterval + extra)
+		select {
+		case <-b.logTruncationStopCh:
+			timer.Stop()
+			return
+		case <-timer.C:
+			b.truncateLog()
+		}
+	}
+}
+
+// truncateLog deletes old log entries if the log has grown beyond snapshotThreshold + trailingLogs.
+// After truncation, only trailingLogs entries are kept.
+func (b *RaftBackend) truncateLog() {
+	minLog, err := b.logStore.FirstIndex()
+	if err != nil || minLog == 0 {
+		return
+	}
+
+	applied, _ := b.fsm.LatestState()
+	if applied.Index < minLog {
+		return
+	}
+
+	entryCount := applied.Index - minLog + 1
+	if entryCount <= b.snapshotThreshold+b.trailingLogs {
+		return
+	}
+
+	maxLog := applied.Index - b.trailingLogs
+	err = b.logStore.DeleteRange(minLog, maxLog)
+	if err != nil {
+		b.logger.Error("raft log truncation failed", "from", minLog, "to", maxLog, "error", err)
+		return
+	}
 }
 
 // HAEnabled is the implementation of the HABackend interface

--- a/internal/physical/raft/raft_test.go
+++ b/internal/physical/raft/raft_test.go
@@ -551,7 +551,7 @@ func TestRaft_Recovery(t *testing.T) {
 
 func TestRaft_Backend_Performance(t *testing.T) {
 	t.Parallel()
-	b := GetRaft(t, true, false)
+	b := GetRaft(t, false, false)
 	dir := b.dataDir
 
 	defaultConfig := raft.DefaultConfig()

--- a/internal/physical/raft/raft_test.go
+++ b/internal/physical/raft/raft_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -647,6 +648,97 @@ func TestRaft_LeaderConstant(t *testing.T) {
 	// Delete(...) operations on the standby result in forwarding
 	// to the active.
 	require.True(t, logical.ShouldForward(raft.ErrNotLeader))
+}
+
+func TestRaft_LogTruncation(t *testing.T) {
+	const (
+		snapshotThreshold = 5
+		trailingLogs      = 5
+	)
+
+	conf := map[string]string{
+		"path":                   t.TempDir(),
+		"node_id":                "abc123",
+		"trailing_logs":          strconv.Itoa(trailingLogs),
+		"snapshot_threshold":     strconv.Itoa(snapshotThreshold),
+		"snapshot_interval":      "1s",
+		"performance_multiplier": "1",
+	}
+
+	backend, err := NewRaftBackend(conf, hclog.NewNullLogger())
+	require.NoError(t, err)
+	rb := backend.(*RaftBackend)
+	require.NoError(t, rb.Bootstrap([]Peer{{ID: rb.NodeID(), Address: rb.NodeID()}}))
+
+	// startCluster restarts the cluster and waits for it to be up.
+	startCluster := func() {
+		require.NoError(t, rb.TeardownCluster(nil))
+		require.NoError(t, rb.SetupCluster(t.Context(), SetupOpts{}))
+		require.Eventually(t, func() bool {
+			return rb.raft.State() == raft.Leader && rb.raft.AppliedIndex() >= rb.raft.LastIndex()
+		}, 3*time.Second, 100*time.Millisecond, "expected leader with all entries applied")
+	}
+
+	// writeEntries writes n entries and waits for them to be applied.
+	writeEntries := func(n int) {
+		for i := range n {
+			require.NoError(t, rb.Put(t.Context(), &physical.Entry{
+				Key:   fmt.Sprintf("key-%d", i),
+				Value: []byte("value"),
+			}))
+		}
+		require.Eventually(t, func() bool {
+			state, _ := rb.fsm.LatestState()
+			return state.Index >= rb.raft.LastIndex()
+		}, 5*time.Second, 100*time.Millisecond, "expected all entries to be applied")
+	}
+
+	// assertFirstIndex until the log's first index equals expected, or fails on timeout
+	assertFirstIndex := func(expected uint64) {
+		t.Helper()
+		var actual uint64
+		require.Eventually(t, func() bool {
+			var err error
+			actual, err = rb.logStore.FirstIndex()
+			return err == nil && actual == expected
+		}, 10*time.Second, 100*time.Millisecond, "expected firstIndex=%d, got %d", expected, actual)
+	}
+
+	// logEntryCount returns the number of log entries currently in the log.
+	logEntryCount := func() uint64 {
+		first, err := rb.logStore.FirstIndex()
+		require.NoError(t, err)
+		last, err := rb.logStore.LastIndex()
+		require.NoError(t, err)
+		return last - first + 1
+	}
+
+	startCluster()
+
+	// 1. Start with empty log. First index in raft.db should be 1.
+	assertFirstIndex(1)
+
+	// 2. Write entries but stay below the truncation trigger (snapshotThreshold + trailingLogs = 10).
+	writeEntries(5)
+	require.Less(t, logEntryCount(), uint64(snapshotThreshold+trailingLogs),
+		"entries below snapshot threshold, no snapshot expected")
+	assertFirstIndex(1)
+
+	// 3. Restart the cluster.
+	startCluster()
+
+	// 4. Write enough entries so the log exceeds the truncation trigger.
+	writeEntries(3)
+	require.Greater(t, logEntryCount(), uint64(snapshotThreshold+trailingLogs),
+		"entries exceed snapshot threshold, snapshot should fire")
+
+	// 5. Snapshot should delete log entries from raft.db, leaving only trailing logs.
+	last, err := rb.logStore.LastIndex()
+	require.NoError(t, err)
+	expectedFirst := last - trailingLogs + 1
+	assertFirstIndex(expectedFirst)
+
+	require.NoError(t, rb.TeardownCluster(nil))
 }
 
 func BenchmarkDB_Puts(b *testing.B) {

--- a/internal/physical/raft/raft_test.go
+++ b/internal/physical/raft/raft_test.go
@@ -730,7 +730,7 @@ func TestRaft_LogTruncation(t *testing.T) {
 	// 4. Write enough entries so the log exceeds the truncation trigger.
 	writeEntries(3)
 	require.Greater(t, logEntryCount(), uint64(snapshotThreshold+trailingLogs),
-		"entries exceed snapshot threshold, snapshot should fire")
+		"entries exceed snapshot threshold, truncation should trigger")
 
 	// 5. Snapshot should delete log entries from raft.db, leaving only trailing logs.
 	last, err := rb.logStore.LastIndex()

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -80,29 +80,29 @@ backend cannot be declared.
   production OpenBao servers. The maximum allowed value is 10.
 
 - `trailing_logs` `(integer: 10000)` - This controls how many log entries are
-  left in the log store on disk after a snapshot is made. This should only be
-  adjusted when followers cannot catch up to the leader due to a very large
-  snapshot size and high write throughput causing log truncation before a
-  snapshot can be fully installed. If you need to use this to recover a cluster,
+  left in the log store on disk after truncation. This should only be
+  adjusted when followers cannot catch up to the leader due to
+  high write throughput causing log truncation before a follower can replicate
+  the entries. If you need to use this to recover a cluster,
   consider reducing write throughput or the amount of data stored on OpenBao. The
   default value is 10000 which is suitable for all normal workloads. The
   `trailing_logs` metric is not the same as `max_trailing_logs`.
 
 - `snapshot_threshold` `(integer: 8192)` - This controls the minimum number of Raft
-  commit entries between snapshots that are saved to disk. This is a low-level
+  commit entries between log truncations. This is a low-level
   parameter that should rarely need to be changed. Very busy clusters
   experiencing excessive disk IO may increase this value to reduce disk IO and
-  minimize the chances of all servers taking snapshots at the same time.
+  minimize the chances of all servers truncating at the same time.
   Increasing this trades off disk IO for disk space since the log will grow much
   larger and the space in the `raft.db` file can't be reclaimed till the next
-  snapshot. Servers may take longer to recover from crashes or failover if this
+  truncation. Servers may take longer to recover from crashes or failover if this
   is increased significantly as more logs will need to be replayed.
 
 - `snapshot_interval` `(integer: 120 seconds)` - The snapshot interval
-   controls how often Raft checks whether a snapshot operation is
-   required. Raft randomly staggers snapshots between the configured
+   controls how often each node checks whether log truncation is
+   needed. Each node randomly staggers between the configured
    interval and twice the configured interval to keep the entire cluster
-   from performing a snapshot at once. The default snapshot interval is
+   from performing a truncation at once. The default snapshot interval is
    120 seconds.
 
 - `retry_join` `(list: [])` <a name="retry_join"></a> - A set of connection details for another node in the

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -103,7 +103,7 @@ backend cannot be declared.
    needed. Each node randomly staggers between the configured
    interval and twice the configured interval to keep the entire cluster
    from performing a truncation at once. The default snapshot interval is
-   120 seconds.
+   120 seconds and the minimum value is 5ms.
 
 - `retry_join` `(list: [])` <a name="retry_join"></a> - A set of connection details for another node in the
   cluster, which is used to help nodes locate a leader in order to join a cluster.

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -75,15 +75,12 @@ are blocked until they are _committed_ and _applied_.
 #### Compacting logs
 
 It would be undesirable to allow a replicated log to grow in an unbounded
-fashion. Raft provides a mechanism by which the current state is saved to
-snapshots and its related logs are compacted. Because of the FSM abstraction,
-restoring the state of the FSM must result in the same state as a replay of old
-logs. This allows Raft to capture the FSM state at a point in time and then remove
-all the logs that were used to reach that state. This is performed automatically
+fashion. OpenBao periodically truncates old log entries that have already been
+applied to the FSM. Since the data is already persisted to disk in
+BoltDB, old log entries can simply be deleted. This is performed automatically
 without user intervention and prevents unbounded disk usage while also minimizing
-the time spent replaying logs. One of the advantages of using BoltDB is that it
-allows OpenBao's snapshots to be very light weight. Since OpenBao's data is already
-persisted to disk in BoltDB, the snapshot process just needs to truncate the raft logs.
+the time spent replaying logs. BoltDB does not shrink files on disk when data is
+deleted; it marks the space as free for reuse by future writes.
 
 #### Quorum
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This pull request replaces `github.com/hashicorp/raft` snapshot-driven log truncation with a background worker in OpenBao. This worker manages log truncation based on the actual number of entries in the log.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Fix a bug where `raft.db` log grows indefinitely if fewer than `snapshot_threshold` entries are written before next restart.

Background:

`github.com/hashicorp/raft` implements the snapshotting mechanism defined by the Raft algorithm. Because BoltDB persists data automatically, OpenBao does not require real snapshots. So, snapshotting is implemented as a no-op, serving only as a trigger to delete old log entries.

This creates a side effect: at startup, the Raft algorithm needs to know the last snapshot point to know which entries to replay from the log. To prevent unnecessary log replays, OpenBao's Raft backend "synthesizes" a snapshot point at the last applied index ([link](https://github.com/openbao/openbao/blob/e7c03d362ce067f614a795fd3c813b538d74bd8e/physical/raft/snapshot.go#L134-L166)). 

While this avoids unnecessary replays, the algorithm also uses this fake snapshot point to manage its snapshotting logic. It assumes a snapshot was just taken and the log was truncated, practically reseting the threshold counter at every restart without considering the actual number of entries in the log. As a result, if fewer than `snapshot_threshold` entries are written before next restart, the algorithm never triggers a snapshot, causing the log file to grow indefinitely.

This change (practically) disables Raft's built-in snapshot mechanism and implements truncation based on the actual log entry count. It also updates the documentation to focus less on how the Raft algorithm works and more on how it is implemented with BoltDB.

Resolves: #3342

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
