### PR TITLE
Add changelog entry for LDAP, Kerberos, and RADIUS (#3371)

### DIFF
--- a/changelog/3371.txt
+++ b/changelog/3371.txt
@@ -1,0 +1,12 @@
+```release-note:deprecation
+secret/ldap: The built-in LDAP secrets plugin has been deprecated and slated for removal from the main OpenBao binary distribution in v2.7.0. It will be included in [openbao-plugins](https://github.com/openbao/openbao-plugins) going forward.
+```
+```release-note:deprecation
+auth/ldap: The built-in LDAP auth plugin has been deprecated and slated for removal from the main OpenBao binary distribution in v2.7.0. It will be included in [openbao-plugins](https://github.com/openbao/openbao-plugins) going forward.
+```
+```release-note:deprecation
+auth/kerberos: The built-in Kerberos auth plugin has been deprecated and slated for removal from the main OpenBao binary distribution in v2.7.0. It will be included in [openbao-plugins](https://github.com/openbao/openbao-plugins) going forward.
+```
+```release-note:deprecation
+auth/radius: The built-in RADIUS auth plugin has been deprecated and slated for removal from the main OpenBao binary distribution in v2.7.0. It will be included in [openbao-plugins](https://github.com/openbao/openbao-plugins) going forward.
+```


### PR DESCRIPTION
Forward port of #3371, which went directly to the 2.6.x release branch.


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
