### PR TITLE
Fix web UI cache path for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Set up UI cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: http/web_ui/
+          path: internal/http/web_ui
           key: ${{ github.ref }}-ui
 
       - name: Build UI
@@ -147,7 +147,7 @@ jobs:
       - name: Set up UI cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: http/web_ui/
+          path: internal/http/web_ui
           key: ${{ github.ref }}-ui
 
       - name: Install Syft
@@ -233,7 +233,7 @@ jobs:
       - name: Set up UI cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: http/web_ui/
+          path: internal/http/web_ui
           key: ${{ github.ref }}-ui
 
       - name: Make LICENSE_NODE_MODULES.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,7 @@ _testmain.go
 /bin
 
 # Generated Web UI goes here
-/http/web_ui/*.*
-/http/web_ui/**/*.*
+/internal/http/web_ui
 
 # OpenBao-specific
 example.hcl
@@ -52,7 +51,7 @@ Vagrantfile
 .idea
 .vscode
 
-dist/*
+/dist
 
 # ignore ctags
 ./tags

--- a/scripts/assetcheck.sh
+++ b/scripts/assetcheck.sh
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-if [[ ! -e http/web_ui/index.html ]]
+if [[ ! -e internal/http/web_ui/index.html ]]
 then
   printf "Compiled UI assets not found. They can be built with: make static-dist\n\n"
   exit 1
 else
-  if [[ `find http/web_ui/index.html -mmin +10080` ]]
+  if [[ `find internal/http/web_ui/index.html -mmin +10080` ]]
   then
     printf "Compiled UI assets are more than one week old. They can be rebuilt with: make static-dist\n\n"
     exit 1

--- a/ui/lib/keep-gitkeep/index.js
+++ b/ui/lib/keep-gitkeep/index.js
@@ -13,8 +13,8 @@ module.exports = {
   },
 
   postBuild(result) {
-    // We gitignore the contents of our output directory http/web_ui
-    // but we need to keep the folder structure for the Vault build
+    // We gitignore the contents of our output directory internal/http/web_ui
+    // but we need to keep the folder structure for the Vault build.
     fs.writeFileSync(result.directory + '/.gitkeep', '');
   },
 };


### PR DESCRIPTION
## Description

Missed this one, breaks nightlies on main. Not present on any other branch.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
