### PR TITLE
Switch to constant-time comparison recovery token (#3388)

### DIFF
--- a/changelog/3388.txt
+++ b/changelog/3388.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core/recovery: Use constant-time token comparison in recovery mode. GHSA-34fc-gh42-pj53.
+```

--- a/http/logical.go
+++ b/http/logical.go
@@ -4,6 +4,7 @@
 package http
 
 import (
+	"crypto/subtle"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -327,8 +328,10 @@ func handleLogicalRecovery(raw *vault.RawBackend, token *atomic.Value) http.Hand
 			respondError(w, statusCode, err)
 			return
 		}
+
 		reqToken := r.Header.Get(consts.AuthHeaderName)
-		if reqToken == "" || token.Load() == "" || reqToken != token.Load() {
+		rToken, rTokenOk := token.Load().(string)
+		if len(reqToken) == 0 || !rTokenOk || len(rToken) == 0 || subtle.ConstantTimeCompare([]byte(reqToken), []byte(rToken)) == 0 {
 			respondError(w, http.StatusForbidden, nil)
 			return
 		}

--- a/vault/external_tests/misc/recovery_test.go
+++ b/vault/external_tests/misc/recovery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecovery(t *testing.T) {
@@ -91,14 +92,29 @@ func TestRecovery(t *testing.T) {
 		defer cluster.Cleanup()
 
 		client := cluster.Cores[0].Client
+
+		// Perform an initial request: make sure nothing can be done before a token can be created.
+		client.SetToken("garbage")
+		secret, err := client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.ErrorContains(t, err, "403", "expected failure with garbage token before generation")
+		require.Nil(t, secret)
+
+		client.SetToken("")
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.ErrorContains(t, err, "403", "expected failure with nil token before generation")
+		require.Nil(t, secret)
+
 		recoveryToken := testhelpers.GenerateRoot(t, cluster, testhelpers.GenerateRecovery)
 		_, err = testhelpers.GenerateRootWithError(t, cluster, testhelpers.GenerateRecovery)
-		if err == nil {
-			t.Fatal("expected second generate-root to fail")
-		}
+		require.ErrorContains(t, err, "attempted to generate recovery operation token when already unsealed", "expected second generate-root to fail")
+
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		require.ErrorContains(t, err, "403", "expected failure with nil token after generation")
+		require.Nil(t, secret)
+
 		client.SetToken(recoveryToken)
 
-		secret, err := client.Logical().List(path.Join("sys/raw/logical", secretUUID))
+		secret, err = client.Logical().List(path.Join("sys/raw/logical", secretUUID))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description

Backport of #3388.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
