### PR TITLE
Allow deleting mounts that are in limbo

### DIFF
--- a/changelog/3486.txt
+++ b/changelog/3486.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Allow unmounting auth/secrets mounts even if the backing plugin is unavailable.
+```

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -1115,13 +1115,14 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 		return nil, err
 	}
 
+	isSingleton := slices.Contains(singletonMounts, entry.Type)
 	origViewReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
 	// ensure that it is reset after. This ensures that there will be no
 	// writes during the construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-	if slices.Contains(singletonMounts, entry.Type) {
+	if isSingleton {
 		defer view.SetReadOnlyErr(origViewReadOnlyErr)
 	}
 
@@ -1191,13 +1192,14 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 	// Bind locally as mount entry might be mutated in-between.
 	localEntry := entry
 	postUnsealFunc := func() {
+		if !isSingleton {
+			view.SetReadOnlyErr(origViewReadOnlyErr)
+		}
+
 		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
 		if backend == nil {
 			postUnsealLogger.Error("skipping initialization for nil auth backend")
 			return
-		}
-		if !slices.Contains(singletonMounts, localEntry.Type) {
-			view.SetReadOnlyErr(origViewReadOnlyErr)
 		}
 
 		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -1498,13 +1498,14 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 		return nil, err
 	}
 
+	isSingleton := slices.Contains(singletonMounts, entry.Type)
 	origReadOnlyErr := view.GetReadOnlyErr()
 
 	// Mark the view as read-only until the mounting is complete and
 	// ensure that it is reset after. This ensures that there will be no
 	// writes during the construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-	if slices.Contains(singletonMounts, entry.Type) {
+	if isSingleton {
 		defer view.SetReadOnlyErr(origReadOnlyErr)
 	}
 
@@ -1563,13 +1564,14 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 	// Bind locally as mount entry might be mutated in-between.
 	localEntry := entry
 	postUnsealFunc := func() {
+		if !isSingleton {
+			view.SetReadOnlyErr(origReadOnlyErr)
+		}
+
 		postUnsealLogger := c.logger.With("type", localEntry.Type, "version", localEntry.RunningVersion, "path", localEntry.Path)
 		if backend == nil {
 			postUnsealLogger.Error("skipping initialization for nil backend", "path", localEntry.Path)
 			return
-		}
-		if !slices.Contains(singletonMounts, localEntry.Type) {
-			view.SetReadOnlyErr(origReadOnlyErr)
 		}
 
 		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})


### PR DESCRIPTION
## Description

When a mount is set up on unseal, its backing view is marked read-only and only later marked available for writing again, depending on the type of mount:

1. For singleton mounts, this happens at the end of `setupMount`/`setupCredential` via `defer`:
  ```
  commit 4c772b49968938418a042b1ad341eefe7c6c0a55
  Author: Jeff Mitchell <jeff@hashicorp.com>
  Date:   Thu Apr 19 13:29:43 2018 -0400
      Defer setting views read/write until the end of postUnseal (#4392)
      A few notes:
      * We exert positive control over singletons and they usually need to
      perform some (known, validated) writes, so this excludes singletons --
      they are simply limited to the end of the mount function as before.
      * I'm not sure how to test this _specifically_; I've done some testing
      of e.g. sealing vault and unsealing and ensuring that I can write to a
      KV mount. I think this is tested by every dev server though, since for a
      dev server Vault is inited, the default mounts are mounted, then it's
      sealed, then it's unsealed for the user, so it already goes through this
      code path. The mere fact that you can write to secret/ on a dev server
      means it was successfully set read-write.
  ```

2. For all other mounts, this happens as part of its `postUnsealFunc`.

When a mount is mounted but the backend isn't available (i.e., the backend is `nil`, this can happen if the associated plugin is no longer available), the post-unseal function will not mark the view as writable again and bails too early.

An unwanted side effect of this is that, since the view remains read-only indefinitely, the mount cannot be removed either, even though this is naturally a common use case for any leftover mounts post plugin removal.

## Rationale

Part of: https://github.com/openbao/openbao/issues/3478

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
