### PR TITLE
Fix LIST ACL deny bypass caused by wildcards

### DIFF
--- a/changelog/3389.txt
+++ b/changelog/3389.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/policies: Prevent LIST operations bypassing `capabilities = ["deny"]` from a more specific wildcard ACL grant. GHSA-xp3c-3jw3-4vcr.
+```

--- a/vault/policy/acl.go
+++ b/vault/policy/acl.go
@@ -406,20 +406,25 @@ func (a *ACL) AllowOperation(ctx context.Context, req *logical.Request, capCheck
 		}
 	}
 
-	// List and Scan operations need to check without the trailing slash first,
-	// because there could be other rules with trailing wildcards that will
-	// match the path.
-	if op == logical.ListOperation && strings.HasSuffix(path, "/") {
+	permissions = a.CheckAllowedFromNonExactPaths(path, false)
+	if permissions != nil {
+		capabilities = permissions.CapabilitiesBitmap
+		goto CHECK
+	}
+
+	// List and Scan operations need to check with the trailing slash first,
+	// as they will always be the most specific rule (according to the policy
+	// syntax docs, the most specific rule wins: a match which isn't present
+	// above but is here must be one which is shorter and thus is lower
+	// priority).
+	//
+	// See also: https://openbao.org/docs/concepts/policies/#policy-syntax
+	if (op == logical.ListOperation || op == logical.ScanOperation) && strings.HasSuffix(path, "/") {
 		permissions = a.CheckAllowedFromNonExactPaths(strings.TrimSuffix(path, "/"), false)
 		if permissions != nil {
 			capabilities = permissions.CapabilitiesBitmap
 			goto CHECK
 		}
-	}
-	permissions = a.CheckAllowedFromNonExactPaths(path, false)
-	if permissions != nil {
-		capabilities = permissions.CapabilitiesBitmap
-		goto CHECK
 	}
 
 	// No exact, prefix, or segment wildcard paths found, return without

--- a/vault/policy/acl_test.go
+++ b/vault/policy/acl_test.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -995,6 +996,84 @@ func TestACLGrantingPolicies(t *testing.T) {
 	}
 }
 
+func TestACL_ListScanWildcardDeny(t *testing.T) {
+	ns := namespace.RootNamespace
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+
+	tests := []struct {
+		path    string
+		allowed bool
+	}{
+		{
+			path:    "foo",
+			allowed: false,
+		},
+		{
+			path:    "foo/metadata",
+			allowed: true,
+		},
+		{
+			path:    "foo/metadata/test",
+			allowed: true,
+		},
+		{
+			path:    "foo/metadata/private",
+			allowed: false,
+		},
+		{
+			path:    "foo/metadata/private/internal",
+			allowed: false,
+		},
+		{
+			path:    "foo/metadata/private/granted",
+			allowed: true,
+		},
+		{
+			path:    "foo/metadata/private/granted/test",
+			allowed: true,
+		},
+	}
+
+	for i, pt := range tests {
+		policy, err := ParseACLPolicy(ns, listScanDenyPolicy)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+
+		acl, err := NewACL(ctx, []*Policy{policy})
+		require.NoError(t, err)
+		require.NotNil(t, acl)
+
+		for _, operation := range []logical.Operation{
+			logical.ScanOperation,
+			logical.ListOperation,
+		} {
+			request := new(logical.Request)
+			request.Path = pt.path
+			request.Operation = operation
+
+			require.False(t, strings.HasSuffix(request.Path, "/"))
+			request.Path += "/"
+
+			authResults := acl.AllowOperation(ctx, request, false)
+			require.Equal(
+				t,
+				pt.allowed,
+				authResults.Allowed,
+				"bad:\n"+
+					"case %d\n"+
+					"\t%#v\n"+
+					"operation: %v\n"+
+					"engine: %v != expected: %v",
+				i,
+				pt,
+				operation,
+				authResults.Allowed,
+				pt.allowed,
+			)
+		}
+	}
+}
+
 var grantingTestPolicy = `
 name = "granting_policy"
 path "kv/foo" {
@@ -1400,4 +1479,10 @@ path "test/star" {
 	denied_parameters = {
 	}
 }
+`
+
+var listScanDenyPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/*" { capabilities = ["deny"] }
+path "foo/metadata/private/granted/*" { capabilities = ["list","scan"] }
 `


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

When using an ACL deny operation on a wildcard with a granting rule on a parent path, the deny operation would be ignored. For example:

    path "foo/metadata/*" { capabilities = ["list"] }
    path "foo/metadata/private/*" { capabilities = ["deny"] }

would allow a LIST operation on foo/metadata/private but correctly deny it on foo/metadata/private/my-app.

Due to a bug, this did not affect SCAN endpoints.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: GHSA-xp3c-3jw3-4vcr

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
