### PR TITLE
Fix PrintRawField function by adding warnings check

### DIFF
--- a/changelog/3672.txt
+++ b/changelog/3672.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+cli: Fix `-field=` flag discarding API warnings (e.g. unrecognized parameters) instead of printing them to stderr

--- a/changelog/3672.txt
+++ b/changelog/3672.txt
@@ -1,2 +1,3 @@
 ```release-note:bug
-cli: Fix `-field=` flag discarding API warnings (e.g. unrecognized parameters) instead of printing them to stderr
+command: Fix `-field=` flag discarding API warnings (e.g., unrecognized parameters) instead of printing them to stderr.
+```

--- a/internal/command/format.go
+++ b/internal/command/format.go
@@ -379,7 +379,7 @@ func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, data any) error {
 }
 
 func (t TableFormatter) OutputList(ui cli.Ui, secret *api.Secret, data any) error {
-	t.printWarnings(ui, secret)
+	printWarnings(ui, secret)
 
 	// Determine if we have additional information from a ListResponseWithInfo endpoint.
 	var additionalInfo map[string]any
@@ -485,7 +485,7 @@ func (t TableFormatter) OutputList(ui cli.Ui, secret *api.Secret, data any) erro
 }
 
 // printWarnings prints any warnings in the secret.
-func (t TableFormatter) printWarnings(ui cli.Ui, secret *api.Secret) {
+func printWarnings(ui cli.Ui, secret *api.Secret) {
 	if secret != nil && len(secret.Warnings) > 0 {
 		ui.Warn("WARNING! The following warnings were returned from OpenBao:\n")
 		for _, warning := range secret.Warnings {
@@ -500,7 +500,7 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret *api.Secret) error {
 		return nil
 	}
 
-	t.printWarnings(ui, secret)
+	printWarnings(ui, secret)
 
 	out := make([]string, 0, 8)
 	if secret.LeaseDuration > 0 {

--- a/internal/command/kv_get.go
+++ b/internal/command/kv_get.go
@@ -209,9 +209,9 @@ func (c *KVGetCommand) Run(args []string) int {
 	if secret.WrapInfo != nil || c.flagFormat != "table" {
 		return OutputSecret(c.UI, secret)
 	}
-	
+
 	printWarnings(c.UI, secret)
-	
+
 	if v2 {
 		outputPath(c.UI, fullPath, "Secret Path")
 	}

--- a/internal/command/kv_get.go
+++ b/internal/command/kv_get.go
@@ -209,12 +209,9 @@ func (c *KVGetCommand) Run(args []string) int {
 	if secret.WrapInfo != nil || c.flagFormat != "table" {
 		return OutputSecret(c.UI, secret)
 	}
-
-	if len(secret.Warnings) > 0 {
-		tf := TableFormatter{}
-		tf.printWarnings(c.UI, secret)
-	}
-
+	
+	printWarnings(c.UI, secret)
+	
 	if v2 {
 		outputPath(c.UI, fullPath, "Secret Path")
 	}

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -105,11 +105,12 @@ func PrintRawField(ui cli.Ui, data any, field string) int {
 		ui.Error(fmt.Sprintf("Field %q not present in secret", field))
 		return 1
 	}
-	if secret, ok := data.(*api.Secret); ok && Format(ui) == "table" {
+	format := Format(ui)
+
+	if secret, ok := data.(*api.Secret); ok && format == "table" {
 		printWarnings(ui, secret)
 	}
 
-	format := Format(ui)
 	if format == "" || format == "table" || format == "raw" {
 		return PrintRaw(ui, fmt.Sprintf("%v", val))
 	}

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -105,13 +105,8 @@ func PrintRawField(ui cli.Ui, data any, field string) int {
 		ui.Error(fmt.Sprintf("Field %q not present in secret", field))
 		return 1
 	}
-	// Really similar to the warning used in openbao/internal/command/format.go. The PrintRawField function was simply missing the warnings check.
-	if secret, ok := data.(*api.Secret); ok && secret != nil && len(secret.Warnings) > 0 {
-		ui.Warn("WARNING! The following warnings were returned from OpenBao\n")
-		for _, warning := range secret.Warnings {
-			ui.Warn(wrapAtLengthWithPadding(fmt.Sprintf("* %s", warning), 2))
-			ui.Warn("")
-		}
+	if secret, ok := data.(*api.Secret); ok {
+		printWarnings(ui, secret)
 	}
 
 	format := Format(ui)

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -106,9 +106,9 @@ func PrintRawField(ui cli.Ui, data any, field string) int {
 		return 1
 	}
 	// Really similar to the warning used in openbao/internal/command/format.go. The PrintRawField function was simply missing the warnings check.
-	if secret, ok := data.(*api.Secret); ok && secret != nil && len(secret.Warnings) > 0{
+	if secret, ok := data.(*api.Secret); ok && secret != nil && len(secret.Warnings) > 0 {
 		ui.Warn("WARNING! The following warnings were returned from OpenBao\n")
-		for _, warning := range secret.Warnings{
+		for _, warning := range secret.Warnings {
 			ui.Warn(wrapAtLengthWithPadding(fmt.Sprintf("* %s", warning), 2))
 			ui.Warn("")
 		}

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -105,6 +105,14 @@ func PrintRawField(ui cli.Ui, data any, field string) int {
 		ui.Error(fmt.Sprintf("Field %q not present in secret", field))
 		return 1
 	}
+	// Really similar to the warning used in openbao/internal/command/format.go. The PrintRawField function was simply missing the warnings check.
+	if secret, ok := data.(*api.Secret); ok && secret != nil && len(secret.Warnings) > 0{
+		ui.Warn("WARNING! The following warnings were returned from OpenBao\n")
+		for _, warning := range secret.Warnings{
+			ui.Warn(wrapAtLengthWithPadding(fmt.Sprintf("* %s", warning), 2))
+			ui.Warn("")
+		}
+	}
 
 	format := Format(ui)
 	if format == "" || format == "table" || format == "raw" {

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -105,7 +105,7 @@ func PrintRawField(ui cli.Ui, data any, field string) int {
 		ui.Error(fmt.Sprintf("Field %q not present in secret", field))
 		return 1
 	}
-	if secret, ok := data.(*api.Secret); ok {
+	if secret, ok := data.(*api.Secret); ok && Format(ui) == "table" {
 		printWarnings(ui, secret)
 	}
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description
Added warnings check to `PrintRawField` function to handle warnings similarly to the `printWarnings` function in `format.go`. This PR adds the missing warnings check.
<!--
Describe in detail the changes you are proposing, and the rationale.
-->

## Rationale
This Bug occured because the `PrintRawField` function didn't do a warnings check, thus all warnings (e.g. wrong parameter) were discarded whenever the `-field` flag was used. The Bug only happened in the CLI and is fixed by adding a warnings check to `PrintRawField`.
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3670 

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
