### PR TITLE
Fix error wrapping in HTTP audit device header parsing

### DIFF
--- a/changelog/3746.txt
+++ b/changelog/3746.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit/http: Fix error wrapping in header parsing so the underlying cause is not lost.
+```

--- a/internal/builtin/audit/http/backend.go
+++ b/internal/builtin/audit/http/backend.go
@@ -84,7 +84,7 @@ func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, err
 			for _, value := range values {
 				modified, err := parseutil.ParsePath(value, parseutil.WithNoTrimSpaces(true), parseutil.WithErrorOnMissingEnv(true))
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse header %v: %w", header, nil)
+					return nil, fmt.Errorf("failed to parse header %v: %w", header, err)
 				}
 
 				headers.Add(header, modified)


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description
`fmt.Errorf("... %w", nil)` was used instead of `fmt.Errorf("... %w", err)` in HTTP audit device header parsing, producing `%!w(<nil>)` in the error message and losing the underlying cause from `parseutil.ParsePath`.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
