### PR TITLE
Make KMS plugin catalog available to core

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,9 @@ linters:
     - misspell
   settings:
     cyclop:
-      # Lower cyclomatic complexity threshold after the max complexity is lowered
-      # 135 -> 124
-      # Highest: (*ServerCommand).Run (123) in command/server.go
-      max-complexity: 124
+      # Lower cyclomatic complexity threshold after the max complexity is lowered.
+      # Highest: (*ServerCommand).Run (126) in internal/command/server.go
+      max-complexity: 126
 formatters:
   enable:
     - gofumpt

--- a/internal/command/operator_diagnose.go
+++ b/internal/command/operator_diagnose.go
@@ -479,7 +479,7 @@ SEALFAIL:
 		return nil
 	})
 
-	coreConfig := createCoreConfig(server, config, *backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
+	coreConfig := createCoreConfig(server, config, *backend, configSR, barrierSeal, unwrapSeal, kms, metricsHelper, metricSink)
 
 	var disableClustering bool
 	_ = diagnose.Test(ctx, "HA Storage", func(ctx context.Context) error {

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -502,13 +502,14 @@ func (c *ServerCommand) runRecoveryMode() int {
 	}()
 
 	coreConfig := &vault.CoreConfig{
-		Physical:     backend,
-		StorageType:  config.Storage.Type,
-		Seal:         seal,
-		LogLevel:     config.LogLevel,
-		Logger:       c.logger,
-		RecoveryMode: c.flagRecovery,
-		ClusterAddr:  config.ClusterAddr,
+		Physical:         backend,
+		StorageType:      config.Storage.Type,
+		Seal:             seal,
+		KMSPluginCatalog: kms,
+		LogLevel:         config.LogLevel,
+		Logger:           c.logger,
+		RecoveryMode:     c.flagRecovery,
+		ClusterAddr:      config.ClusterAddr,
 	}
 
 	core, newCoreError := vault.NewCore(coreConfig)
@@ -1124,7 +1125,7 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, metricsHelper, metricSink)
+	coreConfig := createCoreConfig(c, config, backend, configSR, barrierSeal, unwrapSeal, kms, metricsHelper, metricSink)
 	if c.flagDevThreeNode {
 		return c.enableThreeNodeDevCluster(&coreConfig, info, infoKeys, api.ReadBaoVariable("BAO_DEV_TEMP_DIR"))
 	}
@@ -2763,7 +2764,7 @@ func runUnseal(c *ServerCommand, core *vault.Core, sealShutdownCh chan<- struct{
 }
 
 func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.Backend, configSR sr.ServiceRegistration, barrierSeal, unwrapSeal vault.Seal,
-	metricsHelper *metricsutil.MetricsHelper, metricSink *metricsutil.ClusterMetricSink,
+	kmsPluginCatalog *kmsplugin.Catalog, metricsHelper *metricsutil.MetricsHelper, metricSink *metricsutil.ClusterMetricSink,
 ) vault.CoreConfig {
 	coreConfig := &vault.CoreConfig{
 		RawConfig:                      config,
@@ -2774,6 +2775,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		ServiceRegistration:            configSR,
 		Seal:                           barrierSeal,
 		UnwrapSeal:                     unwrapSeal,
+		KMSPluginCatalog:               kmsPluginCatalog,
 		AuditBackends:                  c.AuditBackends,
 		CredentialBackends:             c.CredentialBackends,
 		LogicalBackends:                c.LogicalBackends,

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openbao/openbao/v2/internal/command/server"
 	fwd "github.com/openbao/openbao/v2/internal/helper/forwarding"
 	"github.com/openbao/openbao/v2/internal/helper/identity"
+	"github.com/openbao/openbao/v2/internal/helper/kmsplugin"
 	"github.com/openbao/openbao/v2/internal/helper/locking"
 	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
@@ -497,6 +498,9 @@ type Core struct {
 	// pluginCatalog is used to manage plugin configurations
 	pluginCatalog *PluginCatalog
 
+	// kmsPluginCatalog provides KMS plugin functionality
+	kmsPluginCatalog *kmsplugin.Catalog
+
 	// The userFailedLoginInfo map has user failed login information.
 	// It has user information (alias-name and mount accessor) as a key
 	// and login counter, last failed login time as value
@@ -682,6 +686,10 @@ type CoreConfig struct {
 	// Unwrap seal is the optional seal marked "disabled"; this is the old
 	// seal in migration scenarios.
 	UnwrapSeal Seal
+
+	// KMSPluginCatalog is used to create any root-level seals and is then
+	// passed on to Core to power External Keys and per-namespace Auto Seals.
+	KMSPluginCatalog *kmsplugin.Catalog
 
 	LogLevel string
 
@@ -929,6 +937,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		shutdownDoneCh:                 new(atomic.Value),
 		allLoggers:                     conf.AllLoggers,
 		builtinRegistry:                conf.BuiltinRegistry,
+		kmsPluginCatalog:               conf.KMSPluginCatalog,
 		metricsHelper:                  conf.MetricsHelper,
 		metricSink:                     conf.MetricSink,
 		recoveryMode:                   conf.RecoveryMode,


### PR DESCRIPTION
## Description

Pass the KMS plugin catalog that's already used to initialize Auto Seals on startup on to core.

## Rationale

This will be used to create instances of `kms.KMS` for External Keys and to create instances of `wrapping.Wrapper` for per-namespace Auto Unseals within core.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
