### PR TITLE
Fix missing OIDC default keys for namespaces

### DIFF
--- a/changelog/3662.txt
+++ b/changelog/3662.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+core/identity: Start writing OIDC 'default' keys per-namespace storage.
+```
+```release-note:bug
+core/namespaces: Fix fatal failures writing 'default' OIDC keys on standby nodes during namespace creation.
+```

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -199,7 +199,9 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origViewReadOnlyErr)
 
-	if err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view}); err != nil {
+	// Initialize, using the core's active context.
+	activeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
+	if err := backend.Initialize(activeCtx, &logical.InitializationRequest{Storage: view}); err != nil {
 		return err
 	}
 

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -198,9 +198,8 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	// restore the original readOnlyErr, so we can write to the view in
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origViewReadOnlyErr)
-	// initialize, using the core's active context.
-	err = backend.Initialize(c.activeContext.Load(), &logical.InitializationRequest{Storage: view})
-	if err != nil {
+
+	if err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view}); err != nil {
 		return err
 	}
 
@@ -1200,8 +1199,7 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 			view.SetReadOnlyErr(origViewReadOnlyErr)
 		}
 
-		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-		if err != nil {
+		if err := backend.Initialize(namespace.ContextWithNamespace(ctx, localEntry.Namespace), &logical.InitializationRequest{Storage: view}); err != nil {
 			postUnsealLogger.Error("failed to initialize auth backend", "error", err)
 		}
 	}

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -341,7 +341,9 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origReadOnlyErr)
 
-	if err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view}); err != nil {
+	// Initialize, using the core's active context.
+	activeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
+	if err := backend.Initialize(activeCtx, &logical.InitializationRequest{Storage: view}); err != nil {
 		return err
 	}
 

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -340,9 +340,8 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	// restore the original readOnlyErr, so we can write to the view in
 	// Initialize() if necessary
 	view.SetReadOnlyErr(origReadOnlyErr)
-	// initialize, using the core's active context.
-	err = backend.Initialize(c.activeContext.Load(), &logical.InitializationRequest{Storage: view})
-	if err != nil {
+
+	if err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view}); err != nil {
 		return err
 	}
 
@@ -1572,8 +1571,7 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 			view.SetReadOnlyErr(origReadOnlyErr)
 		}
 
-		err := backend.Initialize(ctx, &logical.InitializationRequest{Storage: view})
-		if err != nil {
+		if err := backend.Initialize(namespace.ContextWithNamespace(ctx, localEntry.Namespace), &logical.InitializationRequest{Storage: view}); err != nil {
 			postUnsealLogger.Error("failed to initialize mount backend", "error", err)
 		}
 	}


### PR DESCRIPTION
## Description
Identity backend `initialization` method did not get passed context with a respective namespace, also cred/secrets enable methods (also used by invalidation logic) were passing `(*Core).activeContext()` to the backend init method. This in turn made the `OIDC` default keys read (and in turn write) fail, **because we never wrote them for the namespace on the active node in the first place**. This PR changes that (the presence logic was always looking at the root namespace-owned) cache.

## Rationale
We never wrote the OIDC default keys to the namespace space, so adjusting that and changing the context propagation fixes the standby nodes behavior also.

This bug also affected raft multi-node (1+) clusters (multiple nodes at namespace creation) in a sense that standby nodes while checking for `Default` key existence in cache were always using the namespace in ctx (which would be `root` namespace [(*Core) activeContext]), but because it was present, no error from lack of key occurred.

### Why we never wrote `Default` OIDC keys
The logic for "presence" of the default keys is: look at cache -> look at storage.
Because init of the identity backend for namespaces used a context with  *root namespace* stored it was always finding the keys of the root namespace, so we bail out from creation of the keys entry in the namespace storage.

Then for standby nodes the cache is not populated nor keys are in storage, hence the failure.

Resolves: #3661

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
