### PR TITLE
fix(image/ubi): overwrite base image labels

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -154,6 +154,7 @@ jobs:
         run: |
           echo "sha=$(git rev-parse "$VERSION")" >> "$GITHUB_OUTPUT"
           echo "epoch=$(git log -1 --format=%ct "$VERSION")" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images
         id: build
@@ -165,11 +166,20 @@ jobs:
           target: ${{ matrix.distro.target }}
           platforms: ${{ join(matrix.distro.platforms, ',') }}
           outputs: type=registry,rewrite-timestamp=true
-          build-args: 
-            SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
-            VERSION=${{ env.VERSION }}
-            REVISION=${{ steps.info.outputs.sha }}
+          build-args: SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
           labels: |
+            # Legacy Core Metadata Labels
+            name=OpenBao
+            maintainer=OpenBao <openbao@lists.openssf.org>
+            vendor=OpenBao
+            version=${{ env.VERSION }}
+            release=${{ steps.info.outputs.epoch }}
+            build-date=${{ steps.info.outputs.date }}
+            summary=OpenBao is a tool for securely accessing secrets
+            description=OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log
+            url=https://openbao.org
+            vcs-ref=${{ steps.info.outputs.sha }}
+            # OCI Standard Labels
             org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>
             org.opencontainers.image.url=https://github.com/openbao/openbao
             org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -165,7 +165,10 @@ jobs:
           target: ${{ matrix.distro.target }}
           platforms: ${{ join(matrix.distro.platforms, ',') }}
           outputs: type=registry,rewrite-timestamp=true
-          build-args: SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
+          build-args: 
+            SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
+            VERSION=${{ env.VERSION }}
+            REVISION=${{ steps.info.outputs.sha }}
           labels: |
             org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>
             org.opencontainers.image.url=https://github.com/openbao/openbao

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -167,8 +167,11 @@ jobs:
           platforms: ${{ join(matrix.distro.platforms, ',') }}
           outputs: type=registry,rewrite-timestamp=true
           build-args: SOURCE_DATE_EPOCH=${{ steps.info.outputs.epoch }}
+          # We add both "legacy" non-namespaced labels and OCI-standardized
+          # labels. Legacy labels are primarily required for Red Hat to certify
+          # images based on UBI, but it does not harm to add them to all
+          # distributions.
           labels: |
-            # Legacy Core Metadata Labels
             name=OpenBao
             maintainer=OpenBao <openbao@lists.openssf.org>
             vendor=OpenBao
@@ -179,7 +182,6 @@ jobs:
             description=OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log
             url=https://openbao.org
             vcs-ref=${{ steps.info.outputs.sha }}
-            # OCI Standard Labels
             org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>
             org.opencontainers.image.url=https://github.com/openbao/openbao
             org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -182,8 +182,9 @@ jobs:
             description=OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log
             url=https://openbao.org
             vcs-ref=${{ steps.info.outputs.sha }}
+            vcs-type=git
             org.opencontainers.image.authors=OpenBao <openbao@lists.openssf.org>
-            org.opencontainers.image.url=https://github.com/openbao/openbao
+            org.opencontainers.image.url=https://openbao.org
             org.opencontainers.image.documentation=https://github.com/openbao/openbao/blob/main/README.md
             org.opencontainers.image.source=https://github.com/openbao/openbao
             org.opencontainers.image.version=${{ env.VERSION }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           echo "sha=$(git rev-parse "$VERSION")" >> "$GITHUB_OUTPUT"
           echo "epoch=$(git log -1 --format=%ct "$VERSION")" >> "$GITHUB_OUTPUT"
-          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "date=$(TZ=UTC git log -1 --format=%cd --date=iso-strict-local "$VERSION")" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images
         id: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,8 @@ COPY LICENSE /licenses/mozilla.txt
 
 # Overwrite base image labels
 # These labels are required by Red Hat
-LABEL com.redhat.component="" \
-      com.redhat.license_terms="" \
-      io.buildah.version="" \
-      io.k8s.description="${LABEL_DESCRIPTION}" \
+LABEL io.buildah.version="" \
+      io.k8s.description="OpenBao is a tool for securely accessing secrets" \
       io.k8s.display-name="OpenBao" \
       io.openshift.expose-services="8200/tcp:https"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,31 @@ CMD ["server", "-dev", "-dev-no-store-token"]
 
 # This is {docker.io,quay.io,ghcr.io}/openbao/openbao-ubi.
 FROM registry.access.redhat.com/ubi10-minimal:10.2@sha256:b217fa65d8c21058887b18f005f587e47a17dd1281a5196ac88d01724a273dbd AS ubi
+ARG VERSION="0.0.0-dev"
+ARG REVISION="unknown"
 
 COPY LICENSE /licenses/mozilla.txt
+
+ARG LABEL_DESCRIPTION="OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log"
+
+# Overwrite base image labels
+# These labels are required by Red Hat
+LABEL name="OpenBao" \
+      maintainer="OpenBao <openbao@lists.openssf.org>" \
+      vendor="OpenBao" \
+      version="${VERSION}" \
+      release="${VERSION}" \
+      summary="OpenBao is a tool for securely accessing secrets" \
+      description="${LABEL_DESCRIPTION}" \
+      url="https://openbao.org" \
+      build-date="" \
+      com.redhat.component="" \
+      com.redhat.license_terms="" \
+      io.buildah.version="" \
+      io.k8s.description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="OpenBao" \
+      io.openshift.expose-services="8200/tcp:https" \
+      vcs-ref:"${REVISION}" \
 
 # Set up ca-certificates & base tooling.
 RUN microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ LABEL name="OpenBao" \
       io.k8s.description="${LABEL_DESCRIPTION}" \
       io.k8s.display-name="OpenBao" \
       io.openshift.expose-services="8200/tcp:https" \
-      vcs-ref="${REVISION}" \
+      vcs-ref="${REVISION}"
 
 # Set up ca-certificates & base tooling.
 RUN microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,8 @@ FROM registry.access.redhat.com/ubi10-minimal:10.2@sha256:b217fa65d8c21058887b18
 
 COPY LICENSE /licenses/mozilla.txt
 
-# Overwrite base image labels
-# These labels are required by Red Hat
-LABEL io.buildah.version="" \
-      io.k8s.description="OpenBao is a tool for securely accessing secrets" \
+# Overwrite Red Hat-specific labels present on the UBI base image.
+LABEL io.k8s.description="OpenBao is a tool for securely accessing secrets" \
       io.k8s.display-name="OpenBao" \
       io.openshift.expose-services="8200/tcp:https"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,22 +77,12 @@ ARG LABEL_DESCRIPTION="OpenBao is a tool for securely accessing secrets. A secre
 
 # Overwrite base image labels
 # These labels are required by Red Hat
-LABEL name="OpenBao" \
-      maintainer="OpenBao <openbao@lists.openssf.org>" \
-      vendor="OpenBao" \
-      version="${VERSION}" \
-      release="${VERSION}" \
-      summary="OpenBao is a tool for securely accessing secrets" \
-      description="${LABEL_DESCRIPTION}" \
-      url="https://openbao.org" \
-      build-date="" \
-      com.redhat.component="" \
+LABEL com.redhat.component="" \
       com.redhat.license_terms="" \
       io.buildah.version="" \
       io.k8s.description="${LABEL_DESCRIPTION}" \
       io.k8s.display-name="OpenBao" \
-      io.openshift.expose-services="8200/tcp:https" \
-      vcs-ref="${REVISION}"
+      io.openshift.expose-services="8200/tcp:https"
 
 # Set up ca-certificates & base tooling.
 RUN microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,12 +68,8 @@ CMD ["server", "-dev", "-dev-no-store-token"]
 
 # This is {docker.io,quay.io,ghcr.io}/openbao/openbao-ubi.
 FROM registry.access.redhat.com/ubi10-minimal:10.2@sha256:b217fa65d8c21058887b18f005f587e47a17dd1281a5196ac88d01724a273dbd AS ubi
-ARG VERSION="0.0.0-dev"
-ARG REVISION="unknown"
 
 COPY LICENSE /licenses/mozilla.txt
-
-ARG LABEL_DESCRIPTION="OpenBao is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. OpenBao provides a unified interface to any secret, while providing tight access control and recording a detailed audit log"
 
 # Overwrite base image labels
 # These labels are required by Red Hat

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ LABEL name="OpenBao" \
       io.k8s.description="${LABEL_DESCRIPTION}" \
       io.k8s.display-name="OpenBao" \
       io.openshift.expose-services="8200/tcp:https" \
-      vcs-ref:"${REVISION}" \
+      vcs-ref="${REVISION}" \
 
 # Set up ca-certificates & base tooling.
 RUN microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux

--- a/changelog/3504.txt
+++ b/changelog/3504.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
-packaging/container: Overwrite UBI base image labels with our own labels
+packaging/container: Ensure that labels on UBI-based images comply with Red Hat's certification requirements.
+```
+```release-note:change
+packaging/container: Revert removal of legacy, non-opencontainers image labels for maximum compatibility.
 ```

--- a/changelog/3504.txt
+++ b/changelog/3504.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+packaging/container: Overwrite UBI base image labels with our own labels
+```


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When using ubi as the base image we inherit all it's labels and should either overwrite or set it to an empty string.

Without this we have labels on our ubi images like:

```
{
  [...]
  "maintainer": "Red Hat, Inc.",
  "name": "ubi10/ubi-minimal",
  "vendor": "Red Hat, Inc.",
  "version": "10.2"
}
```

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
