### PR TITLE
Improve stdout audit device description

### DIFF
--- a/website/content/blog/2026-07-21-declarative-configuration.md
+++ b/website/content/blog/2026-07-21-declarative-configuration.md
@@ -65,8 +65,8 @@ through configuration files, reloading them on `SIGHUP`. These look like
 the following:
 
 ```hcl
-audit "file" "my-device" {
-    description = "This audit device writes to stdout which never fails."
+audit "file" "to-stdout" {
+    description = "Write audit information to standard output."
     options {
         file_path = "stdout"
     }

--- a/website/content/docs/configuration/audit.mdx
+++ b/website/content/docs/configuration/audit.mdx
@@ -35,9 +35,9 @@ the API: `description` and other parameters are defined at the top level and
     {
       "file": {
         "to-stdout": {
-          "description": "This audit device should never fail.",
+          "description": "Write audit information to standard output.",
           "options": {
-            "file_path": "/dev/stdout",
+            "file_path": "stdout",
             "log_raw": "true"
           }
         }
@@ -52,9 +52,9 @@ the API: `description` and other parameters are defined at the top level and
 
 ```hcl
 audit "file" "to-stdout" {
-  description = "This audit device should never fail."
+  description = "Write audit information to standard output."
   options {
-    file_path = "/dev/stdout"
+    file_path = "stdout"
     log_raw = "true"
   }
 }

--- a/website/content/docs/configuration/audit.mdx
+++ b/website/content/docs/configuration/audit.mdx
@@ -37,8 +37,7 @@ the API: `description` and other parameters are defined at the top level and
         "to-stdout": {
           "description": "Write audit information to standard output.",
           "options": {
-            "file_path": "stdout",
-            "log_raw": "true"
+            "file_path": "stdout"
           }
         }
       }
@@ -55,7 +54,6 @@ audit "file" "to-stdout" {
   description = "Write audit information to standard output."
   options {
     file_path = "stdout"
-    log_raw = "true"
   }
 }
 ```

--- a/website/content/docs/configuration/self-init.mdx
+++ b/website/content/docs/configuration/self-init.mdx
@@ -56,8 +56,7 @@ initial root token and handling recovery keys.
               "data": {
                 "type": "file",
                 "options": {
-                  "file_path": "stdout",
-                  "log_raw": true
+                  "file_path": "stdout"
                 }
               }
             }
@@ -81,7 +80,6 @@ initialize "audit" {
       type = "file"
       options = {
         file_path = "stdout"
-        log_raw = true
       }
     }
   }

--- a/website/content/docs/configuration/self-init.mdx
+++ b/website/content/docs/configuration/self-init.mdx
@@ -56,7 +56,7 @@ initial root token and handling recovery keys.
               "data": {
                 "type": "file",
                 "options": {
-                  "file_path": "/dev/stdout",
+                  "file_path": "stdout",
                   "log_raw": true
                 }
               }
@@ -80,7 +80,7 @@ initialize "audit" {
     data = {
       type = "file"
       options = {
-        file_path = "/dev/stdout"
+        file_path = "stdout"
         log_raw = true
       }
     }


### PR DESCRIPTION
## Description

Improve stdout audit device description. As suggested by @timb-controlplane in https://github.com/openbao/openbao/pull/3595#discussion_r3665732422

Also align the sample in the blog post with the sample in the docs (modulo indentation).

## Rationale

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
