### PR TITLE
Propagate keyring updates of all namespaces to standby nodes

### DIFF
--- a/changelog/3409.txt
+++ b/changelog/3409.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Propagate keyring upgrades of sealable namespaces to read-enabled standby nodes.
+```

--- a/vault/barrier/aes_gcm.go
+++ b/vault/barrier/aes_gcm.go
@@ -35,10 +35,16 @@ const (
 	// termSize the number of bytes used for the key term.
 	termSize = 4
 
+	// AutoRotateCheckInterval is used as a timestep between
+	// automatic barrier key rotation checks.
 	AutoRotateCheckInterval = 5 * time.Minute
 	legacyRotateReason      = "legacy rotation"
+
 	// The keyring is persisted before the root key.
 	keyringTimeout = 1 * time.Second
+
+	// oneYear is the duration after which we deem keyring term 'legacy'.
+	oneYear = 24 * 365 * time.Hour
 )
 
 // Versions of the AESGCM storage methodology
@@ -112,6 +118,8 @@ type AESGCMBarrierTransaction struct {
 }
 
 func (b *AESGCMBarrier) RotationConfig() (kc KeyRotationConfig, err error) {
+	b.l.RLock()
+	defer b.l.RUnlock()
 	if b.keyring == nil {
 		return kc, errors.New("keyring not yet present")
 	}
@@ -124,7 +132,6 @@ func (b *AESGCMBarrier) SetRotationConfig(ctx context.Context, rotConfig KeyRota
 	rotConfig.Sanitize()
 	if !rotConfig.Equals(b.keyring.rotationConfig) {
 		b.keyring.rotationConfig = rotConfig
-
 		return b.persistKeyring(ctx, b.keyring)
 	}
 	return nil
@@ -1203,34 +1210,30 @@ func (b *AESGCMBarrier) TotalLocalEncryptions() int64 {
 }
 
 func (b *AESGCMBarrier) CheckBarrierAutoRotate(ctx context.Context) (string, error) {
-	const oneYear = 24 * 365 * time.Hour
 	reason, err := func() (string, error) {
 		b.l.RLock()
 		defer b.l.RUnlock()
-		if b.keyring != nil {
-			// Rotation Checks
-			var reason string
 
-			rc, err := b.RotationConfig()
-			if err != nil {
-				return "", err
-			}
-
-			if !rc.Disabled {
-				activeKey := b.keyring.ActiveKey()
-				ops := b.encryptions()
-				switch {
-				case activeKey.Encryptions == 0 && !activeKey.InstallTime.IsZero() && time.Since(activeKey.InstallTime) > oneYear:
-					reason = legacyRotateReason
-				case ops > rc.MaxOperations:
-					reason = "reached max operations"
-				case rc.Interval > 0 && time.Since(activeKey.InstallTime) > rc.Interval:
-					reason = "rotation interval reached"
-				}
-			}
-			return reason, nil
+		if b.keyring == nil {
+			return "", nil
 		}
-		return "", nil
+
+		rc := b.keyring.rotationConfig.Clone()
+		if rc.Disabled {
+			return "", nil
+		}
+
+		activeKey := b.keyring.ActiveKey()
+		switch {
+		case activeKey.Encryptions == 0 && !activeKey.InstallTime.IsZero() && time.Since(activeKey.InstallTime) > oneYear:
+			return legacyRotateReason, nil
+		case b.encryptions() > rc.MaxOperations:
+			return "reached max operations", nil
+		case rc.Interval > 0 && time.Since(activeKey.InstallTime) > rc.Interval:
+			return "rotation interval reached", nil
+		default:
+			return "", nil
+		}
 	}()
 	if err != nil {
 		return "", err
@@ -1239,14 +1242,14 @@ func (b *AESGCMBarrier) CheckBarrierAutoRotate(ctx context.Context) (string, err
 		return reason, nil
 	}
 
+	// either rotation is disabled or we do not fulfill
+	// any of the rotation conditions.
 	b.l.Lock()
 	defer b.l.Unlock()
 	if b.keyring != nil {
-		err := b.persistEncryptions(ctx)
-		if err != nil {
-			return "", err
-		}
+		return "", b.persistEncryptions(ctx)
 	}
+
 	return reason, nil
 }
 

--- a/vault/barrier/barrier.go
+++ b/vault/barrier/barrier.go
@@ -67,12 +67,12 @@ const (
 	// used to reload the keyring itself.
 	RootKeyPath = "core/root-key"
 
-	// LegacyRootKeyPath is the former value of rootKeyPath and is replaced
+	// LegacyRootKeyPath is the former value of RootKeyPath and is replaced
 	// on initialization or rotation.
 	LegacyRootKeyPath = "core/master"
 
 	// ShamirKekPath is used with Shamir in v1.3+ to store a copy of the
-	// unseal key behind the barrier. As with rootKeyPath this is primarily
+	// unseal key behind the barrier. As with RootKeyPath this is primarily
 	// used by standbys to handle rotations. It also comes into play when
 	// restoring raft snapshots.
 	ShamirKekPath = "core/shamir-kek"

--- a/vault/core.go
+++ b/vault/core.go
@@ -561,7 +561,7 @@ type Core struct {
 	// became active.
 	activeTime time.Time
 
-	// KeyRotateGracePeriod is how long we allow an upgrade path
+	// keyRotateGracePeriod is how long we allow an upgrade path
 	// for standby instances before we delete the upgrade keys
 	keyRotateGracePeriod atomic.Int64
 
@@ -975,7 +975,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceDisabled))
 	c.clusterAddr.Store(conf.ClusterAddr)
-	c.keyRotateGracePeriod.Store(int64(2 * time.Minute))
+	c.SetKeyRotateGracePeriod(2 * time.Minute)
 
 	// Create a random key for raft peer challenges.
 	_, err := io.ReadFull(rand.Reader, c.pendingRaftPeerChallengeKey)
@@ -3026,7 +3026,7 @@ func (c *Core) SetKeyRotateGracePeriod(t time.Duration) {
 	c.keyRotateGracePeriod.Store(int64(t))
 }
 
-// Periodically test whether to automatically rotate the barrier key
+// autoRotateBarrierLoop checks whether to automatically rotate the barrier key.
 func (c *Core) autoRotateBarrierLoop(ctx context.Context) {
 	t := time.NewTicker(barrier.AutoRotateCheckInterval)
 	for {
@@ -3044,10 +3044,6 @@ func (c *Core) checkBarrierAutoRotate(ctx context.Context) {
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
-	if !c.isPrimary() {
-		return
-	}
-
 	reason, err := c.barrier.CheckBarrierAutoRotate(ctx)
 	if err != nil {
 		lf := c.logger.Error
@@ -3059,20 +3055,13 @@ func (c *Core) checkBarrierAutoRotate(ctx context.Context) {
 	}
 
 	if reason != "" {
-		// Time to rotate. Invoke the rotation handler in order to both rotate and create
-		// the replication canary
 		c.logger.Info("automatic barrier key rotation triggered", "reason", reason)
-
-		if err := c.systemBackend.rotateBarrierKey(ctx); err != nil {
+		if err := c.sealManager.RotateBarrierKey(ctx, namespace.RootNamespace); err != nil {
 			c.logger.Error("error automatically rotating barrier key", "error", err)
 		} else {
 			metrics.IncrCounter(barrier.BarrierRotationsMetric, 1)
 		}
 	}
-}
-
-func (c *Core) isPrimary() bool {
-	return true
 }
 
 func (c *Core) loadLoginMFAConfigs(ctx context.Context) error {

--- a/vault/core_cache_invalidate.go
+++ b/vault/core_cache_invalidate.go
@@ -251,7 +251,7 @@ func isTransactionalMountPath(key string) bool {
 		strings.HasPrefix(key, coreLocalAuthConfigPath+"/")
 }
 
-func isKeyringPath(key string) bool {
+func isCoreKeyPath(key string) bool {
 	return key == barrierSealConfigPath ||
 		key == barrier.KeyringPath ||
 		key == barrier.LegacyRootKeyPath ||
@@ -260,7 +260,7 @@ func isKeyringPath(key string) bool {
 		key == barrier.RootKeyPath ||
 		key == barrier.ShamirKekPath ||
 		key == StoredBarrierKeysPath ||
-		strings.HasPrefix(key, barrier.KeyringUpgradePrefix)
+		key == raftTLSStoragePath
 }
 
 func isMissedMountKey(key string) bool {
@@ -407,9 +407,13 @@ func (ij *invalidationJob) Execute() error {
 	case isTransactionalMountPath(ij.nsKey):
 		ij.fatal = true
 		return ij.transactionalMountInvalidation(ctx)
-	case isKeyringPath(ij.nsKey):
-		// The HA subsystem handles keyring rotations via the
-		// periodicCheckKeyUpgrades(...) actor.
+	case strings.HasPrefix(ij.nsKey, barrier.KeyringUpgradePrefix):
+		ij.fatal = true
+		// this is handled via periodicCheckKeyringUpgrades(...)
+		// for root namespace while run by read-disabled standby nodes.
+		return ij.keyringTermInvalidation(ctx, ns.Path)
+	case isCoreKeyPath(ij.nsKey):
+		// No need to invalidate these entries.
 	case strings.HasPrefix(ij.key, coreLeaderPrefix):
 		// The HA subsystem handles leadership changes.
 	case strings.HasPrefix(ij.key, pluginCatalogPath):
@@ -502,6 +506,19 @@ func (ij *invalidationJob) legacyMountInvalidation(ctx context.Context) error {
 func (ij *invalidationJob) transactionalMountInvalidation(ctx context.Context) error {
 	if err := ij.im.core.reloadMount(ctx, ij.nsKey); err != nil {
 		return fmt.Errorf("unable to invalidate mount for key %q in namespace %q: %w", ij.nsKey, ij.nsUUID, err)
+	}
+
+	return nil
+}
+
+func (ij *invalidationJob) keyringTermInvalidation(ctx context.Context, nsPath string) error {
+	b := ij.im.core.sealManager.NamespaceBarrier(nsPath)
+	if b == nil {
+		return fmt.Errorf("couldn't retrieve barrier for a namespace: %q", nsPath)
+	}
+
+	if err := ij.im.core.checkKeyringUpgrade(ctx, b); err != nil {
+		return fmt.Errorf("unable to invalidate keyring upgrade entry for key %q in namespace %q: %w", ij.nsKey, ij.nsUUID, err)
 	}
 
 	return nil

--- a/vault/core_cache_invalidate_test.go
+++ b/vault/core_cache_invalidate_test.go
@@ -410,6 +410,74 @@ func TestCore_Invalidate_Quota(t *testing.T) {
 	require.Equal(t, 1, resp.Data["interval"])
 }
 
+func TestCore_Upgrade_Keyring(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]func(t *testing.T, c *Core) context.Context{
+		"global": func(t *testing.T, c *Core) context.Context {
+			return namespace.RootContext(t.Context())
+		},
+
+		"unsealed": func(t *testing.T, c *Core) context.Context {
+			ns := &namespace.Namespace{
+				ID:   "unsealed",
+				Path: "unsealed",
+			}
+			TestCoreCreateUnsealedNamespaces(t, c, ns)
+
+			return namespace.ContextWithNamespace(t.Context(), ns)
+		},
+	}
+
+	for name, init := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c, root := testCore_Invalidate_TestCore(t, nil)
+			ctx := init(t, c)
+
+			ns, err := namespace.FromContext(ctx)
+			require.NoError(t, err)
+
+			// 1. Retrieve key status information.
+			req := logical.TestRequest(t, logical.ReadOperation, "sys/key-status")
+			req.ClientToken = root
+			resp := testCore_Invalidate_handleRequest(t, ctx, c, req)
+			require.NotNil(t, resp)
+			prevTerm := resp.Data["term"].(int)
+			require.Equal(t, 1, prevTerm)
+
+			// 2. Manipulate Storage.
+			b := c.sealManager.NamespaceBarrier(ns.Path)
+			require.NoError(t, err)
+
+			path := fmt.Sprintf("core/upgrade/%d", prevTerm)
+			keyring, err := b.Keyring()
+			require.NoError(t, err)
+
+			buf, err := keyring.TermKey(uint32(prevTerm)).Serialize()
+			require.NoError(t, err)
+			value, err := b.Encrypt(ctx, path, buf)
+			require.NoError(t, err)
+
+			newTerm, err := b.Rotate(ctx)
+			require.NoError(t, err)
+			require.Equal(t, uint32(prevTerm+1), newTerm)
+
+			testCore_Invalidate_sneakValueAroundCache(t, ctx, c, &logical.StorageEntry{
+				Key:   strings.TrimPrefix(path, c.NamespaceView(ns).Prefix()),
+				Value: value,
+			})
+
+			// 3. Invalidate path.
+			require.NoError(t, c.invalidateSynchronous(path))
+
+			// 4. Check cache was properly invalidated.
+			req = logical.TestRequest(t, logical.ReadOperation, "sys/key-status")
+			req.ClientToken = root
+			resp = testCore_Invalidate_handleRequest(t, ctx, c, req)
+			require.Equal(t, prevTerm+1, resp.Data["term"].(int))
+		})
+	}
+}
+
 func TestCore_Invalidate_LoginMFA(t *testing.T) {
 	t.Parallel()
 	testCases := map[string]func(t *testing.T, c *Core) context.Context{

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -31,12 +31,14 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
 	vaultseal "github.com/openbao/openbao/vault/seal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
 
 type RaftClusterOpts struct {
 	DisableFollowerJoins           bool
+	DisableStandbyReads            bool
 	InmemCluster                   bool
 	EnableAutopilot                bool
 	PhysicalFactoryConfig          map[string]interface{}
@@ -69,6 +71,7 @@ func raftCluster(t testing.TB, ropts *RaftClusterOpts) (*vault.TestCluster, *vau
 	opts.NumCores = ropts.NumCores
 	opts.VersionMap = ropts.VersionMap
 	opts.EffectiveSDKVersionMap = ropts.EffectiveSDKVersionMap
+	opts.DisableStandbyReads = ropts.DisableStandbyReads
 
 	teststorage.RaftBackendSetup(conf, &opts)
 
@@ -924,6 +927,87 @@ func TestRaft_SnapshotAPI_Rotate_Forward(t *testing.T) {
 					t.Fatal(data)
 				}
 			}
+		})
+	}
+}
+
+func TestRaft_RotateKeyring(t *testing.T) {
+	t.Parallel()
+
+	cluster, _ := raftCluster(t, &RaftClusterOpts{})
+	defer cluster.Cleanup()
+
+	leaderClient := cluster.Cores[0].Client
+	rootCtx := namespace.RootContext(t.Context())
+	output, err := leaderClient.Sys().CreateNamespaceWithContext(rootCtx, "test-ns", &api.CreateNamespaceInput{})
+	require.NoError(t, err)
+	ns := &namespace.Namespace{ID: output.ID, Path: output.Path, UUID: output.UUID}
+
+	tt := []struct {
+		name      string
+		namespace *namespace.Namespace
+	}{
+		{
+			name:      "root namespace",
+			namespace: namespace.RootNamespace,
+		},
+		{
+			name:      "other namespace",
+			namespace: ns,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := namespace.ContextWithNamespace(t.Context(), tc.namespace)
+
+			// Write a secret.
+			_, err := leaderClient.Logical().WriteWithContext(ctx, "secret/foo", map[string]interface{}{
+				"test": "data",
+			})
+			require.NoError(t, err)
+
+			verifyRead := func(path string) {
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+					for _, c := range cluster.Cores {
+						res, err := c.Client.Logical().ReadWithContext(ctx, path)
+						require.NoError(collect, err)
+						require.NotEmpty(collect, res)
+						require.Equal(collect, "data", res.Data["test"].(string))
+					}
+				}, time.Second, 100*time.Millisecond)
+			}
+
+			// Verify written secret.
+			verifyRead("secret/foo")
+
+			status, err := leaderClient.Sys().KeyStatusWithContext(ctx)
+			require.NoError(t, err)
+			prevTerm := status.Term
+
+			// Rotate keyring.
+			require.NoError(t, leaderClient.Sys().RotateKeyringWithContext(ctx))
+
+			// Write secret after keyring rotation.
+			_, err = leaderClient.Logical().WriteWithContext(ctx, "secret/bar", map[string]interface{}{
+				"test": "data",
+			})
+			require.NoError(t, err)
+
+			// Verify standby nodes have upgraded their keyrings.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				for _, c := range cluster.Cores {
+					status, err := c.Client.Sys().KeyStatusWithContext(ctx)
+					require.NoError(collect, err)
+					require.Equal(collect, prevTerm+1, status.Term)
+				}
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// Verify we can read secret written with previous term keyring.
+			verifyRead("secret/foo")
+
+			// Verify we can read secret written with most recent keyring.
+			verifyRead("secret/bar")
 		})
 	}
 }

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -38,8 +38,8 @@ const (
 	// leaderCheckInterval is how often a standby checks for a new leader
 	leaderCheckInterval = 2500 * time.Millisecond
 
-	// keyRotateCheckInterval is how often a standby checks for a key
-	// rotation taking place.
+	// keyRotateCheckInterval is how often a read-disabled standby checks
+	// for a keyring upgrade taking place.
 	keyRotateCheckInterval = 10 * time.Second
 
 	// leaderPrefixCleanDelay is how long to wait between deletions
@@ -495,6 +495,7 @@ func (c *Core) runHALoop(doneCh chan<- struct{}, manualStepDownCh chan struct{},
 
 func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <-chan struct{}) bool {
 	restart := false
+	isReadEnabledStandby := c.StandbyReadsEnabled()
 
 	var g run.Group
 	{
@@ -510,15 +511,15 @@ func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <
 		}, func(error) {})
 	}
 	{
-		// Monitor for key rotations
+
 		keyRotateStop := make(chan struct{})
 
 		g.Add(func() error {
-			c.periodicCheckKeyUpgrades(context.Background(), keyRotateStop)
+			c.periodicCheckKeyringUpgrades(context.Background(), keyRotateStop, isReadEnabledStandby)
 			return nil
 		}, func(error) {
 			close(keyRotateStop)
-			c.logger.Debug("shutting down periodic key rotation checker")
+			c.logger.Debug("shutting down periodic keyring upgrade checker")
 		})
 	}
 	{
@@ -549,7 +550,7 @@ func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <
 		leaderStopCh := make(chan struct{})
 
 		g.Add(func() error {
-			c.waitForLeadership(manualStepDownCh, leaderStopCh)
+			c.waitForLeadership(manualStepDownCh, leaderStopCh, isReadEnabledStandby)
 			return nil
 		}, func(error) {
 			close(leaderStopCh)
@@ -570,7 +571,7 @@ func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <
 // waitForLeadership is a long running routine that is used when an HA backend
 // is enabled. It waits until we are leader and switches this Vault to
 // active.
-func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
+func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}, isReadEnabled bool) {
 	var manualStepDown bool
 	firstIteration := true
 
@@ -611,7 +612,7 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}) {
 
 		// If possible, unseal in read-only mode and start acting as a
 		// read-enabled standby.
-		if c.StandbyReadsEnabled() {
+		if isReadEnabled {
 			if stop := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh); stop {
 				return
 			}
@@ -1049,8 +1050,10 @@ func (c *Core) periodicLeaderRefresh(stopCh chan struct{}) {
 	}
 }
 
-// periodicCheckKeyUpgrade is used to watch for key rotation events as a standby
-func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{}) {
+// periodicCheckKeyringUpgrades is used to watch for root namespace keyring
+// rotation events as a read-disabled standby. Also watches for Raft TLS key
+// upgrades for both types of standby nodes.
+func (c *Core) periodicCheckKeyringUpgrades(ctx context.Context, stopCh chan struct{}, isReadEnabled bool) {
 	raftBackend := c.GetRaftBackend()
 	isRaft := raftBackend != nil
 
@@ -1072,8 +1075,12 @@ func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{
 					return
 				}
 
-				if err := c.checkKeyUpgrades(ctx); err != nil {
-					c.logger.Error("key rotation periodic upgrade check failed", "error", err)
+				// Monitor for keyring upgrades but only for read-disabled nodes.
+				// Otherwise read-enabled nodes are handled through invalidation manager.
+				if !isReadEnabled {
+					if err := c.checkKeyringUpgrade(ctx, c.barrier); err != nil {
+						c.logger.Error("root keyring rotation periodic upgrade check failed", "error", err)
+					}
 				}
 
 				if isRaft {
@@ -1098,28 +1105,19 @@ func (c *Core) periodicCheckKeyUpgrades(ctx context.Context, stopCh chan struct{
 	}
 }
 
-// checkKeyUpgrades is used to check if there have been any key rotations
-// and if there is a chain of upgrades available
-func (c *Core) checkKeyUpgrades(ctx context.Context) error {
+// checkKeyringUpgrade is used to rotate the keyring to the new term
+// if there have been any key rotations performed on a leader node.
+func (c *Core) checkKeyringUpgrade(ctx context.Context, b barrier.SecurityBarrier) error {
 	for {
-		// Check for an upgrade
-		didUpgrade, newTerm, err := c.barrier.CheckUpgrade(ctx)
+		didUpgrade, newTerm, err := b.CheckUpgrade(ctx)
 		if err != nil {
 			return err
 		}
 
-		// Nothing to do if no upgrade
 		if !didUpgrade {
 			break
 		}
 		c.logger.Info("upgraded to new key term", "term", newTerm)
-	}
-	return nil
-}
-
-func (c *Core) reloadRootKey(ctx context.Context) error {
-	if err := c.barrier.ReloadRootKey(ctx); err != nil {
-		return fmt.Errorf("error reloading root key: %w", err)
 	}
 	return nil
 }
@@ -1150,11 +1148,11 @@ func (c *Core) reloadShamirKey(ctx context.Context) error {
 }
 
 func (c *Core) performKeyUpgrades(ctx context.Context) error {
-	if err := c.checkKeyUpgrades(ctx); err != nil {
+	if err := c.checkKeyringUpgrade(ctx, c.barrier); err != nil {
 		return fmt.Errorf("error checking for key upgrades: %w", err)
 	}
 
-	if err := c.reloadRootKey(ctx); err != nil {
+	if err := c.barrier.ReloadRootKey(ctx); err != nil {
 		return fmt.Errorf("error reloading root key: %w", err)
 	}
 
@@ -1174,7 +1172,8 @@ func (c *Core) performKeyUpgrades(ctx context.Context) error {
 }
 
 // scheduleUpgradeCleanup is used to ensure that all the upgrade paths
-// are cleaned up in a timely manner if a leader failover takes place
+// are cleaned up in a timely manner if a leader failover takes place.
+// Unfortunately we have to this for all sealable namespaces also.
 func (c *Core) scheduleUpgradeCleanup(ctx context.Context) error {
 	// List the upgrades
 	upgrades, err := c.barrier.List(ctx, barrier.KeyringUpgradePrefix)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4508,33 +4508,6 @@ func (b *SystemBackend) handleLeaderStatus(ctx context.Context, req *logical.Req
 	return httpResp, nil
 }
 
-func (b *SystemBackend) rotateBarrierKey(ctx context.Context) error {
-	// Rotate to the new term
-	newTerm, err := b.Core.barrier.Rotate(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create new encryption key: %w", err)
-	}
-	b.Backend.Logger().Info("installed new encryption key")
-
-	// In HA mode, we need to an upgrade path for the standby instances
-	if b.Core.ha != nil && b.Core.KeyRotateGracePeriod() > 0 {
-		// Create the upgrade path to the new term
-		if err := b.Core.barrier.CreateUpgrade(ctx, newTerm); err != nil {
-			b.Backend.Logger().Error("failed to create new upgrade", "term", newTerm, "error", err)
-		}
-
-		// Schedule the destroy of the upgrade path
-		time.AfterFunc(b.Core.KeyRotateGracePeriod(), func() {
-			b.Backend.Logger().Debug("cleaning up upgrade keys", "waited", b.Core.KeyRotateGracePeriod())
-			if err := b.Core.barrier.DestroyUpgrade(b.Core.activeContext.Load(), newTerm); err != nil {
-				b.Backend.Logger().Error("failed to destroy upgrade", "term", newTerm, "error", err)
-			}
-		})
-	}
-
-	return nil
-}
-
 func (b *SystemBackend) handleHAStatus(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	// We're always the leader if we're handling this request.
 	nodes, err := b.Core.getHAMembers()

--- a/vault/logical_system_rotate.go
+++ b/vault/logical_system_rotate.go
@@ -406,7 +406,7 @@ func (b *SystemBackend) rotatePaths() []*framework.Path {
 	}
 }
 
-// handleRotate handles the GET `/sys/rotate` and `/sys/rotate/keyring`
+// handleRotate handles the POST `/sys/rotate` and `/sys/rotate/keyring`
 // endpoints used to trigger an encryption key rotation.
 func (b *SystemBackend) handleRotate() framework.OperationFunc {
 	return func(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {

--- a/vault/rotate.go
+++ b/vault/rotate.go
@@ -119,15 +119,16 @@ func (sm *SealManager) RotateBarrierKey(ctx context.Context, ns *namespace.Names
 
 	// In HA mode, we need to an upgrade path for the standby instances
 	// we are using the same key rotate grace period for all namespaces for now.
-	if sm.core.ha != nil && sm.core.KeyRotateGracePeriod() > 0 {
+	gracePeriod := sm.core.KeyRotateGracePeriod()
+	if sm.core.ha != nil && gracePeriod > 0 {
 		// Create the upgrade path to the new term
 		if err := b.CreateUpgrade(ctx, newTerm); err != nil {
 			sm.logger.Error("failed to create new upgrade", "term", newTerm, "error", err, "namespace", ns.Path)
 		}
 
 		// Schedule the destroy of the upgrade path
-		time.AfterFunc(sm.core.KeyRotateGracePeriod(), func() {
-			sm.logger.Debug("cleaning up upgrade keys", "waited", sm.core.KeyRotateGracePeriod())
+		_ = time.AfterFunc(gracePeriod, func() {
+			sm.logger.Debug("cleaning up upgrade keys", "waited", gracePeriod)
 			if err := b.DestroyUpgrade(sm.core.activeContext.Load(), newTerm); err != nil {
 				sm.logger.Error("failed to destroy upgrade", "term", newTerm, "error", err, "namespace", ns.Path)
 			}


### PR DESCRIPTION
## Description
This PR adjusts the existing upgrade polling logic for keyring updates (and raft TLS) for a established (with v2.5 release) invalidation pattern, which would trigger on a `core/upgrade/...` write/delete and properly install new keyring term on a standby node, also respecting the source namespace.

## Rationale
Sealable namespace in a HA raft cluster would be rendered unusable after certain period due to missing keyring update, all new (namespace-owned) entries would be unreadable on standby node.

Resolves: #3379

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
