### PR TITLE
Add documentation on PostgreSQL read scalability

### DIFF
--- a/website/content/docs/concepts/ha.mdx
+++ b/website/content/docs/concepts/ha.mdx
@@ -183,3 +183,15 @@ another backend, we'd love your contributions. Adding HA support requires
 implementing the
 [`physical.HABackend`](https://pkg.go.dev/github.com/openbao/openbao/sdk/physical#HABackend)
 interface for the storage backend.
+
+## Horizontal scalability
+
+Since OpenBao v2.5.0, the [Raft backend](../configuration/storage/raft.mdx)
+has supported horizontal scalability for read requests. Any operation which
+does not result in a storage write will be handled on standby node. Support
+for horizontal scalability was added in OpenBao v2.7.0 for the [PostgreSQL
+backend](../configuration/storage/postgresql.mdx).
+
+This is similar to the Performance Standby node types in Vault Enterprise.
+
+To disable, set [`disable_standby_reads=true`](../configuration/index.mdx#parameters).

--- a/website/content/docs/concepts/ha.mdx
+++ b/website/content/docs/concepts/ha.mdx
@@ -188,7 +188,7 @@ interface for the storage backend.
 
 Since OpenBao v2.5.0, the [Raft backend](../configuration/storage/raft.mdx)
 has supported horizontal scalability for read requests. Any operation which
-does not result in a storage write will be handled on standby node. Support
+does not result in a storage write can be handled by a standby node. Support
 for horizontal scalability was added in OpenBao v2.7.0 for the [PostgreSQL
 backend](../configuration/storage/postgresql.mdx).
 

--- a/website/content/docs/configuration/storage/index.mdx
+++ b/website/content/docs/configuration/storage/index.mdx
@@ -36,25 +36,128 @@ storage "raft" {
 }
 ```
 
+or:
+
+```hcl
+// Set BAO_PG_CONNECTION_URL=postgres://postgres:postgres@localhost:5432.
+storage "postgresql" {
+  ha_enabled = true
+  max_connect_retries = 50
+}
+```
+
 For configuration options which also read an environment variable, the
 environment variable will take precedence over values in the configuration
 file.
 
 ## Integrated Storage (Raft) vs. PostgreSQL
 
-It is recommended to use OpenBao's [integrated storage](raft.mdx)
-for most use cases rather than configuring another system to store OpenBao
-data externally. (Integrated Storage is an **embedded OpenBao data storage**
-writing to the file system).
+It is recommended to evaluate both storage engines on their merits and
+choose the best for your needs. If you're new to running OpenBao, we
+recommend PostgreSQL as an easier storage backend to safely operate than
+Raft.
 
 The table below compares the characteristics of Integrated Storage and PostgreSQL.
 
-|                                | Integrated Storage                                                                                                   | PostgreSQL                                                                                                                                                                                                                              |
-|--------------------------------|----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Production Ready               | Yes                                                                                                                  | Yes                                                                                                                                                                                                                                     |
-| Operation                      | Operationally simpler with no additional software installation required.                                             | Must install and configure the external storage environment outside of OpenBao. For high availability, the external storage should be clustered.                                                                                        |
-| Networking                     | One less network hop: data is stored locally resulting in higher read performance.                                   | Extra network hop between OpenBao and the external storage system if not co-located.                                                                                                                                                    |
-| High Availability support      | Yes                                                                                                                  | Yes                                                                                                                                                                                                                                     |
-| Troubleshooting and monitoring | Integrated Storage is a part of OpenBao; therefore, OpenBao is the only system you need to monitor and troubleshoot. | The source of failure could be the external storage; therefore, you need to check the health of both OpenBao and the external storage. This requires expertise in the chosen storage backend and additional monitoring of that storage. |
-| Data location                  | The encrypted OpenBao data is stored on the same host where the OpenBao server process runs.                         | The encrypted OpenBao data is stored where the external storage is located. Therefore, the OpenBao server and the data storage are hosted on physically separate hosts.                                                                 |
-| System requirements            | Avoid "burstable" CPU and storage options. SSDs should be used for the hard drive.                                   | Follow the system requirements given by your chosen storage backend.                                                                                                                                                                    |
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <td>[**Integrated Storage (Raft)**](./raft.mdx)</td>
+      <td>[**PostgreSQL**](./postgresql.mdx)</td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>**Production Ready**</td>
+      <td>Yes</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>**Operation**</td>
+      <td>
+        Operationally simpler to setup with no additional software installation
+        required. Operator experience with Raft is highly recommended; refer
+        to OpenBao's documentation for more information. OpenBao requires
+        special operations to join, manage, and failover nodes using the Raft
+        backend.
+      </td>
+      <td>
+        Must install and configure the external storage environment outside
+        of OpenBao. For high availability and horizontal scalability,
+        PostgreSQL should be clustered. OpenBao requires no special operation
+        beyond a PostgreSQL connection URL to join, manage, and failover nodes
+        with a PostgreSQL backend.
+      </td>
+    </tr>
+    <tr>
+      <td>**Networking**</td>
+      <td>
+        One less network hop: data is stored locally resulting in better read
+        performance. Write performance is more limited as all nodes must vote
+        to agree on a write, resulting in more latency-sensitive network
+        traffic.
+      </td>
+      <td>
+        Extra network hop between OpenBao and PostgreSQL if not co-located.
+        Reads are cached by default unless
+        [`disable_cache=true`](../index.mdx#parameters)
+        is specified. However, PostgreSQL can often have better write
+        performance than Raft as it has a single active node which mirrors
+        writes to followers.
+      </td>
+    </tr>
+    <tr>
+      <td>**High Availability and Disaster Recovery Support**</td>
+      <td>
+        Yes, with horizontal scalability (read).
+      </td>
+      <td>
+        Yes, with horizontal scalability (read).
+      </td>
+    </tr>
+    <tr>
+      <td>**Troubleshooting and Monitoring**</td>
+      <td>
+        Integrated Storage is a part of OpenBao; therefore, OpenBao is the
+        only system you need to monitor and troubleshoot. However, Raft and
+        BBolt failure modes can often be complex or require specialized
+        expertise to troubleshoot and snapshots to recover from.
+      </td>
+      <td>
+        The source of failure could be the external storage; therefore, you
+        need to check the health of both OpenBao and the external storage.
+        This requires expertise in the chosen storage backend and additional
+        monitoring of that storage.
+      </td>
+    </tr>
+    <tr>
+      <td>**Data Location**</td>
+      <td>
+        The encrypted OpenBao data is stored on the same host where the
+        OpenBao server process runs. This makes it slower to horizontally
+        scale on compute-heavy workloads as data must also be replicated.
+      </td>
+      <td>
+        The encrypted OpenBao data is stored where the external storage is
+        located. Therefore, the OpenBao server and the data storage may be
+        hosted on physically separate hosts. This may make it faster to
+        horizontally scale OpenBao on compute-heavy workloads as existing
+        database nodes may be used.
+      </td>
+    </tr>
+    <tr>
+      <td>**System Requirements**</td>
+      <td>
+        Avoid "burstable" CPU and storage options due to the latency
+        sensitive nature of this backend. SSDs should be used for the hard
+        drives.
+      </td>
+      <td>
+        Follow the system requirements given by your chosen storage backend
+        and size OpenBao nodes according to compute complexity.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -20,7 +20,7 @@ functionality was dropped in OpenBao v2.4.0.
 :::tip
 
 **High Availability** – the PostgreSQL storage backend supports High
-Availability.
+Availability and Horizontal Scalability (as of OpenBao v2.7.0).
 
 :::
 
@@ -138,6 +138,19 @@ CREATE TABLE openbao_ha_locks (
   CONSTRAINT openbao_ha_locks_pkey PRIMARY KEY (ha_key)
 );
 ```
+
+## Horizontal scalability
+
+Since OpenBao v2.7.0, the PostgreSQL storage backend supports horizontal
+scalability. This requires an active cluster GRPC connection; ensure
+`cluster_address` is provided in at least one `listener` block and
+`cluster_addr` is set in the configuration file. When successfully enabled,
+log messages like:
+
+> [DEBUG] setting up GRPC-backed streaming of invalidations
+> [DEBUG] read-only unseal starting
+
+will be visible on standby nodes.
 
 [golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 [postgresql]: https://www.postgresql.org/

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -20,7 +20,8 @@ Algorithm][raft].
 
 :::tip
 
-**High Availability** – the Integrated Storage (Raft) backend supports High Availability.
+**High Availability** – the Integrated Storage (Raft) backend supports High
+Availability and Horizontal Scalability (as of OpenBao v2.5.0).
 
 :::
 


### PR DESCRIPTION
This also refactors and deprograms the storage recommendation table from a very HashiCorp Raft-centric support model.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Besides documenting horizontal scalability support for PostgreSQL, we also begin to deprogram the storage selection table to stop pushing Raft so much. 

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
