### PR TITLE
Copy binary to additional path in test container (#3554)

### DIFF
--- a/changelog/3554.txt
+++ b/changelog/3554.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk: Better support non-usr-merged distributions in containerized testing.
+```

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -884,12 +884,44 @@ func BuildImage(ctx context.Context, api *client.Client, containerfile string, c
 		return nil, fmt.Errorf("failed to build image: %v", err)
 	}
 
-	output, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read image build output: %w", err)
+	var output bytes.Buffer
+	tee := io.TeeReader(resp.Body, &output)
+
+	var buildError error
+	var messages []string
+
+	dec := json.NewDecoder(tee)
+	for {
+		var message map[string]any
+		if err := dec.Decode(&message); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, fmt.Errorf("error decoding output from image build: %w", err)
+		}
+
+		if stream, ok := message["stream"]; ok {
+			messages = append(messages, strings.TrimSpace(stream.(string)))
+		}
+
+		if detail, ok := message["errorDetail"]; ok {
+			contents := fmt.Sprintf("[ERROR]: %v", detail)
+			message, ok := detail.(map[string]any)["message"]
+			if ok {
+				contents = fmt.Sprintf("[ERROR]: %v", message.(string))
+			}
+
+			messages = append(messages, contents)
+			buildError = errors.New(contents)
+		}
 	}
 
-	return output, nil
+	if buildError != nil {
+		return nil, fmt.Errorf("error during container image build: %w\n\nbuild messages:\n\t%v\n\n", buildError, strings.Join(messages, "\n\t"))
+	}
+
+	return output.Bytes(), nil
 }
 
 func (d *Runner) CopyTo(c string, destination string, contents BuildContext) error {

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -1255,7 +1255,7 @@ func (dc *DockerCluster) setupImage(ctx context.Context, opts *DockerClusterOpti
 
 	containerFile := fmt.Sprintf(`
 FROM %s:%s
-COPY bao /bin/bao
+COPY bao /usr/bin/bao
 `, opts.ImageRepo, sourceTag)
 
 	if len(opts.Entrypoint) > 0 {
@@ -1267,7 +1267,7 @@ COPY bao /bin/bao
 		dockhelper.BuildPullParent(true),
 		dockhelper.BuildTags([]string{opts.ImageRepo + ":" + tag}))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to build image: %w", err)
 	}
 	dc.builtTags[tag] = struct{}{}
 	return tag, nil


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

* Copy binary to additional path in container

When usr-merge is not in use, `bao` may either be at `/bin/bao` or `/usr/bin/bao` and we don't necessarily know which ranks higher in the container's `$PATH` without a fair bit of work. Copy the binary to both as a result.

See also: https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/



* Fix container image build errors

This ensures we parse output from the container image build and err if there's an appropriate message rather than blindly accepting err.



* Add changelog entry



---------

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
