### PR TITLE
Fix policy persistence issue, introduce PATCH support for policies

### DIFF
--- a/changelog/3506.txt
+++ b/changelog/3506.txt
@@ -1,6 +1,9 @@
 ```release-note:bug
 core/policies: Fix persistence of new `allow_wildcards_in_identity_templates`, `allow_slashes_in_identity_templates` parameters in storage.
 ```
-```release-note:feature
+```release-note:improvement
 core/policies: Introduce PATCH operation support for modifying the values of specific parameters.
+```
+```release-note:bug
+core/policies: Allow removal of `expiration` from policies on POST/PUT to `sys/policies/acl/<name>` by eliding the parameter; use PATCH to update policies without modifying unnecessary parameters.
 ```

--- a/changelog/3506.txt
+++ b/changelog/3506.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+core/policies: Fix persistence of new `allow_wildcards_in_identity_templates`, `allow_slashes_in_identity_templates` parameters in storage.
+```
+```release-note:feature
+core/policies: Introduce PATCH operation support for modifying the values of specific parameters.
+```

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -2646,8 +2646,8 @@ func (b *SystemBackend) handlePoliciesPatch(policyType policy.Type) framework.Op
 		if name == "" {
 			return logical.ErrorResponse("policy name must be provided in the URL"), nil
 		}
-		if name != strings.ToLower(name) {
-			name = strings.ToLower(name)
+		if n := strings.ToLower(name); name != n {
+			name = n
 			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", name))
 		}
 
@@ -2656,11 +2656,11 @@ func (b *SystemBackend) handlePoliciesPatch(policyType policy.Type) framework.Op
 			return handleError(err)
 		}
 		if oldPolicy == nil {
-			return logical.ErrorResponse("unable to fetch role entry to patch"), nil
+			return handleError(logical.CodedError(http.StatusNotFound, "policy not found"))
 		}
 
 		pol := &policy.Policy{
-			Name:      strings.ToLower(name),
+			Name:      name,
 			Type:      policyType,
 			Namespace: ns,
 

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -2589,6 +2589,8 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.Type) framework.Oper
 			pol.Expiration = expirationRaw.(time.Time)
 		} else if ttlOk {
 			pol.Expiration = time.Now().Add(time.Duration(ttlRaw.(int)) * time.Second)
+		} else {
+			pol.Expiration = time.Time{}
 		}
 
 		if !pol.Expiration.IsZero() && !time.Now().Before(pol.Expiration) {
@@ -2623,6 +2625,98 @@ func (b *SystemBackend) handlePoliciesSet(policyType policy.Type) framework.Oper
 
 		// Update the policy
 		if err := b.Core.policyStore.SetPolicy(ctx, pol, cas); err != nil {
+			return handleError(err)
+		}
+
+		return resp, nil
+	}
+}
+
+// handlePoliciesSet handles the "/sys/policies/<type>/<name>" endpoints to patch a policy
+func (b *SystemBackend) handlePoliciesPatch(policyType policy.Type) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		resp := &logical.Response{}
+
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		name := data.Get("name").(string)
+		if name == "" {
+			return logical.ErrorResponse("policy name must be provided in the URL"), nil
+		}
+		if name != strings.ToLower(name) {
+			name = strings.ToLower(name)
+			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", name))
+		}
+
+		oldPolicy, err := b.Core.policyStore.GetPolicy(ctx, name, policyType)
+		if err != nil {
+			return handleError(err)
+		}
+		if oldPolicy == nil {
+			return logical.ErrorResponse("unable to fetch role entry to patch"), nil
+		}
+
+		pol := &policy.Policy{
+			Name:      strings.ToLower(name),
+			Type:      policyType,
+			Namespace: ns,
+
+			Raw:                               data.GetWithExplicitDefault("policy", oldPolicy.Raw).(string),
+			CASRequired:                       data.GetWithExplicitDefault("cas_required", oldPolicy.CASRequired).(bool),
+			AllowWildcardsInIdentityTemplates: data.GetWithExplicitDefault("allow_wildcards_in_identity_templates", oldPolicy.AllowWildcardsInIdentityTemplates).(bool),
+			AllowSlashesInIdentityTemplates:   data.GetWithExplicitDefault("allow_slashes_in_identity_templates", oldPolicy.AllowSlashesInIdentityTemplates).(bool),
+		}
+
+		if pol.Raw == "" {
+			return logical.ErrorResponse("'policy' parameter not supplied or empty"), nil
+		}
+
+		if polBytes, err := base64.StdEncoding.DecodeString(pol.Raw); err == nil {
+			pol.Raw = string(polBytes)
+		}
+
+		expirationRaw, expirationOk := data.GetOk("expiration")
+		ttlRaw, ttlOk := data.GetOk("ttl")
+		if expirationOk && ttlOk {
+			return logical.ErrorResponse("cannot supply both 'expiration' and 'ttl' for policies"), nil
+		} else if expirationOk {
+			pol.Expiration = expirationRaw.(time.Time)
+		} else if ttlOk {
+			pol.Expiration = time.Now().Add(time.Duration(ttlRaw.(int)) * time.Second)
+		} else {
+			pol.Expiration = oldPolicy.Expiration
+		}
+
+		if !pol.Expiration.IsZero() && !time.Now().Before(pol.Expiration) {
+			return logical.ErrorResponse("refusing to update policy as expiration time has already elapsed"), nil
+		}
+
+		switch policyType {
+		case policy.TypeACL:
+			p, err := policy.ParseACLPolicy(ns, pol.Raw)
+			if err != nil {
+				return handleError(err)
+			}
+
+			pol.Paths = p.Paths
+			pol.Templated = p.Templated
+		default:
+			return logical.ErrorResponse("unknown policy type"), nil
+		}
+
+		// CAS avoids the need for a new method and/or transaction here as
+		// races will be handled nicely and Set can update DataVersion.
+		cas := oldPolicy.DataVersion
+		casRaw, casOk := data.GetOk("cas")
+		if casOk {
+			cas = casRaw.(int)
+		}
+
+		// Update the policy
+		if err := b.Core.policyStore.SetPolicy(ctx, pol, &cas); err != nil {
 			return handleError(err)
 		}
 
@@ -5168,7 +5262,7 @@ This path responds to the following HTTP methods.
 	},
 
 	"policy": {
-		`Read, Modify, or Delete an access control policy.`,
+		`Read, Modify, Patch, or Delete an access control policy.`,
 		`
 Read the rules of an existing policy, create or update the rules of a policy,
 or delete a policy.

--- a/internal/vault/logical_system_paths.go
+++ b/internal/vault/logical_system_paths.go
@@ -3871,6 +3871,17 @@ func (b *SystemBackend) policyPaths() []*framework.Path {
 					},
 					Summary: "Add a new or update an existing ACL policy.",
 				},
+				logical.PatchOperation: &framework.PathOperation{
+					Callback: b.handlePoliciesPatch(policy.TypeACL),
+					Responses: map[int][]framework.Response{
+						http.StatusNoContent: {{
+							Description: "OK",
+							Fields:      map[string]*framework.FieldSchema{},
+						}},
+					},
+					Summary: "Patches an existing ACL policy.",
+				},
+
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: b.handlePoliciesDelete(policy.TypeACL),
 					Responses: map[int][]framework.Response{

--- a/internal/vault/policy/policy.go
+++ b/internal/vault/policy/policy.go
@@ -94,16 +94,21 @@ var cap2Int = map[string]uint32{
 
 // Policy is used to represent the policy specified by an ACL configuration.
 type Policy struct {
-	Name                              string `hcl:"name"`
+	// Computed fields not present in storage.
+	Name      string               `hcl:"name" json:"-"`
+	Namespace *namespace.Namespace `json:"-"`
+	Paths     []*PathRules         `hcl:"-" json:"-"`
+
+	// These fields are persisted in storage. However, the original
+	// policy.Entry{} did not use `json` tags and so we elide them
+	// here as well.
 	DataVersion                       int
 	CASRequired                       bool
-	Paths                             []*PathRules `hcl:"-"`
 	Raw                               string
 	Type                              Type
 	Templated                         bool
 	Expiration                        time.Time
 	Modified                          time.Time
-	Namespace                         *namespace.Namespace
 	AllowWildcardsInIdentityTemplates bool
 	AllowSlashesInIdentityTemplates   bool
 }
@@ -123,6 +128,27 @@ func (p *Policy) ShallowClone() *Policy {
 		AllowWildcardsInIdentityTemplates: p.AllowWildcardsInIdentityTemplates,
 		AllowSlashesInIdentityTemplates:   p.AllowSlashesInIdentityTemplates,
 	}
+}
+
+func (p *Policy) Decode(name string, ns *namespace.Namespace) error {
+	p.Name = name
+	p.Namespace = ns
+
+	switch p.Type {
+	case TypeACL:
+		// Parse normally
+		parsed, err := ParseACLPolicy(ns, p.Raw)
+		if err != nil {
+			return fmt.Errorf("failed to parse policy: %w", err)
+		}
+
+		p.Paths = parsed.Paths
+		p.Templated = parsed.Templated
+	default:
+		return fmt.Errorf("unknown policy type %q", p.Type.String())
+	}
+
+	return nil
 }
 
 // PathRules represents a policy for a path in the namespace.

--- a/internal/vault/policy/policy_store.go
+++ b/internal/vault/policy/policy_store.go
@@ -164,18 +164,6 @@ type Store struct {
 	logger log.Logger
 }
 
-// Entry is used to store a policy by name
-type Entry struct {
-	Version     int
-	DataVersion int
-	CASRequired bool
-	Raw         string
-	Templated   bool
-	Type        Type
-	Expiration  time.Time
-	Modified    time.Time
-}
-
 type core interface {
 	NamespaceByID(context.Context, string) (*namespace.Namespace, error)
 	IdentityStore() *vaultidentity.IdentityStore
@@ -298,7 +286,7 @@ func (ps *Store) setPolicyInternal(ctx context.Context, p *Policy, casVersion *i
 		return fmt.Errorf("unable to get existing policy for check-and-set: %w", err)
 	}
 
-	var existing Entry
+	var existing Policy
 	if existingEntry != nil {
 		if err := existingEntry.DecodeJSON(&existing); err != nil {
 			return fmt.Errorf("failed to decode existing policy: %w", err)
@@ -321,16 +309,7 @@ func (ps *Store) setPolicyInternal(ctx context.Context, p *Policy, casVersion *i
 
 	// Create the entry
 	p.DataVersion = existing.DataVersion + 1
-	entry, err := logical.StorageEntryJSON(p.Name, &Entry{
-		Version:     2,
-		DataVersion: p.DataVersion,
-		CASRequired: p.CASRequired,
-		Raw:         p.Raw,
-		Type:        p.Type,
-		Templated:   p.Templated,
-		Expiration:  p.Expiration,
-		Modified:    p.Modified,
-	})
+	entry, err := logical.StorageEntryJSON(p.Name, p)
 	if err != nil {
 		return fmt.Errorf("failed to create entry: %w", err)
 	}
@@ -483,15 +462,14 @@ func (ps *Store) switchedGetPolicy(ctx context.Context, name string, policyType 
 		return nil, nil
 	}
 
-	policyEntry := new(Entry)
 	pol := new(Policy)
-	err = out.DecodeJSON(policyEntry)
+	err = out.DecodeJSON(pol)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse policy: %w", err)
 	}
 
 	// Handle expiration, removing the entry if it is expired.
-	if !policyEntry.Expiration.IsZero() && time.Now().After(policyEntry.Expiration) {
+	if !pol.Expiration.IsZero() && time.Now().After(pol.Expiration) {
 		if err := view.Delete(ctx, name); err != nil {
 			return nil, fmt.Errorf("failed to remove expired policy: %w", err)
 		}
@@ -501,28 +479,8 @@ func (ps *Store) switchedGetPolicy(ctx context.Context, name string, policyType 
 
 	// Set these up here so that they're available for loading into
 	// Sentinel
-	pol.Name = name
-	pol.DataVersion = policyEntry.DataVersion
-	pol.CASRequired = policyEntry.CASRequired
-	pol.Raw = policyEntry.Raw
-	pol.Type = policyEntry.Type
-	pol.Templated = policyEntry.Templated
-	pol.Expiration = policyEntry.Expiration
-	pol.Modified = policyEntry.Modified
-	pol.Namespace = ns
-	switch policyEntry.Type {
-	case TypeACL:
-		// Parse normally
-		p, err := ParseACLPolicy(ns, policyEntry.Raw)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse policy: %w", err)
-		}
-		pol.Paths = p.Paths
-
-		// Reset this in case they set the name in the policy itself
-		pol.Name = name
-	default:
-		return nil, fmt.Errorf("unknown policy type %q", policyEntry.Type.String())
+	if err := pol.Decode(name, ns); err != nil {
+		return nil, fmt.Errorf("error decoding policy: %w", err)
 	}
 
 	if cache != nil {

--- a/internal/vault/policy_store_test.go
+++ b/internal/vault/policy_store_test.go
@@ -82,19 +82,19 @@ func testPolicyRoot(t *testing.T, ps *policy.Store, ns *namespace.Namespace, exp
 func TestPolicyStore_CRUD(t *testing.T) {
 	t.Run("root-ns", func(t *testing.T) {
 		t.Run("cached", func(t *testing.T) {
-			core, shares, token, ps := mockPolicyWithCore(t, false)
-			testPolicyStoreCRUD(t, core, shares, token, ps, namespace.RootNamespace)
+			core, shares, token, _ := mockPolicyWithCore(t, false)
+			testPolicyStoreCRUD(t, core, shares, token, namespace.RootNamespace)
 		})
 
 		t.Run("no-cache", func(t *testing.T) {
-			core, shares, token, ps := mockPolicyWithCore(t, true)
-			testPolicyStoreCRUD(t, core, shares, token, ps, namespace.RootNamespace)
+			core, shares, token, _ := mockPolicyWithCore(t, true)
+			testPolicyStoreCRUD(t, core, shares, token, namespace.RootNamespace)
 		})
 	})
 }
 
-func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ps *policy.Store, ns *namespace.Namespace) {
-	testPolicyStoreCRUDOneShot(t, ps, ns)
+func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string, ns *namespace.Namespace) {
+	testPolicyStoreCRUDOneShot(t, core.policyStore, ns, false /* create */)
 
 	// Seal, unseal, and try again.
 	require.NoError(t, core.Seal(token), "failed to seal")
@@ -107,12 +107,40 @@ func testPolicyStoreCRUD(t *testing.T, core *Core, shares [][]byte, token string
 		require.NoError(t, err)
 	}
 
-	testPolicyStoreCRUDOneShot(t, ps, ns)
+	// Make sure we refresh our pointer to the policy store here: postUnseal
+	// sets up a new one so we can't use the old one anymore as caches will
+	// still be valid. Namespace is still safe to use as nothing compares by
+	// pointer value.
+	testPolicyStoreCRUDOneShot(t, core.policyStore, ns, true /* validate */)
 }
 
-func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.Store, ns *namespace.Namespace) {
-	// Get should return nothing
+func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.Store, ns *namespace.Namespace, postUnseal bool) {
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	persistedPolicy := &policy.Policy{
+		DataVersion:                       1,
+		CASRequired:                       true,
+		Raw:                               policytest.ACLPolicy,
+		Type:                              policy.TypeACL,
+		Templated:                         false,
+		AllowWildcardsInIdentityTemplates: true,
+		AllowSlashesInIdentityTemplates:   true,
+	}
+
+	err := persistedPolicy.Decode("persisted", namespace.RootNamespace)
+	require.NoError(t, err)
+
+	if postUnseal {
+		actual, err := ps.GetPolicy(ctx, "persisted", policy.TypeACL)
+		require.NoError(t, err)
+		require.False(t, actual.Modified.IsZero())
+		persistedPolicy.Modified = actual.Modified
+		require.Equal(t, actual, persistedPolicy)
+
+		err = ps.DeletePolicy(ctx, "persisted", policy.TypeACL)
+		require.NoError(t, err)
+	}
+
+	// Get should return nothing
 	p, err := ps.GetPolicy(ctx, "Dev", policy.TypeToken)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -196,6 +224,16 @@ func testPolicyStoreCRUDOneShot(t *testing.T, ps *policy.Store, ns *namespace.Na
 	}
 	if p != nil {
 		t.Fatalf("bad: %v", p)
+	}
+
+	if !postUnseal {
+		cas := -1
+		err := ps.SetPolicy(ctx, persistedPolicy, &cas)
+		require.NoError(t, err)
+
+		actual, err := ps.GetPolicy(ctx, "persisted", policy.TypeACL)
+		require.NoError(t, err)
+		require.Equal(t, actual, persistedPolicy)
 	}
 }
 

--- a/internal/vault/policy_store_test.go
+++ b/internal/vault/policy_store_test.go
@@ -595,6 +595,18 @@ func TestPolicyStore_NamespaceAPI(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, rootResp.IsError())
 
+	// Patch a policy.
+	rootResp, err = core.HandleRequest(ctx, &logical.Request{
+		Operation: logical.PatchOperation,
+		Path:      policyPath,
+		Data: map[string]interface{}{
+			"allow_wildcards_in_identity_templates": true,
+		},
+		ClientToken: token,
+	})
+	require.NoError(t, err)
+	require.False(t, rootResp.IsError())
+
 	// Get namespace and create context
 	ns, err := core.namespaceStore.GetNamespaceByPath(ctx, nsPath)
 	require.NoError(t, err)
@@ -633,6 +645,7 @@ func TestPolicyStore_NamespaceAPI(t *testing.T) {
 
 	rootPolicy := rootReadResp.Data["policy"].(string)
 	nsPolicy := nsReadResp.Data["policy"].(string)
+	assert.True(t, rootReadResp.Data["allow_wildcards_in_identity_templates"].(bool))
 	assert.NotEqual(t, rootPolicy, nsPolicy, "policies should be different")
 	assert.Contains(t, nsPolicy, "list", "namespace policy missing list capability")
 	assert.NotContains(t, rootPolicy, "list", "root policy contains unexpected list capability")

--- a/internal/vault/policy_store_test.go
+++ b/internal/vault/policy_store_test.go
@@ -1010,3 +1010,57 @@ func TestPolicyStore_CAS(t *testing.T) {
 	require.NotNil(t, p1)
 	require.Equal(t, p, p1)
 }
+
+func TestPolicyStore_MigrateFromEntry(t *testing.T) {
+	t.Run("root", func(t *testing.T) {
+		t.Parallel()
+
+		core, _, _ := TestCoreUnsealed(t)
+		ps := core.policyStore
+
+		// Write policy into the ACL view, ensuring we can upgrade from
+		// earlier versions of OpenBao. To reproduce:
+		//
+		// $ bao policy write testing /path/to/policy.hcl
+		// $ bao read sys/raw/sys/policy/testing | jq -r .data.value | jq
+		view := ps.GetACLView(namespace.RootNamespace)
+		modifiedTimestamp := "2026-07-16T17:00:19.167037139-05:00"
+		entry, err := logical.StorageEntryJSON("testing", map[string]any{
+			"Version":     2,
+			"DataVersion": 1,
+			"CASRequired": true,
+			"Raw":         "\npath \"*\" {\n\tcapabilities  = [\"create\", \"update\", \"delete\", \"read\", \"patch\", \"list\", \"scan\", \"sudo\"]\n}\n",
+			"Templated":   false,
+			"Type":        0,
+			"Expiration":  "0001-01-01T00:00:00Z",
+			"Modified":    modifiedTimestamp,
+		})
+		require.NoError(t, err)
+		err = view.Put(t.Context(), entry)
+		require.NoError(t, err)
+
+		// This policy is of ACL type.
+		ctx := namespace.ContextWithNamespace(t.Context(), namespace.RootNamespace)
+		out, err := ps.ListPolicies(ctx, policy.TypeACL, true)
+		require.NoError(t, err)
+		require.Contains(t, out, "testing")
+
+		read, err := ps.GetPolicy(ctx, "testing", policy.TypeACL)
+		require.NoError(t, err)
+		require.NotNil(t, read)
+
+		require.Equal(t, read.DataVersion, 1)
+		require.Equal(t, read.CASRequired, true)
+		require.Equal(t, read.Type, policy.TypeACL)
+		require.True(t, read.Expiration.IsZero())
+
+		parsed, err := time.Parse(time.RFC3339, modifiedTimestamp)
+		require.NoError(t, err)
+		require.Equal(t, read.Modified, parsed)
+
+		require.Equal(t, 1, len(read.Paths))
+		require.Equal(t, "", read.Paths[0].Path)
+		require.True(t, read.Paths[0].IsPrefix)
+		require.Contains(t, read.Paths[0].Capabilities, "scan")
+	})
+}

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -72,11 +72,13 @@ $ curl \
 ## Create/Update ACL policy
 
 This endpoint adds a new or updates an existing ACL policy. Once a policy is
-updated, it takes effect immediately to all associated users.
+updated, it takes effect immediately to all associated users. New policies
+cannot be created via patch operation.
 
-| Method | Path                      |
-| :----- | :------------------------ |
-| `POST`  | `/sys/policies/acl/:name` |
+| Method  | Path                      | Scope                                 |
+| :------ | :------------------------ | :------------------------------------ |
+| `POST`  | `/sys/policies/acl/:name` | Unspecified fields reset to defaults. |
+| `PATCH` | `/sys/policies/acl/:name` | Unspecified field values preserved.   |
 
 ### Parameters
 
@@ -84,7 +86,7 @@ updated, it takes effect immediately to all associated users.
   This is specified as part of the request URL.
 
 - `policy` `(string: <required>)` - Specifies the policy document. This can be
-  base64-encoded to avoid string escaping.
+  base64-encoded to avoid string escaping. Optional on patch commands.
 
 - `expiration` `(time: <optional>)` - Specifies an expiration time after which
   the policy will no longer be valid and will be removed on next load. Cannot
@@ -107,6 +109,16 @@ updated, it takes effect immediately to all associated users.
   a create/update operation, this parameter needs to reset to true on every
   subsequent operation for continued usage. When set to true, `cas` becomes
   a required parameter. Defaults to false.
+
+- `allow_wildcards_in_identity_templates` `(bool: false)` - When true, allows
+  wildcards in the output of evaluated identity templates. This occurs when
+  entity or group metadata contains reserved wildcard or glob characters (`+`
+  or `*`) which increase the scope of a specified policy.
+
+- `allow_slashes_in_identity_templates` `(bool: false)` - When true, allows
+  slashes (path separators) in the output of evaluated identity templates.
+  This occurs when entity or group metadata contains the literal value `/`,
+  which can allow path traversal in the specified policy.
 
 ### Sample payload
 

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -69,7 +69,7 @@ $ curl \
 }
 ```
 
-## Create/Update ACL policy
+## Create/Update/Patch ACL policy {#createupdate-acl-policy}
 
 This endpoint adds a new or updates an existing ACL policy. Once a policy is
 updated, it takes effect immediately to all associated users. New policies


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

```
    Fix policy persistence for template controls
    
    When serializing policies, Vault had implemented a pattern which
    separated the data layer (policy.Entry) from the usage layer
    (policy.Policy). The former manually copied fields from the latter which
    resulted in inconsistent serialization if care was not taken to update
    both.
    
    As we've added more fields, it makes less sense to keep the two
    separate especially as the rest of OpenBao does not adopt this pattern
    generally. Additionally the unused Version field was removed.
    
    This should prevent future issues of the same type.
```

```
    Add PATCH support to sys/policies/acl
    
    When the policy API was originally written, there was only one field in
    the object: policy. Since introducing more fields, we might want to
    modify policies without updating the actual contents of the policy and
    without overwriting defaults. Hence, PATCH support.
```

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3502

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
