### PR TITLE
fix(sink): in-memory token retrieval panics if unset

### DIFF
--- a/changelog/3462.txt
+++ b/changelog/3462.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/apiproxy: fix in-memory sink panic when proxying `auth/token/lookup-self` while unauthenticated
+```

--- a/command/agentproxyshared/sink/inmem/inmem_sink.go
+++ b/command/agentproxyshared/sink/inmem/inmem_sink.go
@@ -26,10 +26,13 @@ func New(conf *sink.SinkConfig, leaseCache *cache.LeaseCache) (sink.Sink, error)
 		return nil, errors.New("nil logger provided")
 	}
 
-	return &inmemSink{
+	s := &inmemSink{
 		logger:     conf.Logger,
 		leaseCache: leaseCache,
-	}, nil
+	}
+	s.token.Store("")
+
+	return s, nil
 }
 
 func (s *inmemSink) WriteToken(token string) error {


### PR DESCRIPTION
## Description

Ensure we have a default value set to avoid panics when `Token()` is called before `WriteToken()`, similarly to what existed before the package migation in #1763.

## Rationale

Resolves: #3461

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.


