### PR TITLE
UI fix firefox integration tests

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,3 +1,5 @@
+BROWSER ?= chrome
+
 .PHONY: frontend
 frontend:
 	pnpm start
@@ -8,7 +10,7 @@ backend:
 
 .PHONY: test
 test:
-	pnpm test
+	pnpm test --launch "$(BROWSER)"
 
 .PHONY: check
 check: test

--- a/ui/tests/integration/components/json-editor-test.js
+++ b/ui/tests/integration/components/json-editor-test.js
@@ -74,7 +74,7 @@ module('Integration | Component | json-editor', function (hooks) {
     />`);
 
     assert.dom('.cm-s-hashi-read-only').hasStyle({
-      background: 'rgb(247, 248, 250) none repeat scroll 0% 0% / auto padding-box border-box',
+      backgroundColor: 'rgb(247, 248, 250)',
     });
     assert.dom('.CodeMirror-linenumber').doesNotExist('on readOnly does not show line numbers');
   });


### PR DESCRIPTION
## Description

On Firefox one of our UI integration tests fails.

The assertion uses [`getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) under the hood. There seem to be a difference how Chromium and Firefox implement that method for [shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties). Firefox seems to omit default values, while Chromium includes them. I don't know which one is more correct or if it is defined at all by the spec, but in general it seems like a good idea to avoid using shorthand properties with the `getComputedStyle` API as the can have some corner-cases.

This PR also adds a `BROWSER` env to the `Makefile` (defaulting to `chrome` to keep existing behavior). You can use `BROWSER=firefox make test` to run the integration tests in Firefox and `BROWSER=chromium make test` to run with Chromium (which is helpful, if you don't have the Google-flavor of the browser installed).

## Rationale

Firefox is a supported browser: https://openbao.org/docs/browser-support/

So we should be able to run the integration tests for it.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
