### PR TITLE
rename warning in log message

### DIFF
--- a/internal/command/format.go
+++ b/internal/command/format.go
@@ -487,7 +487,7 @@ func (t TableFormatter) OutputList(ui cli.Ui, secret *api.Secret, data any) erro
 // printWarnings prints any warnings in the secret.
 func (t TableFormatter) printWarnings(ui cli.Ui, secret *api.Secret) {
 	if secret != nil && len(secret.Warnings) > 0 {
-		ui.Warn("WARNING! The following warnings were returned from Vault:\n")
+		ui.Warn("WARNING! The following warnings were returned from OpenBao:\n")
 		for _, warning := range secret.Warnings {
 			ui.Warn(wrapAtLengthWithPadding(fmt.Sprintf("* %s", warning), 2))
 			ui.Warn("")

--- a/internal/command/format.go
+++ b/internal/command/format.go
@@ -633,10 +633,10 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]any) error {
 func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
 	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status}
 
-	// Mask the 'OpenBao is sealed' error, since this means HA is enabled, but that
+	// Mask the 'Vault is sealed' error, since this means HA is enabled, but that
 	// we cannot query for the leader since we are sealed.
 	leaderStatus, err := client.Sys().Leader()
-	if err != nil && strings.Contains(err.Error(), "OpenBao is sealed") {
+	if err != nil && strings.Contains(err.Error(), "Vault is sealed") {
 		leaderStatus = &api.LeaderResponse{HAEnabled: true}
 		err = nil
 	}

--- a/internal/command/format.go
+++ b/internal/command/format.go
@@ -134,7 +134,7 @@ type RawFormatter struct{}
 func (r RawFormatter) Format(data any) ([]byte, error) {
 	byte_data, ok := data.([]byte)
 	if !ok {
-		return nil, errors.New("This command does not support the -format=raw option; only `vault read` does.") //nolint:staticcheck // user-facing error
+		return nil, errors.New("This command does not support the -format=raw option; only `bao read` does.") //nolint:staticcheck // user-facing error
 	}
 
 	return byte_data, nil
@@ -633,10 +633,10 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]any) error {
 func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
 	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status}
 
-	// Mask the 'Vault is sealed' error, since this means HA is enabled, but that
+	// Mask the 'OpenBao is sealed' error, since this means HA is enabled, but that
 	// we cannot query for the leader since we are sealed.
 	leaderStatus, err := client.Sys().Leader()
-	if err != nil && strings.Contains(err.Error(), "Vault is sealed") {
+	if err != nil && strings.Contains(err.Error(), "OpenBao is sealed") {
 		leaderStatus = &api.LeaderResponse{HAEnabled: true}
 		err = nil
 	}
@@ -668,7 +668,7 @@ func looksLikeDuration(k string) bool {
 }
 
 // This struct is responsible for capturing all the fields to be output by a
-// vault status command, including fields that do not come from the status API.
+// bao status command, including fields that do not come from the status API.
 // Currently we are adding the fields from api.LeaderResponse
 type SealStatusOutput struct {
 	api.SealStatusResponse


### PR DESCRIPTION
## Description

While working on OpenBao via the cli I noticed that the warning message is still branded from Vault. While changing that warning I found other messages and comments that still reference vault instead of bao/OpenBao

## Rationale

This aims to remove references to Vault from the comments and errors

Resolves: N/A

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
