### PR TITLE
remove unused const for enabling rate limit audit logging

### DIFF
--- a/internal/vault/quotas/quotas_rate_limit.go
+++ b/internal/vault/quotas/quotas_rate_limit.go
@@ -30,10 +30,6 @@ const (
 
 	// DefaultRateLimitStaleAge defines the default stale age of a client limiter.
 	DefaultRateLimitStaleAge = 3 * time.Minute
-
-	// EnvVaultEnableRateLimitAuditLogging is used to enable audit logging of
-	// requests that get rejected due to rate limit quota violations.
-	EnvVaultEnableRateLimitAuditLogging = "VAULT_ENABLE_RATE_LIMIT_AUDIT_LOGGING"
 )
 
 // Ensure that RateLimitQuota implements the Quota interface


### PR DESCRIPTION
## Description

While trying to find more instances of VAULT_ env vars being used in the code, I stumbled upon this supposed env var defined in a const. I couldn't find any reference to it either in OpenBao itself nor the docs. If this is actually used somewhere, I would be open to documenting its use.
The actual usage that is commented above this const is currently configured in `internal/vault/quotas/quotas.go` and is defined via the config/api.

## Rationale

Remove dead code that could be misleading in a search

Related to: #2793

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
