### PR TITLE
docs(command/operator): fix wrong command name and typos

### DIFF
--- a/command/operator_validate_config.go
+++ b/command/operator_validate_config.go
@@ -45,9 +45,9 @@ Usage: bao operator validate-config
   Some problems like wrong cluster_addr (i.e. a missing DNS entry) won't be
   detected as this can only be detected at runtime.
   Some problems are deliberately not detected, e.g. that the raft path is writable.
-  This is to ensure that a configuration can be validated on a different machine
-  for example an operators laptop or during Pull Request validation.
-  To include this kind of tests use  "bao operator diagnose" instead.
+  This is to ensure that a configuration can be validated on a different machine,
+  for example an operator's laptop, or during Pull Request validation.
+  To include these kinds of tests use "bao operator diagnose" instead.
 
   Validate a configuration file:
 

--- a/website/content/docs/commands/operator/diagnose.mdx
+++ b/website/content/docs/commands/operator/diagnose.mdx
@@ -9,7 +9,7 @@ description: |-
 
 # operator diagnose
 
-The operator diagnose command should be used primarily when OpenBao is down or
+The `operator diagnose` command should be used primarily when OpenBao is down or
 partially inoperational. The command can be used safely regardless of the state
 OpenBao is in, but may return meaningless results for some of the test cases if the
 OpenBao server is already running.
@@ -33,7 +33,7 @@ flags](../index.mdx) included on all commands.
 #### Output layout
 
 The operator diagnose command will output a set of lines in the CLI.
-Each line will begin with a prefix in parenthesis. These are:.
+Each line will begin with a prefix in parenthesis. These are:
 
 - `[ success ]` - Denotes that the check was successful.
 - `[ warning ]` - Denotes that the check has passed, but that there may be potential
@@ -52,7 +52,7 @@ the Storage check fails, the `[ failure ]` prefix will bubble up to the Storage 
 
 ### Command options
 
-- `-config` `(string; "")` - The paths to the OpenBao configuration files used by
+- `-config` `(string: "")` - The paths to the OpenBao configuration files used by
 the OpenBao server on startup. See the [server `-config` option](../../server#command-options) for more details.
 
 ### Diagnose checks

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -87,7 +87,7 @@ flags](../index.mdx) included on all commands.
 - `-init` `(bool: false)` - Start a root token generation. This can only be done
   if there is not currently one in progress.
 
-- `-nonce` `(string; "")`- Nonce value provided at initialization. The same
+- `-nonce` `(string: "")`- Nonce value provided at initialization. The same
   nonce value must be provided with each unseal key.
 
 - `-otp` `(string: "")` - OTP code to use with `-decode` or `-init`.

--- a/website/content/docs/commands/operator/validate-config.mdx
+++ b/website/content/docs/commands/operator/validate-config.mdx
@@ -5,18 +5,18 @@ description: |-
   validating OpenBao configuration. It is similar to "bao operator diagnose",
   but it only validates the config and not the system it is running on (e.g. it
   will not check that the raft directory is writable). This allows it to be
-  used on an operators Laptop or in CI validations.
+  used on an operator's laptop or in CI validations.
 
 ---
 
-# validate-config
+# operator validate-config
 
-The operator diagnose command should be used primarily before the configuration
-is copied to the OpenBao nodes. For example on the operators Laptop and/or in
+The `operator validate-config` command should be used primarily before the configuration
+is copied to the OpenBao nodes. For example on the operator's laptop and/or in
 CI validations, if you manage your configuration with git.
 You might also want to run it on the OpenBao node after updating the configuration
 and before restarting the node.
-In case your OpenBao nodes does not start, running [`bao operator disgnose`](
+In case your OpenBao nodes do not start, running [`bao operator diagnose`](
 ../diagnose) should be preferred.
 
 ## Usage
@@ -32,5 +32,5 @@ flags](../index.mdx) included on all commands.
 
 ### Command options
 
-- `-config` `(string; "")` - The paths to the OpenBao configuration files used by
+- `-config` `(string: "")` - The paths to the OpenBao configuration files used by
 the OpenBao server on startup. See the [server `-config` option](../../server#command-options) for more details.


### PR DESCRIPTION
## Description

- Fixed validate-config.mdx: heading was missing the "operator"  command prefix ("validate-config" -> "operator validate-config"), the description referred to "operator diagnose" instead of "operator  validate-config", and a "disgnose" typo in a link to the diagnose command.
- Fixed grammar/wording: subject-verb agreement ("nodes do not start"), and "operators Laptop" -> "operator's laptop" (validate-config.mdx).
- Fixed stray punctuation: "These are:." -> "These are:" (diagnose.mdx).
- Fixed incorrect semicolon in flag doc syntax: `(string; "")` should  be `(string: "")`. Fixed in diagnose.mdx, validate-config.mdx and generate-root.mdx, matching the convention used elsewhere.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
