### PR TITLE
fix(command/server): preserve missing config fields in Config.Merge() and Config.Sanitized()

### DIFF
--- a/changelog/3433.txt
+++ b/changelog/3433.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+command/server: Fix boolean config fields being dropped when multiple `-config` paths are used
+```
+```release-note:improvement
+command/server: Include `disable_standby_reads`, `allow_unauthenticated_workflows`, and `unsafe_relative_paths` in sanitized config output
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -1413,6 +1413,10 @@ func (c *Config) Sanitized() map[string]interface{} {
 
 		"unsafe_allow_api_audit_creation": c.UnsafeAllowAPIAuditCreation,
 		"allow_audit_log_prefixing":       c.AllowAuditLogPrefixing,
+
+		"disable_standby_reads":           c.DisableStandbyReads,
+		"allow_unauthenticated_workflows": c.AllowUnauthenticatedWorkflows,
+		"unsafe_relative_paths":           c.UnsafeRelativePaths,
 	}
 	maps.Copy(result, sharedResult)
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -638,6 +638,21 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.AllowAuditLogPrefixing = c2.AllowAuditLogPrefixing
 	}
 
+	result.DisableStandbyReads = c.DisableStandbyReads
+	if c2.DisableStandbyReads {
+		result.DisableStandbyReads = c2.DisableStandbyReads
+	}
+
+	result.AllowUnauthenticatedWorkflows = c.AllowUnauthenticatedWorkflows
+	if c2.AllowUnauthenticatedWorkflows {
+		result.AllowUnauthenticatedWorkflows = c2.AllowUnauthenticatedWorkflows
+	}
+
+	result.UnsafeRelativePaths = c.UnsafeRelativePaths
+	if c2.UnsafeRelativePaths {
+		result.UnsafeRelativePaths = c2.UnsafeRelativePaths
+	}
+
 	// Use values from top-level configuration for storage if set
 	if storage := result.Storage; storage != nil {
 		if result.APIAddr != "" {

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -163,3 +163,7 @@ func TestLoadConfigFile_topLevel(t *testing.T) {
 func TestLoadConfigFile_json2(t *testing.T) {
 	testLoadConfigFile_json2(t)
 }
+
+func TestConfigMerge_PreservesFields(t *testing.T) {
+	testConfigMergePreservesFields(t)
+}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -776,6 +776,9 @@ func testConfig_Sanitized(t *testing.T) {
 		"unsafe_cross_namespace_identity": false,
 		"unsafe_allow_api_audit_creation": false,
 		"allow_audit_log_prefixing":       false,
+		"disable_standby_reads":           false,
+		"allow_unauthenticated_workflows": false,
+		"unsafe_relative_paths":           false,
 	}
 
 	addExpectedEntSanitizedConfig(expected, []string{"http"})

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -1175,3 +1175,18 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func testConfigMergePreservesFields(t *testing.T) {
+	c1 := &Config{
+		SharedConfig:        &configutil.SharedConfig{},
+		DisableStandbyReads: true,
+	}
+	c2 := &Config{
+		SharedConfig:                  &configutil.SharedConfig{},
+		AllowUnauthenticatedWorkflows: true,
+	}
+
+	merged := c1.Merge(c2)
+	require.True(t, merged.DisableStandbyReads, "DisableStandbyReads should be preserved from c1")
+	require.True(t, merged.AllowUnauthenticatedWorkflows, "AllowUnauthenticatedWorkflows should be preserved from c2")
+}

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -174,6 +174,9 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"unsafe_cross_namespace_identity": false,
 				"unsafe_allow_api_audit_creation": false,
 				"allow_audit_log_prefixing":       false,
+				"disable_standby_reads":           false,
+				"allow_unauthenticated_workflows": false,
+				"unsafe_relative_paths":           false,
 			}
 
 			if tc.expectedHAStorageOutput != nil {


### PR DESCRIPTION
## Description

`Config.Merge()` only preserves fields that are explicitly listed in its body. Fields added to the `Config` struct at a later point without a corresponding update to `Merge()` are silently dropped, defaulting to their zero value regardless of what either source config specifies.

This PR adds the three fields that were missing:

- `DisableStandbyReads`
- `AllowUnauthenticatedWorkflows`
- `UnsafeRelativePaths`

`Config.Sanitized()` is also updated to include these fields in its output, so that `bao read sys/config/state/sanitized` can be used to verify the effective merged configuration.

A regression test (`TestConfigMergePreservesFields`) is added to verify fields are preserved through a merge.

## Rationale

When OpenBao is started with multiple `-config` paths, `ParseServerConfig` calls `Config.Merge()` to combine them. Any field absent from `Merge()` silently defaults to `false`/zero, overriding the user's intent with no warning.

Resolves: #3432 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
