### PR TITLE
redo the client side validation for userpass

### DIFF
--- a/changelog/3625.txt
+++ b/changelog/3625.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix client side validation for userpass user creation
+```

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -323,11 +323,30 @@ export default Service.extend({
           // Build and add validations on model
           // NOTE: For initial phase, initialize validations only for user pass auth
           if (backend === 'userpass') {
+            const exclusivePairs = { password: 'passwordHash', passwordHash: 'password' };
             const validations = fieldGroups.reduce((obj, element) => {
               if (element.default) {
                 element.default.forEach((v) => {
                   const key = v.options.fieldValue || v.name;
-                  obj[key] = [{ type: 'presence', message: `${v.name} can't be blank` }];
+                  if (exclusivePairs[key]) {
+                    const otherKey = exclusivePairs[key];
+                    obj[key] = [
+                      {
+                        validator: (model) => {
+                          return !!(model[key] || model[otherKey]);
+                        },
+                        message: `Either ${v.name} or the alternate value must be provided.`,
+                      },
+                      {
+                        validator: (model) => {
+                          return !(model[key] && model[otherKey]);
+                        },
+                        message: `Only one of password or password hash may be provided.`,
+                      },
+                    ];
+                  } else {
+                    obj[key] = [{ type: 'presence', message: `${v.name} can't be blank` }];
+                  }
                 });
               }
               return obj;

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -335,7 +335,7 @@ export default Service.extend({
                         validator: (model) => {
                           return !!(model[key] || model[otherKey]);
                         },
-                        message: `Either ${v.name} or the alternate value must be provided.`,
+                        message: `Either ${v.name} or ${otherKey} value must be provided.`,
                       },
                       {
                         validator: (model) => {


### PR DESCRIPTION
## Description

The client side validation when creating a user for the userpass auth method is checking the presence of both password and password hash, but at the same time the server side demands only one of either. This merge request aims to fix this issue as well as provide client side validation for having something in both fields.

Neither value provided:
<img width="719" height="408" alt="image" src="https://github.com/user-attachments/assets/f9211333-6217-4ab0-981e-7b9c432b5c2f" />


Both values provided:
<img width="730" height="418" alt="image" src="https://github.com/user-attachments/assets/51cb6211-0641-4943-8867-45e4ce8a4015" />


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3526 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
