### PR TITLE
support field flag for token lookup

### DIFF
--- a/changelog/3618.txt
+++ b/changelog/3618.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add support for `-field` argument to `bao token lookup`
+```

--- a/changelog/3618.txt
+++ b/changelog/3618.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Add support for `-field` argument to `bao token lookup`
+command/token: Add support for `-field` argument to `bao token lookup`.
 ```

--- a/internal/command/token_create_test.go
+++ b/internal/command/token_create_test.go
@@ -68,7 +68,7 @@ func TestTokenCreateCommand_Run(t *testing.T) {
 			[]string{
 				"-field", "not-a-real-field",
 			},
-			"not present in token",
+			"not present in secret",
 			1,
 		},
 		{

--- a/internal/command/token_create_test.go
+++ b/internal/command/token_create_test.go
@@ -68,7 +68,7 @@ func TestTokenCreateCommand_Run(t *testing.T) {
 			[]string{
 				"-field", "not-a-real-field",
 			},
-			"not present in secret",
+			"not present in token",
 			1,
 		},
 		{

--- a/internal/command/token_lookup.go
+++ b/internal/command/token_lookup.go
@@ -56,7 +56,7 @@ Usage: bao token lookup [options] [TOKEN | ACCESSOR]
 }
 
 func (c *TokenLookupCommand) Flags() *FlagSets {
-	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
 
 	f := set.NewFlagSet("Command Options")
 
@@ -127,6 +127,10 @@ func (c *TokenLookupCommand) Run(args []string) int {
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error looking up token: %s", err))
 		return 2
+	}
+
+	if c.flagField != "" {
+		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
 	return OutputSecret(c.UI, secret)

--- a/internal/command/token_lookup_test.go
+++ b/internal/command/token_lookup_test.go
@@ -50,8 +50,8 @@ func TestTokenLookupCommand_Run(t *testing.T) {
 		},
 		{
 			"field",
-			[]string{"-field", "accessor"},
-			"false",
+			[]string{"-field", "type"},
+			"service",
 			0,
 		},
 		{

--- a/internal/command/token_lookup_test.go
+++ b/internal/command/token_lookup_test.go
@@ -57,7 +57,7 @@ func TestTokenLookupCommand_Run(t *testing.T) {
 		{
 			"field_not_found",
 			[]string{"-field", "not-a-real-field"},
-			"not present in token",
+			"not present in secret",
 			1,
 		},
 	}

--- a/internal/command/token_lookup_test.go
+++ b/internal/command/token_lookup_test.go
@@ -48,6 +48,18 @@ func TestTokenLookupCommand_Run(t *testing.T) {
 			"Too many arguments",
 			1,
 		},
+		{
+			"field",
+			[]string{"-field", "accessor"},
+			"false",
+			0,
+		},
+		{
+			"field_not_found",
+			[]string{"-field", "not-a-real-field"},
+			"not present in token",
+			1,
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {

--- a/website/content/docs/commands/token/lookup.mdx
+++ b/website/content/docs/commands/token/lookup.mdx
@@ -39,6 +39,10 @@ flags](../index.mdx) included on all commands.
 
 ### Output options
 
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
 - `-format` `(default: "table")` - Print the output in the given format. Valid
   formats are "table", "json", or "yaml". This can also be specified via the
   `BAO_FORMAT` environment variable.


### PR DESCRIPTION
## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

The cli command `bao token lookup` currently doesn't support the `field` argument. This merge request adds that functionality.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3617 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
