### PR TITLE
Documentation typo: transit imported key

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Some additional notes on development:
 
 ### Importing OpenBao
 
-This repository publishes two libraries that may be imported by other projects:
+This repository publishes two libraries that may be imported_key by other projects:
 `github.com/openbao/openbao/api/v2` and `github.com/openbao/openbao/sdk/v2`.
 
 Note that this repository also contains OpenBao (the application), and as


### PR DESCRIPTION
## Description

This PR fixes the documentation issue reported in #3683: corrects `imported` to `imported_key` in `README.md`.

Fixes #3683

## Rationale

Resolves: #

## Acknowledgements

 - [ ] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [ ] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

Fixes #3683