### PR TITLE
auth/jwt: surface OIDC discovery errors during configuration

### DIFF
--- a/changelog/3574.txt
+++ b/changelog/3574.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/oidc: error message for oidc_discovery_url now came from the underlying library so we have more details on what's wrong (bad issuer).
+auth/oidc: Return error messages for `oidc_discovery_url` validation errors (like bad issuer) from the underlying library .
 ```

--- a/changelog/3574.txt
+++ b/changelog/3574.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/oidc: Return error messages for `oidc_discovery_url` validation errors (like bad issuer) from the underlying library .
+auth/oidc: Return `oidc_discovery_url` validation errors (like bad issuer) from the underlying library.
 ```

--- a/changelog/3574.txt
+++ b/changelog/3574.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/oidc: error message for oidc_discovery_url now came from the underlying library so we have more details on what's wrong (bad issuer).
+```

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -399,9 +399,8 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		if err != nil {
 			if !skipJwksValidation {
 				b.Logger().Error("error checking oidc discovery URL", "error", err)
-				return logical.ErrorResponse("error checking oidc discovery URL"), nil
+				return logical.ErrorResponse("error checking oidc discovery URL: %s", err.Error()), nil
 			}
-
 			resp.AddWarning("error checking oidc discovery URL")
 		}
 	case config.OIDCClientID != "" && config.OIDCDiscoveryURL == "":

--- a/internal/builtin/credential/jwt/path_config_test.go
+++ b/internal/builtin/credential/jwt/path_config_test.go
@@ -169,6 +169,31 @@ func TestConfig_JWT_Write(t *testing.T) {
 	if !reflect.DeepEqual(expected, conf) {
 		t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
 	}
+
+	t.Run("with trailing slash fails", func(t *testing.T) {
+		b, storage := getBackend(t)
+		s := newOIDCProvider(t)
+		defer s.server.Close()
+
+		cert, err := s.getTLSCert()
+		require.NoError(t, err)
+
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data: map[string]any{
+				"oidc_discovery_url":    s.server.URL + "/",
+				"oidc_discovery_ca_pem": cert,
+			},
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		require.NoError(t, err)
+		require.True(t, resp.IsError())
+		require.EqualError(t, resp.Error(), "error checking oidc discovery URL: "+
+			"issuer did not match the returned issuer, expected \""+s.server.URL+"/\" got \""+s.server.URL+"\"")
+	})
 }
 
 func TestConfig_JWKS_Update(t *testing.T) {


### PR DESCRIPTION
## Description

- OIDC discovery/issuer validation errors were not being properly propagated to the caller during configuration
- The change returns the existing validation error, from the underlying library we use, making the actual problem clearly visible to the user, through the UI too
- The change deliberately does not strip, normalize, or otherwise special-case a trailing /, as this can be a real use-case of an issuer that really contains a backslash at its end
- It also includes the JWT authentication, as this part of the configuration is common tp both auth methods

## Rationale

- A trailing slash is only one possible reason why the configured discovery URL and the issuer returned by the OIDC provider may differ
- More generally, the configured URL may resolve or redirect to a provider advertising a different issuer
- Such a configuration will fail later during authentication anyway
- By the way, a typo can also lead to an error, like "network connection", and this is a goog way to understand immediatly the issue with what we configured

Therefore, it is better to reject the invalid configuration immediately and expose the actual validation error to the user.
This provides earlier and clearer feedback without introducing URL-specific normalization behavior.

Resolves: #3358

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
