### PR TITLE
Add Huy, Wojciech, Pascal, and Philipp as new Dev WG members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ the root of this repository. That document is considered part of this document.
 
 | Working Group                                                  | Chair       | Voting Members                                                                      |
 |----------------------------------------------------------------|-------------| ----------------------------------------------------------------------------------- |
-| [Development Working Group](https://github.com/openbao/dev-wg) | Alex Scheel | Dan Ghita, Nathan Phelps, Jan Martens, Dave Dykstra, Jonas Köhnen, Andrii Fedorchuk |
+| [Development Working Group](https://github.com/openbao/dev-wg) | Alex Scheel | Dan Ghita, Nathan Phelps, Jan Martens, Dave Dykstra, Jonas Köhnen, Andrii Fedorchuk, Wojciech Slabosz, Huy Dinh, Philipp Stehle, Pascal Reeb |
 
 ## Issues
 


### PR DESCRIPTION
## Description

Adding the new Dev WG voting members, see https://lists.openssf.org/g/openbao-dev-wg/topic/dev_wg_new_members_welcome/120031284.

cc @cipherboy 

## Rationale

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
