### PR TITLE
Add API docs for external keys

### DIFF
--- a/website/content/api-docs/system/external-keys.mdx
+++ b/website/content/api-docs/system/external-keys.mdx
@@ -1,0 +1,364 @@
+---
+description: The `/sys/external-keys` endpoint is used to configure external keys in OpenBao.
+---
+
+# `/sys/external-keys`
+
+The `/sys/external-keys` endpoint is used to configure external keys in OpenBao.
+
+## Manage configs
+
+A config is a container for a set of KMS key mappings that share a common set of
+configuration. This includes the name of the KMS plugin that the keys are backed
+by and provider-specific top-level options such as authentication credentials
+and API endpoints.
+
+### List configs
+
+This endpoint lists all configs in a namespace.
+
+| Method | Path                         |
+| :----- | :--------------------------- |
+| `LIST` | `/sys/external-keys/configs` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X LIST --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs
+```
+
+#### Sample response
+
+```json
+{
+  "keys": ["my-transit-config", "my-pkcs11-config"]
+}
+```
+
+### Create/Update/Patch config
+
+This endpoint creates, updates or patches a config.
+
+| Method                 | Path                               |
+| :--------------------- | :--------------------------------- |
+| `POST`, `PUT`, `PATCH` | `/sys/external-keys/configs/:name` |
+
+#### Generic parameters
+
+- `name` `(string: <required>)` - Specifies the name of the config. This is
+  specified as part of the request URL.
+
+- `plugin` `(string: <required>)` - Specifies the name of the KMS plugin to use,
+  e.g., `"transit"` or `"pkcs11"`.
+
+- `verify` `(bool: true)` - Verify that the configured plugin is available and
+  validate the given parameters against it before writing the update. The exact
+  checks performed depend on the plugin. This parameter is not persisted and
+  applies on a per-request basis.
+
+#### Plugin-specific parameters
+
+In addition to generic parameters, this endpoint takes plugin-specific
+parameters.
+
+{
+  // TODO(satoqz): Link to per-provider documentation here once that exists.
+}
+
+#### Notes on PATCH
+
+When modifying via `PATCH`, a JSON merge patch is performed and only parameters
+that should change need to be supplied, not all otherwise required ones. To
+fully replace a config's parameters, prefer `POST` or `PUT`.
+
+#### Sample payload
+
+E.g., when using the Transit plugin:
+
+```json
+{
+    "plugin": "transit",
+    "address": "https://openbao.example.com",
+    "mount_path": "my-transit-engine",
+    "token": "s.yaEiIRFNnkPhzDyvShmVspTS"
+}
+```
+
+or when using the PKCS#11 plugin:
+
+```json
+{
+    "plugin": "pkcs11",
+    "lib": "softhsm",
+    "pin": "hunter2",
+    "slot": 5
+}
+```
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X POST --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config
+```
+
+### Read config
+
+This endpoint returns a config's parameters as previously set. Any sensitive
+parameters (as determined by the config's driving plugin) are returned in
+redacted form, rewritten as `(redacted)`.
+
+| Method | Path                               |
+| :----- | :--------------------------------- |
+| `GET`  | `/sys/external-keys/configs/:name` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X GET --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config
+```
+
+#### Sample response
+
+E.g., when using the Transit plugin:
+
+```json
+{
+  "data": {
+    "address": "https://openbao.example.com",
+    "mount_path": "my-transit-engine",
+    "plugin": "transit",
+    "token": "(redacted)"
+  }
+}
+```
+
+### Delete config
+
+This endpoint deletes a config, including all of its keys. Notably, it does not
+delete the underlying KMS keys, only the mappings in OpenBao.
+
+| Method   | Path                               |
+| :------- | :--------------------------------- |
+| `DELETE` | `/sys/external-keys/configs/:name` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X DELETE --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config
+```
+
+## Manage keys
+
+A key is a virtual mapping to a single version of key material in a KMS. Each
+key is nested within a config (`:config_name` URL path component). See [Manage
+configs](#manage-configs) for more information on configs.
+
+### List keys
+
+This endpoint lists all keys under a given config.
+
+| Method | Path                                           |
+| :----- | :--------------------------------------------- |
+| `LIST` | `/sys/external-keys/configs/:config_name/keys` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X LIST --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys
+```
+
+#### Sample response
+
+```json
+{
+  "keys": ["my-key-1", "my-key-2"]
+}
+```
+
+### Create/Update/Patch key
+
+This endpoint creates, updates or patches a key.
+
+| Method                 | Path                                                     |
+| :--------------------- | :------------------------------------------------------- |
+| `POST`, `PUT`, `PATCH` | `/sys/external-keys/configs/:config_name/keys/:key_name` |
+
+#### Generic parameters
+
+- `config_name` `(string: <required>)` - Specifies the name of the containing
+  config. This is specified as part of the request URL.
+
+- `key_name` `(string: <required>)` - Specifies the name of the key. This is
+  specified as part of the request URL.
+
+- `verify` `(bool: true)` - Verify that the configured plugin is available and
+  validate the given parameters against it before writing the update. The exact
+  checks performed depend on the plugin. This parameter is not persisted and
+  applies on a per-request basis.
+
+#### Plugin-specific parameters
+
+In addition to generic parameters, this endpoint takes plugin-specific
+parameters.
+
+{
+  // TODO(satoqz): Link to per-provider documentation here once that exists.
+}
+
+#### Notes on PATCH
+
+When modifying via `PATCH`, a JSON merge patch is performed and only parameters
+that should change need to be supplied, not all otherwise required ones. To
+fully replace a key's parameters, prefer `POST` or `PUT`.
+
+#### Sample payload
+
+E.g., when using the Transit plugin:
+
+```json
+{
+    "name": "my-transit-key",
+    "version": 3
+}
+```
+
+or when using the PKCS#11 plugin:
+
+```json
+{
+    "label": "my-pkcs11-key-label"
+}
+```
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X POST --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key
+```
+
+### Read key
+
+This endpoint returns a key's parameters as previously set. Any sensitive
+parameters (as determined by the key's driving plugin) are returned in redacted
+form, rewritten as `(redacted)`.
+
+| Method | Path                                                     |
+| :----- | :------------------------------------------------------- |
+| `GET`  | `/sys/external-keys/configs/:config_name/keys/:key_name` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X GET --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key
+```
+
+#### Sample response
+
+E.g., when using the Transit plugin:
+
+```json
+{
+  "data": {
+    "name": "my-transit-key",
+    "version": 3
+  }
+}
+```
+
+### Delete key
+
+This endpoint deletes a key. Notably, it does not delete the underlying KMS key,
+only the mapping in OpenBao.
+
+| Method   | Path                                                     |
+| :------- | :------------------------------------------------------- |
+| `DELETE` | `/sys/external-keys/configs/:config_name/keys/:key_name` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X DELETE --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key
+```
+
+## Manage grants
+
+A grant is a path to a secrets or auth engine mount that is allowed to use the
+key it is placed on. Paths are relative to the key's namespace, i.e., a key can
+only be used by engines present in the same namespace.
+
+### List grants
+
+This endpoint lists all grants on a key. All returned paths are normalized to
+end in a slash.
+
+| Method | Path                                                            |
+| :----- | :-------------------------------------------------------------- |
+| `LIST` | `/sys/external-keys/configs/:config_name/keys/:key_name/grants` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X LIST --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key/grants
+```
+
+#### Sample response
+
+```json
+{
+  "keys": ["pki/"]
+}
+```
+
+### Create grant
+
+This endpoint adds a grant to a key. The grant may already be present, resulting
+in a no-op.
+
+| Method        | Path                                                                        |
+| :------------ | :-------------------------------------------------------------------------- |
+| `POST`, `PUT` | `/sys/external-keys/configs/:config_name/keys/:key_name/grants/:mount-path` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X POST --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key/grants/pki
+```
+
+### Delete grant
+
+This endpoint removes a grant from a key. The grant may already be absent,
+resulting in a no-op.
+
+| Method   | Path                                                                        |
+| :------- | :-------------------------------------------------------------------------- |
+| `DELETE` | `/sys/external-keys/configs/:config_name/keys/:key_name/grants/:mount-path` |
+
+#### Sample request
+
+```shell-session
+$ curl \
+    -X DELETE --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/external-keys/configs/my-config/keys/my-key/grants/pki
+```

--- a/website/content/api-docs/system/namespaces.mdx
+++ b/website/content/api-docs/system/namespaces.mdx
@@ -1,10 +1,10 @@
 ---
-description: The `/sys/namespaces` endpoint is used manage namespaces in OpenBao.
+description: The `/sys/namespaces` endpoint is used to manage namespaces in OpenBao.
 ---
 
 # `/sys/namespaces`
 
-The `/sys/namespaces` endpoint is used manage namespaces in OpenBao.
+The `/sys/namespaces` endpoint is used to manage namespaces in OpenBao.
 
 ## List namespaces
 

--- a/website/content/api-docs/system/policies-password.mdx
+++ b/website/content/api-docs/system/policies-password.mdx
@@ -3,9 +3,9 @@ description: >-
   The `/sys/policies/password` endpoints are used to manage password generation policies in OpenBao.
 ---
 
-# `/sys/policies/password/`
+# `/sys/policies/password`
 
-The `/sys/policies/password/` endpoints are used to manage password generation policies in OpenBao.
+The `/sys/policies/password` endpoints are used to manage password generation policies in OpenBao.
 Not all secret engines utilize password policies, so check the documentation for the engine you
 are using for compatibility.
 

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -1,10 +1,10 @@
 ---
 description: >-
-  The `/sys/policies/` endpoints are used to manage ACL policies
+  The `/sys/policies` endpoints are used to manage ACL policies
   in OpenBao.
 ---
 
-# `/sys/policies/`
+# `/sys/policies`
 
 The `/sys/policies` endpoints are used to manage ACL, RGP, and EGP policies in OpenBao.
 

--- a/website/content/api-docs/system/workflows.mdx
+++ b/website/content/api-docs/system/workflows.mdx
@@ -1,9 +1,9 @@
 ---
 description: >-
-  The `/sys/workflows/` endpoints are used to manage workflows in OpenBao.
+  The `/sys/workflows` endpoints are used to manage workflows in OpenBao.
 ---
 
-# `/sys/workflows/`
+# `/sys/workflows`
 
 The `/sys/workflows` endpoints are used to manage and execute workflows in
 OpenBao. These allow operators to define simplified entrypoints over multiple

--- a/website/sidebarsApi.ts
+++ b/website/sidebarsApi.ts
@@ -87,6 +87,7 @@ const sidebars: SidebarsConfig = {
         "system/config-state",
         "system/config-ui",
         "system/decode-token",
+        "system/external-keys",
         "system/generate-recovery-token",
         "system/generate-root-token",
         "system/generate-root",


### PR DESCRIPTION
## Description

Adds API docs for https://github.com/openbao/openbao/pull/3534.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
