### PR TITLE
Docs: change terms (SHA-256 checksum -> digest, OCI image -> artifact)

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -294,7 +294,7 @@ This endpoint creates or updates a named role.
   format for the key id of a signed certificate. The following variables are
   available for use: '\{\{token_display_name}}' - The display name of the token used
   to make the request. '\{\{role_name}}' - The name of the role signing the request.
-  '\{\{public_key_hash}}' - A SHA256 checksum of the public key that is being signed.
+  '\{\{public_key_hash}}' - A SHA-256 digest of the public key that is being signed.
   e.g. "custom-keyid-\{\{token_display_name}}"
 
 - `allowed_user_key_lengths` `(map<string|(int|[]int|string)>: "")` – Specifies a

--- a/website/content/docs/commands/plugin/register.mdx
+++ b/website/content/docs/commands/plugin/register.mdx
@@ -45,7 +45,8 @@ flags](../index.mdx) included on all commands.
 
 ### Command options
 
-- `-sha256` `(string: <required>)` - Checksum (SHA256) of the plugin binary.
+- `-sha256` `(string: <required>)` - Expected SHA-256 digest of the plugin binary.
+  Must be a 64-character hexadecimal string.
 
 - `-args` `(string: "")` - List of arguments to pass to the binary plugin during
   each invocation. Specify multiple arguments with commas.

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -23,7 +23,7 @@ managing the plugin binaries:
     plugins in code and OpenBao will automatically download and extract them
     during startup.
   * **Integrity Verification:**  When extracting plugin binaries from OCI images
-    OpenBao ensures the SHA256 sum of the extracted binary is the same as in the
+    OpenBao ensures the SHA-256 digest of the extracted binary is the same as in the
     configuration files.
   * **Version Management:** Distributing new a new version of a plugin just
     requires an update of the configuration file instead of manually placing the
@@ -82,7 +82,7 @@ plugin versions.
 
 - `binary_name` `(string: required)` - Name of the plugin binary file within the OCI image.
 
-- `sha256sum` `(string: required)` - Expected SHA256 checksum of the plugin binary. Must be a 64-character hexadecimal string.
+- `sha256sum` `(string: required)` - Expected SHA-256 digest of the plugin binary. Must be a 64-character hexadecimal string.
 
 - `args` `([]string: optional)` - Any arguments to pass to the running plugin. Only used if `plugin_auto_register=true` is set at the global level.
 

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -9,10 +9,10 @@ import TabItem from '@theme/TabItem';
 # Declarative plugins
 
 OpenBao supports the distribution of plugins in Open Container Initiative (OCI)
-images. Operators can define the desired plugins for their OpenBao cluster
+artifacts. Operators can define the desired plugins for their OpenBao cluster
 directly in the server configuration files. On startup, OpenBao will check for
 locally cached binaries, verify their integrity, and only download and extract
-new or updated plugin binaries from the specified OCI images if necessary. This
+new or updated plugin binaries from the specified OCI artifacts if necessary. This
 approach uses existing container ecosystem tooling and infrastructure for
 robust, secure, and efficient plugin management.
 
@@ -22,7 +22,7 @@ managing the plugin binaries:
   * **Automated Discovery and Installation:** Operators can define the used
     plugins in code and OpenBao will automatically download and extract them
     during startup.
-  * **Integrity Verification:**  When extracting plugin binaries from OCI images
+  * **Integrity Verification:**  When extracting plugin binaries from OCI artifacts
     OpenBao ensures the SHA-256 digest of the extracted binary is the same as in the
     configuration files.
   * **Version Management:** Distributing new a new version of a plugin just
@@ -74,7 +74,7 @@ plugin versions.
 
 ### Parameters
 
-- `image` `(string: required)` - OCI image URL including registry and repository. Conflicts with the `command` value. One of `image` or `command` is required.
+- `image` `(string: required)` - OCI artifact/image URL including registry and repository. Conflicts with the `command` value. One of `image` or `command` is required.
 
 - `command` `(string: required)` - Command name of the plugin that has been manually downloaded. Conflicts with the `image` value. One of `image` or `command` is required.
 

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -22,9 +22,6 @@ managing the plugin binaries:
   * **Automated Discovery and Installation:** Operators can define the used
     plugins in code and OpenBao will automatically download and extract them
     during startup.
-  * **Integrity Verification:**  When extracting plugin binaries from OCI artifacts
-    OpenBao ensures the SHA-256 digest of the extracted binary is the same as in the
-    configuration files.
   * **Version Management:** Distributing new a new version of a plugin just
     requires an update of the configuration file instead of manually placing the
     binary on every node.


### PR DESCRIPTION
## Description

This MR changes some terms, as proposed by @timb-controlplane in his review of https://github.com/openbao/openbao/pull/3599.

I used the AE spelling (artifact) instead of BE (artefact). The choice of language should probably be documented in https://openbao.org/community/contributing/ (maybe I missed it)?

## Rationale

*See the commit messages for details.*

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
