### PR TITLE
Replace Maw with Fabien as the primary TSC member of GitLab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ that lacks a sign-off to this agreement will not be accepted by the OpenBao proj
 | James Butcher    | james@iotechsys.com          |                                            | Brad Corrion (brad@iotechsys.com)               | IOTech Systems       | Member       |
 | Julian Cassignol | jcassignol@wallix.com        |                                            | Dan Ghita (dghita@wallix.com)                   | Wallix               | Member       |
 | Michael Hofer    | michael.hofer@adfinis.com    | [@karras](https://github.com/karras)       | Andrii Fedorchuk (andrii.fedorchuk@adfinis.com) | Adfinis              | Chair        |
-| Maw Wildpaner    | maw@gitlab.com               |                                            | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
+| Fabien Catteau   | fcatteau@gitlab.com          | [@fact](https://github.com/fcat)           | Mark Mishaev (mmishaev@gitlab.com)              | GitLab               | Member       |
 | Klaus Kiefer     | klaus.kiefer@sap.com         | [@klaus-sap](https://github.com/klaus-sap) | Jonas Köhnen (j.koehnen@reply.de)               | SAP                  | Member       |
 | Alex Scheel      | alex.scheel@control-plane.io | [@cipherboy](https://github.com/cipherboy) | Eugene Davis (eugene.davis@control-plane.io)    | ControlPlane         | Member       |
 


### PR DESCRIPTION
## Description

Replace Maw with Fabien as the primary TSC member of GitLab:

* https://docs.google.com/document/d/1oNqm4GXCsIZbcNHsIqft4kgciRcuwS9rrIRGXlMz1yg/edit?tab=t.j9lcyrvl3939#heading=h.g0mtamumz5i0

cc @fcat @lambdanature @markmishaev

## Rationale

n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
