### PR TITLE
audit: Fix missing request ID in audit log for help operations

### DIFF
--- a/changelog/3440.txt
+++ b/changelog/3440.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Include `request.id` for `path-help` audit entries
+```

--- a/http/help.go
+++ b/http/help.go
@@ -5,9 +5,11 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
 )
@@ -38,7 +40,14 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, fmt.Errorf("failed to generate identifier for the request: %w", err))
+		return
+	}
+
 	req := &logical.Request{
+		ID:         requestId,
 		Operation:  logical.HelpOperation,
 		Path:       r.URL.Path[len("/v1/"):],
 		Connection: getConnection(r),


### PR DESCRIPTION
## Description

Set ID for help requests

## Rationale

The handleHelp function in http/help.go didn't set an ID unlike all other handlers.
This caused the request.id field to be silently omitted from audit log entries for all
help operations (e.g. `vault path-help`), making it impossible to correlate request and response entries in the audit log.

Fixes #3439

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
