### PR TITLE
allow bao status to set output field

### DIFF
--- a/changelog/3750.txt
+++ b/changelog/3750.txt
@@ -2,5 +2,5 @@
 command/status: Add support for `-field` argument to `bao status`.
 ```
 ```release-note:improvement
-command/namespace/seal-status: Add support for `-field` argument to `bao namespace seal-status`.
+command/namespace/seal-status: Add support for `-field` and `-format` argument to `bao namespace seal-status`.
 ```

--- a/changelog/3750.txt
+++ b/changelog/3750.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/status: Add support for the `-field` argument
+```

--- a/changelog/3750.txt
+++ b/changelog/3750.txt
@@ -1,3 +1,6 @@
 ```release-note:improvement
 command/status: Add support for `-field` argument to `bao status`.
 ```
+```release-note:improvement
+command/namespace/seal-status: Add support for `-field` argument to `bao namespace seal-status`.
+```

--- a/changelog/3750.txt
+++ b/changelog/3750.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-command/status: Add support for the `-field` argument
+command/status: Add support for `-field` argument to `bao status`.
 ```

--- a/internal/command/format.go
+++ b/internal/command/format.go
@@ -629,8 +629,7 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]any) error {
 	return nil
 }
 
-// OutputSealStatus will print *api.SealStatusResponse in the CLI according to the format provided
-func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
+func buildSealStatusOutput(client *api.Client, status *api.SealStatusResponse) (*SealStatusOutput, error) {
 	sealStatusOutput := SealStatusOutput{SealStatusResponse: *status}
 
 	// Mask the 'Vault is sealed' error, since this means HA is enabled, but that
@@ -641,8 +640,7 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 		err = nil
 	}
 	if err != nil {
-		ui.Error(fmt.Sprintf("Error checking leader status: %s", err))
-		return 1
+		return nil, fmt.Errorf("Error checking leader status: %s", err)
 	}
 
 	// copy leaderStatus fields into sealStatusOutput for display later
@@ -653,7 +651,19 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 	sealStatusOutput.LeaderClusterAddress = leaderStatus.LeaderClusterAddress
 	sealStatusOutput.RaftCommittedIndex = leaderStatus.RaftCommittedIndex
 	sealStatusOutput.RaftAppliedIndex = leaderStatus.RaftAppliedIndex
-	OutputData(ui, sealStatusOutput)
+
+	return &sealStatusOutput, nil
+}
+
+// OutputSealStatus will print *api.SealStatusResponse in the CLI according to the format provided
+func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
+	sealStatusOutput, err := buildSealStatusOutput(client, status)
+	if err != nil {
+		ui.Error(err.Error())
+		return 1
+	}
+
+	OutputData(ui, *sealStatusOutput)
 	return 0
 }
 

--- a/internal/command/namespace_seal_status.go
+++ b/internal/command/namespace_seal_status.go
@@ -47,7 +47,7 @@ Usage: bao namespace seal-status [options] PATH
 }
 
 func (c *NamespaceSealStatusCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP | FlagSetOutputField)
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
 }
 
 func (c *NamespaceSealStatusCommand) AutocompleteArgs() complete.Predictor {

--- a/internal/command/namespace_seal_status.go
+++ b/internal/command/namespace_seal_status.go
@@ -47,7 +47,7 @@ Usage: bao namespace seal-status [options] PATH
 }
 
 func (c *NamespaceSealStatusCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP)
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField)
 }
 
 func (c *NamespaceSealStatusCommand) AutocompleteArgs() complete.Predictor {
@@ -89,7 +89,7 @@ func (c *NamespaceSealStatusCommand) Run(args []string) int {
 		return 2
 	}
 
-	return OutputData(c.UI, api.SealStatusResponse{
+	sealStatusResponse := api.SealStatusResponse{
 		Type:        status.Type,
 		Initialized: status.Initialized,
 		Sealed:      status.Sealed,
@@ -97,5 +97,12 @@ func (c *NamespaceSealStatusCommand) Run(args []string) int {
 		N:           status.N,
 		Progress:    status.Progress,
 		Nonce:       status.Nonce,
-	})
+	}
+
+	if c.flagField != "" {
+		sealStatusOutput := SealStatusOutput{SealStatusResponse: sealStatusResponse}
+		return PrintRawField(c.UI, &sealStatusOutput, c.flagField)
+	}
+
+	return OutputData(c.UI, sealStatusResponse)
 }

--- a/internal/command/namespace_seal_status_test.go
+++ b/internal/command/namespace_seal_status_test.go
@@ -44,6 +44,18 @@ func TestNamespaceSealStatusCommand_Run(t *testing.T) {
 			out:  "Too many arguments",
 			code: 1,
 		},
+		{
+			name: "field",
+			args: []string{"-field", "sealed", nsName},
+			out:  "true",
+			code: 0,
+		},
+		{
+			name: "field_not_found",
+			args: []string{"-field", "not-a-real-field", nsName},
+			out:  "not present in secret",
+			code: 1,
+		},
 	}
 	t.Run("validations", func(t *testing.T) {
 		t.Parallel()

--- a/internal/command/namespace_seal_status_test.go
+++ b/internal/command/namespace_seal_status_test.go
@@ -53,7 +53,7 @@ func TestNamespaceSealStatusCommand_Run(t *testing.T) {
 		{
 			name: "field_not_found",
 			args: []string{"-field", "not-a-real-field", nsName},
-			out:  "not present in secret",
+			out:  "not present",
 			code: 1,
 		},
 	}

--- a/internal/command/read_test.go
+++ b/internal/command/read_test.go
@@ -69,7 +69,7 @@ func TestReadCommand_Run(t *testing.T) {
 				"-field", "not-a-real-field",
 				"secret/read/foo",
 			},
-			"not present in secret",
+			"not present",
 			1,
 		},
 	}

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -43,7 +43,7 @@ Usage: bao status [options]
 }
 
 func (c *StatusCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
 }
 
 func (c *StatusCommand) AutocompleteArgs() complete.Predictor {
@@ -84,6 +84,19 @@ func (c *StatusCommand) Run(args []string) int {
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error checking seal status: %s", err))
 		return 1
+	}
+
+	if c.flagField != "" {
+		sealStatusOutput, err := buildSealStatusOutput(client, status)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+		PrintRawField(c.UI, sealStatusOutput, c.flagField)
+		if sealStatusOutput.Sealed {
+			return 2
+		}
+		return 0
 	}
 
 	// Do not return the int here yet, since we may want to return a custom error

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -46,6 +46,24 @@ func TestStatusCommand_Run(t *testing.T) {
 			2,
 		},
 		{
+			"field",
+			[]string{
+				"-field", "Sealed",
+			},
+			true,
+			"true",
+			2,
+		},
+		{
+			"field_not_found",
+			[]string{
+				"-field", "not-a-real-field",
+			},
+			true,
+			"not present in secret",
+			2,
+		},
+		{
 			"args",
 			[]string{"foo"},
 			false,

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -60,7 +60,7 @@ func TestStatusCommand_Run(t *testing.T) {
 				"-field", "not-a-real-field",
 			},
 			true,
-			"not present in secret",
+			"not present",
 			2,
 		},
 		{

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -48,7 +48,7 @@ func TestStatusCommand_Run(t *testing.T) {
 		{
 			"field",
 			[]string{
-				"-field", "Sealed",
+				"-field", "sealed",
 			},
 			true,
 			"true",

--- a/internal/command/token_create_test.go
+++ b/internal/command/token_create_test.go
@@ -68,7 +68,7 @@ func TestTokenCreateCommand_Run(t *testing.T) {
 			[]string{
 				"-field", "not-a-real-field",
 			},
-			"not present in secret",
+			"not present",
 			1,
 		},
 		{

--- a/internal/command/token_lookup_test.go
+++ b/internal/command/token_lookup_test.go
@@ -57,7 +57,7 @@ func TestTokenLookupCommand_Run(t *testing.T) {
 		{
 			"field_not_found",
 			[]string{"-field", "not-a-real-field"},
-			"not present in secret",
+			"not present",
 			1,
 		},
 	}

--- a/internal/command/unwrap_test.go
+++ b/internal/command/unwrap_test.go
@@ -65,7 +65,7 @@ func TestUnwrapCommand_Run(t *testing.T) {
 		{
 			"field_not_found",
 			[]string{"-field", "not-a-real-field"},
-			"not present in secret",
+			"not present",
 			1,
 		},
 	}

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
 	"github.com/openbao/openbao/v2/internal/command/config"
 	"github.com/openbao/openbao/v2/internal/command/token"
 )
@@ -94,52 +95,18 @@ func RawSecretField(secret *api.Secret, field string) any {
 func RawSealStatusField(status *SealStatusOutput, field string) any {
 	var val any
 	switch field {
-	case "Seal Type":
-		val = status.Type
-	case "Recovery Seal Type":
-		val = status.RecoverySealType
-	case "Initialized":
-		val = status.Initialized
-	case "Sealed":
-		val = status.Sealed
-	case "Total Recovery Shares", "Total Shares":
-		val = status.N
-	case "Threshold":
-		val = status.T
-	case "Unseal Progress":
+	case "unseal_progress":
 		val = fmt.Sprintf("%d/%d", status.Progress, status.T)
-	case "Unseal Nonce":
-		val = status.Nonce
-	case "Seal Migration in Progress":
-		val = status.Migration
-	case "Version":
-		val = status.Version
-	case "Commit Date":
-		val = status.CommitDate
-	case "Storage Type":
-		val = status.StorageType
-	case "Cluster Name":
-		val = status.ClusterName
-	case "Cluster ID":
-		val = status.ClusterID
-	case "HA Enabled":
-		val = status.HAEnabled
-	case "HA Cluster":
-		val = status.LeaderClusterAddress
-	case "HA Mode":
+	case "ha_mode":
 		mode := "standby"
 		if status.IsSelf {
 			mode = "active"
 		}
 		val = mode
-	case "Active Since":
+	case "active_since":
 		val = status.ActiveTime.Format(time.RFC3339Nano)
-	case "Active Node Address":
-		val = status.LeaderAddress
-	case "Raft Committed Index":
-		val = status.RaftCommittedIndex
-	case "Raft Applied Index":
-		val = status.RaftAppliedIndex
+	default:
+		val = structtomap.Map(status)[field]
 	}
 
 	return val

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -103,7 +103,7 @@ func RawSealStatusField(status *SealStatusOutput, field string) any {
 			mode = "active"
 		}
 		val = mode
-	case "active_since":
+	case "active_time":
 		val = status.ActiveTime.Format(time.RFC3339Nano)
 	default:
 		val = structtomap.Map(status)[field]

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -22,9 +22,9 @@ func DefaultTokenHelper(vaultAddr string) (token.TokenHelper, error) {
 	return config.DefaultTokenHelper(vaultAddr)
 }
 
-// RawField extracts the raw field from the given data and returns it as a
+// RawSecretField extracts the raw field from the given secret data and returns it as a
 // string for printing purposes.
-func RawField(secret *api.Secret, field string) any {
+func RawSecretField(secret *api.Secret, field string) any {
 	var val any
 	switch {
 	case secret.Auth != nil:
@@ -91,12 +91,68 @@ func RawField(secret *api.Secret, field string) any {
 	return val
 }
 
+func RawSealStatusField(status *SealStatusOutput, field string) any {
+	var val any
+	switch field {
+	case "Seal Type":
+		val = status.Type
+	case "Recovery Seal Type":
+		val = status.RecoverySealType
+	case "Initialized":
+		val = status.Initialized
+	case "Sealed":
+		val = status.Sealed
+	case "Total Recovery Shares", "Total Shares":
+		val = status.N
+	case "Threshold":
+		val = status.T
+	case "Unseal Progress":
+		val = fmt.Sprintf("%d/%d", status.Progress, status.T)
+	case "Unseal Nonce":
+		val = status.Nonce
+	case "Seal Migration in Progress":
+		val = status.Migration
+	case "Version":
+		val = status.Version
+	case "Commit Date":
+		val = status.CommitDate
+	case "Storage Type":
+		val = status.StorageType
+	case "Cluster Name":
+		val = status.ClusterName
+	case "Cluster ID":
+		val = status.ClusterID
+	case "HA Enabled":
+		val = status.HAEnabled
+	case "HA Cluster":
+		val = status.LeaderClusterAddress
+	case "HA Mode":
+		mode := "standby"
+		if status.IsSelf {
+			mode = "active"
+		}
+		val = mode
+	case "Active Since":
+		val = status.ActiveTime.Format(time.RFC3339Nano)
+	case "Active Node Address":
+		val = status.LeaderAddress
+	case "Raft Committed Index":
+		val = status.RaftCommittedIndex
+	case "Raft Applied Index":
+		val = status.RaftAppliedIndex
+	}
+
+	return val
+}
+
 // PrintRawField prints raw field from the secret.
 func PrintRawField(ui cli.Ui, data any, field string) int {
 	var val any
 	switch data := data.(type) {
 	case *api.Secret:
-		val = RawField(data, field)
+		val = RawSecretField(data, field)
+	case *SealStatusOutput:
+		val = RawSealStatusField(data, field)
 	case map[string]any:
 		val = data[field]
 	}

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -112,20 +112,27 @@ func RawSealStatusField(status *SealStatusOutput, field string) any {
 	return val
 }
 
-// PrintRawField prints raw field from the secret.
+// PrintRawField prints a raw field from a data structure.
 func PrintRawField(ui cli.Ui, data any, field string) int {
 	var val any
+	var typeName string
 	switch data := data.(type) {
 	case *api.Secret:
+		typeName = "secret"
 		val = RawSecretField(data, field)
 	case *SealStatusOutput:
+		typeName = "seal status"
 		val = RawSealStatusField(data, field)
 	case map[string]any:
+		typeName = "map"
 		val = data[field]
+	default:
+		ui.Error(fmt.Sprintf("%T is not supported by PrintRawField", data))
+		return 1
 	}
 
 	if val == nil {
-		ui.Error(fmt.Sprintf("Field %q not present in secret", field))
+		ui.Error(fmt.Sprintf("Field %q not present in %s", field, typeName))
 		return 1
 	}
 	format := Format(ui)

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -95,8 +95,6 @@ func RawSecretField(secret *api.Secret, field string) any {
 func RawSealStatusField(status *SealStatusOutput, field string) any {
 	var val any
 	switch field {
-	case "unseal_progress":
-		val = fmt.Sprintf("%d/%d", status.Progress, status.T)
 	case "ha_mode":
 		mode := "standby"
 		if status.IsSelf {

--- a/internal/command/write_test.go
+++ b/internal/command/write_test.go
@@ -89,7 +89,7 @@ func TestWriteCommand_Run(t *testing.T) {
 				"-field", "not-a-real-field",
 				"auth/token/create", "display_name=foo",
 			},
-			"not present in secret",
+			"not present",
 			1,
 		},
 	}

--- a/internal/command/write_test.go
+++ b/internal/command/write_test.go
@@ -94,27 +94,31 @@ func TestWriteCommand_Run(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
 
-			client, closer := testVaultServer(t)
-			defer closer()
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 
-			ui, cmd := testWriteCommand(t)
-			cmd.client = client
+				client, closer := testVaultServer(t)
+				defer closer()
 
-			code := cmd.Run(tc.args)
-			if code != tc.code {
-				t.Errorf("expected %d to be %d", code, tc.code)
-			}
+				ui, cmd := testWriteCommand(t)
+				cmd.client = client
 
-			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
-			if !strings.Contains(combined, tc.out) {
-				t.Errorf("expected %q to contain %q", combined, tc.out)
-			}
-		})
-	}
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
 
 	t.Run("force", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Description

I noticed that the `bao status` command didn't support the `-field` output. This merge request aims to add that functionality (including tests)

## Rationale

Resolves: #3749 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
