### PR TITLE
Switch to constant-time comparison recovery token

### DIFF
--- a/changelog/3388.txt
+++ b/changelog/3388.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/recovery: Use constant-time token comparison in recovery mode. GHSA-34fc-gh42-pj53.
+```

--- a/http/logical.go
+++ b/http/logical.go
@@ -4,6 +4,7 @@
 package http
 
 import (
+	"crypto/subtle"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -327,8 +328,10 @@ func handleLogicalRecovery(raw *vault.RawBackend, token *atomic.Value) http.Hand
 			respondError(w, statusCode, err)
 			return
 		}
+
 		reqToken := r.Header.Get(consts.AuthHeaderName)
-		if reqToken == "" || token.Load() == "" || reqToken != token.Load() {
+		rToken, rTokenOk := token.Load().(string)
+		if len(reqToken) == 0 || !rTokenOk || len(rToken) == 0 || subtle.ConstantTimeCompare([]byte(reqToken), []byte(rToken)) == 0 {
 			respondError(w, http.StatusForbidden, nil)
 			return
 		}

--- a/vault/external_tests/misc/recovery_test.go
+++ b/vault/external_tests/misc/recovery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecovery(t *testing.T) {
@@ -91,14 +92,31 @@ func TestRecovery(t *testing.T) {
 		defer cluster.Cleanup()
 
 		client := cluster.Cores[0].Client
+
+		// Perform an initial request: make sure nothing can be done before a token can be created.
+		client.SetToken("garbage")
+		secret, err := client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.Error(t, err, "expected failure with garbage token before generation")
+		require.Nil(t, secret)
+
+		client.SetToken("")
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.Error(t, err, "expected failure with nil token before generation")
+		require.Nil(t, secret)
+
 		recoveryToken := testhelpers.GenerateRoot(t, cluster, testhelpers.GenerateRecovery)
 		_, err = testhelpers.GenerateRootWithError(t, cluster, testhelpers.GenerateRecovery)
 		if err == nil {
 			t.Fatal("expected second generate-root to fail")
 		}
+
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.Error(t, err, "expected failure with nil token after generation")
+		require.Nil(t, secret)
+
 		client.SetToken(recoveryToken)
 
-		secret, err := client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/vault/external_tests/misc/recovery_test.go
+++ b/vault/external_tests/misc/recovery_test.go
@@ -96,22 +96,20 @@ func TestRecovery(t *testing.T) {
 		// Perform an initial request: make sure nothing can be done before a token can be created.
 		client.SetToken("garbage")
 		secret, err := client.Logical().List(path.Join("sys/raw/logical", secretUUID))
-		require.Error(t, err, "expected failure with garbage token before generation")
+		require.ErrorContains(t, err, "403", "expected failure with garbage token before generation")
 		require.Nil(t, secret)
 
 		client.SetToken("")
 		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
-		require.Error(t, err, "expected failure with nil token before generation")
+		require.ErrorContains(t, err, "403", "expected failure with nil token before generation")
 		require.Nil(t, secret)
 
 		recoveryToken := testhelpers.GenerateRoot(t, cluster, testhelpers.GenerateRecovery)
 		_, err = testhelpers.GenerateRootWithError(t, cluster, testhelpers.GenerateRecovery)
-		if err == nil {
-			t.Fatal("expected second generate-root to fail")
-		}
+		require.ErrorContains(t, err, "attempted to generate recovery operation token when already unsealed", "expected second generate-root to fail")
 
 		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
-		require.Error(t, err, "expected failure with nil token after generation")
+		require.ErrorContains(t, err, "403", "expected failure with nil token after generation")
 		require.Nil(t, secret)
 
 		client.SetToken(recoveryToken)


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Recovery mode is a privileged mode whereby operators can directly perform underlying storage operations on the instance. This requires use of recovery key shares to build a singular recovery token which protects API operations. As reported in Vault v2.0.3 changelog (**without corresponding CVE assignment**), the comparison of the recovery token was not constant-time.

We address that and expand unit tests to ensure adequate coverage of edge conditions in token behaviors.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: GHSA-34fc-gh42-pj53

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
