### PR TITLE
Automatic reload of TLS certificate files without SIGHUP signal

### DIFF
--- a/changelog/3530.txt
+++ b/changelog/3530.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/server: Add `tls_auto_reload` configuration option to automatically reload TLS certificate and key files when their contents change, without requiring `SIGHUP`.
+```

--- a/internal/command/agent.go
+++ b/internal/command/agent.go
@@ -499,7 +499,7 @@ func (c *AgentCommand) Run(args []string) int {
 			}
 			ln = inProcListener
 		} else {
-			lnBundle, err := cache.StartListener(lnConfig)
+			lnBundle, err := cache.StartListener(lnConfig, c.logger)
 			if err != nil {
 				c.UI.Error(fmt.Sprintf("Error starting listener: %v", err))
 				return 1

--- a/internal/command/agentproxyshared/cache/listener.go
+++ b/internal/command/agentproxyshared/cache/listener.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
 	"github.com/openbao/openbao/v2/internal/command/server"
 	"github.com/openbao/openbao/v2/internal/helper/configutil"
@@ -22,7 +23,7 @@ type ListenerBundle struct {
 	TLSReloadFunc reloadutil.ReloadFunc
 }
 
-func StartListener(lnConfig *configutil.Listener) (*ListenerBundle, error) {
+func StartListener(lnConfig *configutil.Listener, logger hclog.Logger) (*ListenerBundle, error) {
 	addr := lnConfig.Address
 
 	var ln net.Listener
@@ -73,6 +74,14 @@ func StartListener(lnConfig *configutil.Listener) (*ListenerBundle, error) {
 	}
 	if tlsConf != nil {
 		ln = tls.NewListener(ln, tlsConf)
+	}
+
+	if lnConfig.TLSAutoReload && lnConfig.TLSCertFile != "" && cg != nil {
+		paths := []string{lnConfig.TLSCertFile}
+		if lnConfig.TLSKeyFile != "" {
+			paths = append(paths, lnConfig.TLSKeyFile)
+		}
+		ln = listenerutil.NewTLSReloadListener(ln, paths, lnConfig.TLSAutoReloadInterval, cg.Reload, logger)
 	}
 
 	cfg := &ListenerBundle{

--- a/internal/command/agentproxyshared/cache/listener_test.go
+++ b/internal/command/agentproxyshared/cache/listener_test.go
@@ -51,7 +51,7 @@ func servedCertName(addr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	return conn.ConnectionState().PeerCertificates[0].Subject.CommonName, nil
 }
 

--- a/internal/command/agentproxyshared/cache/listener_test.go
+++ b/internal/command/agentproxyshared/cache/listener_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package cache
+
+import (
+	"crypto/tls"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/openbao/openbao/v2/internal/helper/configutil"
+	"github.com/stretchr/testify/require"
+)
+
+const reloadFixturesDir = "../../server/test-fixtures/reload/"
+
+func TestStartListener_TLSAutoReloadServesRotatedCertWithoutRestart(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	installCertPair(t, "foo", certPath, keyPath)
+
+	bundle, err := StartListener(&configutil.Listener{
+		Type:                  "tcp",
+		Address:               "127.0.0.1:0",
+		TLSCertFile:           certPath,
+		TLSKeyFile:            keyPath,
+		TLSAutoReload:         true,
+		TLSAutoReloadInterval: 50 * time.Millisecond,
+	}, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	ln := bundle.Listener
+	t.Cleanup(func() { _ = ln.Close() })
+	go serveTLSHandshakes(ln)
+
+	installCertPair(t, "bar", certPath, keyPath)
+
+	require.Eventually(t, func() bool {
+		certName, err := servedCertName(ln.Addr().String())
+		return err == nil && certName == "bar.example.com"
+	}, 3*time.Second, 50*time.Millisecond, "cert was not auto-reloaded")
+}
+
+func servedCertName(addr string) (string, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return conn.ConnectionState().PeerCertificates[0].Subject.CommonName, nil
+}
+
+func serveTLSHandshakes(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			_ = conn.(*tls.Conn).Handshake()
+			_ = conn.Close()
+		}()
+	}
+}
+
+func installCertPair(t *testing.T, fixtureName, certPath, keyPath string) {
+	t.Helper()
+	copyFile(t, reloadFixturesDir+"reload_"+fixtureName+".pem", certPath)
+	copyFile(t, reloadFixturesDir+"reload_"+fixtureName+".key", keyPath)
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	content, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst+".tmp", content, 0o600))
+	require.NoError(t, os.Rename(dst+".tmp", dst))
+}

--- a/internal/command/proxy.go
+++ b/internal/command/proxy.go
@@ -476,7 +476,7 @@ func (c *ProxyCommand) Run(args []string) int {
 			}
 			ln = inProcListener
 		} else {
-			lnBundle, err := cache.StartListener(lnConfig)
+			lnBundle, err := cache.StartListener(lnConfig, c.logger)
 			if err != nil {
 				c.UI.Error(fmt.Sprintf("Error starting listener: %v", err))
 				return 1

--- a/internal/command/server/listener_tcp.go
+++ b/internal/command/server/listener_tcp.go
@@ -74,6 +74,14 @@ func tcpListenerFactory(l *configutil.Listener, logger hclog.Logger, ui cli.Ui) 
 		ln = tls.NewListener(ln, tlsConfig)
 	}
 
+	if l.TLSAutoReload && l.TLSCertFile != "" && cg != nil {
+		paths := []string{l.TLSCertFile}
+		if l.TLSKeyFile != "" {
+			paths = append(paths, l.TLSKeyFile)
+		}
+		ln = listenerutil.NewTLSReloadListener(ln, paths, l.TLSAutoReloadInterval, cg.Reload, logger)
+	}
+
 	return ln, props, cg, nil
 }
 

--- a/internal/helper/configutil/listener.go
+++ b/internal/helper/configutil/listener.go
@@ -71,17 +71,21 @@ type Listener struct {
 	TLSDisableRaw any  `hcl:"tls_disable"`
 	TLSCertGetter any  `hcl:"-"`
 
-	TLSCertFile                      string   `hcl:"tls_cert_file"`
-	TLSKeyFile                       string   `hcl:"tls_key_file"`
-	TLSMinVersion                    string   `hcl:"tls_min_version"`
-	TLSMaxVersion                    string   `hcl:"tls_max_version"`
-	TLSCipherSuites                  []uint16 `hcl:"-"`
-	TLSCipherSuitesRaw               string   `hcl:"tls_cipher_suites"`
-	TLSRequireAndVerifyClientCert    bool     `hcl:"-"`
-	TLSRequireAndVerifyClientCertRaw any      `hcl:"tls_require_and_verify_client_cert"`
-	TLSClientCAFile                  string   `hcl:"tls_client_ca_file"`
-	TLSDisableClientCerts            bool     `hcl:"-"`
-	TLSDisableClientCertsRaw         any      `hcl:"tls_disable_client_certs"`
+	TLSCertFile                      string        `hcl:"tls_cert_file"`
+	TLSKeyFile                       string        `hcl:"tls_key_file"`
+	TLSMinVersion                    string        `hcl:"tls_min_version"`
+	TLSMaxVersion                    string        `hcl:"tls_max_version"`
+	TLSCipherSuites                  []uint16      `hcl:"-"`
+	TLSCipherSuitesRaw               string        `hcl:"tls_cipher_suites"`
+	TLSRequireAndVerifyClientCert    bool          `hcl:"-"`
+	TLSRequireAndVerifyClientCertRaw any           `hcl:"tls_require_and_verify_client_cert"`
+	TLSClientCAFile                  string        `hcl:"tls_client_ca_file"`
+	TLSDisableClientCerts            bool          `hcl:"-"`
+	TLSDisableClientCertsRaw         any           `hcl:"tls_disable_client_certs"`
+	TLSAutoReload                    bool          `hcl:"-"`
+	TLSAutoReloadRaw                 any           `hcl:"tls_auto_reload"`
+	TLSAutoReloadInterval            time.Duration `hcl:"-"`
+	TLSAutoReloadIntervalRaw         any           `hcl:"tls_auto_reload_interval"`
 
 	TLSACMECachePath               string   `hcl:"tls_acme_cache_path"`
 	TLSACMECADirectory             string   `hcl:"tls_acme_ca_directory"`
@@ -334,6 +338,32 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				}
 
 				l.TLSDisableClientCertsRaw = nil
+			}
+
+			if l.TLSAutoReloadRaw != nil {
+				if l.TLSAutoReload, err = parseutil.ParseBool(l.TLSAutoReloadRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("invalid value for tls_auto_reload: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.TLSAutoReloadRaw = nil
+			}
+
+			if l.TLSAutoReloadIntervalRaw != nil {
+				if l.TLSAutoReloadInterval, err = parseutil.ParseDurationSecond(l.TLSAutoReloadIntervalRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("error parsing tls_auto_reload_interval: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				if l.TLSAutoReloadInterval < 5*time.Second {
+					return multierror.Prefix(fmt.Errorf("tls_auto_reload_interval must be at least 5s"), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.TLSAutoReloadIntervalRaw = nil
+			} else if l.TLSAutoReload {
+				l.TLSAutoReloadInterval = 30 * time.Second
+			}
+
+			if l.TLSAutoReload && l.TLSCertFile == "" {
+				return multierror.Prefix(fmt.Errorf("tls_auto_reload requires tls_cert_file"), fmt.Sprintf("listeners.%d", i))
 			}
 		}
 

--- a/internal/helper/listenerutil/tls_autoreload.go
+++ b/internal/helper/listenerutil/tls_autoreload.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package listenerutil
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func NewTLSReloadListener(ln net.Listener, paths []string, interval time.Duration, reload func() error, logger hclog.Logger) net.Listener {
+	wg := &sync.WaitGroup{}
+	stop := make(chan struct{})
+	wg.Go(func() {
+		pollTLSCertificateChanges(paths, interval, reload, stop, logger)
+	})
+	return &tlsReloadListener{Listener: ln, wg: wg, stop: stop}
+}
+
+type tlsReloadListener struct {
+	net.Listener
+	wg   *sync.WaitGroup
+	stop chan struct{}
+}
+
+func (l *tlsReloadListener) Close() error {
+	close(l.stop)
+	l.wg.Wait()
+	return l.Listener.Close()
+}
+
+func pollTLSCertificateChanges(paths []string, interval time.Duration, reload func() error, stopCh <-chan struct{}, logger hclog.Logger) {
+	hash := func() []byte {
+		h := sha256.New()
+		for _, p := range paths {
+			data, err := os.ReadFile(p)
+			if err != nil {
+				logger.Warn("tls auto-reload: cannot read file", "path", p, "error", err)
+				continue
+			}
+			h.Write(data)
+		}
+		return h.Sum(nil)
+	}
+
+	last := hash()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			current := hash()
+			if bytes.Equal(current, last) {
+				continue
+			}
+
+			if err := reload(); err != nil {
+				logger.Warn("tls auto-reload: reload failed, keeping previous certificate", "error", err)
+				continue
+			}
+
+			last = current
+			logger.Info("tls auto-reload: reloaded TLS certificate", "paths", paths)
+		}
+	}
+}

--- a/internal/helper/listenerutil/tls_autoreload_test.go
+++ b/internal/helper/listenerutil/tls_autoreload_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package listenerutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollTLSCertificateChanges(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "tls.crt")
+	key := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(cert, []byte("cert-v1"), 0o600))
+	require.NoError(t, os.WriteFile(key, []byte("key-v1"), 0o600))
+
+	reloaded := make(chan struct{}, 10)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	go pollTLSCertificateChanges([]string{cert, key}, 10*time.Millisecond, func() error {
+		reloaded <- struct{}{}
+		return nil
+	}, stopCh, hclog.NewNullLogger())
+
+	// Unchanged files must not trigger a reload.
+	select {
+	case <-reloaded:
+		t.Fatal("reload triggered without file change")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A content change must trigger exactly one reload.
+	tmp := filepath.Join(dir, "tls.crt.tmp")
+	require.NoError(t, os.WriteFile(tmp, []byte("cert-v2"), 0o600))
+	require.NoError(t, os.Rename(tmp, cert))
+	select {
+	case <-reloaded:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload not triggered after file change")
+	}
+	select {
+	case <-reloaded:
+		t.Fatal("reload triggered twice for a single change")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -159,7 +159,18 @@ default value in the `"/sys/config/ui"` [API endpoint](/api-docs/system/config-u
   startup_ will be used for reloading the certificate; modifying this value
   while OpenBao is running will have no effect for `SIGHUP`s.
 
-- `tls_min_version` `(string: "tls12")` – Specifies the minimum supported
+- `tls_auto_reload` `(bool: false)`: When enabled, OpenBao periodically checks
+  the `tls_cert_file` and `tls_key_file` paths and automatically reloads the
+  certificate and key when their contents change, without requiring a `SIGHUP`.
+  Requires `tls_cert_file` to be set. This is useful when certificates are
+  rotated by an external tool such as cert-manager.
+
+- `tls_auto_reload_interval` `(string: "30s")`: Specifies how often OpenBao
+  polls the certificate files for changes when `tls_auto_reload` is enabled.
+  Accepts a Go duration string (e.g. `"1m"`) or an integer number of seconds.
+  The minimum accepted value is `5s`.
+
+- `tls_min_version` `(string: "tls12")` Specifies the minimum supported
   version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13".
 
   :::warning


### PR DESCRIPTION
## Description

The TCP listener loads tls_cert_file and tls_key_file only once at startup and rereads them only when the process receives a SIGHUP signal. The reload mechanism works well, but its activation still depends on a trigger external to the process.

In Kubernetes, where certificates are generally issued by cert-manager and mounted from a Secret volume, this requires setting up your own mechanism, such as a CronJob or a sidecar container that monitors the certificate files in order to send a SIGHUP signal.

This reduces process isolation between containers with configurations such as `shareProcessNamespace: true`; see: https://github.com/openbao/openbao-helm/blob/e926cc75f9ca4e024a78a4a38c3d66f060d57d16/charts/openbao/values.yaml#L614. The comment relating to `extraContainers` in the Helm chart even suggests this model, but each deployment has to reimplement it: https://github.com/openbao/openbao-helm/blob/e926cc75f9ca4e024a78a4a38c3d66f060d57d16/charts/openbao/values.yaml#L610.

Missing a renewal signal can have significant consequences: with short-lived certificates, TLS handshakes may fail as soon as their cached certificate authority no longer matches the certificate presented by the server. Restarting the pod is not a neutral solution either: with Shamir unsealing, every restart requires a manual unseal.

### Reproduction


To make the work easier, I’ve created a test folder with a readme file describing the steps and showing how to reproduce the changes made:
https://github.com/clement-software/openbao-testbench-tls-autoreload

1. Start bao server with tls_cert_file and tls_key_file.
2. Replace both files with a new certificate pair.
3. Open a TLS connection: the **old** certificate is still presented until an operator sends a `SIGHUP` signal.

### Solution

Add an optional periodic polling mechanism that reuses the existing reload path. When enabled, the server calculates the fingerprints of the configured certificate and key files at a fixed interval and, when a change is detected, calls the same CertificateGetter.Reload method that is already registered for SIGHUP. The behaviour of SIGHUP remains unchanged.

```hcl
listener "tcp" {
  tls_cert_file            = "/openbao/tls/tls.crt"
  tls_key_file             = "/openbao/tls/tls.key"

  tls_auto_reload          = true    # default value: false
  tls_auto_reload_interval = "30s"   # default value: 30 s, minimum: 5 s
}
```

As PEM files are small, calculating their fingerprints every 30 seconds using polling to compare two hashes is a solution with a low resource cost.

Error handling: if a reload fails, for example in the event of a partial update where the certificate is written before the key, the previous certificate continues to be presented, a warning is logged, and another attempt is made during the next cycle. Reload replaces the presented certificate only after `tls.X509KeyPair` succeeds. An invalid state on disk can therefore never make the listener unavailable.

### Out of scope

* tls_client_ca_file is not monitored: it is incorporated into tls.Config.ClientCAs at startup and is not currently reloaded, even by SIGHUP. Making it reloadable requires a separate change using GetConfigForClient.

### Tests

* Unit test covering the following cases: no reload while the files remain unchanged, then exactly one reload after the certificate file is replaced.
* Manual test: repeat the reproduction procedure above with `tls_auto_reload = true`. The new certificate is presented within a maximum period corresponding to one interval, without sending signal SIGHUP.

## Rationale

This change removes the need for an external mechanism to trigger TLS certificate reloads in Kubernetes deployments, while preserving the existing SIGHUP behaviour.

Related prior work: PR #3038 added `SIGHUP`-based client-side TLS reloading in the agent. This change is complementary: it targets the server listener and removes the need for an external trigger.

There is this request: https://github.com/openbao/openbao/issues/3189 which my implementation could address, regarding: OpenBao could also periodically rotate the certificate.

Resolves: https://github.com/openbao/openbao/issues/3533

## Acknowledgements

* [ X] By contributing this change, I certify I have not used generative AI
  (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
  filling out the pull request description or associated issue.
* [X ] By contributing this change, I certify I have signed-off on the
  [[DCO ownership](https://developercertificate.org/)](https://developercertificate.org/) statement
  and this change did not use post-BUSL-licensed code from HashiCorp.
  Existing MPL-licensed code is still allowed, subject to attribution.
  Code authored by yourself and submitted to HashiCorp for inclusion is
  also allowed.