### PR TITLE
core/metrics: expose sys/metrics unauthenticated when sealed

### DIFF
--- a/changelog/3430.txt
+++ b/changelog/3430.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: Report `vault.core.unsealed=0` when OpenBao is sealed via dedicated metrics loop.
+```

--- a/changelog/3430.txt
+++ b/changelog/3430.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:improvement
 core/metrics: Report `vault.core.unsealed=0` when OpenBao is sealed via dedicated metrics loop.
 ```

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -995,6 +995,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 0, nil)
 
 	c.shutdownDoneCh.Store(make(chan struct{}))
+	go c.emitUnsealedStatusMetric(c.shutdownDoneCh.Load().(chan struct{}))
 
 	c.allLoggers = append(c.allLoggers, c.logger, routerLogger)
 

--- a/internal/vault/core_metrics.go
+++ b/internal/vault/core_metrics.go
@@ -43,9 +43,9 @@ func (c *Core) metricsLoop(stopCh chan struct{}) {
 
 	// This loop covers
 	// vault.expire.num_leases
-	// vault.core.unsealed
 	// vault.identity.num_entities
 	// and the non-telemetry request counters shown in the UI.
+	// vault.core.unsealed is handled by emitUnsealedStatusMetric instead.
 	for {
 		select {
 		case <-emitTimer:
@@ -60,13 +60,6 @@ func (c *Core) metricsLoop(stopCh chan struct{}) {
 					c.expiration.emitMetrics()
 				}
 				c.metricsMutex.Unlock()
-			}
-
-			// Refresh the sealed gauge, on all nodes
-			if c.Sealed() {
-				c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 0, nil)
-			} else {
-				c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 1, nil)
 			}
 
 			// Refresh the standby gauge, on all nodes
@@ -165,6 +158,26 @@ func (c *Core) tokenGaugeTtlCollector(ctx context.Context) ([]metricsutil.GaugeL
 		return []metricsutil.GaugeLabelValues{}, errors.New("nil token store")
 	}
 	return ts.gaugeCollectorByTtl(ctx)
+}
+
+// emitUnsealedStatusMetric refreshes vault.core.unsealed every second for the
+// lifetime of the process so that monitoring systems always observe a current
+// value regardless of seal state.
+func (c *Core) emitUnsealedStatusMetric(shutdownCh <-chan struct{}) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-shutdownCh:
+			return
+		case <-ticker.C:
+			if c.Sealed() {
+				c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 0, nil)
+			} else {
+				c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 1, nil)
+			}
+		}
+	}
 }
 
 // emitMetricsActiveNode is used to start all the periodic metrics; all of them should


### PR DESCRIPTION
## Description

`sys/metrics` was inaccessible while the node was sealed because requests went through the standard logical handler, which returns `ErrSealed` for all requests when the core is not unsealed. This made it impossible for monitoring systems to observe `vault.core.unsealed` before the node finished unsealing — the very metric that signals when the node is ready.

Two changes are needed to fix this:

1. **Handler routing** (`http/handler.go`, `http/sys_metrics.go`): when `unauthenticated_metrics_access` is enabled, the existing `handleMetricsUnauthenticated` handler already bypasses the sealed check and is left unchanged. For the default case (no flag), a new `handleMetricsUnauthenticatedOrSealed` handler is introduced: it serves metrics unauthenticated when sealed, and falls back to the authenticated handler when unsealed. This is intentionally analogous to `sys/health`, which is already unauthenticated regardless of seal state.

2. **Gauge freshness** (`vault/core_metrics.go`, `vault/core.go`): `metricsLoop` only runs after unseal, so `vault.core.unsealed` would expire from the `InMemSink` (10 s interval) before a monitoring system could observe it. A lightweight goroutine `emitSealedMetrics` is started at core init and refreshes `vault.core.unsealed = 0` every second while the node is sealed; once unsealed, `metricsLoop` takes over and the goroutine becomes a no-op.

## Rationale

Resolves: #1695


## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
