### PR TITLE
Fix Test_RandomOpsTransactionalBackends

### DIFF
--- a/internal/vault/barrier/aes_gcm.go
+++ b/internal/vault/barrier/aes_gcm.go
@@ -1065,7 +1065,11 @@ func (b *AESGCMBarrier) decrypt(path string, gcm cipher.AEAD, cipher []byte) ([]
 	}
 
 	raw := cipher[5:]
-	var out []byte
+
+	// Pass a zero-length slice to gcm.Open to ensure that empty data decrypts
+	// to an empty slice opposed to a nil slice, which is consistent with other
+	// implementations of logical.Storage.
+	out := []byte{}
 
 	// Attempt to open
 	switch cipher[4] {


### PR DESCRIPTION
## Description

`var out []byte` creates a `nil` slice that is returned directly by `gcm.Open` if the passed data is empty. Before https://github.com/openbao/openbao/pull/3290, the barrier would always return at least a zero-size slice, which is consistent with other backends as asserted in the test.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
