### PR TITLE
Fix(docs): Built-in plugins don't need to be manually upgraded 

### DIFF
--- a/website/content/docs/upgrading/plugins.mdx
+++ b/website/content/docs/upgrading/plugins.mdx
@@ -8,8 +8,13 @@ description: These are general upgrade instructions for OpenBao plugins.
 ## Plugin upgrade procedure
 
 The following procedures detail steps for upgrading a plugin that has been mounted
-at a path on a running server. The steps are the same whether the plugin being
-upgraded is built-in or external.
+at a path on a running server.
+
+:::info
+This guide only applies to external plugins (which are distributed as separate binaries).
+Built-in plugins do **not** need to be upgraded separately (because they are compiled
+into the main OpenBao binary).
+:::
 
 ### Upgrading auth and secrets plugins
 
@@ -17,7 +22,7 @@ The process is nearly identical for auth and secret plugins. If you are upgradin
 an auth plugin, just replace all usages of `secrets` or `secret` with `auth`.
 
 1. [Register][plugin_registration] the first version of your plugin to the catalog.
-   Skip this step if your initial plugin is built-in or already registered.
+   Skip this step if your initial plugin is already registered.
 
     ```shell-session
     $ bao plugin register \
@@ -34,8 +39,7 @@ an auth plugin, just replace all usages of `secrets` or `secret` with `auth`.
     ```
 
 1. Register a second version of your plugin. You **must** use the same plugin
-   type and name (the last two arguments) as the plugin being upgraded. This is
-   true regardless of whether the plugin being upgraded is built-in or external.
+   type and name (the last two arguments) as the plugin being upgraded.
 
     ```shell-session
     $ bao plugin register \
@@ -85,7 +89,7 @@ by setting the 'scope' parameter of the reload to 'global'.
 ### Upgrading database plugins
 
 1. [Register][plugin_registration] the first version of your plugin to the catalog.
-   Skip this step if your initial plugin is built-in or already registered.
+   Skip this step if your initial plugin is already registered.
 
     ```shell-session
     $ bao plugin register
@@ -105,8 +109,7 @@ by setting the 'scope' parameter of the reload to 'global'.
     ```
 
 1. Register a second version of your plugin. You **must** use the same plugin
-   type and name (the last two arguments) as the plugin being upgraded. This is
-   true regardless of whether the plugin being upgraded is built-in or external.
+   type and name (the last two arguments) as the plugin being upgraded.
 
     ```shell-session
     $ bao plugin register \

--- a/website/content/docs/upgrading/plugins.mdx
+++ b/website/content/docs/upgrading/plugins.mdx
@@ -5,8 +5,6 @@ description: These are general upgrade instructions for OpenBao plugins.
 
 # Upgrading OpenBao plugins
 
-## Plugin upgrade procedure
-
 The following procedures detail steps for upgrading a plugin that has been mounted
 at a path on a running server.
 
@@ -16,7 +14,7 @@ Built-in plugins do **not** need to be upgraded separately (because they are com
 into the main OpenBao binary).
 :::
 
-### Upgrading auth and secrets plugins
+## Upgrading auth and secrets plugins
 
 The process is nearly identical for auth and secret plugins. If you are upgrading
 an auth plugin, just replace all usages of `secrets` or `secret` with `auth`.
@@ -86,7 +84,7 @@ by setting the 'scope' parameter of the reload to 'global'.
 
 :::
 
-### Upgrading database plugins
+## Upgrading database plugins
 
 1. [Register][plugin_registration] the first version of your plugin to the catalog.
    Skip this step if your initial plugin is already registered.
@@ -133,7 +131,7 @@ Until the last step, the mount will still run the first version of `my-db-plugin
 the reload is triggered, OpenBao will kill `my-db-plugin`’s process and start the
 new plugin process for `my-db-plugin` version 1.0.1.
 
-### Downgrading plugins
+## Downgrading plugins
 
 Plugin downgrades follow the same procedure as upgrades. You can use the OpenBao
 plugin list command to check what plugin versions are available to downgrade to:
@@ -155,7 +153,7 @@ totp                v1.12.0+builtin.bao
 transit             v1.12.0+builtin.bao
 ```
 
-### Additional upgrade notes
+## Additional upgrade notes
 
 * As mentioned earlier, disabling existing mounts will wipe the existing data.
 * Overwriting an existing version in the catalog will affect all uses of that


### PR DESCRIPTION
## Description

This MR updates the ["Plugin Upgrade" guide](https://openbao.org/docs/upgrading/plugins/) to no longer claim that built-in plugins need to be manually  upgraded.

## Rationale

As @satoqz confirmed in https://github.com/orgs/openbao/discussions/3546#discussioncomment-17719637:

> > How are built-in plugins upgraded?
>
> You don't, they're built-in and as such there can only be one version at a time, and mounts &co move along automatically.

Therefore, update the docs accordingly.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
