### PR TITLE
fix(sink): in-memory token retrieval panics if unset (#3462)

### DIFF
--- a/changelog/3462.txt
+++ b/changelog/3462.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent/apiproxy: fix in-memory sink panic when proxying `auth/token/lookup-self` while unauthenticated
+```

--- a/command/agentproxyshared/sink/inmem/inmem_sink.go
+++ b/command/agentproxyshared/sink/inmem/inmem_sink.go
@@ -26,10 +26,13 @@ func New(conf *sink.SinkConfig, leaseCache *cache.LeaseCache) (sink.Sink, error)
 		return nil, errors.New("nil logger provided")
 	}
 
-	return &inmemSink{
+	s := &inmemSink{
 		logger:     conf.Logger,
 		leaseCache: leaseCache,
-	}, nil
+	}
+	s.token.Store("")
+
+	return s, nil
 }
 
 func (s *inmemSink) WriteToken(token string) error {


### PR DESCRIPTION
Backport of https://github.com/openbao/openbao/pull/3462 (clean cherry-pick)
