### PR TITLE
ui: hide cubbyhole from the Secrets Engines list

### DIFF
--- a/changelog/3650.txt
+++ b/changelog/3650.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: hide the cubbyhole secrets engine from the Secrets Engines list, consistent with system and identity
+```

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -14,7 +14,7 @@ const LINKED_BACKENDS = supportedSecretBackends();
 
 // identity will be managed separately and the inclusion
 // of the system backend is an implementation detail
-const LIST_EXCLUDED_BACKENDS = ['system', 'identity'];
+const LIST_EXCLUDED_BACKENDS = ['system', 'identity', 'cubbyhole'];
 
 const validations = {
   path: [


### PR DESCRIPTION
The UI already omits `system` and `identity` from the Secrets Engines list via
`LIST_EXCLUDED_BACKENDS` — the source even notes the system backend "is an
implementation detail". `cubbyhole` is the same kind of built-in mount: a
per-token scratch space with no meaningful interactive use in the engines list,
and its main purpose (response wrapping) works without the engine being listed.

This adds `cubbyhole` to that same exclusion list so a freshly logged-in user is
not shown an obscure primitive alongside their real secrets engines.