### PR TITLE
ui: fix broken documentation link on database connection page

### DIFF
--- a/changelog/3604.txt
+++ b/changelog/3604.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+Corrected link in `ui/app/templates/components/database-connection.hbs` from `/api/secret/databases` to `/api-docs/secret/databases` to send to the correct documentation page [https://openbao.org/api-docs/secret/databases](https://openbao.org/api-docs/secret/databases)
+```

--- a/changelog/3604.txt
+++ b/changelog/3604.txt
@@ -1,3 +1,2 @@
-```release-note:fix
-Corrected link in `ui/app/templates/components/database-connection.hbs` from `/api/secret/databases` to `/api-docs/secret/databases` to send to the correct documentation page [https://openbao.org/api-docs/secret/databases](https://openbao.org/api-docs/secret/databases)
-```
+```release-note:bug
+Fixed broken documentation link on UI's unsupported database plugin render.

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -310,7 +310,7 @@
       <Chevron @direction="left" />
       Go back
     </LinkTo>
-    <DocLink @path="/api/secret/databases">Documentation</DocLink>
+    <DocLink @path="/api-docs/secret/databases">Documentation</DocLink>
   </EmptyState>
 {{else}}
   {{#each @model.showAttrs as |attr|}}


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description
In `ui/app/templates/components/database-connection.hbs`, i changed the link of documentation from `/api/secret/databases` to `/api-docs/secret/databases`, to point at the correct documentation page which is [https://openbao.org/api-docs/secret/databases](https://openbao.org/api-docs/secret/databases)
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3603

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
