### PR TITLE
UI: ensure OpenBao is fully operational after unseal test

### DIFF
--- a/ui/tests/acceptance/unseal-test.js
+++ b/ui/tests/acceptance/unseal-test.js
@@ -51,5 +51,10 @@ module('Acceptance | unseal', function (hooks) {
 
     assert.dom('[data-test-cluster-status]').doesNotExist('ui does not show sealed warning');
     assert.strictEqual(currentRouteName(), 'vault.cluster.auth', 'vault is ready to authenticate');
+
+    // Give the OpenBao server a guaranteed window to finish its background
+    // leader election and stabilization before this test exits and the
+    // next tests start.
+    await new Promise((resolve) => setTimeout(resolve, 10000));
   });
 });


### PR DESCRIPTION
## Description

This fixes the failure of `wrapped_token` tests in CI we've been seeing lately.
Some recent changes caused OpenBao to take longer to unseal and get fully
operational, so when the `unseal` test finishes after sealing and unsealing the
server, the requests sent by the `wrapped_token` tests fail.

To fix this, we introduce a simple 10 second delay after the unseal test runs,
to ensure the server is up again before continuing. 


Signed-off-by: Jan Martens <jan@martens.eu.org>

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.