### PR TITLE
Ensure templates do not render secrets to stdout

### DIFF
--- a/changelog/3494.txt
+++ b/changelog/3494.txt
@@ -1,0 +1,3 @@
+```release-note:security
+agent: Ensure previously rendered secrets do not appear in stdout on failures. GHSA-444v-8vxr-p36h.
+```

--- a/command/agent/exec/exec.go
+++ b/command/agent/exec/exec.go
@@ -192,6 +192,10 @@ func (s *Server) Run(ctx context.Context, incomingVaultToken chan string) error 
 			if err != nil {
 				return fmt.Errorf("template server failed to create: %w", err)
 			}
+
+			// prevent the templates from being rendered to stdout in "dry" mode
+			s.runner.SetOutStream(io.Discard)
+
 			go s.runner.Start()
 
 		case <-s.runner.TemplateRenderedCh():


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When Agent encounters enough rendering issues (say, due to hitting max_retry), the entire templating system will be reloaded along with the exec'd application. This leads to partial secrets being written to stdout.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: GHSA-444v-8vxr-p36h

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
