### PR TITLE
hide commit "interface{} -> any (#3544)" from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# interface{} -> any (#3544)
+1e88fafed1b763bc08dd631b9e118a0dd7e675f9

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ lint:
 # dependency.
 prep:
 	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
+	@if [ -f .git-blame-ignore-revs ]; then git config blame.ignoreRevsFile .git-blame-ignore-revs; fi
 
 # bootstrap the build by downloading additional tools that may be used by devs
 #


### PR DESCRIPTION
## Description

- Add a file with a list PRs (i.e. sha sums of PR squash commits) which are usually noise when looking at a "git blame". Currently with one entry, the merge of #3544, which touched a lot of files, but only to change `interface{}` to `any`
- In the `make prep` target: add a call to `git config` to configure `git blame` to ignore all commits in the file[^1]

## Rationale

Reduce noise in `git blame` output.

This is also respected by GitHub[^2] and other tools which integrate blame viewing like VSCode and Zed.


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

[^1]: I did add a test that the file exists, which will help for sparse checkouts
[^2]: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
