### PR TITLE
Remove build info lookup from helper/versions

### DIFF
--- a/internal/helper/versions/version.go
+++ b/internal/helper/versions/version.go
@@ -5,10 +5,8 @@ package versions
 
 import (
 	"fmt"
-	"runtime/debug"
 	"slices"
 	"strings"
-	"sync"
 
 	semver "github.com/hashicorp/go-version"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -20,45 +18,11 @@ const (
 )
 
 var (
-	buildInfoOnce         sync.Once // once is used to ensure we only parse build info once.
-	buildInfo             *debug.BuildInfo
 	DefaultBuiltinVersion = fmt.Sprintf("v%s+%s.bao", version.GetVersion().Version, BuiltinMetadata)
 )
 
 func GetBuiltinVersion(pluginType consts.PluginType, pluginName string) string {
-	buildInfoOnce.Do(func() {
-		buildInfo, _ = debug.ReadBuildInfo()
-	})
-
-	// Should never happen, means the binary was built without Go modules.
-	// Fall back to just the Vault version.
-	if buildInfo == nil {
-		return DefaultBuiltinVersion
-	}
-
-	// Vault builtin plugins are all either:
-	// a) An external repo within the hashicorp org - return external repo version with +builtin
-	// b) Within the Vault repo itself - return Vault version with +builtin.bao
-	//
-	// The repo names are predictable, but follow slightly different patterns
-	// for each plugin type.
-	t := pluginType.String()
-	switch pluginType {
-	case consts.PluginTypeDatabase:
-		// Database plugin built-ins are registered as e.g. "postgresql-database-plugin"
-		pluginName = strings.TrimSuffix(pluginName, "-database-plugin")
-	case consts.PluginTypeSecrets:
-		// Repos use "secrets", pluginType.String() is "secret".
-		t = "secrets"
-	}
-	pluginModulePath := fmt.Sprintf("github.com/hashicorp/vault-plugin-%s-%s", t, pluginName)
-
-	for _, dep := range buildInfo.Deps {
-		if dep.Path == pluginModulePath {
-			return dep.Version + "+" + BuiltinMetadata
-		}
-	}
-
+	// pluginType and pluginName are ignored as of now.
 	return DefaultBuiltinVersion
 }
 


### PR DESCRIPTION
## Description

OpenBao's builtin plugin version string is effectively constant, this drops legacy dynamic builtin versions that only made sense with HashiCorp's repo layout.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
