### PR TITLE
Add plugin client handling for go-kms-wrapping/kms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,8 +98,9 @@ require (
 	github.com/moby/moby/client v0.5.0
 	github.com/oklog/run v1.2.0
 	github.com/okta/okta-sdk-golang/v2 v2.20.0
-	github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0
-	github.com/openbao/go-kms-wrapping/v2 v2.8.0
+	github.com/openbao/go-kms-wrapping/kms/transit/v2 v2.0.0-20260626131931-998c8a6f17f4
+	github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.1-0.20260626131931-998c8a6f17f4
+	github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4
 	github.com/openbao/go-kms-wrapping/wrappers/kmip/v2 v2.2.0
 	github.com/openbao/go-kms-wrapping/wrappers/static/v2 v2.2.0
 	github.com/openbao/go-kms-wrapping/wrappers/transit/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -605,10 +605,12 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0 h1:LxZHcCv8S3888OSAKs2n0rPurDstKiisAkr0U5s/qg8=
-github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0/go.mod h1:BSu5AczP5Y/8a/VDoBv/+aIooj09axNPVg/XYq9u2AQ=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0 h1:9gXkCmcMadJO2Ozf9TNTIInSqdOwAD6k3HhHMhIqzrs=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0/go.mod h1:KyL1nfZM8SzLgMchvFU2F5jS/XlauD3TRCjmILLErh4=
+github.com/openbao/go-kms-wrapping/kms/transit/v2 v2.0.0-20260626131931-998c8a6f17f4 h1:LDxQjQsELH6tiqZBl77u/GYIZRt2qqKj1IKCdFc2i+U=
+github.com/openbao/go-kms-wrapping/kms/transit/v2 v2.0.0-20260626131931-998c8a6f17f4/go.mod h1:6YvCS2DdKEIf1s6ZGWaIeFOyXg9yGQH1jYKRBBDCXmI=
+github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.1-0.20260626131931-998c8a6f17f4 h1:CfrD/C7qk3ulknCQt/tVcL2cIqqI7fZI+S6M4gvOkgM=
+github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.1-0.20260626131931-998c8a6f17f4/go.mod h1:4GW0HdXEvYJN4gkNU9uZWHIX+fBSc0cPLiRj+vLanw8=
+github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4 h1:SfN6JMUOfRHMt2dyYHumvIWEiTshQiTOYXGLyNgikz0=
+github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4/go.mod h1:KyL1nfZM8SzLgMchvFU2F5jS/XlauD3TRCjmILLErh4=
 github.com/openbao/go-kms-wrapping/wrappers/kmip/v2 v2.2.0 h1:7aw+PZT0FDYdDwFgY1DYwfYQM/AGeeVuR8rZiMRDVW0=
 github.com/openbao/go-kms-wrapping/wrappers/kmip/v2 v2.2.0/go.mod h1:Hy4IzXyXggGmea0f5bmd2Za6tj+E6i6BY5lQ0lLcMjE=
 github.com/openbao/go-kms-wrapping/wrappers/static/v2 v2.2.0 h1:/x6gb7EucO++KI7wtx14L/E7eoErHXzNi+9DWJDB7lM=

--- a/internal/helper/kmsplugin/catalog_test.go
+++ b/internal/helper/kmsplugin/catalog_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/go-kms-wrapping/kms/transit/v2"
 	gkwplugin "github.com/openbao/go-kms-wrapping/plugin/v2"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/go-kms-wrapping/wrappers/static/v2"
@@ -20,39 +21,56 @@ import (
 
 const TestPluginServerEnv = "BAO_TEST_PLUGIN_SERVER"
 
-// TestPluginServer is not an actual test but a hack to reuse the test binary
-// as a plugin binary that is called into by the same test binary from the main
-// test runner process.
-func TestPluginServer(t *testing.T) {
+// TestStaticPluginServer runs a plugin that serves the static wrapper.
+func TestStaticPluginServer(t *testing.T) {
 	if _, ok := os.LookupEnv(TestPluginServerEnv); !ok {
 		t.Skip()
 	}
 
 	gkwplugin.Serve(&gkwplugin.ServeOpts{
 		WrapperFactoryFunc: func() wrapping.Wrapper {
-			// We use the static wrapper as the wrapper to test with as it does
-			// not require making any external infrastructure available.
 			return static.NewWrapper()
 		},
 	})
 }
 
-// testBinaryHash returns the SHA-256 hash of the executing test binary.
-func testBinaryHash(t *testing.T) string {
-	hash, err := osutil.FileSha256Sum(os.Args[0])
-	require.NoError(t, err)
-	return hash
+// TestTransitPluginServer runs a plugin that serves the Transit KMS.
+func TestTransitPluginServer(t *testing.T) {
+	if _, ok := os.LookupEnv(TestPluginServerEnv); !ok {
+		t.Skip()
+	}
+
+	gkwplugin.Serve(&gkwplugin.ServeOpts{
+		KMSFactoryFunc: transit.New,
+	})
 }
 
-// testPluginConfig returns a plugin config for [TestPluginServer].
-func testPluginConfig(t *testing.T) *server.PluginConfig {
-	return &server.PluginConfig{
-		Type:      consts.PluginTypeKMS.String(),
-		Name:      "static",
-		Command:   filepath.Base(os.Args[0]),
-		Env:       []string{TestPluginServerEnv + "=1"},
-		Args:      []string{"-test.run=TestPluginServer"},
-		SHA256Sum: testBinaryHash(t),
+var StaticPluginConfig = &server.PluginConfig{
+	Name: "static",
+	Args: []string{"-test.run=TestStaticPluginServer"},
+}
+
+var TransitPluginConfig = &server.PluginConfig{
+	Name: "transit",
+	Args: []string{"-test.run=TestTransitPluginServer"},
+}
+
+func init() {
+	command := filepath.Base(os.Args[0])
+
+	sha256sum, err := osutil.FileSha256Sum(os.Args[0])
+	if err != nil {
+		panic(err)
+	}
+
+	for _, config := range []*server.PluginConfig{
+		StaticPluginConfig,
+		TransitPluginConfig,
+	} {
+		config.Type = consts.PluginTypeKMS.String()
+		config.Command = command
+		config.SHA256Sum = sha256sum
+		config.Env = []string{TestPluginServerEnv + "=1"}
 	}
 }
 
@@ -62,7 +80,7 @@ func TestGetClient(t *testing.T) {
 	catalog, err := NewCatalog(logger, &server.Config{
 		PluginDirectory: filepath.Dir(os.Args[0]),
 		Plugins: []*server.PluginConfig{
-			testPluginConfig(t),
+			StaticPluginConfig,
 			// This one should be ignored as it is a secrets engine plugin.
 			{Type: consts.PluginTypeSecrets.String(), Name: "foo"},
 		},
@@ -101,7 +119,7 @@ func TestReloadClient(t *testing.T) {
 	logger := hclog.Default()
 	catalog, err := NewCatalog(logger, &server.Config{
 		PluginDirectory: filepath.Dir(os.Args[0]),
-		Plugins:         []*server.PluginConfig{testPluginConfig(t)},
+		Plugins:         []*server.PluginConfig{StaticPluginConfig},
 	})
 	require.NoError(t, err, "catalog should create successfully")
 
@@ -137,27 +155,32 @@ func TestBadClientConfig(t *testing.T) {
 	logger := hclog.Default()
 	tests := map[string]*server.Config{
 		"NoPluginDirectory": {
-			Plugins: []*server.PluginConfig{testPluginConfig(t)},
+			Plugins: []*server.PluginConfig{StaticPluginConfig},
 		},
 		"BadPluginDirectory": {
 			PluginDirectory: t.TempDir(),
-			Plugins:         []*server.PluginConfig{testPluginConfig(t)},
+			Plugins:         []*server.PluginConfig{StaticPluginConfig},
 		},
 		"NoChecksum": {
 			PluginDirectory: filepath.Dir(os.Args[0]),
-			Plugins: []*server.PluginConfig{func() *server.PluginConfig {
-				config := testPluginConfig(t)
-				config.SHA256Sum = ""
-				return config
-			}()},
+			Plugins: []*server.PluginConfig{{
+				Type:    StaticPluginConfig.Type,
+				Name:    StaticPluginConfig.Name,
+				Command: StaticPluginConfig.Command,
+				Args:    StaticPluginConfig.Args,
+				Env:     StaticPluginConfig.Env,
+			}},
 		},
 		"BadChecksum": {
 			PluginDirectory: filepath.Dir(os.Args[0]),
-			Plugins: []*server.PluginConfig{func() *server.PluginConfig {
-				config := testPluginConfig(t)
-				config.SHA256Sum = config.SHA256Sum[1:] + "0"
-				return config
-			}()},
+			Plugins: []*server.PluginConfig{{
+				Type:      StaticPluginConfig.Type,
+				Name:      StaticPluginConfig.Name,
+				Command:   StaticPluginConfig.Command,
+				Args:      StaticPluginConfig.Args,
+				Env:       StaticPluginConfig.Env,
+				SHA256Sum: StaticPluginConfig.SHA256Sum[:1] + "0",
+			}},
 		},
 	}
 

--- a/internal/helper/kmsplugin/kms.go
+++ b/internal/helper/kmsplugin/kms.go
@@ -1,0 +1,357 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package kmsplugin
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/openbao/go-kms-wrapping/kms/transit/v2"
+	gkwplugin "github.com/openbao/go-kms-wrapping/plugin/v2"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
+)
+
+var builtinKMSes = map[string]func() kms.KMS{
+	"transit": transit.New,
+}
+
+// OpenKMS creates a new KMS instance and calls Open with the provided options.
+// This may dispatch to either a builtin KMS or an external pluginized one.
+func (c *Catalog) OpenKMS(ctx context.Context, name string, opts *kms.OpenOptions) (s kms.KMS, err error) {
+	client, ok, err := c.getClient(name)
+	switch {
+	case err != nil:
+		return nil, err
+
+	case !ok:
+		// Try builtin KMSes.
+		if builtin, ok := builtinKMSes[name]; ok {
+			s = builtin()
+		} else {
+			return nil, fmt.Errorf("unknown KMS: %s", name)
+		}
+
+	default:
+		defer func() {
+			if err != nil {
+				client.close()
+			}
+		}()
+
+		// Each call to Dispense creates a new KMS instance on the remote.
+		raw, err := client.Dispense("kms")
+		if err != nil {
+			return nil, err
+		}
+
+		s = &remoteKMS{
+			client: client,
+			kms:    raw.(kms.KMS),
+		}
+	}
+
+	if err := s.Open(ctx, opts); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// remoteKMS adds plugin reloading & finalization hooks on top of a pluginized
+// kms.KMS.
+type remoteKMS struct {
+	kms.UnimplementedKMS
+
+	mu sync.RWMutex
+
+	client *client
+	kms    kms.KMS
+
+	canary int
+	opts   *kms.OpenOptions
+}
+
+// retry calls f and retries it once if interrupted by a plugin shutdown.
+func (s *remoteKMS) retry(ctx context.Context, f func() error) error {
+	var canary int
+
+	// call is a helper to call f under a read lock and record the current
+	// client pointer as a reload canary value.
+	call := func() error {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		if s.kms == nil {
+			return errors.New("KMS was closed")
+		}
+
+		canary = s.canary
+
+		return f()
+	}
+
+	if err := call(); err != gkwplugin.ErrPluginShutdown {
+		// Plugin works and call either succeeded or returned an
+		// application-level error.
+		return err
+	}
+
+	// Try to reload the plugin & reinstantiate the KMS.
+	if err := s.reload(ctx, canary); err != nil {
+		return err
+	}
+
+	// Then give this another shot.
+	return call()
+}
+
+// reload attempts to reload the underlying plugin and reinstantiate the remote
+// KMS instance.
+func (s *remoteKMS) reload(ctx context.Context, canary int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.client == nil {
+		return errors.New("KMS was closed")
+	}
+
+	if s.canary > canary {
+		// Another caller managed to reload before we got the lock.
+		return nil
+	}
+
+	client, err := s.client.catalog.reloadClient(s.client)
+	if err != nil {
+		return err
+	}
+
+	raw, err := client.Dispense("kms")
+	if err != nil {
+		return err
+	}
+
+	kms := raw.(kms.KMS)
+
+	if s.opts != nil {
+		// Replay Open if it was called on the original KMS.
+		if err := kms.Open(ctx, s.opts); err != nil {
+			return err
+		}
+	}
+
+	// Update self on success.
+	s.canary++
+	s.client, s.kms = client, kms
+
+	return nil
+}
+
+func (s *remoteKMS) Open(ctx context.Context, opts *kms.OpenOptions) error {
+	if err := s.retry(ctx, func() error {
+		return s.kms.Open(ctx, opts)
+	}); err != nil {
+		return err
+	}
+
+	// Save opts so Open can be replayed when the plugin is reloaded. We assume
+	// that locking is not needed as Open calls should not be made concurrently.
+	s.opts = opts
+
+	return nil
+}
+
+func (s *remoteKMS) Close(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	defer func() {
+		s.kms = nil      // Mark as closed.
+		s.client.close() // Release the client reference.
+	}()
+
+	// No need to retry, but ignore any plugin shutdown errors.
+	switch err := s.kms.Close(ctx); err {
+	case gkwplugin.ErrPluginShutdown:
+		return nil
+	default:
+		return err
+	}
+}
+
+func (s *remoteKMS) GetKey(ctx context.Context, opts *kms.KeyOptions) (key kms.Key, err error) {
+	var canary int
+	err = s.retry(ctx, func() error {
+		canary = s.canary
+		key, err = s.kms.GetKey(ctx, opts)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &remoteKey{
+		kms:    s,
+		key:    key,
+		canary: canary,
+		opts:   opts,
+	}, nil
+}
+
+// remoteKey adds plugin reloading & finalization hooks on top of a pluginized
+// kms.Key.
+type remoteKey struct {
+	kms.UnimplementedKey
+
+	mu sync.RWMutex
+
+	kms *remoteKMS
+	key kms.Key
+
+	canary int
+	opts   *kms.KeyOptions
+}
+
+// retry calls f and retries it once if interrupted by a plugin shutdown.
+func (k *remoteKey) retry(ctx context.Context, f func() error) error {
+	var canary int
+
+	// call is a helper to call f under a read lock and record the current inner
+	// key value as a reload canary values.
+	call := func() error {
+		k.mu.RLock()
+		defer k.mu.RUnlock()
+
+		k.kms.mu.RLock()
+		defer k.kms.mu.RUnlock()
+
+		switch {
+		case k.key == nil:
+			return errors.New("key was closed")
+		case k.kms.kms == nil:
+			return errors.New("KMS was closed")
+		}
+
+		canary = k.kms.canary
+
+		return f()
+	}
+
+	if err := call(); !errors.Is(err, gkwplugin.ErrPluginShutdown) {
+		// Plugin works and call either succeeded or returned an
+		// application-level error.
+		return err
+	}
+
+	// If we saw a shutdown error, give a first attempt to reloading only the
+	// key, assuming the KMS may already have been reloaded by another call and
+	// we just have a stale key.
+	err := k.reload(ctx, canary)
+	switch {
+	case err == nil:
+		return call()
+	case !errors.Is(err, gkwplugin.ErrPluginShutdown):
+		return err
+	}
+
+	// If we still see a shutdown error, reload the KMS, too.
+	if err := k.kms.reload(ctx, canary); err != nil {
+		return err
+	}
+	if err := k.reload(ctx, canary); err != nil {
+		return err
+	}
+
+	// Then retry.
+	return call()
+}
+
+// reload attempts to reinstantiate the remote key instance.
+func (k *remoteKey) reload(ctx context.Context, canary int) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	k.kms.mu.RLock()
+	defer k.kms.mu.RUnlock()
+
+	switch {
+	case k.key == nil:
+		return errors.New("key was closed")
+	case k.kms.kms == nil:
+		return errors.New("KMS was closed")
+	}
+
+	if k.canary > canary {
+		// Another caller managed to reload before we got the lock.
+		return nil
+	}
+
+	// Note: This should call into the remoteKMS's underlying KMS instance, not
+	// into its retry-wrapped method.
+	key, err := k.kms.kms.GetKey(ctx, k.opts)
+	if err != nil {
+		return err
+	}
+
+	// Update self on success.
+	k.key, k.canary = key, canary
+
+	return nil
+}
+
+func (k *remoteKey) Encrypt(ctx context.Context, opts *kms.CipherOptions) (ciphertext []byte, err error) {
+	err = k.retry(ctx, func() error {
+		ciphertext, err = k.key.Encrypt(ctx, opts)
+		return err
+	})
+	return ciphertext, err
+}
+
+func (k *remoteKey) Decrypt(ctx context.Context, opts *kms.CipherOptions) (plaintext []byte, err error) {
+	err = k.retry(ctx, func() error {
+		plaintext, err = k.key.Decrypt(ctx, opts)
+		return err
+	})
+	return plaintext, err
+}
+
+func (k *remoteKey) Sign(ctx context.Context, opts *kms.SignOptions) (signature []byte, err error) {
+	err = k.retry(ctx, func() error {
+		signature, err = k.key.Sign(ctx, opts)
+		return err
+	})
+	return signature, err
+}
+
+func (k *remoteKey) Verify(ctx context.Context, opts *kms.VerifyOptions) error {
+	return k.retry(ctx, func() error {
+		return k.key.Verify(ctx, opts)
+	})
+}
+
+func (k *remoteKey) ExportPublic(ctx context.Context) (public crypto.PublicKey, err error) {
+	err = k.retry(ctx, func() error {
+		public, err = k.key.ExportPublic(ctx)
+		return err
+	})
+	return public, err
+}
+
+func (k *remoteKey) Close(ctx context.Context) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	defer func() {
+		k.key = nil // Mark as closed.
+	}()
+
+	// No need to retry, but ignore any plugin shutdown errors.
+	switch err := k.key.Close(ctx); err {
+	case gkwplugin.ErrPluginShutdown:
+		return nil
+	default:
+		return err
+	}
+}

--- a/internal/helper/kmsplugin/kms_test.go
+++ b/internal/helper/kmsplugin/kms_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package kmsplugin
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/testcluster/docker"
+	"github.com/openbao/openbao/v2/internal/command/server"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKMS(t *testing.T) {
+	ctx := t.Context()
+
+	// Start out by setting up a Transit engine server to test against.
+	clusterOpts := docker.DefaultOptions(t)
+	clusterOpts.Storage = docker.InmemStorage{}
+	clusterOpts.NumCores = 1
+	clusterOpts.HADisabled = true
+
+	cluster := docker.NewTestDockerCluster(t, clusterOpts)
+	defer cluster.Cleanup()
+
+	client := cluster.ClusterNodes[0].APIClient()
+
+	require.NoError(t, client.Sys().Mount("transit", &api.MountInput{
+		Type: "transit",
+	}))
+
+	// Create some keys to play with.
+	for _, name := range []string{
+		"aes256-gcm96", "ed25519",
+	} {
+		_, err := client.Logical().WriteWithContext(ctx, path.Join("transit/keys", name), map[string]any{
+			"type": name,
+		})
+		require.NoError(t, err)
+	}
+
+	opts := &kms.OpenOptions{
+		ConfigMap: kms.ConfigMap{
+			"address":         client.Address(),
+			"token":           client.Token(),
+			"tls_ca_cert":     string(cluster.CACertPEM),
+			"disable_renewal": true,
+		},
+	}
+
+	t.Run("builtin", func(t *testing.T) {
+		catalog, err := NewCatalog(hclog.Default(), &server.Config{})
+		require.NoError(t, err)
+
+		_, err = catalog.OpenKMS(ctx, "bogus", opts)
+		require.Error(t, err)
+
+		s, err := catalog.OpenKMS(ctx, "transit", opts)
+		require.NoError(t, err)
+		require.IsNotType(t, &remoteKMS{}, s)
+		require.NoError(t, s.Close(ctx))
+	})
+
+	config := &server.Config{
+		PluginDirectory: filepath.Dir(os.Args[0]),
+		Plugins:         []*server.PluginConfig{TransitPluginConfig},
+	}
+
+	catalog, err := NewCatalog(hclog.Default(), config)
+	require.NoError(t, err)
+
+	_, err = catalog.OpenKMS(ctx, "bogus", opts)
+	require.Error(t, err)
+
+	s, err := catalog.OpenKMS(ctx, "transit", opts)
+	require.NoError(t, err)
+	require.IsType(t, &remoteKMS{}, s)
+
+	defer func() {
+		require.NoError(t, s.Close(ctx))
+	}()
+
+	input := []byte("tom")
+
+	t.Run("Encrypt+Decrypt", func(t *testing.T) {
+		key, err := s.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "aes256-gcm96"},
+		})
+		require.NoError(t, err)
+
+		defer func() {
+			require.NoError(t, key.Close(ctx))
+		}()
+
+		opts := &kms.CipherOptions{Data: input}
+		ciphertext, err := key.Encrypt(ctx, opts)
+		require.NoError(t, err)
+
+		plaintext, err := key.Decrypt(ctx, &kms.CipherOptions{
+			Data:       ciphertext,
+			Nonce:      opts.Nonce,
+			KeyVersion: opts.KeyVersion,
+		})
+		require.NoError(t, err)
+		require.Equal(t, input, plaintext)
+	})
+
+	t.Run("Sign+Verify", func(t *testing.T) {
+		key, err := s.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "ed25519"},
+		})
+		require.NoError(t, err)
+
+		defer func() {
+			require.NoError(t, key.Close(ctx))
+		}()
+
+		opts := &kms.SignOptions{Data: input}
+		sig, err := key.Sign(ctx, opts)
+		require.NoError(t, err)
+
+		require.NoError(t, key.Verify(ctx, &kms.VerifyOptions{
+			Data:       input,
+			Signature:  sig,
+			KeyVersion: opts.KeyVersion,
+		}))
+	})
+
+	t.Run("ExportPublic", func(t *testing.T) {
+		key, err := s.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "ed25519"},
+		})
+		require.NoError(t, err)
+
+		defer func() {
+			require.NoError(t, key.Close(ctx))
+		}()
+
+		pub, err := key.ExportPublic(ctx)
+		require.NoError(t, err)
+		require.IsType(t, ed25519.PublicKey{}, pub)
+	})
+
+	t.Run("reload", func(t *testing.T) {
+		catalog, err := NewCatalog(hclog.Default(), config)
+		require.NoError(t, err)
+
+		// Open two instances of KMS from the same plugin.
+		s1, err := catalog.OpenKMS(ctx, "transit", opts)
+		require.NoError(t, err)
+		s2, err := catalog.OpenKMS(ctx, "transit", opts)
+		require.NoError(t, err)
+
+		// Acquire a key from each instance.
+		k1, err := s1.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "ed25519"},
+		})
+		require.NoError(t, err)
+		k2, err := s2.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "ed25519"},
+		})
+		require.NoError(t, err)
+
+		// Simulate a crashed plugin.
+		s1.(*remoteKMS).client.process.Kill()
+
+		// Check that both keys recover.
+		_, err = k1.Sign(ctx, &kms.SignOptions{Data: []byte("foo")})
+		require.NoError(t, err)
+		_, err = k2.Sign(ctx, &kms.SignOptions{Data: []byte("foo")})
+		require.NoError(t, err)
+
+		// Kill again, but this time dispatch a KMS-level request before
+		// touching the key so the key must be re-fetched but the plugin was
+		// already reloaded.
+		s1.(*remoteKMS).client.process.Kill()
+
+		// KMS-level request, this should reload the KMS but no keys.
+		k3, err := s1.GetKey(ctx, &kms.KeyOptions{
+			ConfigMap: kms.ConfigMap{"name": "ed25519"},
+		})
+		require.NoError(t, err)
+
+		// Pull these out to demonstrate that the key will reload without
+		// reloading the KMS if the KMS has already been reloaded.
+		inner := k1.(*remoteKey)
+		innerKey, innerKMS := inner.key, inner.kms.kms
+
+		// Now try to use k1, which should reload the key automatically.
+		_, err = k1.Sign(ctx, &kms.SignOptions{Data: []byte("foo")})
+		require.NoError(t, err)
+
+		// Assert that we haven't recycled the KMS, but the key was renewed.
+		require.True(t, innerKey != inner.key)
+		require.True(t, innerKMS == inner.kms.kms)
+
+		// Close everything.
+		require.NoError(t, k1.Close(ctx))
+		require.NoError(t, k2.Close(ctx))
+		require.NoError(t, k3.Close(ctx))
+		require.NoError(t, s1.Close(ctx))
+		require.NoError(t, s2.Close(ctx))
+	})
+}

--- a/internal/helper/kmsplugin/wrapper.go
+++ b/internal/helper/kmsplugin/wrapper.go
@@ -16,13 +16,11 @@ import (
 	"github.com/openbao/go-kms-wrapping/wrappers/transit/v2"
 )
 
-var builtinWrappers = map[wrapping.WrapperType]wrapperFactory{
+var builtinWrappers = map[wrapping.WrapperType]func() wrapping.Wrapper{
 	kmip.Type:    toWrapper(kmip.NewWrapper),
 	static.Type:  toWrapper(static.NewWrapper),
 	transit.Type: toWrapper(transit.NewWrapper),
 }
-
-type wrapperFactory func() (wrapping.Wrapper, error)
 
 // wrapperInitFinalizer is a joint wrapping.Wrapper & wrapping.InitFinalizer, as
 // is always returned by go-kms-wrapping/plugin.
@@ -32,10 +30,10 @@ type wrapperInitFinalizer interface {
 }
 
 // toWrapper is a hack to go from func() <concrete wrapper type> to func()
-// (wrapping.Wrapper, error), as constructors in go-kms-wrapping tend to return
-// the concrete type.
-func toWrapper[T wrapping.Wrapper](f func() T) wrapperFactory {
-	return func() (wrapping.Wrapper, error) { return f(), nil }
+// wrapping.Wrapper, as constructors in go-kms-wrapping tend to return the
+// concrete type.
+func toWrapper[T wrapping.Wrapper](f func() T) func() wrapping.Wrapper {
+	return func() wrapping.Wrapper { return f() }
 }
 
 // ConfigureWrapper creates a new wrapper instance and calls SetConfig with
@@ -51,7 +49,7 @@ func (c *Catalog) ConfigureWrapper(ctx context.Context, name string, opts ...wra
 	if err != nil {
 		// If we fail to configure the wrapper, ensure any underlying client is
 		// closed to avoid leaking it.
-		if w, ok := w.(*wrapper); ok {
+		if w, ok := w.(*remoteWrapper); ok {
 			w.client.close()
 		}
 		return nil, nil, err
@@ -81,8 +79,7 @@ func (c *Catalog) getWrapper(name string) (wrapping.Wrapper, bool, error) {
 	case !ok:
 		// Try builtin wrappers.
 		if builtin, ok := builtinWrappers[wrapping.WrapperType(name)]; ok {
-			w, err := builtin()
-			return w, true, err
+			return builtin(), true, nil
 		}
 		return nil, false, fmt.Errorf("unknown wrapper: %s", name)
 	}
@@ -94,15 +91,15 @@ func (c *Catalog) getWrapper(name string) (wrapping.Wrapper, bool, error) {
 		return nil, false, err
 	}
 
-	return &wrapper{
+	return &remoteWrapper{
 		client:  client,
 		wrapper: raw.(wrapperInitFinalizer),
 	}, false, nil
 }
 
-// wrapper adds plugin reloading & finalization hooks on top of a pluginized
-// wrapping.Wrapper.
-type wrapper struct {
+// remoteWrapper adds plugin reloading & finalization hooks on top of a
+// pluginized wrapping.Wrapper.
+type remoteWrapper struct {
 	mu sync.RWMutex
 
 	client  *client
@@ -112,7 +109,7 @@ type wrapper struct {
 }
 
 // retry calls f and retries it once if interrupted by a plugin shutdown.
-func (w *wrapper) retry(ctx context.Context, f func() error) error {
+func (w *remoteWrapper) retry(ctx context.Context, f func() error) error {
 	canary, err := w.call(f)
 
 	if err != gkwplugin.ErrPluginShutdown {
@@ -133,7 +130,7 @@ func (w *wrapper) retry(ctx context.Context, f func() error) error {
 
 // call is a helper to call f under a read lock and return the current client
 // pointer as a reload canary value.
-func (w *wrapper) call(f func() error) (*client, error) {
+func (w *remoteWrapper) call(f func() error) (*client, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -146,7 +143,7 @@ func (w *wrapper) call(f func() error) (*client, error) {
 
 // reload attempts to reload the underlying external plugin and reinstantiate
 // the remote wrapper instance.
-func (w *wrapper) reload(ctx context.Context, canary *client) error {
+func (w *remoteWrapper) reload(ctx context.Context, canary *client) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -191,7 +188,7 @@ func (w *wrapper) reload(ctx context.Context, canary *client) error {
 	return nil
 }
 
-func (w *wrapper) SetConfig(ctx context.Context, opts ...wrapping.Option) (config *wrapping.WrapperConfig, err error) {
+func (w *remoteWrapper) SetConfig(ctx context.Context, opts ...wrapping.Option) (config *wrapping.WrapperConfig, err error) {
 	if err = w.retry(ctx, func() error {
 		config, err = w.wrapper.SetConfig(ctx, opts...)
 		return err
@@ -207,7 +204,7 @@ func (w *wrapper) SetConfig(ctx context.Context, opts ...wrapping.Option) (confi
 	return config, nil
 }
 
-func (w *wrapper) Init(ctx context.Context, opts ...wrapping.Option) error {
+func (w *remoteWrapper) Init(ctx context.Context, opts ...wrapping.Option) error {
 	if err := w.retry(ctx, func() error {
 		return w.wrapper.Init(ctx, opts...)
 	}); err != nil {
@@ -222,7 +219,7 @@ func (w *wrapper) Init(ctx context.Context, opts ...wrapping.Option) error {
 	return nil
 }
 
-func (w *wrapper) Finalize(ctx context.Context, opts ...wrapping.Option) error {
+func (w *remoteWrapper) Finalize(ctx context.Context, opts ...wrapping.Option) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -243,7 +240,7 @@ func (w *wrapper) Finalize(ctx context.Context, opts ...wrapping.Option) error {
 	}
 }
 
-func (w *wrapper) Type(ctx context.Context) (ty wrapping.WrapperType, err error) {
+func (w *remoteWrapper) Type(ctx context.Context) (ty wrapping.WrapperType, err error) {
 	err = w.retry(ctx, func() (err error) {
 		ty, err = w.wrapper.Type(ctx)
 		return err
@@ -251,7 +248,7 @@ func (w *wrapper) Type(ctx context.Context) (ty wrapping.WrapperType, err error)
 	return ty, err
 }
 
-func (w *wrapper) KeyId(ctx context.Context) (id string, err error) {
+func (w *remoteWrapper) KeyId(ctx context.Context) (id string, err error) {
 	err = w.retry(ctx, func() (err error) {
 		id, err = w.wrapper.KeyId(ctx)
 		return err
@@ -259,7 +256,7 @@ func (w *wrapper) KeyId(ctx context.Context) (id string, err error) {
 	return id, err
 }
 
-func (w *wrapper) Encrypt(ctx context.Context, plaintext []byte, opts ...wrapping.Option) (blob *wrapping.BlobInfo, err error) {
+func (w *remoteWrapper) Encrypt(ctx context.Context, plaintext []byte, opts ...wrapping.Option) (blob *wrapping.BlobInfo, err error) {
 	err = w.retry(ctx, func() (err error) {
 		blob, err = w.wrapper.Encrypt(ctx, plaintext, opts...)
 		return err
@@ -267,7 +264,7 @@ func (w *wrapper) Encrypt(ctx context.Context, plaintext []byte, opts ...wrappin
 	return blob, err
 }
 
-func (w *wrapper) Decrypt(ctx context.Context, blob *wrapping.BlobInfo, opts ...wrapping.Option) (plaintext []byte, err error) {
+func (w *remoteWrapper) Decrypt(ctx context.Context, blob *wrapping.BlobInfo, opts ...wrapping.Option) (plaintext []byte, err error) {
 	err = w.retry(ctx, func() (err error) {
 		plaintext, err = w.wrapper.Decrypt(ctx, blob, opts...)
 		return err

--- a/internal/helper/kmsplugin/wrapper_test.go
+++ b/internal/helper/kmsplugin/wrapper_test.go
@@ -24,7 +24,7 @@ func TestConfigureWrapper(t *testing.T) {
 
 	catalog, err := NewCatalog(logger, &server.Config{
 		PluginDirectory: filepath.Dir(os.Args[0]),
-		Plugins:         []*server.PluginConfig{testPluginConfig(t)},
+		Plugins:         []*server.PluginConfig{StaticPluginConfig},
 	})
 	require.NoError(t, err, "catalog should create successfully")
 
@@ -45,7 +45,7 @@ func TestConfigureWrapper(t *testing.T) {
 	require.NoError(t, err, "should configure wrapper successfully")
 	require.NotNil(t, config, "should return a config")
 	require.NotNil(t, w1, "should return a wrapper")
-	require.IsType(t, &wrapper{}, w1, "wrapper should be external")
+	require.IsType(t, &remoteWrapper{}, w1, "wrapper should be external")
 
 	blob, err := w1.Encrypt(ctx, plaintext)
 	require.NoError(t, err, "should encrypt plaintext")
@@ -61,7 +61,7 @@ func TestConfigureWrapper(t *testing.T) {
 	require.NoError(t, err, "should configure wrapper successfully")
 	require.NotNil(t, config, "should return a config")
 	require.NotNil(t, w2, "should return a wrapper")
-	require.IsType(t, &wrapper{}, w1, "wrapper should be external")
+	require.IsType(t, &remoteWrapper{}, w1, "wrapper should be external")
 
 	require.NoError(t, w1.(wrapping.InitFinalizer).Finalize(ctx), "should finalize gracefully")
 	require.Len(t, catalog.clients, 1, "should keep the plugin client alive")
@@ -87,7 +87,7 @@ func TestReloadWrapper(t *testing.T) {
 
 	catalog, err := NewCatalog(logger, &server.Config{
 		PluginDirectory: filepath.Dir(os.Args[0]),
-		Plugins:         []*server.PluginConfig{testPluginConfig(t)},
+		Plugins:         []*server.PluginConfig{StaticPluginConfig},
 	})
 	require.NoError(t, err, "catalog should create successfully")
 
@@ -102,7 +102,7 @@ func TestReloadWrapper(t *testing.T) {
 		}))
 	require.NoError(t, err, "should configure wrapper successfully")
 	require.NotNil(t, w1, "should return a wrapper")
-	require.IsType(t, &wrapper{}, w1, "wrapper should be external")
+	require.IsType(t, &remoteWrapper{}, w1, "wrapper should be external")
 
 	w2, _, err := catalog.ConfigureWrapper(ctx, "static",
 		wrapping.WithConfigMap(map[string]string{
@@ -111,13 +111,13 @@ func TestReloadWrapper(t *testing.T) {
 		}))
 	require.NoError(t, err, "should configure wrapper successfully")
 	require.NotNil(t, w2, "should return a wrapper")
-	require.IsType(t, &wrapper{}, w2, "wrapper should be external")
+	require.IsType(t, &remoteWrapper{}, w2, "wrapper should be external")
 
 	blob, err := w1.Encrypt(ctx, plaintext)
 	require.NoError(t, err, "should encrypt plaintext")
 
 	// Kill the underlying plugin process that serves both wrappers:
-	w1.(*wrapper).client.process.Kill()
+	w1.(*remoteWrapper).client.process.Kill()
 
 	output, err := w1.Decrypt(ctx, blob)
 	require.NoError(t, err, "should decrypt blob with reloaded wrapper")
@@ -150,5 +150,5 @@ func TestBuiltinWrapper(t *testing.T) {
 	require.NoError(t, err, "should configure wrapper successfully")
 	require.NotNil(t, config, "should return a config")
 	require.NotNil(t, w, "should return a wrapper")
-	require.IsNotType(t, &wrapper{}, w, "wrapper should not be external")
+	require.IsNotType(t, &remoteWrapper{}, w, "wrapper should not be external")
 }

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
-	github.com/openbao/go-kms-wrapping/v2 v2.8.0
+	github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4
 	github.com/openbao/openbao/api/v2 v2.6.0
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.11.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -216,8 +216,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0 h1:9gXkCmcMadJO2Ozf9TNTIInSqdOwAD6k3HhHMhIqzrs=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0/go.mod h1:KyL1nfZM8SzLgMchvFU2F5jS/XlauD3TRCjmILLErh4=
+github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4 h1:SfN6JMUOfRHMt2dyYHumvIWEiTshQiTOYXGLyNgikz0=
+github.com/openbao/go-kms-wrapping/v2 v2.8.1-0.20260626131931-998c8a6f17f4/go.mod h1:KyL1nfZM8SzLgMchvFU2F5jS/XlauD3TRCjmILLErh4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -1273,6 +1273,21 @@ COPY bao /bin/bao
 	return tag, nil
 }
 
+// InmemStorage configures a test cluster to use the inmem storage backend.
+// This avoids waiting for initial Raft leader election or PostgreSQL container
+// startup when testing against a single-node cluster, significantly reducing
+// test setup time.
+type InmemStorage struct{}
+
+func (InmemStorage) Start(context.Context, *testcluster.ClusterOptions) error { return nil }
+func (InmemStorage) Cleanup() error                                           { return nil }
+func (InmemStorage) Opts() map[string]any                                     { return make(map[string]any) }
+func (InmemStorage) Type() string                                             { return "inmem" }
+
+var _ testcluster.ClusterStorage = InmemStorage{}
+
+// PostgreSQLStorage configures a test cluster to use the postgresql storage
+// backend and provides the required PostgreSQL instance in a container.
 type PostgreSQLStorage struct {
 	cleanup     func()
 	ExternalUrl string
@@ -1284,8 +1299,8 @@ type PostgreSQLStorage struct {
 
 var _ testcluster.ClusterStorage = &PostgreSQLStorage{}
 
-// NewPostgreSQLStorage starts the underlying PSQL container and saves its
-// connection URL.
+// NewPostgreSQLStorage creates a new PostgreSQLStorage and starts its backing
+// container.
 func NewPostgreSQLStorage(t *testing.T, network string) *PostgreSQLStorage {
 	env := []string{
 		"POSTGRES_PASSWORD=secret",


### PR DESCRIPTION
## Description

Add support for the `kms.KMS` and `kms.Key` interfaces in `helper/kmsplugin`, adding to the existing support for `wrapping.Wrapper`.

## Rationale

This is part of foundational work for External Keys. No user-facing changes yet, so no changelog.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
