### PR TITLE
Introduce GRPC-based invalidation mechanism

### DIFF
--- a/internal/physical/postgresql/index.go
+++ b/internal/physical/postgresql/index.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package postgresql
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+var _ physical.ReplicationIndexBackend = &PostgreSQLBackend{}
+
+const lsnIndexQuery = `
+SELECT value.index::varchar
+FROM (
+	SELECT CASE pg_is_in_recovery()
+	WHEN true
+	THEN pg_last_wal_receive_lsn()
+	ELSE pg_current_wal_lsn()
+	END
+	AS index
+)
+AS value;
+`
+
+func (p *PostgreSQLBackend) AppliedReplicationIndex(ctx context.Context) (string, error) {
+	var index string
+	if err := p.client.QueryRowContext(ctx, lsnIndexQuery).Scan(&index); err != nil {
+		return "", fmt.Errorf("getting WAL LSN failed: %w", err)
+	}
+
+	return index, nil
+}
+
+func (p *PostgreSQLBackend) GreaterEqualReplicationIndex(ctx context.Context, left string, right string) (bool, error) {
+	leftInt, err := indexToUint64(left)
+	if err != nil {
+		return false, fmt.Errorf("error parsing left: %w", err)
+	}
+
+	rightInt, err := indexToUint64(right)
+	if err != nil {
+		return false, fmt.Errorf("error parsing right: %w", err)
+	}
+
+	return leftInt >= rightInt, nil
+}
+
+func indexToUint64(index string) (uint64, error) {
+	if strings.Count(index, "/") != 1 {
+		return 0, fmt.Errorf("expected PG WAL LSN to contain exactly one slash: was %q", index)
+	}
+
+	parts := strings.SplitN(index, "/", 2)
+
+	// See https://pgpedia.info/x/xlogrecptr.html for naming info.
+	xlogid, err := strconv.ParseUint(parts[0], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse PG WAL LSN's log file number: %w", err)
+	}
+
+	xrecoff, err := strconv.ParseUint(parts[1], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse PG WAL LSN's byte offset: %w", err)
+	}
+
+	return xlogid<<32 | xrecoff, nil
+}

--- a/internal/physical/raft/raft.go
+++ b/internal/physical/raft/raft.go
@@ -69,6 +69,7 @@ var (
 	_ physical.Transactional            = (*RaftBackend)(nil)
 	_ physical.HABackend                = (*RaftBackend)(nil)
 	_ physical.CacheInvalidationBackend = (*RaftBackend)(nil)
+	_ physical.ReplicationIndexBackend  = (*RaftBackend)(nil)
 	_ physical.Lock                     = (*RaftLock)(nil)
 )
 
@@ -1191,6 +1192,28 @@ func (b *RaftBackend) AppliedIndex() uint64 {
 	// raft.AppliedIndex() due to the async nature of the raft library.
 	indexState, _ := b.fsm.LatestState()
 	return indexState.Index
+}
+
+// AppliedReplicationIndex returns the last index applied to the FSM as
+// an opaque identifier.
+func (b *RaftBackend) AppliedReplicationIndex(_ context.Context) (string, error) {
+	return strconv.FormatUint(b.AppliedIndex(), 10), nil
+}
+
+// GreaterEqualReplicationIndex returns whether the left index is greater
+// than or equal to the right index.
+func (b *RaftBackend) GreaterEqualReplicationIndex(ctx context.Context, left string, right string) (bool, error) {
+	leftInt, err := strconv.ParseUint(left, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("error parsing left: %w", err)
+	}
+
+	rightInt, err := strconv.ParseUint(right, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("error parsing right: %w", err)
+	}
+
+	return leftInt >= rightInt, nil
 }
 
 // Term returns the raft term of this node.

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -629,6 +629,15 @@ type Core struct {
 	// refreshing the Core-adjacent caches afterwards.
 	invalidations *invalidationManager
 
+	// When awaitInvalidateHook is set early on startup, this maintains a list
+	// of connected invalidation peers. When connections blip, we maintain an
+	// invalidation state.
+	connectedInvalidationPeers *invalidationPeers
+
+	// indexManager allows caching of indices from a physical.ReplicationIndexBackend,
+	// reducing the number of calls to the underlying database.
+	indexManager *indexManager
+
 	// Whether unauthenticated workflows are allowed by this OpenBao
 	// instance.
 	allowUnauthedWorkflows bool
@@ -1032,16 +1041,55 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	}
 	c.seal.SetCore(c)
 
-	// Create the invalidation manager.
+	// Create the invalidation manager and track connected peers for GRPC.
 	c.NewInvalidationManager()
+	c.NewInvalidationPeers()
+
+	if replicated, ok := c.underlyingPhysical.(physical.ReplicationIndexBackend); ok {
+		c.indexManager = NewIndexManager(replicated, 0)
+	}
 
 	return c, nil
 }
 
+func shouldUseGRPCInvalidation(phys physical.Backend) bool {
+	if _, ok := phys.(physical.CacheInvalidationBackend); ok {
+		return false
+	}
+
+	_, ok := phys.(physical.ReplicationIndexBackend)
+	return ok
+}
+
+func (c *Core) shouldHookInvalidate(phys physical.Backend) bool {
+	if !c.StandbyReadsEnabled() {
+		return false
+	}
+
+	_, ok := phys.(physical.CacheInvalidationBackend)
+	return ok
+}
+
 func coreInit(c *Core, conf *CoreConfig) error {
 	phys := conf.Physical
+	hookLayer := c.underlyingPhysical
+
+	haEnabled := conf.HAPhysical != nil && conf.HAPhysical.HAEnabled()
+
 	// Wrap the physical backend in a cache layer if enabled
 	cacheLogger := c.baseLogger.Named("storage.cache")
+
+	// Wrap physical for invalidation.
+	if haEnabled && shouldUseGRPCInvalidation(phys) {
+		c.logger.Info("enabling grpc-based invalidation on HA backend which doesn't natively support invalidation notifications")
+
+		grpcLogger := c.baseLogger.Named("storage.grpcinv")
+		c.allLoggers = append(c.allLoggers, grpcLogger)
+
+		phys = physical.NewWriteNotifier(phys, grpcLogger, c.SendInvalidationNotice)
+		hookLayer = phys
+	}
+
 	c.allLoggers = append(c.allLoggers, cacheLogger)
 	c.physical = physical.NewCache(phys, conf.CacheSize, cacheLogger, c.MetricSink().Sink)
 	c.physicalCache = c.physical.(physical.ToggleablePurgemonster)
@@ -1051,8 +1099,8 @@ func coreInit(c *Core, conf *CoreConfig) error {
 		c.physical = physical.NewStorageEncoding(c.physical)
 	}
 
-	if c.StandbyReadsEnabled() {
-		c.underlyingPhysical.(physical.CacheInvalidationBackend).HookInvalidate(c.Invalidate)
+	if haEnabled && c.shouldHookInvalidate(hookLayer) {
+		hookLayer.(physical.CacheInvalidationBackend).HookInvalidate(c.Invalidate)
 	}
 
 	return nil
@@ -2158,6 +2206,10 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	c.clearForwardingClients()
 	c.requestForwardingConnectionLock.Unlock()
 
+	if shouldUseGRPCInvalidation(c.underlyingPhysical) {
+		c.SetupInvalidationPeers()
+	}
+
 	// Mark the active time. We do this first so it can be correlated to the logs
 	// for the active startup.
 	c.activeTime = time.Now().UTC()
@@ -2427,10 +2479,9 @@ func (c *Core) preSeal() error {
 	c.stopForwarding()
 	c.stopRaftActiveNode()
 	c.cancelNamespaceDeletion()
+	c.CleanupInvalidationPeers()
+	c.invalidations.Stop()
 
-	if err := c.invalidations.Stop(); err != nil {
-		result = multierror.Append(result, fmt.Errorf("error tearing down invalidations: %w", err))
-	}
 	if err := c.teardownAudits(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down audits: %w", err))
 	}
@@ -3878,12 +3929,19 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 	)
 	c.rpcForwardingClient.Start()
 
+	if _, ok := c.underlyingPhysical.(physical.CacheInvalidationBackend); !ok {
+		c.logger.Info("restarting standby as active node has changed; may enable grpc invalidation")
+		c.Restart()
+	}
+
 	return nil
 }
 
 func (c *Core) clearForwardingClients() {
 	c.logger.Debug("clearing forwarding clients")
 	defer c.logger.Debug("done clearing forwarding clients")
+
+	c.rpcForwardingClient.StopInvalidations()
 
 	if c.rpcClientConnCancelFunc != nil {
 		c.rpcClientConnCancelFunc()

--- a/internal/vault/forwarding/request_forwarding.go
+++ b/internal/vault/forwarding/request_forwarding.go
@@ -45,6 +45,12 @@ type core interface {
 	NamespacesMissingKeys() []string
 	SetNamespaceKeys(context.Context, map[string][]byte) error
 	NamespaceKeys(context.Context, []string) (map[string][]byte, error)
+
+	Restart()
+
+	MarkPeerStarted(ctx context.Context, uuid string) (string, error)
+	AddInvalidationPeer(stream grpc.ServerStreamingServer[CheckInvalidationResponse]) (string, chan struct{}, error)
+	AwaitInvalidation(ctx context.Context, cleanup func(), index string, keys ...string)
 }
 
 type clusterPeerClusterAddrsCache interface {

--- a/internal/vault/forwarding/request_forwarding_rpc.go
+++ b/internal/vault/forwarding/request_forwarding_rpc.go
@@ -5,6 +5,7 @@ package forwarding
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/v2/internal/helper/forwarding"
 	"github.com/openbao/openbao/v2/internal/physical/raft"
+	"google.golang.org/grpc"
 )
 
 type forwardedRequestRPCServer struct {
@@ -123,6 +125,40 @@ func (s *forwardedRequestRPCServer) AdvertiseNamespaceKeys(ctx context.Context, 
 	return ret, nil
 }
 
+func (s *forwardedRequestRPCServer) StartInvalidations(ctx context.Context, req *StartInvalidationRequest) (*StartInvalidationResponse, error) {
+	index, err := s.core.MarkPeerStarted(ctx, req.Uuid)
+
+	var errMsg string
+	if err != nil {
+		s.core.Logger().Error("invalidation: failed to mark peer as started", "err", err)
+		errMsg = "failed to start invalidations; check active logs for more info"
+	}
+
+	return &StartInvalidationResponse{
+		Err:   errMsg,
+		Index: index,
+	}, nil
+}
+
+func (s *forwardedRequestRPCServer) CheckInvalidations(req *CheckInvalidationRequest, stream grpc.ServerStreamingServer[CheckInvalidationResponse]) error {
+	uuid, stopCh, err := s.core.AddInvalidationPeer(stream)
+	if err != nil {
+		s.core.Logger().Error("invalidation: failed registering invalidation peer", "err", err)
+		return fmt.Errorf("not registered; check active server's logs for information")
+	}
+
+	s.core.Logger().Trace("invalidation: starting invalidation handling for peer", "uuid", uuid)
+
+	// Wait for the peer's connection to be closed. When we call
+	// AddInvalidationPeer(...) above, we effectively consume the stream
+	// and sending of events on it. But this function returning closes the
+	// stream so we need to block until we're done with the stream.
+	<-stopCh
+	s.core.Logger().Trace("invalidation: finished invalidation handling for peer", "uuid", uuid)
+
+	return nil
+}
+
 func (s *forwardedRequestRPCServer) SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error) {
 	keys := make(map[string][]byte, len(in.Keys))
 
@@ -166,6 +202,10 @@ type Client struct {
 	taskContext  context.Context
 	echoTicker   *time.Ticker
 	nsSyncTicker *time.Ticker
+
+	invalidationsContext       context.Context
+	invalidationsContextCancel context.CancelFunc
+	peerUUID                   atomic.Pointer[string]
 }
 
 func NewClient(core core, requestForwardingClient RequestForwardingClient, taskContext context.Context, echoTicker *time.Ticker, nsSyncTicker *time.Ticker) *Client {
@@ -208,6 +248,7 @@ func (c *Client) Start() {
 				req.RaftUpgradeVersion = raftBackend.EffectiveVersion()
 				labels = append(labels, metrics.Label{Name: "peer_id", Value: raftBackend.NodeID()})
 			}
+
 			defer metrics.MeasureSinceWithLabels([]string{"ha", "rpc", "client", "echo"}, now, labels)
 
 			ctx, cancel := context.WithTimeout(c.taskContext, 2*time.Second)
@@ -359,4 +400,127 @@ func (c *Client) getKeys(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// CheckReplicationIndex returns the current index on the active node.
+func (c *Client) CheckReplicationIndex(ctx context.Context) (string, error) {
+	var uuid string
+
+	if value := c.peerUUID.Load(); value != nil && *value != "" {
+		uuid = *value
+	} else {
+		return "", errors.New("active node has not returned a uuid")
+	}
+
+	resp, err := c.StartInvalidations(ctx, &StartInvalidationRequest{
+		Uuid: uuid,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error checking active node's replication index: %w", err)
+	}
+
+	if resp == nil {
+		return "", errors.New("no replication index returned by active node")
+	}
+
+	if resp.Err != "" {
+		return "", fmt.Errorf("error checking replication index: %v", resp.Err)
+	}
+
+	return resp.Index, nil
+}
+
+func (c *Client) StreamInvalidations(ctx context.Context) error {
+	c.peerUUID.Store(nil)
+	c.invalidationsContext, c.invalidationsContextCancel = context.WithCancel(c.taskContext)
+
+	commonCleanup := func() {
+		c.peerUUID.Store(nil)
+		c.invalidationsContextCancel()
+	}
+
+	doCleanup := true
+	defer func() {
+		if doCleanup {
+			commonCleanup()
+		}
+	}()
+
+	// Start streaming invalidations from the active.
+	stream, err := c.CheckInvalidations(c.invalidationsContext, &CheckInvalidationRequest{})
+	if err != nil {
+		return fmt.Errorf("failed starting invalidation stream: %w", err)
+	}
+
+	// Receive our first invalidation.
+	invalidation, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("error during initial invalidation receive: %w", err)
+	}
+
+	// Every response should have UUID.
+	uuid := invalidation.Uuid
+	c.peerUUID.Store(&uuid)
+
+	// No longer perform cleanup when we exit this function: we're kicking
+	// off a background goroutine to handle invalidations including this one.
+	doCleanup = false
+
+	go func() {
+		cleanup := func() {
+			commonCleanup()
+
+			// In our goroutine, the read-enabled standby has already started.
+			// If our stream goes away, we need to ensure that we cancel the
+			// current read-enabled standby state as we won't be getting any
+			// more invalidations and thus be stale. If we were to just
+			// re-establish the stream, we'd have lost any invalidations the
+			// server has generated in the meantime. We'd also have no way of
+			// catching back up to the current state as we don't track read
+			// data versus indices.
+			//
+			// Thus a restart is the cleanest solution here, so that we know
+			// we catch up to initial state again on stream re-establishment.
+			c.core.Restart()
+		}
+		defer cleanup()
+
+		// While the server immediately send back an empty invalidation with
+		// the uuid in it, we don't hold any exclusive locks so (pending
+		// timing) a regular invalidation could be handed to us ahead of it.
+		// That's why this loop is inverted: we want to process the above
+		// invalidation first before we get a new one.
+
+		var err error
+		for {
+			select {
+			case <-c.invalidationsContext.Done():
+				return
+			default:
+			}
+
+			if invalidation.Restart {
+				c.core.Logger().Info("forwarding: active node indicated restart on invalidation")
+				return
+			}
+
+			c.core.AwaitInvalidation(c.invalidationsContext, cleanup, invalidation.Index, invalidation.Keys...)
+
+			invalidation, err = stream.Recv()
+			if err != nil {
+				c.core.Logger().Warn("forwarding: error receiving invalidation from active node", "err", err)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *Client) StopInvalidations() {
+	if c == nil || c.invalidationsContextCancel == nil {
+		return
+	}
+
+	c.invalidationsContextCancel()
 }

--- a/internal/vault/forwarding/request_forwarding_service.pb.go
+++ b/internal/vault/forwarding/request_forwarding_service.pb.go
@@ -381,6 +381,206 @@ func (x *ClientKey) GetD() []byte {
 	return nil
 }
 
+type StartInvalidationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uuid          string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartInvalidationRequest) Reset() {
+	*x = StartInvalidationRequest{}
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartInvalidationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartInvalidationRequest) ProtoMessage() {}
+
+func (x *StartInvalidationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartInvalidationRequest.ProtoReflect.Descriptor instead.
+func (*StartInvalidationRequest) Descriptor() ([]byte, []int) {
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *StartInvalidationRequest) GetUuid() string {
+	if x != nil {
+		return x.Uuid
+	}
+	return ""
+}
+
+type StartInvalidationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Err           string                 `protobuf:"bytes,2,opt,name=err,proto3" json:"err,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartInvalidationResponse) Reset() {
+	*x = StartInvalidationResponse{}
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartInvalidationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartInvalidationResponse) ProtoMessage() {}
+
+func (x *StartInvalidationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartInvalidationResponse.ProtoReflect.Descriptor instead.
+func (*StartInvalidationResponse) Descriptor() ([]byte, []int) {
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *StartInvalidationResponse) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *StartInvalidationResponse) GetErr() string {
+	if x != nil {
+		return x.Err
+	}
+	return ""
+}
+
+type CheckInvalidationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckInvalidationRequest) Reset() {
+	*x = CheckInvalidationRequest{}
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckInvalidationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckInvalidationRequest) ProtoMessage() {}
+
+func (x *CheckInvalidationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckInvalidationRequest.ProtoReflect.Descriptor instead.
+func (*CheckInvalidationRequest) Descriptor() ([]byte, []int) {
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{6}
+}
+
+type CheckInvalidationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Keys          []string               `protobuf:"bytes,2,rep,name=keys,proto3" json:"keys,omitempty"`
+	Restart       bool                   `protobuf:"varint,3,opt,name=restart,proto3" json:"restart,omitempty"`
+	Uuid          string                 `protobuf:"bytes,4,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckInvalidationResponse) Reset() {
+	*x = CheckInvalidationResponse{}
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckInvalidationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckInvalidationResponse) ProtoMessage() {}
+
+func (x *CheckInvalidationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckInvalidationResponse.ProtoReflect.Descriptor instead.
+func (*CheckInvalidationResponse) Descriptor() ([]byte, []int) {
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CheckInvalidationResponse) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *CheckInvalidationResponse) GetKeys() []string {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+func (x *CheckInvalidationResponse) GetRestart() bool {
+	if x != nil {
+		return x.Restart
+	}
+	return false
+}
+
+func (x *CheckInvalidationResponse) GetUuid() string {
+	if x != nil {
+		return x.Uuid
+	}
+	return ""
+}
+
 type NamespaceKey struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Uuid          string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
@@ -391,7 +591,7 @@ type NamespaceKey struct {
 
 func (x *NamespaceKey) Reset() {
 	*x = NamespaceKey{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -403,7 +603,7 @@ func (x *NamespaceKey) String() string {
 func (*NamespaceKey) ProtoMessage() {}
 
 func (x *NamespaceKey) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[4]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -416,7 +616,7 @@ func (x *NamespaceKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceKey.ProtoReflect.Descriptor instead.
 func (*NamespaceKey) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{4}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NamespaceKey) GetUuid() string {
@@ -442,7 +642,7 @@ type AdvertiseNamespaceKeysRequest struct {
 
 func (x *AdvertiseNamespaceKeysRequest) Reset() {
 	*x = AdvertiseNamespaceKeysRequest{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -454,7 +654,7 @@ func (x *AdvertiseNamespaceKeysRequest) String() string {
 func (*AdvertiseNamespaceKeysRequest) ProtoMessage() {}
 
 func (x *AdvertiseNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[5]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -467,7 +667,7 @@ func (x *AdvertiseNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvertiseNamespaceKeysRequest.ProtoReflect.Descriptor instead.
 func (*AdvertiseNamespaceKeysRequest) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{5}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *AdvertiseNamespaceKeysRequest) GetNamespaces() []string {
@@ -487,7 +687,7 @@ type AdvertiseNamespaceKeysReply struct {
 
 func (x *AdvertiseNamespaceKeysReply) Reset() {
 	*x = AdvertiseNamespaceKeysReply{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -499,7 +699,7 @@ func (x *AdvertiseNamespaceKeysReply) String() string {
 func (*AdvertiseNamespaceKeysReply) ProtoMessage() {}
 
 func (x *AdvertiseNamespaceKeysReply) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[6]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -512,7 +712,7 @@ func (x *AdvertiseNamespaceKeysReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvertiseNamespaceKeysReply.ProtoReflect.Descriptor instead.
 func (*AdvertiseNamespaceKeysReply) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{6}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AdvertiseNamespaceKeysReply) GetNamespaces() []string {
@@ -538,7 +738,7 @@ type SendNamespaceKeysRequest struct {
 
 func (x *SendNamespaceKeysRequest) Reset() {
 	*x = SendNamespaceKeysRequest{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -550,7 +750,7 @@ func (x *SendNamespaceKeysRequest) String() string {
 func (*SendNamespaceKeysRequest) ProtoMessage() {}
 
 func (x *SendNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[7]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -563,7 +763,7 @@ func (x *SendNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendNamespaceKeysRequest.ProtoReflect.Descriptor instead.
 func (*SendNamespaceKeysRequest) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{7}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SendNamespaceKeysRequest) GetKeys() []*NamespaceKey {
@@ -582,7 +782,7 @@ type SendNamespaceKeysReply struct {
 
 func (x *SendNamespaceKeysReply) Reset() {
 	*x = SendNamespaceKeysReply{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -594,7 +794,7 @@ func (x *SendNamespaceKeysReply) String() string {
 func (*SendNamespaceKeysReply) ProtoMessage() {}
 
 func (x *SendNamespaceKeysReply) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[8]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -607,7 +807,7 @@ func (x *SendNamespaceKeysReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendNamespaceKeysReply.ProtoReflect.Descriptor instead.
 func (*SendNamespaceKeysReply) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{8}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SendNamespaceKeysReply) GetRetry() bool {
@@ -626,7 +826,7 @@ type GetNamespaceKeysRequest struct {
 
 func (x *GetNamespaceKeysRequest) Reset() {
 	*x = GetNamespaceKeysRequest{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -638,7 +838,7 @@ func (x *GetNamespaceKeysRequest) String() string {
 func (*GetNamespaceKeysRequest) ProtoMessage() {}
 
 func (x *GetNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[9]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -651,7 +851,7 @@ func (x *GetNamespaceKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceKeysRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceKeysRequest) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{9}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetNamespaceKeysRequest) GetNamespaces() []string {
@@ -670,7 +870,7 @@ type GetNamespaceKeysReply struct {
 
 func (x *GetNamespaceKeysReply) Reset() {
 	*x = GetNamespaceKeysReply{}
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -682,7 +882,7 @@ func (x *GetNamespaceKeysReply) String() string {
 func (*GetNamespaceKeysReply) ProtoMessage() {}
 
 func (x *GetNamespaceKeysReply) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[10]
+	mi := &file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -695,7 +895,7 @@ func (x *GetNamespaceKeysReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceKeysReply.ProtoReflect.Descriptor instead.
 func (*GetNamespaceKeysReply) Descriptor() ([]byte, []int) {
-	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{10}
+	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetNamespaceKeysReply) GetKeys() []*NamespaceKey {
@@ -743,7 +943,18 @@ const file_internal_vault_forwarding_request_forwarding_service_proto_rawDesc = 
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\f\n" +
 	"\x01x\x18\x02 \x01(\fR\x01x\x12\f\n" +
 	"\x01y\x18\x03 \x01(\fR\x01y\x12\f\n" +
-	"\x01d\x18\x04 \x01(\fR\x01d\"4\n" +
+	"\x01d\x18\x04 \x01(\fR\x01d\".\n" +
+	"\x18StartInvalidationRequest\x12\x12\n" +
+	"\x04uuid\x18\x01 \x01(\tR\x04uuid\"C\n" +
+	"\x19StartInvalidationResponse\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12\x10\n" +
+	"\x03err\x18\x02 \x01(\tR\x03err\"\x1a\n" +
+	"\x18CheckInvalidationRequest\"s\n" +
+	"\x19CheckInvalidationResponse\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12\x12\n" +
+	"\x04keys\x18\x02 \x03(\tR\x04keys\x12\x18\n" +
+	"\arestart\x18\x03 \x01(\bR\arestart\x12\x12\n" +
+	"\x04uuid\x18\x04 \x01(\tR\x04uuid\"4\n" +
 	"\fNamespaceKey\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x10\n" +
 	"\x03key\x18\x02 \x01(\fR\x03key\"?\n" +
@@ -765,13 +976,15 @@ const file_internal_vault_forwarding_request_forwarding_service_proto_rawDesc = 
 	"namespaces\x18\x01 \x03(\tR\n" +
 	"namespaces\"E\n" +
 	"\x15GetNamespaceKeysReply\x12,\n" +
-	"\x04keys\x18\x01 \x03(\v2\x18.forwarding.NamespaceKeyR\x04keys2\xbb\x03\n" +
+	"\x04keys\x18\x01 \x03(\v2\x18.forwarding.NamespaceKeyR\x04keys2\x87\x05\n" +
 	"\x11RequestForwarding\x128\n" +
 	"\x04Echo\x12\x17.forwarding.EchoRequest\x1a\x15.forwarding.EchoReply\"\x00\x12=\n" +
 	"\x0eForwardRequest\x12\x13.forwarding.Request\x1a\x14.forwarding.Response\"\x00\x12n\n" +
 	"\x16AdvertiseNamespaceKeys\x12).forwarding.AdvertiseNamespaceKeysRequest\x1a'.forwarding.AdvertiseNamespaceKeysReply\"\x00\x12_\n" +
 	"\x11SendNamespaceKeys\x12$.forwarding.SendNamespaceKeysRequest\x1a\".forwarding.SendNamespaceKeysReply\"\x00\x12\\\n" +
-	"\x10GetNamespaceKeys\x12#.forwarding.GetNamespaceKeysRequest\x1a!.forwarding.GetNamespaceKeysReply\"\x00B9Z7github.com/openbao/openbao/v2/internal/vault/forwardingb\x06proto3"
+	"\x10GetNamespaceKeys\x12#.forwarding.GetNamespaceKeysRequest\x1a!.forwarding.GetNamespaceKeysReply\"\x00\x12c\n" +
+	"\x12StartInvalidations\x12$.forwarding.StartInvalidationRequest\x1a%.forwarding.StartInvalidationResponse\"\x00\x12e\n" +
+	"\x12CheckInvalidations\x12$.forwarding.CheckInvalidationRequest\x1a%.forwarding.CheckInvalidationResponse\"\x000\x01B9Z7github.com/openbao/openbao/v2/internal/vault/forwardingb\x06proto3"
 
 var (
 	file_internal_vault_forwarding_request_forwarding_service_proto_rawDescOnce sync.Once
@@ -785,39 +998,47 @@ func file_internal_vault_forwarding_request_forwarding_service_proto_rawDescGZIP
 	return file_internal_vault_forwarding_request_forwarding_service_proto_rawDescData
 }
 
-var file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_internal_vault_forwarding_request_forwarding_service_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_internal_vault_forwarding_request_forwarding_service_proto_goTypes = []any{
 	(*EchoRequest)(nil),                   // 0: forwarding.EchoRequest
 	(*EchoReply)(nil),                     // 1: forwarding.EchoReply
 	(*NodeInformation)(nil),               // 2: forwarding.NodeInformation
 	(*ClientKey)(nil),                     // 3: forwarding.ClientKey
-	(*NamespaceKey)(nil),                  // 4: forwarding.NamespaceKey
-	(*AdvertiseNamespaceKeysRequest)(nil), // 5: forwarding.AdvertiseNamespaceKeysRequest
-	(*AdvertiseNamespaceKeysReply)(nil),   // 6: forwarding.AdvertiseNamespaceKeysReply
-	(*SendNamespaceKeysRequest)(nil),      // 7: forwarding.SendNamespaceKeysRequest
-	(*SendNamespaceKeysReply)(nil),        // 8: forwarding.SendNamespaceKeysReply
-	(*GetNamespaceKeysRequest)(nil),       // 9: forwarding.GetNamespaceKeysRequest
-	(*GetNamespaceKeysReply)(nil),         // 10: forwarding.GetNamespaceKeysReply
-	(*forwarding.Request)(nil),            // 11: forwarding.Request
-	(*forwarding.Response)(nil),           // 12: forwarding.Response
+	(*StartInvalidationRequest)(nil),      // 4: forwarding.StartInvalidationRequest
+	(*StartInvalidationResponse)(nil),     // 5: forwarding.StartInvalidationResponse
+	(*CheckInvalidationRequest)(nil),      // 6: forwarding.CheckInvalidationRequest
+	(*CheckInvalidationResponse)(nil),     // 7: forwarding.CheckInvalidationResponse
+	(*NamespaceKey)(nil),                  // 8: forwarding.NamespaceKey
+	(*AdvertiseNamespaceKeysRequest)(nil), // 9: forwarding.AdvertiseNamespaceKeysRequest
+	(*AdvertiseNamespaceKeysReply)(nil),   // 10: forwarding.AdvertiseNamespaceKeysReply
+	(*SendNamespaceKeysRequest)(nil),      // 11: forwarding.SendNamespaceKeysRequest
+	(*SendNamespaceKeysReply)(nil),        // 12: forwarding.SendNamespaceKeysReply
+	(*GetNamespaceKeysRequest)(nil),       // 13: forwarding.GetNamespaceKeysRequest
+	(*GetNamespaceKeysReply)(nil),         // 14: forwarding.GetNamespaceKeysReply
+	(*forwarding.Request)(nil),            // 15: forwarding.Request
+	(*forwarding.Response)(nil),           // 16: forwarding.Response
 }
 var file_internal_vault_forwarding_request_forwarding_service_proto_depIDxs = []int32{
 	2,  // 0: forwarding.EchoRequest.node_info:type_name -> forwarding.NodeInformation
 	2,  // 1: forwarding.EchoReply.node_info:type_name -> forwarding.NodeInformation
-	4,  // 2: forwarding.SendNamespaceKeysRequest.keys:type_name -> forwarding.NamespaceKey
-	4,  // 3: forwarding.GetNamespaceKeysReply.keys:type_name -> forwarding.NamespaceKey
+	8,  // 2: forwarding.SendNamespaceKeysRequest.keys:type_name -> forwarding.NamespaceKey
+	8,  // 3: forwarding.GetNamespaceKeysReply.keys:type_name -> forwarding.NamespaceKey
 	0,  // 4: forwarding.RequestForwarding.Echo:input_type -> forwarding.EchoRequest
-	11, // 5: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
-	5,  // 6: forwarding.RequestForwarding.AdvertiseNamespaceKeys:input_type -> forwarding.AdvertiseNamespaceKeysRequest
-	7,  // 7: forwarding.RequestForwarding.SendNamespaceKeys:input_type -> forwarding.SendNamespaceKeysRequest
-	9,  // 8: forwarding.RequestForwarding.GetNamespaceKeys:input_type -> forwarding.GetNamespaceKeysRequest
-	1,  // 9: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
-	12, // 10: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
-	6,  // 11: forwarding.RequestForwarding.AdvertiseNamespaceKeys:output_type -> forwarding.AdvertiseNamespaceKeysReply
-	8,  // 12: forwarding.RequestForwarding.SendNamespaceKeys:output_type -> forwarding.SendNamespaceKeysReply
-	10, // 13: forwarding.RequestForwarding.GetNamespaceKeys:output_type -> forwarding.GetNamespaceKeysReply
-	9,  // [9:14] is the sub-list for method output_type
-	4,  // [4:9] is the sub-list for method input_type
+	15, // 5: forwarding.RequestForwarding.ForwardRequest:input_type -> forwarding.Request
+	9,  // 6: forwarding.RequestForwarding.AdvertiseNamespaceKeys:input_type -> forwarding.AdvertiseNamespaceKeysRequest
+	11, // 7: forwarding.RequestForwarding.SendNamespaceKeys:input_type -> forwarding.SendNamespaceKeysRequest
+	13, // 8: forwarding.RequestForwarding.GetNamespaceKeys:input_type -> forwarding.GetNamespaceKeysRequest
+	4,  // 9: forwarding.RequestForwarding.StartInvalidations:input_type -> forwarding.StartInvalidationRequest
+	6,  // 10: forwarding.RequestForwarding.CheckInvalidations:input_type -> forwarding.CheckInvalidationRequest
+	1,  // 11: forwarding.RequestForwarding.Echo:output_type -> forwarding.EchoReply
+	16, // 12: forwarding.RequestForwarding.ForwardRequest:output_type -> forwarding.Response
+	10, // 13: forwarding.RequestForwarding.AdvertiseNamespaceKeys:output_type -> forwarding.AdvertiseNamespaceKeysReply
+	12, // 14: forwarding.RequestForwarding.SendNamespaceKeys:output_type -> forwarding.SendNamespaceKeysReply
+	14, // 15: forwarding.RequestForwarding.GetNamespaceKeys:output_type -> forwarding.GetNamespaceKeysReply
+	5,  // 16: forwarding.RequestForwarding.StartInvalidations:output_type -> forwarding.StartInvalidationResponse
+	7,  // 17: forwarding.RequestForwarding.CheckInvalidations:output_type -> forwarding.CheckInvalidationResponse
+	11, // [11:18] is the sub-list for method output_type
+	4,  // [4:11] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name
@@ -834,7 +1055,7 @@ func file_internal_vault_forwarding_request_forwarding_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_vault_forwarding_request_forwarding_service_proto_rawDesc), len(file_internal_vault_forwarding_request_forwarding_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/vault/forwarding/request_forwarding_service.proto
+++ b/internal/vault/forwarding/request_forwarding_service.proto
@@ -52,6 +52,24 @@ message ClientKey {
 	bytes d = 4;
 }
 
+message StartInvalidationRequest {
+	string uuid = 1;
+}
+
+message StartInvalidationResponse {
+	string index = 1;
+	string err = 2;
+}
+
+message CheckInvalidationRequest {}
+
+message CheckInvalidationResponse {
+	string index = 1;
+	repeated string keys = 2;
+	bool restart = 3;
+	string uuid = 4;
+}
+
 message NamespaceKey {
 	string uuid = 1;
 	bytes key = 2;
@@ -88,23 +106,27 @@ message GetNamespaceKeysReply {
 //
 // See also: https://medium.com/@hoangxuantoank13/grpc-non-breaking-changes-breaking-changes-and-versioning-solution-1dcb989beb16
 service RequestForwarding {
-    // Service health.
+	// Service health.
 
 	rpc Echo(EchoRequest) returns (EchoReply) {}
 
-    // Request forwarding.
+	// Request forwarding.
 
 	rpc ForwardRequest(forwarding.Request) returns (forwarding.Response) {}
 
 	// Namespace key sharing.
 
 	// standby->active key sharing; used when the standby has knowledge of
-    // namespace keys that a new active node does not. This is a two-step
+	// namespace keys that a new active node does not. This is a two-step
 	// process to avoid sending keys which the active node already knows
-    // about over the wire.
+	// about over the wire.
 	rpc AdvertiseNamespaceKeys(AdvertiseNamespaceKeysRequest) returns (AdvertiseNamespaceKeysReply) {};
 	rpc SendNamespaceKeys(SendNamespaceKeysRequest) returns (SendNamespaceKeysReply) {};
 
 	// active->standby key sharing; used by the standby to refresh keys.
 	rpc GetNamespaceKeys(GetNamespaceKeysRequest) returns (GetNamespaceKeysReply) {};
+
+	// GRPC-backed invalidation
+	rpc StartInvalidations(StartInvalidationRequest) returns (StartInvalidationResponse)  {}
+	rpc CheckInvalidations(CheckInvalidationRequest) returns (stream CheckInvalidationResponse) {}
 }

--- a/internal/vault/forwarding/request_forwarding_service_grpc.pb.go
+++ b/internal/vault/forwarding/request_forwarding_service_grpc.pb.go
@@ -28,6 +28,8 @@ const (
 	RequestForwarding_AdvertiseNamespaceKeys_FullMethodName = "/forwarding.RequestForwarding/AdvertiseNamespaceKeys"
 	RequestForwarding_SendNamespaceKeys_FullMethodName      = "/forwarding.RequestForwarding/SendNamespaceKeys"
 	RequestForwarding_GetNamespaceKeys_FullMethodName       = "/forwarding.RequestForwarding/GetNamespaceKeys"
+	RequestForwarding_StartInvalidations_FullMethodName     = "/forwarding.RequestForwarding/StartInvalidations"
+	RequestForwarding_CheckInvalidations_FullMethodName     = "/forwarding.RequestForwarding/CheckInvalidations"
 )
 
 // RequestForwardingClient is the client API for RequestForwarding service.
@@ -50,6 +52,9 @@ type RequestForwardingClient interface {
 	SendNamespaceKeys(ctx context.Context, in *SendNamespaceKeysRequest, opts ...grpc.CallOption) (*SendNamespaceKeysReply, error)
 	// active->standby key sharing; used by the standby to refresh keys.
 	GetNamespaceKeys(ctx context.Context, in *GetNamespaceKeysRequest, opts ...grpc.CallOption) (*GetNamespaceKeysReply, error)
+	// GRPC-backed invalidation
+	StartInvalidations(ctx context.Context, in *StartInvalidationRequest, opts ...grpc.CallOption) (*StartInvalidationResponse, error)
+	CheckInvalidations(ctx context.Context, in *CheckInvalidationRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CheckInvalidationResponse], error)
 }
 
 type requestForwardingClient struct {
@@ -110,6 +115,35 @@ func (c *requestForwardingClient) GetNamespaceKeys(ctx context.Context, in *GetN
 	return out, nil
 }
 
+func (c *requestForwardingClient) StartInvalidations(ctx context.Context, in *StartInvalidationRequest, opts ...grpc.CallOption) (*StartInvalidationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StartInvalidationResponse)
+	err := c.cc.Invoke(ctx, RequestForwarding_StartInvalidations_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *requestForwardingClient) CheckInvalidations(ctx context.Context, in *CheckInvalidationRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CheckInvalidationResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &RequestForwarding_ServiceDesc.Streams[0], RequestForwarding_CheckInvalidations_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[CheckInvalidationRequest, CheckInvalidationResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RequestForwarding_CheckInvalidationsClient = grpc.ServerStreamingClient[CheckInvalidationResponse]
+
 // RequestForwardingServer is the server API for RequestForwarding service.
 // All implementations must embed UnimplementedRequestForwardingServer
 // for forward compatibility.
@@ -130,6 +164,9 @@ type RequestForwardingServer interface {
 	SendNamespaceKeys(context.Context, *SendNamespaceKeysRequest) (*SendNamespaceKeysReply, error)
 	// active->standby key sharing; used by the standby to refresh keys.
 	GetNamespaceKeys(context.Context, *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error)
+	// GRPC-backed invalidation
+	StartInvalidations(context.Context, *StartInvalidationRequest) (*StartInvalidationResponse, error)
+	CheckInvalidations(*CheckInvalidationRequest, grpc.ServerStreamingServer[CheckInvalidationResponse]) error
 	mustEmbedUnimplementedRequestForwardingServer()
 }
 
@@ -154,6 +191,12 @@ func (UnimplementedRequestForwardingServer) SendNamespaceKeys(context.Context, *
 }
 func (UnimplementedRequestForwardingServer) GetNamespaceKeys(context.Context, *GetNamespaceKeysRequest) (*GetNamespaceKeysReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNamespaceKeys not implemented")
+}
+func (UnimplementedRequestForwardingServer) StartInvalidations(context.Context, *StartInvalidationRequest) (*StartInvalidationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StartInvalidations not implemented")
+}
+func (UnimplementedRequestForwardingServer) CheckInvalidations(*CheckInvalidationRequest, grpc.ServerStreamingServer[CheckInvalidationResponse]) error {
+	return status.Error(codes.Unimplemented, "method CheckInvalidations not implemented")
 }
 func (UnimplementedRequestForwardingServer) mustEmbedUnimplementedRequestForwardingServer() {}
 func (UnimplementedRequestForwardingServer) testEmbeddedByValue()                           {}
@@ -266,6 +309,35 @@ func _RequestForwarding_GetNamespaceKeys_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RequestForwarding_StartInvalidations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartInvalidationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RequestForwardingServer).StartInvalidations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RequestForwarding_StartInvalidations_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RequestForwardingServer).StartInvalidations(ctx, req.(*StartInvalidationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RequestForwarding_CheckInvalidations_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(CheckInvalidationRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(RequestForwardingServer).CheckInvalidations(m, &grpc.GenericServerStream[CheckInvalidationRequest, CheckInvalidationResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RequestForwarding_CheckInvalidationsServer = grpc.ServerStreamingServer[CheckInvalidationResponse]
+
 // RequestForwarding_ServiceDesc is the grpc.ServiceDesc for RequestForwarding service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -293,7 +365,17 @@ var RequestForwarding_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "GetNamespaceKeys",
 			Handler:    _RequestForwarding_GetNamespaceKeys_Handler,
 		},
+		{
+			MethodName: "StartInvalidations",
+			Handler:    _RequestForwarding_StartInvalidations_Handler,
+		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "CheckInvalidations",
+			Handler:       _RequestForwarding_CheckInvalidations_Handler,
+			ServerStreams: true,
+		},
+	},
 	Metadata: "internal/vault/forwarding/request_forwarding_service.proto",
 }

--- a/internal/vault/grpc_invalidation.go
+++ b/internal/vault/grpc_invalidation.go
@@ -1,0 +1,472 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openbao/openbao/v2/internal/helper/fairshare"
+	"github.com/openbao/openbao/v2/internal/vault/forwarding"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	uuid "github.com/hashicorp/go-uuid"
+	"google.golang.org/grpc"
+	"zgo.at/zcache/v2"
+)
+
+// invalidationPeers manages GRPC invalidation and tracking of peers.
+type invalidationPeers struct {
+	core   *Core
+	logger log.Logger
+
+	// l is for the below items. These are set to nil between state changes.
+	// A write lock only needs to be acquired when modifying the actual
+	// pointer values of the below; each item should still be thread-safe so
+	// a read-lock is only necessary most of the time.
+	l sync.RWMutex
+
+	// peers is a cache of all standby nodes the active node is aware of that
+	// are requesting GRPC synchronization of invalidations.
+	peers *zcache.Cache[string, *invalidationPeerInfo]
+
+	// dispatcher is a job manager for executing invalidations from the GRPC
+	// bridge, bidirectionally. It is used on both active nodes (to dispatch
+	// events to individual peers without unnecessary blocking) and standby
+	// nodes (to handle waiting for the specified invalidation index).
+	dispatcher *fairshare.JobManager
+}
+
+type invalidationPeerInfo struct {
+	stream grpc.ServerStreamingServer[forwarding.CheckInvalidationResponse]
+	stopCh chan struct{}
+
+	started bool
+}
+
+func (c *Core) NewInvalidationPeers() {
+	logger := c.logger.Named("grpc-invalidation")
+	c.AddLogger(logger)
+
+	c.connectedInvalidationPeers = &invalidationPeers{
+		core:   c,
+		logger: logger,
+	}
+}
+
+func (c *Core) SetupInvalidationPeers() {
+	c.connectedInvalidationPeers.Setup()
+}
+
+func (c *Core) LocalGRPCDispatching() {
+	c.connectedInvalidationPeers.SetupStandby()
+}
+
+func (i *invalidationPeers) Setup() {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	i.peers = zcache.New[string, *invalidationPeerInfo](16*i.core.clusterHeartbeatInterval, 1*time.Second)
+	i.peers.OnEvicted(func(uuid string, peer *invalidationPeerInfo) {
+		i.logger.Debug("evicting stale invalidation client for peer", "uuid", uuid)
+		close(peer.stopCh)
+	})
+
+	i.dispatcher = fairshare.NewJobManager("active-grpc-invalidation", 2+32, i.logger, i.core.metricSink)
+	i.dispatcher.Start()
+
+	i.dispatcher.AddJob(&pingInvalidationJob{
+		peers: i,
+		ctx:   i.core.activeContext.Load(),
+	}, "ping")
+}
+
+func (i *invalidationPeers) SetupStandby() {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	i.dispatcher = fairshare.NewJobManager("standby-grpc-invalidation", 2, i.logger, i.core.metricSink)
+	i.dispatcher.Start()
+}
+
+func (c *Core) CleanupInvalidationPeers() {
+	c.connectedInvalidationPeers.Cleanup()
+}
+
+func (i *invalidationPeers) Cleanup() {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	if i.peers != nil {
+		i.peers.DeleteAll()
+	}
+
+	if i.dispatcher != nil {
+		i.dispatcher.Stop()
+	}
+
+	i.dispatcher = nil
+	i.peers = nil
+}
+
+// SendInvalidationNotice is used by the GRPCInvalidator mechanism to hook
+// back into core and send the notice of invalidation to all participating
+// peers.
+func (c *Core) SendInvalidationNotice(keys ...string) {
+	// Ensure we're called on the active node only.
+	if c.standby.Load() {
+		return
+	}
+
+	// Ensure the active context has not been canceled under us.
+	ctx := c.activeContext.Load()
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Get the index from the underlying storage backend.
+	index, err := c.indexManager.Latest(ctx)
+	if err != nil {
+		c.logger.Error("failed to get latest applied replication index", "error", err)
+		return
+	}
+
+	// Enqueue invalidation notifications to all peers.
+	if err := c.connectedInvalidationPeers.SendInvalidation(index, keys); err != nil {
+		c.logger.Error("failed to queue invalidation to send to peers", "error", err)
+		return
+	}
+}
+
+// SendInvalidation takes the given invalidation denoted by (index, keys) and
+// enqueues jobs per known, ready peer to handle the specified.
+func (i *invalidationPeers) SendInvalidation(index string, keys []string) error {
+	i.l.RLock()
+	defer i.l.RUnlock()
+
+	if i.peers == nil || i.dispatcher == nil {
+		return errors.New("core is restarting")
+	}
+
+	var failed []string
+	var retErr error
+	for peerUUID, peerInfoItem := range i.peers.Items() {
+		peerInfo := peerInfoItem.Object
+		if !peerInfo.started {
+			// Peers which have not yet been started and caught up are
+			// safe to ignore.
+			continue
+		}
+
+		if peerInfo.stream == nil {
+			retErr = multierror.Append(retErr, fmt.Errorf("while sending invalidation to %v: no active stream", peerUUID))
+			failed = append(failed, peerUUID)
+			continue
+		}
+
+		// We additionally need to grab the state lock here. While we could
+		// do this linearly from this thread, using a job manager with
+		// per-peer queues ensures that a slow peer does not starve other
+		// peers from their invalidations.
+		i.dispatcher.AddJob(&dispatchInvalidationToPeer{
+			scheduled: time.Now(),
+			index:     index,
+			keys:      keys,
+			peers:     i,
+			peer:      peerUUID,
+		}, peerUUID)
+	}
+
+	for _, failedPeer := range failed {
+		i.peers.Delete(failedPeer)
+	}
+
+	return retErr
+}
+
+// AddInvalidationPeer tracks a new invalidation peer identified by the given
+// stream, yielding (an identifier and a cancel channel) or an error.
+func (c *Core) AddInvalidationPeer(stream grpc.ServerStreamingServer[forwarding.CheckInvalidationResponse]) (string, chan struct{}, error) {
+	return c.connectedInvalidationPeers.AddPeer(stream)
+}
+
+// AddPeer handles assignment of the peer to the currently tracked subset,
+// using the specified stream. It yields (an identifier and a cancel channel)
+// or an error.
+func (i *invalidationPeers) AddPeer(stream grpc.ServerStreamingServer[forwarding.CheckInvalidationResponse]) (string, chan struct{}, error) {
+	i.l.RLock()
+	defer i.l.RUnlock()
+
+	info := &invalidationPeerInfo{
+		stream: stream,
+		stopCh: make(chan struct{}),
+	}
+
+	// Peer identifiers are ephemeral and matched to the stream.
+	for {
+		peerUUID, err := uuid.GenerateUUID()
+		if err != nil {
+			return "", nil, err
+		}
+
+		if err := i.peers.Add(peerUUID, info); err != nil {
+			// This should practically never happen.
+			continue
+		}
+
+		// Send an initial empty response with the uuid.
+		if err := stream.Send(&forwarding.CheckInvalidationResponse{
+			Uuid: peerUUID,
+		}); err != nil {
+			i.peers.Delete(peerUUID)
+			return "", nil, fmt.Errorf("failed to send uuid to peer on stream: %w", err)
+		}
+
+		return peerUUID, info.stopCh, nil
+	}
+}
+
+// MarkPeerStarted flags the selected peer as wanting to begin active service;
+// it yields an initial index after which all events will be sent.
+func (core *Core) MarkPeerStarted(ctx context.Context, uuid string) (string, error) {
+	err := core.connectedInvalidationPeers.markPeerStarted(uuid)
+	if err != nil {
+		return "", fmt.Errorf("failed marking peer as started: %w", err)
+	}
+
+	index, err := core.indexManager.Latest(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed getting current physical replication index: %w", err)
+	}
+
+	return index, nil
+}
+
+// markPeerStarted associates the given replication index as the initial
+// state of the specified invalidation peer.
+func (i *invalidationPeers) markPeerStarted(uuid string) error {
+	i.l.RLock()
+	defer i.l.RUnlock()
+
+	if _, existing := i.peers.Modify(uuid, func(peerInfo *invalidationPeerInfo) *invalidationPeerInfo {
+		peerInfo.started = true
+		return peerInfo
+	}); !existing {
+		return fmt.Errorf("peer %q does not have an active replication stream", uuid)
+	}
+
+	return nil
+}
+
+// AwaitInvalidation is used by the GRPC layer on standby nodes to dispatch
+// events into the invalidation based on the specified storage index being
+// replicated from the primary.
+func (core *Core) AwaitInvalidation(ctx context.Context, cleanup func(), index string, keys ...string) {
+	if len(keys) == 0 || index == "" {
+		return
+	}
+
+	i := core.connectedInvalidationPeers
+
+	i.l.RLock()
+	defer i.l.RUnlock()
+
+	if i.dispatcher == nil {
+		i.logger.Error("skipping invalidation as dispatcher is missing", "index", index, "keys", keys)
+		cleanup()
+		return
+	}
+
+	i.dispatcher.AddJob(&awaitInvalidationJob{
+		scheduled: time.Now(),
+		core:      core,
+		ctx:       ctx,
+		index:     index,
+		keys:      keys,
+		cleanup:   cleanup,
+		logger:    i.logger,
+	}, "invalidations")
+}
+
+// AwaitReplication allows us to be sure that all state loaded after this
+// point will have been loaded from an index, after which the active node
+// will know to send us invalidations for updates. And because we already
+// started tracking invalidations, any invalidations which we get will be
+// queued locally.
+func (core *Core) AwaitReplication(ctx context.Context) error {
+	core.requestForwardingConnectionLock.RLock()
+	activeIndex, err := core.rpcForwardingClient.CheckReplicationIndex(ctx)
+	core.requestForwardingConnectionLock.RUnlock()
+
+	if err != nil {
+		return err
+	}
+
+	core.logger.Debug("awaiting GRPC-indicated start checkpoint", "index", activeIndex)
+
+	if err := core.indexManager.Await(ctx, activeIndex); err != nil {
+		return fmt.Errorf("unable to await storage index %v: %w", activeIndex, err)
+	}
+
+	return nil
+}
+
+type dispatchInvalidationToPeer struct {
+	scheduled time.Time
+	index     string
+	keys      []string
+	peers     *invalidationPeers
+	peer      string
+}
+
+var _ fairshare.Job = &dispatchInvalidationToPeer{}
+
+func (d *dispatchInvalidationToPeer) Execute() error {
+	d.peers.l.RLock()
+	defer d.peers.l.RUnlock()
+
+	if d.peers.peers == nil {
+		return errors.New("core is restarting")
+	}
+
+	peerInfo, ok := d.peers.peers.Get(d.peer)
+	if !ok {
+		return errors.New("peer disappeared after dispatch")
+	}
+
+	if !peerInfo.started {
+		return errors.New("peer start index has been reset")
+	}
+
+	if peerInfo.stream == nil {
+		return errors.New("peer has no active stream")
+	}
+
+	err := peerInfo.stream.Send(&forwarding.CheckInvalidationResponse{
+		Uuid:    d.peer,
+		Index:   d.index,
+		Keys:    d.keys,
+		Restart: false,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.peers.peers.Touch(d.peer)
+	return nil
+}
+
+func (d *dispatchInvalidationToPeer) OnFailure(err error) {
+	d.peers.logger.Error("failed to propagate write to peer", "peer", d.peer, "keys", d.keys, "err", err)
+
+	d.peers.l.RLock()
+	defer d.peers.l.RUnlock()
+
+	if d.peers.peers == nil {
+		return
+	}
+
+	d.peers.peers.Delete(d.peer)
+}
+
+type awaitInvalidationJob struct {
+	scheduled time.Time
+	core      *Core
+
+	ctx   context.Context
+	index string
+	keys  []string
+
+	logger  log.Logger
+	cleanup func()
+}
+
+var _ fairshare.Job = &awaitInvalidationJob{}
+
+func (a *awaitInvalidationJob) Execute() error {
+	if a.ctx.Err() != nil {
+		return a.ctx.Err()
+	}
+
+	if err := a.core.indexManager.Await(a.ctx, a.index); err != nil {
+		return fmt.Errorf("unable to await invalidation at index %v: %w", a.index, err)
+	}
+
+	a.core.Invalidate(a.keys...)
+	return nil
+}
+
+func (a *awaitInvalidationJob) OnFailure(err error) {
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		a.logger.Error("failed to await invalidation", "index", a.index, "keys", a.keys, "err", err)
+	}
+
+	a.cleanup()
+}
+
+type pingInvalidationJob struct {
+	peers *invalidationPeers
+	ctx   context.Context
+}
+
+var _ fairshare.Job = &pingInvalidationJob{}
+
+func (p *pingInvalidationJob) Execute() error {
+	// Skip executing if we've shut down.
+	if p.ctx.Err() != nil {
+		return p.ctx.Err()
+	}
+
+	defer p.requeueJob()
+	return p.queueNotifications()
+}
+
+func (p *pingInvalidationJob) queueNotifications() error {
+	p.peers.l.RLock()
+	defer p.peers.l.RUnlock()
+
+	if p.peers.peers == nil || p.peers.dispatcher == nil {
+		return errors.New("core is restarting")
+	}
+
+	for peerUUID := range p.peers.peers.Items() {
+		p.peers.dispatcher.AddJob(&dispatchInvalidationToPeer{
+			scheduled: time.Now(),
+			peers:     p.peers,
+			peer:      peerUUID,
+		}, peerUUID)
+	}
+
+	return nil
+}
+
+func (p *pingInvalidationJob) requeueJob() {
+	// Dispatcher does not allow adding a job from the same thread and
+	// there's no point blocking shutdown for a sleep.
+	go func() {
+		time.Sleep(1 * time.Second)
+
+		p.peers.l.RLock()
+		defer p.peers.l.RUnlock()
+
+		if p.peers.peers == nil || p.peers.dispatcher == nil {
+			return
+		}
+
+		p.peers.dispatcher.AddJob(&pingInvalidationJob{
+			peers: p.peers,
+			ctx:   p.ctx,
+		}, "ping")
+	}()
+}
+
+func (p *pingInvalidationJob) OnFailure(err error) {
+	if strings.Contains(err.Error(), context.Canceled.Error()) {
+		return
+	}
+
+	p.peers.logger.Debug("ping invalidation job failure", "error", err)
+}

--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -168,7 +168,7 @@ func (c *Core) LeaderLocked() (isLeader bool, leaderAddr, clusterAddr string, er
 		return false, localRedirectAddr, localClusterAddr, nil
 	}
 
-	c.logger.Trace("found new active node information, refreshing")
+	c.logger.Trace("found new active node information, refreshing", "old_uuid", localLeaderUUID, "old_cluster_addr", localClusterAddr, "new_uuid", leaderUUID)
 
 	c.leaderParamsLock.Lock()
 	defer c.leaderParamsLock.Unlock()
@@ -386,7 +386,7 @@ func (c *Core) stopHALoop() {
 	}
 }
 
-func (c *Core) restart() {
+func (c *Core) Restart() {
 	restartCh := c.haLoopRestartCh.Load()
 	if restartCh == nil {
 		return
@@ -613,8 +613,11 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}, isRea
 		// If possible, unseal in read-only mode and start acting as a
 		// read-enabled standby.
 		if isReadEnabled {
-			if stop := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh); stop {
+			stop, retry := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh)
+			if stop {
 				return
+			} else if retry {
+				continue
 			}
 		}
 
@@ -891,15 +894,62 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}, isRea
 	}
 }
 
+func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) bool {
+	// Potentially refresh replication information before we get
+	// too far. This ensures we do not attempt to contact a stale
+	// leader.
+	if _, _, _, err := c.LeaderLocked(); err != nil {
+		c.logger.Error("skipping invalidation streaming as unable to read leader information", "err", err)
+		return false
+	}
+
+	c.requestForwardingConnectionLock.RLock()
+	defer c.requestForwardingConnectionLock.RUnlock()
+
+	if c.rpcForwardingClient == nil {
+		// When the active node has not indicated a cluster address
+		// or there's a problem connecting, we may not have a
+		// forwarding client. This renders us unable to perform any
+		// invalidations so we're unable to start-up in read-enabled
+		// mode.
+		c.logger.Error("skipping invalidation streaming as no RPC client is present")
+		return false
+	}
+
+	// Start tracking any invalidations; we won't begin processing
+	// them until after unseal is complete. This is necessary because
+	// we'll immediately start receiving events but our underlying data
+	// store might be late to arrive. Since we'll only wait to the
+	// awaited index, any events that come in for a later index than our
+	// awaited one before readOnlyUnseal starts the invalidation subsystem
+	// will be silently ignored otherwise. This ensures that they're not
+	// dropped and that we'll re-trigger them once both the index has been
+	// reached and the startup is complete.
+	c.invalidations.Track()
+
+	// Start the dispatch manager on the standby nodes.
+	c.LocalGRPCDispatching()
+
+	// Start streaming invalidation events from the primary.
+	if err := c.rpcForwardingClient.StreamInvalidations(ctx); err != nil {
+		c.logger.Error("failed to begin streaming invalidations", "err", err)
+		return false
+	}
+
+	return true
+}
+
 // runReadEnabledStandby grabs the state lock and unseals in read-only mode. It
-// returns true if stopped or timed out.
-func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.CancelFunc, stopCh <-chan struct{}) bool {
+// returns two booleans:
+// - stop: true if state lock acquisition stopped or timed out
+// - retry: if the operation should be retried.
+func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.CancelFunc, stopCh <-chan struct{}) (stop bool, retry bool) {
 	c.logger.Info("enabling horizontal scalability (reads)")
 	c.barrier.SetReadOnly(true)
 
 	if err := c.runStandbyGrabStateLock(stopCh); err != nil {
 		c.logger.Error("unable to grab state lock for standby", "err", err)
-		return true
+		return true, false
 	}
 
 	defer c.stateLock.Unlock()
@@ -911,13 +961,47 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 
 	c.drainPendingRestarts()
 
+	// Before unseal, check if we need to do GRPC based invalidation;
+	// if so, start streaming invalidations.
+	if shouldUseGRPCInvalidation(c.underlyingPhysical) {
+		c.logger.Debug("setting up GRPC-backed streaming of invalidations")
+
+		if ok := c.setupGRPCStandbyInvalidations(ctx); !ok {
+			// Clear any events we might have received.
+			c.CleanupInvalidationPeers()
+			c.invalidations.Stop()
+
+			// Try this again.
+			return false, true
+		}
+
+		// Wait for our initial invalidation checkpoint.
+		if err := c.AwaitReplication(ctx); err != nil {
+			// Clear any events we might have received.
+			c.CleanupInvalidationPeers()
+			c.invalidations.Stop()
+
+			c.logger.Error("failed to await replication", "err", err)
+			return false, true
+		}
+	}
+
 	// Unseal, holding the state lock.
 	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
 	if err := c.postUnseal(ctx, ctxCancel, readonlyUnsealStrategy{}); err != nil {
 		c.logger.Error("read-only post-unseal setup failed", "error", err)
+
+		// Clear any events we might have received and quit tracking new ones.
+		c.CleanupInvalidationPeers()
+		c.invalidations.Stop()
+
+		// We shouldn't attempt to keep grabbing the HA lock if we failed to
+		// unseal.
+		return false, true
 	}
 
-	return false
+	// All good.
+	return false, false
 }
 
 // grabLockOrStop returns stopped=false if the lock is acquired. Returns
@@ -1304,7 +1388,11 @@ func (c *Core) clearLeader(uuid string) error {
 // StandbyReadsEnabled returns true iff standby read are enabled and supported
 // by the physical backend
 func (c *Core) StandbyReadsEnabled() bool {
-	if _, ok := c.underlyingPhysical.(physical.CacheInvalidationBackend); !ok {
+	if shouldUseGRPCInvalidation(c.underlyingPhysical) {
+		if c.rpcForwardingClient == nil {
+			return false
+		}
+	} else if _, ok := c.underlyingPhysical.(physical.CacheInvalidationBackend); !ok {
 		return false
 	}
 

--- a/internal/vault/ha_test.go
+++ b/internal/vault/ha_test.go
@@ -115,7 +115,7 @@ func testCoreRestart(t *testing.T, core int) {
 	c.Cores[core].stateLock.RUnlock()
 
 	// trigger the restart
-	c.Cores[core].restart()
+	c.Cores[core].Restart()
 
 	// wait until the active context is cancelled
 	select {

--- a/internal/vault/invalidation.go
+++ b/internal/vault/invalidation.go
@@ -52,13 +52,13 @@ type invalidationManager struct {
 
 	// Invalidate stages pending invalidations into this queue.
 	pendingLock   sync.Mutex
-	enabled       atomic.Bool
+	accepting     atomic.Bool
 	pending       []string
 	pendingNotify chan struct{}
 
 	// quitCh notifies that we should stop actively processing invalidations.
 	//
-	// We'll still keep appending to pending, though, assuming enabled=true
+	// We'll still keep appending to pending, though, assuming accepting=true
 	quitCh      chan struct{}
 	quitContext context.Context
 	doneCh      chan struct{}
@@ -81,13 +81,21 @@ func (core *Core) NewInvalidationManager() {
 }
 
 func (im *invalidationManager) Track() {
-	// Clear any leftover remaining items.
-	im.pendingLock.Lock()
-	im.pending = nil
-	im.pendingLock.Unlock()
+	if im.accepting.Load() {
+		return
+	}
 
-	// Start tracking new changes.
-	im.enabled.Store(true)
+	// Clear any leftover remaining items if we're changing state.
+	im.pendingLock.Lock()
+	defer im.pendingLock.Unlock()
+
+	// Revalidate that we should clear the queue, holding the lock.
+	if im.accepting.Load() {
+		return
+	}
+
+	im.pending = nil
+	im.accepting.Store(true)
 }
 
 func (im *invalidationManager) Start(ctx context.Context) {
@@ -103,12 +111,12 @@ func (im *invalidationManager) Start(ctx context.Context) {
 	go im.processPendingQueue(im.quitCh, im.quitContext, im.doneCh)
 }
 
-func (im *invalidationManager) Stop() error {
+func (im *invalidationManager) Stop() {
 	im.dispacherLogger.Debug("stop triggered")
 	defer im.dispacherLogger.Debug("finished stopping")
 
 	// Prevent enqueuing more items.
-	im.enabled.Store(false)
+	im.accepting.Store(false)
 
 	// Close the quit channel to cancel any yet-to-be-dispatched.
 	if im.quitCh != nil {
@@ -144,8 +152,6 @@ func (im *invalidationManager) Stop() error {
 	im.quitContext = nil
 	im.dispatcher = nil
 	im.doneCh = nil
-
-	return nil
 }
 
 func (im *invalidationManager) processPendingQueue(quitCh chan struct{}, quitContext context.Context, doneCh chan struct{}) {
@@ -566,12 +572,12 @@ func (ij *invalidationJob) OnFailure(err error) {
 
 	// This was a fatal failure; dispatch a restart.
 	ij.im.dispacherLogger.Error("fatal failure dispatching invalidation; restarting core", "key", ij.key, "err", err)
-	ij.im.core.restart()
+	ij.im.core.Restart()
 }
 
 func (im *invalidationManager) Add(key ...string) {
-	// Skip invalidations if we're not enabled yet.
-	if !im.enabled.Load() {
+	// Skip invalidations if we're not accepting invalidations yet.
+	if !im.accepting.Load() {
 		return
 	}
 

--- a/internal/vault/storage_index.go
+++ b/internal/vault/storage_index.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/openbao/openbao/sdk/v2/physical"
+)
+
+var (
+	minBackoff     = 2 * time.Millisecond
+	defaultBackoff = 5 * time.Millisecond
+)
+
+type indexManager struct {
+	backend physical.ReplicationIndexBackend
+	backoff time.Duration
+
+	l          sync.RWMutex
+	lastIndex  string
+	lastUpdate time.Time
+}
+
+func NewIndexManager(backend physical.ReplicationIndexBackend, backoff time.Duration) *indexManager {
+	if backoff == 0 {
+		backoff = defaultBackoff
+	} else if backoff < minBackoff {
+		backoff = minBackoff
+	}
+
+	return &indexManager{
+		backend: backend,
+		backoff: backoff,
+	}
+}
+
+// Latest always refreshes the index, returning the latest.
+func (i *indexManager) Latest(ctx context.Context) (string, error) {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	return i.getIndexLocked(ctx)
+}
+
+// Get returns the latest index if it is within freshness thresholds.
+func (i *indexManager) Get(ctx context.Context) (string, error) {
+	if index := func() string {
+		i.l.RLock()
+		defer i.l.RUnlock()
+
+		if time.Now().After(i.lastUpdate.Add(i.backoff)) {
+			return ""
+		}
+
+		return i.lastIndex
+	}(); index != "" {
+		return index, nil
+	}
+
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	return i.getIndexLocked(ctx)
+}
+
+func (i *indexManager) Await(ctx context.Context, index string) error {
+	// Before checking the underlying index, check if we're already past our
+	// last-seen index.
+
+	i.l.RLock()
+	first := i.lastIndex
+	i.l.RUnlock()
+	if first != "" {
+		if passed, err := i.backend.GreaterEqualReplicationIndex(ctx, first, index); err == nil && passed {
+			return nil
+		}
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = i.backoff
+	b.MaxInterval = 1 * time.Second
+
+	timeBoxed, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	op := func() (none struct{}, err error) {
+		current, err := i.Get(timeBoxed)
+		if err != nil {
+			return none, err
+		}
+
+		passed, err := i.backend.GreaterEqualReplicationIndex(timeBoxed, current, index)
+		if err != nil {
+			return none, err
+		}
+
+		if !passed {
+			return none, errors.New("not yet reached specified storage index")
+		}
+
+		return none, nil
+	}
+
+	_, err := backoff.Retry(timeBoxed, op, backoff.WithBackOff(b))
+	return err
+}
+
+func (i *indexManager) getIndexLocked(ctx context.Context) (string, error) {
+	// Assume the index is relative to the start of the check operation,
+	// not the end.
+	when := time.Now()
+
+	storageIndex, err := i.backend.AppliedReplicationIndex(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error checking replication index: %w", err)
+	}
+
+	i.lastIndex = storageIndex
+	i.lastUpdate = when
+
+	return storageIndex, nil
+}

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -71,6 +71,22 @@ type CacheInvalidationBackend interface {
 
 type InvalidateFunc func(key ...string)
 
+// ReplicationIndexBackend is an extension to the standard physical backend
+// to support checking the current applied replication index. In the case of
+// a backend utilizing a WAL, such as Raft or PostgreSQL, this would be the
+// last applied WAL index. Note that references are opaque strings and may not
+// make any sense to the end-consumer.
+type ReplicationIndexBackend interface {
+	// AppliedReplicationIndex returns the last applied replication index as
+	// an opaque identifier.
+	AppliedReplicationIndex(ctx context.Context) (string, error)
+
+	// GreaterEqualReplicationIndex returns whether the left index is greater
+	// than or equal to the right index. Context is passed so that online
+	// comparisons which require a round-trip to the remote can be performed.
+	GreaterEqualReplicationIndex(ctx context.Context, left string, right string) (bool, error)
+}
+
 // HABackend is an extensions to the standard physical
 // backend to support high-availability. Vault only expects to
 // use mutual exclusion to allow multiple instances to act as a

--- a/sdk/physical/write_notifier.go
+++ b/sdk/physical/write_notifier.go
@@ -1,0 +1,149 @@
+package physical
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+
+	log "github.com/hashicorp/go-hclog"
+)
+
+type writeNotifier struct {
+	backend     Backend
+	logger      log.Logger
+	notifyWrite InvalidateFunc
+}
+
+type transactionalWriteNotifier struct {
+	*writeNotifier
+}
+
+type writeNotifierTransaction struct {
+	*writeNotifier
+	txn       Transaction
+	writeLock sync.Mutex
+	writes    map[string]struct{}
+}
+
+func NewWriteNotifier(b Backend, logger log.Logger, notifyWrite InvalidateFunc) Backend {
+	w := &writeNotifier{
+		backend:     b,
+		logger:      logger,
+		notifyWrite: notifyWrite,
+	}
+
+	if _, ok := b.(TransactionalBackend); ok {
+		return &transactionalWriteNotifier{
+			w,
+		}
+	}
+
+	return w
+}
+
+// We do nothing here. We don't directly call this hook as its handled by the
+// GRPC-based invalidation that is inserted into Core directly. Phrased
+// differently, it is impossible to implement this as this particular layer
+// is not replicated in any way and thus nothing would be able to call this
+// hook on a standby when new data appears.
+func (w *writeNotifier) HookInvalidate(hook InvalidateFunc) {}
+
+func (w *writeNotifier) Put(ctx context.Context, entry *Entry) error {
+	err := w.backend.Put(ctx, entry)
+	if err == nil {
+		w.notifyWrite(entry.Key)
+	}
+
+	return err
+}
+
+func (w *writeNotifier) Get(ctx context.Context, key string) (*Entry, error) {
+	return w.backend.Get(ctx, key)
+}
+
+func (w *writeNotifier) Delete(ctx context.Context, key string) error {
+	err := w.backend.Delete(ctx, key)
+	if err == nil {
+		w.notifyWrite(key)
+	}
+
+	return err
+}
+
+func (w *writeNotifier) List(ctx context.Context, prefix string) ([]string, error) {
+	return w.backend.List(ctx, prefix)
+}
+
+func (w *writeNotifier) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return w.backend.ListPage(ctx, prefix, after, limit)
+}
+
+func (w *transactionalWriteNotifier) BeginReadOnlyTx(ctx context.Context) (Transaction, error) {
+	// Read-only transactions don't need write tracking.
+	return w.writeNotifier.backend.(TransactionalBackend).BeginReadOnlyTx(ctx)
+}
+
+func (w *transactionalWriteNotifier) BeginTx(ctx context.Context) (Transaction, error) {
+	txn, err := w.writeNotifier.backend.(TransactionalBackend).BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &writeNotifierTransaction{
+		writeNotifier: w.writeNotifier,
+		txn:           txn,
+		writes:        map[string]struct{}{},
+	}, nil
+}
+
+func (w *writeNotifierTransaction) Put(ctx context.Context, entry *Entry) error {
+	w.writeLock.Lock()
+	defer w.writeLock.Unlock()
+
+	err := w.txn.Put(ctx, entry)
+	if err == nil {
+		w.writes[entry.Key] = struct{}{}
+	}
+
+	return err
+}
+
+func (w *writeNotifierTransaction) Get(ctx context.Context, key string) (*Entry, error) {
+	return w.txn.Get(ctx, key)
+}
+
+func (w *writeNotifierTransaction) Delete(ctx context.Context, key string) error {
+	w.writeLock.Lock()
+	defer w.writeLock.Unlock()
+
+	err := w.txn.Delete(ctx, key)
+	if err == nil {
+		w.writes[key] = struct{}{}
+	}
+
+	return err
+}
+
+func (w *writeNotifierTransaction) List(ctx context.Context, prefix string) ([]string, error) {
+	return w.txn.List(ctx, prefix)
+}
+
+func (w *writeNotifierTransaction) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return w.txn.ListPage(ctx, prefix, after, limit)
+}
+
+func (w *writeNotifierTransaction) Commit(ctx context.Context) error {
+	w.writeLock.Lock()
+	defer w.writeLock.Unlock()
+
+	err := w.txn.Commit(ctx)
+	if err == nil {
+		w.notifyWrite(slices.Collect(maps.Keys(w.writes))...)
+	}
+	return err
+}
+
+func (w *writeNotifierTransaction) Rollback(ctx context.Context) error {
+	return w.txn.Rollback(ctx)
+}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This introduces a three-part GRPC-invalidation mechanism:

1. A new physical shim to catch storage write operations and dispatch it into a GRPC invalidation queue.
2. A new index manager for caching calls to update storage replication indices and reduce load on the backend database.
3. A new GRPC layer to ship invalidations from the active to all registered standby nodes and subsequently invalidate on them when the respective index has been hit.

We introduce new hooks for this GRPC to delay standby startup until the standby has caught the active node's state.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Tests will be introduced in a subsequent change; let me know if anyone wants me to move it to a feature branch, though I think this is the bulk of the change.

Related: #3027

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
