### PR TITLE
listener: apply unix socket_mode without requiring user/group

### DIFF
--- a/internal/command/agentproxyshared/cache/listener.go
+++ b/internal/command/agentproxyshared/cache/listener.go
@@ -49,9 +49,8 @@ func StartListener(lnConfig *configutil.Listener, logger hclog.Logger) (*Listene
 
 	case "unix":
 		var uConfig *listenerutil.UnixSocketsConfig
-		if lnConfig.SocketMode != "" &&
-			lnConfig.SocketUser != "" &&
-			lnConfig.SocketGroup != "" {
+		// Any of mode/user/group may be set independently (e.g. mode-only).
+		if lnConfig.SocketMode != "" || lnConfig.SocketUser != "" || lnConfig.SocketGroup != "" {
 			uConfig = &listenerutil.UnixSocketsConfig{
 				Mode:  lnConfig.SocketMode,
 				User:  lnConfig.SocketUser,

--- a/internal/command/server/listener_unix.go
+++ b/internal/command/server/listener_unix.go
@@ -19,9 +19,8 @@ func unixListenerFactory(l *configutil.Listener, _ hclog.Logger, ui cli.Ui) (net
 	}
 
 	var cfg *listenerutil.UnixSocketsConfig
-	if l.SocketMode != "" &&
-		l.SocketUser != "" &&
-		l.SocketGroup != "" {
+	// Any of mode/user/group may be set independently (e.g. mode-only).
+	if l.SocketMode != "" || l.SocketUser != "" || l.SocketGroup != "" {
 		cfg = &listenerutil.UnixSocketsConfig{
 			Mode:  l.SocketMode,
 			User:  l.SocketUser,

--- a/internal/command/server/listener_unix_test.go
+++ b/internal/command/server/listener_unix_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,4 +26,24 @@ func TestUnixListener(t *testing.T) {
 	}
 
 	testListenerImpl(t, ln, connFn, "", 0, "", false)
+}
+
+func TestUnixListenerModeOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mode-only.sock")
+	ln, _, _, err := unixListenerFactory(&configutil.Listener{
+		Address:    path,
+		SocketMode: "660",
+	}, nil, cli.NewMockUi())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer ln.Close()
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o660 {
+		t.Fatalf("mode-only factory: got %o, want 660", fi.Mode().Perm())
+	}
 }

--- a/internal/helper/listenerutil/listener_test.go
+++ b/internal/helper/listenerutil/listener_test.go
@@ -6,6 +6,7 @@ package listenerutil
 import (
 	"os"
 	osuser "os/user"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
@@ -84,6 +85,28 @@ func TestUnixSocketListener(t *testing.T) {
 		}
 		if fi.Mode().Perm() != os.FileMode(mode) {
 			t.Fatal("failed to set permissions on the socket file")
+		}
+	})
+	t.Run("mode only", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mode-only.sock")
+		l, err := UnixSocketListener(path, &UnixSocketsConfig{
+			Mode: "660",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mode, err := strconv.ParseUint("660", 8, 32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != os.FileMode(mode) {
+			t.Fatalf("mode-only: got permissions %o, want %o", fi.Mode().Perm(), os.FileMode(mode))
 		}
 	})
 }


### PR DESCRIPTION
`socket_mode` alone did nothing: the unix listener factory only built the permission config when mode **and** user **and** group were all non-empty. `setFilePermissions` already allows mode-only (user/group default to the current process).

Switched those checks to OR and added mode-only coverage.

Fixes #2594