### PR TITLE
Ensure AppRole salt is created without transaction

### DIFF
--- a/changelog/3556.txt
+++ b/changelog/3556.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Ensure initial salt is created without transaction to avoid deadlocks.
+```

--- a/internal/builtin/credential/approle/backend.go
+++ b/internal/builtin/credential/approle/backend.go
@@ -5,6 +5,7 @@ package approle
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -33,9 +34,6 @@ type backend struct {
 	// by this backend.
 	salt      *salt.Salt
 	saltMutex sync.RWMutex
-
-	// The view to use when creating the salt
-	view logical.Storage
 
 	// Guard to clean-up the expired SecretID entries
 	tidySecretIDCASGuard atomic.Bool
@@ -76,7 +74,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func Backend(conf *logical.BackendConfig) *backend {
 	b := &backend{
-		view: conf.StorageView,
 		// Create locks to modify the registered roles
 		roleLocks: locksutil.CreateLocks(),
 		// Create locks to modify the generated RoleIDs
@@ -112,11 +109,25 @@ func Backend(conf *logical.BackendConfig) *backend {
 		Invalidate:     b.invalidate,
 		BackendType:    logical.TypeCredential,
 		RunningVersion: ReportedVersion,
+		InitializeFunc: b.Initialize,
 	}
 	return b
 }
 
-func (b *backend) Salt(ctx context.Context) (*salt.Salt, error) {
+func (b *backend) Initialize(ctx context.Context, req *logical.InitializationRequest) error {
+	if b.System().ReplicationState().HasState(consts.ReplicationDRSecondary|consts.ReplicationPerformanceStandby) ||
+		(!b.System().LocalMount() && b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary)) {
+		return nil
+	}
+
+	if _, err := b.Salt(ctx, req.Storage); err != nil {
+		return fmt.Errorf("error creating initial salt: %w", err)
+	}
+
+	return nil
+}
+
+func (b *backend) Salt(ctx context.Context, storage logical.Storage) (*salt.Salt, error) {
 	b.saltMutex.RLock()
 	if b.salt != nil {
 		defer b.saltMutex.RUnlock()
@@ -128,7 +139,7 @@ func (b *backend) Salt(ctx context.Context) (*salt.Salt, error) {
 	if b.salt != nil {
 		return b.salt, nil
 	}
-	salt, err := salt.NewSalt(ctx, b.view, &salt.Config{
+	salt, err := salt.NewSalt(ctx, storage, &salt.Config{
 		HashFunc: salt.SHA256Hash,
 		Location: salt.DefaultLocation,
 	})

--- a/internal/builtin/credential/approle/backend_test.go
+++ b/internal/builtin/credential/approle/backend_test.go
@@ -19,6 +19,7 @@ func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
 
 	b := Backend(config)
 	require.NoError(t, b.Setup(t.Context(), config))
+	require.NoError(t, b.Initialize(t.Context(), &logical.InitializationRequest{Storage: config.StorageView}))
 	return b, config.StorageView
 }
 

--- a/internal/builtin/credential/approle/path_role.go
+++ b/internal/builtin/credential/approle/path_role.go
@@ -3515,7 +3515,7 @@ func (b *backend) setRoleIDEntry(ctx context.Context, s logical.Storage, roleID 
 	lock.Lock()
 	defer lock.Unlock()
 
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -3543,7 +3543,7 @@ func (b *backend) roleIDEntry(ctx context.Context, s logical.Storage, roleID str
 
 	var result roleIDStorageEntry
 
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -3571,7 +3571,7 @@ func (b *backend) roleIDEntryDelete(ctx context.Context, s logical.Storage, role
 	lock.Lock()
 	defer lock.Unlock()
 
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/internal/builtin/credential/approle/path_tidy_user_id.go
+++ b/internal/builtin/credential/approle/path_tidy_user_id.go
@@ -79,7 +79,7 @@ func (b *backend) tidySecretIDinternal(s logical.Storage) {
 	// Don't cancel when the original client request goes away
 	ctx := context.Background()
 
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		logger.Error("error tidying secret IDs", "error", err)
 		return

--- a/internal/builtin/credential/approle/validation.go
+++ b/internal/builtin/credential/approle/validation.go
@@ -327,7 +327,7 @@ func (b *backend) secretIDAccessorEntry(ctx context.Context, s logical.Storage, 
 	var result secretIDAccessorStorageEntry
 
 	// Create index entry, mapping the accessor to the token ID
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +364,7 @@ func (b *backend) createSecretIDAccessorEntry(ctx context.Context, s logical.Sto
 	entry.SecretIDAccessor = accessorUUID
 
 	// Create index entry, mapping the accessor to the token ID
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (b *backend) createSecretIDAccessorEntry(ctx context.Context, s logical.Sto
 
 // deleteSecretIDAccessorEntry deletes the storage index mapping the accessor to a SecretID.
 func (b *backend) deleteSecretIDAccessorEntry(ctx context.Context, s logical.Storage, secretIDAccessor, roleSecretIDPrefix string) error {
-	salt, err := b.Salt(ctx)
+	salt, err := b.Salt(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/internal/vault/external_tests/plugin/external_plugin_test.go
+++ b/internal/vault/external_tests/plugin/external_plugin_test.go
@@ -126,6 +126,11 @@ func TestExternalPlugin_RollbackAndReload(t *testing.T) {
 
 func testRegisterAndEnable(t *testing.T, client *api.Client, plugin pluginhelpers.TestPlugin) {
 	t.Helper()
+	testRegisterPlugin(t, client, plugin)
+	testEnablePlugin(t, client, plugin)
+}
+
+func testRegisterPlugin(t *testing.T, client *api.Client, plugin pluginhelpers.TestPlugin) {
 	if err := client.Sys().RegisterPlugin(&api.RegisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
@@ -135,7 +140,9 @@ func testRegisterAndEnable(t *testing.T, client *api.Client, plugin pluginhelper
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
 
+func testEnablePlugin(t *testing.T, client *api.Client, plugin pluginhelpers.TestPlugin) {
 	switch plugin.Typ {
 	case consts.PluginTypeSecrets:
 		if err := client.Sys().Mount(plugin.Name, &api.MountInput{
@@ -225,36 +232,25 @@ func testExternalPlugin_ContinueOnError(t *testing.T, mismatch bool, pluginType 
 		}
 	}
 
-	// Seal the cluster
+	// Seal and unseal the cluster
 	cluster.EnsureCoresSealed(t)
+	cluster.UnsealCores(t)
 
-	// Unseal the cluster
-	barrierKeys := cluster.BarrierKeys
-	for _, core := range cluster.Cores {
-		for _, key := range barrierKeys {
-			_, err := core.Unseal(vault.TestKeyCopy(key))
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		if core.Sealed() {
-			t.Fatal("should not be sealed")
-		}
-	}
-
-	// Wait for active so post-unseal takes place
-	// If it fails, it means unseal process failed
-	vault.TestWaitActive(t, core.Core)
-
-	// unmount
+	// unmount -- this invokes the plugin, though we don't really care if it
+	// passes or fails. It will fail if the plugin has written any data but
+	// succeed vacuously if the plugin has not done anything during
+	// initialization.
+	unmountFailed := false
 	switch pluginType {
 	case consts.PluginTypeSecrets:
 		if err := client.Sys().Unmount(plugin.Name); err != nil {
-			t.Fatal(err)
+			t.Logf("got (non-fatal) error unmounting: %v", err)
+			unmountFailed = true
 		}
 	case consts.PluginTypeCredential:
 		if err := client.Sys().DisableAuth(plugin.Name); err != nil {
-			t.Fatal(err)
+			t.Logf("got (non-fatal) error unmounting: %v", err)
+			unmountFailed = true
 		}
 	}
 
@@ -264,7 +260,27 @@ func testExternalPlugin_ContinueOnError(t *testing.T, mismatch bool, pluginType 
 	cluster.Plugins = plugins
 
 	// Re-add the plugin to the catalog
-	testRegisterAndEnable(t, client, plugin)
+	testRegisterPlugin(t, client, plugin)
+
+	// Clean up our old one should now succeed after a restart.
+	if unmountFailed {
+		// Seal and unseal the cluster
+		cluster.EnsureCoresSealed(t)
+		cluster.UnsealCores(t)
+
+		switch pluginType {
+		case consts.PluginTypeSecrets:
+			if err := client.Sys().Unmount(plugin.Name); err != nil {
+				t.Fatalf("failed to unmount after re-loading plugin: %v", err)
+			}
+		case consts.PluginTypeCredential:
+			if err := client.Sys().DisableAuth(plugin.Name); err != nil {
+				t.Fatalf("failed to unmount after re-loading plugin: %v", err)
+			}
+		}
+	}
+
+	testEnablePlugin(t, client, plugin)
 
 	// Reload the plugin
 	req = logical.TestRequest(t, logical.UpdateOperation, "sys/plugins/reload/backend")


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When starting the backend, fetch the initial salt from storage. This ensures on initial startup we've provisioned the salt and thus do not have to create it. While invalidation may reset it later, we know that we don't have to create it again as we're on a standby and would be unable to write it anyways.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3157

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
