### PR TITLE
Return request data in sys/control-group/request

### DIFF
--- a/internal/vault/control_group.go
+++ b/internal/vault/control_group.go
@@ -49,6 +49,11 @@ var controlGroupRequestResponseSchema = map[string]*framework.FieldSchema{
 		Description: "The original request path",
 		Required:    true,
 	},
+	"request_data": {
+		Type:        framework.TypeMap,
+		Description: "The original request data",
+		Required:    true,
+	},
 	"request_entity": {
 		Type:        framework.TypeMap,
 		Description: "The original requesting entity",
@@ -355,6 +360,7 @@ func (c *Core) handleControlGroupRequest(ctx context.Context, req *logical.Reque
 			"approved":          approved,
 			"request_operation": originalRequest.Operation,
 			"request_path":      originalRequest.Path,
+			"request_data":      originalRequest.Data,
 			"request_entity":    originalEntity,
 			"authorizations":    auths,
 		},

--- a/internal/vault/logical_system_paths.go
+++ b/internal/vault/logical_system_paths.go
@@ -4276,7 +4276,7 @@ func (b *SystemBackend) wrappingPaths() []*framework.Path {
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
+				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.Core.handleControlGroupRequest,
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{

--- a/internal/vault/request_handling_test.go
+++ b/internal/vault/request_handling_test.go
@@ -88,9 +88,7 @@ func TestRequestHandling_ControlGroupWrapping(t *testing.T) {
 		Path:  "cg_test",
 		Type:  "kv",
 	})
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Create a secret
 	req := &logical.Request{
@@ -102,20 +100,16 @@ func TestRequestHandling_ControlGroupWrapping(t *testing.T) {
 		},
 	}
 	resp, err := core.HandleRequest(namespace.RootContext(t.Context()), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp != nil {
-		t.Fatalf("bad: %#v", resp)
-	}
+	require.NoError(t, err)
+	require.Nil(t, resp)
 
 	// Create a ControlGroup policy governing secret path
 	cgPolicy := `path "cg_test/foo" {
-		capabilities = ["create", "list", "read"]
+		capabilities = ["create", "update", "list", "read"]
 		control_group = {
 			ttl = "15s"
 			factor "admin-approval" {
-				controlled_capabilities = ["read"]
+				controlled_capabilities = ["create", "read", "update"]
 				identity = {
 					group_names = ["admin"]
 					approvals = 1
@@ -151,22 +145,23 @@ func TestRequestHandling_ControlGroupWrapping(t *testing.T) {
 	req = &logical.Request{
 		Path:        "cg_test/foo",
 		ClientToken: nonRootToken,
-		Operation:   logical.ReadOperation,
+		Operation:   logical.UpdateOperation,
+		Data: map[string]any{
+			"zip": "stopped",
+		},
 	}
 	resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("bad: %v", resp)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 
 	// Expect it to be wrapped
-	if resp.WrapInfo == nil || resp.WrapInfo.TTL != time.Duration(15*time.Second) {
-		t.Fatalf("bad wrap_info: %#v", resp)
-	}
+	require.NotNil(t, resp.WrapInfo)
 
-	// Fetch token with accessor
+	wrapTTL := resp.WrapInfo.TTL
+	wrapToken := resp.WrapInfo.Token
+	require.Equal(t, wrapTTL, 15*time.Second)
+
+	// Lookup accessor information
 	accessor := resp.WrapInfo.Accessor
 	req = &logical.Request{
 		Path:        "auth/token/lookup-accessor",
@@ -177,12 +172,39 @@ func TestRequestHandling_ControlGroupWrapping(t *testing.T) {
 		},
 	}
 	resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "accessor")
+	require.Equal(t, resp.Data["accessor"], accessor)
+	require.LessOrEqual(t, resp.Data["ttl"], int64(wrapTTL/time.Second))
+
+	// Use of the token should not work yet as it was not approved.
+	req = &logical.Request{
+		Path:        "sys/wrapping/unwrap",
+		ClientToken: wrapToken,
+		Operation:   logical.UpdateOperation,
 	}
-	if resp == nil {
-		t.Fatalf("bad: %v", resp)
+	resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	// Check the request status.
+	req = &logical.Request{
+		Path:        "sys/control-group/request",
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+		Data: map[string]any{
+			"accessor": accessor,
+		},
 	}
+	resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "request_entity")
+	require.Contains(t, resp.Data, "request_path")
+	require.Contains(t, resp.Data, "request_data")
+	require.Contains(t, resp.Data["request_data"], "zip")
+	require.Equal(t, resp.Data["approved"], false)
 }
 
 func TestRequestHandling_LoginWrapping(t *testing.T) {

--- a/internal/vault/token_store_test.go
+++ b/internal/vault/token_store_test.go
@@ -906,7 +906,7 @@ path "sys/control-group/authorize" {
 }
 
 path "sys/control-group/request" {
-  capabilities = ["read"]
+  capabilities = ["update"]
 }
 `
 	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, policyHCL)
@@ -1056,7 +1056,7 @@ path "sys/control-group/request" {
 	require.Len(t, cgFetched.Factors[2].Authorizations, 1)
 
 	// verify the original request state
-	viewReq := logical.TestRequest(t, logical.ReadOperation, "sys/control-group/request")
+	viewReq := logical.TestRequest(t, logical.UpdateOperation, "sys/control-group/request")
 	viewReq.ClientToken = "approver-token"
 	viewReq.Data = map[string]any{
 		"accessor": wrapped.Accessor,


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When approving a request, often the most important field is the request data. Ensure we return it so authorizing parties can make an informed decision.

This also fixes the request method to align with the documentation from Vault.

See also: #3436


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
