### PR TITLE
fix: make the capabilities-self query in the token's namespace

### DIFF
--- a/changelog/3724.txt
+++ b/changelog/3724.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: query capabilities-self in the token's own namespace so cross-namespace browsing does not 403
+```

--- a/changelog/3724.txt
+++ b/changelog/3724.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: query capabilities-self in the token's own namespace so cross-namespace browsing does not 403
+ui: Query capabilities-self in the token's own namespace preventing 403 responses for cross-namespace browsing.
 ```

--- a/ui/app/adapters/capabilities.js
+++ b/ui/app/adapters/capabilities.js
@@ -12,8 +12,26 @@ export default ApplicationAdapter.extend({
     return 'capabilities-self';
   },
 
+  // the namespace being browsed, relative to the one the token was issued in
+  relativeNamespace() {
+    const { userRootNamespace, path } = this.namespaceService;
+    if (!userRootNamespace) {
+      return path;
+    }
+    if (path === userRootNamespace) {
+      return '';
+    }
+    return path.startsWith(`${userRootNamespace}/`) ? path.slice(userRootNamespace.length + 1) : path;
+  },
+
   findRecord(store, type, id) {
-    return this.ajax(this.buildURL(type), 'POST', { data: { paths: [id] } }).catch((e) => {
+    const relativeNamespace = this.relativeNamespace();
+    const prefix = relativeNamespace ? `${relativeNamespace}/` : '';
+
+    return this.ajax(this.buildURL(type), 'POST', {
+      namespace: this.namespaceService.userRootNamespace,
+      data: { paths: [`${prefix}${id}`] },
+    }).catch((e) => {
       if (e instanceof AdapterError) {
         set(e, 'policyPath', 'sys/capabilities-self');
       }

--- a/ui/tests/unit/adapters/capabilities-test.js
+++ b/ui/tests/unit/adapters/capabilities-test.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { resolve } from 'rsvp';
+import AdapterError from '@ember-data/adapter/error';
+import { reject, resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -23,5 +24,43 @@ module('Unit | Adapter | capabilities', function (hooks) {
     assert.strictEqual(url, '/v1/sys/capabilities-self', 'calls the correct URL');
     assert.deepEqual({ paths: ['foo'] }, options.data, 'data params OK');
     assert.strictEqual(method, 'POST', 'method OK');
+  });
+
+  // the check always happens in the namespace the token was issued in, so the path
+  // is qualified with the namespace being browsed, relative to that one
+  [
+    ['the root namespace', '', '', 'foo'],
+    ['a child namespace', '', 'org', 'org/foo'],
+    ['a nested child namespace', '', 'org/team', 'org/team/foo'],
+    ['the token namespace', 'org', 'org', 'foo'],
+    ['a child of the token namespace', 'org', 'org/team', 'team/foo'],
+    ['a sibling of the token namespace', 'org', 'organization', 'organization/foo'],
+  ].forEach(([description, userRootNamespace, path, expectedPath]) => {
+    test(`browsing ${description}`, function (assert) {
+      let options;
+      const adapter = this.owner.factoryFor('adapter:capabilities').create({
+        namespaceService: { userRootNamespace, path },
+        ajax: (...args) => {
+          options = args[2];
+          return resolve();
+        },
+      });
+
+      adapter.findRecord(null, 'capabilities', 'foo');
+      assert.deepEqual({ paths: [expectedPath] }, options.data, `asks about ${expectedPath}`);
+      assert.strictEqual(options.namespace, userRootNamespace, 'asks in the token namespace');
+    });
+  });
+
+  test('reports the unqualified policy path when the request is denied', async function (assert) {
+    assert.expect(1);
+    const adapter = this.owner.factoryFor('adapter:capabilities').create({
+      namespaceService: { userRootNamespace: '', path: 'org' },
+      ajax: () => reject(new AdapterError()),
+    });
+
+    await adapter.findRecord(null, 'capabilities', 'foo').catch((e) => {
+      assert.strictEqual(e.policyPath, 'sys/capabilities-self', 'policyPath is not namespaced');
+    });
   });
 });


### PR DESCRIPTION
## Description

This changes the UI code for the capabilities adaptor so that it makes POSTs to `sys/capabilities-self` in the namespace the token was issued in. This also means that it prepends the namespace you're browsing to the path when making the request. This fixes the issue described in #3723, which was resulting in 403s for read-only users browsing namespaces (due to how default policy works). 

## Rationale

IMO, the default policy, which grants this capability, should be used appropriately when we make API calls from the UI. A 403 is a really odd one to run into here since it works just fine via the CLI (using a `read` or `list` of the exact kv paths) and it implies that you don't have access to the secrets themselves. It is also very confusing because default policy *does* have that permission, so finding out where to go to add this is a bit confusing. Additionally, we stumbled across this at my dayjob during a migration from vault to openbao, and the behavior is unique to openbao, so I suspect that it was changed on that side at some point after the fork. 

This seems pretty low impact and will resolve this for us at least, and means we won't have to make the workaround of re-granting permissions that are already in `default` in the namespace policies.

Resolves: #3723 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
