### PR TITLE
Add context cancellation to initialization

### DIFF
--- a/changelog/3623.txt
+++ b/changelog/3623.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Prevent recovered panic in request handler due to uncancelled active context between initialization and standby/active enablement.
+```

--- a/internal/vault/init.go
+++ b/internal/vault/init.go
@@ -394,6 +394,7 @@ func (c *Core) initializeInternal(ctx context.Context, initParams *InitParams) (
 	}
 
 	activeCtx, ctxCancel := context.WithCancel(namespace.RootContext(ctx))
+	defer ctxCancel()
 	if err := c.postUnseal(activeCtx, ctxCancel, standardUnsealStrategy{}); err != nil {
 		c.logger.Error("post-unseal setup failed during init", "error", err)
 		return nil, err

--- a/internal/vault/init_test.go
+++ b/internal/vault/init_test.go
@@ -4,12 +4,16 @@
 package vault
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/vault/seal"
@@ -136,4 +140,77 @@ func testCoreInitCommon(t *testing.T, s Seal, barrierConf, recoveryConf *SealCon
 		require.NoError(t, err)
 		require.Equal(t, recoveryConf, outConf)
 	}
+}
+
+func TestCore_InitParallelRequests(t *testing.T) {
+	logger := logging.NewVaultLogger(log.Trace)
+
+	inm, err := inmem.NewInmemHA(nil, logger)
+	require.NoError(t, err)
+
+	inmha, err := inmem.NewInmemHA(nil, logger)
+	require.NoError(t, err)
+
+	redirectOriginal := "http://127.0.0.1:8200"
+	conf := &CoreConfig{
+		Physical:   inm,
+		HAPhysical: inmha.(physical.HABackend),
+		LogicalBackends: map[string]logical.Factory{
+			"kv": LeasedPassthroughBackendFactory,
+		},
+		RedirectAddr: redirectOriginal,
+		DisableCache: true,
+		Seal:         nil,
+	}
+	c, err := NewCore(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c.Shutdown() //nolint:errcheck
+	})
+
+	ctx := namespace.RootContext(t.Context())
+	init, err := c.Initialized(ctx)
+	require.NoError(t, err)
+	require.False(t, init)
+
+	var wg sync.WaitGroup
+	spamCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	for range 32 {
+		wg.Go(func() {
+			for {
+				if spamCtx.Err() != nil {
+					return
+				}
+
+				// We don't actually care about anything here.
+				c.HandleRequest(ctx, &logical.Request{ //nolint:errcheck
+					Path:      "sys/mounts/kv",
+					Operation: logical.CreateOperation,
+					Data: map[string]any{
+						"type": "kv",
+					},
+				})
+			}
+		})
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	resp, err := c.Initialize(ctx, &InitParams{
+		BarrierConfig: &SealConfig{SecretShares: 5, SecretThreshold: 3},
+	})
+	require.NoError(t, err)
+
+	for _, key := range resp.SecretShares {
+		_, err := TestCoreUnseal(c, key)
+		require.NoError(t, err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	cancel()
+	wg.Wait()
 }


### PR DESCRIPTION
Notably, `preSeal(...)` does not cancel the active context. Because initialization will eventually finish (and we want to manually re-un-seal if using Shamir's), we should just defer the cancellation of the scoped active context we create during initialization. This will correctly mark `c.activeContext.Load()` as a cancelled context and we won't get panics like:

    sync.(*RWMutex).RLock(...)
    	/usr/local/go/src/sync/rwmutex.go:72
    github.com/openbao/openbao/v2/internal/vault.(*NamespaceStore).ResolveNamespaceFromRequest(0x0, {0x0?, 0x14cac65eb0a0?}, {0x14cac7659549, 0x34})
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/vault/namespace_store.go:1589 +0x81
    github.com/openbao/openbao/v2/internal/vault.(*Core).switchedLockHandleRequest(0x14cac5e2e308, {0x4a10948, 0x14cac7f43380}, 0x14cac7f10fc0, 0x1)
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/vault/request_handling.go:619 +0x431
    github.com/openbao/openbao/v2/internal/vault.(*Core).HandleRequest(...)
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/vault/request_handling.go:569
    github.com/openbao/openbao/v2/internal/http.request(0x14cac5e2e308?, {0x4a06da0, 0x14cac7f43260}, 0x14cac7f5f7c0?, 0x14cac7f10fc0)
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/http/handler.go:946 +0x6b
    github.com/openbao/openbao/v2/internal/http.handler.handleLogicalWithInjector.handleLogicalInternal.func59({0x4a06da0, 0x14cac7f43260}, 0x14cac7f5f7c0)
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/http/logical.go:374 +0xce

when sending requests between initialization and actual node startup (whether as active or standby).

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This was exacerbated locally by #3542, though I'm still not entirely sure why other than different function call structure. Regardless, this bug was introduced sometime in the v2.5.x cycle AFAICT. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
