### PR TITLE
fix small mistakes in the mfa/totp docs

### DIFF
--- a/website/content/api-docs/secret/identity/mfa/totp.mdx
+++ b/website/content/api-docs/secret/identity/mfa/totp.mdx
@@ -228,7 +228,7 @@ the `admin-generate` API stores the generated secret on the given entity ID.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
-    --data @payload.json
+    --data @payload.json \
     http://127.0.0.1:8200/v1/identity/mfa/method/totp/admin-generate
 ```
 

--- a/website/content/api-docs/secret/identity/mfa/totp.mdx
+++ b/website/content/api-docs/secret/identity/mfa/totp.mdx
@@ -243,7 +243,7 @@ $ curl \
 }
 ```
 
-### Administratively destroy TOTP MFA secret
+## Administratively destroy TOTP MFA secret
 
 This endpoint deletes a TOTP MFA secret from the given entity ID.
 


### PR DESCRIPTION
## Description

While working with the docs I noticed a few small errors inside of the mfa/totp section, so I wanted to create this merge request to fix these. Specifically it is a wrong header for a title and a missing backslash for a curl command.

## Rationale

Correct small mistakes inside of the docs

Resolves: N/A

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
