### PR TITLE
Add Core.namedLogger to unify the Named()+AddLogger idiom

### DIFF
--- a/internal/vault/audit.go
+++ b/internal/vault/audit.go
@@ -391,8 +391,7 @@ func (c *Core) persistAudit(ctx context.Context, table *routing.MountTable, loca
 // setupAudit is invoked after we've loaded the audit able to
 // initialize the audit backends
 func (c *Core) setupAudits(ctx context.Context) error {
-	brokerLogger := c.baseLogger.Named("audit")
-	c.AddLogger(brokerLogger)
+	brokerLogger := c.namedLogger("audit")
 	c.auditBroker = NewAuditBroker(brokerLogger)
 
 	err := c.reconcileAudits(reconcileAuditsRequests{
@@ -552,8 +551,7 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *routing.MountEntry, v
 		return nil, fmt.Errorf("nil backend returned from %q factory function", entry.Type)
 	}
 
-	auditLogger := c.baseLogger.Named("audit")
-	c.AddLogger(auditLogger)
+	auditLogger := c.namedLogger("audit")
 
 	switch entry.Type {
 	case "file":

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -1293,8 +1293,7 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEnt
 	conf["plugin_type"] = consts.PluginTypeCredential.String()
 	conf["plugin_version"] = entry.Version
 
-	authLogger := c.baseLogger.Named(fmt.Sprintf("auth.%s.%s", t, entry.Accessor))
-	c.AddLogger(authLogger)
+	authLogger := c.namedLogger(fmt.Sprintf("auth.%s.%s", t, entry.Accessor))
 
 	config := &logical.BackendConfig{
 		StorageView: view,

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -2758,6 +2758,16 @@ func (c *Core) AddLogger(logger log.Logger) {
 	c.allLoggers = append(c.allLoggers, logger)
 }
 
+// namedLogger returns a sub-logger named name, derived from the base logger so
+// its prefix is preserved (see baseLogger), and registers it with the Core so
+// its level tracks dynamic log-level changes. It collapses the common
+// `logger := c.baseLogger.Named(name); c.AddLogger(logger)` idiom into one call.
+func (c *Core) namedLogger(name string) log.Logger {
+	logger := c.baseLogger.Named(name)
+	c.AddLogger(logger)
+	return logger
+}
+
 // SetLogLevel sets logging level for all tracked loggers to the level provided
 func (c *Core) SetLogLevel(level log.Level) {
 	c.allLoggersLock.RLock()
@@ -4015,8 +4025,7 @@ func (c *Core) setupPolicyStore(ctx context.Context) error {
 	// Create the policy store
 	var err error
 	sysView := &dynamicSystemView{core: c}
-	psLogger := c.baseLogger.Named("policy")
-	c.AddLogger(psLogger)
+	psLogger := c.namedLogger("policy")
 	c.policyStore, err = policy.NewStore(ctx, c, c.systemBarrierView, sysView, psLogger)
 	if err != nil {
 		return err

--- a/internal/vault/expiration.go
+++ b/internal/vault/expiration.go
@@ -388,8 +388,7 @@ func (c *Core) setupExpiration(e ExpireLeaseStrategy, standby bool) error {
 	c.metricsMutex.Lock()
 	defer c.metricsMutex.Unlock()
 
-	expLogger := c.baseLogger.Named("expiration")
-	c.AddLogger(expLogger)
+	expLogger := c.namedLogger("expiration")
 
 	// Create the manager
 	c.expiration = NewExpirationManager(c, e, expLogger, slices.Contains(c.detectDeadlocks, "expiration"), !standby)

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -1661,8 +1661,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *routing.MountEntry,
 	conf["plugin_type"] = consts.PluginTypeSecrets.String()
 	conf["plugin_version"] = entry.Version
 
-	backendLogger := c.baseLogger.Named(fmt.Sprintf("secrets.%s.%s", t, entry.Accessor))
-	c.AddLogger(backendLogger)
+	backendLogger := c.namedLogger(fmt.Sprintf("secrets.%s.%s", t, entry.Accessor))
 
 	config := &logical.BackendConfig{
 		StorageView: view,

--- a/internal/vault/namespace_store.go
+++ b/internal/vault/namespace_store.go
@@ -263,8 +263,7 @@ func (ns *NamespaceStore) loadNamespacesRecursive(
 func (c *Core) setupNamespaceStore(ctx context.Context) error {
 	// Create the Namespace store
 	var err error
-	nsLogger := c.baseLogger.Named("namespace")
-	c.AddLogger(nsLogger)
+	nsLogger := c.namedLogger("namespace")
 	c.namespaceStore, err = NewNamespaceStore(ctx, c, nsLogger)
 	return err
 }

--- a/internal/vault/rollback.go
+++ b/internal/vault/rollback.go
@@ -400,8 +400,7 @@ func (c *Core) startRollback() error {
 		}
 		return ret
 	}
-	rollbackLogger := c.baseLogger.Named("rollback")
-	c.AddLogger(rollbackLogger)
+	rollbackLogger := c.namedLogger("rollback")
 	c.rollback = NewRollbackManager(c.activeContext.Load(), rollbackLogger, backendsFunc, c.router, c)
 	c.rollback.Start()
 	return nil

--- a/internal/vault/seal_manager.go
+++ b/internal/vault/seal_manager.go
@@ -75,8 +75,7 @@ func NewSealManager(core *Core, logger hclog.Logger) *SealManager {
 
 // SetupSealManager is called on core creation to initialize the seal manager.
 func (c *Core) SetupSealManager() {
-	sealLogger := c.baseLogger.Named("seals")
-	c.AddLogger(sealLogger)
+	sealLogger := c.namedLogger("seals")
 	c.sealManager = NewSealManager(c, sealLogger)
 	c.sealManager.Reset()
 }

--- a/internal/vault/workflow_store.go
+++ b/internal/vault/workflow_store.go
@@ -105,8 +105,7 @@ type WorkflowStore struct {
 }
 
 func NewWorkflowStore(c *Core) *WorkflowStore {
-	logger := c.baseLogger.Named("workflow")
-	c.AddLogger(logger)
+	logger := c.namedLogger("workflow")
 	return &WorkflowStore{
 		core:        c,
 		modifyLocks: locksutil.CreateLocks(),


### PR DESCRIPTION
## What

Adds a small `(*Core).namedLogger(name string) log.Logger` helper that names a sub-logger off `baseLogger` and registers it with the Core, and migrates the call sites that use this exact idiom:

```go
logger := c.baseLogger.Named(name)
c.AddLogger(logger)
```

becomes

```go
logger := c.namedLogger(name)
```

## Why

Per @cipherboy in https://github.com/openbao/openbao/pull/3448#discussion_r3616794099 ("This should just be a single pattern tbh"), tracked in #3541. The `Named(...)` + `AddLogger(...)` two-step was duplicated across the vault package; every sub-logger has to remember to register itself so its level tracks dynamic log-level changes.

## Scope / behavior

This PR migrates only the call sites that derive their sub-logger from `c.baseLogger` (audit, auth, expiration, mount, namespace_store, policy, rollback, seal_manager, workflow_store). **Behavior is unchanged** — the sub-loggers keep the exact same names and are still registered. `go build ./internal/vault/...` and `go vet ./internal/vault/` pass; `gofmt` clean.

A couple of related sites are intentionally left out because folding them in would change behavior, and I'd rather get your steer first:

- A few sub-loggers are named off `c.logger` (the `core`-named logger) rather than `c.baseLogger` — e.g. `raft` and `cluster-listener.tcp`. Switching those to `namedLogger` would drop the `core.` prefix from their log names (`core.raft` -> `raft`). If that normalization is the intended single pattern, I'm happy to include them.
- A few sites name off a local `logger` passed into a setup helper (e.g. token/system/identity in `core.go`, `mfa` in `login_mfa.go`). Those can also be routed through `namedLogger` if you'd like, but I kept this PR to the unambiguous, behavior-preserving cases.

`internal/vault/identity` has its own `AddLogger` on a different type, so it's out of scope here.

Signed-off-by is included (DCO).

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). I designed the helper, chose the `baseLogger`-derived scope to keep log names identical, and verified with `go build ./internal/vault/...` and `go vet ./internal/vault/` (both pass) plus `gofmt`.*
