### PR TITLE
Fix limit=0 and negative limits bypassing pagination_limit ACL cap

### DIFF
--- a/changelog/3518.txt
+++ b/changelog/3518.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/policies: Fix `limit=0` and negative limits bypassing the `pagination_limit` ACL option.
+```

--- a/internal/vault/external_tests/policy/policy_test.go
+++ b/internal/vault/external_tests/policy/policy_test.go
@@ -478,15 +478,12 @@ path "kv/metadata/" {
 	require.NotNil(t, resp.Data)
 	require.Equal(t, 10, len(resp.Data["keys"].([]interface{})))
 
-	// Test negative value.
-	resp, err = client.Logical().ReadWithData("kv/metadata/d", map[string][]string{
+	// Negative values are denied.
+	_, err = client.Logical().ReadWithData("kv/metadata/d", map[string][]string{
 		"list":  {"true"},
 		"limit": {"-1"},
 	})
-	require.NoError(t, err, "failed to list with limit=-1")
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.Data)
-	require.Equal(t, 10, len(resp.Data["keys"].([]interface{})))
+	require.Error(t, err, "expected failure to list with limit=-1")
 
 	// This endpoint has no limit.
 	resp, err = client.Logical().ReadWithData("kv/metadata/a", map[string][]string{

--- a/internal/vault/external_tests/policy/policy_test.go
+++ b/internal/vault/external_tests/policy/policy_test.go
@@ -468,6 +468,26 @@ path "kv/metadata/" {
 	require.NotNil(t, resp.Data)
 	require.Equal(t, 10, len(resp.Data["keys"].([]interface{})))
 
+	// Test '0' value.
+	resp, err = client.Logical().ReadWithData("kv/metadata/d", map[string][]string{
+		"list":  {"true"},
+		"limit": {"0"},
+	})
+	require.NoError(t, err, "failed to list with limit=0")
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, 10, len(resp.Data["keys"].([]interface{})))
+
+	// Test negative value.
+	resp, err = client.Logical().ReadWithData("kv/metadata/d", map[string][]string{
+		"list":  {"true"},
+		"limit": {"-1"},
+	})
+	require.NoError(t, err, "failed to list with limit=-1")
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, 10, len(resp.Data["keys"].([]interface{})))
+
 	// This endpoint has no limit.
 	resp, err = client.Logical().ReadWithData("kv/metadata/a", map[string][]string{
 		"list":  {"true"},

--- a/internal/vault/external_tests/policy/policy_test.go
+++ b/internal/vault/external_tests/policy/policy_test.go
@@ -483,7 +483,7 @@ path "kv/metadata/" {
 		"list":  {"true"},
 		"limit": {"-1"},
 	})
-	require.Error(t, err, "expected failure to list with limit=-1")
+	require.ErrorContains(t, err, "permission denied", "expected failure to list with limit=-1")
 
 	// This endpoint has no limit.
 	resp, err = client.Logical().ReadWithData("kv/metadata/a", map[string][]string{

--- a/internal/vault/policy/acl.go
+++ b/internal/vault/policy/acl.go
@@ -625,6 +625,11 @@ CHECK:
 					if val > permissions.PaginationLimit {
 						return ret
 					}
+					// Also check if the value is 0 or negative, since downstream
+					// list handlers are treating zero or negative limit as unbounded.
+					if val <= 0 {
+						req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
+					}
 				}
 			}
 		} else {

--- a/internal/vault/policy/acl.go
+++ b/internal/vault/policy/acl.go
@@ -625,9 +625,12 @@ CHECK:
 					if val > permissions.PaginationLimit {
 						return ret
 					}
-					// Also check if the value is 0 or negative, since downstream
-					// list handlers are treating zero or negative limit as unbounded.
-					if val <= 0 {
+					// Per PR discussion, deny negative limits
+					if val < 0 {
+						return ret
+					}
+					// And if the value is zero, we set it to the maximum allowed.
+					if val == 0 {
 						req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
 					}
 				}

--- a/internal/vault/policy/acl.go
+++ b/internal/vault/policy/acl.go
@@ -625,7 +625,7 @@ CHECK:
 					if val > permissions.PaginationLimit {
 						return ret
 					}
-					// Per PR discussion, deny negative limits
+					// deny negative limits
 					if val < 0 {
 						return ret
 					}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->
A policy sets pagination_limit on a list/scan path, but a caller with list access can pass limit=0 (or a negative) and get the full result set — the configured cap isn't enforced for non-positive values.


This PR fix this bug and added test for it.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3517

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
