### PR TITLE
Add fingerprinting resistance as a non-goal

### DIFF
--- a/website/content/docs/internals/security.mdx
+++ b/website/content/docs/internals/security.mdx
@@ -15,7 +15,7 @@ to access data or modify policies. All interactions must be auditable and traced
 uniquely back to the origin entity, and the system must be robust against intentional
 attempts to bypass any of its access controls.
 
-# Threat model
+## Threat model
 
 The following are the various parts of the OpenBao threat model:
 
@@ -39,6 +39,8 @@ The following are the various parts of the OpenBao threat model:
 
 - **Availability of secret material in the face of failure.** OpenBao supports
   running in a highly available configuration to avoid loss of availability.
+
+### Out of Scope
 
 The following are not considered part of the OpenBao threat model:
 
@@ -82,7 +84,19 @@ The following are not considered part of the OpenBao threat model:
   configuration files should be validated. If an attacker can write to OpenBao's
   configuration, then the confidentiality or integrity of data can be compromised.
 
-# External threat overview
+- **Protecting against fingerprinting**. Traffic patterns between clients,
+  agents, and server are highly recognizable even when encrypted. Likewise, the
+  server may return certain non-sensitive information including server version
+  number or otherwise be fingerprintable by e.g., behavior of the Go standard
+  library's TCP, HTTP, or TLS stacks. Likewise, fingerprinting of operations
+  back to the underlying storage database (whether entry names, access
+  patterns, number of requests, &c.) are also out of scope.
+
+  - **Namespace existence**. The existence of namespaces can often be inferred
+    through unauthenticated requests, e.g., to `sys/`. This also allows for
+    fingerprinting the service as being an OpenBao instance.
+
+## External threat overview
 
 OpenBao architecture compromises of three distinct systems:
 
@@ -120,7 +134,7 @@ this is not applicable. Because storage backends are untrusted, an eavesdropper
 would only gain access to encrypted data even if communication with the backend
 was intercepted.
 
-# Internal threat overview
+## Internal threat overview
 
 Within the OpenBao system, a critical security concern is an attacker attempting
 to gain access to secret material they are not authorized to. This is an internal


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This expands the threat model after various discussions to reflect that fingerprinting (of the existence of the server, of the server's version, of namespace existence, and of storage patterns) are explicitly out of scope.

_Aside_: should this page be moved under `community` and no longer versioned? :thinking: 

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

See also: https://github.com/openbao/openbao/pull/3052#discussion_r3655080471
See also: https://github.com/openbao/openbao/issues/2509

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
