### PR TITLE
Improve `TestNamespaceManyLeases` stability

### DIFF
--- a/internal/vault/namespace_store_test.go
+++ b/internal/vault/namespace_store_test.go
@@ -1877,7 +1877,7 @@ func TestNamespaceManyLeases(t *testing.T) {
 					require.True(collect, found, "did not find expected lease: %v", leaseId)
 					return true
 				})
-			}, time.Second, 100*time.Millisecond)
+			}, 3*time.Second, 100*time.Millisecond)
 
 		}
 	}

--- a/internal/vault/namespace_store_test.go
+++ b/internal/vault/namespace_store_test.go
@@ -1250,8 +1250,12 @@ func TestNamespaceSealResourcesLifecycle(t *testing.T) {
 
 		// leases
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			c.stateLock.RLock()
+			expiration := c.expiration
+			c.stateLock.RUnlock()
+
 			found := false
-			c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+			expiration.pending.Range(func(keyRaw any, _ any) bool {
 				key := keyRaw.(string)
 				if ns.MatchesID(key) {
 					found = true
@@ -1499,8 +1503,12 @@ func TestNamespaceSealManyLeases(t *testing.T) {
 
 			// leases
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				c.stateLock.RLock()
+				expiration := c.expiration
+				c.stateLock.RUnlock()
+
 				count := 0
-				c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+				expiration.pending.Range(func(keyRaw any, _ any) bool {
 					key := keyRaw.(string)
 					if ns.MatchesID(key) {
 						count += 1
@@ -1517,7 +1525,7 @@ func TestNamespaceSealManyLeases(t *testing.T) {
 					}
 
 					found := false
-					c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+					expiration.pending.Range(func(keyRaw any, _ any) bool {
 						key := keyRaw.(string)
 						found = found || key == leaseId
 						return true
@@ -1839,8 +1847,12 @@ func TestNamespaceManyLeases(t *testing.T) {
 
 			// leases
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				c.stateLock.RLock()
+				expiration := c.expiration
+				c.stateLock.RUnlock()
+
 				count := 0
-				c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+				expiration.pending.Range(func(keyRaw any, _ any) bool {
 					key := keyRaw.(string)
 					if ns.MatchesID(key) {
 						count += 1
@@ -1857,7 +1869,7 @@ func TestNamespaceManyLeases(t *testing.T) {
 					}
 
 					found := false
-					c.expiration.pending.Range(func(keyRaw any, _ any) bool {
+					expiration.pending.Range(func(keyRaw any, _ any) bool {
 						key := keyRaw.(string)
 						found = found || key == leaseId
 						return true


### PR DESCRIPTION


## Description

1. Give the test more time to run
2. Fix potential nil-pointer and data-race when the test fails: `EventuallyWithT` runs the "check function" asynchronously. If the timeout expires, it will fail the test without waiting for the function to return, which means the cleanup might run in parallel to the check function, causing races. (also changed `TestNamespaceSealManyLeases` and `TestNamespaceSealResourcesLifecycle`)


## Rationale

https://github.com/openbao/openbao/actions/runs/30889437309?pr=3677


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
