### PR TITLE
Add missing baoNamespace CSI provider parameter documentation

### DIFF
--- a/changelog/3689.txt
+++ b/changelog/3689.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-website: Add missing "baoNamespace" parameter to OpenBao CSI Provider documentation.
-```

--- a/changelog/3689.txt
+++ b/changelog/3689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+website: Add missing "baoNamespace" parameter to OpenBao CSI Provider documentation.
+```

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -97,6 +97,8 @@ structure is illustrated in the [examples](examples.mdx).
   for caching and renewals, but setting `openbaoAddress` here will cause the OpenBao
   CSI Provider to bypass the Agent's cache.
 
+- `baoNamespace` `(string: "")` -  The OpenBao namespace to use.
+
 - `baoSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the OpenBao server
   certificate. Setting this to true is not recommended for production.
 

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -97,7 +97,7 @@ structure is illustrated in the [examples](examples.mdx).
   for caching and renewals, but setting `openbaoAddress` here will cause the OpenBao
   CSI Provider to bypass the Agent's cache.
 
-- `baoNamespace` `(string: "")` -  The OpenBao namespace to use.
+- `baoNamespace` `(string: "")` - The OpenBao namespace to use.
 
 - `baoSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the OpenBao server
   certificate. Setting this to true is not recommended for production.


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Added missing OpenBao CSI Provider documentation to the website for the "baoNamespace" configuration parameter.
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Website documentation should accurately reflect configuration options for `SecretProviderClass` parameters.
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3689 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
