### PR TITLE
Use external keys in Transit

### DIFF
--- a/internal/builtin/logical/transit/backend.go
+++ b/internal/builtin/logical/transit/backend.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/keysutil"
@@ -289,4 +290,23 @@ func (b *backend) rotateIfRequired(ctx context.Context, req *logical.Request, ke
 
 	}
 	return nil
+}
+
+type ExternalKeyFactory struct {
+	ctx  context.Context
+	view logical.SystemView
+}
+
+var _ keysutil.ExternalKeyFactory = &ExternalKeyFactory{}
+
+func (e *ExternalKeyFactory) GetExternalKey(ref string) (context.Context, kms.Key, error) {
+	key, err := e.view.GetExternalKey(e.ctx, ref)
+	return e.ctx, key, err
+}
+
+func (b *backend) ExternalKeyFactory(ctx context.Context) *ExternalKeyFactory {
+	return &ExternalKeyFactory{
+		ctx:  ctx,
+		view: b.System(),
+	}
 }

--- a/internal/builtin/logical/transit/path_decrypt.go
+++ b/internal/builtin/logical/transit/path_decrypt.go
@@ -171,17 +171,20 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 			continue
 		}
 
-		var factory any
+		var factories []any
 		if item.AssociatedData != "" {
 			if !p.Type.AssociatedDataSupported() {
 				batchResponseItems[i].Error = fmt.Sprintf("'[%d].associated_data' provided for non-AEAD cipher suite %v", i, p.Type.String())
 				continue
 			}
 
-			factory = AssocDataFactory{item.AssociatedData}
+			factories = append(factories, AssocDataFactory{item.AssociatedData})
+		}
+		if p.Type == keysutil.KeyType_ExternalKey {
+			factories = append(factories, b.ExternalKeyFactory(ctx))
 		}
 
-		plaintext, err := p.DecryptWithFactory(item.DecodedContext, nil, item.Ciphertext, factory)
+		plaintext, err := p.DecryptWithFactory(item.DecodedContext, nil, item.Ciphertext, factories...)
 		if err != nil {
 			switch err.(type) {
 			case errutil.InternalError:

--- a/internal/builtin/logical/transit/path_encrypt.go
+++ b/internal/builtin/logical/transit/path_encrypt.go
@@ -430,17 +430,21 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 			continue
 		}
 
-		var factory any
+		var factories []any
 		if item.AssociatedData != "" {
 			if !p.Type.AssociatedDataSupported() {
 				batchResponseItems[i].Error = fmt.Sprintf("'[%d].associated_data' provided for non-AEAD cipher suite %v", i, p.Type.String())
 				continue
 			}
 
-			factory = AssocDataFactory{item.AssociatedData}
+			factories = append(factories, AssocDataFactory{item.AssociatedData})
 		}
 
-		ciphertext, err := p.EncryptWithFactory(item.KeyVersion, item.DecodedContext, nil, item.Plaintext, factory)
+		if p.Type == keysutil.KeyType_ExternalKey {
+			factories = append(factories, b.ExternalKeyFactory(ctx))
+		}
+
+		ciphertext, err := p.EncryptWithFactory(item.KeyVersion, item.DecodedContext, nil, item.Plaintext, factories...)
 		if err != nil {
 			switch err.(type) {
 			case errutil.InternalError:

--- a/internal/builtin/logical/transit/path_keys.go
+++ b/internal/builtin/logical/transit/path_keys.go
@@ -136,6 +136,12 @@ key.`,
 				Default:     0,
 				Description: fmt.Sprintf("The key size in bytes for the algorithm.  Only applies to HMAC and must be no fewer than %d bytes and no more than %d", keysutil.HmacMinKeySize, keysutil.HmacMaxKeySize),
 			},
+			"external_key_ref": {
+				Type: framework.TypeString,
+				Description: `Reference to the external key to use. This follows
+the format <config name>:<key name>, uniquely identifying the key configured
+under sys/external-keys/configs/<config name>/keys/<key name>.`,
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -246,6 +252,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	keyType := d.Get("type").(string)
 	keySize := d.Get("key_size").(int)
 	exportable := d.Get("exportable").(bool)
+	externalKeyRef := d.Get("external_key_ref").(string)
 	allowPlaintextBackup := d.Get("allow_plaintext_backup").(bool)
 	autoRotatePeriod := time.Second * time.Duration(d.Get("auto_rotate_period").(int))
 
@@ -266,6 +273,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		Exportable:           exportable,
 		AllowPlaintextBackup: allowPlaintextBackup,
 		AutoRotatePeriod:     autoRotatePeriod,
+		ExternalKeyRef:       externalKeyRef,
 	}
 
 	switch keyType {
@@ -293,17 +301,39 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		polReq.KeyType = keysutil.KeyType_RSA4096
 	case "hmac":
 		polReq.KeyType = keysutil.KeyType_HMAC
+	case "external-key":
+		polReq.KeyType = keysutil.KeyType_ExternalKey
 	default:
 		return logical.ErrorResponse("unknown key type %v", keyType), logical.ErrInvalidRequest
 	}
 	if keySize != 0 {
-		if polReq.KeyType != keysutil.KeyType_HMAC {
+		if polReq.KeyType != keysutil.KeyType_HMAC && polReq.KeyType != keysutil.KeyType_ExternalKey {
 			return logical.ErrorResponse("key_size is not valid for algorithm %v", polReq.KeyType), logical.ErrInvalidRequest
 		}
 		if keySize < keysutil.HmacMinKeySize || keySize > keysutil.HmacMaxKeySize {
 			return logical.ErrorResponse("invalid key_size %d", keySize), logical.ErrInvalidRequest
 		}
 		polReq.KeySize = keySize
+	}
+	if polReq.KeyType == keysutil.KeyType_ExternalKey {
+		if polReq.ExternalKeyRef == "" {
+			return logical.ErrorResponse("must provide external_key_ref to create policy of type external-key"), logical.ErrInvalidRequest
+		}
+
+		if autoRotatePeriod != 0 {
+			return logical.ErrorResponse("cannot enable auto-rotation with external keys"), nil
+		}
+
+		key, err := b.System().GetExternalKey(ctx, polReq.ExternalKeyRef)
+		if err != nil {
+			return logical.ErrorResponse("unknown external key reference: %v", polReq.ExternalKeyRef), logical.ErrInvalidRequest
+		}
+
+		if err := key.Close(ctx); err != nil {
+			return nil, fmt.Errorf("unable to close external key: %w", err)
+		}
+	} else if polReq.ExternalKeyRef != "" {
+		return logical.ErrorResponse("must provide type=external-key to use external_key_ref"), logical.ErrInvalidRequest
 	}
 
 	p, upserted, err := b.GetPolicy(ctx, polReq, b.GetRandomReader())
@@ -494,6 +524,12 @@ func (b *backend) formatKeyPolicy(p *keysutil.Policy, context []byte) (*logical.
 			}
 
 			retKeys[k] = structtomap.Map(key)
+		}
+		resp.Data["keys"] = retKeys
+	case keysutil.KeyType_ExternalKey:
+		retKeys := map[string]string{}
+		for k, v := range p.Keys {
+			retKeys[k] = v.ExternalKeyRef
 		}
 		resp.Data["keys"] = retKeys
 	}

--- a/internal/builtin/logical/transit/path_keys_config.go
+++ b/internal/builtin/logical/transit/path_keys_config.go
@@ -227,6 +227,10 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 			p.AutoRotatePeriod = autoRotatePeriod
 			persistNeeded = true
 		}
+
+		if p.Type == keysutil.KeyType_ExternalKey && p.AutoRotatePeriod != 0 {
+			return logical.ErrorResponse("auto rotate period must be disabled on external keys"), nil
+		}
 	}
 
 	if !persistNeeded {

--- a/internal/builtin/logical/transit/path_rotate.go
+++ b/internal/builtin/logical/transit/path_rotate.go
@@ -5,6 +5,7 @@ package transit
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/keysutil"
@@ -25,6 +26,12 @@ func (b *backend) pathRotate() *framework.Path {
 			"name": {
 				Type:        framework.TypeString,
 				Description: "Name of the key",
+			},
+			"external_key_ref": {
+				Type: framework.TypeString,
+				Description: `Reference to the external key to use. This follows
+the format <config name>:<key name>, uniquely identifying the key configured
+under sys/external-keys/configs/<config name>/keys/<key name>.`,
 			},
 		},
 
@@ -60,6 +67,26 @@ func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse("key not found"), logical.ErrInvalidRequest
 	}
 	defer p.Unlock()
+
+	externalKeyRef := d.Get("external_key_ref").(string)
+	if p.Type == keysutil.KeyType_ExternalKey {
+		if externalKeyRef == "" {
+			return logical.ErrorResponse("must provide external_key_ref to rotate policy of type external-key"), logical.ErrInvalidRequest
+		}
+
+		key, err := b.System().GetExternalKey(ctx, externalKeyRef)
+		if err != nil {
+			return logical.ErrorResponse("unknown external key reference: %v", externalKeyRef), logical.ErrInvalidRequest
+		}
+
+		if err := key.Close(ctx); err != nil {
+			return nil, fmt.Errorf("unable to close external key: %w", err)
+		}
+
+		p.ExternalKeyRef = externalKeyRef
+	} else if externalKeyRef != "" {
+		return logical.ErrorResponse("cannot use external_key_ref on key of type %v", p.Type.String()), logical.ErrInvalidRequest
+	}
 
 	// Rotate the policy
 	err = p.Rotate(ctx, req.Storage, b.GetRandomReader())

--- a/internal/builtin/logical/transit/path_sign_verify.go
+++ b/internal/builtin/logical/transit/path_sign_verify.go
@@ -436,10 +436,11 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 
 		sig, err := p.SignWithOptions(ver, context, input, &keysutil.SigningOptions{
-			HashAlgorithm: hashAlgorithm,
-			Marshaling:    marshaling,
-			SaltLength:    saltLength,
-			SigAlgorithm:  sigAlgorithm,
+			HashAlgorithm:      hashAlgorithm,
+			Marshaling:         marshaling,
+			SaltLength:         saltLength,
+			SigAlgorithm:       sigAlgorithm,
+			ExternalKeyFactory: b.ExternalKeyFactory(ctx),
 		})
 		if err != nil {
 			if batchInputRaw != nil {
@@ -656,10 +657,11 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		}
 
 		signingOptions := &keysutil.SigningOptions{
-			HashAlgorithm: hashAlgorithm,
-			Marshaling:    marshaling,
-			SaltLength:    saltLength,
-			SigAlgorithm:  sigAlgorithm,
+			HashAlgorithm:      hashAlgorithm,
+			Marshaling:         marshaling,
+			SaltLength:         saltLength,
+			SigAlgorithm:       sigAlgorithm,
+			ExternalKeyFactory: b.ExternalKeyFactory(ctx),
 		}
 
 		valid, err := p.VerifySignatureWithOptions(context, input, sig, signingOptions)

--- a/internal/vault/external_keys/registry.go
+++ b/internal/vault/external_keys/registry.go
@@ -447,6 +447,10 @@ func (r *Registry) ModifyKey(ctx context.Context, s logical.Storage, configName,
 			return err
 		}
 
+		if key == nil {
+			return errMissingKey
+		}
+
 		// Unlike KMS clients, keys aren't cached so just close it again.
 		if err := key.Close(ctx); err != nil {
 			r.logger.Error("failed to close key", "error", err.Error(), "config", configName, "key", keyName, "namespace", ns.Path)
@@ -507,6 +511,11 @@ func (r *Registry) GetExternalKey(ctx context.Context, s logical.Storage, ns *na
 		return nil, err
 	}
 
+	// Better to err than pass along or wrap a nil key.
+	if key == nil {
+		return nil, errMissingKey
+	}
+
 	return nilCheckingKey{key}, nil
 }
 
@@ -516,6 +525,7 @@ var (
 	// against names passed in by a plugin via the system view.
 	namePattern   = regexp.MustCompile("^" + framework.GenericNameRegex("name") + "$")
 	errInvalidRef = errors.New(`invalid key reference: must be "<config name>:<key name>"`)
+	errMissingKey = errors.New(`plugin returned nil key; report to OpenBao authors`)
 )
 
 // ParseRef parses a key reference into config name and key name.

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -60,8 +60,8 @@ type PolicyRequest struct {
 	// Indicates whether a private or public key is imported/upserted
 	IsPrivateKey bool
 
-	// The UUID of the managed key, if using one
-	ManagedKeyUUID string
+	// The reference to the external key, if using one.
+	ExternalKeyRef string
 }
 
 type LockManager struct {
@@ -390,6 +390,15 @@ func (lm *LockManager) GetPolicyWithLockType(ctx context.Context, req PolicyRequ
 				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 
+		case KeyType_ExternalKey:
+			if req.Derived || req.Convergent {
+				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
+			}
+
+			if req.AutoRotatePeriod != 0 {
+				return nil, false, fmt.Errorf("auto-rotation is not supported for keys of type %v", req.KeyType)
+			}
+
 		default:
 			return nil, false, fmt.Errorf("unsupported key type %v", req.KeyType)
 		}
@@ -403,6 +412,7 @@ func (lm *LockManager) GetPolicyWithLockType(ctx context.Context, req PolicyRequ
 			AllowPlaintextBackup: req.AllowPlaintextBackup,
 			AutoRotatePeriod:     req.AutoRotatePeriod,
 			KeySize:              req.KeySize,
+			ExternalKeyRef:       req.ExternalKeyRef,
 		}
 
 		if req.Derived {

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/crypto/hkdf"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -71,6 +72,9 @@ const (
 	KeyType_RSA3072
 	KeyType_HMAC
 	KeyType_XChaCha20_Poly1305
+
+	// External keys is a meta-type.
+	KeyType_ExternalKey = 10000
 )
 
 const (
@@ -86,12 +90,12 @@ const (
 	DefaultVersionTemplate = "vault:v{{version}}:"
 )
 
-type AEADFactory interface {
-	GetAEAD(iv []byte) (cipher.AEAD, error)
-}
-
 type AssociatedDataFactory interface {
 	GetAssociatedData() ([]byte, error)
+}
+
+type ExternalKeyFactory interface {
+	GetExternalKey(ref string) (context.Context, kms.Key, error)
 }
 
 type RestoreInfo struct {
@@ -105,10 +109,11 @@ type BackupInfo struct {
 }
 
 type SigningOptions struct {
-	HashAlgorithm HashType
-	Marshaling    MarshalingType
-	SaltLength    int
-	SigAlgorithm  string
+	HashAlgorithm      HashType
+	Marshaling         MarshalingType
+	SaltLength         int
+	SigAlgorithm       string
+	ExternalKeyFactory ExternalKeyFactory
 }
 
 type SigningResult struct {
@@ -124,7 +129,7 @@ type KeyType int
 
 func (kt KeyType) EncryptionSupported() bool {
 	switch kt {
-	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
+	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096, KeyType_ExternalKey:
 		return true
 	}
 	return false
@@ -132,7 +137,7 @@ func (kt KeyType) EncryptionSupported() bool {
 
 func (kt KeyType) DecryptionSupported() bool {
 	switch kt {
-	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
+	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096, KeyType_ExternalKey:
 		return true
 	}
 	return false
@@ -140,7 +145,7 @@ func (kt KeyType) DecryptionSupported() bool {
 
 func (kt KeyType) SigningSupported() bool {
 	switch kt {
-	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_ED25519, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
+	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_ED25519, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096, KeyType_ExternalKey:
 		return true
 	}
 	return false
@@ -148,7 +153,7 @@ func (kt KeyType) SigningSupported() bool {
 
 func (kt KeyType) HashSignatureInput() bool {
 	switch kt {
-	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
+	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096, KeyType_ExternalKey:
 		return true
 	}
 	return false
@@ -172,7 +177,7 @@ func (kt KeyType) KeyAgreementSupported() bool {
 
 func (kt KeyType) AssociatedDataSupported() bool {
 	switch kt {
-	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305:
+	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305, KeyType_ExternalKey:
 		return true
 	}
 	return false
@@ -212,6 +217,8 @@ func (kt KeyType) String() string {
 		return "rsa-4096"
 	case KeyType_HMAC:
 		return "hmac"
+	case KeyType_ExternalKey:
+		return "external-key"
 	}
 
 	return "[unknown]"
@@ -253,10 +260,13 @@ type KeyEntry struct {
 
 	// Key entry certificate chain. If set, leaf certificate key matches the keyEntry 'key'. The leaf certificate is the first element in the chain.
 	CertificateChain [][]byte `json:"certificate_chain"`
+
+	// Reference to the named external key.
+	ExternalKeyRef string `json:"external_key_ref"`
 }
 
 func (ke *KeyEntry) IsPrivateKeyMissing() bool {
-	if ke.RSAKey != nil || ke.EC_D != nil || len(ke.Key) != 0 {
+	if ke.RSAKey != nil || ke.EC_D != nil || len(ke.Key) != 0 || ke.ExternalKeyRef != "" {
 		return false
 	}
 
@@ -447,6 +457,12 @@ type Policy struct {
 
 	// Whether the key has been soft deleted.
 	SoftDeleted bool `json:"soft_deleted"`
+
+	// Reference to the named external key. This is only used during
+	// creation and rotation of policies. To rotate an external key,
+	// first set this field and then call p.Rotate(...) or
+	// p.RotateInMemory(...).
+	ExternalKeyRef string `json:"-"`
 }
 
 func (p *Policy) Lock(exclusive bool) {
@@ -987,7 +1003,7 @@ func (p *Policy) Decrypt(context, nonce []byte, value string) (string, error) {
 	return p.DecryptWithFactory(context, nonce, value, nil)
 }
 
-func (p *Policy) DecryptWithFactory(context, nonce []byte, value string, factories ...any) (string, error) {
+func (p *Policy) DecryptWithFactory(derivationContext, nonce []byte, value string, factories ...any) (string, error) {
 	if p.SoftDeleted {
 		return "", errutil.UserError{Err: ErrSoftDeleted}
 	}
@@ -1050,7 +1066,7 @@ func (p *Policy) DecryptWithFactory(context, nonce []byte, value string, factori
 			numBytes = 16
 		}
 
-		encKey, err := p.GetKey(context, ver, numBytes)
+		encKey, err := p.GetKey(derivationContext, ver, numBytes)
 		if err != nil {
 			return "", err
 		}
@@ -1068,8 +1084,6 @@ func (p *Policy) DecryptWithFactory(context, nonce []byte, value string, factori
 				continue
 			}
 			switch factory := rawFactory.(type) {
-			case AEADFactory:
-				symopts.AEADFactory = factory
 			case AssociatedDataFactory:
 				symopts.AdditionalData, err = factory.GetAssociatedData()
 				if err != nil {
@@ -1096,6 +1110,54 @@ func (p *Policy) DecryptWithFactory(context, nonce []byte, value string, factori
 		plain, err = rsa.DecryptOAEP(sha256.New(), rand.Reader, key, decoded, nil)
 		if err != nil {
 			return "", errutil.InternalError{Err: fmt.Sprintf("failed to RSA decrypt the ciphertext: %v", err)}
+		}
+	case KeyType_ExternalKey:
+		keyEntry, err := p.safeGetKeyEntry(ver)
+		if err != nil {
+			return "", err
+		}
+
+		var ctx context.Context
+		var key kms.Key
+		var aad []byte
+
+		for index, factory := range factories {
+			if factory == nil {
+				continue
+			}
+
+			switch typed := factory.(type) {
+			case ExternalKeyFactory:
+				ctx, key, err = typed.GetExternalKey(keyEntry.ExternalKeyRef)
+				if err != nil {
+					return "", fmt.Errorf("factory[%d] failed to fetch external key: %w", index, err)
+				} else if key == nil {
+					return "", fmt.Errorf("factory[%d] returned nil key with no error; key not found", index)
+				}
+
+				defer key.Close(ctx) //nolint:errcheck
+			case AssociatedDataFactory:
+				aad, err = typed.GetAssociatedData()
+				if err != nil {
+					return "", errutil.InternalError{Err: fmt.Sprintf("unable to get associated_data/additional_data from factory[%d]: %v", index, err)}
+				}
+			default:
+				return "", errutil.InternalError{Err: fmt.Sprintf("unknown type of factory[%d]: %T", index, factory)}
+			}
+		}
+
+		if key == nil {
+			return "", fmt.Errorf("external key not found or no factory provided to request it")
+		}
+
+		opts := &kms.CipherOptions{
+			Data: decoded,
+			AAD:  aad,
+		}
+
+		plain, err = key.Decrypt(ctx, opts)
+		if err != nil {
+			return "", fmt.Errorf("call to Decrypt with external key failed: %w", err)
 		}
 
 	default:
@@ -1153,7 +1215,7 @@ func (p *Policy) validRSAPSSSaltLength(keyBitLen int, hash crypto.Hash, saltLeng
 	return p.minRSAPSSSaltLength() <= saltLength && saltLength <= p.maxRSAPSSSaltLength(keyBitLen, hash)
 }
 
-func (p *Policy) SignWithOptions(ver int, context, input []byte, options *SigningOptions) (*SigningResult, error) {
+func (p *Policy) SignWithOptions(ver int, derivationContext, input []byte, options *SigningOptions) (*SigningResult, error) {
 	if p.SoftDeleted {
 		return nil, errutil.UserError{Err: ErrSoftDeleted}
 	}
@@ -1262,7 +1324,7 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 		if p.Derived {
 			// Derive the key that should be used
 			var err error
-			key, err = p.GetKey(context, ver, 32)
+			key, err = p.GetKey(derivationContext, ver, 32)
 			if err != nil {
 				return nil, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
 			}
@@ -1307,6 +1369,42 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 		default:
 			return nil, errutil.InternalError{Err: fmt.Sprintf("unsupported rsa signature algorithm %s", sigAlgorithm)}
 		}
+	case KeyType_ExternalKey:
+		keyEntry, err := p.safeGetKeyEntry(ver)
+		if err != nil {
+			return nil, err
+		}
+
+		if options.ExternalKeyFactory == nil {
+			return nil, fmt.Errorf("external key not found or no factory provided to request it")
+		}
+
+		ctx, key, err := options.ExternalKeyFactory.GetExternalKey(keyEntry.ExternalKeyRef)
+		if err != nil {
+			return nil, fmt.Errorf("factory failed to fetch external key: %w", err)
+		}
+
+		if key == nil {
+			return nil, errors.New("factory returned nil key with no error; key not found")
+		}
+
+		defer key.Close(ctx) //nolint:errcheck
+
+		algo, ok := CryptoHashMap[hashAlgorithm]
+		if !ok {
+			return nil, errutil.InternalError{Err: "unsupported hash algorithm"}
+		}
+
+		opts := &kms.SignOptions{
+			Data:       input,
+			SignerOpts: algo,
+			Prehashed:  true,
+		}
+
+		sig, err = key.Sign(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("call to Sign with external key failed: %w", err)
+		}
 
 	default:
 		return nil, fmt.Errorf("unsupported key type %v", p.Type)
@@ -1337,7 +1435,7 @@ func (p *Policy) VerifySignature(context, input []byte, hashAlgorithm HashType, 
 	})
 }
 
-func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, options *SigningOptions) (bool, error) {
+func (p *Policy) VerifySignatureWithOptions(derivationContext, input []byte, sig string, options *SigningOptions) (bool, error) {
 	if p.SoftDeleted {
 		return false, errutil.UserError{Err: ErrSoftDeleted}
 	}
@@ -1443,7 +1541,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 
 		if p.Derived {
 			// Derive the key that should be used
-			key, err := p.GetKey(context, ver, 32)
+			key, err := p.GetKey(derivationContext, ver, 32)
 			if err != nil {
 				return false, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
 			}
@@ -1501,6 +1599,45 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 
 		return err == nil, nil
 
+	case KeyType_ExternalKey:
+		if options.ExternalKeyFactory == nil {
+			return false, fmt.Errorf("external key not found or no factory provided to request it")
+		}
+
+		keyEntry, err := p.safeGetKeyEntry(ver)
+		if err != nil {
+			return false, err
+		}
+
+		ctx, key, err := options.ExternalKeyFactory.GetExternalKey(keyEntry.ExternalKeyRef)
+		if err != nil {
+			return false, fmt.Errorf("factory failed to fetch external key: %w", err)
+		}
+
+		if key == nil {
+			return false, errors.New("factory returned nil key with no error; key not found")
+		}
+
+		defer key.Close(ctx) //nolint:errcheck
+
+		algo, ok := CryptoHashMap[hashAlgorithm]
+		if !ok {
+			return false, errutil.InternalError{Err: "unsupported hash algorithm"}
+		}
+
+		opts := &kms.VerifyOptions{
+			Data:       input,
+			Signature:  sigBytes,
+			SignerOpts: algo,
+			Prehashed:  true,
+		}
+
+		err = key.Verify(ctx, opts)
+		if err != nil {
+			return false, fmt.Errorf("call to Verify with external key failed: %w", err)
+		}
+
+		return err == nil, nil
 	default:
 		return false, errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}
 	}
@@ -1513,6 +1650,10 @@ func (p *Policy) Import(ctx context.Context, storage logical.Storage, key []byte
 func (p *Policy) ImportPublicOrPrivate(ctx context.Context, storage logical.Storage, key []byte, isPrivateKey bool, randReader io.Reader) error {
 	if p.SoftDeleted {
 		return errutil.UserError{Err: ErrSoftDeleted}
+	}
+
+	if p.Type == KeyType_ExternalKey {
+		return errors.New("unable to import keys to a policy of type external key")
 	}
 
 	now := time.Now()
@@ -1539,6 +1680,10 @@ func (p *Policy) ImportPublicOrPrivate(ctx context.Context, storage logical.Stor
 			return err
 		}
 		entry.HMACKey = hmacKey
+	}
+
+	if p.Type == KeyType_ExternalKey {
+		return errors.New("unable to import keys to a policy of type external key")
 	}
 
 	if p.Type == KeyType_ED25519 && p.Derived && !isPrivateKey {
@@ -1647,6 +1792,7 @@ func (p *Policy) Rotate(ctx context.Context, storage logical.Storage, randReader
 			p.LatestVersion = priorLatestVersion
 			p.MinDecryptionVersion = priorMinDecryptionVersion
 			p.Keys = priorKeys
+			p.ExternalKeyRef = ""
 		}
 	}()
 
@@ -1664,10 +1810,19 @@ func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 		return errutil.UserError{Err: ErrSoftDeleted}
 	}
 
+	if p.Type == KeyType_ExternalKey {
+		if p.ExternalKeyRef == "" {
+			return errors.New("expected external key reference to be set on policy to rotate external key")
+		}
+	} else if p.ExternalKeyRef != "" {
+		return fmt.Errorf("unexpected external key reference on non-external policy of type %v", p.Type.String())
+	}
+
 	now := time.Now()
 	entry := KeyEntry{
 		CreationTime:           now,
 		DeprecatedCreationTime: now.Unix(),
+		ExternalKeyRef:         p.ExternalKeyRef,
 	}
 
 	hmacKey, err := uuid.GenerateRandomBytesWithReader(32, randReader)
@@ -1901,8 +2056,6 @@ type SymmetricOpts struct {
 	AdditionalData []byte
 	// The HMAC key, for generating IVs in convergent encryption
 	HMACKey []byte
-	// Allows an external provider of the AEAD, for e.g. managed keys
-	AEADFactory AEADFactory
 }
 
 // Symmetrically encrypt a plaintext given the convergence configuration and appropriate keys
@@ -2060,7 +2213,7 @@ func (p *Policy) SymmetricDecryptRaw(encKey, ciphertext []byte, opts SymmetricOp
 	return plain, nil
 }
 
-func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value string, factories ...any) (string, error) {
+func (p *Policy) EncryptWithFactory(ver int, derivationContext []byte, nonce []byte, value string, factories ...any) (string, error) {
 	if p.SoftDeleted {
 		return "", errutil.UserError{Err: ErrSoftDeleted}
 	}
@@ -2090,7 +2243,7 @@ func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value
 
 	switch p.Type {
 	case KeyType_AES128_GCM96, KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305, KeyType_XChaCha20_Poly1305:
-		hmacKey := context
+		hmacKey := derivationContext
 
 		var encKey []byte
 		var deriveHMAC bool
@@ -2111,7 +2264,7 @@ func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value
 			encBytes = 16
 		}
 
-		key, err := p.GetKey(context, ver, encBytes+hmacBytes)
+		key, err := p.GetKey(derivationContext, ver, encBytes+hmacBytes)
 		if err != nil {
 			return "", err
 		}
@@ -2141,8 +2294,6 @@ func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value
 				continue
 			}
 			switch factory := rawFactory.(type) {
-			case AEADFactory:
-				symopts.AEADFactory = factory
 			case AssociatedDataFactory:
 				symopts.AdditionalData, err = factory.GetAssociatedData()
 				if err != nil {
@@ -2172,7 +2323,58 @@ func (p *Policy) EncryptWithFactory(ver int, context []byte, nonce []byte, value
 		if err != nil {
 			return "", errutil.InternalError{Err: fmt.Sprintf("failed to RSA encrypt the plaintext: %v", err)}
 		}
+	case KeyType_ExternalKey:
+		keyEntry, err := p.safeGetKeyEntry(ver)
+		if err != nil {
+			return "", err
+		}
 
+		var ctx context.Context
+		var key kms.Key
+		var aad []byte
+
+		for index, factory := range factories {
+			if factory == nil {
+				continue
+			}
+
+			switch typed := factory.(type) {
+			case ExternalKeyFactory:
+				ctx, key, err = typed.GetExternalKey(keyEntry.ExternalKeyRef)
+				if err != nil {
+					return "", fmt.Errorf("factory[%d] failed to fetch external key: %w", index, err)
+				} else if key == nil {
+					return "", fmt.Errorf("factory[%d] returned nil key with no error; key not found", index)
+				}
+
+				defer key.Close(ctx) //nolint:errcheck
+			case AssociatedDataFactory:
+				aad, err = typed.GetAssociatedData()
+				if err != nil {
+					return "", errutil.InternalError{Err: fmt.Sprintf("unable to get associated_data/additional_data from factory[%d]: %v", index, err)}
+				}
+			default:
+				return "", errutil.InternalError{Err: fmt.Sprintf("unknown type of factory[%d]: %T", index, factory)}
+			}
+		}
+
+		if key == nil {
+			return "", fmt.Errorf("external key not found or no factory provided to request it")
+		}
+
+		opts := &kms.CipherOptions{
+			Data: plaintext,
+			AAD:  aad,
+		}
+
+		ciphertext, err = key.Encrypt(ctx, opts)
+		if err != nil {
+			return "", fmt.Errorf("call to Encrypt with external key failed: %w", err)
+		}
+
+		if len(opts.Nonce) > 0 {
+			ciphertext = append(opts.Nonce, ciphertext...)
+		}
 	default:
 		return "", errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}
 	}
@@ -2211,6 +2413,10 @@ func (p *Policy) KeyVersionCanBeUpdated(keyVersion int, isPrivateKey bool) error
 func (p *Policy) ImportPrivateKeyForVersion(ctx context.Context, storage logical.Storage, keyVersion int, key []byte) error {
 	if p.SoftDeleted {
 		return errutil.UserError{Err: ErrSoftDeleted}
+	}
+
+	if p.Type == KeyType_ExternalKey {
+		return errors.New("unable to import keys to a policy of type external key")
 	}
 
 	keyEntry, err := p.safeGetKeyEntry(keyVersion)
@@ -2390,7 +2596,7 @@ func (p *Policy) WrapKey(ver int, targetKey any, targetKeyType KeyType, hash has
 	}
 
 	if !p.Type.SigningSupported() {
-		return "", fmt.Errorf("message signing not supported for key type %v", p.Type)
+		return "", fmt.Errorf("key wrapping (requring message signing) is not supported for key type %v", p.Type)
 	}
 
 	switch {

--- a/website/content/community/rfcs/external-keys.mdx
+++ b/website/content/community/rfcs/external-keys.mdx
@@ -181,7 +181,7 @@ Transit will not support modes which require HMAC.
 ### Plugin Key Usage
 
 Upstream HashiCorp Vault Enterprise uses the `managed_key_name` and
-`managed_key_uuid` fields. We will support an `external_key_name` field as
+`managed_key_uuid` fields. We will support an `external_key_ref` field as
 well as an equivalent alternative `managed_key_name` field to offer some
 compatibility with existing workflows that target upstream. UUID fields are
 unsupported, external keys are addressed by config name + key name only.
@@ -189,12 +189,12 @@ unsupported, external keys are addressed by config name + key name only.
 The intention here is that plugin authors will enable external keys via an
 explicit key type (`key_type=external_key` or `key_type=managed_key`). The
 actual key type will be inferred from the underlying external key instance.
-When providing these parameters, the above `external_key_name` or
+When providing these parameters, the above `external_key_ref` or
 `managed_key_name` fields will need to be provided, which will be used for
 the lookup via the SystemView API.
 
 In Transit in particular, each key version could reference a different external
-key via the `external_key_name` value. Any automatic rotation will be disabled.
+key via the `external_key_ref` value. Any automatic rotation will be disabled.
 
 ## Rationale and Alternatives
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

I'll work on automated testing in a follow-up part.


<details>

<summary> Testing script </summary>

```bash
#!/bin/bash

set -euxo pipefail

( killall bao && sleep 1 ) || true

devbao node start --force --initialize --unseal --profiles secret,userpass,pki,transit --audit --seals static:// --ui

. <(devbao node env prod)

bao write transit/keys/pki-signing type=rsa-2048

bao write sys/external-keys/configs/transit plugin=transit token=$VAULT_TOKEN address=$VAULT_ADDR mount_path=transit
bao write sys/external-keys/configs/transit/keys/key name=auto-unseal version=1
bao write -f sys/external-keys/configs/transit/keys/key/grants/transit

bao write sys/external-keys/configs/transit/keys/signing-key name=pki-signing version=1
bao write -f sys/external-keys/configs/transit/keys/signing-key/grants/transit

bao write transit/keys/enc-external external_key_name=transit:key type=external_key
bao write transit/encrypt/enc-external plaintext=asdf
bao write transit/decrypt/auto-unseal ciphertext="$(bao write -field=ciphertext transit/encrypt/enc-external plaintext=asdf associated_data=asdf)" associated_data=asdf
bao write transit/decrypt/enc-external ciphertext="$(bao write -field=ciphertext transit/encrypt/enc-external plaintext=asdf associated_data=asdf)" associated_data=asdf
ciphertext_one="$(bao write -field=ciphertext transit/encrypt/enc-external plaintext=asdf associated_data=asdf)"

bao write transit/keys/sig-external external_key_name=transit:signing-key type=external_key
bao write transit/sign/sig-external input=asdf
bao write transit/verify/pki-signing signature="$(bao write -field=signature transit/sign/sig-external input=asdf)" input="asdf"
bao write transit/verify/sig-external signature="$(bao write -field=signature transit/sign/sig-external input=asdf)" input="asdf"

bao write -f transit/keys/auto-unseal/rotate
bao write sys/external-keys/configs/transit/keys/key-2 name=auto-unseal version=2
bao write -f sys/external-keys/configs/transit/keys/key-2/grants/transit

bao write transit/keys/enc-external/rotate external_key_name=transit:key-2
bao write transit/decrypt/enc-external ciphertext="$ciphertext_one" associated_data=asdf
bao write transit/decrypt/auto-unseal ciphertext="$ciphertext_one" associated_data=asdf

bao write transit/encrypt/enc-external plaintext=asdf
bao write transit/decrypt/auto-unseal ciphertext="$(bao write -field=ciphertext transit/encrypt/enc-external plaintext=asdf associated_data=asdf)" associated_data=asdf
bao write transit/decrypt/enc-external ciphertext="$(bao write -field=ciphertext transit/encrypt/enc-external plaintext=asdf associated_data=asdf)" associated_data=asdf
```

</details>

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: #1320

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
