### PR TITLE
Add profile creation to CLI, API

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -234,6 +234,14 @@ type Config struct {
 	// with the same client. Cloning a client will not clone this value.
 	OutputPolicy bool
 
+	// OutputProfile causes the actual request to return an error of type
+	// *OutputProfileError. Type asserting the error message will display
+	// an example of the required profile request description in HCL format.
+	//
+	// Note: It is not thread-safe to set this and make concurrent requests
+	// with the same client. Cloning a client will not clone this value.
+	OutputProfile bool
+
 	// curlCACert, curlCAPath, curlClientCert and curlClientKey are used to keep
 	// track of the name of the TLS certs and keys when OutputCurlString is set.
 	// Cloning a client will also not clone those values.
@@ -1055,6 +1063,24 @@ func (c *Client) SetOutputPolicy(isSet bool) {
 	c.config.OutputPolicy = isSet
 }
 
+func (c *Client) OutputProfile() bool {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
+	c.config.modifyLock.RLock()
+	defer c.config.modifyLock.RUnlock()
+
+	return c.config.OutputProfile
+}
+
+func (c *Client) SetOutputProfile(isSet bool) {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
+	c.config.modifyLock.Lock()
+	defer c.config.modifyLock.Unlock()
+
+	c.config.OutputProfile = isSet
+}
+
 // CurrentWrappingLookupFunc sets a lookup function that returns desired wrap TTLs
 // for a given operation and path.
 func (c *Client) CurrentWrappingLookupFunc() WrappingLookupFunc {
@@ -1423,6 +1449,7 @@ func (c *Client) rawRequestWithContext(ctx context.Context, r *Request) (*Respon
 	ns := c.headers.Get(NamespaceHeaderName)
 	outputCurlString := c.config.OutputCurlString
 	outputPolicy := c.config.OutputPolicy
+	outputProfile := c.config.OutputProfile
 	logger := c.config.Logger
 	disableRedirects := c.config.DisableRedirects
 	c.config.modifyLock.RUnlock()
@@ -1480,6 +1507,13 @@ START:
 			params: req.URL.Query(),
 		}
 		return nil, LastOutputPolicyError
+	}
+
+	if outputProfile {
+		LastOutputProfileError = &OutputProfileError{
+			Request: req,
+		}
+		return nil, LastOutputProfileError
 	}
 
 	req.Request = req.Request.WithContext(ctx)
@@ -1571,6 +1605,7 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 	httpClient := c.config.HttpClient
 	outputCurlString := c.config.OutputCurlString
 	outputPolicy := c.config.OutputPolicy
+	outputProfile := c.config.OutputProfile
 	disableRedirects := c.config.DisableRedirects
 
 	// add headers
@@ -1595,6 +1630,9 @@ func (c *Client) httpRequestWithContext(ctx context.Context, r *Request) (*Respo
 	}
 	if outputPolicy {
 		return nil, errors.New("output-policy is not implemented for this request")
+	}
+	if outputProfile {
+		return nil, errors.New("output-profile is not implemented for this request")
 	}
 
 	req.URL.User = r.URL.User

--- a/api/output_profile.go
+++ b/api/output_profile.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+const (
+	ErrOutputProfileRequest = "output a profile, please"
+)
+
+var LastOutputProfileError *OutputProfileError
+
+type OutputProfileError struct {
+	*retryablehttp.Request
+	finalProfile string
+}
+
+func (d *OutputProfileError) Error() string {
+	if d.finalProfile == "" {
+		cs, err := d.buildProfile()
+		if err != nil {
+			return err.Error()
+		}
+		d.finalProfile = cs
+	}
+
+	return ErrOutputProfileRequest
+}
+
+func (d *OutputProfileError) HCLString() (string, error) {
+	if d.finalProfile == "" {
+		cs, err := d.buildProfile()
+		if err != nil {
+			return "", err
+		}
+		d.finalProfile = cs
+	}
+	return d.finalProfile, nil
+}
+
+func (d *OutputProfileError) operation() string {
+	switch d.Method {
+	case "GET":
+		params := d.URL.Query()
+		switch {
+		case params.Get("list") != "":
+			return "list"
+		case params.Get("scan") != "":
+			return "scan"
+		default:
+			return "read"
+		}
+	case "POST", "PUT":
+		// Cannot disambiguate create versus update here; default to update.
+		return "update"
+	case "DELETE":
+		return "delete"
+	case "PATCH":
+		return "patch"
+	}
+
+	return "<unknown>"
+}
+
+func (d *OutputProfileError) path() string {
+	return strings.TrimPrefix(d.URL.Path, "/v1")
+}
+
+func (d *OutputProfileError) token() string {
+	return d.Header.Get(AuthHeaderName)
+}
+
+func (d *OutputProfileError) headers() (map[string]string, error) {
+	headers := make(map[string]string, len(d.Header))
+	for key, values := range d.Header {
+		if key == AuthHeaderName || key == RequestHeaderName {
+			// Token is specified via a dedicated field and the X-Vault-Request
+			// header is unnecessary as we know we're not likely taking to the
+			// agent.
+			continue
+		}
+
+		output, err := json.Marshal(values)
+		if err != nil {
+			return nil, fmt.Errorf("while marshaling header %q: %w", key, err)
+		}
+
+		headers[key] = string(output)
+	}
+
+	return headers, nil
+}
+
+func (d *OutputProfileError) dataSource() (map[string]any, error) {
+	data := make(map[string]any)
+	if d.Method == "GET" {
+		for key, values := range d.URL.Query() {
+			if key == "list" || key == "scan" {
+				// LIST or SCAN operation already handled.
+				continue
+			}
+
+			if len(values) == 1 {
+				data[key] = values[0]
+			} else {
+				data[key] = values
+			}
+		}
+
+		return data, nil
+	}
+
+	body, err := d.BodyBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request body as JSON: %w", err)
+	}
+
+	return data, nil
+}
+
+func (d *OutputProfileError) indent(prefix string, value string) string {
+	return strings.TrimSuffix(strings.Join(strings.Split(value, "\n"), "\n"+prefix), prefix)
+}
+
+// formatHCL exists because hashicorp/hcl (on the v1 branch) lacks an encoder
+// and github.com/hashicorp/hcl/v2/gohcl assumes using a struct with tags,
+// which is not true of our CLI/API usage.
+func (d *OutputProfileError) formatHCL(_value any) (string, error) {
+	switch value := _value.(type) {
+	case string:
+		return fmt.Sprintf("%q", value), nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, bool:
+		return fmt.Sprintf("%v", value), nil
+	case []any:
+		result := "[\n"
+		for index, item := range value {
+			formatted, err := d.formatHCL(item)
+			if err != nil {
+				return "", fmt.Errorf("at index %d: %w", index, err)
+			}
+
+			if index > 0 {
+				result += ",\n"
+			}
+			result += "  " + d.indent("  ", formatted) + ",\n"
+		}
+
+		return result + "]", nil
+	case map[string]any:
+		result := "{\n"
+		for key, item := range value {
+			formatted, err := d.formatHCL(item)
+			if err != nil {
+				return "", fmt.Errorf("at key %q: %w", key, err)
+			}
+
+			equals := " = "
+			if strings.HasPrefix(formatted, "{") {
+				equals = " "
+			}
+
+			result += fmt.Sprintf("  %q%v%v\n", key, equals, d.indent("  ", formatted))
+		}
+
+		return result + "}", nil
+	default:
+		return "", fmt.Errorf("unknown type for field: %T", value)
+	}
+}
+
+func (d *OutputProfileError) data() (map[string]string, error) {
+	data, err := d.dataSource()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string, len(data))
+	for key, value := range data {
+		formatted, err := d.formatHCL(value)
+		if err != nil {
+			return nil, fmt.Errorf("at top-level data key %q: %w", key, err)
+		}
+
+		result[key] = formatted
+	}
+
+	return result, nil
+}
+
+func (d *OutputProfileError) buildProfile() (string, error) {
+	var profile strings.Builder
+	profile.WriteString(`request "cli-generated-request" {`)
+	profile.WriteByte('\n')
+
+	fmt.Fprintf(&profile, "  operation = %q\n", d.operation())
+
+	fmt.Fprintf(&profile, "  path = %q\n", d.path())
+
+	if d.token() != "" {
+		fmt.Fprintf(&profile, "  token = %q\n", d.token())
+	}
+
+	headers, err := d.headers()
+	if err != nil {
+		return "", err
+	}
+
+	if len(headers) > 0 {
+		profile.WriteString("  headers = {\n")
+		for header, value := range headers {
+			fmt.Fprintf(&profile, "    %q = %v\n", header, value)
+		}
+		profile.WriteString("  }\n")
+	}
+
+	data, err := d.data()
+	if err != nil {
+		return "", err
+	}
+
+	if len(data) > 0 {
+		profile.WriteString("  data = {\n")
+		for key, value := range data {
+			fmt.Fprintf(&profile, "    %q = %v\n", key, d.indent("    ", value))
+		}
+		profile.WriteString("  }\n")
+	}
+
+	profile.WriteString("}\n")
+
+	return profile.String(), nil
+}

--- a/changelog/3403.txt
+++ b/changelog/3403.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command: Support `-output-profile` to display a profile request compatible with server-side workflows and self-initialization.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -62,6 +62,7 @@ type BaseCommand struct {
 	flagDetailed         bool
 	flagOutputCurlString bool
 	flagOutputPolicy     bool
+	flagOutputProfile    bool
 	flagNonInteractive   bool
 
 	flagMFA []string
@@ -100,6 +101,9 @@ func (c *BaseCommand) ClientWithoutToken() (*api.Client, error) {
 	}
 	if c.flagOutputPolicy {
 		config.OutputPolicy = c.flagOutputPolicy
+	}
+	if c.flagOutputProfile {
+		config.OutputProfile = c.flagOutputProfile
 	}
 
 	// If we need custom TLS configuration, then set it
@@ -488,6 +492,14 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				Default: false,
 				Usage: "Instead of executing the request, print an example HCL " +
 					"policy that would be required to run this command and exit.",
+			})
+
+			f.BoolVar(&BoolVar{
+				Name:    "output-profile",
+				Target:  &c.flagOutputProfile,
+				Default: false,
+				Usage: "Instead of executing the request, print an example HCL " +
+					"profile that replicates this command and exit.",
 			})
 
 			f.StringVar(&StringVar{

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -60,6 +60,9 @@ func kvPreflightVersionRequest(client *api.Client, path string) (string, int, er
 	currentOutputPolicy := client.OutputPolicy()
 	client.SetOutputPolicy(false)
 	defer client.SetOutputPolicy(currentOutputPolicy)
+	currentOutputProfile := client.OutputProfile()
+	client.SetOutputProfile(false)
+	defer client.SetOutputProfile(currentOutputProfile)
 
 	resp, err := client.Logical().ReadRaw("sys/internal/ui/mounts/" + path)
 	if resp != nil {

--- a/command/main.go
+++ b/command/main.go
@@ -31,17 +31,30 @@ type VaultUI struct {
 const (
 	globalFlagOutputCurlString = "output-curl-string"
 	globalFlagOutputPolicy     = "output-policy"
+	globalFlagOutputProfile    = "output-profile"
 	globalFlagFormat           = "format"
 	globalFlagDetailed         = "detailed"
 )
 
 var globalFlags = []string{
-	globalFlagOutputCurlString, globalFlagOutputPolicy, globalFlagFormat, globalFlagDetailed,
+	globalFlagOutputCurlString,
+	globalFlagOutputPolicy,
+	globalFlagOutputProfile,
+	globalFlagFormat,
+	globalFlagDetailed,
 }
 
 // setupEnv parses args and may replace them and sets some env vars to known
 // values based on format options
-func setupEnv(args []string) (retArgs []string, format string, detailed bool, outputCurlString bool, outputPolicy bool) {
+func setupEnv(args []string) (ret struct {
+	args             []string
+	format           string
+	detailed         bool
+	outputCurlString bool
+	outputPolicy     bool
+	outputProfile    bool
+},
+) {
 	var err error
 	var nextArgFormat bool
 	var haveDetailed bool
@@ -49,7 +62,7 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 	for _, arg := range args {
 		if nextArgFormat {
 			nextArgFormat = false
-			format = arg
+			ret.format = arg
 			continue
 		}
 
@@ -63,18 +76,23 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 		}
 
 		if isGlobalFlag(arg, globalFlagOutputCurlString) {
-			outputCurlString = true
+			ret.outputCurlString = true
 			continue
 		}
 
 		if isGlobalFlag(arg, globalFlagOutputPolicy) {
-			outputPolicy = true
+			ret.outputPolicy = true
+			continue
+		}
+
+		if isGlobalFlag(arg, globalFlagOutputProfile) {
+			ret.outputProfile = true
 			continue
 		}
 
 		// Parse a given flag here, which overrides the env var
 		if isGlobalFlagWithValue(arg, globalFlagFormat) {
-			format = getGlobalFlagValue(arg)
+			ret.format = getGlobalFlagValue(arg)
 		}
 		// For backwards compat, it could be specified without an equal sign
 		if isGlobalFlag(arg, globalFlagFormat) {
@@ -83,41 +101,42 @@ func setupEnv(args []string) (retArgs []string, format string, detailed bool, ou
 
 		// Parse a given flag here, which overrides the env var
 		if isGlobalFlagWithValue(arg, globalFlagDetailed) {
-			detailed, err = strconv.ParseBool(getGlobalFlagValue(globalFlagDetailed))
+			ret.detailed, err = strconv.ParseBool(getGlobalFlagValue(globalFlagDetailed))
 			if err != nil {
-				detailed = false
+				ret.detailed = false
 			}
 			haveDetailed = true
 		}
 		// For backwards compat, it could be specified without an equal sign to enable
 		// detailed output.
 		if isGlobalFlag(arg, globalFlagDetailed) {
-			detailed = true
+			ret.detailed = true
 			haveDetailed = true
 		}
 	}
 
 	envVaultFormat := api.ReadBaoVariable(EnvVaultFormat)
 	// If we did not parse a value, fetch the env var
-	if format == "" && envVaultFormat != "" {
-		format = envVaultFormat
+	if ret.format == "" && envVaultFormat != "" {
+		ret.format = envVaultFormat
 	}
 	// Lowercase for consistency
-	format = strings.ToLower(format)
-	if format == "" {
-		format = "table"
+	ret.format = strings.ToLower(ret.format)
+	if ret.format == "" {
+		ret.format = "table"
 	}
 
 	envVaultDetailed := api.ReadBaoVariable(EnvVaultDetailed)
 	// If we did not parse a value, fetch the env var
 	if !haveDetailed && envVaultDetailed != "" {
-		detailed, err = strconv.ParseBool(envVaultDetailed)
+		ret.detailed, err = strconv.ParseBool(envVaultDetailed)
 		if err != nil {
-			detailed = false
+			ret.detailed = false
 		}
 	}
 
-	return args, format, detailed, outputCurlString, outputPolicy
+	ret.args = args
+	return ret
 }
 
 func isGlobalFlag(arg string, flag string) bool {
@@ -153,11 +172,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 		runOpts = &RunOptions{}
 	}
 
-	var format string
-	var detailed bool
-	var outputCurlString bool
-	var outputPolicy bool
-	args, format, detailed, outputCurlString, outputPolicy = setupEnv(args)
+	env := setupEnv(args)
 
 	// Don't use color if disabled
 	useColor := !color.NoColor && api.ReadBaoVariable(EnvVaultCLINoColor) == ""
@@ -170,7 +185,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 	}
 
 	// Only use colored UI if stdout is a tty, and not disabled
-	if useColor && format == "table" {
+	if useColor && env.format == "table" {
 		if f, ok := runOpts.Stdout.(*os.File); ok {
 			runOpts.Stdout = colorable.NewColorable(f)
 		}
@@ -183,7 +198,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 	}
 
 	uiErrWriter := runOpts.Stderr
-	if outputCurlString || outputPolicy {
+	if env.outputCurlString || env.outputPolicy || env.outputProfile {
 		uiErrWriter = &bytes.Buffer{}
 	}
 
@@ -197,8 +212,8 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 				ErrorWriter: uiErrWriter,
 			},
 		},
-		format:   format,
-		detailed: detailed,
+		format:   env.format,
+		detailed: env.detailed,
 	}
 
 	serverCmdUi := &VaultUI{
@@ -210,11 +225,11 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 				Writer: runOpts.Stdout,
 			},
 		},
-		format: format,
+		format: env.format,
 	}
 
-	if _, ok := Formatters[format]; !ok {
-		ui.Error(fmt.Sprintf("Invalid output format: %s", format))
+	if _, ok := Formatters[env.format]; !ok {
+		ui.Error(fmt.Sprintf("Invalid output format: %s", env.format))
 		return 1
 	}
 
@@ -224,7 +239,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 
 	cli := &cli.CLI{
 		Name:     "bao",
-		Args:     args,
+		Args:     env.args,
 		Commands: commands,
 		HelpFunc: groupedHelpFunc(
 			cli.BasicHelpFunc("bao"),
@@ -237,10 +252,12 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 	}
 
 	exitCode, err := cli.Run()
-	if outputCurlString {
+	if env.outputCurlString {
 		return generateCurlString(exitCode, runOpts, uiErrWriter.(*bytes.Buffer))
-	} else if outputPolicy {
+	} else if env.outputPolicy {
 		return generatePolicy(exitCode, runOpts, uiErrWriter.(*bytes.Buffer))
+	} else if env.outputProfile {
+		return generateProfile(exitCode, runOpts, uiErrWriter.(*bytes.Buffer))
 	} else if err != nil {
 		_, _ = fmt.Fprintf(runOpts.Stderr, "Error executing CLI: %s\n", err.Error())
 		return 1
@@ -347,6 +364,32 @@ func generatePolicy(exitCode int, runOpts *RunOptions, preParsingErrBuf *bytes.B
 	hcl, err := api.LastOutputPolicyError.HCLString()
 	if err != nil {
 		_, _ = fmt.Fprintf(runOpts.Stderr, "Error assembling policy HCL: %s\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(runOpts.Stdout, "%s\n", hcl)
+	return 0
+}
+
+func generateProfile(exitCode int, runOpts *RunOptions, preParsingErrBuf *bytes.Buffer) int {
+	if exitCode == 0 {
+		_, _ = fmt.Fprint(runOpts.Stderr, "Could not generate profile")
+		return 1
+	}
+
+	if api.LastOutputProfileError == nil {
+		if exitCode == 127 {
+			// Usage, just pass it through
+			return exitCode
+		}
+		_, _ = runOpts.Stderr.Write(preParsingErrBuf.Bytes())
+		_, _ = fmt.Fprint(runOpts.Stderr, "Unable to generate profile from command\n")
+		return exitCode
+	}
+
+	hcl, err := api.LastOutputProfileError.HCLString()
+	if err != nil {
+		_, _ = fmt.Fprintf(runOpts.Stderr, "Error assembling profile HCL: %s\n", err)
 		return 1
 	}
 

--- a/command/namespace_unseal_test.go
+++ b/command/namespace_unseal_test.go
@@ -149,11 +149,11 @@ func TestNamespaceUnsealCommand_Format(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _, _ := setupEnv([]string{"namespace", "unseal", "-format", "json", "ns"})
-	require.Equal(t, "json", format)
+	env := setupEnv([]string{"namespace", "unseal", "-format", "json", "ns"})
+	require.Equal(t, "json", env.format)
 
 	// Unseal with one key
-	code := RunCustom(append(args, []string{unsealShares[0]}...), runOpts)
+	code := RunCustom(append(env.args, []string{unsealShares[0]}...), runOpts)
 	assert.Equalf(t, 0, code, "expected %d to be 0: %s", code, stderr.String())
 	assert.True(t, json.Valid(stdout.Bytes()), "expected output to be valid JSON")
 }

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -192,13 +192,13 @@ func TestOperatorUnsealCommand_Format(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _, _ := setupEnv([]string{"operator", "unseal", "-format", "json"})
-	if format != "json" {
-		t.Fatalf("expected %q, got %q", "json", format)
+	env := setupEnv([]string{"operator", "unseal", "-format", "json"})
+	if env.format != "json" {
+		t.Fatalf("expected %q, got %q", "json", env.format)
 	}
 
 	// Unseal with one key
-	code := RunCustom(append(args, []string{
+	code := RunCustom(append(env.args, []string{
 		keys[0],
 	}...), runOpts)
 	if exp := 0; code != exp {

--- a/command/version_history_test.go
+++ b/command/version_history_test.go
@@ -60,12 +60,12 @@ func TestVersionHistoryCommand_JsonOutput(t *testing.T) {
 		Client: client,
 	}
 
-	args, format, _, _, _ := setupEnv([]string{"version-history", "-format", "json"})
-	if format != "json" {
-		t.Fatalf("expected format to be %q, actual %q", "json", format)
+	env := setupEnv([]string{"version-history", "-format", "json"})
+	if env.format != "json" {
+		t.Fatalf("expected format to be %q, actual %q", "json", env.format)
 	}
 
-	code := RunCustom(args, runOpts)
+	code := RunCustom(env.args, runOpts)
 
 	if expectedCode := 0; code != expectedCode {
 		t.Fatalf("expected %d to be %d: %s", code, expectedCode, stderr.String())


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This allows operators to more easily construct profiles from request snippets executed via the CLI or API client.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

I believe @satoqz mentioned this would be a good feature at some point in time, but not sure I recall where :laughing: 

Resolves: (n/a?)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
