### PR TITLE
helper/docker: reduce pulls

### DIFF
--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 )
 
 type Runner struct {
@@ -406,6 +407,51 @@ func shouldPull(ctx context.Context, dockerAPI *client.Client, image string) boo
 	}
 }
 
+var (
+	pullLocks = locksutil.CreateLocks()
+	pullCache = map[string]error{}
+)
+
+func (d *Runner) pull(ctx context.Context, image string) (result error) {
+	lock := locksutil.LockForKey(pullLocks, image)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// first we check if the current process has already pulled the image (or skipped pulling based on the second check)
+	if err, ok := pullCache[image]; ok {
+		return err
+	}
+	defer func() {
+		pullCache[image] = result
+	}()
+
+	// second we check if the image is "reasonable recent"
+	if !shouldPull(ctx, d.DockerAPI, image) {
+		return
+	}
+
+	// best-effort pull
+	var opts client.ImagePullOptions
+	if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
+		var buf bytes.Buffer
+		auth := map[string]string{
+			"username": d.RunOptions.AuthUsername,
+			"password": d.RunOptions.AuthPassword,
+		}
+		if err := json.NewEncoder(&buf).Encode(auth); err != nil {
+			result = err
+			return
+		}
+		opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
+	}
+	resp, _ := d.DockerAPI.ImagePull(ctx, image, opts)
+	if resp != nil {
+		_, _ = io.ReadAll(resp)
+	}
+
+	return
+}
+
 func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*StartResult, error) {
 	name := d.RunOptions.ContainerName
 	if addSuffix {
@@ -451,24 +497,9 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 		}
 	}
 
-	if shouldPull(ctx, d.DockerAPI, cfg.Image) {
-		// best-effort pull
-		var opts client.ImagePullOptions
-		if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
-			var buf bytes.Buffer
-			auth := map[string]string{
-				"username": d.RunOptions.AuthUsername,
-				"password": d.RunOptions.AuthPassword,
-			}
-			if err := json.NewEncoder(&buf).Encode(auth); err != nil {
-				return nil, err
-			}
-			opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
-		}
-		resp, _ := d.DockerAPI.ImagePull(ctx, cfg.Image, opts)
-		if resp != nil {
-			_, _ = io.ReadAll(resp)
-		}
+	err := d.pull(ctx, cfg.Image)
+	if err != nil {
+		return nil, err
 	}
 
 	for vol, mtpt := range d.RunOptions.VolumeNameToMountPoint {

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/url"
 	"os"
 	"strconv"
@@ -357,6 +358,54 @@ type StartResult struct {
 	RealIP    string
 }
 
+func shouldPull(ctx context.Context, dockerAPI *client.Client, image string) bool {
+	// check if the image is present locally
+	imageInspect, err := dockerAPI.ImageInspect(ctx, image)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return true
+		}
+
+		log.Default().Printf("[WARNING] error while checking if image %q is present locally, assuming no: %v\n", image, err)
+		return true
+	}
+
+	// check if it has been built less than 24 hours ago
+	createdTime, err := time.Parse(time.RFC3339Nano, imageInspect.Created)
+	if err != nil {
+		log.Default().Printf("[WARNING] error while checking if %q is recent, assuming no: %v\n", image, err)
+		return true
+	}
+
+	if time.Since(createdTime) < 24*time.Hour {
+		return false
+	}
+
+	// check if it has been pull less than 24 hours ago
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	events := dockerAPI.Events(ctx, client.EventsListOptions{
+		Since:   "24h",
+		Until:   "0s",
+		Filters: make(client.Filters).Add("event", "pull").Add("image", image),
+	})
+
+	for {
+		select {
+		case err := <-events.Err:
+			if errors.Is(err, io.EOF) {
+				return true
+			}
+
+			log.Default().Printf("[WARNING] error while trying to check if image %q has been pulled already, assuming no: %v\n", image, err)
+			return true
+		case <-events.Messages:
+			return false
+		}
+	}
+}
+
 func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*StartResult, error) {
 	name := d.RunOptions.ContainerName
 	if addSuffix {
@@ -402,22 +451,24 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 		}
 	}
 
-	// best-effort pull
-	var opts client.ImagePullOptions
-	if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
-		var buf bytes.Buffer
-		auth := map[string]string{
-			"username": d.RunOptions.AuthUsername,
-			"password": d.RunOptions.AuthPassword,
+	if shouldPull(ctx, d.DockerAPI, cfg.Image) {
+		// best-effort pull
+		var opts client.ImagePullOptions
+		if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
+			var buf bytes.Buffer
+			auth := map[string]string{
+				"username": d.RunOptions.AuthUsername,
+				"password": d.RunOptions.AuthPassword,
+			}
+			if err := json.NewEncoder(&buf).Encode(auth); err != nil {
+				return nil, err
+			}
+			opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
 		}
-		if err := json.NewEncoder(&buf).Encode(auth); err != nil {
-			return nil, err
+		resp, _ := d.DockerAPI.ImagePull(ctx, cfg.Image, opts)
+		if resp != nil {
+			_, _ = io.ReadAll(resp)
 		}
-		opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
-	}
-	resp, _ := d.DockerAPI.ImagePull(ctx, cfg.Image, opts)
-	if resp != nil {
-		_, _ = io.ReadAll(resp)
 	}
 
 	for vol, mtpt := range d.RunOptions.VolumeNameToMountPoint {

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -409,21 +409,19 @@ func shouldPull(ctx context.Context, dockerAPI *client.Client, image string) boo
 
 var (
 	pullLocks = locksutil.CreateLocks()
-	pullCache = map[string]error{}
+	pullCache = map[string]struct{}{}
 )
 
-func (d *Runner) pull(ctx context.Context, image string) (result error) {
+func (d *Runner) pull(ctx context.Context, image string, opts client.ImagePullOptions) {
 	lock := locksutil.LockForKey(pullLocks, image)
 	lock.Lock()
 	defer lock.Unlock()
 
 	// first we check if the current process has already pulled the image (or skipped pulling based on the second check)
-	if err, ok := pullCache[image]; ok {
-		return err
+	if _, ok := pullCache[image]; ok {
+		return
 	}
-	defer func() {
-		pullCache[image] = result
-	}()
+	pullCache[image] = struct{}{}
 
 	// second we check if the image is "reasonable recent"
 	if !shouldPull(ctx, d.DockerAPI, image) {
@@ -431,25 +429,10 @@ func (d *Runner) pull(ctx context.Context, image string) (result error) {
 	}
 
 	// best-effort pull
-	var opts client.ImagePullOptions
-	if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
-		var buf bytes.Buffer
-		auth := map[string]string{
-			"username": d.RunOptions.AuthUsername,
-			"password": d.RunOptions.AuthPassword,
-		}
-		if err := json.NewEncoder(&buf).Encode(auth); err != nil {
-			result = err
-			return
-		}
-		opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
-	}
 	resp, _ := d.DockerAPI.ImagePull(ctx, image, opts)
 	if resp != nil {
 		_, _ = io.ReadAll(resp)
 	}
-
-	return
 }
 
 func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*StartResult, error) {
@@ -497,10 +480,19 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 		}
 	}
 
-	err := d.pull(ctx, cfg.Image)
-	if err != nil {
-		return nil, err
+	var opts client.ImagePullOptions
+	if d.RunOptions.AuthUsername != "" && d.RunOptions.AuthPassword != "" {
+		var buf bytes.Buffer
+		auth := map[string]string{
+			"username": d.RunOptions.AuthUsername,
+			"password": d.RunOptions.AuthPassword,
+		}
+		if err := json.NewEncoder(&buf).Encode(auth); err != nil {
+			return nil, err
+		}
+		opts.RegistryAuth = base64.URLEncoding.EncodeToString(buf.Bytes())
 	}
+	d.pull(ctx, cfg.Image, opts)
 
 	for vol, mtpt := range d.RunOptions.VolumeNameToMountPoint {
 		hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -409,7 +409,7 @@ func shouldPull(ctx context.Context, dockerAPI *client.Client, image string) boo
 
 var (
 	pullLocks = locksutil.CreateLocks()
-	pullCache = map[string]struct{}{}
+	pullCache sync.Map
 )
 
 func (d *Runner) pull(ctx context.Context, image string, opts client.ImagePullOptions) {
@@ -418,10 +418,9 @@ func (d *Runner) pull(ctx context.Context, image string, opts client.ImagePullOp
 	defer lock.Unlock()
 
 	// first we check if the current process has already pulled the image (or skipped pulling based on the second check)
-	if _, ok := pullCache[image]; ok {
+	if _, ok := pullCache.LoadOrStore(image, nil); ok {
 		return
 	}
-	pullCache[image] = struct{}{}
 
 	// second we check if the image is "reasonable recent"
 	if !shouldPull(ctx, d.DockerAPI, image) {


### PR DESCRIPTION
## Description

Currently our docker testhelper will always try to pull the target image before running it.

An easy fix would be to check if the image is present locally and only pull if not. I don't think this is a good idea, because this means that a developer running the tests locally might get a totally different version than the CI will use (especially in cases were we use the `latest` tag)

So with this PR I tried to implement a "smart" pulling behavior: skip pulling if the local copy is "reasonably fresh":

- check an in-process map, if we have pulled already => return cached result
- check if the image exists in daemon => if no: pull
- check if image build date < 24h ago => if yes: skip pull
- find any image pull events in the daemon event log (last 24h) => if found: skip pull

if any of the steps above fails: pull (and print a warning)

This might still result in different major versions of a container image running in CI and locally, but only for about 24 hours after the version bump (and running `latest` will always have this risk, if you don't pull at the exact same time), which to me seams like a reasonable tradeoff.

## Rationale

Always pulling has some drawbacks:

- Some registries (famously Docker Hub) impose rate limits on pulls. For Docker Hub it does not matter if you pull 50GB or simply get a response that your locally cached image is still fresh: it does count against your limit ([200 per free user or 100 per unauthenticated IP](https://docs.docker.com/docker-hub/usage/))
- Stability: Assume your test suite contains 100 docker based tests[^1] and a docker registry might return a `500 Internal Server Error` randomly every 10.000 requests (not sure how realistic this numbers is): This results in 1% of your CI runs to fail.
- Slowdown: Docker based tests tend to be on the slower end of the spectrum, but doing a pull for every tests will further slow down the tests (when running `go test ./physical/postgresql/` I noticed a 10s speedup[^2]).


Related https://github.com/openbao/openbao/issues/3399

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.



[^1]: based on the debug prints I added to the draft version of this PR, this is a realistic number for this openbao/openbao: If I analyzed the logs correctly 105 pulls were prevented.
[^2]: The HashiCorp mirror seems to be particularly slow: `podman pull docker.mirror.hashicorp.services/postgres:11.1` with a hot cache takes a full 5 seconds while `docker.io/library/postgres:11.1` takes only 2.