### PR TITLE
Allow all log messages in multiplexed plugins

### DIFF
--- a/changelog/3536.txt
+++ b/changelog/3536.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/plugin: Ensure all log messages are visible under `plugin.ServeMultiplex(...)` by default to align with `plugin.Serve(...)`.
+```

--- a/sdk/plugin/serve.go
+++ b/sdk/plugin/serve.go
@@ -97,7 +97,7 @@ func ServeMultiplex(opts *ServeOpts) error {
 	logger := opts.Logger
 	if logger == nil {
 		logger = log.New(&log.LoggerOptions{
-			Level:      log.Info,
+			Level:      log.Trace,
 			Output:     os.Stderr,
 			JSONFormat: true,
 		})


### PR DESCRIPTION
In 07927e036ce96efe1f75d09cafab1e9f3558a194, multiplexed plugin serving was added. This brought a discrepancy with non-multiplexed plugins in that the log level was limited to info by default. Align this back to trace so all log messages are visible.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
