### PR TITLE
Bump security-insights.yml to 2.2.0 and update content

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,116 +1,154 @@
 header:
-  schema-version: 2.0.0
-  last-updated: '2025-09-19'
-  last-reviewed: '2025-09-19'
+  schema-version: 2.2.0
+  last-updated: '2026-07-28'
+  last-reviewed: '2026-07-28'
   url: https://github.com/openbao/openbao
 
 project:
   name: OpenBao
   administrators:
+    - name: Alex Scheel
+      affiliation: ControlPlane
+      email: alexander.m.scheel@gmail.com
+      social: https://github.com/cipherboy
+      primary: false
+    - name: Andrii Fedorchuk
+      affiliation: Adfinis
+      email: andrii.fedorchuk@adfinis.com
+      social: https://github.com/driif
+      primary: false
+    - name: Brad Corrion
+      affiliation: IOTech Systems
+      email: brad@iotechsys.com
+      primary: false
+    - name: Dan Ghita
+      affiliation: Wallix
+      email: dghita@wallix.com
+      social: https://github.com/DanGhita
+      primary: false
+    - name: Eugene Davis
+      affiliation: ControlPlane
+      email: eugene.davis@control-plane.io
+      social: https://github.com/eugene-davis
+      primary: false
+    - name: Fabien Catteau
+      affiliation: GitLab
+      email: fcatteau@gitlab.com
+      social: https://github.com/fcat
+      primary: false
     - name: James Butcher
       affiliation: IOTech Systems
       email: james@iotechsys.com
       primary: false
+    - name: Jonas Köhnen
+      affiliation: SAP (Liquid Reply)
+      email: j.koehnen@reply.de
+      social: https://github.com/satoqz
+      primary: false
     - name: Julian Cassignol
-      affiliation: Wallix
+      affiliation: WALLIX
       email: jcassignol@wallix.com
+      primary: false
+    - name: Klaus Kiefer
+      affiliation: SAP
+      email: klaus.kiefer@sap.com
+      social: https://github.com/klaus-sap
+      primary: false
+    - name: Mark Mishaev
+      affiliation: GitLab
+      email: mmishaev@gitlab.com
+      social: https://github.com/markmishaev76
       primary: false
     - name: Michael Hofer
       affiliation: Adfinis
       email: michael.hofer@adfinis.com
       social: https://github.com/karras
-      primary: false
-    - name: Alex Scheel
-      affiliation: GitLab
-      email: alexander.m.scheel@gmail.com
-      social: https://github.com/cipherboy
       primary: true
-    - name: Brad Corrion
-      affiliation: IOTech Systems
-      email: brad@iotechsys.com
-      primary: false
-    - name: Dan Ghita 
-      affiliation: Wallix
-      email: dghita@wallix.com
-      primary: false
-    - name: Andrii Fedorchuk
-      affiliation: Adfinis
-      email: andrii.fedorchuk@adfinis.com
-      primary: false
-
   repositories:
-    - name: openbao
-      url: https://github.com/openbao/openbao/
-      comment: |
-        This is the core repo for OpenBao.
-    - name: openbao-plugins
-      url: https://github.com/openbao/openbao-plugins
-      comment : |
-        This repository contains plugins for OpenBao, an open-source fork of HashiCorp Vault. These plugins are maintained by the OpenBao project but are not included in the core OpenBao binary.
-    - name: openbao-fedora
-      url: https://github.com/openbao/openbao-fedora
-      comment : |
-        EPEL/Fedora packaging for OpenBao.
-    - name: openbao-csi-provider
-      url: https://github.com/openbao/openbao-csi-provider
-      comment : |
-        OpenBao Provider for Secret Store CSI Driver.
-    - name: openbao-helm
-      url: https://github.com/openbao/openbao-helm
-      comment : |
-        Helm chart to install OpenBao and other associated components.
-    - name: openbao-plugin-secrets-oauthapp
-      url: https://github.com/openbao/openbao-plugin-secrets-oauthapp
-      comment : |
-        OAuth 2.0 secrets plugin for OpenBao supporting a variety of grant types.
-    - name: openbao-nightly
-      url: https://github.com/openbao/openbao-nightly
-      comment : |
-        Mirror of openbao for nightly build process.
-    - name: go-kms-wrapping
-      url: https://github.com/openbao/go-kms-wrapping
-      comment : |
-        KMS wrapping libraries split out from OpenBao.
-    - name: openbao-k8
-      url: https://github.com/openbao/openbao-k8s
-      comment : |
-        First-class support for OpenBao and Kubernetes.
-    - name: dough
-      url: https://github.com/openbao/dough
-      comment : |
-        Greenfield UI rewrite.
-    - name: dev-wg
-      url: https://github.com/openbao/dev-wg
-      comment : |
-        Meta project for the Development Working Group.
-    - name: benchmark-openbao
-      url: https://github.com/openbao/benchmark-openbao
-      comment : |
-        A tool for benchmarking usage of OpenBao.
-    - name: devbao
-      url: https://github.com/openbao/devbao
-      comment : |
-        Development environment for starting OpenBao (Vault) instances
-    - name: artwork
-      url: https://github.com/openbao/artwork
-      comment : |
-        In this repository we provide artwork for the OpenBao project in standardized formats.
-    - name: openbao-template
-      url: https://github.com/openbao/openbao-template
-      comment : |
-        Template rendering, notifier, and supervisor for OpenBao data.
-    - name: go-secure-stdlib
-      url: https://github.com/openbao/go-secure-stdlib
-      comment : |
-        Stdlib for OpenBao Secure products.
-    - name: openbao-secrets-operator
-      url: https://github.com/openbao/openbao-secrets-operator
-      comment : |
-        The OpenBao Secrets Operator (bso) allows Pods to consume openbao secrets natively from Kubernetes Secrets.
     - name: .github
       url: https://github.com/openbao/.github
       comment : |
         Meta project to provide information about the OpenBao Github organisation.
+    - name: artwork
+      url: https://github.com/openbao/artwork
+      comment : |
+        Artwork for the OpenBao project in standardized formats.
+    - name: benchmark-openbao
+      url: https://github.com/openbao/benchmark-openbao
+      comment : |
+        A tool for benchmarking usage of OpenBao.
+    - name: dependency-vulnerabilities
+      url: https://github.com/openbao/dependency-vulnerabilities
+      comment : |
+        Automates the identification and tracking of security vulnerabilities.
+    - name: dev-wg
+      url: https://github.com/openbao/dev-wg
+      comment : |
+        Meta project for the Development Working Group.
+    - name: devbao
+      url: https://github.com/openbao/devbao
+      comment : |
+        Development environment for starting OpenBao (Vault) instances.
+    - name: dough
+      url: https://github.com/openbao/dough
+      comment : |
+        Greenfield UI rewrite.
+    - name: go-kms-wrapping
+      url: https://github.com/openbao/go-kms-wrapping
+      comment : |
+        KMS wrapping libraries split out from OpenBao.
+    - name: go-secure-stdlib
+      url: https://github.com/openbao/go-secure-stdlib
+      comment : |
+        Stdlib for OpenBao Secure products.
+    - name: marketing-wg
+      url: https://github.com/openbao/marketing-wg
+      comment : |
+        Meta project for the Marketing Working Group.
+    - name: openbao
+      url: https://github.com/openbao/openbao/
+      comment: |
+        This is the core repo for OpenBao.
+    - name: openbao-csi-provider
+      url: https://github.com/openbao/openbao-csi-provider
+      comment : |
+        OpenBao provider for Secret Store CSI Driver.
+    - name: openbao-ecosystem-logos
+      url: https://github.com/openbao/openbao-ecosystem-logos
+      comment : |
+        Logos for the OpenBao ecosystem page.
+    - name: openbao-fedora
+      url: https://github.com/openbao/openbao-fedora
+      comment : |
+        EPEL/Fedora packaging for OpenBao.
+    - name: openbao-helm
+      url: https://github.com/openbao/openbao-helm
+      comment : |
+        Helm chart to install OpenBao and other associated components.
+    - name: openbao-k8s
+      url: https://github.com/openbao/openbao-k8s
+      comment : |
+        Sidecar OpenBao agent injector for Kubernetes.
+    - name: openbao-nightly
+      url: https://github.com/openbao/openbao-nightly
+      comment : |
+        Mirror of openbao for nightly build process.
+    - name: openbao-plugin-secrets-oauthapp
+      url: https://github.com/openbao/openbao-plugin-secrets-oauthapp
+      comment : |
+        OAuth 2.0 secrets plugin for OpenBao supporting a variety of grant types.
+    - name: openbao-plugins
+      url: https://github.com/openbao/openbao-plugins
+      comment : |
+        Plugins for OpenBao, which are maintained by the project but are not included in the core OpenBao binary.
+    - name: openbao-snapshot-agent
+      url: https://github.com/openbao/openbao-snapshot-agent
+      comment : |
+        Snapshot agent to create OpenBao backups.
+    - name: openbao-template
+      url: https://github.com/openbao/openbao-template
+      comment : |
+        Template rendering, notifier, and supervisor for OpenBao data.
   vulnerability-reporting:
     reports-accepted: true
     bug-bounty-available: false
@@ -122,7 +160,7 @@ project:
   documentation:
     detailed-guide: https://openbao.org/docs/
     quickstart-guide: https://openbao.org/docs/get-started/developer-qs/
-    support-policy: https://openbao.org/docs/policies/support/
+    support-policy: https://openbao.org/community/policies/support/
   homepage: https://openbao.org/
 
 repository:
@@ -131,6 +169,10 @@ repository:
   accepts-change-request: true
   accepts-automated-change-request: true
   core-team:
+    - name: Alex Scheel
+      email: alexander.m.scheel@gmail.com
+      social: https://github.com/cipherboy
+      primary: true
     - name: Dan Ghita
       email: dghita@wallix.com
       social: https://github.com/DanGhita
@@ -139,14 +181,10 @@ repository:
       email: jan@martens.eu.org
       social: https://github.com/JanMa
       primary: false
-    - name: Alex Scheel
-      email: alexander.m.scheel@gmail.com
-      social: https://github.com/cipherboy
-      primary: true
     - name: Jonas Köhnen
       email: jonas@satoqz.net
       social: https://github.com/satoqz
-      primary: true
+      primary: false
   license:
     url: https://github.com/openbao/openbao/blob/main/LICENSE
     expression: 'Mozilla Public License 2.0'


### PR DESCRIPTION
## Description

It looks like our security-insights.yml needed a brush up since various things were missing. I've used the opportunity to adjust a few things, happy to take feedback:

* Sorted contacts and repos alphabetically for easier comparison
* Added all remaining, missing TSC members to `administrators`
  - Ensured Alex is actually working at ControlPlane ;)
  - Added Eugene, Mark, and Fabien
  - Switched the primary flag to Hofi as chair
* For the `core-team`, switched Jonas' flag to false since the schema only wants one primary and Alex is chair, and sorted alphabetically
* Added a few missing repos such as openbao-snapshot-agent
  - Ensured we don't list any private and/or archived repos
* Bumped the [schema to 2.2.0](https://security-insights.openssf.org/schema.html)

Tested with [cue](https://security-insights.openssf.org/get-started.html):
```sh
curl -O https://raw.githubusercontent.com/ossf/security-insights/main/spec/schema.cue
cue vet -d '#SecurityInsights' schema.cue security-insights.yml
```

## Rationale

Update our security-insights.yml every few months to keep it maintained.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
