### PR TITLE
Fix removal of config-based audit device

### DIFF
--- a/changelog/3488.txt
+++ b/changelog/3488.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/audit: Ensure config-driven audit mounts are removed from storage when removed from configuration.
+```

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -720,7 +720,7 @@ func (c *Core) handleAuditLogSetup(ctx context.Context, standby bool) error {
 		}
 
 		c.logger.Info("disabling removed audit device", "path", auditMount.Path)
-		if existed, err := c.disableAudit(ctx, auditMount.Path, standby); existed && err != nil {
+		if existed, err := c.disableAudit(ctx, auditMount.Path, true); existed && err != nil {
 			return fmt.Errorf("failed to disable removed audit %v: %w", auditMount.Path, err)
 		}
 	}


### PR DESCRIPTION
## Description

The passed parameter is whether we should write, not whether we're standby. If we are standby, we bail earlier anyhow, so this can default to `true.`

Credits to @nielsdt-rabobank who suggested the same patch that I landed on, I'm opening this up just so we can squeeze it into v2.6.0 GA.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3477

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
