### PR TITLE
fix(command/server): correct merge condition for plugin_download_max_size in Config.Merge()

### DIFF
--- a/changelog/3437.txt
+++ b/changelog/3437.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/server: Correct merge condition for `plugin_download_max_size` in `Config.Merge()`
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -699,7 +699,7 @@ func (c *Config) Merge(c2 *Config) *Config {
 	}
 
 	result.PluginDownloadMaxSize = c.PluginDownloadMaxSize
-	if c2.PluginAutoDownloadRaw != nil {
+	if c2.PluginDownloadMaxSizeRaw != nil {
 		result.PluginDownloadMaxSize = c2.PluginDownloadMaxSize
 		result.PluginDownloadMaxSizeRaw = c2.PluginDownloadMaxSizeRaw
 	}


### PR DESCRIPTION
## Description

`Config.Merge()` used `c2.PluginAutoDownloadRaw != nil` as the condition for merging `PluginDownloadMaxSize`. As a result, `plugin_download_max_size` was only preserved when `plugin_auto_download` was also set in the subsequent config file. The condition should check `c2.PluginDownloadMaxSizeRaw != nil`.

## Rationale

When OpenBao is started with multiple `-config` paths, `ParseServerConfig` calls `Config.Merge()` to combine them. Due to the wrong condition,`plugin_download_max_size` set in an earlier config file would be silently dropped unless `plugin_auto_download` happened to be set in a later one.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
