### PR TITLE
Import hclog in plugin example

### DIFF
--- a/website/content/docs/plugins/plugin-development.mdx
+++ b/website/content/docs/plugins/plugin-development.mdx
@@ -63,6 +63,7 @@ package main
 import (
 	"os"
 
+	hclog "github.com/hashicorp/go-hclog"
 	myPlugin "your/plugin/import/path"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/plugin"


### PR DESCRIPTION
## Description

This adds a missing import in the plugin development example.

## Rationale

`hclog` is used but not defined in the example.  This is the import used for example in the [aws auth plugin](https://github.com/openbao/openbao-plugins/blob/auth-aws-v0.1.1/auth/aws/cmd/main.go#L9).

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
