### PR TITLE
Take initial hash over cert+key before starting polling worker

### DIFF
--- a/internal/helper/listenerutil/tls_autoreload.go
+++ b/internal/helper/listenerutil/tls_autoreload.go
@@ -17,8 +17,9 @@ import (
 func NewTLSReloadListener(ln net.Listener, paths []string, interval time.Duration, reload func() error, logger hclog.Logger) net.Listener {
 	wg := &sync.WaitGroup{}
 	stop := make(chan struct{})
+	currentHash := hash(paths, logger)
 	wg.Go(func() {
-		pollTLSCertificateChanges(paths, interval, reload, stop, logger)
+		pollTLSCertificateChanges(paths, currentHash, interval, reload, stop, logger)
 	})
 	return &tlsReloadListener{Listener: ln, wg: wg, stop: stop}
 }
@@ -35,21 +36,7 @@ func (l *tlsReloadListener) Close() error {
 	return l.Listener.Close()
 }
 
-func pollTLSCertificateChanges(paths []string, interval time.Duration, reload func() error, stopCh <-chan struct{}, logger hclog.Logger) {
-	hash := func() []byte {
-		h := sha256.New()
-		for _, p := range paths {
-			data, err := os.ReadFile(p)
-			if err != nil {
-				logger.Warn("tls auto-reload: cannot read file", "path", p, "error", err)
-				continue
-			}
-			h.Write(data)
-		}
-		return h.Sum(nil)
-	}
-
-	last := hash()
+func pollTLSCertificateChanges(paths []string, last []byte, interval time.Duration, reload func() error, stopCh <-chan struct{}, logger hclog.Logger) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -58,7 +45,7 @@ func pollTLSCertificateChanges(paths []string, interval time.Duration, reload fu
 		case <-stopCh:
 			return
 		case <-ticker.C:
-			current := hash()
+			current := hash(paths, logger)
 			if bytes.Equal(current, last) {
 				continue
 			}
@@ -72,4 +59,17 @@ func pollTLSCertificateChanges(paths []string, interval time.Duration, reload fu
 			logger.Info("tls auto-reload: reloaded TLS certificate", "paths", paths)
 		}
 	}
+}
+
+func hash(paths []string, logger hclog.Logger) []byte {
+	h := sha256.New()
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			logger.Warn("tls auto-reload: cannot read file", "path", p, "error", err)
+			continue
+		}
+		h.Write(data)
+	}
+	return h.Sum(nil)
 }

--- a/internal/helper/listenerutil/tls_autoreload_test.go
+++ b/internal/helper/listenerutil/tls_autoreload_test.go
@@ -24,7 +24,7 @@ func TestPollTLSCertificateChanges(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	go pollTLSCertificateChanges([]string{cert, key}, 10*time.Millisecond, func() error {
+	go pollTLSCertificateChanges([]string{cert, key}, hash([]string{cert, key}, hclog.NewNullLogger()), 10*time.Millisecond, func() error {
 		reloaded <- struct{}{}
 		return nil
 	}, stopCh, hclog.NewNullLogger())


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->
Fixes a race condition. The race was accidentally introduced with the TLS server cert auto-reload feature in #3530.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


Test `TestStartListener_TLSAutoReloadServesRotatedCertWithoutRestart` was failing occasionally in CI, and every time if running it with

```
GOMAXPROCS=1 go test ./internal/command/agentproxyshared/cache/ -run TestStartListener_TLSAutoReloadServesRotatedCertWithoutRestart -count=1
```

The initial hash of the certificate files was computed inside the polling goroutine  ([link](https://github.com/openbao/openbao/blob/17439a279e67d114d4e1a5b4d0c7f4aa077b9811/internal/helper/listenerutil/tls_autoreload.go#L52)). If the files were replaced _before_ that goroutine was first scheduled, the initial hash is for the new content while the listener was still serving the certificate loaded at startup.

The hash is now computed in `NewTLSReloadListener()` before the goroutine starts.

In theory, the problem could happen also in production if certificates were rotated at very unfortunate moment.


Resolves: #3674

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
