### PR TITLE
docs: Remove rsa_oaep_hash from samples

### DIFF
--- a/website/content/blog/2026-07-30-declarative-plugins.md
+++ b/website/content/blog/2026-07-30-declarative-plugins.md
@@ -201,7 +201,6 @@ seal "pkcs11" {
     token_label = "OpenBao"
     pin = "4321"
     key_label = "bao-root-key-rsa"
-    rsa_oaep_hash = "sha1"
 }
 ```
 

--- a/website/content/community/rfcs/parallel-unseal.mdx
+++ b/website/content/community/rfcs/parallel-unseal.mdx
@@ -83,7 +83,6 @@ seal "pkcs11" {
   token_label = "OpenBao"
   pin = "4321"
   key_label = "bao-root-key-rsa"
-  rsa_oaep_hash = "sha1"
 }
 
 ...
@@ -104,7 +103,6 @@ seal "pkcs11" {
   token_label = "OpenBao"
   pin = "4321"
   key_label = "bao-root-key-rsa"
-  rsa_oaep_hash = "sha1"
 }
 
 seal "transit" {

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -63,7 +63,6 @@ seal "pkcs11" {
   token_label = "OpenBao"
   pin = "4321"
   key_label = "bao-root-key-rsa"
-  rsa_oaep_hash = "sha1"
 }
 ```
 


### PR DESCRIPTION
## Description

People tend to copy&paste samples, and then end up with sha1 as a legacy value. See e.g. https://github.com/openbao/openbao/pull/3732#discussion_r3744906276.
Use sha256 as a better, secure sample value.

I also updated the blog post and RFC to remove all occurrences of sha1. Please let me know if I should not touch these, then I will revert those edits.

## Rationale

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
