### PR TITLE
switch `services/store.js` to native class

### DIFF
--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -9,7 +9,7 @@ import { copy } from 'ember-copy';
 import { resolve, Promise } from 'rsvp';
 import { dasherize } from '@ember/string';
 import { assert } from '@ember/debug';
-import { set, get, computed } from '@ember/object';
+import { set, get } from '@ember/object';
 import clamp from 'vault/utils/clamp';
 import config from 'vault/config/environment';
 import sortObjects from 'vault/utils/sort-objects';
@@ -33,17 +33,20 @@ export function keyForCache(query) {
   return JSON.stringify(cacheKeyObject);
 }
 
-export default Store.extend({
+export default class extends Store {
   // this is a map of map that stores the caches
-  // eslint-disable-next-line
-  lazyCaches: computed({
-    get() {
-      return this._lazyCaches || new Map();
-    },
-    set(key, value) {
-      return (this._lazyCaches = value);
-    },
-  }),
+  #lazyCaches;
+
+  get lazyCaches() {
+    if (!this.#lazyCaches) {
+      this.#lazyCaches = new Map();
+    }
+    return this.#lazyCaches;
+  }
+
+  set lazyCaches(lazyCaches) {
+    this.#lazyCaches = lazyCaches;
+  }
 
   setLazyCacheForModel(modelName, key, value) {
     const cacheKey = keyForCache(key);
@@ -52,7 +55,7 @@ export default Store.extend({
     const lazyCaches = this.lazyCaches;
     const modelKey = normalizeModelName(modelName);
     lazyCaches.set(modelKey, cache);
-  },
+  }
 
   getLazyCacheForModel(modelName, key) {
     const cacheKey = keyForCache(key);
@@ -60,11 +63,11 @@ export default Store.extend({
     if (modelCache) {
       return modelCache.get(cacheKey);
     }
-  },
+  }
 
   lazyCacheForModel(modelName) {
     return this.lazyCaches.get(normalizeModelName(modelName));
-  },
+  }
 
   // This is the public interface for the store extension - to be used just
   // like `Store.query`. Special handling of the response is controlled by
@@ -106,7 +109,7 @@ export default Store.extend({
       .catch(function (e) {
         throw e;
       });
-  },
+  }
 
   filterData(filter, dataset) {
     let newData = dataset || [];
@@ -117,7 +120,7 @@ export default Store.extend({
       });
     }
     return newData;
-  },
+  }
 
   // reconstructs the original form of the response from the server
   // with an additional `meta` block
@@ -148,7 +151,7 @@ export default Store.extend({
     };
 
     return response;
-  },
+  }
 
   // pushes records into the store and returns the result
   fetchPage(modelName, query) {
@@ -170,12 +173,12 @@ export default Store.extend({
         resolve(model);
       });
     });
-  },
+  }
 
   // get cached data
   getDataset(modelName, query) {
     return this.getLazyCacheForModel(modelName, query);
-  },
+  }
 
   // store data cache as { response, dataset}
   // also populated `lazyCaches` attribute
@@ -186,7 +189,7 @@ export default Store.extend({
       dataset,
     };
     this.setLazyCacheForModel(modelName, query, value);
-  },
+  }
 
   clearDataset(modelName) {
     const cacheList = this.lazyCaches;
@@ -198,12 +201,12 @@ export default Store.extend({
     } else {
       cacheList.clear();
     }
-    this.set('lazyCaches', cacheList);
-  },
+    this.lazyCaches = cacheList;
+  }
 
   clearAllDatasets() {
     this.clearDataset();
-  },
+  }
 
   unloadAll(modelName) {
     if (this.isDestroying || this.isDestroyed) {
@@ -214,9 +217,9 @@ export default Store.extend({
     if (hasMountConfig.includes(modelName)) {
       this.peekAll(modelName).forEach((record) => this.unloadRecord(record));
     } else {
-      this._super(modelName);
+      super.unloadAll(modelName);
     }
-  },
+  }
 
   unloadRecord(record) {
     if (this.isDestroying || this.isDestroyed) {
@@ -225,8 +228,8 @@ export default Store.extend({
 
     const hasMountConfig = ['auth-method', 'secret-engine'];
     if (record && hasMountConfig.includes(record.constructor.modelName) && record.config) {
-      this._super(record.config);
+      super.unloadRecord(record.config);
     }
-    this._super(record);
-  },
-});
+    super.unloadRecord(record);
+  }
+}

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -9,7 +9,7 @@ import { copy } from 'ember-copy';
 import { resolve, Promise } from 'rsvp';
 import { dasherize } from '@ember/string';
 import { assert } from '@ember/debug';
-import { set, get, computed } from '@ember/object';
+import { set, get } from '@ember/object';
 import clamp from 'vault/utils/clamp';
 import config from 'vault/config/environment';
 import sortObjects from 'vault/utils/sort-objects';
@@ -33,17 +33,20 @@ export function keyForCache(query) {
   return JSON.stringify(cacheKeyObject);
 }
 
-export default Store.extend({
+export default class extends Store {
   // this is a map of map that stores the caches
-  // eslint-disable-next-line
-  lazyCaches: computed({
-    get() {
-      return this._lazyCaches || new Map();
-    },
-    set(key, value) {
-      return (this._lazyCaches = value);
-    },
-  }),
+  #lazyCaches;
+
+  get lazyCaches() {
+    if (!this.#lazyCaches) {
+      this.#lazyCaches = new Map();
+    }
+    return this.#lazyCaches;
+  }
+
+  set lazyCaches(lazyCaches) {
+    this.#lazyCaches = lazyCaches;
+  }
 
   setLazyCacheForModel(modelName, key, value) {
     const cacheKey = keyForCache(key);
@@ -52,7 +55,7 @@ export default Store.extend({
     const lazyCaches = this.lazyCaches;
     const modelKey = normalizeModelName(modelName);
     lazyCaches.set(modelKey, cache);
-  },
+  }
 
   getLazyCacheForModel(modelName, key) {
     const cacheKey = keyForCache(key);
@@ -60,11 +63,11 @@ export default Store.extend({
     if (modelCache) {
       return modelCache.get(cacheKey);
     }
-  },
+  }
 
   lazyCacheForModel(modelName) {
     return this.lazyCaches.get(normalizeModelName(modelName));
-  },
+  }
 
   // This is the public interface for the store extension - to be used just
   // like `Store.query`. Special handling of the response is controlled by
@@ -106,7 +109,7 @@ export default Store.extend({
       .catch(function (e) {
         throw e;
       });
-  },
+  }
 
   filterData(filter, dataset) {
     let newData = dataset || [];
@@ -117,7 +120,7 @@ export default Store.extend({
       });
     }
     return newData;
-  },
+  }
 
   // reconstructs the original form of the response from the server
   // with an additional `meta` block
@@ -148,7 +151,7 @@ export default Store.extend({
     };
 
     return response;
-  },
+  }
 
   // pushes records into the store and returns the result
   fetchPage(modelName, query) {
@@ -170,12 +173,12 @@ export default Store.extend({
         resolve(model);
       });
     });
-  },
+  }
 
   // get cached data
   getDataset(modelName, query) {
     return this.getLazyCacheForModel(modelName, query);
-  },
+  }
 
   // store data cache as { response, dataset}
   // also populated `lazyCaches` attribute
@@ -186,7 +189,7 @@ export default Store.extend({
       dataset,
     };
     this.setLazyCacheForModel(modelName, query, value);
-  },
+  }
 
   clearDataset(modelName) {
     const cacheList = this.lazyCaches;
@@ -196,35 +199,35 @@ export default Store.extend({
       return;
     }
     cacheList.clear();
-    this.set('lazyCaches', cacheList);
-  },
+    this.lazyCaches = cacheList;
+  }
 
   clearAllDatasets() {
     this.clearDataset();
-  },
+  }
 
   unloadAll(modelName) {
     if (this.isDestroying || this.isDestroyed) {
-      return this._super(modelName);
+      return super.unloadAll(modelName);
     }
 
     const hasMountConfig = ['auth-method', 'secret-engine'];
     if (hasMountConfig.includes(modelName)) {
       this.peekAll(modelName).forEach((record) => this.unloadRecord(record));
     } else {
-      this._super(modelName);
+      super.unloadAll(modelName);
     }
-  },
+  }
 
   unloadRecord(record) {
     if (this.isDestroying || this.isDestroyed) {
-      return this._super(record);
+      return super.unloadRecord(record);
     }
 
     const hasMountConfig = ['auth-method', 'secret-engine'];
     if (record && hasMountConfig.includes(record.constructor.modelName) && record.config) {
-      this._super(record.config);
+      super.unloadRecord(record.config);
     }
-    this._super(record);
-  },
-});
+    super.unloadRecord(record);
+  }
+}


### PR DESCRIPTION
## Description

Use JavaScripts native `extend` over the `.extend()` helper (which as used to emulate inheritance before JavaScript natively supported this).

## Rationale

This is a prerequisite to eventually upgrade beyond ember-data 4.11.x.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
