### PR TITLE
Fix HMAC verification for non default algorithms

### DIFF
--- a/changelog/3668.txt
+++ b/changelog/3668.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+secrets/transit: Respect the `hash_algorithm` parameter when verifying HMACs.
+```

--- a/internal/builtin/logical/transit/path_hmac.go
+++ b/internal/builtin/logical/transit/path_hmac.go
@@ -237,12 +237,17 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 
 func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
-	algorithm := d.Get("urlalgorithm").(string)
-	if algorithm == "" {
-		algorithm = d.Get("algorithm").(string)
+	hashAlgorithmStr := d.Get("urlalgorithm").(string)
+	if hashAlgorithmStr == "" {
+		hashAlgorithmStr = d.Get("hash_algorithm").(string)
+		if hashAlgorithmStr == "" {
+			hashAlgorithmStr = d.Get("algorithm").(string)
+			if hashAlgorithmStr == "" {
+				hashAlgorithmStr = defaultHashAlgorithm
+			}
+		}
 	}
 
-	// Get the policy
 	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
 		Storage: req.Storage,
 		Name:    name,
@@ -255,12 +260,12 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 	}
 	defer p.Unlock()
 
-	hashAlgorithm, ok := keysutil.HashTypeMap[algorithm]
+	hashAlgorithmType, ok := keysutil.HashTypeMap[hashAlgorithmStr]
 	if !ok {
-		return logical.ErrorResponse("unsupported algorithm %q", hashAlgorithm), nil
+		return logical.ErrorResponse("invalid hash algorithm %q", hashAlgorithmStr), logical.ErrInvalidRequest
 	}
 
-	hashAlg := keysutil.HashFuncMap[hashAlgorithm]
+	hashAlg := keysutil.HashFuncMap[hashAlgorithmType]
 
 	batchInputRaw := d.Raw["batch_input"]
 	var batchInputItems []batchRequestHMACItem

--- a/internal/builtin/logical/transit/path_hmac_test.go
+++ b/internal/builtin/logical/transit/path_hmac_test.go
@@ -4,218 +4,166 @@
 package transit
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/openbao/openbao/sdk/v2/helper/keysutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransit_HMAC(t *testing.T) {
 	b, storage := createBackendWithSysView(t)
+	keyName := "foo"
 
-	cases := []struct {
-		name string
-		typ  string
-	}{
-		{
-			name: "foo",
-			typ:  "",
-		},
-		{
-			name: "dedicated",
-			typ:  "hmac",
-		},
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.UpdateOperation,
+		Path:      "keys/" + keyName,
+	}
+	_, err := b.HandleRequest(t.Context(), req)
+	require.NoError(t, err)
+
+	// Now, change the key value to something we control
+	p, _, err := b.GetPolicy(t.Context(), keysutil.PolicyRequest{
+		Storage: storage,
+		Name:    keyName,
+	}, b.GetRandomReader())
+	require.NoError(t, err)
+
+	// We don't care as we're the only one using this
+	latestVersion := strconv.Itoa(p.LatestVersion)
+	keyEntry := p.Keys[latestVersion]
+	keyEntry.HMACKey = []byte("01234567890123456789012345678901")
+	keyEntry.Key = []byte("01234567890123456789012345678901")
+	p.Keys[latestVersion] = keyEntry
+	require.NoError(t, p.Persist(t.Context(), storage))
+
+	p.Unlock()
+
+	req.Path = "hmac/" + keyName
+	req.Data = map[string]any{
+		"input": "dGhlIHF1aWNrIGJyb3duIGZveA==",
 	}
 
-	for _, c := range cases {
-		req := &logical.Request{
-			Storage:   storage,
-			Operation: logical.UpdateOperation,
-			Path:      "keys/" + c.name,
-		}
-		_, err := b.HandleRequest(t.Context(), req)
-		if err != nil {
-			t.Fatal(err)
-		}
+	doRequest := func(req *logical.Request, errExpected bool, expected string) {
+		path := req.Path
+		defer func() { req.Path = path }()
 
-		// Now, change the key value to something we control
-		p, _, err := b.GetPolicy(t.Context(), keysutil.PolicyRequest{
-			Storage: storage,
-			Name:    c.name,
-		}, b.GetRandomReader())
-		if err != nil {
-			t.Fatal(err)
-		}
-		// We don't care as we're the only one using this
-		latestVersion := strconv.Itoa(p.LatestVersion)
-		keyEntry := p.Keys[latestVersion]
-		keyEntry.HMACKey = []byte("01234567890123456789012345678901")
-		keyEntry.Key = []byte("01234567890123456789012345678901")
-		p.Keys[latestVersion] = keyEntry
-		if err = p.Persist(t.Context(), storage); err != nil {
-			t.Fatal(err)
-		}
-		p.Unlock()
-
-		req.Path = "hmac/" + c.name
-		req.Data = map[string]any{
-			"input": "dGhlIHF1aWNrIGJyb3duIGZveA==",
-		}
-
-		doRequest := func(req *logical.Request, errExpected bool, expected string) {
-			path := req.Path
-			defer func() { req.Path = path }()
-
-			resp, err := b.HandleRequest(t.Context(), req)
-			if err != nil && !errExpected {
-				panic(fmt.Sprintf("%v", err))
-			}
-			if resp == nil {
-				t.Fatal("expected non-nil response")
-			}
-			if errExpected {
-				if !resp.IsError() {
-					t.Fatalf("bad: got error response: %#v", *resp)
-				}
-				return
-			}
-			if resp.IsError() {
-				t.Fatalf("bad: got error response: %#v", *resp)
-			}
-			value, ok := resp.Data["hmac"]
-			if !ok {
-				t.Fatalf("no hmac key found in returned data, got resp data %#v", resp.Data)
-			}
-			if value.(string) != expected {
-				panic(fmt.Sprintf("mismatched hashes; expected %s, got resp data %#v", expected, resp.Data))
-			}
-
-			// Now verify
-			req.Path = strings.ReplaceAll(req.Path, "hmac", "verify")
-			req.Data["hmac"] = value.(string)
-			resp, err = b.HandleRequest(t.Context(), req)
-			if err != nil {
-				t.Fatalf("%v: %v", err, resp)
-			}
-			if resp == nil {
-				t.Fatal("expected non-nil response")
-			}
-			if resp.Data["valid"].(bool) == false {
-				panic(fmt.Sprintf("error validating hmac;\nreq:\n%#v\nresp:\n%#v", *req, *resp))
-			}
-		}
-
-		// Comparisons are against values generated via openssl
-
-		// Test defaults -- sha2-256
-		doRequest(req, false, "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4=")
-
-		// Test algorithm selection in the path
-		req.Path = "hmac/" + c.name + "/sha2-224"
-		doRequest(req, false, "vault:v1:3p+ZWVquYDvu2dSTCa65Y3fgoMfIAc6fNaBbtg==")
-
-		// Reset and test algorithm selection in the data
-		req.Path = "hmac/" + c.name
-		req.Data["algorithm"] = "sha2-224"
-		doRequest(req, false, "vault:v1:3p+ZWVquYDvu2dSTCa65Y3fgoMfIAc6fNaBbtg==")
-
-		req.Data["algorithm"] = "sha2-384"
-		doRequest(req, false, "vault:v1:jDB9YXdPjpmr29b1JCIEJO93IydlKVfD9mA2EO9OmJtJQg3QAV5tcRRRb7IQGW9p")
-
-		req.Data["algorithm"] = "sha2-512"
-		doRequest(req, false, "vault:v1:PSXLXvkvKF4CpU65e2bK1tGBZQpcpCEM32fq2iUoiTyQQCfBcGJJItQ+60tMwWXAPQrC290AzTrNJucGrr4GFA==")
-
-		// Test returning as base64
-		req.Data["format"] = "base64"
-		doRequest(req, false, "vault:v1:PSXLXvkvKF4CpU65e2bK1tGBZQpcpCEM32fq2iUoiTyQQCfBcGJJItQ+60tMwWXAPQrC290AzTrNJucGrr4GFA==")
-
-		// Test SHA3
-		req.Path = "hmac/" + c.name
-		req.Data["algorithm"] = "sha3-224"
-		doRequest(req, false, "vault:v1:TGipmKH8LR/BkMolYpDYy0BJCIhTtGPDhV2VkQ==")
-
-		req.Data["algorithm"] = "sha3-256"
-		doRequest(req, false, "vault:v1:+px9V/7QYLfdK808zPESC2T/L33uFf4Blzsn9Jy838o=")
-
-		req.Data["algorithm"] = "sha3-384"
-		doRequest(req, false, "vault:v1:YGoRwN4UdTRYZeOER86jsQOB8piWenzLDzJ2wJQK/Jq59rAsY8lh7SCdqqCyFg70")
-
-		req.Data["algorithm"] = "sha3-512"
-		doRequest(req, false, "vault:v1:GrNA8sU88naMPEQ7UZGj9EJl7YJhl03AFHfxcEURFrtvnobdea9ZlZHePpxAx/oCaC7R2HkrAO+Tu3uXPIl3lg==")
-
-		// Test returning SHA3 as base64
-		req.Data["format"] = "base64"
-		doRequest(req, false, "vault:v1:GrNA8sU88naMPEQ7UZGj9EJl7YJhl03AFHfxcEURFrtvnobdea9ZlZHePpxAx/oCaC7R2HkrAO+Tu3uXPIl3lg==")
-
-		req.Data["algorithm"] = "foobar"
-		doRequest(req, true, "")
-
-		req.Data["algorithm"] = "sha2-256"
-		req.Data["input"] = "foobar"
-		doRequest(req, true, "")
-		req.Data["input"] = "dGhlIHF1aWNrIGJyb3duIGZveA=="
-
-		// Rotate
-		err = p.Rotate(t.Context(), storage, b.GetRandomReader())
-		if err != nil {
-			t.Fatal(err)
-		}
-		keyEntry = p.Keys["2"]
-		// Set to another value we control
-		keyEntry.HMACKey = []byte("12345678901234567890123456789012")
-		p.Keys["2"] = keyEntry
-		if err = p.Persist(t.Context(), storage); err != nil {
-			t.Fatal(err)
-		}
-
-		doRequest(req, false, "vault:v2:Dt+mO/B93kuWUbGMMobwUNX5Wodr6dL3JH4DMfpQ0kw=")
-
-		// Verify a previous version
-		req.Path = "verify/" + c.name
-
-		req.Data["hmac"] = "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
 		resp, err := b.HandleRequest(t.Context(), req)
-		if err != nil {
-			t.Fatalf("%v: %v", err, resp)
+		if !errExpected {
+			require.NoError(t, err)
 		}
-		if resp == nil {
-			t.Fatal("expected non-nil response")
-		}
-		if resp.Data["valid"].(bool) == false {
-			t.Fatalf("error validating hmac\nreq\n%#v\nresp\n%#v", *req, *resp)
+		require.NotNil(t, resp)
+
+		if errExpected {
+			require.True(t, resp.IsError())
+			return
 		}
 
-		// Try a bad value
-		req.Data["hmac"] = "vault:v1:UcBvm4VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
+		require.False(t, resp.IsError())
+
+		value, ok := resp.Data["hmac"]
+		require.Truef(t, ok, "no hmac key found in returned data, got resp data %#v", resp.Data)
+		require.Equalf(t, expected, value.(string), "mismatched hashes; expected %s, got resp data %#v", expected, resp.Data)
+
+		// Test hmac verification
+		req.Path = strings.ReplaceAll(req.Path, "hmac", "verify")
+
+		req.Data["hmac"] = value.(string)
+		// Verify respects `hash_algorithm` first, as `algorithm` field name was deprecated.
+		req.Data["hash_algorithm"] = req.Data["algorithm"]
 		resp, err = b.HandleRequest(t.Context(), req)
-		if err != nil {
-			t.Fatalf("%v: %v", err, resp)
-		}
-		if resp == nil {
-			t.Fatal("expected non-nil response")
-		}
-		if resp.Data["valid"].(bool) {
-			t.Fatal("expected error validating hmac")
-		}
-
-		// Set min decryption version, attempt to verify
-		p.MinDecryptionVersion = 2
-		if err = p.Persist(t.Context(), storage); err != nil {
-			t.Fatal(err)
-		}
-
-		req.Data["hmac"] = "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
-		resp, err = b.HandleRequest(t.Context(), req)
-		if err == nil {
-			t.Fatalf("expected an error, got response %#v", resp)
-		}
-		if err != logical.ErrInvalidRequest {
-			t.Fatalf("expected invalid request error, got %v", err)
-		}
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Truef(t, resp.Data["valid"].(bool), "error validating hmac\nreq\n%#v\nresp\n%#v", *req, *resp)
 	}
+
+	// Comparisons are against values generated via openssl
+
+	// Test defaults -- sha2-256
+	doRequest(req, false, "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4=")
+
+	// Test algorithm selection in the path
+	req.Path = "hmac/" + keyName + "/sha2-224"
+	doRequest(req, false, "vault:v1:3p+ZWVquYDvu2dSTCa65Y3fgoMfIAc6fNaBbtg==")
+
+	// Reset and test algorithm selection in the data
+	req.Path = "hmac/" + keyName
+	req.Data["algorithm"] = "sha2-224"
+	doRequest(req, false, "vault:v1:3p+ZWVquYDvu2dSTCa65Y3fgoMfIAc6fNaBbtg==")
+
+	req.Data["algorithm"] = "sha2-384"
+	doRequest(req, false, "vault:v1:jDB9YXdPjpmr29b1JCIEJO93IydlKVfD9mA2EO9OmJtJQg3QAV5tcRRRb7IQGW9p")
+
+	req.Data["algorithm"] = "sha2-512"
+	doRequest(req, false, "vault:v1:PSXLXvkvKF4CpU65e2bK1tGBZQpcpCEM32fq2iUoiTyQQCfBcGJJItQ+60tMwWXAPQrC290AzTrNJucGrr4GFA==")
+
+	// Test returning as base64
+	req.Data["format"] = "base64"
+	doRequest(req, false, "vault:v1:PSXLXvkvKF4CpU65e2bK1tGBZQpcpCEM32fq2iUoiTyQQCfBcGJJItQ+60tMwWXAPQrC290AzTrNJucGrr4GFA==")
+
+	// Test SHA3
+	req.Path = "hmac/" + keyName
+	req.Data["algorithm"] = "sha3-224"
+	doRequest(req, false, "vault:v1:TGipmKH8LR/BkMolYpDYy0BJCIhTtGPDhV2VkQ==")
+
+	req.Data["algorithm"] = "sha3-256"
+	doRequest(req, false, "vault:v1:+px9V/7QYLfdK808zPESC2T/L33uFf4Blzsn9Jy838o=")
+
+	req.Data["algorithm"] = "sha3-384"
+	doRequest(req, false, "vault:v1:YGoRwN4UdTRYZeOER86jsQOB8piWenzLDzJ2wJQK/Jq59rAsY8lh7SCdqqCyFg70")
+
+	req.Data["algorithm"] = "sha3-512"
+	doRequest(req, false, "vault:v1:GrNA8sU88naMPEQ7UZGj9EJl7YJhl03AFHfxcEURFrtvnobdea9ZlZHePpxAx/oCaC7R2HkrAO+Tu3uXPIl3lg==")
+
+	// Test returning SHA3 as base64
+	req.Data["format"] = "base64"
+	doRequest(req, false, "vault:v1:GrNA8sU88naMPEQ7UZGj9EJl7YJhl03AFHfxcEURFrtvnobdea9ZlZHePpxAx/oCaC7R2HkrAO+Tu3uXPIl3lg==")
+
+	req.Data["algorithm"] = "foobar"
+	doRequest(req, true, "")
+
+	req.Data["algorithm"] = "sha2-256"
+	req.Data["input"] = "foobar"
+	doRequest(req, true, "")
+	req.Data["input"] = "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	// Rotate
+	require.NoError(t, p.Rotate(t.Context(), storage, b.GetRandomReader()))
+	keyEntry = p.Keys["2"]
+	// Set to another value we control
+	keyEntry.HMACKey = []byte("12345678901234567890123456789012")
+	p.Keys["2"] = keyEntry
+	require.NoError(t, p.Persist(t.Context(), storage))
+
+	doRequest(req, false, "vault:v2:Dt+mO/B93kuWUbGMMobwUNX5Wodr6dL3JH4DMfpQ0kw=")
+
+	// Verify a previous version
+	req.Path = "verify/" + keyName
+
+	req.Data["hmac"] = "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
+	resp, err := b.HandleRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Truef(t, resp.Data["valid"].(bool), "error validating hmac\nreq\n%#v\nresp\n%#v", *req, *resp)
+
+	// Try a bad value
+	req.Data["hmac"] = "vault:v1:UcBvm4VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
+	resp, err = b.HandleRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.Data["valid"].(bool))
+
+	// Set min decryption version, attempt to verify
+	p.MinDecryptionVersion = 2
+	require.NoError(t, p.Persist(t.Context(), storage))
+
+	req.Data["hmac"] = "vault:v1:UcBvm5VskkukzZHlPgm3p5P/Yr/PV6xpuOGZISya3A4="
+	_, err = b.HandleRequest(t.Context(), req)
+	require.Error(t, err)
+	require.ErrorIs(t, err, logical.ErrInvalidRequest)
 }
 
 func TestTransit_batchHMAC(t *testing.T) {


### PR DESCRIPTION
## Description
HMAC verify endpoint didn't work for the UI due to use of unrecognized algorithm parameter `hash_algorithm`, this PR aligns the request body parsing with the signature verification.

## Rationale
This bug seems like a oversight on the account of the deprecation of `algorithm` parameter in `pathVerifyWrite` handler.

Resolves: #3667

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
