### PR TITLE
Set user=root when invoking OpenBao for Alpine

### DIFF
--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -42,6 +42,7 @@ type RunOptions struct {
 	ImageRepo              string
 	ImageTag               string
 	ContainerName          string
+	User                   string
 	Cmd                    []string
 	Entrypoint             []string
 	Env                    []string
@@ -447,6 +448,7 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 	cfg := &container.Config{
 		Hostname: name,
 		Image:    fmt.Sprintf("%s:%s", d.RunOptions.ImageRepo, d.RunOptions.ImageTag),
+		User:     d.RunOptions.User,
 		Env:      d.RunOptions.Env,
 		Cmd:      d.RunOptions.Cmd,
 	}

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -740,6 +740,11 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 	r, err := dockhelper.NewServiceRunner(dockhelper.RunOptions{
 		ImageRepo: n.ImageRepo,
 		ImageTag:  n.ImageTag,
+		// The alpine build has changed in v2.6.0 to now run as non-root by
+		// default, aligning with UBI images. However, we don't write
+		// /openbao/config with proper permissions, which means we'll attempt
+		// to invoke chown as openbao which will fail.
+		User: "root",
 		// We don't need to run update-ca-certificates in the container, because
 		// we're providing the CA in the raft join call, and otherwise Vault
 		// servers don't talk to one another on the API port.
@@ -1253,9 +1258,6 @@ FROM %s:%s
 COPY bao /bin/bao
 `, opts.ImageRepo, sourceTag)
 
-	if opts.Root {
-		containerFile += "USER root\n"
-	}
 	if len(opts.Entrypoint) > 0 {
 		containerFile += "COPY entrypoint /usr/local/bin/docker-entrypoint.sh\n"
 	}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Introduces a new `User` option in our container helpers and uses it within our containerized clustering support for Alpine. 

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This fixes current build issues on `main`. 

Related: #2589.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
