### PR TITLE
Don't read BAO_WRAP_TTL if DisableEnvironment is set

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1326,11 +1326,16 @@ func (c *Client) SetPolicyOverride(override bool) {
 // doesn't need to be called externally.
 func (c *Client) NewRequest(method, requestPath string) *Request {
 	c.modifyLock.RLock()
+	c.config.modifyLock.RLock()
+
 	addr := c.addr
 	token := c.token
 	mfaCreds := c.mfaCreds
 	wrappingLookupFunc := c.wrappingLookupFunc
 	policyOverride := c.policyOverride
+	disableEnvironment := c.config.DisableEnvironment
+
+	c.config.modifyLock.RUnlock()
 	c.modifyLock.RUnlock()
 
 	host := addr.Host
@@ -1371,6 +1376,8 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 
 	if wrappingLookupFunc != nil {
 		req.WrapTTL = wrappingLookupFunc(method, lookupPath)
+	} else if disableEnvironment {
+		req.WrapTTL = BaseWrappingLookupFunc(method, lookupPath)
 	} else {
 		req.WrapTTL = DefaultWrappingLookupFunc(method, lookupPath)
 	}

--- a/api/logical.go
+++ b/api/logical.go
@@ -23,14 +23,22 @@ var (
 	// changed
 	DefaultWrappingTTL = "5m"
 
-	// The default function used if no other function is set. It honors the env
-	// var to set the wrap TTL. The default wrap TTL will apply when when writing
-	// to `sys/wrapping/wrap` when the env var is not set.
+	// DefaultWrappingLookupFunc is the default function used if no other
+	// function is set and environment access isn't disabled, honoring the
+	// BAO_WRAP_TTL variable. The default wrap TTL will apply when when writing
+	// to `sys/wrapping/wrap` when the environment variable is not set.
 	DefaultWrappingLookupFunc = func(operation, path string) string {
-		if ReadBaoVariable(EnvVaultWrapTTL) != "" {
-			return ReadBaoVariable(EnvVaultWrapTTL)
+		if env := ReadBaoVariable(EnvVaultWrapTTL); env != "" {
+			return env
 		}
 
+		return BaseWrappingLookupFunc(operation, path)
+	}
+
+	// BaseWrappingLookupFunc is the default function used if no other function
+	// is set and env access is disabled. DefaultWrappingLookupFunc calls into
+	// this function if no environment variable was set.
+	BaseWrappingLookupFunc = func(operation, path string) string {
 		if (operation == http.MethodPut || operation == http.MethodPost) && path == "sys/wrapping/wrap" {
 			return DefaultWrappingTTL
 		}

--- a/changelog/3527.txt
+++ b/changelog/3527.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Don't read `BAO_WRAP_TTL` to determine a request's wrap TTL if `DisableEnvironment` is set.
+```


### PR DESCRIPTION
## Description

This plugs up the final hole (that I could find?) not yet covered by `DisableEnvironment`.

## Rationale

Related:
- https://github.com/openbao/go-kms-wrapping/pull/83#discussion_r3079358886
- https://github.com/openbao/go-kms-wrapping/issues/110

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
