### PR TITLE
Move release signing out of goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,17 +186,19 @@ jobs:
           TARGET_OS: ${{ matrix.target.os }}
           TARGET_ARM: ${{ matrix.target.arm }}
           TARGET_ARCH: ${{ matrix.target.arch }}
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          GPG_FINGERPRINT: ${{ steps.gpg-import.outputs.fingerprint }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           NFPM_DEFAULT_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
 
       - name: Remove GPG key from disk
         if: always()
         run: rm -f "$GPG_KEY_FILE"
 
-      - name: Upload build artifacts
+      - name: Sign artifacts
+        run: ./scripts/release/sign-artifacts.sh
+        env:
+          GPG_FINGERPRINT: ${{ steps.gpg-import.outputs.fingerprint }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.target.os }}-${{ matrix.target.arch }}${{ matrix.target.arm }}

--- a/goreleaser.linux.yaml
+++ b/goreleaser.linux.yaml
@@ -107,25 +107,3 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
-
-signs:
-  - id: cosign
-    artifacts: all
-    cmd: cosign
-    signature: "${artifact}.sigstore.json"
-    args:
-      - "sign-blob"
-      - "--bundle=${signature}" # needed on cosign 3.0.0+
-      - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
-  - id: gpg
-    artifacts: all
-    signature: "${artifact}.gpgsig"
-    cmd: gpg
-    stdin: "{{ .Env.GPG_PASSWORD }}"
-    args:
-      - "--batch"
-      - "--default-key={{ .Env.GPG_FINGERPRINT }}"
-      - "--output=${signature}"
-      - "--detach-sign"
-      - "${artifact}"

--- a/goreleaser.other.yaml
+++ b/goreleaser.other.yaml
@@ -46,25 +46,3 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
-
-signs:
-  - id: cosign
-    artifacts: all
-    cmd: cosign
-    signature: "${artifact}.sigstore.json"
-    args:
-      - "sign-blob"
-      - "--bundle=${signature}" # needed on cosign 3.0.0+
-      - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
-  - id: gpg
-    artifacts: all
-    signature: "${artifact}.gpgsig"
-    cmd: gpg
-    stdin: "{{ .Env.GPG_PASSWORD }}"
-    args:
-      - "--batch"
-      - "--default-key={{ .Env.GPG_FINGERPRINT }}"
-      - "--output=${signature}"
-      - "--detach-sign"
-      - "${artifact}"

--- a/scripts/release/sign-artifacts.sh
+++ b/scripts/release/sign-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script signs release artifacts (Tarballs with binaries, Linux packages,
+# SBOMs) via cosign and gpg. Checksums are separately signed as part of
+# checksums.sh.
+
+set -euo pipefail
+
+cd dist
+
+# Avoid signing any existing signatures.
+artifacts=$(find . -type f -not -name '*.gpgsig' -not -name '*.sigstore.json')
+
+echo "Signing w/ gpg..."
+
+while read -r f; do
+    gpg \
+        --batch \
+        --detach-sign \
+        --default-key="$GPG_FINGERPRINT" \
+        --output="${f}.gpgsig" \
+        "$f" <<< "$GPG_PASSWORD"
+done <<< "$artifacts"
+
+echo "Signing w/ cosign..."
+
+while read -r f; do
+    cosign sign-blob \
+        --yes \
+        --bundle="${f}.sigstore.json" \
+        "$f"
+done <<< "$artifacts"


### PR DESCRIPTION
## Description

Part 1 of a series to working towards https://github.com/openbao/openbao/issues/3380, moving artifact signing out of Goreleaser.

Sample release: https://github.com/Ki-Reply-GmbH/openbao/releases
Sample run: https://github.com/Ki-Reply-GmbH/openbao/actions/runs/30469837276/job/90639040758

204 is the expected amount of artifacts. v2.6.1 had 253, we deduct 48 openbao-hsm artifacts and the public GPG key which is not uploaded on nightly runs, yielding 204.

There's still some GPG signing going on for Linux packages that I need to look at more closely. This doesn't touch that yet, just the `*.sigstore.json` and `*.gpg` files that are part of immediate release assets. (Edit: done in  #3639)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
