### PR TITLE
Add semgrep rule to enforce testify usage for error checking

### DIFF
--- a/tools/semgrep/ci/tests-assertions.yaml
+++ b/tools/semgrep/ci/tests-assertions.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
 # SPDX-License-Identifier: MPL-2.0
 
-rules:
-  - id: use-testify-for-error-checks
-    
+__metadata: &metadata
     metadata: 
       category: best-practice
     languages:
@@ -11,7 +9,38 @@ rules:
     severity: ERROR
     message: "use github.com/stretchr/testify for test assertions"
 
+rules:
+  - id: use-testify-for-error-checks
+    <<: *metadata
+
     patterns:
-      - pattern: 'if $ERR != nil { $T.Fatal(err) }'
+      - pattern-not: &with-generic-init |
+          if $INIT; $ERR != nil {
+            ($T: *testing.T).Fatal($ERR)
+          }
+      - pattern: |
+          if $ERR != nil {
+            ($T: *testing.T).Fatal($ERR)
+          }
 
     fix: require.NoError($T, $ERR)
+
+  - id: use-testify-for-error-checks-with-simple-init
+    <<: *metadata
+
+    patterns:
+      - pattern: &with-simple-init |
+          if $ERR = $X($...ARGS); $ERR != nil {
+            ($T: *testing.T).Fatal($ERR)
+          }
+
+    fix: require.NoError($T, $X($...ARGS))
+
+  - id: use-testify-for-error-checks-with-generic-init
+    <<: *metadata
+
+    patterns:
+      - pattern: *with-generic-init
+      - pattern-not: *with-simple-init
+
+    fix: "$INIT\n\trequire.NoError($T, $ERR)"

--- a/tools/semgrep/ci/tests-assertions.yaml
+++ b/tools/semgrep/ci/tests-assertions.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: use-testify-for-error-checks
+    
+    metadata: 
+      category: best-practice
+    languages:
+     - go
+    severity: ERROR
+    message: "use github.com/stretchr/testify for test assertions"
+
+    patterns:
+      - pattern: 'if $ERR != nil { $T.Fatal(err) }'
+
+    fix: require.NoError($T, $ERR)

--- a/tools/semgrep/ci/tests-assertions.yaml
+++ b/tools/semgrep/ci/tests-assertions.yaml
@@ -22,6 +22,9 @@ rules:
           if $ERR != nil {
             ($T: *testing.T).Fatal($ERR)
           }
+      - metavariable-regex: &err-regex
+          metavariable: $ERR
+          regex: (err|.*Err)$
 
     fix: require.NoError($T, $ERR)
 
@@ -33,6 +36,7 @@ rules:
           if $ERR = $X($...ARGS); $ERR != nil {
             ($T: *testing.T).Fatal($ERR)
           }
+      - metavariable-regex: *err-regex
 
     fix: require.NoError($T, $X($...ARGS))
 
@@ -42,5 +46,6 @@ rules:
     patterns:
       - pattern: *with-generic-init
       - pattern-not: *with-simple-init
+      - metavariable-regex: *err-regex
 
     fix: "$INIT\n\trequire.NoError($T, $ERR)"


### PR DESCRIPTION

## Description

enforce that we don't do this

```go
if err != nil {
	t.Fatal(err)
}
```

but use

```go
require.NoError(t, err)
```

instead via semgrep rule.

## Rationale


especially in longer tests, this helps with readability by allowing more of the test to be on the screen at the same time (without saying shorter is always better for readability :laughing:)


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
