### PR TITLE
specify correct variable in test case skips

### DIFF
--- a/changelog/3627.txt
+++ b/changelog/3627.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-tests: reference correct environment variable in skip reason
-```

--- a/changelog/3627.txt
+++ b/changelog/3627.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+tests: reference correct environment variable in skip reason
+```

--- a/internal/vault/external_tests/misc/misc_binary/recovery_test.go
+++ b/internal/vault/external_tests/misc/misc_binary/recovery_test.go
@@ -27,7 +27,7 @@ func TestRecovery_Docker(t *testing.T) {
 	t.Parallel()
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running docker test when $VAULT_BINARY present")
+		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",

--- a/internal/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/internal/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -26,7 +26,7 @@ import (
 func TestPostgreSQL_FencedWrites(t *testing.T) {
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running docker test when $VAULT_BINARY present")
+		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 
 	psql := docker.NewPostgreSQLStorage(t, "")

--- a/internal/vault/external_tests/pprof/pprof_binary/pprof_test.go
+++ b/internal/vault/external_tests/pprof/pprof_binary/pprof_test.go
@@ -19,7 +19,7 @@ func TestSysPprof_Exec(t *testing.T) {
 	t.Parallel()
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running exec test when $VAULT_BINARY present")
+		t.Skip("only running exec test when $BAO_BINARY present")
 	}
 	cluster := testcluster.NewTestExecDevCluster(t, &testcluster.ExecDevClusterOptions{
 		ClusterOptions: testcluster.ClusterOptions{
@@ -41,7 +41,7 @@ func TestSysPprof_Standby_Exec(t *testing.T) {
 	t.Parallel()
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running exec test when $VAULT_BINARY present")
+		t.Skip("only running exec test when $BAO_BINARY present")
 	}
 	cluster := testcluster.NewTestExecDevCluster(t, &testcluster.ExecDevClusterOptions{
 		ClusterOptions: testcluster.ClusterOptions{

--- a/internal/vault/external_tests/raft/raft_binary/raft_test.go
+++ b/internal/vault/external_tests/raft/raft_binary/raft_test.go
@@ -15,7 +15,7 @@ func TestRaft_Configuration_Docker(t *testing.T) {
 	t.Parallel()
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
-		t.Skip("only running docker test when $VAULT_BINARY present")
+		t.Skip("only running docker test when $BAO_BINARY present")
 	}
 	opts := &docker.DockerClusterOptions{
 		ImageRepo: "quay.io/openbao/openbao",


### PR DESCRIPTION
## Description

While checking out some tests I saw that the skip reasons reference the vault env var instead of bao. I know this is a bit more low hanging, but I still wanted to correct it :)

## Rationale

Prevent confusion and keep the logs correct to the code.

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
