### PR TITLE
Fix ACL templates allow wildcard chars in substitution (#3401)

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3653,9 +3653,12 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 
 	// Write test policy for userpass auth method.
 	err := client.Sys().PutPolicy("test", `
-   path "pki/*" {
-     capabilities = ["update"]
-   }`)
+	path "pki/*" {
+		capabilities = ["update", "patch"]
+	}
+	path "identity/entity" {
+		capabilities = ["update"]
+	}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3681,6 +3684,7 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	userpassToken := secret.Auth.ClientToken
+	entityId := secret.Auth.EntityID
 
 	// Get auth accessor for identity template.
 	auths, err := client.Sys().ListAuth()
@@ -3740,12 +3744,10 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 	// Issue certificate with non-matching identity template parameter
 	client.SetToken(userpassToken)
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"uri_sans": "spiffe://domain/unknownuser"})
-	if err == nil {
-		t.Fatal(err)
-	}
+	require.ErrorContains(t, err, "URI Subject Alternative Names were provided via the API which are not valid for this role")
 
 	// Set allowed_uri_sans_template to false.
-	_, err = client.Logical().Write("pki/roles/test", map[string]interface{}{
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]interface{}{
 		"allowed_uri_sans_template": false,
 	})
 	if err != nil {
@@ -3754,9 +3756,37 @@ func TestBackend_AllowedURISANsTemplate(t *testing.T) {
 
 	// Issue certificate with userpassToken.
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"uri_sans": "spiffe://domain/users/userpassname"})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.ErrorContains(t, err, "URI Subject Alternative Names were provided via the API which are not valid for this role")
+
+	// Add wildcard to entity metadata
+	_, err = client.Logical().WriteWithContext(t.Context(), "identity/entity", map[string]any{
+		"id": entityId,
+		"metadata": map[string]any{
+			"sans": "spiffe://domain/users/*",
+		},
+	})
+	require.NoError(t, err)
+
+	// Update Allowed URI SANs to include entity metadata
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]any{
+		"allowed_uri_sans":          []string{"{{identity.entity.metadata.sans}}"},
+		"allowed_uri_sans_template": true,
+	})
+	require.NoError(t, err)
+
+	// Expect failure (wildcards are prohibited by default)
+	_, err = client.Logical().WriteWithContext(t.Context(), "pki/issue/test", map[string]any{"uri_sans": "spiffe://domain/users/userpassname"})
+	require.ErrorContains(t, err, "URI Subject Alternative Names were provided via the API which are not valid for this role")
+
+	// Allow Globs
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]any{
+		"allow_globs_in_substitutions": true,
+	})
+	require.NoError(t, err)
+
+	// Expect successful issue
+	_, err = client.Logical().WriteWithContext(t.Context(), "pki/issue/test", map[string]any{"uri_sans": "spiffe://domain/users/userpassname"})
+	require.NoError(t, err)
 }
 
 func TestBackend_AllowedDomainsTemplate(t *testing.T) {
@@ -3778,9 +3808,12 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 
 	// Write test policy for userpass auth method.
 	err := client.Sys().PutPolicy("test", `
-   path "pki/*" {
-     capabilities = ["update"]
-   }`)
+	path "pki/*" {
+		capabilities = ["update", "patch"]
+	}
+	path "identity/entity" {
+		capabilities = ["update"]
+	}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3840,6 +3873,7 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 		},
 		"allowed_domains_template": true,
 		"allow_bare_domains":       true,
+		"allow_glob_domains":       true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3853,6 +3887,8 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 	if err != nil || secret == nil {
 		t.Fatal(err)
 	}
+	entityId := secret.Auth.EntityID
+
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"common_name": "userpassname"})
 	if err != nil {
 		t.Fatal(err)
@@ -3866,9 +3902,7 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 
 	// Issue certificate for unknown userpassname.
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"common_name": "unknownuserpassname"})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.ErrorContains(t, err, "common name unknownuserpassname not allowed by this role")
 
 	// Issue certificate for foo.userpassname.domain.
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"common_name": "foo.userpassname.example.com"})
@@ -3877,7 +3911,7 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 	}
 
 	// Set allowed_domains_template to false.
-	_, err = client.Logical().Write("pki/roles/test", map[string]interface{}{
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]any{
 		"allowed_domains_template": false,
 	})
 	if err != nil {
@@ -3886,9 +3920,37 @@ func TestBackend_AllowedDomainsTemplate(t *testing.T) {
 
 	// Issue certificate with userpassToken.
 	_, err = client.Logical().Write("pki/issue/test", map[string]interface{}{"common_name": "userpassname"})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.ErrorContains(t, err, "common name userpassname not allowed by this role")
+
+	// Add wildcard to entity metadata
+	_, err = client.Logical().WriteWithContext(t.Context(), "identity/entity", map[string]any{
+		"id": entityId,
+		"metadata": map[string]any{
+			"domains": "*.example.com",
+		},
+	})
+	require.NoError(t, err)
+
+	// Update Allowed Domains to include entity metadata
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]any{
+		"allowed_domains":          []string{"{{identity.entity.metadata.domains}}"},
+		"allowed_domains_template": true,
+	})
+	require.NoError(t, err)
+
+	// Expect failure (wildcards are prohibited by default)
+	_, err = client.Logical().WriteWithContext(t.Context(), "pki/issue/test", map[string]any{"common_name": "foo.example.com"})
+	require.ErrorContains(t, err, "common name foo.example.com not allowed by this role")
+
+	// Allow Globs
+	_, err = client.Logical().JSONMergePatch(t.Context(), "pki/roles/test", map[string]any{
+		"allow_globs_in_substitutions": true,
+	})
+	require.NoError(t, err)
+
+	// Expect successful issue
+	_, err = client.Logical().WriteWithContext(t.Context(), "pki/issue/test", map[string]any{"common_name": "foo.example.com"})
+	require.NoError(t, err)
 }
 
 func TestReadWriteDeleteRoles(t *testing.T) {
@@ -3961,6 +4023,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 		"policy_identifiers":                 []interface{}{},
 		"require_cn":                         true,
 		"allowed_domains_template":           false,
+		"allow_globs_in_substitutions":       false,
 		"allow_token_displayname":            false,
 		"country":                            []interface{}{},
 		"not_before_bound":                   "permit",

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
+	"github.com/openbao/openbao/sdk/v2/helper/identitytpl"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/ryanuber/go-glob"
 	"golang.org/x/crypto/cryptobyte"
@@ -272,11 +273,31 @@ func validateURISAN(b *backend, data *inputBundle, uri string) bool {
 		if data.role.AllowedURISANsTemplate {
 			isTemplate, _ := framework.ValidateIdentityTemplate(allowed)
 			if isTemplate && data.req.EntityID != "" {
-				tmpAllowed, err := framework.PopulateIdentityTemplate(allowed, data.req.EntityID, b.System())
+				entity, err := b.System().EntityInfo(data.req.EntityID)
+				if err != nil || entity == nil {
+					continue
+				}
+
+				groups, err := b.System().GroupsForEntity(data.req.EntityID)
 				if err != nil {
 					continue
 				}
-				allowed = tmpAllowed
+
+				input := identitytpl.PopulateStringInput{
+					String: allowed,
+					Entity: entity,
+					Groups: groups,
+					Mode:   identitytpl.ACLTemplating,
+				}
+
+				if !data.role.AllowGlobsInSubstitutions {
+					input.BlockedSubstitutions = []string{"*"}
+				}
+
+				_, allowed, err = identitytpl.PopulateString(input)
+				if err != nil {
+					continue
+				}
 			}
 		}
 		validURI := glob.Glob(allowed, uri)
@@ -564,12 +585,31 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 				if data.role.AllowedDomainsTemplate {
 					isTemplate, _ := framework.ValidateIdentityTemplate(currDomain)
 					if isTemplate && data.req.EntityID != "" {
-						tmpCurrDomain, err := framework.PopulateIdentityTemplate(currDomain, data.req.EntityID, b.System())
+						entity, err := b.System().EntityInfo(data.req.EntityID)
+						if err != nil || entity == nil {
+							continue
+						}
+
+						groups, err := b.System().GroupsForEntity(data.req.EntityID)
 						if err != nil {
 							continue
 						}
 
-						currDomain = tmpCurrDomain
+						input := identitytpl.PopulateStringInput{
+							String: currDomain,
+							Entity: entity,
+							Groups: groups,
+							Mode:   identitytpl.ACLTemplating,
+						}
+
+						if !data.role.AllowGlobsInSubstitutions {
+							input.BlockedSubstitutions = []string{"*"}
+						}
+
+						_, currDomain, err = identitytpl.PopulateString(input)
+						if err != nil {
+							continue
+						}
 					}
 				}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -114,6 +114,15 @@ accepts a comma-separated string or list of domains.`,
 			Description: `If set, Allowed domains can be specified using identity template policies.
 				Non-templated domains are also permitted.`,
 		},
+		"allow_globs_in_substitutions": {
+			Type:     framework.TypeBool,
+			Required: true,
+			Description: `If set and templating is enabled, the values substituted in
+				for allowed_uri_sans_template and allowed_domains template expression
+				might contain a wildcard characters ('*' and '+'). This can enable
+				injection attacks. Only use this, if the data used by the templates
+				is trusted.`,
+		},
 		"allow_bare_domains": {
 			Type:     framework.TypeBool,
 			Required: true,
@@ -505,6 +514,15 @@ accepts a comma-separated string or list of domains.`,
 				Type: framework.TypeBool,
 				Description: `If set, Allowed domains can be specified using identity template policies.
 				Non-templated domains are also permitted.`,
+				Default: false,
+			},
+			"allow_globs_in_substitutions": {
+				Type: framework.TypeBool,
+				Description: `If set and templating is enabled, the values substituted in
+					for allowed_uri_sans_template and allowed_domains template expression
+					might contain a wildcard characters ('*' and '+'). This can enable
+					injection attacks. Only use this, if the data used by the templates
+					is trusted.`,
 				Default: false,
 			},
 			"allow_bare_domains": {
@@ -1142,6 +1160,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		AllowLocalhost:                data.Get("allow_localhost").(bool),
 		AllowedDomains:                data.Get("allowed_domains").([]string),
 		AllowedDomainsTemplate:        data.Get("allowed_domains_template").(bool),
+		AllowGlobsInSubstitutions:     data.Get("allow_globs_in_substitutions").(bool),
 		AllowBareDomains:              data.Get("allow_bare_domains").(bool),
 		AllowSubdomains:               data.Get("allow_subdomains").(bool),
 		AllowGlobDomains:              data.Get("allow_glob_domains").(bool),
@@ -1395,6 +1414,7 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		AllowLocalhost:                data.GetWithExplicitDefault("allow_localhost", oldEntry.AllowLocalhost).(bool),
 		AllowedDomains:                data.GetWithExplicitDefault("allowed_domains", oldEntry.AllowedDomains).([]string),
 		AllowedDomainsTemplate:        data.GetWithExplicitDefault("allowed_domains_template", oldEntry.AllowedDomainsTemplate).(bool),
+		AllowGlobsInSubstitutions:     data.GetWithExplicitDefault("allow_globs_in_substitutions", oldEntry.AllowGlobsInSubstitutions).(bool),
 		AllowBareDomains:              data.GetWithExplicitDefault("allow_bare_domains", oldEntry.AllowBareDomains).(bool),
 		AllowSubdomains:               data.GetWithExplicitDefault("allow_subdomains", oldEntry.AllowSubdomains).(bool),
 		AllowGlobDomains:              data.GetWithExplicitDefault("allow_glob_domains", oldEntry.AllowGlobDomains).(bool),
@@ -1635,6 +1655,7 @@ type roleEntry struct {
 	AllowedDomainsOld             string        `json:"allowed_domains,omitempty"`
 	AllowedDomains                []string      `json:"allowed_domains_list"`
 	AllowedDomainsTemplate        bool          `json:"allowed_domains_template"`
+	AllowGlobsInSubstitutions     bool          `json:"allow_globs_in_substitutions"`
 	AllowBaseDomain               bool          `json:"allow_base_domain"`
 	AllowBareDomains              bool          `json:"allow_bare_domains"`
 	AllowTokenDisplayName         bool          `json:"allow_token_displayname"`
@@ -1703,6 +1724,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"allow_localhost":                    r.AllowLocalhost,
 		"allowed_domains":                    r.AllowedDomains,
 		"allowed_domains_template":           r.AllowedDomainsTemplate,
+		"allow_globs_in_substitutions":       r.AllowGlobsInSubstitutions,
 		"allow_bare_domains":                 r.AllowBareDomains,
 		"allow_token_displayname":            r.AllowTokenDisplayName,
 		"allow_subdomains":                   r.AllowSubdomains,

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -374,6 +374,7 @@ func TestBackend_AllowedUsersTemplate(t *testing.T) {
 		testUserName, map[string]string{
 			"ssh_username": testUserName,
 		},
+		false,
 	)
 }
 
@@ -384,6 +385,7 @@ func TestBackend_MultipleAllowedUsersTemplate(t *testing.T) {
 		testUserName, map[string]string{
 			"ssh_username": testMultiUserName,
 		},
+		true,
 	)
 }
 
@@ -394,6 +396,7 @@ func TestBackend_AllowedUsersTemplate_WithStaticPrefix(t *testing.T) {
 		"ssh-"+testUserName, map[string]string{
 			"ssh_username": testUserName,
 		},
+		false,
 	)
 }
 
@@ -417,6 +420,56 @@ func TestBackend_DefaultUserTemplate_WithStaticPrefix(t *testing.T) {
 			"ssh_username": testUserName,
 		},
 	)
+}
+
+func TestBackend_ForbiddenCommaInTemplate(t *testing.T) {
+	cluster, userpassToken := getSshCaTestCluster(t, testUserName)
+	defer cluster.Cleanup()
+	client := cluster.Cores[0].Client
+
+	// set metadata "ssh_username" to userpass username
+	tokenLookupResponse, err := client.Logical().Write("/auth/token/lookup", map[string]interface{}{
+		"token": userpassToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entityID := tokenLookupResponse.Data["entity_id"].(string)
+	_, err = client.Logical().Write("/identity/entity/id/"+entityID, map[string]interface{}{
+		"metadata": map[string]string{
+			"ssh_username": testMultiUserName,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("ssh/roles/my-role", map[string]interface{}{
+		"key_type":                      testCaKeyType,
+		"allow_user_certificates":       true,
+		"default_user":                  "{{identity.entity.metadata.ssh_username}}",
+		"default_user_template":         true,
+		"allowed_users":                 "{{identity.entity.metadata.ssh_username}}",
+		"allowed_users_template":        true,
+		"allow_commas_in_substitutions": false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sign SSH key as userpass user
+	client.SetToken(userpassToken)
+	_, err = client.Logical().Write("ssh/sign/my-role", map[string]interface{}{
+		"public_key": testCAPublicKey,
+	})
+	if err == nil {
+		t.Error("signing request should fail when default_user is not in the allowed_users list, because allowed_users_template is true and default_user_template is not")
+	}
+
+	expectedErrStr := `template '{{identity.entity.metadata.ssh_username}}' could not be rendered -> template substitution contains forbidden value ","`
+	if !strings.Contains(err.Error(), expectedErrStr) {
+		t.Errorf("expected error to include %q but it was: %q", expectedErrStr, err.Error())
+	}
 }
 
 func TestBackend_DefaultUserTemplateFalse_AllowedUsersTemplateTrue(t *testing.T) {
@@ -1959,15 +2012,17 @@ func testAllowedPrincipalsTemplate(t *testing.T, testAllowedDomainsTemplate stri
 
 func testAllowedUsersTemplate(t *testing.T, testAllowedUsersTemplate string,
 	expectedValidPrincipal string, testEntityMetadata map[string]string,
+	allowCommasInSubstitutions bool,
 ) {
 	testAllowedPrincipalsTemplate(
 		t, testAllowedUsersTemplate,
 		expectedValidPrincipal, testEntityMetadata,
 		map[string]interface{}{
-			"key_type":                testCaKeyType,
-			"allow_user_certificates": true,
-			"allowed_users":           testAllowedUsersTemplate,
-			"allowed_users_template":  true,
+			"key_type":                      testCaKeyType,
+			"allow_user_certificates":       true,
+			"allowed_users":                 testAllowedUsersTemplate,
+			"allowed_users_template":        true,
+			"allow_commas_in_substitutions": allowCommasInSubstitutions,
 		},
 		map[string]interface{}{
 			"public_key":       testCAPublicKey,

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
+	"github.com/openbao/openbao/sdk/v2/helper/identitytpl"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"golang.org/x/crypto/ssh"
 )
@@ -79,7 +80,7 @@ func (b *backend) pathSignIssueCertificateHelper(sc *storageContext, req *logica
 	} else {
 		defaultPrincipal := role.DefaultUser
 		if role.DefaultUserTemplate {
-			defaultPrincipal, err = b.renderPrincipal(role.DefaultUser, req)
+			defaultPrincipal, err = b.renderPrincipal(role.DefaultUser, req, true)
 			if err != nil {
 				return nil, err
 			}
@@ -163,21 +164,48 @@ func (b *backend) pathSignIssueCertificateHelper(sc *storageContext, req *logica
 	return response, nil
 }
 
-func (b *backend) renderPrincipal(principal string, req *logical.Request) (string, error) {
+func (b *backend) renderPrincipal(principal string, req *logical.Request, allowCommasInSubstitutions bool) (string, error) {
+	if req.EntityID == "" {
+		return principal, nil
+	}
+
 	// Look for templating markers {{ .* }}
 	matched := containsTemplateRegex.MatchString(principal)
-	if matched {
-		if req.EntityID != "" {
-			// Retrieve principal based on template + entityID from request.
-			renderedPrincipal, err := framework.PopulateIdentityTemplate(principal, req.EntityID, b.System())
-			if err != nil {
-				return "", fmt.Errorf("template '%s' could not be rendered -> %s", principal, err)
-			}
-			return renderedPrincipal, nil
-		}
+	if !matched {
+		// Static principal
+		return principal, nil
 	}
-	// Static principal
-	return principal, nil
+
+	// Retrieve principal based on template + entityID from request.
+	entity, err := b.System().EntityInfo(req.EntityID)
+	if err != nil {
+		return "", err
+	}
+	if entity == nil {
+		return "", errors.New("no entity found")
+	}
+
+	groups, err := b.System().GroupsForEntity(req.EntityID)
+	if err != nil {
+		return "", err
+	}
+
+	input := identitytpl.PopulateStringInput{
+		String: principal,
+		Entity: entity,
+		Groups: groups,
+		Mode:   identitytpl.ACLTemplating,
+	}
+	if !allowCommasInSubstitutions {
+		input.BlockedSubstitutions = []string{","}
+	}
+
+	_, renderedPrincipal, err := identitytpl.PopulateString(input)
+	if err != nil {
+		return "", fmt.Errorf("template '%s' could not be rendered -> %s", principal, err)
+	}
+
+	return renderedPrincipal, nil
 }
 
 func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logical.Request, role *sshRole, defaultPrincipal, principalsAllowedByRole string, enableTemplating bool, validatePrincipal func([]string, string) bool) ([]string, error) {
@@ -193,7 +221,7 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 	// Build list of allowed Principals from template and static principalsAllowedByRole
 	var allowedPrincipals []string
 	if enableTemplating {
-		rendered, err := b.renderPrincipal(principalsAllowedByRole, req)
+		rendered, err := b.renderPrincipal(principalsAllowedByRole, req, role.AllowCommasInSubstitutions)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +349,7 @@ func (b *backend) calculateCriticalOptions(data *framework.FieldData, role *sshR
 }
 
 func (b *backend) calculateExtensions(data *framework.FieldData, req *logical.Request, role *sshRole) (map[string]string, bool, error) {
-	unparsedExtensions := data.Get("extensions").(map[string]interface{})
+	unparsedExtensions := data.Get("extensions").(map[string]any)
 	extensions := make(map[string]string)
 
 	if len(unparsedExtensions) > 0 {
@@ -345,32 +373,58 @@ func (b *backend) calculateExtensions(data *framework.FieldData, req *logical.Re
 		return extensions, false, nil
 	}
 
-	haveMissingEntityInfoWithTemplatedExt := false
+	if !role.DefaultExtensionsTemplate {
+		return role.DefaultExtensions, false, nil
+	}
 
-	if role.DefaultExtensionsTemplate {
-		for extensionKey, extensionValue := range role.DefaultExtensions {
-			// Look for templating markers {{ .* }}
-			matched := containsTemplateRegex.MatchString(extensionValue)
-			if matched {
-				if req.EntityID != "" {
-					// Retrieve extension value based on template + entityID from request.
-					templateExtensionValue, err := framework.PopulateIdentityTemplate(extensionValue, req.EntityID, b.System())
-					if err == nil {
-						// Template returned an extension value that we can use
-						extensions[extensionKey] = templateExtensionValue
-					} else {
-						return nil, false, fmt.Errorf("template '%s' could not be rendered -> %s", extensionValue, err)
-					}
-				} else {
-					haveMissingEntityInfoWithTemplatedExt = true
-				}
-			} else {
-				// Static extension value or err template
-				extensions[extensionKey] = extensionValue
+	haveMissingEntityInfoWithTemplatedExt := false
+	var (
+		// entity and groups are lazy loaded
+		entity *logical.Entity
+		groups []*logical.Group
+		err    error
+	)
+
+	for extensionKey, extensionValue := range role.DefaultExtensions {
+		// Look for templating markers {{ .* }}
+		matched := containsTemplateRegex.MatchString(extensionValue)
+		if !matched {
+			// Static extension value or err template
+			extensions[extensionKey] = extensionValue
+			continue
+		}
+
+		if req.EntityID == "" {
+			haveMissingEntityInfoWithTemplatedExt = true
+			continue
+		}
+
+		// Retrieve extension value based on template + entityID from request.
+		if entity == nil {
+			entity, err = b.System().EntityInfo(req.EntityID)
+			if err != nil {
+				return nil, false, err
+			}
+			if entity == nil {
+				return nil, false, errors.New("no entity found")
+			}
+
+			groups, err = b.System().GroupsForEntity(req.EntityID)
+			if err != nil {
+				return nil, false, err
 			}
 		}
-	} else {
-		extensions = role.DefaultExtensions
+
+		input := identitytpl.PopulateStringInput{
+			String: extensionValue,
+			Entity: entity,
+			Groups: groups,
+			Mode:   identitytpl.ACLTemplating,
+		}
+		_, extensions[extensionKey], err = identitytpl.PopulateString(input)
+		if err != nil {
+			return nil, false, fmt.Errorf("template '%s' could not be rendered -> %s", extensionValue, err)
+		}
 	}
 
 	return extensions, haveMissingEntityInfoWithTemplatedExt, nil

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -62,6 +62,7 @@ type sshRole struct {
 	AllowSubdomains            bool              `mapstructure:"allow_subdomains" json:"allow_subdomains"`
 	AllowUserKeyIDs            bool              `mapstructure:"allow_user_key_ids" json:"allow_user_key_ids"`
 	AllowEmptyPrincipals       bool              `mapstructure:"allow_empty_principals" json:"allow_empty_principals"`
+	AllowCommasInSubstitutions bool              `mapstructure:"allow_commas_in_substitutions" json:"allow_commas_in_substitutions"`
 	KeyIDFormat                string            `mapstructure:"key_id_format" json:"key_id_format"`
 	OldAllowedUserKeyLengths   map[string]int    `mapstructure:"allowed_user_key_lengths" json:"allowed_user_key_lengths,omitempty"`
 	AllowedUserKeyTypesLengths map[string][]int  `mapstructure:"allowed_user_key_types_lengths" json:"allowed_user_key_types_lengths"`
@@ -379,6 +380,21 @@ func pathRoles(b *backend) *framework.Path {
 					Value: 30,
 				},
 			},
+			"allow_commas_in_substitutions": {
+				Type: framework.TypeBool,
+				Description: `
+				If true and templating is enabled, the values substituted in for
+				allowed_users and allowed_domains template expressions might contain a
+				comma (','). As these values are comma separated lists, this can enable
+				injection attacks. Only use this, if the data used by the templates is
+				trusted.`,
+				Default: false,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "Allow Commas in Substitutions",
+					Value: false,
+				},
+			},
+
 			"allow_empty_principals": {
 				Type: framework.TypeBool,
 				Description: `
@@ -524,27 +540,28 @@ func (b *backend) createCARole(allowedUsers, defaultUser, signer string, data *f
 	ttl := time.Duration(data.Get("ttl").(int)) * time.Second
 	maxTTL := time.Duration(data.Get("max_ttl").(int)) * time.Second
 	role := &sshRole{
-		AllowedCriticalOptions:    data.Get("allowed_critical_options").(string),
-		AllowedExtensions:         data.Get("allowed_extensions").(string),
-		AllowUserCertificates:     data.Get("allow_user_certificates").(bool),
-		AllowHostCertificates:     data.Get("allow_host_certificates").(bool),
-		AllowedUsers:              allowedUsers,
-		AllowedUsersTemplate:      data.Get("allowed_users_template").(bool),
-		AllowedDomains:            data.Get("allowed_domains").(string),
-		AllowedDomainsTemplate:    data.Get("allowed_domains_template").(bool),
-		DefaultUser:               defaultUser,
-		DefaultUserTemplate:       data.Get("default_user_template").(bool),
-		AllowBareDomains:          data.Get("allow_bare_domains").(bool),
-		AllowSubdomains:           data.Get("allow_subdomains").(bool),
-		AllowUserKeyIDs:           data.Get("allow_user_key_ids").(bool),
-		AllowEmptyPrincipals:      data.Get("allow_empty_principals").(bool),
-		DefaultExtensionsTemplate: data.Get("default_extensions_template").(bool),
-		KeyIDFormat:               data.Get("key_id_format").(string),
-		KeyType:                   KeyTypeCA,
-		AlgorithmSigner:           signer,
-		Version:                   roleEntryVersion,
-		NotBeforeDuration:         time.Duration(data.Get("not_before_duration").(int)) * time.Second,
-		Issuer:                    data.Get("issuer_ref").(string),
+		AllowedCriticalOptions:     data.Get("allowed_critical_options").(string),
+		AllowedExtensions:          data.Get("allowed_extensions").(string),
+		AllowUserCertificates:      data.Get("allow_user_certificates").(bool),
+		AllowHostCertificates:      data.Get("allow_host_certificates").(bool),
+		AllowedUsers:               allowedUsers,
+		AllowedUsersTemplate:       data.Get("allowed_users_template").(bool),
+		AllowedDomains:             data.Get("allowed_domains").(string),
+		AllowedDomainsTemplate:     data.Get("allowed_domains_template").(bool),
+		DefaultUser:                defaultUser,
+		DefaultUserTemplate:        data.Get("default_user_template").(bool),
+		AllowBareDomains:           data.Get("allow_bare_domains").(bool),
+		AllowSubdomains:            data.Get("allow_subdomains").(bool),
+		AllowUserKeyIDs:            data.Get("allow_user_key_ids").(bool),
+		AllowCommasInSubstitutions: data.Get("allow_commas_in_substitutions").(bool),
+		AllowEmptyPrincipals:       data.Get("allow_empty_principals").(bool),
+		DefaultExtensionsTemplate:  data.Get("default_extensions_template").(bool),
+		KeyIDFormat:                data.Get("key_id_format").(string),
+		KeyType:                    KeyTypeCA,
+		AlgorithmSigner:            signer,
+		Version:                    roleEntryVersion,
+		NotBeforeDuration:          time.Duration(data.Get("not_before_duration").(int)) * time.Second,
+		Issuer:                     data.Get("issuer_ref").(string),
 	}
 
 	if !role.AllowUserCertificates && !role.AllowHostCertificates {
@@ -728,31 +745,32 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 		}
 
 		result = map[string]interface{}{
-			"allowed_users":               role.AllowedUsers,
-			"allowed_users_template":      role.AllowedUsersTemplate,
-			"allowed_domains":             role.AllowedDomains,
-			"allowed_domains_template":    role.AllowedDomainsTemplate,
-			"default_user":                role.DefaultUser,
-			"default_user_template":       role.DefaultUserTemplate,
-			"ttl":                         int64(ttl.Seconds()),
-			"max_ttl":                     int64(maxTTL.Seconds()),
-			"allowed_critical_options":    role.AllowedCriticalOptions,
-			"allowed_extensions":          role.AllowedExtensions,
-			"allow_user_certificates":     role.AllowUserCertificates,
-			"allow_host_certificates":     role.AllowHostCertificates,
-			"allow_bare_domains":          role.AllowBareDomains,
-			"allow_subdomains":            role.AllowSubdomains,
-			"allow_user_key_ids":          role.AllowUserKeyIDs,
-			"allow_empty_principals":      role.AllowEmptyPrincipals,
-			"key_id_format":               role.KeyIDFormat,
-			"key_type":                    role.KeyType,
-			"default_critical_options":    role.DefaultCriticalOptions,
-			"default_extensions":          role.DefaultExtensions,
-			"default_extensions_template": role.DefaultExtensionsTemplate,
-			"allowed_user_key_lengths":    role.AllowedUserKeyTypesLengths,
-			"algorithm_signer":            role.AlgorithmSigner,
-			"not_before_duration":         int64(role.NotBeforeDuration.Seconds()),
-			"issuer_ref":                  role.Issuer,
+			"allowed_users":                 role.AllowedUsers,
+			"allowed_users_template":        role.AllowedUsersTemplate,
+			"allowed_domains":               role.AllowedDomains,
+			"allowed_domains_template":      role.AllowedDomainsTemplate,
+			"default_user":                  role.DefaultUser,
+			"default_user_template":         role.DefaultUserTemplate,
+			"ttl":                           int64(ttl.Seconds()),
+			"max_ttl":                       int64(maxTTL.Seconds()),
+			"allowed_critical_options":      role.AllowedCriticalOptions,
+			"allowed_extensions":            role.AllowedExtensions,
+			"allow_user_certificates":       role.AllowUserCertificates,
+			"allow_host_certificates":       role.AllowHostCertificates,
+			"allow_bare_domains":            role.AllowBareDomains,
+			"allow_subdomains":              role.AllowSubdomains,
+			"allow_user_key_ids":            role.AllowUserKeyIDs,
+			"allow_commas_in_substitutions": role.AllowCommasInSubstitutions,
+			"allow_empty_principals":        role.AllowEmptyPrincipals,
+			"key_id_format":                 role.KeyIDFormat,
+			"key_type":                      role.KeyType,
+			"default_critical_options":      role.DefaultCriticalOptions,
+			"default_extensions":            role.DefaultExtensions,
+			"default_extensions_template":   role.DefaultExtensionsTemplate,
+			"allowed_user_key_lengths":      role.AllowedUserKeyTypesLengths,
+			"algorithm_signer":              role.AlgorithmSigner,
+			"not_before_duration":           int64(role.NotBeforeDuration.Seconds()),
+			"issuer_ref":                    role.Issuer,
 		}
 	case KeyTypeDynamic:
 		return nil, errors.New("dynamic key type roles are no longer supported")

--- a/changelog/3401.txt
+++ b/changelog/3401.txt
@@ -1,0 +1,12 @@
+```release-note:security
+core/policies: If the value of a template expression contains a `+` or `*` character it will now be rejected by default. Set `allow_wildcards_in_substitutions = true` to overwrite. GHSA-59w7-v8rr-pr4p.
+```
+```release-note:security
+core/policies: If the value of a template expression contains a `/` character it will now be rejected by default. Set `allow_slashes_in_substitutions = true` to overwrite. GHSA-59w7-v8rr-pr4p.
+```
+```release-note:security
+secret/pki: If the value of a template expression in `allowed_uri_sans_template` and `allowed_domains` contains a `*` character it will now be rejected by default. Set `allow_globs_in_substitutions = true` to overwrite. GHSA-59w7-v8rr-pr4p.
+```
+```release-note:security
+secret/ssh: If the value of a template expression in `allowed_users` or `allowed_domains` contains a `,` character it will now be rejected by default. Set `allow_commas_in_substitutions = true` to overwrite. GHSA-59w7-v8rr-pr4p.
+```

--- a/http/sys_policy_test.go
+++ b/http/sys_policy_test.go
@@ -20,20 +20,20 @@ func TestSysPolicies(t *testing.T) {
 
 	resp := testHttpGet(t, token, addr+"/v1/sys/policy")
 
-	var actual map[string]interface{}
-	expected := map[string]interface{}{
+	var actual map[string]any
+	expected := map[string]any{
 		"lease_id":       "",
 		"renewable":      false,
 		"lease_duration": json.Number("0"),
 		"wrap_info":      nil,
 		"warnings":       nil,
 		"auth":           nil,
-		"data": map[string]interface{}{
-			"policies": []interface{}{"default", "root"},
-			"keys":     []interface{}{"default", "root"},
+		"data": map[string]any{
+			"policies": []any{"default", "root"},
+			"keys":     []any{"default", "root"},
 		},
-		"policies": []interface{}{"default", "root"},
-		"keys":     []interface{}{"default", "root"},
+		"policies": []any{"default", "root"},
+		"keys":     []any{"default", "root"},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
@@ -51,24 +51,28 @@ func TestSysReadPolicy(t *testing.T) {
 
 	resp := testHttpGet(t, token, addr+"/v1/sys/policy/root")
 
-	var actual map[string]interface{}
-	expected := map[string]interface{}{
+	var actual map[string]any
+	expected := map[string]any{
 		"lease_id":       "",
 		"renewable":      false,
 		"lease_duration": json.Number("0"),
 		"wrap_info":      nil,
 		"warnings":       nil,
 		"auth":           nil,
-		"data": map[string]interface{}{
-			"name":         "root",
-			"rules":        "",
-			"cas_required": false,
-			"version":      json.Number("0"),
+		"data": map[string]any{
+			"name":                             "root",
+			"rules":                            "",
+			"cas_required":                     false,
+			"version":                          json.Number("0"),
+			"allow_slashes_in_substitutions":   false,
+			"allow_wildcards_in_substitutions": false,
 		},
-		"name":         "root",
-		"rules":        "",
-		"cas_required": false,
-		"version":      json.Number("0"),
+		"name":                             "root",
+		"rules":                            "",
+		"cas_required":                     false,
+		"version":                          json.Number("0"),
+		"allow_slashes_in_substitutions":   false,
+		"allow_wildcards_in_substitutions": false,
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
@@ -84,27 +88,27 @@ func TestSysWritePolicy(t *testing.T) {
 	defer ln.Close()
 	TestServerAuth(t, addr, token)
 
-	resp := testHttpPost(t, token, addr+"/v1/sys/policy/foo", map[string]interface{}{
+	resp := testHttpPost(t, token, addr+"/v1/sys/policy/foo", map[string]any{
 		"rules": `path "*" { capabilities = ["read"] }`,
 	})
 	testResponseStatus(t, resp, 200)
 
 	resp = testHttpGet(t, token, addr+"/v1/sys/policy")
 
-	var actual map[string]interface{}
-	expected := map[string]interface{}{
+	var actual map[string]any
+	expected := map[string]any{
 		"lease_id":       "",
 		"renewable":      false,
 		"lease_duration": json.Number("0"),
 		"wrap_info":      nil,
 		"warnings":       nil,
 		"auth":           nil,
-		"data": map[string]interface{}{
-			"policies": []interface{}{"default", "foo", "root"},
-			"keys":     []interface{}{"default", "foo", "root"},
+		"data": map[string]any{
+			"policies": []any{"default", "foo", "root"},
+			"keys":     []any{"default", "foo", "root"},
 		},
-		"policies": []interface{}{"default", "foo", "root"},
-		"keys":     []interface{}{"default", "foo", "root"},
+		"policies": []any{"default", "foo", "root"},
+		"keys":     []any{"default", "foo", "root"},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
@@ -113,7 +117,7 @@ func TestSysWritePolicy(t *testing.T) {
 		t.Fatalf("bad: got\n%#v\nexpected\n%#v\n", actual, expected)
 	}
 
-	resp = testHttpPost(t, token, addr+"/v1/sys/policy/response-wrapping", map[string]interface{}{
+	resp = testHttpPost(t, token, addr+"/v1/sys/policy/response-wrapping", map[string]any{
 		"rules": ``,
 	})
 	testResponseStatus(t, resp, 400)
@@ -125,7 +129,7 @@ func TestSysDeletePolicy(t *testing.T) {
 	defer ln.Close()
 	TestServerAuth(t, addr, token)
 
-	resp := testHttpPost(t, token, addr+"/v1/sys/policy/foo", map[string]interface{}{
+	resp := testHttpPost(t, token, addr+"/v1/sys/policy/foo", map[string]any{
 		"rules": `path "*" { capabilities = ["read"] }`,
 	})
 	testResponseStatus(t, resp, 200)
@@ -140,20 +144,20 @@ func TestSysDeletePolicy(t *testing.T) {
 
 	resp = testHttpGet(t, token, addr+"/v1/sys/policy")
 
-	var actual map[string]interface{}
-	expected := map[string]interface{}{
+	var actual map[string]any
+	expected := map[string]any{
 		"lease_id":       "",
 		"renewable":      false,
 		"lease_duration": json.Number("0"),
 		"wrap_info":      nil,
 		"warnings":       nil,
 		"auth":           nil,
-		"data": map[string]interface{}{
-			"policies": []interface{}{"default", "root"},
-			"keys":     []interface{}{"default", "root"},
+		"data": map[string]any{
+			"policies": []any{"default", "root"},
+			"keys":     []any{"default", "root"},
 		},
-		"policies": []interface{}{"default", "root"},
-		"keys":     []interface{}{"default", "root"},
+		"policies": []any{"default", "root"},
+		"keys":     []any{"default", "root"},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)

--- a/sdk/framework/identity.go
+++ b/sdk/framework/identity.go
@@ -15,6 +15,9 @@ import (
 // instance of system view. It will query system view for information about the
 // entity and use the resulting identity information to populate the template
 // string.
+//
+// Deprecated: This function does not expose all options of
+// [identitytpl.PopulateString] consider inlining
 func PopulateIdentityTemplate(tpl string, entityID string, sysView logical.SystemView) (string, error) {
 	entity, err := sysView.EntityInfo(entityID)
 	if err != nil {

--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -20,6 +20,7 @@ var (
 	ErrNoEntityAttachedToToken       = errors.New("string contains entity template directives but no entity was provided")
 	ErrNoGroupsAttachedToToken       = errors.New("string contains groups template directives but no groups were provided")
 	ErrTemplateValueNotFound         = errors.New("no value could be found for one of the template directives")
+	ErrTemplateWildcard              = `template substitution contains forbidden value %q`
 )
 
 const (
@@ -28,13 +29,14 @@ const (
 )
 
 type PopulateStringInput struct {
-	String            string
-	ValidityCheckOnly bool
-	Entity            *logical.Entity
-	Groups            []*logical.Group
-	NamespaceID       string
-	Mode              int       // processing mode, ACLTemplate or JSONTemplating
-	Now               time.Time // optional, defaults to current time
+	String               string
+	ValidityCheckOnly    bool
+	Entity               *logical.Entity
+	Groups               []*logical.Group
+	NamespaceID          string
+	Mode                 int       // processing mode, ACLTemplate or JSONTemplating
+	Now                  time.Time // optional, defaults to current time
+	BlockedSubstitutions []string  // optional, defaults to ["*", "+"] if (.Mode == ACLTemplate) and [] otherwise
 
 	templateHandler templateHandlerFunc
 	groupIDs        []string
@@ -154,6 +156,11 @@ func PopulateString(p PopulateStringInput) (bool, string, error) {
 				tmplStr, err := performTemplating(strings.TrimSpace(splitPiece[0]), &p)
 				if err != nil {
 					return false, "", err
+				}
+				for _, blocked := range p.BlockedSubstitutions {
+					if strings.Contains(tmplStr, blocked) {
+						return false, "", fmt.Errorf(ErrTemplateWildcard, blocked)
+					}
 				}
 				b.WriteString(tmplStr)
 				b.WriteString(splitPiece[1])

--- a/sdk/helper/identitytpl/templating_test.go
+++ b/sdk/helper/identitytpl/templating_test.go
@@ -20,24 +20,25 @@ var testNow = time.Now().Add(100 * time.Hour)
 
 func TestPopulate_Basic(t *testing.T) {
 	tests := []struct {
-		mode                int
-		name                string
-		input               string
-		output              string
-		err                 error
-		entityName          string
-		metadata            map[string]string
-		aliasAccessor       string
-		aliasID             string
-		aliasName           string
-		nilEntity           bool
-		validityCheckOnly   bool
-		aliasMetadata       map[string]string
-		aliasCustomMetadata map[string]string
-		groupName           string
-		groupMetadata       map[string]string
-		groupMemberships    []string
-		now                 time.Time
+		mode                 int
+		name                 string
+		input                string
+		blockedSubstitutions []string
+		output               string
+		err                  error
+		entityName           string
+		metadata             map[string]string
+		aliasAccessor        string
+		aliasID              string
+		aliasName            string
+		nilEntity            bool
+		validityCheckOnly    bool
+		aliasMetadata        map[string]string
+		aliasCustomMetadata  map[string]string
+		groupName            string
+		groupMetadata        map[string]string
+		groupMemberships     []string
+		now                  time.Time
 	}{
 		// time.* tests. Keep tests with time.Now() at the front to avoid false
 		// positives due to the second changing during the test
@@ -380,6 +381,56 @@ func TestPopulate_Basic(t *testing.T) {
 			aliasCustomMetadata: map[string]string{"foo": "abc", "bar": "123"},
 			output:              `{}`,
 		},
+
+		// wildcard injection tests
+		{
+			mode:                 ACLTemplating,
+			name:                 "wildcard in template definition (acl)",
+			input:                `path "*" {{identity.entity.metadata.x}}`,
+			blockedSubstitutions: []string{"*", "+"},
+			metadata:             map[string]string{"x": "ok", "unused_wildcard_is_ok": "*"},
+			output:               `path "*" ok`,
+		},
+		{
+			mode:                 ACLTemplating,
+			name:                 "wildcard star in template substitution (acl)",
+			input:                `path "bad" {{identity.entity.metadata.x}}`,
+			blockedSubstitutions: []string{"*", "+"},
+			metadata:             map[string]string{"x": "this * is not ok"},
+			err:                  errors.New(`template substitution contains forbidden value "*"`),
+		},
+		{
+			mode:                 ACLTemplating,
+			name:                 "allowed wildcard in template substitution (acl)",
+			input:                `path "ok" "{{identity.entity.metadata.x}}"`,
+			blockedSubstitutions: []string{},
+			metadata:             map[string]string{"x": "this + is * explicitly allowed"},
+			output:               `path "ok" "this + is * explicitly allowed"`,
+		},
+		{
+			mode:                 JSONTemplating,
+			name:                 "wildcard in template definition (json)",
+			input:                `{ "test/*": {{identity.entity.metadata.x}} }`,
+			blockedSubstitutions: []string{"*", "+"},
+			metadata:             map[string]string{"x": "ok", "unused_wildcard_is_ok": "*"},
+			output:               `{ "test/*": "ok" }`,
+		},
+		{
+			mode:                 JSONTemplating,
+			name:                 "wildcard in template substitution (json)",
+			input:                `{ "test/bad": {{identity.entity.metadata.x}} }`,
+			blockedSubstitutions: []string{},
+			metadata:             map[string]string{"x": "this * is also + ok"},
+			output:               `{ "test/bad": "this * is also + ok" }`,
+		},
+		{
+			mode:                 JSONTemplating,
+			name:                 "explicitly block string in template substitution (json)",
+			input:                `{ "test/bad": {{identity.entity.metadata.x}} }`,
+			blockedSubstitutions: []string{"that", "this", "other"},
+			metadata:             map[string]string{"x": `+ and * are ok, but "this" is not`},
+			err:                  errors.New(`template substitution contains forbidden value "this"`),
+		},
 	}
 
 	for _, test := range tests {
@@ -422,20 +473,21 @@ func TestPopulate_Basic(t *testing.T) {
 		}
 
 		subst, out, err := PopulateString(PopulateStringInput{
-			Mode:              test.mode,
-			ValidityCheckOnly: test.validityCheckOnly,
-			String:            test.input,
-			Entity:            entity,
-			Groups:            groups,
-			NamespaceID:       "root",
-			Now:               test.now,
+			Mode:                 test.mode,
+			ValidityCheckOnly:    test.validityCheckOnly,
+			String:               test.input,
+			BlockedSubstitutions: test.blockedSubstitutions,
+			Entity:               entity,
+			Groups:               groups,
+			NamespaceID:          "root",
+			Now:                  test.now,
 		})
 		if err != nil {
 			if test.err == nil {
 				t.Fatalf("%s: expected success, got error: %v", test.name, err)
 			}
 			if err.Error() != test.err.Error() {
-				t.Fatalf("%s: got error: %v", test.name, err)
+				t.Fatalf("%s: expected %v, got error: %v", test.name, test.err, err)
 			}
 		}
 		if out != test.output {

--- a/vault/external_tests/policy/acl_templating_test.go
+++ b/vault/external_tests/policy/acl_templating_test.go
@@ -18,12 +18,14 @@ func TestPolicyTemplating(t *testing.T) {
 	goodPolicy1 := `
 path "secret/{{ identity.entity.name}}/*" {
 	capabilities = ["read", "create", "update"]
-
 }
 
 path "secret/{{ identity.entity.aliases.%s.name}}/*" {
 	capabilities = ["read", "create", "update"]
+}
 
+path "secret/{{ identity.entity.metadata.key}}/*" {
+	capabilities = ["read", "create", "update"]
 }
 `
 
@@ -66,6 +68,9 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 		"policies": []string{
 			"goodPolicy1",
 			"badPolicy1",
+		},
+		"metadata": map[string]string{
+			"key": "metadata",
 		},
 	})
 	if err != nil {
@@ -180,18 +185,25 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 			name: "bad group name",
 			path: "secret/foobar/foo",
 		},
+		{
+			name: "entity metadata",
+			path: "secret/metadata/test/foo",
+		},
 	}
 
-	runTests := func(failGroupName bool) {
+	runTests := func(failGroupName, failMetadata bool) {
 		for _, test := range tests {
 			resp, err := client.Logical().Write(test.path, map[string]interface{}{"zip": "zap"})
 			fail := test.fail
 			if test.name == "bad group name" {
 				fail = failGroupName
 			}
+			if test.name == "entity metadata" {
+				fail = failMetadata
+			}
 			if err != nil && !fail {
-				if resp.Data["error"].(string) != "permission denied" {
-					t.Fatalf("unexpected status %v", resp.Data["error"])
+				if resp != nil && resp.Data["error"].(string) != "permission denied" {
+					t.Fatalf("%s: unexpected status %v", test.name, resp.Data["error"])
 				}
 				t.Fatalf("%s: got unexpected error: %v", test.name, err)
 			}
@@ -203,7 +215,7 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 
 	rootToken := client.Token()
 	client.SetToken(clientToken)
-	runTests(true)
+	runTests(true, false)
 
 	client.SetToken(rootToken)
 	// Test that a policy with bad group membership doesn't kill the other paths
@@ -212,7 +224,7 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 		t.Fatal(err)
 	}
 	client.SetToken(clientToken)
-	runTests(true)
+	runTests(true, false)
 
 	// Test that adding group membership now allows access
 	client.SetToken(rootToken)
@@ -226,5 +238,34 @@ path "secret/{{ identity.groups.names.foobar.name}}/*" {
 		t.Fatal(err)
 	}
 	client.SetToken(clientToken)
-	runTests(false)
+	runTests(false, false)
+
+	// Test invalid metadata is rejected (wildcard characters and slashes)
+	client.SetToken(rootToken)
+	_, err = client.Logical().WriteWithContext(t.Context(), "identity/entity", map[string]any{
+		"name": "entity_name",
+		"metadata": map[string]string{
+			"key": "metadata/+",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.SetToken(clientToken)
+	runTests(false, true)
+
+	// Test with explicitly allowed wildcards and slashes
+	client.SetToken(rootToken)
+	_, err = client.Logical().WriteWithContext(t.Context(), "sys/policy/goodPolicy1", map[string]any{
+		"policy":                           goodPolicy1,
+		"allow_wildcards_in_substitutions": true,
+		"allow_slashes_in_substitutions":   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.SetToken(clientToken)
+	runTests(false, false)
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2522,10 +2522,12 @@ func (b *SystemBackend) handlePoliciesRead(policyType policy.Type) framework.Ope
 
 func readPolicyResponse(policy *policy.Policy) map[string]interface{} {
 	data := map[string]interface{}{
-		"name":         policy.Name,
-		"version":      policy.DataVersion,
-		"cas_required": policy.CASRequired,
-		"policy":       policy.Raw,
+		"name":                             policy.Name,
+		"version":                          policy.DataVersion,
+		"cas_required":                     policy.CASRequired,
+		"policy":                           policy.Raw,
+		"allow_wildcards_in_substitutions": policy.AllowWildcardsInSubstitutions,
+		"allow_slashes_in_substitutions":   policy.AllowSlashesInSubstitutions,
 	}
 
 	if !policy.Expiration.IsZero() {
@@ -2615,6 +2617,9 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.Type) framework.Oper
 
 		casRequired := data.Get("cas_required").(bool)
 		pol.CASRequired = casRequired
+
+		pol.AllowWildcardsInSubstitutions = data.Get("allow_wildcards_in_substitutions").(bool)
+		pol.AllowSlashesInSubstitutions = data.Get("allow_slashes_in_substitutions").(bool)
 
 		// Update the policy
 		if err := b.Core.policyStore.SetPolicy(ctx, pol, cas); err != nil {

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3620,6 +3620,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Type:        framework.TypeBool,
 					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
 				},
+				"allow_wildcards_in_substitutions": {
+					Type:    framework.TypeBool,
+					Default: false,
+				},
+				"allow_slashes_in_substitutions": {
+					Type:    framework.TypeBool,
+					Default: false,
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -3654,6 +3662,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 									Required: true,
 								},
 								"cas_required": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"allow_wildcards_in_substitutions": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"allow_slashes_in_substitutions": {
 									Type:     framework.TypeBool,
 									Required: true,
 								},
@@ -3770,6 +3786,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					Type:        framework.TypeBool,
 					Description: strings.TrimSpace(sysHelp["policy-rules"][0]),
 				},
+				"allow_wildcards_in_substitutions": {
+					Type:    framework.TypeBool,
+					Default: false,
+				},
+				"allow_slashes_in_substitutions": {
+					Type:    framework.TypeBool,
+					Default: false,
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -3804,6 +3828,14 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 									Required: true,
 								},
 								"cas_required": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"allow_wildcards_in_substitutions": {
+									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"allow_slashes_in_substitutions": {
 									Type:     framework.TypeBool,
 									Required: true,
 								},

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2479,10 +2479,12 @@ func TestSystemBackend_policyCRUD(t *testing.T) {
 	delete(resp.Data, "modified")
 
 	exp := map[string]interface{}{
-		"name":         "foo",
-		"rules":        rules,
-		"cas_required": false,
-		"version":      1,
+		"name":                             "foo",
+		"rules":                            rules,
+		"cas_required":                     false,
+		"version":                          1,
+		"allow_slashes_in_substitutions":   false,
+		"allow_wildcards_in_substitutions": false,
 	}
 	if !reflect.DeepEqual(resp.Data, exp) {
 		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)
@@ -2501,10 +2503,12 @@ func TestSystemBackend_policyCRUD(t *testing.T) {
 	delete(resp.Data, "modified")
 
 	exp = map[string]interface{}{
-		"name":         "foo",
-		"rules":        rules,
-		"cas_required": false,
-		"version":      1,
+		"name":                             "foo",
+		"rules":                            rules,
+		"cas_required":                     false,
+		"version":                          1,
+		"allow_slashes_in_substitutions":   false,
+		"allow_wildcards_in_substitutions": false,
 	}
 	if !reflect.DeepEqual(resp.Data, exp) {
 		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)

--- a/vault/policy/policy.go
+++ b/vault/policy/policy.go
@@ -94,30 +94,34 @@ var cap2Int = map[string]uint32{
 
 // Policy is used to represent the policy specified by an ACL configuration.
 type Policy struct {
-	Name        string `hcl:"name"`
-	DataVersion int
-	CASRequired bool
-	Paths       []*PathRules `hcl:"-"`
-	Raw         string
-	Type        Type
-	Templated   bool
-	Expiration  time.Time
-	Modified    time.Time
-	Namespace   *namespace.Namespace
+	Name                          string `hcl:"name"`
+	DataVersion                   int
+	CASRequired                   bool
+	Paths                         []*PathRules `hcl:"-"`
+	Raw                           string
+	Type                          Type
+	Templated                     bool
+	Expiration                    time.Time
+	Modified                      time.Time
+	Namespace                     *namespace.Namespace
+	AllowWildcardsInSubstitutions bool
+	AllowSlashesInSubstitutions   bool
 }
 
 // ShallowClone returns a shallow clone of the policy. This should not be used
 // if any of the reference-typed fields are going to be modified
 func (p *Policy) ShallowClone() *Policy {
 	return &Policy{
-		Name:        p.Name,
-		DataVersion: p.DataVersion,
-		CASRequired: p.CASRequired,
-		Paths:       p.Paths,
-		Raw:         p.Raw,
-		Type:        p.Type,
-		Templated:   p.Templated,
-		Namespace:   p.Namespace,
+		Name:                          p.Name,
+		DataVersion:                   p.DataVersion,
+		CASRequired:                   p.CASRequired,
+		Paths:                         p.Paths,
+		Raw:                           p.Raw,
+		Type:                          p.Type,
+		Templated:                     p.Templated,
+		Namespace:                     p.Namespace,
+		AllowWildcardsInSubstitutions: p.AllowWildcardsInSubstitutions,
+		AllowSlashesInSubstitutions:   p.AllowSlashesInSubstitutions,
 	}
 }
 
@@ -252,14 +256,14 @@ func addGrantingPoliciesToMap(m map[uint32][]logical.PolicyInfo, policy *Policy,
 // intermediary set of policies, before being compiled into
 // the ACL
 func ParseACLPolicy(ns *namespace.Namespace, rules string) (*Policy, error) {
-	return ParseACLPolicyWithTemplating(ns, rules, false, nil, nil)
+	return ParseACLPolicyWithTemplating(ns, rules, false, nil, nil, nil)
 }
 
 // ParseACLPolicyWithTemplating performs the actual work and checks whether we
 // should perform substitutions. If performTemplating is true we know that it
 // is templated so we don't check again, otherwise we check to see if it's a
 // templated policy.
-func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
+func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, blockedSubstitutions []string, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
 	// Parse the rules
 	root, err := hclutil.ParseConfig([]byte(rules))
 	if err != nil {
@@ -292,7 +296,7 @@ func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	}
 
 	if o := list.Filter("path"); len(o.Items) > 0 {
-		if err := parsePaths(&p, o, performTemplating, entity, groups); err != nil {
+		if err := parsePaths(&p, o, performTemplating, blockedSubstitutions, entity, groups); err != nil {
 			return nil, fmt.Errorf("failed to parse policy: %w", err)
 		}
 	}
@@ -300,7 +304,7 @@ func ParseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	return &p, nil
 }
 
-func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group) error {
+func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, blockedSubstitutions []string, entity *identity.Entity, groups []*identity.Group) error {
 	paths := make([]*PathRules, 0, len(list.Items))
 	for _, item := range list.Items {
 		key := "path"
@@ -311,11 +315,12 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		// Check the path
 		if performTemplating {
 			_, templated, err := identitytpl.PopulateString(identitytpl.PopulateStringInput{
-				Mode:        identitytpl.ACLTemplating,
-				String:      key,
-				Entity:      identity.ToSDKEntity(entity),
-				Groups:      identity.ToSDKGroups(groups),
-				NamespaceID: result.Namespace.ID,
+				Mode:                 identitytpl.ACLTemplating,
+				String:               key,
+				Entity:               identity.ToSDKEntity(entity),
+				Groups:               identity.ToSDKGroups(groups),
+				NamespaceID:          result.Namespace.ID,
+				BlockedSubstitutions: blockedSubstitutions,
 			})
 			if err != nil {
 				continue

--- a/vault/policy/policy_store.go
+++ b/vault/policy/policy_store.go
@@ -676,7 +676,16 @@ func (ps *Store) ACL(ctx context.Context, entity *identity.Entity, policyNames m
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := ParseACLPolicyWithTemplating(pol.Namespace, pol.Raw, true, entity, groups)
+
+			blockedSubstitutions := make([]string, 0, 3)
+			if !pol.AllowSlashesInSubstitutions {
+				blockedSubstitutions = append(blockedSubstitutions, "/")
+			}
+			if !pol.AllowWildcardsInSubstitutions {
+				blockedSubstitutions = append(blockedSubstitutions, "*", "+")
+			}
+
+			p, err := ParseACLPolicyWithTemplating(pol.Namespace, pol.Raw, true, blockedSubstitutions, entity, groups)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing templated policy %q: %w", pol.Name, err)
 			}

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -551,6 +551,7 @@ $ curl \
 {
   "data": {
     "allow_any_name": false,
+    "allow_globs_in_substitutions": false,
     "allow_ip_sans": true,
     "allow_localhost": true,
     "allow_subdomains": false,
@@ -3732,6 +3733,12 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
   shell-style globbing. When empty, custom-specified serial numbers will be
   forbidden. It is strongly recommended to allow OpenBao to generate random
   serial numbers instead.
+
+- `allow_globs_in_substitutions` `(bool: false)` - If set and templating is
+  enabled, the values substituted in for `allowed_uri_sans_template` and
+  `allowed_domains` template expression might contain a glob characters ('*').
+  This can enable injection attacks. Only use this, if the data used by the
+  templates is trusted. Defaults to false.
 
 - `server_flag` `(bool: true)` - Specifies if certificates are flagged for
   server authentication use. See [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -363,6 +363,12 @@ to `*` (corresponding to the role/certificate type),
   use for signing requests. If not set, the default issuer will be used.
   This field is only applicable for CA type roles.
 
+- `allow_commas_in_substitutions` `(bool: false)` - If set and templating
+  is enabled, the values substituted in for `allowed_users` and
+  `allowed_domains` template expressions might contain a comma (','). As these
+  values are comma separated lists, this can enable injection attacks. Only use
+  this, if the data used by the templates is trusted. Defaults to false.
+
 #### Sample payload
 
 ```json
@@ -424,6 +430,7 @@ For a CA role:
   "allow_subdomains": false,
   "allow_user_key_ids": false,
   "allow_user_certificates": true,
+  "allow_commas_in_substitutions": false,
   "allowed_critical_options": "",
   "allowed_extensions": "",
   "default_critical_options": {},

--- a/website/content/api-docs/system/policy.mdx
+++ b/website/content/api-docs/system/policy.mdx
@@ -61,7 +61,9 @@ $ curl \
   "rules": "path \"secret/*\"...",
   "modified": "2025-03-25T16:50:49.348095648-05:00",
   "version": "1",
-  "cas_required": false
+  "cas_required": false,
+  "allow_slashes_in_substitutions": false,
+  "allow_wildcards_in_substitutions": false
 }
 ```
 
@@ -102,6 +104,17 @@ updated, it takes effect immediately to all associated users.
   a create/update operation, this parameter needs to reset to true on every
   subsequent operation for continued usage. When set to true, `cas` becomes
   a required parameter. Defaults to false.
+
+- `allow_slashes_in_substitutions` `(bool: <optional>)` - If set, the values
+  substituted in for template expression in the policy definition might contain
+  a slash ('/'). This can enable injection attacks. Only use this, if the data
+  used by the templates is trusted. Defaults to false.
+
+- `allow_wildcards_in_substitutions` `(bool: <optional>)` - If set, the values
+  substituted in for template expression in the policy definition might contain
+  a wildcard characters ('*' and '+'). This can enable injection attacks. Only
+  use this, if the data used by the templates is trusted. Defaults to false.
+
 
 ### Sample payload
 


### PR DESCRIPTION
## Description

Backport of #3401.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
