### PR TITLE
docs: fix imported_key typo

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -347,7 +347,7 @@ $ curl \
     "supports_decryption": true,
     "supports_derivation": true,
     "supports_signing": false,
-    "imported": false
+    "imported_key": false
   }
 }
 ```


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Fixed a transit secret engine read key documentation typo: `imported` -> `imported_key`

## Rationale

https://github.com/openbao/openbao/issues/3683

Resolves: #3683

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
