### PR TITLE
Publish betas into testing RPM/DEB repos 

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -95,8 +95,15 @@ jobs:
       - name: Install rpm & createrepo_c
         run: sudo apt install -y rpm createrepo-c
 
+      - name: Determine repository
+        run: |
+          case "$VERSION" in
+            *-*) echo REPO=rpm-testing ;;
+            *)   echo REPO=rpm ;;
+          esac > "$GITHUB_ENV"
+
       - name: Download repodata
-        run: aws s3 sync "s3://${BUCKET}/rpm" build/rpm --exclude \*.rpm
+        run: aws s3 sync "s3://${BUCKET}/${REPO}" build/rpm --exclude \*.rpm
 
       - name: Download packages from release
         run: ./scripts/release/download-artifacts.sh
@@ -108,4 +115,4 @@ jobs:
         run: ./scripts/release/update-rpm-repo.sh
 
       - name: Upload repository
-        run: aws s3 sync build/rpm "s3://${BUCKET}/rpm"
+        run: aws s3 sync build/rpm "s3://${BUCKET}/${REPO}"

--- a/scripts/release/update-deb-repo.sh
+++ b/scripts/release/update-deb-repo.sh
@@ -5,6 +5,11 @@
 
 set -euo pipefail
 
+case "$VERSION" in
+  *-*) SUITE=testing ;;
+  *)   SUITE=stable  ;;
+esac
+
 mkdir -p build/deb/conf
 
 cat > build/deb/conf/distributions <<-EOF
@@ -14,9 +19,19 @@ cat > build/deb/conf/distributions <<-EOF
 	Codename: stable
 	Architectures: amd64 arm64 armhf ppc64el riscv64 s390x
 	Components: main
-	Description: Official APT repository for OpenBao
+	Description: Official APT repository for OpenBao releases
+	SignWith: ${GPG_FINGERPRINT}
+	Limit: 0
+
+	Origin: OpenBao - Official
+	Label: OpenBao
+	Suite: testing
+	Codename: testing
+	Architectures: amd64 arm64 armhf ppc64el riscv64 s390x
+	Components: main
+	Description: Official APT repository for OpenBao pre-releases
 	SignWith: ${GPG_FINGERPRINT}
 	Limit: 0
 EOF
 
-reprepro -b build/deb includedeb stable dist/*.deb
+reprepro -b build/deb includedeb "$SUITE" dist/*.deb

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -217,7 +217,7 @@ const Asset = ({ urls }) => {
   );
 };
 
-const DebRepo = ({ gpgKeyName }) => {
+const DebRepo = ({ version, gpgKeyName }) => {
   const [gpgKey, setGPGKey] = useState("");
   useEffect(() => {
     try {
@@ -242,7 +242,7 @@ const DebRepo = ({ gpgKeyName }) => {
       >
         {`Types: deb
 URIs: https://pkgs.openbao.org/deb/
-Suites: stable
+Suites: ${version.includes("-") ? "testing" : "stable"}
 Components: main
 Signed-By:
 ` + gpgKey.replaceAll(/^(?!$)/gm, " ")}
@@ -255,7 +255,7 @@ Signed-By:
   );
 };
 
-const RpmRepo = ({ gpgKeyName }) => {
+const RpmRepo = ({ version, gpgKeyName }) => {
   return (
     <>
       <h4>Installation via official Package Repository</h4>
@@ -269,7 +269,7 @@ const RpmRepo = ({ gpgKeyName }) => {
       >
         {`[openbao]
 name=openbao
-baseurl=https://pkgs.openbao.org/rpm/$basearch
+baseurl=https://pkgs.openbao.org/${version.includes("-") ? "rpm-testing" : "rpm"}/$basearch
 repo_gpgcheck=0
 gpgcheck=1
 enabled=1
@@ -286,13 +286,13 @@ metadata_expire=300`}
   );
 };
 
-const PackageRepo = ({ type }) => {
-  var gpgKeyName = "openbao-gpg-pub-20240618.asc";
+const PackageRepo = ({ type, version }) => {
+  const gpgKeyName = "openbao-gpg-pub-20240618.asc";
 
   return (
     <>
-      {type === "deb" && <DebRepo gpgKeyName={gpgKeyName} />}
-      {type === "rpm" && <RpmRepo gpgKeyName={gpgKeyName} />}
+      {type === "deb" && <DebRepo version={version} gpgKeyName={gpgKeyName} />}
+      {type === "rpm" && <RpmRepo version={version} gpgKeyName={gpgKeyName} />}
     </>
   );
 };
@@ -344,60 +344,6 @@ const Docker = ({ version, name }) => {
   );
 };
 
-const LinuxPackage = ({ version, name }) => {
-  const { options } = useOptions();
-  return (
-    <Tabs>
-      <TabItem value="deb" label="DEB">
-        <PackageRepo type={"deb"} />
-        <nav className="pagination-nav">
-          {version &&
-            Object(options)[version]["assets"][name] &&
-            Object(options)[version]["assets"][name]["deb"] &&
-            ArchPackageMapApply(
-              Object(options)[version]["assets"][name]["deb"],
-              (props, idx) => <Asset key={idx} urls={props} />,
-            )}
-        </nav>
-      </TabItem>
-      <TabItem value="rpm" label="RPM">
-        <PackageRepo type={"rpm"} />
-        <nav className="pagination-nav">
-          {version &&
-            Object(options)[version]["assets"][name] &&
-            Object(options)[version]["assets"][name]["rpm"] &&
-            ArchPackageMapApply(
-              Object(options)[version]["assets"][name]["rpm"],
-              (props, idx) => <Asset key={idx} urls={props} />,
-            )}
-        </nav>
-      </TabItem>
-      <TabItem value="pkg" label="PKG">
-        <nav className="pagination-nav">
-          {version &&
-            Object(options)[version]["assets"][name] &&
-            Object(options)[version]["assets"][name]["pkg"] &&
-            ArchPackageMapApply(
-              Object(options)[version]["assets"][name]["pkg"],
-              (props, idx) => <Asset key={idx} urls={props} />,
-            )}
-        </nav>
-      </TabItem>
-      <TabItem value="binary" label="Binary">
-        <nav className="pagination-nav">
-          {version &&
-            Object(options)[version]["assets"][name] &&
-            Object(options)[version]["assets"][name]["binary"] &&
-            ArchPackageMapApply(
-              Object(options)[version]["assets"][name]["binary"],
-              (props, idx) => <Asset key={idx} urls={props} />,
-            )}
-        </nav>
-      </TabItem>
-    </Tabs>
-  );
-};
-
 const OS = ({ name }) => {
   const { options, selectedItem } = useOptions();
   var version = "";
@@ -431,7 +377,7 @@ const OS = ({ name }) => {
 
     return (
       <>
-        <PackageRepo type={tab.type} />
+        <PackageRepo type={tab.type} version={version} />
         {tab.header && <h4>{tab.header}</h4>}
         {hasAssets && (
           <nav className="pagination-nav">


### PR DESCRIPTION
## Description

Publish beta releases into separate repos on pkgs.openbao.org. For RPMs, this introduces a separate "rpm-testing" repo, for DEBs, this adds a "testing" suite.

Removing v2.6-beta from stable repos is another challenge, but this at least ensures that future betas won't land in the wrong place. We can however re-publish the beta into the testing repo rather easily by just re-running the workflow, so the downloads page won't point at an empty repo. Hosted repos were originally introduced with v2.5 GA, so v2.6 beta is the only version to worry about at the moment.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3384

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
