### PR TITLE
fix "Edit this page" URL for versioned docs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
+import type { EditUrlFunction } from "@docusaurus/plugin-content-docs";
 import type * as Preset from "@docusaurus/preset-classic";
 import { includeMarkdown } from "@hashicorp/remark-plugins";
 import * as path from "path";
@@ -15,6 +16,15 @@ function getDocVersions() {
     return {
       current: { label: "Development" },
     };
+  }
+}
+
+function getEditUrlFn(dir: string): EditUrlFunction {
+  return (editUrlParams) => {
+    let branch = editUrlParams.version === "current" ?
+      `main` :
+      `release/${editUrlParams.version}`;
+    return `https://github.com/openbao/openbao/blob/${branch}/website/content/${dir}/${editUrlParams.docPath}`;
   }
 }
 
@@ -91,7 +101,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/openbao/openbao/tree/main/website/",
+          editUrl: getEditUrlFn("docs"),
           beforeDefaultRemarkPlugins: [
             [
               includeMarkdown,
@@ -136,7 +146,7 @@ const config: Config = {
         path: "content/api-docs",
         routeBasePath: "api-docs",
         sidebarPath: "./sidebarsApi.ts",
-        editUrl: "https://github.com/openbao/openbao/tree/main/website/",
+        editUrl: getEditUrlFn("api-docs"),
         beforeDefaultRemarkPlugins: [
           [
             includeMarkdown,


### PR DESCRIPTION
## Description


Currently, if you click the [:pen: Edit this page](https://openbao.org/docs/concepts/policies/#:~:text=Edit%20this%20page) link in our versioned docs (all except "Development") it will lead you to a 404 like this: `https://github.com/openbao/openbao/tree/main/website/versioned_docs/version-2.6.x/concepts/policies.mdx` 

This PR fixes this.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
