### PR TITLE
docs: align supported kubernetes versions doc

### DIFF
--- a/website/content/partials/kubernetes-supported-versions.mdx
+++ b/website/content/partials/kubernetes-supported-versions.mdx
@@ -1,12 +1,7 @@
 ## Supported kubernetes versions
 
-The following [Kubernetes minor releases][k8s-releases] are currently supported.
-The latest version is tested against each Kubernetes version. It may work with
-other versions of Kubernetes, but those are not supported.
-
-* 1.30
-* 1.31
-* 1.32
-* 1.33
+In line with the Kubernetes project, we support and run tests against the three
+most recent [Kubernetes minor releases][k8s-releases]. It may work with
+other versions of Kubernetes, but those are not supported or tested against.
 
 [k8s-releases]: https://kubernetes.io/releases/


### PR DESCRIPTION
## Description

We got an issue over the openbao-helm repo asking if Kubernetes 1.35.x was supported. (https://github.com/openbao/openbao-helm/issues/194)

This clarifies the docs on the website in that regard and aligns with what we are doing.

## Rationale

We are aligned with the Kubernetes project where only the 3 most recent releases are supported.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
