### PR TITLE
auth/jwt: fix patch operation of CEL roles lost data

### DIFF
--- a/changelog/3551.txt
+++ b/changelog/3551.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/jwt: fix patch operation of CEL roles lost existing data (`bound_audiences` `not_before_leeway`, `clock_skew_leeway and `expiration_leeway`)
+```

--- a/internal/builtin/credential/jwt/path_cel_role.go
+++ b/internal/builtin/credential/jwt/path_cel_role.go
@@ -315,9 +315,13 @@ func (b *jwtAuthBackend) pathCelRolePatch(ctx context.Context, req *logical.Requ
 	}
 
 	entry := &celRoleEntry{
-		Name:    roleName,
-		Program: oldEntry.Program,
-		Message: data.GetWithExplicitDefault("message", oldEntry.Message).(string),
+		Name:             roleName,
+		Program:          oldEntry.Program,
+		Message:          data.GetWithExplicitDefault("message", oldEntry.Message).(string),
+		NotBeforeLeeway:  data.GetTimeWithExplicitDefault("not_before_leeway", oldEntry.NotBeforeLeeway),
+		ClockSkewLeeway:  data.GetTimeWithExplicitDefault("clock_skew_leeway", oldEntry.ClockSkewLeeway),
+		ExpirationLeeway: data.GetTimeWithExplicitDefault("expiration_leeway", oldEntry.ExpirationLeeway),
+		BoundAudiences:   data.GetWithExplicitDefault("bound_audiences", oldEntry.BoundAudiences).([]string),
 	}
 
 	// Update the program field if provided.

--- a/internal/builtin/credential/jwt/path_cel_role_test.go
+++ b/internal/builtin/credential/jwt/path_cel_role_test.go
@@ -119,3 +119,115 @@ func TestJwt_CelRoleCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestJwt_CelRoleCRUD(t *testing.T) {
+	b, storage := getBackend(t)
+	path := "cel/role/testrole"
+
+	type TestCase struct {
+		operation    logical.Operation
+		data         map[string]any
+		expectedRole map[string]any
+	}
+
+	cases := []TestCase{{
+		operation: logical.UpdateOperation,
+		data: map[string]any{
+			"cel_program": map[string]any{
+				"expression": "1 == 1",
+			},
+			"clock_skew_leeway": 10,
+			"expiration_leeway": 11,
+			"not_before_leeway": 12,
+		},
+		expectedRole: map[string]any{
+			"bound_audiences": []string{},
+			"cel_program": &celhelper.Program{
+				Expression: "1 == 1",
+			},
+			"clock_skew_leeway": int64(10),
+			"expiration_leeway": int64(11),
+			"message":           "",
+			"name":              "testrole",
+			"not_before_leeway": int64(12),
+		},
+	}, {
+		operation: logical.PatchOperation,
+		data: map[string]any{
+			"message":         "my-message",
+			"bound_audiences": "a,b,c",
+			"cel_program": map[string]any{
+				"variables": []map[string]any{{
+					"name":       "x",
+					"expression": "true",
+				}},
+			},
+			"clock_skew_leeway": 120,
+		},
+		// should keep previous fields + updates
+		expectedRole: map[string]any{
+			"bound_audiences": []string{"a", "b", "c"},
+			"cel_program": &celhelper.Program{
+				Expression: "1 == 1",
+				Variables:  []celhelper.Variable{{Name: "x", Expression: "true"}},
+			},
+			"clock_skew_leeway": int64(120),
+			"expiration_leeway": int64(11),
+			"message":           "my-message",
+			"name":              "testrole",
+			"not_before_leeway": int64(12),
+		},
+	}, {
+		operation: logical.UpdateOperation,
+		data: map[string]any{
+			"cel_program": map[string]any{
+				"expression": "2 == 2",
+			},
+		},
+		// this time we expect the defaults to be restored
+		expectedRole: map[string]any{
+			"bound_audiences": []string{},
+			"cel_program": &celhelper.Program{
+				Expression: "2 == 2",
+			},
+			"clock_skew_leeway": int64(60),
+			"expiration_leeway": int64(150),
+			"message":           "",
+			"name":              "testrole",
+			"not_before_leeway": int64(150),
+		},
+	}, {
+		operation:    logical.DeleteOperation,
+		data:         nil,
+		expectedRole: nil,
+	}}
+
+	for i, tc := range cases {
+		t.Logf("executing case %d: %s", i, tc.operation)
+		roleReq := &logical.Request{
+			Operation: tc.operation,
+			Path:      path,
+			Storage:   storage,
+			Data:      tc.data,
+		}
+		resp, err := b.HandleRequest(t.Context(), roleReq)
+		require.NoError(t, err)
+		if tc.expectedRole == nil {
+			require.Nil(t, resp)
+			continue
+		}
+		require.NotNil(t, resp)
+		require.NoError(t, resp.Error())
+
+		resp, err = b.HandleRequest(t.Context(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      path,
+			Storage:   storage,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NoError(t, resp.Error())
+
+		require.Equal(t, resp.Data, tc.expectedRole)
+	}
+}


### PR DESCRIPTION
## Description

Executing a patch operation against a CEL Role in the JWT auth engine causes some fields (`bound_audiences` `not_before_leeway`, `clock_skew_leeway and `expiration_leeway`) to loose their current value (even if provided explicitly). They are not reset to the default, instead they are set to the "empty value" of their datatype (e.g. 0 for time)
 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
