### PR TITLE
Drop VOLUME instructions from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,6 @@ RUN mkdir -p /openbao/logs && \
     mkdir -p /openbao/config && \
     chown -R openbao:openbao /openbao
 
-# Expose the logs directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/logs
-
-# Expose the file directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/file
-
 # 8200/tcp is the primary interface that applications use to interact with
 # OpenBao.
 EXPOSE 8200
@@ -101,14 +93,6 @@ RUN mkdir -p /openbao/logs && \
     chown -R openbao /openbao && chown -R openbao $HOME && \
     chgrp -R 0 $HOME && chmod -R g+rwX $HOME && \
     chgrp -R 0 /openbao && chmod -R g+rwX /openbao
-
-# Expose the logs directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/logs
-
-# Expose the file directory as a volume since there's potentially long-running
-# state in there
-VOLUME /openbao/file
 
 # 8200/tcp is the primary interface that applications use to interact with
 # OpenBao.

--- a/changelog/3711.txt
+++ b/changelog/3711.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+packaging/container: Remove all `VOLUME` instructions.
+```


### PR DESCRIPTION
## Description

Remove `VOLUME` instructions from the `Dockerfile`, impacting Alpine & UBI distributions.

## Rationale

I've been debating this in the back of my mind for week or so and I've concluded that these instructions present a net-negative to OpenBao's container images and are safe to remove.

The result of this will be no more automatically created anonymous volumes via Docker, Podman & co (Not Kubernetes, which the instruction never had effects on).

The primary benefit is that a test run will not leak hundreds of anonymous volumes anymore[^1] (though we can also fix this just within sdk by adding a tmpfs mount at `/openbao/logs`). The same benefit goes for any one-off invocations of the container image for testing when persistence is not desired (and yet forced onto you in useless ways via the instruction).

I find it extremely unlikely for anyone to rely on these instructions in production:

- They don't have any effect in Kubernetes, so only Docker/Podman-based setups are affected.
- While the volume directories are pre-created, container images do not ship with default configuration pointing at them. Actually writing data to these locations is deliberate configuration, which is a natural opportunity to configure explicit volume mounts.
- When using anonymous volumes, you'd need to keep track of its randomly generated ID between container recreations, e.g., when upgrading to a newer version of OpenBao. This also counts for compose-based setups, a single `docker compose down && docker compose up` loses service -> anonymous volume mappings.

Further reading: https://github.com/moby/moby/issues/43190, which has lots of additional links if you'd like to go down the rabbit hole yourself.


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.

[^1]: At least those implicitly created by Docker, which should only be the logs volume. It will still leak volumes whenever containers are leaked and the volume explicitly created for `/openbao/file` is not cleaned up.