### PR TITLE
Add external key usage docs for Transit

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -65,6 +65,17 @@ values set here cannot be changed after key creation.
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
   - `hmac` - HMAC (HMAC generation, verification)
+  - `external-key`: Reference to an entry under the [external keys
+    registry](../system/external-keys.mdx). This is HSM- or KMS-backed
+    key material and available operations are dependent on the underlying
+    key type.
+
+    :::info
+
+    External keys do not support auto-rotation, exporting, convergent
+    encryption, or context-derived keys.
+
+    :::
 
 - `key_size` `(int: "0", optional)` - The key size in bytes for algorithms
   that allow variable key sizes.  Currently only applicable to HMAC, where
@@ -74,6 +85,13 @@ values set here cannot be changed after key creation.
   this key should be rotated automatically. Setting this to "0" (the default)
   will disable automatic key rotation. This value cannot be shorter than one
   hour. Uses [duration format strings](/docs/concepts/duration-format).
+
+- `external_key_ref` `(string: "")` - When `type=external-key`, this specifies
+  the reference to the external key to use for operations. This takes the
+  format `<config name>:<key name>` referring to an object at
+  `sys/external-keys/configs/<config name>/keys/<key name>`. Note that
+  external keys need a [grant](../system/external-keys.mdx#manage-grants)
+  to be usable from a given mount.
 
 ### Sample payload
 
@@ -153,6 +171,10 @@ the hash function defaults to SHA256.
   - `rsa-2048` - RSA with bit size of 2048 (asymmetric)
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
+
+  :::info
+  External keys are not supported by import.
+  :::
 
 - `public_key` `(string: "", optional)` - A plaintext PEM public key to be
 imported. This limits the operations available under this key to verification
@@ -505,6 +527,12 @@ rotated within OpenBao, it will not support further import operations.
 
 - `name` `(string: <required>)` – Specifies the name of the encryption key to
   rotate. This is specified as part of the URL.
+- `external_key_ref` `(string: "")` - When `type=external-key`, this specifies
+  the reference to the external key to use for operations. This takes the
+  format `<config name>:<key name>` referring to an object at
+  `sys/external-keys/configs/<config name>/keys/<key name>`. Note that
+  external keys need a [grant](../system/external-keys.mdx#manage-grants)
+  to be usable from a given mount.
 
 ### Sample request
 
@@ -2089,3 +2117,17 @@ $ curl \
   }
 }
 ```
+
+## External keys (#managed-keys)
+
+[External keys](../system/external-keys.mdx) can be used with the Transit
+Secrets Engine to use key material backed by another HSM or KMS. Availability
+of sign, verify, encrypt, and decrypt operations are dependent on the
+underlying KMS plugin and specific underlying key type. Both are opaque from
+Transit's PoV and it simply delegates operations to the underlying KMS to
+handle. This assumes the caller has some understanding of what the
+corresponding key's expected operations and parameters are.
+
+Transit's `/keys/` API refers to a keyring with multiple key versions. While
+key material of different types can be included in the same keyring, we
+recommend only using a single type of keys per keyring to avoid confusion.

--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -95,6 +95,10 @@ types also generate separate HMAC keys):
   key type uses a 256-bit key.
 
   :::
+- `external-key`: Reference to an entry under the [external keys
+  registry](/api-docs/system/external-keys). This is HSM- or KMS-backed
+  key material and available operations are dependent on the underlying
+  key type.
 
 RSA operations use one of the following methods:
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Related to #3602, this adds external key usage documentation for Transit.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
