### PR TITLE
Support Login MFA in profile engine

### DIFF
--- a/changelog/3465.txt
+++ b/changelog/3465.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+core/workflows: Ensure logical.Request.Connection is set to allow certificate auth, login MFA to work.
+```
+```release-note:improvement
+core/profiles: Parse login MFA from request header information.
+```
+```release-note:improvement
+core/profiles: Canonicalize headers before evaluating request.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1867,6 +1867,10 @@ func (c *ServerCommand) doSelfInit(core *vault.Core, config *server.Config, root
 
 		// Hook the profile system directly up to our core request handler.
 		profiles.WithRequestHandler(func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+			// Ensure Connection is not nil so login MFA works.
+			req.Connection = &logical.Connection{
+				RemoteAddr: "127.0.0.1",
+			}
 			return core.HandleRequest(ctx, req)
 		}),
 

--- a/helper/profiles/history.go
+++ b/helper/profiles/history.go
@@ -161,7 +161,7 @@ func (eh *EvaluationHistory) getField(obj interface{}, rawFieldSelector []interf
 
 			val, present := mapBase[selector]
 			if !present {
-				return nil, fmt.Errorf("field %q at depth %v is missing:\n\tavailable keys: %v\n\tobj: %#v", selector, i, presentKeys(mapBase), mapBase)
+				return nil, fmt.Errorf("field %q at depth %v is missing:\n\tavailable keys: %v", selector, i, presentKeys(mapBase))
 			}
 
 			if i == len(rawFieldSelector)-1 {

--- a/helper/profiles/profiles.go
+++ b/helper/profiles/profiles.go
@@ -487,6 +487,15 @@ func (p *ProfileEngine) buildRequest(ctx context.Context, history *EvaluationHis
 		}
 	}
 
+	// Canonicalize headers so Core can understand them.
+	req.CanonicalizeHeaders()
+
+	// Parse headers to MFA fields.
+	if err := req.ParseMFAHeaders(); err != nil {
+		err = fmt.Errorf("failed to evaluate MFA fields: %w", err)
+		return req, execute, allowFailure, err
+	}
+
 	return req, execute, allowFailure, err
 }
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -59,10 +59,6 @@ const (
 )
 
 var (
-	// canonicalMFAHeaderName is the MFA header value's format in the request
-	// headers. Do not alter the casing of this string.
-	canonicalMFAHeaderName = http.CanonicalHeaderKey(consts.MFAHeaderName)
-
 	// Set to false by stub_asset if the ui build tag isn't enabled
 	uiBuiltIn = true
 
@@ -1108,52 +1104,6 @@ func requestWrapInfo(r *http.Request, req *logical.Request) (*logical.Request, e
 	}
 
 	return req, nil
-}
-
-// parseMFAHeader parses the MFAHeaderName in the request headers and organizes
-// them with MFA method name as the index.
-func parseMFAHeader(req *logical.Request) error {
-	if req == nil {
-		return errors.New("request is nil")
-	}
-
-	if req.Headers == nil {
-		return nil
-	}
-
-	// Reset and initialize the credentials in the request
-	req.MFACreds = make(map[string][]string)
-
-	for _, mfaHeaderValue := range req.Headers[canonicalMFAHeaderName] {
-		// Skip the header with no value in it
-		if mfaHeaderValue == "" {
-			continue
-		}
-
-		// Handle the case where only method name is mentioned and no value
-		// is supplied
-		if !strings.Contains(mfaHeaderValue, ":") {
-			// Mark the presence of method name, but set an empty set to it
-			// indicating that there were no values supplied for the method
-			if req.MFACreds[mfaHeaderValue] == nil {
-				req.MFACreds[mfaHeaderValue] = []string{}
-			}
-			continue
-		}
-
-		shardSplits := strings.SplitN(mfaHeaderValue, ":", 2)
-		if shardSplits[0] == "" {
-			return fmt.Errorf("invalid data in header %q; missing method name or ID", consts.MFAHeaderName)
-		}
-
-		if shardSplits[1] == "" {
-			return fmt.Errorf("invalid data in header %q; missing method value", consts.MFAHeaderName)
-		}
-
-		req.MFACreds[shardSplits[0]] = append(req.MFACreds[shardSplits[0]], shardSplits[1])
-	}
-
-	return nil
 }
 
 // isForm tries to determine whether the request should be

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/textproto"
 	"net/url"
 	"reflect"
 	"runtime"
@@ -30,93 +29,6 @@ import (
 	"github.com/openbao/openbao/vault"
 	"github.com/stretchr/testify/require"
 )
-
-func TestHandler_parseMFAHandler(t *testing.T) {
-	var err error
-	var expectedMFACreds logical.MFACreds
-	req := &logical.Request{
-		Headers: make(map[string][]string),
-	}
-
-	headerName := textproto.CanonicalMIMEHeaderKey(consts.MFAHeaderName)
-
-	// Set TOTP passcode in the MFA header
-	req.Headers[headerName] = []string{
-		"my_totp:123456",
-		"my_totp:111111",
-		"my_second_mfa:hi=hello",
-		"my_third_mfa",
-	}
-	err = parseMFAHeader(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify that it is being parsed properly
-	expectedMFACreds = logical.MFACreds{
-		"my_totp": []string{
-			"123456",
-			"111111",
-		},
-		"my_second_mfa": []string{
-			"hi=hello",
-		},
-		"my_third_mfa": []string{},
-	}
-	if !reflect.DeepEqual(expectedMFACreds, req.MFACreds) {
-		t.Fatalf("bad: parsed MFACreds; expected: %#v\n actual: %#v\n", expectedMFACreds, req.MFACreds)
-	}
-
-	// Split the creds of a method type in different headers and check if they
-	// all get merged together
-	req.Headers[headerName] = []string{
-		"my_mfa:passcode=123456",
-		"my_mfa:month=july",
-		"my_mfa:day=tuesday",
-	}
-	err = parseMFAHeader(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedMFACreds = logical.MFACreds{
-		"my_mfa": []string{
-			"passcode=123456",
-			"month=july",
-			"day=tuesday",
-		},
-	}
-	if !reflect.DeepEqual(expectedMFACreds, req.MFACreds) {
-		t.Fatalf("bad: parsed MFACreds; expected: %#v\n actual: %#v\n", expectedMFACreds, req.MFACreds)
-	}
-
-	// Header without method name should error out
-	req.Headers[headerName] = []string{
-		":passcode=123456",
-	}
-	err = parseMFAHeader(req)
-	if err == nil {
-		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
-	}
-
-	// Header without method name and method value should error out
-	req.Headers[headerName] = []string{
-		":",
-	}
-	err = parseMFAHeader(req)
-	if err == nil {
-		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
-	}
-
-	// Header without method name and method value should error out
-	req.Headers[headerName] = []string{
-		"my_totp:",
-	}
-	err = parseMFAHeader(req)
-	if err == nil {
-		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
-	}
-}
 
 type nilResponseWriter struct{}
 

--- a/http/logical.go
+++ b/http/logical.go
@@ -288,7 +288,7 @@ func buildLogicalRequest(core *vault.Core, w http.ResponseWriter, r *http.Reques
 		return nil, http.StatusBadRequest, fmt.Errorf("error parsing X-Vault-Wrap-TTL header: %w", err)
 	}
 
-	err = parseMFAHeader(req)
+	err = req.ParseMFAHeaders()
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("failed to parse X-Vault-MFA header: %w", err)
 	}

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -5,6 +5,7 @@ package logical
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/copystructure"
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 )
 
 // RequestWrapInfo is a struct that stores information about desired response
@@ -440,4 +442,67 @@ func ContextOriginalBodyValue(ctx context.Context) (io.ReadCloser, bool) {
 
 func CreateContextOriginalBody(parent context.Context, body io.ReadCloser) context.Context {
 	return context.WithValue(parent, ctxKeyOriginalBody{}, body)
+}
+
+func (req *Request) CanonicalizeHeaders() {
+	if req == nil {
+		return
+	}
+
+	canonicalized := make(map[string][]string, len(req.Headers))
+	for name, value := range req.Headers {
+		canonicalized[http.CanonicalHeaderKey(name)] = value
+	}
+
+	req.Headers = canonicalized
+}
+
+// canonicalMFAHeaderName is the MFA header value's format in the request
+// headers. Do not alter the casing of this string.
+var canonicalMFAHeaderName = http.CanonicalHeaderKey(consts.MFAHeaderName)
+
+// ParseMFAHeader parses the MFAHeaderName in the request headers and organizes
+// them with MFA method name as the index.
+func (req *Request) ParseMFAHeaders() error {
+	if req == nil {
+		return errors.New("request is nil")
+	}
+
+	if req.Headers == nil {
+		return nil
+	}
+
+	// Reset and initialize the credentials in the request
+	req.MFACreds = make(map[string][]string)
+
+	for _, mfaHeaderValue := range req.Headers[canonicalMFAHeaderName] {
+		// Skip the header with no value in it
+		if mfaHeaderValue == "" {
+			continue
+		}
+
+		// Handle the case where only method name is mentioned and no value
+		// is supplied
+		if !strings.Contains(mfaHeaderValue, ":") {
+			// Mark the presence of method name, but set an empty set to it
+			// indicating that there were no values supplied for the method
+			if req.MFACreds[mfaHeaderValue] == nil {
+				req.MFACreds[mfaHeaderValue] = []string{}
+			}
+			continue
+		}
+
+		shardSplits := strings.SplitN(mfaHeaderValue, ":", 2)
+		if shardSplits[0] == "" {
+			return fmt.Errorf("invalid data in header %q; missing method name or ID", consts.MFAHeaderName)
+		}
+
+		if shardSplits[1] == "" {
+			return fmt.Errorf("invalid data in header %q; missing method value", consts.MFAHeaderName)
+		}
+
+		req.MFACreds[shardSplits[0]] = append(req.MFACreds[shardSplits[0]], shardSplits[1])
+	}
+
+	return nil
 }

--- a/sdk/logical/request_test.go
+++ b/sdk/logical/request_test.go
@@ -1,8 +1,11 @@
 package logical
 
 import (
+	"net/textproto"
+	reflect "reflect"
 	"testing"
 
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,5 +45,92 @@ func TestValidateOperation(t *testing.T) {
 				assert.NoError(t, err, "expected no error for ValidateOperation")
 			}
 		})
+	}
+}
+
+func TestRequest_ParseMFAHandlers(t *testing.T) {
+	var err error
+	var expectedMFACreds MFACreds
+	req := &Request{
+		Headers: make(map[string][]string),
+	}
+
+	headerName := textproto.CanonicalMIMEHeaderKey(consts.MFAHeaderName)
+
+	// Set TOTP passcode in the MFA header
+	req.Headers[headerName] = []string{
+		"my_totp:123456",
+		"my_totp:111111",
+		"my_second_mfa:hi=hello",
+		"my_third_mfa",
+	}
+	err = req.ParseMFAHeaders()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that it is being parsed properly
+	expectedMFACreds = MFACreds{
+		"my_totp": []string{
+			"123456",
+			"111111",
+		},
+		"my_second_mfa": []string{
+			"hi=hello",
+		},
+		"my_third_mfa": []string{},
+	}
+	if !reflect.DeepEqual(expectedMFACreds, req.MFACreds) {
+		t.Fatalf("bad: parsed MFACreds; expected: %#v\n actual: %#v\n", expectedMFACreds, req.MFACreds)
+	}
+
+	// Split the creds of a method type in different headers and check if they
+	// all get merged together
+	req.Headers[headerName] = []string{
+		"my_mfa:passcode=123456",
+		"my_mfa:month=july",
+		"my_mfa:day=tuesday",
+	}
+	err = req.ParseMFAHeaders()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMFACreds = MFACreds{
+		"my_mfa": []string{
+			"passcode=123456",
+			"month=july",
+			"day=tuesday",
+		},
+	}
+	if !reflect.DeepEqual(expectedMFACreds, req.MFACreds) {
+		t.Fatalf("bad: parsed MFACreds; expected: %#v\n actual: %#v\n", expectedMFACreds, req.MFACreds)
+	}
+
+	// Header without method name should error out
+	req.Headers[headerName] = []string{
+		":passcode=123456",
+	}
+	err = req.ParseMFAHeaders()
+	if err == nil {
+		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
+	}
+
+	// Header without method name and method value should error out
+	req.Headers[headerName] = []string{
+		":",
+	}
+	err = req.ParseMFAHeaders()
+	if err == nil {
+		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
+	}
+
+	// Header without method name and method value should error out
+	req.Headers[headerName] = []string{
+		"my_totp:",
+	}
+	err = req.ParseMFAHeaders()
+	if err == nil {
+		t.Fatalf("expected an error; actual: %#v\n", req.MFACreds)
 	}
 }

--- a/vault/external_tests/workflows/workflow_test.go
+++ b/vault/external_tests/workflows/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/builtin/credential/userpass"
 	logicalKv "github.com/openbao/openbao/builtin/logical/kv"
+	logicalTotp "github.com/openbao/openbao/builtin/logical/totp"
 	vaulthttp "github.com/openbao/openbao/http"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/vault"
@@ -23,6 +24,7 @@ func TestWorkflow(t *testing.T) {
 		},
 		LogicalBackends: map[string]logical.Factory{
 			"kv-v2": logicalKv.VersionedKVFactory,
+			"totp":  logicalTotp.Factory,
 		},
 	}
 
@@ -54,6 +56,14 @@ func TestWorkflow(t *testing.T) {
 
 		client := client.WithNamespace("recursion")
 		testWorkflowRecursion(t, client)
+	})
+
+	t.Run("mfa", func(t *testing.T) {
+		_, err := client.Logical().Write("sys/namespaces/mfa", map[string]any{})
+		require.NoError(t, err)
+
+		client := client.WithNamespace("mfa")
+		testWorkflowLoginMFA(t, client)
 	})
 }
 
@@ -125,6 +135,39 @@ func testWorkflowRecursion(t *testing.T, client *api.Client) {
 
 	_, err = client.Logical().Write("sys/workflows/execute/endless-recursion", nil)
 	require.Contains(t, err.Error(), "too much workflow recursion")
+}
+
+func testWorkflowLoginMFA(t *testing.T, client *api.Client) {
+	// Create workflow.
+	_, err := client.Logical().Write("sys/workflows/manage/setup-admin", map[string]interface{}{
+		"workflow": loginMFAWorkflow,
+	})
+	require.NoError(t, err)
+
+	// Should exist.
+	resp, err := client.Logical().List("sys/workflows/manage")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data["keys"], "setup-admin")
+
+	// Should be able to execute it.
+	workflowResp, err := client.Logical().Write("sys/workflows/execute/setup-admin", map[string]interface{}{
+		"username": "admin",
+		"password": "Secret123",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, workflowResp)
+	require.Contains(t, workflowResp.Data, "token")
+	require.NotEmpty(t, workflowResp.Data["token"])
+
+	// The token should work.
+	testClient, err := client.Clone()
+	require.NoError(t, err)
+
+	testClient.SetToken(workflowResp.Data["token"].(string))
+	resp, err = testClient.Logical().Read("auth/token/lookup-self")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 }
 
 const createNamespaceWorkflow = `
@@ -255,6 +298,219 @@ flow "loop" {
   request "recursion" {
     path = "sys/workflows/execute/endless-recursion"
     operation = "update"
+  }
+}
+`
+
+const loginMFAWorkflow = `
+input {
+  field "string" "username" {
+    description = "username to provision into auth mount"
+    required = true
+  }
+
+  field "string" "password" {
+    description = "password to authenticate with"
+    required = true
+  }
+}
+
+flow "administration" {
+  request "auth" {
+    operation = "create"
+    path = "sys/auth/userpass"
+    data = {
+      type = "userpass"
+    }
+  }
+
+  request "auth-read" {
+    operation = "read"
+    path = "sys/auth/userpass"
+  }
+
+  request "policy" {
+    operation = "create"
+    path = "sys/policies/acl/admin"
+    data = {
+      policy = <<-EOT
+      path "*" {
+        capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
+      }
+      EOT
+    }
+  }
+
+  request "admin" {
+    operation = "create"
+    path = {
+      eval_source = "template"
+      eval_type = "string"
+      template = "auth/userpass/users/{{ .input.username }}"
+    }
+    data = {
+      password = {
+        eval_source = "input"
+        eval_type = "string"
+        field_name = "password"
+      }
+      token_policies = "default,admin"
+    }
+  }
+}
+
+flow "identity" {
+  request "entity" {
+    operation = "create"
+    path = "identity/entity"
+    data = {
+      metadata = {
+        testing = "true"
+      }
+    }
+  }
+
+  request "entity-alias" {
+    operation = "create"
+    path = "identity/entity-alias"
+    data = {
+      name = "admin"
+      canonical_id = {
+        eval_source = "response"
+        eval_type = "string"
+        flow_name = "identity"
+        response_name = "entity"
+        field_selector = ["data", "id"]
+      }
+      mount_accessor = {
+        eval_source = "response"
+        eval_type = "string"
+        flow_name = "administration"
+        response_name = "auth-read"
+        field_selector = ["data", "accessor"]
+      }
+    }
+  }
+}
+
+flow "mfa" {
+  request "method" {
+    operation = "create"
+    path = "identity/mfa/method/totp"
+    data = {
+      method_name = "testing"
+      issuer = "openbao"
+    }
+  }
+
+  request "secret" {
+    operation = "update"
+    path = "identity/mfa/method/totp/admin-generate"
+    data = {
+      method_id = {
+        eval_source = "response"
+        eval_type = "string"
+        flow_name = "mfa"
+        response_name = "method"
+        field_selector = ["data", "method_id"]
+      }
+      entity_id = {
+        eval_source = "response"
+        eval_type = "string"
+        flow_name = "identity"
+        response_name = "entity"
+        field_selector = ["data", "id"]
+      }
+    }
+  }
+
+  request "enforce" {
+    operation = "create"
+    path = "identity/mfa/login-enforcement/admin"
+    data = {
+      mfa_method_ids = [
+        {
+          eval_source = "response"
+          eval_type = "string"
+          flow_name = "mfa"
+          response_name = "method"
+          field_selector = ["data", "method_id"]
+        }
+      ]
+      identity_entity_ids = [
+        {
+          eval_source = "response"
+          eval_type = "string"
+          flow_name = "identity"
+          response_name = "entity"
+          field_selector = ["data", "id"]
+        }
+      ]
+    }
+  }
+
+  request "totp-mount" {
+    operation = "create"
+    path = "sys/mounts/totp"
+    data = {
+      type = "totp"
+    }
+  }
+
+  request "totp-import" {
+    operation = "create"
+    path = "totp/keys/mfa"
+    data = {
+      url = {
+        eval_source = "response"
+        eval_type = "string"
+        flow_name = "mfa"
+        response_name = "secret"
+        field_selector = ["data", "url"]
+      }
+    }
+  }
+}
+
+flow "authentication" {
+  request "mfa" {
+    operation = "read"
+    path = "totp/code/mfa"
+  }
+
+  request "login" {
+    operation = "update"
+    path = {
+      eval_source = "template"
+      eval_type = "string"
+      template = "auth/userpass/login/{{ .input.username }}"
+    }
+	headers = {
+	  "X-Vault-MFA" = {
+		eval_source = "template"
+		eval_type = "string"
+		template = "{{ .responses.mfa.method.data.method_id }}:{{ .responses.authentication.mfa.data.code }}"
+	  }
+    }
+    data = {
+      password = {
+        eval_source = "input"
+        eval_type = "string"
+        field_name = "password"
+      }
+    }
+  }
+}
+
+output {
+  data = {
+    token = {
+      eval_type = "string"
+      eval_source = "response"
+      flow_name = "authentication"
+      response_name = "login"
+      field_selector = ["auth", "client_token"]
+    }
   }
 }
 `

--- a/vault/workflow_store.go
+++ b/vault/workflow_store.go
@@ -369,20 +369,24 @@ func (ws *WorkflowStore) Execute(ctx context.Context, reqId string, path string,
 		// Execute our request handler here; here is where we validate that
 		// this policy can only access requests under its own namespace and
 		// forbid requests to parent namespaces.
-		profiles.WithRequestHandler(func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+		profiles.WithRequestHandler(func(ctx context.Context, profileReq *logical.Request) (*logical.Response, error) {
 			// When a namespace header exists in the synthetic request, we have
 			// to inject it into the namespace header.
-			if values, ok := req.Headers[consts.NamespaceHeaderName]; ok {
+			if values, ok := profileReq.Headers[consts.NamespaceHeaderName]; ok {
 				if len(values) > 1 {
 					return nil, fmt.Errorf("have %q values for %q header; expected only 1", len(values), consts.NamespaceHeaderName)
 				}
 				ctx = namespace.ContextWithNamespaceHeader(ctx, values[0])
 			}
 
+			// Set our connection to match. This allows use of cert auth and
+			// login MFA from within profiles.
+			profileReq.Connection = req.Connection
+
 			// We guarantee we come in from the profile system, which means
 			// we're already executing a request; no need to re-grab the lock
 			// here.
-			return ws.core.switchedLockHandleRequest(ctx, req, false)
+			return ws.core.switchedLockHandleRequest(ctx, profileReq, false)
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
This adds logic to the profile engine to make it support login MFA:

1. Header canonicalization to aid lookup.
2. Parsing of Headers to MFA Creds.
3. Pass req.Connection in the workflow engine and self-init.


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


Resolves: #3387

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
