### PR TITLE
bump semgrep and make sure `make` uses same version

### DIFF
--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -52,7 +52,7 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@sha256:ffc6f3567654f9431456d49fd059dfe548f007c494a7eb6cd5a1a3e50d813fb3
+      image: docker.io/semgrep/semgrep@sha256:296fc4912420833abfcf5090ec49a81bf1330bb61fc193cd09255f88b8267ba9 # 1.171.0
     # Skip any PR created by dependabot and any check triggered by merge group
     if: (github.actor != 'dependabot[bot]') && (github.event != 'merge_group')
     steps:

--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -52,7 +52,7 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-latest
     container:
-      image: docker.io/semgrep/semgrep@sha256:296fc4912420833abfcf5090ec49a81bf1330bb61fc193cd09255f88b8267ba9 # 1.171.0
+      image: docker.io/semgrep/semgrep:1.171.0@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8
     # Skip any PR created by dependabot and any check triggered by merge group
     if: (github.actor != 'dependabot[bot]') && (github.event != 'merge_group')
     steps:

--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,10 @@ semgrep-ci:
 SEMGREP_IMAGE=$(shell grep -o '[^ ]*/semgrep:[^ ]*@sha256:[^ ]*' .github/workflows/code-checker.yml | head -n1)
 
 docker-semgrep:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMAGE) semgrep --include '*.go' -a -f tools/semgrep .
+	$(DOCKER_CMD) run --rm --volume "$(PWD):/src" $(SEMGREP_IMAGE) semgrep --include '*.go' -a -f tools/semgrep .
 
 docker-semgrep-ci:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMAGE) semgrep --error --include '*.go' -a -f tools/semgrep/ci .
+	$(DOCKER_CMD) run --rm --volume "$(PWD):/src" $(SEMGREP_IMAGE) semgrep --error --include '*.go' -a -f tools/semgrep/ci .
 
 assetcheck:
 	@echo "==> Checking compiled UI assets..."

--- a/Makefile
+++ b/Makefile
@@ -206,11 +206,13 @@ semgrep:
 semgrep-ci:
 	semgrep --error --include '*.go' -f tools/semgrep/ci .
 
+SEMGREP_IMGE=$(shell grep -o '[^ ]*/semgrep@sha256:[a-f0-9]*' .github/workflows/code-checker.yml | head -n1)
+
 docker-semgrep:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" docker.io/returntocorp/semgrep:latest semgrep --include '*.go' -a -f tools/semgrep .
+	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMGE) semgrep --include '*.go' -a -f tools/semgrep .
 
 docker-semgrep-ci:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" docker.io/returntocorp/semgrep:latest semgrep --error --include '*.go' -a -f tools/semgrep/ci .
+	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMGE) semgrep --error --include '*.go' -a -f tools/semgrep/ci .
 
 assetcheck:
 	@echo "==> Checking compiled UI assets..."

--- a/Makefile
+++ b/Makefile
@@ -206,13 +206,13 @@ semgrep:
 semgrep-ci:
 	semgrep --error --include '*.go' -f tools/semgrep/ci .
 
-SEMGREP_IMGE=$(shell grep -o '[^ ]*/semgrep@sha256:[a-f0-9]*' .github/workflows/code-checker.yml | head -n1)
+SEMGREP_IMAGE=$(shell grep -o '[^ ]*/semgrep:[^ ]*@sha256:[^ ]*' .github/workflows/code-checker.yml | head -n1)
 
 docker-semgrep:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMGE) semgrep --include '*.go' -a -f tools/semgrep .
+	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMAGE) semgrep --include '*.go' -a -f tools/semgrep .
 
 docker-semgrep-ci:
-	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMGE) semgrep --error --include '*.go' -a -f tools/semgrep/ci .
+	$(DOCKER_CMD) run --rm --mount "type=bind,source=$(PWD),destination=/src,chown=true,relabel=shared" $(SEMGREP_IMAGE) semgrep --error --include '*.go' -a -f tools/semgrep/ci .
 
 assetcheck:
 	@echo "==> Checking compiled UI assets..."


### PR DESCRIPTION
## Description

1. Update the version of the semgrep image to 1.171.0 (was 1.10.0)
2. Switch from `returntocorp/semgrep` to `semgrep/semgrep`:

   > We've moved! Official Docker images for Semgrep now available at semgrep/semgrep.
   > https://hub.docker.com/r/returntocorp/semgrep

   They still push images to both, but I don't know for how long.
3. Change the Makefile target `docker-semgrep` and `docker-semgrep-ci` to use the same version as GitHub Actions


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
