### PR TITLE
docs: Add kms plugin upgrade guide

### DIFF
--- a/website/content/docs/guides/upgrade/plugins.mdx
+++ b/website/content/docs/guides/upgrade/plugins.mdx
@@ -131,6 +131,26 @@ Until the last step, the mount will still run the first version of `my-db-plugin
 the reload is triggered, OpenBao will kill `my-db-plugin`’s process and start the
 new plugin process for `my-db-plugin` version 1.0.1.
 
+## Upgrading KMS plugins
+
+1. Edit the [`plugin` stanza](../../configuration/plugins.mdx) of your `kms` plugin
+   and change the `version` and `sha256sum` fields to the new values.
+
+1. Download the new plugin binary.
+
+   - For plugins distributed as raw binaries: Place the new binary into the `plugin_directory`.
+   - For plugins distributed as OCI artifacts with `plugin_auto_download = true`:
+     OpenBao will automatically download it at the config reload step.
+   - For plugins distributed as OCI artifacts with `plugin_auto_download = false`:
+     Run [`plugin init`](../../commands/plugin/init.mdx) to trigger the download.
+
+      ```shell-session
+      $ bao plugin init -config=/etc/openbao/openbao.hcl
+      ```
+
+1. Restart OpenBao or send a SIGHUP to reload the config.
+   OpenBao should now use the new `kms` plugin version.
+
 ## Downgrading plugins
 
 Plugin downgrades follow the same procedure as upgrades. You can use the OpenBao


### PR DESCRIPTION
## Description

Add kms plugin upgrade guide. Previously, there was no guide for kms plugins.

As pointed out in https://github.com/openbao/openbao-plugins/pull/121#discussion_r3730728021:

> perhaps we should add a mention of the KMS plugin upgrade process, which is the simplest of them all (replace binary, update config, restart server, done).

This PR will conflict with https://github.com/openbao/openbao/pull/3726. I'll rebase once that is merged.

## Rationale

Resolves: n/a

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
