### PR TITLE
fix(doc): community/rfcs: add missing entry for Control Groups to sidebar

### DIFF
--- a/website/sidebarsCommunity.ts
+++ b/website/sidebarsCommunity.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/postgresql",
                 "rfcs/invalidation",
                 "rfcs/grpc-invalidation",
+                "rfcs/control-groups",
             ],
         },
         {


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Add missing RFC entry. Was missing from the RFC commit.

(Possibly consider generating from the folder contents in the future ?)

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Completeness. Sidebar doesn't render on the page.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Quickfix for a menu entry. Do we really want an issue?

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
