### PR TITLE
Clarify difference between the two plugin development/author guides

### DIFF
--- a/website/content/docs/plugins/plugin-authors-guide.mdx
+++ b/website/content/docs/plugins/plugin-authors-guide.mdx
@@ -3,7 +3,7 @@ sidebar_label: Plugin Development Patterns
 description: OpenBao's plugin authors guide.
 ---
 
-# Plugin Author Guide
+# Plugin Development Patterns
 
 :::warning
 
@@ -13,8 +13,9 @@ plugins, we recommend not reading this section of the documentation.
 
 :::
 
-This page is a guide for developers interested in creating, managing, and enhancing
-plugins for OpenBao.
+This page contains some common patterns/practices/tips for plugin developers.
+This guide assumes that you are already familiar with the
+[basics of plugin development](./plugin-development.mdx).
 
 ## List pagination
 

--- a/website/content/docs/plugins/plugin-authors-guide.mdx
+++ b/website/content/docs/plugins/plugin-authors-guide.mdx
@@ -1,9 +1,17 @@
 ---
-sidebar_label: Plugin Author Guide
+sidebar_label: Plugin Development Patterns
 description: OpenBao's plugin authors guide.
 ---
 
 # Plugin Author Guide
+
+:::warning
+
+Advanced topic! Plugin development is a highly advanced topic in OpenBao, and
+is not required knowledge for day-to-day usage. If you don't plan on writing any
+plugins, we recommend not reading this section of the documentation.
+
+:::
 
 This page is a guide for developers interested in creating, managing, and enhancing
 plugins for OpenBao.

--- a/website/content/docs/plugins/plugin-authors-guide.mdx
+++ b/website/content/docs/plugins/plugin-authors-guide.mdx
@@ -8,14 +8,6 @@ description: OpenBao's plugin authors guide.
 This page is a guide for developers interested in creating, managing, and enhancing
 plugins for OpenBao.
 
-## Table of contents
-
-- [List pagination](#list-pagination)
-- [Listing Detailed Endpoints](#listing-detailed-endpoints)
-- [Revoke Operations Should Ignore "Not Found" Errors](#revoke-operations-should-ignore-not-found-errors)
-- [Docker-based Tests](#docker-based-tests)
-- [Dangers of Custom Auto Unseal Mechanisms](#dangers-of-custom-auto-unseal-mechanisms)
-
 ## List pagination
 
 When implementing listing, it is recommended to use pagination so that items are


### PR DESCRIPTION
## Description

This MR renames the title of the "Plugin Author Guide" to make it clearer what the difference to the "Plugin Development" page is.

Plus other small changes to this page, see the commit messages.

## Rationale

Currently, there are two docs pages for plugin developers:

- https://openbao.org/docs/plugins/plugin-development/
- https://openbao.org/docs/plugins/plugin-authors-guide/

From the titles and introductions alone, it is not clear what the "Author Guide" does.

That said, the distinction between the two pages makes sense, it just needs to be made clearer in the title. As @cipherboy [noted](https://github.com/openbao/openbao/pull/767#issuecomment-2555346983) in the MR that added the "Author Guide":

> I'm thinking the other one will be more overview-y and this one will be more esoterica, FAQ-y.

I am open to other title suggestions. "Patterns" is the local optimum of my creativity. The title should be explanatory of the page contents, not be too long, and ideally start with "Plugin Development ..." for consistency.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
