### PR TITLE
Add tests for GRPC invalidation with PostgreSQL

### DIFF
--- a/internal/physical/postgresql/postgresql_test.go
+++ b/internal/physical/postgresql/postgresql_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/helper/testhelpers/postgresql"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -798,4 +799,43 @@ func TestPostgreSQLBackend_ParallelTables(t *testing.T) {
 	logger.Info("Running basic backend tests")
 	physical.ExerciseBackend(t, b1)
 	physical.ExerciseBackend(t, b2)
+}
+
+func TestPostgreSQLBackend_Clustered(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	primary, secondary, cleanup := GetTestReplicatedPostgreSQLBackend(t, "clustered", logger)
+	defer cleanup()
+
+	logger.Info("Running basic backend tests")
+	physical.ExerciseBackend(t, primary)
+
+	logger.Info("Ensuring cross-node data visibility")
+	err := primary.Put(t.Context(), &physical.Entry{
+		Key:   "foo",
+		Value: []byte("testing"),
+	})
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		contents, err := secondary.List(t.Context(), "")
+		require.NoError(collect, err)
+		require.Contains(collect, contents, "foo")
+
+		entry, err := secondary.Get(t.Context(), "foo")
+		require.NoError(collect, err)
+		require.Equal(collect, entry.Value, []byte("testing"))
+
+		primaryIndex, err := primary.(physical.ReplicationIndexBackend).AppliedReplicationIndex(t.Context())
+		require.NoError(collect, err)
+
+		secondaryIndex, err := secondary.(physical.ReplicationIndexBackend).AppliedReplicationIndex(t.Context())
+		require.NoError(collect, err)
+
+		require.Equal(collect, primaryIndex, secondaryIndex)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	t.Logf("done")
 }

--- a/internal/physical/postgresql/testing.go
+++ b/internal/physical/postgresql/testing.go
@@ -85,3 +85,28 @@ func GetTestPostgreSQLBackend(t *testing.T, logger log.Logger) (physical.Backend
 
 	return pg, cleanup
 }
+
+func GetTestReplicatedPostgreSQLBackend(t *testing.T, name string, logger log.Logger) (physical.Backend, physical.Backend, func()) {
+	cfg := thpsql.DefaultClusterConfig(name)
+	cluster, err := cfg.NewCluster(t.Context())
+	require.NoError(t, err)
+
+	replica, err := cluster.AddNode(t.Context())
+	require.NoError(t, err)
+
+	primaryBackend, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": cluster.Primary.ConnectionURL,
+		"ha_enable":      "true",
+	}, logger)
+	require.NoError(t, err, "failed initializing postgres database")
+
+	SetupDatabaseObjects(t, primaryBackend.(*PostgreSQLBackend))
+
+	replicaBackend, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url": replica.ConnectionURL,
+		"ha_enable":      "true",
+	}, logger)
+	require.NoError(t, err, "failed initializing postgres database")
+
+	return primaryBackend, replicaBackend, cluster.Cleanup
+}

--- a/internal/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/internal/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -337,25 +337,22 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 	pLogger := logger.Named("postgresql-cluster")
 	cLogger := logger.Named("openbao-cluster")
 
-	var returned atomic.Int32
-	var nodesOnPrimary int32 = 2
-
-	mapper := func(ctx context.Context, cluster *thpsql.Cluster) (string, error) {
-		index := returned.Add(1)
-		if index <= nodesOnPrimary {
-			return cluster.Primary.InternalURL(ctx)
+	nodesOnPrimary := 2
+	mapper := func(ctx context.Context, cluster *thpsql.Cluster, index int) (*thpsql.Node, error) {
+		if index < nodesOnPrimary {
+			return cluster.Primary, nil
 		}
 
-		if index == nodesOnPrimary+1 {
+		if index == nodesOnPrimary {
 			node, err := cluster.AddNode(ctx)
 			if err != nil {
-				return "", fmt.Errorf("failed to add replica: %w", err)
+				return nil, fmt.Errorf("failed to add replica: %w", err)
 			}
 
-			return node.InternalURL(ctx)
+			return node, nil
 		}
 
-		return cluster.Nodes[1].InternalURL(ctx)
+		return cluster.Nodes[1], nil
 	}
 
 	pCluster, err := docker.NewPostgreSQLClusterStorage(t.Context(), pLogger, "scalability", "", mapper)

--- a/internal/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/internal/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -10,12 +10,15 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster/docker"
+	thpsql "github.com/openbao/openbao/sdk/v2/helper/testhelpers/postgresql"
 	"github.com/openbao/openbao/sdk/v2/physical"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -137,8 +140,6 @@ func TestPostgreSQL_FencedWrites(t *testing.T) {
 }
 
 func TestPostgreSQL_ParallelInit(t *testing.T) {
-	t.Parallel()
-
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("missing $BAO_BINARY")
@@ -204,8 +205,6 @@ func TestPostgreSQL_ParallelInit(t *testing.T) {
 }
 
 func TestPostgreSQL_FatalInit(t *testing.T) {
-	t.Parallel()
-
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("missing $BAO_BINARY")
@@ -259,8 +258,6 @@ func TestPostgreSQL_FatalInit(t *testing.T) {
 }
 
 func TestPostgreSQL_Upgrade(t *testing.T) {
-	t.Parallel()
-
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
 		t.Skip("missing $BAO_BINARY")
@@ -297,10 +294,12 @@ func TestPostgreSQL_Upgrade(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to mount kv")
 
-	_, err = client.KVv2("kv").Put(t.Context(), "a/key", map[string]any{
-		"value": "known-value",
-	})
-	require.NoError(t, err, "failed writing k/v key")
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err = client.KVv2("kv").Put(t.Context(), "a/key", map[string]any{
+			"value": "known-value",
+		})
+		require.NoError(collect, err, "failed writing k/v key")
+	}, 10*time.Second, 100*time.Millisecond)
 
 	// Now upgrade the nodes one at a time.
 	opts.VaultBinary = binary
@@ -326,4 +325,229 @@ func TestPostgreSQL_Upgrade(t *testing.T) {
 	value, err := client.KVv2("kv").Get(t.Context(), "a/key")
 	require.NoError(t, err, "failed reading k/v key")
 	require.Equal(t, value.Data["value"], "known-value")
+}
+
+func TestPostgreSQL_Scalability(t *testing.T) {
+	binary := api.ReadBaoVariable("BAO_BINARY")
+	if binary == "" {
+		t.Skip("missing $BAO_BINARY")
+	}
+
+	logger := logging.NewVaultLogger(log.Trace).Named(t.Name())
+	pLogger := logger.Named("postgresql-cluster")
+	cLogger := logger.Named("openbao-cluster")
+
+	var returned atomic.Int32
+	var nodesOnPrimary int32 = 2
+
+	mapper := func(ctx context.Context, cluster *thpsql.Cluster) (string, error) {
+		index := returned.Add(1)
+		if index <= nodesOnPrimary {
+			return cluster.Primary.InternalURL(ctx)
+		}
+
+		if index == nodesOnPrimary+1 {
+			node, err := cluster.AddNode(ctx)
+			if err != nil {
+				return "", fmt.Errorf("failed to add replica: %w", err)
+			}
+
+			return node.InternalURL(ctx)
+		}
+
+		return cluster.Nodes[1].InternalURL(ctx)
+	}
+
+	pCluster, err := docker.NewPostgreSQLClusterStorage(t.Context(), pLogger, "scalability", "", mapper)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, pCluster.Cleanup()) }()
+
+	opts := &docker.DockerClusterOptions{
+		ImageRepo:   "quay.io/openbao/openbao",
+		ImageTag:    "latest",
+		Storage:     pCluster,
+		VaultBinary: binary,
+		ClusterOptions: testcluster.ClusterOptions{
+			VaultNodeConfig: &testcluster.VaultNodeConfig{
+				// Audit logs help with debugging.
+				AuditLogStdout:      true,
+				LogLevel:            "TRACE",
+				DisableStandbyReads: false,
+			},
+			ClusterName: "psql-upgrade",
+			NumCores:    3,
+			Logger:      cLogger,
+		},
+	}
+
+	cluster := docker.NewTestDockerCluster(t, opts)
+	defer cluster.Cleanup()
+
+	nodes := cluster.Nodes()
+	client := nodes[0].APIClient()
+
+	t.Logf("token: %v vs %v", client.Token(), cluster.GetRootToken())
+
+	// Create some data to test persistence.
+	err = client.Sys().Mount("kv", &api.MountInput{
+		Type: "kv",
+		Options: map[string]string{
+			"version": "2",
+		},
+	})
+	require.NoError(t, err, "failed to mount kv")
+
+	_, err = client.KVv2("kv").Put(t.Context(), "a/key", map[string]any{
+		"value": "known-value",
+	})
+	require.NoError(t, err, "failed writing k/v key")
+
+	// Read the key; it should exist.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		for index, node := range cluster.Nodes() {
+			nodeClientCfg := node.APIClient().CloneConfig()
+
+			// Do not allow redirects from standby->active; force local
+			// handling and/or GRPC transparent forwarding.
+			nodeClientCfg.DisableRedirects = true
+
+			nodeClient, err := api.NewClient(nodeClientCfg)
+			require.NoError(t, err, "failed to create client from config for node %v", index)
+
+			nodeClient.SetToken(node.APIClient().Token())
+
+			resp, err := nodeClient.KVv2("kv").Get(t.Context(), "a/key")
+			require.NoError(collect, err, "on node %v", index)
+			require.NotNil(collect, resp, "on node %v", index)
+			require.Equal(collect, resp.Data["value"], "known-value", "on node %v", index)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// Eventually we should be able to write to the primary but fail to see
+	// it immediately on the read-only tertiary.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		primary := nodes[0].APIClient()
+		standby := nodes[2].APIClient()
+
+		value, err := uuid.GenerateUUID()
+		require.NoError(collect, err, "failed to generate UUID")
+
+		_, err = primary.KVv2("kv").Put(t.Context(), "a/key", map[string]any{
+			"value": value,
+		})
+		require.NoError(collect, err, "failed writing k/v key on primary")
+
+		resp, err := standby.KVv2("kv").Get(t.Context(), "a/key")
+		require.NoError(collect, err, "failed reading k/v key on tertiary")
+		require.NotNil(collect, resp, "failed reading k/v key on tertiary")
+		require.NotEqual(collect, resp.Data["value"], value)
+	}, 15*time.Second, 1*time.Millisecond)
+
+	// Sealing the primary should result in the secondary taking over.
+	err = nodes[0].APIClient().Sys().Seal()
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err = nodes[1].APIClient().KVv2("kv").Put(t.Context(), "a/key", map[string]any{
+			"value": "post-transfer-known-value",
+		})
+		require.NoError(collect, err, "failed writing k/v key")
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// This should eventually be visible on the secondary node.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		nodeClientCfg := nodes[2].APIClient().CloneConfig()
+
+		// Do not allow redirects from standby->active; force local
+		// handling and/or GRPC transparent forwarding.
+		nodeClientCfg.DisableRedirects = true
+
+		nodeClient, err := api.NewClient(nodeClientCfg)
+		require.NoError(t, err, "failed to create client from config for node 2")
+
+		nodeClient.SetToken(client.Token())
+
+		resp, err := nodeClient.KVv2("kv").Get(t.Context(), "a/key")
+		require.NoError(collect, err, "on node 2")
+		require.NotNil(collect, resp, "on node 2")
+		require.Equal(collect, resp.Data["value"], "post-transfer-known-value", "on node 2")
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// Sealing the secondary should result in no requests being handled: the
+	// tertiary is on a read-only node.
+	err = nodes[1].APIClient().Sys().Seal()
+	require.NoError(t, err)
+
+	resp, err := nodes[2].APIClient().KVv2("kv").Get(t.Context(), "a/key")
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	// Unsealing should work.
+	err = testcluster.UnsealAllNodes(t.Context(), cluster)
+	require.NoError(t, err)
+
+	// All nodes should have the same data
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		for index, node := range cluster.Nodes() {
+			nodeClientCfg := node.APIClient().CloneConfig()
+
+			// Do not allow redirects from standby->active; force local
+			// handling and/or GRPC transparent forwarding.
+			nodeClientCfg.DisableRedirects = true
+
+			nodeClient, err := api.NewClient(nodeClientCfg)
+			require.NoError(t, err, "failed to create client from config for node %v", index)
+
+			nodeClient.SetToken(node.APIClient().Token())
+
+			resp, err := nodeClient.KVv2("kv").Get(t.Context(), "a/key")
+			require.NoError(collect, err, "on node %v", index)
+			require.NotNil(collect, resp, "on node %v", index)
+			require.Equal(collect, resp.Data["value"], "post-transfer-known-value", "on node %v", index)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// Taking down the primary PostgreSQL node should cause problems for all
+	// nodes talking to it.
+	require.NoError(t, pCluster.Cluster.RemovePrimary(t.Context()))
+	time.Sleep(2 * time.Second)
+
+	start := time.Now()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		for index, node := range cluster.Nodes()[0:1] {
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+
+			_, err = node.APIClient().KVv2("kv").Put(ctx, "a/key", map[string]any{
+				"value": "post-removal-known-value",
+			})
+			require.Error(collect, err, "on node %v / duration %v", index, time.Since(start))
+
+			resp, err := node.APIClient().KVv2("kv").Get(ctx, "a/key")
+			require.Error(collect, err, "on node %v / duration: %v", index, time.Since(start))
+			require.Nil(collect, resp, "on node %v / duration: %v", index, time.Since(start))
+		}
+	}, 30*time.Second, 100*time.Millisecond)
+
+	// We should be able to promote the replica and the tertiary should follow.
+	require.NoError(t, pCluster.Cluster.PromoteNode(t.Context(), 0))
+	time.Sleep(2 * time.Second)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		for index, node := range cluster.Nodes()[2:] {
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+
+			_, err = nodes[2].APIClient().KVv2("kv").Put(ctx, "a/key", map[string]any{
+				"value": "post-failover-known-value",
+			})
+			require.NoError(collect, err, "failed writing k/v key")
+
+			resp, err := node.APIClient().KVv2("kv").Get(ctx, "a/key")
+			require.NoError(collect, err, "on node %v", index)
+			require.NotNil(collect, resp, "on node %v", index)
+			require.Equal(collect, resp.Data["value"], "post-failover-known-value", "on node %v", index)
+		}
+	}, 60*time.Second, 100*time.Millisecond)
 }

--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -550,7 +550,7 @@ func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <
 		leaderStopCh := make(chan struct{})
 
 		g.Add(func() error {
-			c.waitForLeadership(manualStepDownCh, leaderStopCh, isReadEnabledStandby)
+			c.leadershipLoop(manualStepDownCh, leaderStopCh, isReadEnabledStandby)
 			return nil
 		}, func(error) {
 			close(leaderStopCh)
@@ -568,25 +568,13 @@ func (c *Core) runHALoopOnce(manualStepDownCh chan struct{}, stopCh, restartCh <
 	return restart
 }
 
-// waitForLeadership is a long running routine that is used when an HA backend
-// is enabled. It waits until we are leader and switches this Vault to
-// active.
-func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}, isReadEnabled bool) {
+// leadershipLoop is a long-running routine that is used when an HA backend is
+// enabled. It waits until we are the leader and switches this node to active.
+func (c *Core) leadershipLoop(manualStepDownCh, stopCh <-chan struct{}, isReadEnabled bool) {
 	var manualStepDown bool
-	firstIteration := true
-
-	// We pin the current standby or active context to this out-of-loop variable
-	// to ensure it gets a deferred cancel if the loop exits due to an error.
-	// This method really needs a refactor :)
-	ctxCancel := context.CancelFunc(func() {})
-	defer func() {
-		ctxCancel()
-	}()
+	iteration := 0
 
 	for {
-		// Cancel any old context from the previous iteration.
-		ctxCancel()
-
 		// Check for a shutdown
 		select {
 		case <-stopCh:
@@ -595,303 +583,343 @@ func (c *Core) waitForLeadership(manualStepDownCh, stopCh <-chan struct{}, isRea
 		default:
 		}
 
-		if !firstIteration && !manualStepDown {
-			// If we restarted the for loop due to an error, wait a second
-			// so that we don't busy loop if the error persists.
-			time.Sleep(1 * time.Second)
-		}
-
-		firstIteration = false
-
-		c.logger.Info("entering standby mode")
-
-		// Create the standby context (this becomes activeCtx on core, oh well).
-		standbyCtx, standbyCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
-		// Cancel if we exit the loop without transitioning to active.
-		ctxCancel = standbyCtxCancel
-
-		// If possible, unseal in read-only mode and start acting as a
-		// read-enabled standby.
-		if isReadEnabled {
-			stop, retry := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh)
-			if stop {
-				return
-			} else if retry {
-				continue
-			}
-		}
-
-		// If we've just stepped down, we could instantly grab the lock
-		// again. Give the other nodes a chance.
-		if manualStepDown {
-			time.Sleep(manualStepDownSleepPeriod)
-			manualStepDown = false
-		}
-
-		// Create a lock
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			c.logger.Error("failed to generate uuid", "error", err)
-			continue
-		}
-		lock, err := c.ha.LockWith(CoreLockPath, uuid)
-		if err != nil {
-			c.logger.Error("failed to create lock", "error", err)
-			continue
-		}
-
-		// Attempt the acquisition
-		leaderLostCh := c.acquireLock(lock, stopCh)
-
-		// Bail if we are being shutdown
-		if leaderLostCh == nil {
+		stop := c.waitForLeadership(iteration, &manualStepDown, manualStepDownCh, stopCh, isReadEnabled)
+		if stop {
 			return
 		}
 
-		// If the backend is a FencingHABackend, register the lock with it so it can
-		// correctly fence all writes from now on  (i.e. assert that we still hold
-		// the lock atomically with each write).
-		if fba, ok := c.ha.(physical.FencingHABackend); ok {
-			err := fba.RegisterActiveNodeLock(lock)
-			if err != nil {
-				// Can't register lock, bail out
-				c.heldHALock = nil
-				lock.Unlock()
-				c.logger.Error("failed registering lock with fencing backend, giving up active state")
-				continue
-			}
+		iteration += 1
+	}
+}
+
+// waitForLeadership handles a single loop of leadershipLoop, trying to
+// become leader and potentially running a read-enabled standby in the
+// interim.
+func (c *Core) waitForLeadership(iteration int, manualStepDown *bool, manualStepDownCh, stopCh <-chan struct{}, isReadEnabled bool) (stop bool) {
+	if iteration == 0 && !*manualStepDown {
+		// If we restarted the for loop due to an error, wait a second
+		// so that we don't busy loop if the error persists.
+		time.Sleep(1 * time.Second)
+	}
+
+	c.logger.Info("entering standby mode")
+
+	// Create the standby context (this becomes activeCtx on core, oh well).
+	standbyCtx, standbyCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
+	// Cancel if we exit the loop without transitioning to active.
+	defer standbyCtxCancel()
+
+	failedLeaderAcquisition := make(chan struct{})
+	acquiredLeadership := make(chan struct{})
+
+	// If possible, unseal in read-only mode and start acting as a
+	// read-enabled standby.
+	if isReadEnabled {
+		stop, retry, tryActive := c.runReadEnabledStandby(standbyCtx, standbyCtxCancel, stopCh)
+		if stop {
+			return true
+		} else if retry && !tryActive && iteration < 5 {
+			// When iteration count reaches too high, it suggests we've
+			// perhaps all failed to unseal. See if attempting to become
+			// leader will help us to make progress.
+			return false
+		} else if retry {
+			go func() {
+				// If we've been told to stop, give up.
+				select {
+				case <-stopCh:
+					return
+				case <-failedLeaderAcquisition:
+					return
+				case <-acquiredLeadership:
+					return
+				case <-time.After(1 * time.Minute):
+				}
+
+				// Restart.
+				c.logger.Info("ha: re-attempting failed standby setup as not yet active")
+				c.Restart()
+			}()
+		}
+	}
+
+	// If we've just stepped down, we could instantly grab the lock
+	// again. Give the other nodes a chance.
+	if *manualStepDown {
+		time.Sleep(manualStepDownSleepPeriod)
+		*manualStepDown = false
+	}
+
+	// Create a lock
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		c.logger.Error("failed to generate uuid", "error", err)
+		close(failedLeaderAcquisition)
+		return false
+	}
+	lock, err := c.ha.LockWith(CoreLockPath, uuid)
+	if err != nil {
+		c.logger.Error("failed to create lock", "error", err)
+		close(failedLeaderAcquisition)
+		return false
+	}
+
+	// Attempt the acquisition
+	leaderLostCh := c.acquireLock(lock, stopCh)
+
+	// Bail if we are being shutdown
+	if leaderLostCh == nil {
+		close(failedLeaderAcquisition)
+		return true
+	}
+
+	// If the backend is a FencingHABackend, register the lock with it so it can
+	// correctly fence all writes from now on  (i.e. assert that we still hold
+	// the lock atomically with each write).
+	if fba, ok := c.ha.(physical.FencingHABackend); ok {
+		err := fba.RegisterActiveNodeLock(lock)
+		if err != nil {
+			// Can't register lock, bail out
+			c.heldHALock = nil
+			lock.Unlock()
+			c.logger.Error("failed registering lock with fencing backend, giving up active state")
+			return false
+		}
+	}
+
+	c.logger.Info("acquired lock, enabling active operation")
+	close(acquiredLeadership)
+
+	// This is used later to log a metrics event; this can be helpful to
+	// detect flapping
+	activeTime := time.Now()
+
+	// We're transitioning to active, so cancel the standby context.
+	// Spawn this in a goroutine so we can cancel the context and unblock
+	// any inflight requests that are holding the state lock.
+	go func() {
+		timer := time.NewTimer(DefaultMaxRequestDuration)
+		select {
+		case <-standbyCtx.Done():
+			timer.Stop()
+		case <-timer.C:
+			// Attempt to drain any inflight requests.
+			standbyCtxCancel()
+		}
+	}()
+
+	// Grab the statelock or stop
+	l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, stopCh)
+	go l.grab()
+	if stopped := l.lockOrStop(); stopped {
+		lock.Unlock()
+		metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+		return true
+	}
+
+	if c.Sealed() {
+		c.logger.Warn("grabbed HA lock but already sealed, exiting")
+		lock.Unlock()
+		c.stateLock.Unlock()
+		metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+		return true
+	}
+
+	// Cancel the standby context if it hasn't already been.
+	standbyCtxCancel()
+
+	// Clear pending standby restarts, not that it matters too much.
+	c.drainPendingRestarts()
+
+	// Store the lock so that we can manually clear it later if needed
+	c.heldHALock = lock
+
+	// Create the active context
+	activeCtx, activeCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
+	c.activeContext.Store(NewAtomicContext(activeCtx, activeCtxCancel))
+
+	// Ensure it gets cancelled eventually.
+	defer activeCtxCancel()
+
+	// Mark storage as readable again.
+	c.barrier.SetReadOnly(false)
+
+	// Perform seal migration
+	if err := c.migrateSeal(activeCtx); err != nil {
+		c.logger.Error("root seal migration error", "error", err)
+		// nothing we can do about it here
+		_ = c.sealManager.sealAll()
+		c.logger.Warn("OpenBao is sealed")
+		c.heldHALock = nil
+		lock.Unlock()
+		c.stateLock.Unlock()
+		return true
+	}
+
+	// This block is used to wipe barrier/seal state and verify that
+	// everything is sane. If we have no sanity in the barrier, we actually
+	// seal, as there's little we can do.
+	{
+		c.seal.SetBarrierConfig(activeCtx, nil)
+		if c.seal.RecoveryKeySupported() {
+			c.seal.SetRecoveryConfig(activeCtx, nil)
 		}
 
-		c.logger.Info("acquired lock, enabling active operation")
+		if err := c.performKeyUpgrades(activeCtx); err != nil {
+			c.logger.Error("error performing key upgrades", "error", err)
 
-		// This is used later to log a metrics event; this can be helpful to
-		// detect flapping
-		activeTime := time.Now()
+			// If we fail due to anything other than a context canceled
+			// error we should shutdown as we may have the incorrect Keys.
+			if !strings.Contains(err.Error(), context.Canceled.Error()) {
+				// We call this in a goroutine so that we can give up the
+				// statelock and have this shut us down; sealInternal has a
+				// workflow where it watches for the stopCh to close so we want
+				// to return from here
+				go c.Shutdown()
+			}
 
-		// We're transitioning to active, so cancel the standby context.
-		// Spawn this in a goroutine so we can cancel the context and unblock
-		// any inflight requests that are holding the state lock.
+			c.heldHALock = nil
+			lock.Unlock()
+			c.stateLock.Unlock()
+			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+
+			// If we are shutting down we should return from this function,
+			// otherwise continue
+			if !strings.Contains(err.Error(), context.Canceled.Error()) {
+				return false
+			} else {
+				return true
+			}
+		}
+	}
+
+	{
+		// Clear previous local cluster cert info so we generate new. Since the
+		// UUID will have changed, standbys will know to look for new info
+		c.localClusterParsedCert.Store(nil)
+		c.localClusterCert.Store(nil)
+		c.localClusterPrivateKey.Store(nil)
+
+		if err := c.setupCluster(activeCtx); err != nil {
+			c.heldHALock = nil
+			lock.Unlock()
+			c.stateLock.Unlock()
+			c.logger.Error("cluster setup failed", "error", err)
+			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+			return false
+		}
+
+	}
+	// Advertise as leader
+	if err := c.advertiseLeader(activeCtx, uuid, leaderLostCh); err != nil {
+		c.heldHALock = nil
+		lock.Unlock()
+		c.stateLock.Unlock()
+		c.logger.Error("leader advertisement setup failed", "error", err)
+		metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+		return false
+	}
+
+	// wipe any existing mount tables before stepping up as leader
+	if err := c.preSeal(); err != nil {
+		c.logger.Error("pre-seal teardown failed", "error", err)
+	}
+
+	// Attempt the post-unseal process
+	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformancePrimary))
+	err = c.postUnseal(activeCtx, activeCtxCancel, standardUnsealStrategy{})
+	if err == nil {
+		c.standby.Store(false)
+		c.leaderUUID = uuid
+		c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 1, nil)
+	}
+
+	c.stateLock.Unlock()
+
+	// Handle a failure to unseal
+	if err != nil {
+		c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
+		c.standby.Store(true)
+		c.logger.Error("post-unseal setup failed", "error", err)
+		lock.Unlock()
+		metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
+		return false
+	}
+
+	// Monitor a loss of leadership
+	select {
+	case <-leaderLostCh:
+		c.logger.Warn("leadership lost, stopping active operation")
+	case <-stopCh:
+	case <-manualStepDownCh:
+		*manualStepDown = true
+		c.logger.Warn("stepping down from active operation to standby")
+	}
+
+	// Stop Active Duty
+	{
+		// Spawn this in a goroutine so we can cancel the context and
+		// unblock any inflight requests that are holding the state lock.
 		go func() {
 			timer := time.NewTimer(DefaultMaxRequestDuration)
 			select {
-			case <-standbyCtx.Done():
+			case <-activeCtx.Done():
 				timer.Stop()
 			case <-timer.C:
 				// Attempt to drain any inflight requests.
-				standbyCtxCancel()
+				activeCtxCancel()
 			}
 		}()
 
-		// Grab the statelock or stop
+		// Grab lock if we are not stopped
 		l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, stopCh)
 		go l.grab()
-		if stopped := l.lockOrStop(); stopped {
-			lock.Unlock()
-			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-			return
-		}
+		stopped := l.lockOrStop()
 
-		if c.Sealed() {
-			c.logger.Warn("grabbed HA lock but already sealed, exiting")
-			lock.Unlock()
-			c.stateLock.Unlock()
-			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-			return
-		}
+		// Cancel the context incase the above go routine hasn't done it
+		// yet
+		activeCtxCancel()
+		metrics.MeasureSince([]string{"core", "leadership_lost"}, activeTime)
 
-		// Cancel the standby context if it hasn't already been.
-		standbyCtxCancel()
+		// Mark as standby
+		c.standby.Store(true)
+		c.leaderUUID = ""
+		c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 0, nil)
 
-		// Clear pending standby restarts, not that it matters too much.
-		c.drainPendingRestarts()
-
-		// Store the lock so that we can manually clear it later if needed
-		c.heldHALock = lock
-
-		// Create the active context
-		activeCtx, activeCtxCancel := context.WithCancel(namespace.RootContext(context.Background()))
-		c.activeContext.Store(NewAtomicContext(activeCtx, activeCtxCancel))
-
-		// Ensure it gets cancelled eventually.
-		ctxCancel = activeCtxCancel
-
-		// Mark storage as readable again.
-		c.barrier.SetReadOnly(false)
-
-		// Perform seal migration
-		if err := c.migrateSeal(activeCtx); err != nil {
-			c.logger.Error("root seal migration error", "error", err)
-			// nothing we can do about it here
-			_ = c.sealManager.sealAll()
-			c.logger.Warn("OpenBao is sealed")
-			c.heldHALock = nil
-			lock.Unlock()
-			c.stateLock.Unlock()
-			return
-		}
-
-		// This block is used to wipe barrier/seal state and verify that
-		// everything is sane. If we have no sanity in the barrier, we actually
-		// seal, as there's little we can do.
-		{
-			c.seal.SetBarrierConfig(activeCtx, nil)
-			if c.seal.RecoveryKeySupported() {
-				c.seal.SetRecoveryConfig(activeCtx, nil)
-			}
-
-			if err := c.performKeyUpgrades(activeCtx); err != nil {
-				c.logger.Error("error performing key upgrades", "error", err)
-
-				// If we fail due to anything other than a context canceled
-				// error we should shutdown as we may have the incorrect Keys.
-				if !strings.Contains(err.Error(), context.Canceled.Error()) {
-					// We call this in a goroutine so that we can give up the
-					// statelock and have this shut us down; sealInternal has a
-					// workflow where it watches for the stopCh to close so we want
-					// to return from here
-					go c.Shutdown()
-				}
-
-				c.heldHALock = nil
-				lock.Unlock()
-				c.stateLock.Unlock()
-				metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-
-				// If we are shutting down we should return from this function,
-				// otherwise continue
-				if !strings.Contains(err.Error(), context.Canceled.Error()) {
-					continue
-				} else {
-					return
-				}
+		// Seal if this was a regular leadership change or stepdown. We
+		// do not seal when the stop channel is acquired, as
+		// sealInternal(...) handles that for us.
+		if !stopped {
+			if err := c.preSeal(); err != nil {
+				c.logger.Error("pre-seal teardown failed", "error", err)
 			}
 		}
 
-		{
-			// Clear previous local cluster cert info so we generate new. Since the
-			// UUID will have changed, standbys will know to look for new info
-			c.localClusterParsedCert.Store(nil)
-			c.localClusterCert.Store(nil)
-			c.localClusterPrivateKey.Store(nil)
+		if err := c.clearLeader(uuid); err != nil {
+			c.logger.Error("clearing leader advertisement failed", "error", err)
+		}
 
-			if err := c.setupCluster(activeCtx); err != nil {
-				c.heldHALock = nil
-				lock.Unlock()
-				c.stateLock.Unlock()
-				c.logger.Error("cluster setup failed", "error", err)
-				metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-				continue
+		if err := c.heldHALock.Unlock(); err != nil {
+			c.logger.Error("unlocking HA lock failed", "error", err)
+		}
+		c.heldHALock = nil
+
+		// Advertise ourselves as a standby.
+		if c.serviceRegistration != nil {
+			if err := c.serviceRegistration.NotifyActiveStateChange(false); err != nil {
+				c.logger.Warn("failed to notify standby status", "error", err)
 			}
-
-		}
-		// Advertise as leader
-		if err := c.advertiseLeader(activeCtx, uuid, leaderLostCh); err != nil {
-			c.heldHALock = nil
-			lock.Unlock()
-			c.stateLock.Unlock()
-			c.logger.Error("leader advertisement setup failed", "error", err)
-			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-			continue
 		}
 
-		// wipe any existing mount tables before stepping up as leader
-		if err := c.preSeal(); err != nil {
-			c.logger.Error("pre-seal teardown failed", "error", err)
+		// If we are stopped return, otherwise unlock the statelock
+		if stopped {
+			return true
 		}
-
-		// Attempt the post-unseal process
-		c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformancePrimary))
-		err = c.postUnseal(activeCtx, activeCtxCancel, standardUnsealStrategy{})
-		if err == nil {
-			c.standby.Store(false)
-			c.leaderUUID = uuid
-			c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 1, nil)
-		}
-
 		c.stateLock.Unlock()
-
-		// Handle a failure to unseal
-		if err != nil {
-			c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
-			c.standby.Store(true)
-			c.logger.Error("post-unseal setup failed", "error", err)
-			lock.Unlock()
-			metrics.MeasureSince([]string{"core", "leadership_setup_failed"}, activeTime)
-			continue
-		}
-
-		// Monitor a loss of leadership
-		select {
-		case <-leaderLostCh:
-			c.logger.Warn("leadership lost, stopping active operation")
-		case <-stopCh:
-		case <-manualStepDownCh:
-			manualStepDown = true
-			c.logger.Warn("stepping down from active operation to standby")
-		}
-
-		// Stop Active Duty
-		{
-			// Spawn this in a goroutine so we can cancel the context and
-			// unblock any inflight requests that are holding the state lock.
-			go func() {
-				timer := time.NewTimer(DefaultMaxRequestDuration)
-				select {
-				case <-activeCtx.Done():
-					timer.Stop()
-				case <-timer.C:
-					// Attempt to drain any inflight requests.
-					activeCtxCancel()
-				}
-			}()
-
-			// Grab lock if we are not stopped
-			l := newLockGrabber(c.stateLock.Lock, c.stateLock.Unlock, stopCh)
-			go l.grab()
-			stopped := l.lockOrStop()
-
-			// Cancel the context incase the above go routine hasn't done it
-			// yet
-			activeCtxCancel()
-			metrics.MeasureSince([]string{"core", "leadership_lost"}, activeTime)
-
-			// Mark as standby
-			c.standby.Store(true)
-			c.leaderUUID = ""
-			c.metricSink.SetGaugeWithLabels([]string{"core", "active"}, 0, nil)
-
-			// Seal if this was a regular leadership change or stepdown. We
-			// do not seal when the stop channel is acquired, as
-			// sealInternal(...) handles that for us.
-			if !stopped {
-				if err := c.preSeal(); err != nil {
-					c.logger.Error("pre-seal teardown failed", "error", err)
-				}
-			}
-
-			if err := c.clearLeader(uuid); err != nil {
-				c.logger.Error("clearing leader advertisement failed", "error", err)
-			}
-
-			if err := c.heldHALock.Unlock(); err != nil {
-				c.logger.Error("unlocking HA lock failed", "error", err)
-			}
-			c.heldHALock = nil
-
-			// Advertise ourselves as a standby.
-			if c.serviceRegistration != nil {
-				if err := c.serviceRegistration.NotifyActiveStateChange(false); err != nil {
-					c.logger.Warn("failed to notify standby status", "error", err)
-				}
-			}
-
-			// If we are stopped return, otherwise unlock the statelock
-			if stopped {
-				return
-			}
-			c.stateLock.Unlock()
-		}
 	}
+
+	// Try again
+	return false
 }
 
 func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) bool {
@@ -941,15 +969,17 @@ func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) bool {
 
 // runReadEnabledStandby grabs the state lock and unseals in read-only mode. It
 // returns two booleans:
-// - stop: true if state lock acquisition stopped or timed out
-// - retry: if the operation should be retried.
-func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.CancelFunc, stopCh <-chan struct{}) (stop bool, retry bool) {
+//   - stop: true if state lock acquisition stopped or timed out
+//   - retry: if the operation should be retried.
+//   - attempt active: if retry is also true, if we should retry after a
+//     period of time if we don't become the active in the interim.
+func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.CancelFunc, stopCh <-chan struct{}) (stop bool, retry bool, activeAttempt bool) {
 	c.logger.Info("enabling horizontal scalability (reads)")
 	c.barrier.SetReadOnly(true)
 
 	if err := c.runStandbyGrabStateLock(stopCh); err != nil {
 		c.logger.Error("unable to grab state lock for standby", "err", err)
-		return true, false
+		return true, false, false
 	}
 
 	defer c.stateLock.Unlock()
@@ -971,8 +1001,8 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 			c.CleanupInvalidationPeers()
 			c.invalidations.Stop()
 
-			// Try this again.
-			return false, true
+			// Try this again, but allow attempting to become active.
+			return false, true, true
 		}
 
 		// Wait for our initial invalidation checkpoint.
@@ -982,7 +1012,7 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 			c.invalidations.Stop()
 
 			c.logger.Error("failed to await replication", "err", err)
-			return false, true
+			return false, true, true
 		}
 	}
 
@@ -997,11 +1027,11 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 
 		// We shouldn't attempt to keep grabbing the HA lock if we failed to
 		// unseal.
-		return false, true
+		return false, true, false
 	}
 
 	// All good.
-	return false, false
+	return false, false, false
 }
 
 // grabLockOrStop returns stopped=false if the lock is acquired. Returns

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -61,6 +61,11 @@ type RunOptions struct {
 	LogStderr              io.Writer
 	LogStdout              io.Writer
 	VolumeNameToMountPoint map[string]string
+
+	// WriteInto is provided instead of Runner.CopyTo(...) so that it executes
+	// before the container starts, providing an opportunity to provision
+	// initial data. Map of destination -> contents.
+	WriteInto map[string]BuildContext
 }
 
 func NewDockerAPI() (*client.Client, error) {
@@ -221,7 +226,7 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 			}
 		}
 	}
-	result, err := d.Start(context.Background(), addSuffix, forceLocalAddr)
+	result, err := d.Start(ctx, addSuffix, forceLocalAddr)
 	if err != nil {
 		return nil, "", err
 	}
@@ -318,7 +323,7 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 	op := func() (ServiceConfig, error) {
 		container, err := d.DockerAPI.ContainerInspect(ctx, result.Container.ID, client.ContainerInspectOptions{})
 		if err != nil || !container.Container.State.Running {
-			return nil, backoff.Permanent(fmt.Errorf("failed inspect or container %q not running: %w", result.Container.ID, err))
+			return nil, backoff.Permanent(fmt.Errorf("failed inspect or container %q not running (%v): %w", result.Container.ID, container.Container.State.Status, err))
 		}
 
 		c, err := connect(ctx, pieces[0], portInt)
@@ -519,6 +524,22 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 		if err := copyToContainer(ctx, d.DockerAPI, c.ID, from, to); err != nil {
 			_, _ = d.DockerAPI.ContainerRemove(ctx, c.ID, client.ContainerRemoveOptions{})
 			return nil, err
+		}
+	}
+
+	for destination, contents := range d.RunOptions.WriteInto {
+		// Convert our provided contents to a tarball to ship up.
+		tar, err := contents.ToTarball()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build contents for directory %q into tarball: %w", destination, err)
+		}
+
+		_, err = d.DockerAPI.CopyToContainer(ctx, c.ID, client.CopyToContainerOptions{
+			DestinationPath: destination,
+			Content:         tar,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to copy contents for directory %q into container: %w", destination, err)
 		}
 	}
 

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -75,7 +75,7 @@ type DockerCluster struct {
 	Logger    log.Logger
 	builtTags map[string]struct{}
 
-	storage testcluster.ClusterStorage
+	storage testcluster.Storage
 
 	// Whether HA mode is disabled
 	HADisabled bool
@@ -145,6 +145,12 @@ func (dc *DockerCluster) cleanup() error {
 	var result *multierror.Error
 	for _, node := range dc.ClusterNodes {
 		if err := node.cleanup(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if dc.storage != nil {
+		if err := dc.storage.Cleanup(); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -431,7 +437,6 @@ func NewDockerCluster(ctx context.Context, opts *DockerClusterOptions) (*DockerC
 		Logger:      opts.Logger,
 		builtTags:   map[string]struct{}{},
 		CA:          opts.CA,
-		storage:     opts.Storage,
 		HADisabled:  opts.HADisabled,
 	}
 
@@ -475,6 +480,7 @@ type DockerClusterNode struct {
 	ImageTag             string
 	DataVolumeName       string
 	cleanupVolume        func()
+	Storage              testcluster.NodeStorage
 }
 
 func (n *DockerClusterNode) TLSConfig() *tls.Config {
@@ -556,6 +562,11 @@ func (n *DockerClusterNode) cleanup() error {
 	}
 	n.cleanupContainer()
 	n.cleanupVolume()
+	if n.Storage != nil {
+		if err := n.Storage.Cleanup(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -642,13 +653,9 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 		"node_id": n.NodeID,
 	}
 
-	if opts.Storage != nil {
-		var err error
-		storageType = opts.Storage.Type()
-		storageOpts, err = opts.Storage.Opts(ctx)
-		if err != nil {
-			return err
-		}
+	if n.Storage != nil {
+		storageType = n.Storage.Type()
+		storageOpts = n.Storage.Opts()
 	}
 
 	if opts != nil && opts.VaultNodeConfig != nil {
@@ -1009,7 +1016,7 @@ type DockerClusterOptions struct {
 	Args        []string
 	CopyFromTo  map[string]string
 	StartProbe  func(*api.Client) error
-	Storage     testcluster.ClusterStorage
+	Storage     testcluster.Storage // either testcluster.ClusterStorage or testcluster.NodeStorage
 	StorageType string
 	Root        bool
 	Entrypoint  string
@@ -1053,6 +1060,52 @@ func ensureLeaderMatches(ctx context.Context, client *api.Client, ready func(res
 
 const DefaultNumCores = 3
 
+// resolveStorage returns a NodeStorage object, having already started it.
+// This handles various causes for us of reusing the same storage object &c.,
+// though we still assume we only ever call this once per index.
+func (dc *DockerCluster) resolveStorage(ctx context.Context, opts *DockerClusterOptions, index int) (testcluster.NodeStorage, error) {
+	storage := opts.Storage
+	if opts.Storage == nil && dc.storage != nil {
+		storage = dc.storage
+	}
+
+	if storage == nil {
+		return nil, nil
+	}
+
+	switch typed := storage.(type) {
+	case testcluster.ClusterStorage:
+		if dc.storage == nil {
+			dc.storage = typed
+		}
+
+		node, err := typed.ForNode(ctx, index)
+		if err != nil {
+			return nil, fmt.Errorf("error getting storage for node %d: %w", index, err)
+		}
+
+		if err := node.Start(ctx, &opts.ClusterOptions); err != nil {
+			return nil, fmt.Errorf("error starting storage for node %d: %w", index, err)
+		}
+
+		return node, nil
+	case testcluster.NodeStorage:
+		if (dc.storage != nil && opts.Storage != dc.storage) || dc.storage == nil {
+			if err := typed.Start(ctx, &opts.ClusterOptions); err != nil {
+				return nil, fmt.Errorf("error starting storage for node %d: %w", index, err)
+			}
+		}
+
+		if dc.storage == nil {
+			dc.storage = typed
+		}
+
+		return typed, nil
+	default:
+		return nil, fmt.Errorf("unknown type of storage; expected either testcluster.ClusterStorage or testcluster.NodeStorage; got %T", typed)
+	}
+}
+
 // creates a managed docker container running Vault
 func (dc *DockerCluster) setupDockerCluster(ctx context.Context, opts *DockerClusterOptions) error {
 	if opts.TmpDir != "" {
@@ -1092,12 +1145,6 @@ func (dc *DockerCluster) setupDockerCluster(ctx context.Context, opts *DockerClu
 	}
 	dc.RootCAs = x509.NewCertPool()
 	dc.RootCAs.AddCert(dc.CACert)
-
-	if dc.storage != nil {
-		if err := dc.storage.Start(ctx, &opts.ClusterOptions); err != nil {
-			return err
-		}
-	}
 
 	for i := 0; i < numCores; i++ {
 		if err := dc.addNode(ctx, opts); err != nil {
@@ -1148,6 +1195,12 @@ func (dc *DockerCluster) addNode(ctx context.Context, opts *DockerClusterOptions
 		ImageRepo: opts.ImageRepo,
 		ImageTag:  tag,
 	}
+
+	node.Storage, err = dc.resolveStorage(ctx, opts, i)
+	if err != nil {
+		return err
+	}
+
 	dc.ClusterNodes = append(dc.ClusterNodes, node)
 	if err := os.MkdirAll(node.WorkDir, 0o755); err != nil {
 		return err
@@ -1159,17 +1212,18 @@ func (dc *DockerCluster) addNode(ctx context.Context, opts *DockerClusterOptions
 }
 
 func (dc *DockerCluster) joinNode(ctx context.Context, nodeIdx int, leaderIdx int) error {
-	if dc.storage != nil && dc.storage.Type() != "raft" {
+	if nodeIdx >= len(dc.ClusterNodes) {
+		return fmt.Errorf("invalid node %d", nodeIdx)
+	}
+
+	node := dc.ClusterNodes[nodeIdx]
+	leader := dc.ClusterNodes[leaderIdx]
+
+	if node.Storage != nil && node.Storage.Type() != "raft" {
 		// Storage is not raft so nothing to do but unseal.
 		return testcluster.UnsealNode(ctx, dc, nodeIdx)
 	}
 
-	leader := dc.ClusterNodes[leaderIdx]
-
-	if nodeIdx >= len(dc.ClusterNodes) {
-		return fmt.Errorf("invalid node %d", nodeIdx)
-	}
-	node := dc.ClusterNodes[nodeIdx]
 	client := node.APIClient()
 
 	var resp *api.RaftJoinResponse

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -25,7 +24,6 @@ import (
 	mathrand "math/rand"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,8 +43,6 @@ import (
 	dockhelper "github.com/openbao/openbao/sdk/v2/helper/docker"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
-	thpsql "github.com/openbao/openbao/sdk/v2/helper/testhelpers/postgresql"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
 
@@ -647,8 +643,12 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 	}
 
 	if opts.Storage != nil {
+		var err error
 		storageType = opts.Storage.Type()
-		storageOpts = opts.Storage.Opts()
+		storageOpts, err = opts.Storage.Opts(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	if opts != nil && opts.VaultNodeConfig != nil {
@@ -1271,114 +1271,6 @@ COPY bao /usr/bin/bao
 	}
 	dc.builtTags[tag] = struct{}{}
 	return tag, nil
-}
-
-// InmemStorage configures a test cluster to use the inmem storage backend.
-// This avoids waiting for initial Raft leader election or PostgreSQL container
-// startup when testing against a single-node cluster, significantly reducing
-// test setup time.
-type InmemStorage struct{}
-
-func (InmemStorage) Start(context.Context, *testcluster.ClusterOptions) error { return nil }
-func (InmemStorage) Cleanup() error                                           { return nil }
-func (InmemStorage) Opts() map[string]any                                     { return make(map[string]any) }
-func (InmemStorage) Type() string                                             { return "inmem" }
-
-var _ testcluster.ClusterStorage = InmemStorage{}
-
-// PostgreSQLStorage configures a test cluster to use the postgresql storage
-// backend and provides the required PostgreSQL instance in a container.
-type PostgreSQLStorage struct {
-	cleanup     func()
-	ExternalUrl string
-	InternalUrl string
-	Runner      *dockhelper.Runner
-	Service     *dockhelper.Service
-	Id          string
-}
-
-var _ testcluster.ClusterStorage = &PostgreSQLStorage{}
-
-// NewPostgreSQLStorage creates a new PostgreSQLStorage and starts its backing
-// container.
-func NewPostgreSQLStorage(t *testing.T, network string) *PostgreSQLStorage {
-	env := []string{
-		"POSTGRES_PASSWORD=secret",
-		"POSTGRES_DB=database",
-	}
-
-	runner, svc, cleanup, externalUrl, containerID := thpsql.PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", "latest", "secret", true, false, false, env, false /* don't wait */, network)
-
-	u, err := url.Parse(externalUrl)
-	require.NoError(t, err, "failed to parse returned external URL")
-
-	var host string
-	if network != "" {
-		host = svc.Container.NetworkSettings.Networks[network].IPAddress.String()
-	} else {
-		for name, info := range svc.Container.NetworkSettings.Networks {
-			network = name
-			host = info.IPAddress.String()
-
-			t.Logf("found network [%v]: %v", network, info)
-		}
-
-		if len(svc.Container.NetworkSettings.Networks) != 1 {
-			t.Fatalf("expected only one network if no network name given: %v", network)
-		}
-	}
-	u.Host = fmt.Sprintf("%v:5432", host)
-
-	internalUrl := u.String()
-
-	return &PostgreSQLStorage{
-		cleanup:     cleanup,
-		ExternalUrl: externalUrl,
-		InternalUrl: internalUrl,
-		Runner:      runner,
-		Service:     svc,
-		Id:          containerID,
-	}
-}
-
-func (p *PostgreSQLStorage) Start(context.Context, *testcluster.ClusterOptions) error {
-	// Initialization already occurred when creating this object.
-	return nil
-}
-
-func (p *PostgreSQLStorage) Cleanup() error {
-	if p.cleanup != nil {
-		p.cleanup()
-		p.cleanup = nil
-	}
-	return nil
-}
-
-func (p *PostgreSQLStorage) Opts() map[string]any {
-	return map[string]any{
-		"connection_url":       p.InternalUrl,
-		"ha_enabled":           true,
-		"max_parallel":         5,
-		"max_idle_connections": 3,
-		"max_connect_retries":  30,
-	}
-}
-
-func (p *PostgreSQLStorage) Type() string {
-	return "postgresql"
-}
-
-func (p *PostgreSQLStorage) Client(ctx context.Context) (*sql.DB, error) {
-	db, err := sql.Open("pgx", p.ExternalUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = db.PingContext(ctx); err != nil {
-		return nil, err
-	}
-
-	return db, nil
 }
 
 /* Notes on testing the non-bridge network case:

--- a/sdk/helper/testcluster/docker/storage.go
+++ b/sdk/helper/testcluster/docker/storage.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package docker
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+
+	dockhelper "github.com/openbao/openbao/sdk/v2/helper/docker"
+	"github.com/openbao/openbao/sdk/v2/helper/testcluster"
+	thpsql "github.com/openbao/openbao/sdk/v2/helper/testhelpers/postgresql"
+)
+
+// InmemStorage configures a test cluster to use the inmem storage backend.
+// This avoids waiting for initial Raft leader election or PostgreSQL container
+// startup when testing against a single-node cluster, significantly reducing
+// test setup time.
+type InmemStorage struct{}
+
+func (InmemStorage) Start(context.Context, *testcluster.ClusterOptions) error { return nil }
+func (InmemStorage) Cleanup() error                                           { return nil }
+func (InmemStorage) Opts(_ context.Context) (map[string]any, error) {
+	return make(map[string]any), nil
+}
+func (InmemStorage) Type() string { return "inmem" }
+
+var _ testcluster.ClusterStorage = InmemStorage{}
+
+type PostgreSQLStorage struct {
+	cleanup     func()
+	ExternalUrl string
+	InternalUrl string
+	Runner      *dockhelper.Runner
+	Service     *dockhelper.Service
+	Id          string
+}
+
+var _ testcluster.ClusterStorage = &PostgreSQLStorage{}
+
+// NewPostgreSQLStorage starts the underlying PSQL container and saves its
+// connection URL.
+func NewPostgreSQLStorage(t *testing.T, network string) *PostgreSQLStorage {
+	env := []string{
+		"POSTGRES_PASSWORD=secret",
+		"POSTGRES_DB=database",
+	}
+
+	runner, svc, cleanup, externalUrl, containerID := thpsql.PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", "latest", "secret", true, false, false, env, false /* don't wait */, network)
+
+	u, err := url.Parse(externalUrl)
+	require.NoError(t, err, "failed to parse returned external URL")
+
+	var host string
+	if network != "" {
+		host = svc.Container.NetworkSettings.Networks[network].IPAddress.String()
+	} else {
+		for name, info := range svc.Container.NetworkSettings.Networks {
+			network = name
+			host = info.IPAddress.String()
+
+			t.Logf("found network [%v]: %v", network, info)
+		}
+
+		if len(svc.Container.NetworkSettings.Networks) != 1 {
+			t.Fatalf("expected only one network if no network name given: %v", network)
+		}
+	}
+	u.Host = fmt.Sprintf("%v:5432", host)
+
+	internalUrl := u.String()
+
+	return &PostgreSQLStorage{
+		cleanup:     cleanup,
+		ExternalUrl: externalUrl,
+		InternalUrl: internalUrl,
+		Runner:      runner,
+		Service:     svc,
+		Id:          containerID,
+	}
+}
+
+func (p *PostgreSQLStorage) Start(context.Context, *testcluster.ClusterOptions) error {
+	// Initialization already occurred when creating this object.
+	return nil
+}
+
+func (p *PostgreSQLStorage) Cleanup() error {
+	if p.cleanup != nil {
+		p.cleanup()
+	}
+	return nil
+}
+
+func (p *PostgreSQLStorage) Opts(_ context.Context) (map[string]any, error) {
+	return map[string]any{
+		"connection_url":       p.InternalUrl,
+		"ha_enabled":           true,
+		"max_parallel":         5,
+		"max_idle_connections": 3,
+		"max_connect_retries":  30,
+	}, nil
+}
+
+func (p *PostgreSQLStorage) Type() string {
+	return "postgresql"
+}
+
+func (p *PostgreSQLStorage) Client(ctx context.Context) (*sql.DB, error) {
+	db, err := sql.Open("pgx", p.ExternalUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = db.PingContext(ctx); err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+type PostgreSQLClusterStorage struct {
+	Cluster *thpsql.Cluster
+	mapper  PostgreSQLClusterMapper
+}
+
+type PostgreSQLClusterMapper func(ctx context.Context, cluster *thpsql.Cluster) (string, error)
+
+func NewPostgreSQLClusterStorage(ctx context.Context, logger log.Logger, name string, network string, mapper PostgreSQLClusterMapper) (*PostgreSQLClusterStorage, error) {
+	cfg := thpsql.DefaultClusterConfig(name)
+	if logger != nil {
+		cfg.Logger = logger
+	}
+
+	cluster, err := cfg.NewCluster(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set up cluster: %w", err)
+	}
+
+	return &PostgreSQLClusterStorage{
+		Cluster: cluster,
+		mapper:  mapper,
+	}, nil
+}
+
+func (p *PostgreSQLClusterStorage) Start(context.Context, *testcluster.ClusterOptions) error {
+	// Initialization already occurred when creating this object.
+	return nil
+}
+
+func (p *PostgreSQLClusterStorage) Cleanup() error {
+	p.Cluster.Cleanup()
+	return nil
+}
+
+func (p *PostgreSQLClusterStorage) Opts(ctx context.Context) (map[string]any, error) {
+	url, err := p.mapper(ctx, p.Cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed mapping to connection url: %w", err)
+	}
+
+	return map[string]any{
+		"connection_url":       url,
+		"ha_enabled":           true,
+		"max_parallel":         5,
+		"max_idle_connections": 3,
+		"max_connect_retries":  30,
+	}, nil
+}
+
+func (p *PostgreSQLClusterStorage) Type() string {
+	return "postgresql"
+}

--- a/sdk/helper/testcluster/docker/storage.go
+++ b/sdk/helper/testcluster/docker/storage.go
@@ -27,12 +27,12 @@ type InmemStorage struct{}
 
 func (InmemStorage) Start(context.Context, *testcluster.ClusterOptions) error { return nil }
 func (InmemStorage) Cleanup() error                                           { return nil }
-func (InmemStorage) Opts(_ context.Context) (map[string]any, error) {
-	return make(map[string]any), nil
+func (InmemStorage) Opts() map[string]any {
+	return make(map[string]any)
 }
 func (InmemStorage) Type() string { return "inmem" }
 
-var _ testcluster.ClusterStorage = InmemStorage{}
+var _ testcluster.NodeStorage = InmemStorage{}
 
 type PostgreSQLStorage struct {
 	cleanup     func()
@@ -43,7 +43,7 @@ type PostgreSQLStorage struct {
 	Id          string
 }
 
-var _ testcluster.ClusterStorage = &PostgreSQLStorage{}
+var _ testcluster.NodeStorage = &PostgreSQLStorage{}
 
 // NewPostgreSQLStorage starts the underlying PSQL container and saves its
 // connection URL.
@@ -87,6 +87,16 @@ func NewPostgreSQLStorage(t *testing.T, network string) *PostgreSQLStorage {
 	}
 }
 
+// NewStaticPostgreSQLStorage returns a new PostgreSQLStorage based on static
+// connection information without caring where it came from.
+func NewStaticPostgreSQLStorage(extConnUrl string, intConnUrl string) *PostgreSQLStorage {
+	return &PostgreSQLStorage{
+		cleanup:     nil,
+		ExternalUrl: extConnUrl,
+		InternalUrl: intConnUrl,
+	}
+}
+
 func (p *PostgreSQLStorage) Start(context.Context, *testcluster.ClusterOptions) error {
 	// Initialization already occurred when creating this object.
 	return nil
@@ -99,14 +109,14 @@ func (p *PostgreSQLStorage) Cleanup() error {
 	return nil
 }
 
-func (p *PostgreSQLStorage) Opts(_ context.Context) (map[string]any, error) {
+func (p *PostgreSQLStorage) Opts() map[string]any {
 	return map[string]any{
 		"connection_url":       p.InternalUrl,
 		"ha_enabled":           true,
 		"max_parallel":         5,
 		"max_idle_connections": 3,
 		"max_connect_retries":  30,
-	}, nil
+	}
 }
 
 func (p *PostgreSQLStorage) Type() string {
@@ -126,12 +136,14 @@ func (p *PostgreSQLStorage) Client(ctx context.Context) (*sql.DB, error) {
 	return db, nil
 }
 
+type PostgreSQLClusterMapper func(ctx context.Context, cluster *thpsql.Cluster, index int) (*thpsql.Node, error)
+
 type PostgreSQLClusterStorage struct {
 	Cluster *thpsql.Cluster
 	mapper  PostgreSQLClusterMapper
 }
 
-type PostgreSQLClusterMapper func(ctx context.Context, cluster *thpsql.Cluster) (string, error)
+var _ testcluster.ClusterStorage = &PostgreSQLClusterStorage{}
 
 func NewPostgreSQLClusterStorage(ctx context.Context, logger log.Logger, name string, network string, mapper PostgreSQLClusterMapper) (*PostgreSQLClusterStorage, error) {
 	cfg := thpsql.DefaultClusterConfig(name)
@@ -150,31 +162,26 @@ func NewPostgreSQLClusterStorage(ctx context.Context, logger log.Logger, name st
 	}, nil
 }
 
-func (p *PostgreSQLClusterStorage) Start(context.Context, *testcluster.ClusterOptions) error {
-	// Initialization already occurred when creating this object.
-	return nil
-}
-
 func (p *PostgreSQLClusterStorage) Cleanup() error {
 	p.Cluster.Cleanup()
 	return nil
 }
 
-func (p *PostgreSQLClusterStorage) Opts(ctx context.Context) (map[string]any, error) {
-	url, err := p.mapper(ctx, p.Cluster)
-	if err != nil {
-		return nil, fmt.Errorf("failed mapping to connection url: %w", err)
-	}
-
-	return map[string]any{
-		"connection_url":       url,
-		"ha_enabled":           true,
-		"max_parallel":         5,
-		"max_idle_connections": 3,
-		"max_connect_retries":  30,
-	}, nil
-}
-
 func (p *PostgreSQLClusterStorage) Type() string {
 	return "postgresql"
+}
+
+func (p *PostgreSQLClusterStorage) ForNode(ctx context.Context, index int) (testcluster.NodeStorage, error) {
+	pNode, err := p.mapper(ctx, p.Cluster, index)
+	if err != nil {
+		return nil, fmt.Errorf("error invoking mapper(ctx, cluster, %d): %w", index, err)
+	}
+
+	extUrl := pNode.ConnectionURL
+	intUrl, err := pNode.InternalURL(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting internal URL for node %d->%v: %w", index, pNode.ContainerID, err)
+	}
+
+	return NewStaticPostgreSQLStorage(extUrl, intUrl), nil
 }

--- a/sdk/helper/testcluster/types.go
+++ b/sdk/helper/testcluster/types.go
@@ -123,6 +123,6 @@ type CA struct {
 type ClusterStorage interface {
 	Start(context.Context, *ClusterOptions) error
 	Cleanup() error
-	Opts() map[string]any
+	Opts(ctx context.Context) (map[string]any, error)
 	Type() string
 }

--- a/sdk/helper/testcluster/types.go
+++ b/sdk/helper/testcluster/types.go
@@ -120,9 +120,35 @@ type CA struct {
 	CAKeyPEM      []byte
 }
 
-type ClusterStorage interface {
-	Start(context.Context, *ClusterOptions) error
-	Cleanup() error
-	Opts(ctx context.Context) (map[string]any, error)
+// Storage is a common base type for use in docker.DockerClusterOptions
+// to abstract between ClusterStorage and NodeStorage. The former is
+// generally preferred as it gives more control over multi-node storage
+// via a factory pattern. It should never be directly implemented; the
+// Docker test cluster architecture requires either child interface.
+type Storage interface {
 	Type() string
+
+	// Cleanup may be called multiple times or not at all.
+	Cleanup() error
+}
+
+// ClusterStorage yields a new NodeStorage for the requested node.
+type ClusterStorage interface {
+	Storage
+	ForNode(ctx context.Context, index int) (NodeStorage, error)
+}
+
+// NodeStorage is an instance of a storage backend for a single OpenBao node.
+// This was previously named ClusterStorage and gave the impression that all
+// decisions needed to be made up front (as Opts() is more or less static);
+//
+// We've now renamed this to make it more clear and added a new factory
+// pattern.
+type NodeStorage interface {
+	Storage
+
+	// A best effort is made to call Start exactly once, but be prepared to
+	// ignore it if called multiple times.
+	Start(context.Context, *ClusterOptions) error
+	Opts() map[string]any
 }

--- a/sdk/helper/testhelpers/postgresql/postgresqlhelper.go
+++ b/sdk/helper/testhelpers/postgresql/postgresqlhelper.go
@@ -6,14 +6,24 @@ package postgresql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/containerd/errdefs"
+	log "github.com/hashicorp/go-hclog"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/moby/moby/client"
 
 	"github.com/openbao/openbao/sdk/v2/helper/docker"
+)
+
+const (
+	DefaultPSQLRepo   = "docker.mirror.hashicorp.services/postgres"
+	DefaultRepmgrRepo = "docker.mirror.hashicorp.services/bitnami/postgresql-repmgr"
 )
 
 func PrepareTestContainer(t *testing.T, version string) (func(), string) {
@@ -22,7 +32,7 @@ func PrepareTestContainer(t *testing.T, version string) (func(), string) {
 		"POSTGRES_DB=database",
 	}
 
-	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env, true, "")
+	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", DefaultPSQLRepo, version, "secret", true, false, false, env, true, "")
 
 	return cleanup, url
 }
@@ -36,7 +46,7 @@ func TestContainerNoWait(t *testing.T) (func(), string) {
 		"POSTGRES_DB=database",
 	}
 
-	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", "17", "secret", true, false, false, env, false, "")
+	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", DefaultPSQLRepo, "17", "secret", true, false, false, env, false, "")
 
 	return cleanup, url
 }
@@ -50,7 +60,7 @@ func PrepareTestContainerWithVaultUser(t *testing.T, ctx context.Context, versio
 		"POSTGRES_DB=database",
 	}
 
-	runner, _, cleanup, url, id := PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, "secret", true, false, false, env, true, "")
+	runner, _, cleanup, url, id := PrepareTestContainerRaw(t, "postgres", DefaultPSQLRepo, version, "secret", true, false, false, env, true, "")
 
 	cmd := []string{"psql", "-U", "postgres", "-c", "CREATE USER vaultadmin WITH LOGIN PASSWORD 'vaultpass' SUPERUSER"}
 	_, err := runner.RunCmdInBackground(ctx, id, cmd)
@@ -67,7 +77,7 @@ func PrepareTestContainerWithPassword(t *testing.T, version, password string) (f
 		"POSTGRES_DB=database",
 	}
 
-	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", "docker.mirror.hashicorp.services/postgres", version, password, true, false, false, env, true, "")
+	_, _, cleanup, url, _ := PrepareTestContainerRaw(t, "postgres", DefaultPSQLRepo, version, password, true, false, false, env, true, "")
 
 	return cleanup, url
 }
@@ -79,7 +89,7 @@ func PrepareTestContainerRepmgr(t *testing.T, name, version string, envVars []st
 		"REPMGR_PASSWORD=repmgrpass",
 		"POSTGRESQL_PASSWORD=secret")
 
-	runner, _, cleanup, url, id := PrepareTestContainerRaw(t, name, "docker.mirror.hashicorp.services/bitnami/postgresql-repmgr", version, "secret", false, true, true, env, true, "")
+	runner, _, cleanup, url, id := PrepareTestContainerRaw(t, name, DefaultRepmgrRepo, version, "secret", false, true, true, env, true, "")
 	return runner, cleanup, url, id
 }
 
@@ -113,12 +123,12 @@ func PrepareTestContainerRaw(t *testing.T, name, repo, version, password string,
 		t.Fatalf("Could not start docker Postgres: %s", err)
 	}
 
-	upCheck := connectPostgres(password, repo)
+	upCheck := connectPostgres(password)
 	if !wait {
-		upCheck = connectPostgresNoWait(password, repo)
+		upCheck = connectPostgresNoWait(password)
 	}
 
-	svc, containerID, err := runner.StartNewService(context.Background(), addSuffix, forceLocalAddr, upCheck)
+	svc, containerID, err := runner.StartNewService(t.Context(), addSuffix, forceLocalAddr, upCheck)
 	if err != nil {
 		t.Fatalf("Could not start docker Postgres: %s", err)
 	}
@@ -126,7 +136,7 @@ func PrepareTestContainerRaw(t *testing.T, name, repo, version, password string,
 	return runner, svc, svc.Cleanup, svc.Config.URL().String(), containerID
 }
 
-func connectPostgres(password, repo string) docker.ServiceAdapter {
+func connectPostgres(password string) docker.ServiceAdapter {
 	return func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
 		u := url.URL{
 			Scheme:   "postgres",
@@ -136,13 +146,13 @@ func connectPostgres(password, repo string) docker.ServiceAdapter {
 			RawQuery: "sslmode=disable",
 		}
 
-		fmt.Fprintf(os.Stderr, "opening database\n")
+		fmt.Fprintf(os.Stderr, "opening database: %v\n", u.String())
 
 		db, err := sql.Open("pgx", u.String())
 		if err != nil {
 			return nil, err
 		}
-		defer db.Close()
+		defer db.Close() //nolint:errcheck
 
 		if err = db.PingContext(ctx); err != nil {
 			return nil, err
@@ -152,7 +162,7 @@ func connectPostgres(password, repo string) docker.ServiceAdapter {
 	}
 }
 
-func connectPostgresNoWait(password, repo string) docker.ServiceAdapter {
+func connectPostgresNoWait(password string) docker.ServiceAdapter {
 	return func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
 		u := url.URL{
 			Scheme:   "postgres",
@@ -176,4 +186,375 @@ func RestartContainer(t *testing.T, ctx context.Context, runner *docker.Runner, 
 	if err := runner.Restart(ctx, containerID); err != nil {
 		t.Fatalf("Could not restart docker Postgres: %s", err)
 	}
+}
+
+type ClusterConfig struct {
+	Name      string
+	AddSuffix bool
+
+	Repo    string
+	Version string
+
+	Password        string
+	DoNotAutoRemove bool
+
+	WALLevel string
+	EnvVars  []string
+
+	Logger log.Logger
+}
+
+func DefaultClusterConfig(name string) *ClusterConfig {
+	return &ClusterConfig{
+		Name:            name,
+		AddSuffix:       true,
+		Repo:            DefaultPSQLRepo,
+		Version:         "17",
+		Password:        "secret",
+		DoNotAutoRemove: true,
+		WALLevel:        "replica",
+		EnvVars: []string{
+			"POSTGRES_DB=database",
+		},
+		Logger: log.NewNullLogger(),
+	}
+}
+
+type Cluster struct {
+	Config *ClusterConfig
+
+	Primary *Node
+	Nodes   []*Node
+
+	Network string
+}
+
+type Node struct {
+	Runner        *docker.Runner
+	Service       *docker.Service
+	ConnectionURL string
+	ContainerID   string
+}
+
+// NewCluster sets up the cluster and adds the initial node.
+func (c *ClusterConfig) NewCluster(ctx context.Context) (*Cluster, error) {
+	cluster := &Cluster{
+		Config: c,
+	}
+
+	primary, err := cluster.addPrimary(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add primary node: %w", err)
+	}
+	cluster.Primary = primary
+	cluster.Nodes = append(cluster.Nodes, primary)
+
+	cluster.Network, err = primary.Network()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check network: %w", err)
+	}
+
+	return cluster, err
+}
+
+func (c *Cluster) Cleanup() {
+	c.CleanupWithContext(context.Background())
+}
+
+func (c *Cluster) CleanupWithContext(ctx context.Context) {
+	if c == nil {
+		return
+	}
+
+	c.Primary.Cleanup()
+	for _, node := range c.Nodes {
+		node.Cleanup()
+	}
+}
+
+func (c *Cluster) env() []string {
+	env := make([]string, len(c.Config.EnvVars)+1)
+	env[0] = "POSTGRES_PASSWORD=" + c.Config.Password
+	copy(env[1:], c.Config.EnvVars)
+	return env
+}
+
+func (c *Cluster) primaryCmd() []string {
+	return []string{
+		"postgres",
+		"-cwal_level=" + c.Config.WALLevel,
+		"-chot_standby=on",
+		"-cmax_wal_senders=10",
+		"-cmax_replication_slots=10",
+		"-chot_standby_feedback=on",
+	}
+}
+
+func (c *Cluster) runOpts(node string) docker.RunOptions {
+	return docker.RunOptions{
+		ContainerName:   fmt.Sprintf("%v-%v", c.Config.Name, node),
+		ImageRepo:       c.Config.Repo,
+		ImageTag:        c.Config.Version,
+		Env:             c.env(),
+		Ports:           []string{"5432/tcp"},
+		DoNotAutoRemove: c.Config.DoNotAutoRemove,
+		NetworkName:     c.Network,
+		WriteInto:       map[string]docker.BuildContext{},
+	}
+}
+
+func (c *Cluster) primaryInit() string {
+	// See https://sadeesha.medium.com/building-a-postgresql-replication-cluster-with-docker-compose-45406078de72
+	script := `#!/bin/bash
+
+set -euxo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+ CREATE USER replicator WITH REPLICATION ENCRYPTED PASSWORD '` + c.Config.Password + `';
+EOSQL
+
+# Allow replication connections from any host in the Docker network
+echo "host replication replicator 0.0.0.0/0 md5" >> "$PGDATA/pg_hba.conf"
+
+# Reload PostgreSQL configuration
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "SELECT pg_reload_conf();"
+  `
+
+	return script
+}
+
+func (c *Cluster) addPrimary(ctx context.Context) (*Node, error) {
+	c.Config.Logger.Debug("starting primary")
+	node := &Node{}
+
+	runOpts := c.runOpts("primary")
+	runOpts.WriteInto["/docker-entrypoint-initdb.d"] = docker.NewBuildContext()
+	runOpts.WriteInto["/docker-entrypoint-initdb.d"]["init-primary.sh"] = docker.PathContentsFromString(c.primaryInit())
+
+	runOpts.Cmd = c.primaryCmd()
+
+	runner, err := docker.NewServiceRunner(runOpts)
+	if err != nil {
+		return nil, fmt.Errorf("could not create runner for primary node: %w", err)
+	}
+
+	upCheck := connectPostgres(c.Config.Password)
+	svc, containerID, err := runner.StartNewService(ctx, c.Config.AddSuffix, true, upCheck)
+	if err != nil {
+		return nil, fmt.Errorf("could not start primary node: %w", err)
+	}
+
+	node.Runner = runner
+	node.Service = svc
+	node.ConnectionURL = svc.Config.URL().String()
+	node.ContainerID = containerID
+
+	return node, err
+}
+
+func (c *Cluster) addReplica(ctx context.Context) (*Node, error) {
+	c.Config.Logger.Debug("adding replica")
+
+	// Take the primary node, connect to it, and add a new replication slot.
+	db, err := c.Primary.Client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get primary's client: %w", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	slot := len(c.Nodes)
+
+	_, err = db.Exec(fmt.Sprintf("SELECT * FROM pg_create_physical_replication_slot('replication_slot_%d');", slot))
+	if err != nil {
+		return nil, fmt.Errorf("failed add new replication slot %v: %w", slot, err)
+	}
+
+	host, err := c.Primary.NetworkIP(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get primary's network IP address: %w", err)
+	}
+
+	script := `
+pg_ctl stop -D /var/lib/postgresql/data
+
+rm -rf /var/lib/postgresql/data/*
+
+until PGPASSWORD=` + c.Config.Password + ` pg_basebackup -h ` + host + ` -U replicator -D /var/lib/postgresql/data -R -X stream -c fast -S replication_slot_` + strconv.Itoa(slot) + `; do
+	echo "Waiting for primary..."
+	sleep 2
+done
+
+echo "primary_conninfo = 'host=` + host + ` port=5432 user=replicator password=` + c.Config.Password + `'" >> /var/lib/postgresql/data/postgresql.conf
+
+touch /var/lib/postgresql/data/standby.signal
+
+pg_ctl start -D /var/lib/postgresql/data
+
+docker-entrypoint.sh postgres
+`
+
+	runOpts := c.runOpts(fmt.Sprintf("replica_%v", slot))
+	runOpts.Entrypoint = []string{"bash", "-c", script}
+	runOpts.NetworkID = c.Network
+
+	runner, err := docker.NewServiceRunner(runOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create replica %d's service runner: %w", slot, err)
+	}
+
+	upCheck := connectPostgres(c.Config.Password)
+	svc, containerID, err := runner.StartNewService(ctx, c.Config.AddSuffix, true, upCheck)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start replica %d: %w", slot, err)
+	}
+
+	return &Node{
+		Runner:        runner,
+		Service:       svc,
+		ConnectionURL: svc.Config.URL().String(),
+		ContainerID:   containerID,
+	}, nil
+}
+
+func (c *Cluster) AddNode(ctx context.Context) (*Node, error) {
+	replica, err := c.addReplica(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Nodes = append(c.Nodes, replica)
+	return replica, nil
+}
+
+func (c *Cluster) RemovePrimary(ctx context.Context) error {
+	primary := c.Primary
+
+	_, err := primary.Runner.DockerAPI.ContainerRemove(ctx, primary.ContainerID, client.ContainerRemoveOptions{Force: true})
+	if err != nil && errdefs.IsNotFound(err) {
+		return fmt.Errorf("failed to kill primary: %w", err)
+	}
+
+	defer primary.Cleanup()
+
+	c.Primary = nil
+
+	idx := -1
+	for index, node := range c.Nodes {
+		if node == primary {
+			idx = index
+			break
+		}
+	}
+
+	if idx != -1 {
+		c.Nodes = append(c.Nodes[0:idx], c.Nodes[idx+1:]...)
+	}
+
+	return nil
+}
+
+func (c *Cluster) PromoteNode(ctx context.Context, index int) error {
+	if index < 0 || index >= len(c.Nodes) {
+		return fmt.Errorf("index %v out of bounds: %v nodes", index, len(c.Nodes))
+	}
+	if len(c.Nodes) != 1 {
+		return fmt.Errorf("have %v nodes but can only promote with one right now", len(c.Nodes))
+	}
+
+	node := c.Nodes[index]
+
+	db, err := node.Client(ctx)
+	if err != nil {
+		return fmt.Errorf("failed getting node's client: %w", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	var inRecovery bool
+	if err := db.QueryRowContext(ctx, "SELECT pg_is_in_recovery();").Scan(&inRecovery); err != nil {
+		return fmt.Errorf("failed to read recovery mode status: %w", err)
+	}
+
+	if !inRecovery {
+		return fmt.Errorf("cannot promote node with pg_is_in_recovery()=%v", inRecovery)
+	}
+
+	_, err = db.ExecContext(ctx, "SELECT pg_promote();")
+	if err != nil {
+		return fmt.Errorf("failed to promote node: %w", err)
+	}
+
+	c.Primary = node
+	return nil
+}
+
+func (n *Node) Cleanup() {
+	if n == nil || n.Service == nil {
+		return
+	}
+
+	n.Service.Cleanup()
+}
+
+func (n *Node) Network() (string, error) {
+	networks, err := n.Runner.GetNetworkAndAddresses(n.ContainerID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get network addresses: %w", err)
+	}
+
+	if len(networks) != 1 {
+		return "", fmt.Errorf("expected only a single network: %#v", networks)
+	}
+
+	for name := range networks {
+		return name, nil
+	}
+
+	return "", errors.New("unknown failure?")
+}
+
+func (n *Node) NetworkIP(ctx context.Context) (string, error) {
+	inspect, err := n.Runner.DockerAPI.ContainerInspect(ctx, n.ContainerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container %v: %w", n.ContainerID, err)
+	}
+
+	network, err := n.Network()
+	if err != nil {
+		return "", fmt.Errorf("failed to get network for primary container: %w", err)
+	}
+
+	if _, ok := inspect.Container.NetworkSettings.Networks[network]; !ok {
+		return "", fmt.Errorf("network %v not in container %v's networks list: %#v", network, n.ContainerID, inspect.Container.NetworkSettings.Networks)
+	}
+
+	info := inspect.Container.NetworkSettings.Networks[network]
+	return info.IPAddress.String(), nil
+}
+
+func (n *Node) InternalURL(ctx context.Context) (string, error) {
+	u, err := url.Parse(n.ConnectionURL)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse connection URL: %w", err)
+	}
+
+	host, err := n.NetworkIP(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to get node's network IP address: %w", err)
+	}
+
+	u.Host = fmt.Sprintf("%v:5432", host)
+	return u.String(), nil
+}
+
+func (n *Node) Client(ctx context.Context) (*sql.DB, error) {
+	db, err := sql.Open("pgx", n.ConnectionURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("failed to verify database was working: %w", err)
+	}
+
+	return db, nil
 }


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

Based on #3448; will be rebased once that lands.

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This adds a new clustered PostgreSQL storage helper, allowing custom
mappings of OpenBao nodes to PostgreSQL nodes. We add a new OpenBao
test for ensuring horizontal scalability works on all nodes and
ensures it works with a replicated PostgreSQL backend. When the primary
fails, the nodes attached to it should quit working and the nodes
attached to the replicas should become writers.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
