### PR TITLE
Fix `enable_rate_limit_audit_logging` not working

### DIFF
--- a/changelog/3673.txt
+++ b/changelog/3673.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/quotas: fix `enable_rate_limit_audit_logging` did not work
+```

--- a/changelog/3673.txt
+++ b/changelog/3673.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core/quotas: fix `enable_rate_limit_audit_logging` did not work
+sys/quotas: Fix broken `enable_rate_limit_audit_logging` option.
 ```

--- a/internal/http/util.go
+++ b/internal/http/util.go
@@ -213,7 +213,7 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 					return
 				}
 
-				err = core.AuditLogger().AuditRequest(r.Context(), &logical.LogInput{
+				err = core.AuditLogger().AuditRequest(ctx, &logical.LogInput{
 					Request:  req,
 					OuterErr: quotaErr,
 				})

--- a/internal/vault/external_tests/quotas/quotas_test.go
+++ b/internal/vault/external_tests/quotas/quotas_test.go
@@ -4,6 +4,10 @@
 package quotas
 
 import (
+	"encoding/json"
+	"os"
+	"path"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,10 +17,13 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openbao/openbao/v2/internal/audit"
+	auditFile "github.com/openbao/openbao/v2/internal/builtin/audit/file"
 	"github.com/openbao/openbao/v2/internal/builtin/credential/userpass"
 	"github.com/openbao/openbao/v2/internal/builtin/logical/pki"
 	"github.com/openbao/openbao/v2/internal/helper/testhelpers/teststorage"
 	"github.com/openbao/openbao/v2/internal/vault"
+	"github.com/openbao/openbao/v2/internal/vault/quotas"
 )
 
 var coreConfig = &vault.CoreConfig{
@@ -25,6 +32,9 @@ var coreConfig = &vault.CoreConfig{
 	},
 	CredentialBackends: map[string]logical.Factory{
 		"userpass": userpass.Factory,
+	},
+	AuditBackends: map[string]audit.Factory{
+		"file": auditFile.Factory,
 	},
 }
 
@@ -269,6 +279,64 @@ func TestQuotas_RateLimitQuota_DefaultExemptPaths(t *testing.T) {
 	// If the response is nil, then we are being rate limited
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Data)
+}
+
+func TestQuotas_RateLimitQuota_AuditLogging(t *testing.T) {
+	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
+	opts.RequestResponseCallback = schema.ResponseValidatingCallback(t)
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	core := cluster.Cores[0].Core
+	client := cluster.Cores[0].Client
+	vault.TestWaitActive(t, core)
+
+	// Enable Audit Logging
+	_, err := client.Logical().WriteWithContext(t.Context(), "sys/quotas/config", map[string]any{
+		"enable_rate_limit_audit_logging": true,
+	})
+	require.NoError(t, err)
+
+	// Create temporary audit log file
+	auditLogFile, err := os.Create(path.Join(t.TempDir(), "audit.json"))
+	require.NoError(t, err)
+
+	require.NoError(t, client.Sys().EnableAuditWithOptions("file", &api.EnableAuditOptions{
+		Type: "file",
+		Options: map[string]string{
+			"file_path": auditLogFile.Name(),
+		},
+	}))
+
+	// Set limit to 1
+	_, err = client.Logical().WriteWithContext(t.Context(), "sys/quotas/rate-limit/rlq", map[string]any{
+		"rate": 1,
+	})
+	require.NoError(t, err)
+
+	// First requests should pass
+	_, err = client.Sys().ListNamespacesWithContext(t.Context())
+	require.NoError(t, err)
+
+	// Second request should fail
+	_, err = client.Sys().ListNamespacesWithContext(t.Context())
+	require.ErrorContains(t, err, "429") // HTTP 429 => "Too Many Requests"
+
+	// Count matching audit log entries
+	decoder := json.NewDecoder(auditLogFile)
+	var auditRecord map[string]any
+	var rateLimitAuditLogCount int
+	for decoder.Decode(&auditRecord) == nil {
+		if auditRecord["type"] == "request" {
+			if error, ok := auditRecord["error"]; ok && strings.HasSuffix(error.(string), quotas.ErrRateLimitQuotaExceeded.Error()) {
+				rateLimitAuditLogCount++
+			}
+		}
+	}
+
+	require.Equal(t, 1, rateLimitAuditLogCount, "expected exactly one rate limit exceeded audit log entry")
 }
 
 func TestQuotas_RateLimitQuota_Mount(t *testing.T) {


### PR DESCRIPTION
## Description

The audit backend expects a namespace in the context.

In addition to fixing this, should we change this from an error to generating a audit log with `namespace: <unknown>` (+ error log)?

## Rationale


Resolves: #3659

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
