### PR TITLE
Add v2.6.0 to docs website (#3475)

### DIFF
--- a/website/doc-versions.json
+++ b/website/doc-versions.json
@@ -2,13 +2,13 @@
     "current": {
         "label": "Development"
     },
+    "2.6.x": {
+        "label": "Version 2.6.x"
+    },
     "2.5.x": {
         "label": "Version 2.5.x"
     },
     "2.4.x": {
         "label": "Version 2.4.x"
-    },
-    "2.3.x": {
-        "label": "Version 2.3.x"
     }
 }


### PR DESCRIPTION
## Description

Backport of #3475.

## Rationale

Unless I've guessed wrong, this must backport such that docs build on _PRs_ to v2.6.x, so "development" refers to "current" not as 2.5.x but 2.6.x.

Also see CI failure on https://github.com/openbao/openbao/pull/3484, which was not effected by that PR, and did not result in a failed website deployment from main after merging.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
