### PR TITLE
Add transit key count metric

### DIFF
--- a/changelog/3682.txt
+++ b/changelog/3682.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/metrics: Add metric for the number of keys in the transit engine (grouped by mount).
+```

--- a/internal/vault/core_metrics.go
+++ b/internal/vault/core_metrics.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -392,6 +393,111 @@ func (c *Core) kvSecretGaugeCollector(ctx context.Context) ([]metricsutil.GaugeL
 
 		c.walkKvMountSecrets(ctx, m)
 		results[i].Value = float32(m.NumSecrets)
+	}
+
+	return results, nil
+}
+
+type transitMount struct {
+	Namespace  *namespace.Namespace
+	MountPoint string
+}
+
+func (c *Core) findTransitMounts() []*transitMount {
+	mounts := make([]*transitMount, 0)
+
+	c.mountsLock.RLock()
+	defer c.mountsLock.RUnlock()
+
+	// we don't grab the statelock, so this code might run during or after the seal process.
+	// Therefore, we need to check if c.mounts is nil. If we do not, this will panic when
+	// run after seal.
+	if c.mounts == nil {
+		return mounts
+	}
+
+	for _, entry := range c.mounts.Entries {
+		if entry.Type != "transit" {
+			continue
+		}
+
+		mounts = append(mounts, &transitMount{
+			Namespace:  entry.Namespace,
+			MountPoint: entry.Path,
+		})
+	}
+	return mounts
+}
+
+func (c *Core) transitKeysCollectionErrorCount() {
+	c.MetricSink().IncrCounterWithLabels(
+		[]string{"metrics", "collection", "error"},
+		1,
+		[]metrics.Label{{Name: "gauge", Value: "transit_keys_by_mountpoint"}},
+	)
+}
+
+func (c *Core) transitKeyGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	mounts := c.findTransitMounts()
+	results := make([]metricsutil.GaugeLabelValues, len(mounts))
+
+	// Use a root namespace, so include namespace path
+	// in any queries.
+	ctx = namespace.RootContext(ctx)
+
+	// Route list requests to all the identified mounts.
+	// (All of these will show up as activity in the vault.route metric.)
+	// Then we have to explore each subdirectory.
+	for i, m := range mounts {
+		// Check for cancellation, return empty array
+		select {
+		case <-ctx.Done():
+			return []metricsutil.GaugeLabelValues{}, nil
+		default:
+		}
+
+		results[i].Labels = []metrics.Label{
+			metricsutil.NamespaceLabel(m.Namespace),
+			{Name: "mount_point", Value: m.MountPoint},
+		}
+
+		listRequest := &logical.Request{
+			Operation: logical.ListOperation,
+			Path:      m.Namespace.Path + m.MountPoint + "keys",
+		}
+
+		resp, err := c.router.Route(ctx, listRequest)
+		if err != nil {
+			if errors.Is(err, logical.ErrUnsupportedPath) {
+				// ErrUnsupportedPath probably means that the mount is not there
+				// any more, don't log those cases.
+				continue
+			}
+			c.logger.Error("failed to perform internal transit key list", "mount_point", m.MountPoint, "error", err)
+			c.transitKeysCollectionErrorCount()
+			continue
+		}
+
+		if resp == nil {
+			c.logger.Error("failed to perform internal transit key list: got nil response", "mount_point", m.MountPoint)
+			c.transitKeysCollectionErrorCount()
+			continue
+		}
+
+		keysAny, ok := resp.Data["keys"]
+		if !ok {
+			results[i].Value = 0 // keys is only present, if at least one keys is there
+			continue
+		}
+
+		keys, ok := keysAny.([]string)
+		if !ok {
+			c.logger.Error("failed to perform internal transit key list: expected keys to be of type []string", "mount_point", m.MountPoint, "keys_type", fmt.Sprintf("%T", keys))
+			c.transitKeysCollectionErrorCount()
+			continue
+		}
+
+		results[i].Value = float32(len(keys))
 	}
 
 	return results, nil

--- a/internal/vault/core_metrics.go
+++ b/internal/vault/core_metrics.go
@@ -179,54 +179,54 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 		MetadataLabel []metrics.Label
 		CollectorFunc metricsutil.GaugeCollector
 		DisableEnvVar string
+		EnableEnvVar  string
 	}{
 		{
-			[]string{"token", "count"},
-			[]metrics.Label{{Name: "gauge", Value: "token_by_namespace"}},
-			c.tokenGaugeCollector,
-			"",
+			MetricName:    []string{"token", "count"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "token_by_namespace"}},
+			CollectorFunc: c.tokenGaugeCollector,
 		},
 		{
-			[]string{"token", "count", "by_policy"},
-			[]metrics.Label{{Name: "gauge", Value: "token_by_policy"}},
-			c.tokenGaugePolicyCollector,
-			"",
+			MetricName:    []string{"token", "count", "by_policy"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "token_by_policy"}},
+			CollectorFunc: c.tokenGaugePolicyCollector,
 		},
 		{
-			[]string{"expire", "leases", "by_expiration"},
-			[]metrics.Label{{Name: "gauge", Value: "leases_by_expiration"}},
-			c.leaseExpiryGaugeCollector,
-			"",
+			MetricName:    []string{"expire", "leases", "by_expiration"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "leases_by_expiration"}},
+			CollectorFunc: c.leaseExpiryGaugeCollector,
 		},
 		{
-			[]string{"token", "count", "by_auth"},
-			[]metrics.Label{{Name: "gauge", Value: "token_by_auth"}},
-			c.tokenGaugeMethodCollector,
-			"",
+			MetricName:    []string{"token", "count", "by_auth"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "token_by_auth"}},
+			CollectorFunc: c.tokenGaugeMethodCollector,
 		},
 		{
-			[]string{"token", "count", "by_ttl"},
-			[]metrics.Label{{Name: "gauge", Value: "token_by_ttl"}},
-			c.tokenGaugeTtlCollector,
-			"",
+			MetricName:    []string{"token", "count", "by_ttl"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "token_by_ttl"}},
+			CollectorFunc: c.tokenGaugeTtlCollector,
 		},
 		{
-			[]string{"secret", "kv", "count"},
-			[]metrics.Label{{Name: "gauge", Value: "kv_secrets_by_mountpoint"}},
-			c.kvSecretGaugeCollector,
-			"BAO_DISABLE_KV_GAUGE",
+			MetricName:    []string{"secret", "kv", "count"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "kv_secrets_by_mountpoint"}},
+			CollectorFunc: c.kvSecretGaugeCollector,
+			DisableEnvVar: "BAO_DISABLE_KV_GAUGE",
 		},
 		{
-			[]string{"identity", "entity", "count"},
-			[]metrics.Label{{Name: "gauge", Value: "identity_by_namespace"}},
-			c.entityGaugeCollector,
-			"",
+			MetricName:    []string{"secret", "transit", "key", "count"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "transit_keys_by_mountpoint"}},
+			CollectorFunc: c.transitKeyGaugeCollector,
+			EnableEnvVar:  "BAO_ENABLE_TRANSIT_GAUGE",
 		},
 		{
-			[]string{"identity", "entity", "alias", "count"},
-			[]metrics.Label{{Name: "gauge", Value: "identity_by_mountpoint"}},
-			c.entityGaugeCollectorByMount,
-			"",
+			MetricName:    []string{"identity", "entity", "count"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "identity_by_namespace"}},
+			CollectorFunc: c.entityGaugeCollector,
+		},
+		{
+			MetricName:    []string{"identity", "entity", "alias", "count"},
+			MetadataLabel: []metrics.Label{{Name: "gauge", Value: "identity_by_mountpoint"}},
+			CollectorFunc: c.entityGaugeCollectorByMount,
 		},
 	}
 
@@ -241,6 +241,13 @@ func (c *Core) emitMetricsActiveNode(stopCh chan struct{}) {
 						"metric", init.MetricName)
 					continue
 				}
+			}
+			if init.EnableEnvVar != "" {
+				if api.ReadBaoVariable(init.EnableEnvVar) == "" {
+					continue
+				}
+				c.logger.Info("usage gauge collection is enabled for",
+					"metric", init.MetricName)
 			}
 
 			proc, err := c.MetricSink().NewGaugeCollectionProcess(

--- a/internal/vault/core_metrics_test.go
+++ b/internal/vault/core_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,9 +15,12 @@ import (
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	logicalKv "github.com/openbao/openbao/v2/internal/builtin/logical/kv"
+	"github.com/openbao/openbao/v2/internal/builtin/logical/transit"
+	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	ident "github.com/openbao/openbao/v2/internal/vault/identity"
 	"github.com/openbao/openbao/v2/internal/vault/routing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoreMetrics_KvSecretGauge(t *testing.T) {
@@ -356,4 +360,111 @@ func testCoreMetricsEntityGauges(t *testing.T, ctx context.Context, is *ident.Id
 			"auth_method": "userpass",
 			"mount_point": "auth/userpass/",
 		})
+}
+
+func TestCoreMetrics_TransitKeysGauge(t *testing.T) {
+	AddTestLogicalBackend(t, "transit", transit.Factory)
+	core, _, root := TestCoreUnsealed(t)
+
+	ctx := namespace.RootContext(t.Context())
+
+	// create a namespace
+	ns := &namespace.Namespace{
+		Path: "test",
+	}
+	require.NoError(t, core.namespaceStore.SetNamespace(ctx, ns))
+	require.NotEmpty(t, ns.UUID)
+
+	// create a few mounts with some keys
+	testMounts := []struct {
+		Path      string
+		Namespace *namespace.Namespace
+		Count     int
+	}{{
+		Path:  "three/",
+		Count: 3,
+	}, {
+		Path:  "empty/",
+		Count: 0,
+	}, {
+		Path:  "four/",
+		Count: 4,
+	}, {
+		Path:  "prefixed/and/empty/",
+		Count: 0,
+	}, {
+		Path:  "prefixed/five/",
+		Count: 5,
+	}, {
+		Path:      "namespaced/",
+		Namespace: ns,
+		Count:     3,
+	}}
+	for _, tm := range testMounts {
+		// create the mount
+		ctx := ctx
+		if tm.Namespace != nil {
+			ctx = namespace.ContextWithNamespace(ctx, ns)
+		}
+		me := &routing.MountEntry{
+			Table: routing.MountTableType,
+			Path:  sanitizePath(tm.Path),
+			Type:  "transit",
+		}
+		require.NoError(t, core.mount(ctx, me))
+
+		// create the keys
+		for i := range tm.Count {
+			path := me.Path + "keys/" + strconv.Itoa(i)
+			req := logical.TestRequest(t, logical.CreateOperation, path)
+			req.Data["data"] = map[string]any{}
+			req.ClientToken = root
+			resp, err := core.HandleRequest(ctx, req)
+			require.NoError(t, err, "error while creating %q", path)
+			require.Nil(t, resp.Error(), "error while creating %q", path)
+		}
+	}
+
+	// collect the metrics
+	values, err := core.transitKeyGaugeCollector(ctx)
+	require.NoError(t, err)
+
+	expectedValues := []metricsutil.GaugeLabelValues{{
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "root"},
+			{Name: "mount_point", Value: "three/"},
+		},
+		Value: 3,
+	}, {
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "root"},
+			{Name: "mount_point", Value: "empty/"},
+		},
+		Value: 0,
+	}, {
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "root"},
+			{Name: "mount_point", Value: "four/"},
+		},
+		Value: 4,
+	}, {
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "root"},
+			{Name: "mount_point", Value: "prefixed/and/empty/"},
+		},
+		Value: 0,
+	}, {
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "root"},
+			{Name: "mount_point", Value: "prefixed/five/"},
+		},
+		Value: 5,
+	}, {
+		Labels: []metricsutil.Label{
+			{Name: "namespace", Value: "test"},
+			{Name: "mount_point", Value: "namespaced/"},
+		},
+		Value: 3,
+	}}
+	require.Equal(t, expectedValues, values)
 }

--- a/internal/vault/core_metrics_test.go
+++ b/internal/vault/core_metrics_test.go
@@ -15,18 +15,13 @@ import (
 	"github.com/openbao/openbao/sdk/v2/logical"
 	logicalKv "github.com/openbao/openbao/v2/internal/builtin/logical/kv"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
-	be "github.com/openbao/openbao/v2/internal/vault/backend"
 	ident "github.com/openbao/openbao/v2/internal/vault/identity"
 	"github.com/openbao/openbao/v2/internal/vault/routing"
 )
 
 func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 	// Use the real KV implementation instead of Passthrough
-	AddTestLogicalBackend("kv", logicalKv.Factory)
-	// Clean up for the next test-- is there a better way?
-	defer func() {
-		delete(be.TestLogicalBackends, "kv")
-	}()
+	AddTestLogicalBackend(t, "kv", logicalKv.Factory)
 	core, _, root := TestCoreUnsealed(t)
 
 	testMounts := []struct {
@@ -156,11 +151,7 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 
 func TestCoreMetrics_KvSecretGauge_BadPath(t *testing.T) {
 	// Use the real KV implementation instead of Passthrough
-	AddTestLogicalBackend("kv", logicalKv.Factory)
-	// Clean up for the next test.
-	defer func() {
-		delete(be.TestLogicalBackends, "kv")
-	}()
+	AddTestLogicalBackend(t, "kv", logicalKv.Factory)
 	core, _, _ := TestCoreUnsealed(t)
 
 	me := &routing.MountEntry{

--- a/internal/vault/testing.go
+++ b/internal/vault/testing.go
@@ -699,15 +699,15 @@ func TestPluginClientConfig(c *Core, pluginType consts.PluginType, pluginName st
 
 // This adds a logical backend for the test core. This needs to be
 // invoked before the test core is created.
-func AddTestLogicalBackend(name string, factory logical.Factory) error {
-	if name == "" {
-		return errors.New("missing backend name")
-	}
-	if factory == nil {
-		return errors.New("missing backend factory function")
-	}
+func AddTestLogicalBackend(t testing.T, name string, factory logical.Factory) {
+	t.Helper()
+	t.Setenv("DO_NOT_RUN_IN_PARALLEL", "this is a hack to prevent the helper to be used in a parallel test")
+	require.NotEmpty(t, name, "missing backend name")
+	require.NotNil(t, factory, "missing backend factory function")
 	be.TestLogicalBackends[name] = factory
-	return nil
+	t.Cleanup(func() {
+		delete(be.TestLogicalBackends, name)
+	})
 }
 
 type rawHTTP struct{}

--- a/website/content/docs/internals/telemetry/metrics/all.mdx
+++ b/website/content/docs/internals/telemetry/metrics/all.mdx
@@ -437,11 +437,15 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/vault/runtime/total_gc_runs.mdx'
 
-@include 'telemetry-metrics/vault/secret/kv/count.mdx'
+import VaultSecretKvCount from "@site/content/partials/telemetry-metrics/vault/secret/kv/count.mdx";
+
+<VaultSecretKvCount/>
 
 @include 'telemetry-metrics/vault/secret/lease/creation.mdx'
 
-@include 'telemetry-metrics/vault/secret/transit/key/count.mdx'
+import VaultSecretTransitKeyCount from "@site/content/partials/telemetry-metrics/vault/secret/transit/key/count.mdx";
+
+<VaultSecretTransitKeyCount/>
 
 @include 'telemetry-metrics/vault/token/count.mdx'
 

--- a/website/content/docs/internals/telemetry/metrics/all.mdx
+++ b/website/content/docs/internals/telemetry/metrics/all.mdx
@@ -441,6 +441,8 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/vault/secret/lease/creation.mdx'
 
+@include 'telemetry-metrics/vault/secret/transit/key/count.mdx'
+
 @include 'telemetry-metrics/vault/token/count.mdx'
 
 @include 'telemetry-metrics/vault/token/count/by_auth.mdx'

--- a/website/content/docs/internals/telemetry/metrics/secrets.mdx
+++ b/website/content/docs/internals/telemetry/metrics/secrets.mdx
@@ -11,7 +11,9 @@ operations.
 
 ## Default metrics
 
-@include 'telemetry-metrics/vault/secret/kv/count.mdx'
+import VaultSecretKvCount from "@site/content/partials/telemetry-metrics/vault/secret/kv/count.mdx";
+
+<VaultSecretKvCount/>
 
 @include 'telemetry-metrics/vault/secret/lease/creation.mdx'
 
@@ -91,4 +93,6 @@ operations.
 
 ## Transit Metrics
 
-@include 'telemetry-metrics/vault/secret/transit/key/count.mdx'
+import VaultSecretTransitKeyCount from "@site/content/partials/telemetry-metrics/vault/secret/transit/key/count.mdx";
+
+<VaultSecretTransitKeyCount/>

--- a/website/content/docs/internals/telemetry/metrics/secrets.mdx
+++ b/website/content/docs/internals/telemetry/metrics/secrets.mdx
@@ -88,3 +88,7 @@ operations.
 @include 'telemetry-metrics/database/revokeuser.mdx'
 
 @include 'telemetry-metrics/database/revokeuser/error.mdx'
+
+## Transit Metrics
+
+@include 'telemetry-metrics/vault/secret/transit/key/count.mdx'

--- a/website/content/partials/telemetry-metrics/vault/secret/kv/count.mdx
+++ b/website/content/partials/telemetry-metrics/vault/secret/kv/count.mdx
@@ -5,3 +5,11 @@ Metric type | Value   | Description
 gauge       | number  | Number of entries in each key-value secrets engines
 
 OpenBao organizes the key-value pair count by cluster, namespace, and mount point.
+
+:::note
+
+On instances with many key-value pairs, this metric can affect the overall
+performance. It can be disabled via the `BAO_DISABLE_KV_GAUGE` environment
+variable.
+
+:::

--- a/website/content/partials/telemetry-metrics/vault/secret/transit/key/count.mdx
+++ b/website/content/partials/telemetry-metrics/vault/secret/transit/key/count.mdx
@@ -1,0 +1,21 @@
+### vault.secret.transit.key.count {#vault-secret-transit-key-count}
+
+Metric type | Value   | Description
+----------- | ------- | -----------
+gauge       | number  | Number of keys in each transit secrets engines
+
+OpenBao organizes the key count by cluster, namespace, and mount point.
+
+:::note
+
+This metric is disabled by default. Set environment variable
+`BAO_ENABLE_TRANSIT_GAUGE` to enable it.
+
+:::
+
+:::note
+
+This does count the number of logical keys, meaning a key with multiple versions
+will counted as one key.
+
+:::


### PR DESCRIPTION
## Description

Add a new metric `vault.secret.transit.key.count` similar to the existing [`vault.secret.kv.count`](https://openbao.org/docs/internals/telemetry/metrics/secrets/#vault-secret-kv-count) metric.

It count the number of keys in the transit engine grouped by mount (instead of key-value pairs in the kv engine).

It is opt in and can be enabled via `BAO_ENABLE_TRANSIT_GAUGE` (instead of being opt out via `BAO_DISABLE_KV_GAUGE`).

Other changes:

- Refactor `AddTestLogicalBackend` to use `t.Cleanup` (which did not exist when this helper was writen)
- Document the `BAO_DISABLE_KV_GAUGE` environment variable

## Open Questions

- Should we check that the `BAO_ENABLE_TRANSIT_GAUGE` env variable has a "truthy" value (currently `BAO_ENABLE_TRANSIT_GAUGE=false` would still enable it)?
  - `BAO_DISABLE_KV_GAUGE` doesn't do this, should it also?
- Should we make the KV gauge also opt-in?

## Rationale

"Feature parity" between KV and transit

For performance reasons, this is opt-in.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
