### PR TITLE
Make providing a plugin sha256sum optional

### DIFF
--- a/changelog/3759.txt
+++ b/changelog/3759.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core/plugins: Declarative plugin registration (`plugin` stanza) no longer requires setting a `sha256sum` for manually installed plugin binaries.
+```

--- a/internal/command/server/config.go
+++ b/internal/command/server/config.go
@@ -380,7 +380,9 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 		})
 	}
 
-	if p.Image != "" {
+	isOCI := p.Image != ""
+
+	if isOCI {
 		// Ensure Image:Version is a valid image reference
 		if _, err := name.ParseReference(p.URL()); err != nil {
 			results = append(results, configutil.ConfigError{
@@ -389,7 +391,7 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 		}
 	}
 
-	if typ != consts.PluginTypeKMS || p.Image != "" {
+	if isOCI || typ != consts.PluginTypeKMS {
 		// Validate version is not empty. KMS plugins do not require or enforce
 		// that a version is set. OCI-based plugins however require a version be
 		// set at all times.
@@ -400,12 +402,16 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 		}
 	}
 
-	// Validate sha256sum is exactly 64 hex characters
-	if len(p.SHA256Sum) != 64 {
+	switch {
+	case len(p.SHA256Sum) == 0 && !isOCI:
+		// sha256sum may be omitted unless OCI images are used, where they are
+		// required as cache sentinels.
+	case len(p.SHA256Sum) != 64:
+		// Unless omitted, validate sha256sum is exactly 64 hex characters.
 		results = append(results, configutil.ConfigError{
 			Problem: fmt.Sprintf("plugin %q: sha256sum must be exactly 64 characters, got %d", p.Slug(), len(p.SHA256Sum)),
 		})
-	} else {
+	default:
 		// Check if it's valid hex
 		_, err := hex.DecodeString(p.SHA256Sum)
 		if err != nil {

--- a/internal/helper/kmsplugin/catalog.go
+++ b/internal/helper/kmsplugin/catalog.go
@@ -145,9 +145,17 @@ func (c *Catalog) getClientLocked(name string) (*client, bool, error) {
 		return nil, true, err
 	}
 
-	checksum, err := hex.DecodeString(config.SHA256Sum)
-	if err != nil {
-		return nil, true, fmt.Errorf("invalid plugin sha256: %w", err)
+	// Supply a SecureConfig if a sha256 checksum is configured.
+	var secureConfig *plugin.SecureConfig
+	if len(config.SHA256Sum) > 0 {
+		checksum, err := hex.DecodeString(config.SHA256Sum)
+		if err != nil {
+			return nil, true, fmt.Errorf("invalid plugin sha256: %w", err)
+		}
+		secureConfig = &plugin.SecureConfig{
+			Checksum: checksum,
+			Hash:     sha256.New(),
+		}
 	}
 
 	// Spawn a new plugin process.
@@ -161,10 +169,7 @@ func (c *Catalog) getClientLocked(name string) (*client, bool, error) {
 		HandshakeConfig:  gkwplugin.HandshakeConfig,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		AutoMTLS:         true,
-		SecureConfig: &plugin.SecureConfig{
-			Checksum: checksum,
-			Hash:     sha256.New(),
-		},
+		SecureConfig:     secureConfig,
 		// go-plugin will create a sub-logger with the plugin executable's name,
 		// so avoid duplicating that here and pass the catalog's logger without
 		// modification.

--- a/internal/helper/kmsplugin/catalog.go
+++ b/internal/helper/kmsplugin/catalog.go
@@ -110,9 +110,17 @@ func (c *Catalog) getClientLocked(name string) (*client, bool, error) {
 		return nil, true, err
 	}
 
-	checksum, err := hex.DecodeString(config.SHA256Sum)
-	if err != nil {
-		return nil, true, fmt.Errorf("invalid plugin sha256: %w", err)
+	// Supply a SecureConfig if a sha256 checksum is configured.
+	var secureConfig *plugin.SecureConfig
+	if len(config.SHA256Sum) > 0 {
+		checksum, err := hex.DecodeString(config.SHA256Sum)
+		if err != nil {
+			return nil, true, fmt.Errorf("invalid plugin sha256: %w", err)
+		}
+		secureConfig = &plugin.SecureConfig{
+			Checksum: checksum,
+			Hash:     sha256.New(),
+		}
 	}
 
 	// Spawn a new plugin process.
@@ -126,10 +134,7 @@ func (c *Catalog) getClientLocked(name string) (*client, bool, error) {
 		HandshakeConfig:  gkwplugin.HandshakeConfig,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		AutoMTLS:         true,
-		SecureConfig: &plugin.SecureConfig{
-			Checksum: checksum,
-			Hash:     sha256.New(),
-		},
+		SecureConfig:     secureConfig,
 		// go-plugin will create a sub-logger with the plugin executable's name,
 		// so avoid duplicating that here and pass the catalog's logger without
 		// modification.

--- a/internal/helper/kmsplugin/catalog_test.go
+++ b/internal/helper/kmsplugin/catalog_test.go
@@ -157,16 +157,6 @@ func TestBadClientConfig(t *testing.T) {
 			PluginDirectory: t.TempDir(),
 			Plugins:         []*server.PluginConfig{StaticPluginConfig},
 		},
-		"NoChecksum": {
-			PluginDirectory: filepath.Dir(os.Args[0]),
-			Plugins: []*server.PluginConfig{{
-				Type:    StaticPluginConfig.Type,
-				Name:    StaticPluginConfig.Name,
-				Command: StaticPluginConfig.Command,
-				Args:    StaticPluginConfig.Args,
-				Env:     StaticPluginConfig.Env,
-			}},
-		},
 		"BadChecksum": {
 			PluginDirectory: filepath.Dir(os.Args[0]),
 			Plugins: []*server.PluginConfig{{

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -152,7 +152,7 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	var backend logical.Backend
 	// Create the new backend
 	sysView := c.mountEntrySysView(entry)
-	backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
+	backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
 	}
@@ -169,14 +169,6 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 	backendType := backend.Type()
 	if backendType != logical.TypeCredential {
 		return fmt.Errorf("cannot mount %q of type %q as an auth backend", entry.Type, backendType)
-	}
-	// update the entry running version with the configured version, which was verified during registration.
-	entry.RunningVersion = entry.Version
-	if entry.RunningVersion == "" {
-		// don't set the running version to a builtin if it is running as an external plugin
-		if entry.RunningSha256 == "" {
-			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-		}
 	}
 
 	// Update the auth table
@@ -1129,7 +1121,7 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 	// Initialize the backend
 	var backend logical.Backend
 	sysView := c.mountEntrySysView(entry)
-	backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
+	backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	if err != nil {
 		c.logger.Error("failed to create credential entry", "path", entry.Path, "error", err)
 		if !c.isMountable(ctx, entry, consts.PluginTypeCredential) {
@@ -1138,14 +1130,6 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 
 		c.logger.Warn("skipping plugin-based auth entry", "path", entry.Path)
 	} else {
-		// update the entry running version with the configured
-		// version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" && entry.RunningSha256 == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-		}
-
 		// Do not start up deprecated builtin plugins. If this is a major
 		// upgrade, stop unsealing and shutdown. If we've already mounted this
 		// plugin, skip backend initialization and mount the data for posterity.
@@ -1250,35 +1234,39 @@ func (c *Core) teardownCredentials(ctx context.Context) error {
 
 // newCredentialBackend is used to create and configure a new credential backend by name.
 // It also returns the SHA256 of the plugin, if available.
-func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, string, error) {
+func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, error) {
 	t := entry.Type
 	if alias, ok := credentialAliases[t]; ok {
 		t = alias
 	}
 
-	var runningSha string
+	var runningSha, runningVersion string
+
 	f, ok := c.credentialBackends[t]
 	if !ok {
 		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeCredential, entry.Version)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 		if plug == nil {
 			errContext := t
 			if entry.Version != "" {
 				errContext += fmt.Sprintf(", version=%s", entry.Version)
 			}
-			return nil, "", fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
 		}
-		if len(plug.Sha256) > 0 {
-			runningSha = hex.EncodeToString(plug.Sha256)
-		}
+
+		runningSha = hex.EncodeToString(plug.Sha256)
+		runningVersion = plug.Version
 
 		f = plugin.Factory
 		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
+	} else {
+		runningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, t)
 	}
+
 	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
 	maps.Copy(conf, entry.Options)
@@ -1306,13 +1294,16 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *routing.MountEnt
 
 	b, err := f(ctx, config)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	if b == nil {
-		return nil, "", fmt.Errorf("nil backend of type %q returned from factory", t)
+		return nil, fmt.Errorf("nil backend of type %q returned from factory", t)
 	}
 
-	return b, runningSha, nil
+	entry.RunningSha256 = runningSha
+	entry.RunningVersion = runningVersion
+
+	return b, nil
 }
 
 // defaultAuthTable creates a default auth table

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -502,6 +502,10 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, _ *logica
 		return logical.ErrorResponse("Could not decode SHA-256 value from Hex"), err
 	}
 
+	if len(sha256Bytes) != 32 {
+		return logical.ErrorResponse("Decoded SHA-256 value is not 32 bytes"), nil
+	}
+
 	err = b.Core.pluginCatalog.Set(ctx, pluginName, pluginType, pluginVersion, parts[0], args, env, sha256Bytes, oci)
 	if err != nil {
 		if errors.Is(err, ErrPluginNotFound) || strings.HasPrefix(err.Error(), "plugin version mismatch") {

--- a/internal/vault/logical_system_test.go
+++ b/internal/vault/logical_system_test.go
@@ -48,6 +48,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var fakeSHA256 = strings.Repeat("0", 64)
+
 func TestSystemBackend_RootPaths(t *testing.T) {
 	expected := []string{
 		"auth/*",
@@ -3674,7 +3676,7 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	command := fmt.Sprintf("%s --test", filepath.Base(file.Name()))
 	req = logical.TestRequest(t, logical.UpdateOperation, "plugins/catalog/database/test-plugin")
 	req.Data["args"] = []string{"--foo"}
-	req.Data["sha_256"] = hex.EncodeToString([]byte{'1'})
+	req.Data["sha_256"] = fakeSHA256
 	req.Data["command"] = command
 	resp, err = b.HandleRequest(namespace.RootContext(t.Context()), req)
 	if err != nil {
@@ -3708,7 +3710,7 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 		"name":        "test-plugin",
 		"command":     filepath.Base(file.Name()),
 		"args":        []string{"--test"},
-		"sha256":      "31",
+		"sha256":      fakeSHA256,
 		"builtin":     false,
 		"version":     "",
 		"oci":         false,
@@ -3741,7 +3743,7 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 	// Add a versioned plugin, and check we get the version back in the right form when we read.
 	req = logical.TestRequest(t, logical.UpdateOperation, "plugins/catalog/database/test-plugin")
 	req.Data["version"] = "v0.1.0"
-	req.Data["sha_256"] = hex.EncodeToString([]byte{'1'})
+	req.Data["sha_256"] = fakeSHA256
 	req.Data["command"] = command
 	resp, err = b.HandleRequest(namespace.RootContext(t.Context()), req)
 	if err != nil || resp.Error() != nil {
@@ -3760,7 +3762,7 @@ func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {
 		"name":        "test-plugin",
 		"command":     filepath.Base(file.Name()),
 		"args":        []string{"--test"},
-		"sha256":      "31",
+		"sha256":      fakeSHA256,
 		"builtin":     false,
 		"version":     "v0.1.0",
 		"oci":         false,
@@ -3860,7 +3862,7 @@ func TestSystemBackend_PluginCatalog_List(t *testing.T) {
 
 	// Set a plugin
 	req := logical.TestRequest(t, logical.UpdateOperation, "plugins/catalog/database/test-plugin")
-	req.Data["sha256"] = hex.EncodeToString([]byte{'1'})
+	req.Data["sha256"] = fakeSHA256
 	req.Data["command"] = "foo"
 	req.Data["version"] = "v1.2.3"
 	resp, err := b.HandleRequest(namespace.RootContext(t.Context()), req)
@@ -3977,7 +3979,7 @@ func TestSystemBackend_PluginCatalog_List(t *testing.T) {
 				"type":               "database",
 				"version":            "v2.0.0+builtin.bao",
 			}, {
-				"sha256":  "31",
+				"sha256":  fakeSHA256,
 				"builtin": false,
 				"name":    "test-plugin",
 				"type":    "database",

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -287,7 +287,7 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	var backend logical.Backend
 	// Create the new backend
 	sysView := c.mountEntrySysView(entry)
-	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
+	backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		return err
 	}
@@ -305,15 +305,6 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 	if backendType != logical.TypeLogical {
 		if err := knownMountType(entry.Type); err != nil {
 			return err
-		}
-	}
-
-	// update the entry running version with the configured version, which was verified during registration.
-	entry.RunningVersion = entry.Version
-	if entry.RunningVersion == "" {
-		// don't set the running version to a builtin if it is running as an external plugin
-		if entry.RunningSha256 == "" {
-			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
 		}
 	}
 
@@ -1512,7 +1503,7 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 	// Create the new backend
 	var backend logical.Backend
 	sysView := c.mountEntrySysView(entry)
-	backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
+	backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	if err != nil {
 		c.logger.Error("failed to create mount entry", "path", entry.Path, "error", err)
 		if !c.isMountable(ctx, entry, consts.PluginTypeSecrets) {
@@ -1521,14 +1512,6 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 
 		c.logger.Warn("skipping plugin-based mount entry", "path", entry.Path)
 	} else {
-		// update the entry running version with the configured
-		// version, which was verified during registration.
-		entry.RunningVersion = entry.Version
-		if entry.RunningVersion == "" && entry.RunningSha256 == "" {
-			// don't set the running version to a builtin if it is running as an external plugin
-			entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
-		}
-
 		// Do not start up deprecated builtin plugins. If this is a major
 		// upgrade, stop unsealing and shutdown. If we've already mounted this
 		// plugin, proceed with unsealing and skip backend initialization.
@@ -1618,35 +1601,38 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 
 // newLogicalBackend is used to create and configure a new logical backend by name.
 // It also returns the SHA256 of the plugin, if available.
-func (c *Core) newLogicalBackend(ctx context.Context, entry *routing.MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, string, error) {
+func (c *Core) newLogicalBackend(ctx context.Context, entry *routing.MountEntry, sysView logical.SystemView, view logical.Storage) (logical.Backend, error) {
 	t := entry.Type
 	if alias, ok := mountAliases[t]; ok {
 		t = alias
 	}
 
-	var runningSha string
+	var runningSha, runningVersion string
 	f, ok := c.logicalBackends[t]
 	if !ok {
 		plug, err := c.pluginCatalog.Get(ctx, t, consts.PluginTypeSecrets, entry.Version)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 		if plug == nil {
 			errContext := t
 			if entry.Version != "" {
 				errContext += fmt.Sprintf(", version=%s", entry.Version)
 			}
-			return nil, "", fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, errContext)
 		}
-		if len(plug.Sha256) > 0 {
-			runningSha = hex.EncodeToString(plug.Sha256)
-		}
+
+		runningSha = hex.EncodeToString(plug.Sha256)
+		runningVersion = plug.Version
 
 		f = plugin.Factory
 		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
+	} else {
+		runningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, t)
 	}
+
 	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
 	maps.Copy(conf, entry.Options)
@@ -1676,13 +1662,16 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *routing.MountEntry,
 	ctx = context.WithValue(ctx, "core_number", c.coreNumber)
 	b, err := f(ctx, config)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	if b == nil {
-		return nil, "", fmt.Errorf("nil backend of type %q returned from factory", t)
+		return nil, fmt.Errorf("nil backend of type %q returned from factory", t)
 	}
 
-	return b, runningSha, nil
+	entry.RunningSha256 = runningSha
+	entry.RunningVersion = runningVersion
+
+	return b, nil
 }
 
 // defaultMountTable creates a default mount table

--- a/internal/vault/plugin_reload.go
+++ b/internal/vault/plugin_reload.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
-	"github.com/openbao/openbao/v2/internal/helper/versions"
 	"github.com/openbao/openbao/v2/internal/vault/routing"
 
 	"github.com/hashicorp/go-multierror"
@@ -181,39 +180,25 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *routing.MountEntr
 
 	var backend logical.Backend
 	var err error
-	oldSha := entry.RunningSha256
+	oldSha, oldVersion := entry.RunningSha256, entry.RunningVersion
 	if !isAuth {
 		// Dispense a new backend
-		backend, entry.RunningSha256, err = c.newLogicalBackend(ctx, entry, sysView, view)
+		backend, err = c.newLogicalBackend(ctx, entry, sysView, view)
 	} else {
-		backend, entry.RunningSha256, err = c.newCredentialBackend(ctx, entry, sysView, view)
+		backend, err = c.newCredentialBackend(ctx, entry, sysView, view)
 	}
 	if err != nil {
 		return err
 	}
 
-	// update the entry running version with the configured version, which was verified during registration.
-	entry.RunningVersion = entry.Version
-	if entry.RunningVersion == "" {
-		// don't set the running version to a builtin if it is running as an external plugin
-		if entry.RunningSha256 == "" {
-			if isAuth {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeCredential, entry.Type)
-			} else {
-				entry.RunningVersion = versions.GetBuiltinVersion(consts.PluginTypeSecrets, entry.Type)
-			}
-		}
-	}
-
-	// update the mount table since we changed the runningSha
-	if oldSha != entry.RunningSha256 {
+	// Update the mount table since we changed the runningSha or runningVersion.
+	if oldSha != entry.RunningSha256 || oldVersion != entry.RunningVersion {
 		barrier := c.NamespaceView(entry.Namespace)
 		if isAuth {
 			err = c.persistAuth(ctx, barrier, c.auth, &entry.Local, entry.UUID)
 		} else {
 			err = c.persistMounts(ctx, barrier, c.mounts, &entry.Local, entry.UUID)
 		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/vault/routing/mount_entry.go
+++ b/internal/vault/routing/mount_entry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mitchellh/copystructure"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
+	"github.com/openbao/openbao/v2/internal/helper/versions"
 )
 
 // MountEntry is used to represent a mount table entry
@@ -61,10 +62,9 @@ func (e *MountEntry) Clone() (*MountEntry, error) {
 	return cp.(*MountEntry), nil
 }
 
-// IsExternalPlugin returns whether the plugin is running externally
-// if the RunningSha256 is non-empty, the builtin is external. Otherwise, it's builtin
+// IsExternalPlugin returns whether the plugin is an external one.
 func (e *MountEntry) IsExternalPlugin() bool {
-	return e.RunningSha256 != ""
+	return !versions.IsBuiltinVersion(e.RunningVersion)
 }
 
 // MountClass returns the mount class based on Accessor and Path

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -96,9 +96,13 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", api.UpstreamVariableName(PluginUnwrapTokenEnv), wrapToken))
 	}
 
-	secureConfig := &plugin.SecureConfig{
-		Checksum: rc.sha256,
-		Hash:     sha256.New(),
+	// Supply a SecureConfig if a sha256 checksum is configured.
+	var secureConfig *plugin.SecureConfig
+	if len(rc.sha256) > 0 {
+		secureConfig = &plugin.SecureConfig{
+			Checksum: rc.sha256,
+			Hash:     sha256.New(),
+		}
 	}
 
 	clientConfig := &plugin.ClientConfig{

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -64,7 +64,6 @@ plugin_auto_register = true
 plugin "type" "name" {
   command     = "plugin-binary-name"
   version     = "v0.0.0"
-  sha256sum   = "sha256-checksum"
   env         = ["MY_ENV=value"]
   args        = ["-some-argument"]
 }
@@ -80,17 +79,30 @@ plugin versions.
 
 ### Parameters
 
-- `image` `(string: required)` - OCI artifact/image URL including registry and repository. Conflicts with the `command` value. One of `image` or `command` is required.
+- `image` `(string: required)` - OCI artifact/image URL including registry and
+  repository. Conflicts with the `command` value. One of `image` or `command` is
+  required.
 
-- `command` `(string: required)` - Command name of the plugin that has been manually downloaded. Conflicts with the `image` value. One of `image` or `command` is required.
+- `command` `(string: required)` - Command name of the plugin that has been
+  manually downloaded. Conflicts with the `image` value. One of `image` or
+  `command` is required.
 
-- `version` `(string: required)` - The image version or tag.
+- `version` `(string: required)` - The (semantic) version of the plugin. When
+  `image` is set, this doubles as the image tag on the registry.
 
-- `sha256sum` `(string: required)` - Expected SHA-256 digest of the plugin binary. Must be a 64-character hexadecimal string.
+- `sha256sum` `(string: optional)` - Expected SHA-256 digest of the plugin
+  binary. Must be a 64-character hexadecimal string. This is **required**
+  when `image` is set, but **optional** otherwise. When set, OpenBao will
+  revalidate the digest of the plugin binary on disk against what was configured
+  before executing the plugin, though note that the check is subject to a
+  [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) problem.
 
-- `args` `([]string: optional)` - Any arguments to pass to the running plugin. Only used if `plugin_auto_register=true` is set at the global level.
+- `args` `([]string: optional)` - Any arguments to pass to the running plugin.
+  Only used if `plugin_auto_register=true` is set at the global level.
 
-- `env` `([]string: optional)` - Any environment variables to pass to the running plugin. Only used if `plugin_auto_register=true` is set at the global level.
+- `env` `([]string: optional)` - Any environment variables to pass to the
+  running plugin. Only used if `plugin_auto_register=true` is set at the global
+  level.
 
 - `binary_name` `(string: optional)` - Name of the plugin binary file
   within the OCI image. Only applies when `image` is set. If unset, OpenBao

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -62,7 +62,6 @@ Or it specifies a plugin to automatically register that was manually downloaded:
 plugin "type" "name" {
   command     = "plugin-binary-name"
   version     = "v0.0.0"
-  sha256sum   = "sha256-checksum"
   env         = ["MY_ENV=value"]
   args        = ["-some-argument"]
 }
@@ -78,13 +77,23 @@ plugin versions.
 
 ### Parameters
 
-- `image` `(string: required)` - OCI artifact/image URL including registry and repository. Conflicts with the `command` value. One of `image` or `command` is required.
+- `image` `(string: required)` - OCI artifact/image URL including registry and
+  repository. Conflicts with the `command` value. One of `image` or `command` is
+  required.
 
-- `command` `(string: required)` - Command name of the plugin that has been manually downloaded. Conflicts with the `image` value. One of `image` or `command` is required.
+- `command` `(string: required)` - Command name of the plugin that has been
+  manually downloaded. Conflicts with the `image` value. One of `image` or
+  `command` is required.
 
-- `version` `(string: required)` - The image version or tag.
+- `version` `(string: required)` - The (semantic) version of the plugin. When
+  `image` is set, this doubles as the image tag on the registry.
 
-- `sha256sum` `(string: required)` - Expected SHA-256 digest of the plugin binary. Must be a 64-character hexadecimal string.
+- `sha256sum` `(string: optional)` - Expected SHA-256 digest of the plugin
+  binary. Must be a 64-character hexadecimal string. This is **required**
+  when `image` is set, but **optional** otherwise. When set, OpenBao will
+  revalidate the digest of the plugin binary on disk against what was configured
+  before executing the plugin, though note that the check is subject to a
+  [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) problem.
 
 - `args` `([]string: optional)` - Any arguments to pass to the running plugin.
 

--- a/website/content/docs/configuration/seal/index.mdx
+++ b/website/content/docs/configuration/seal/index.mdx
@@ -75,7 +75,6 @@ For example, to use the `pkcs11` seal, you must install the `pkcs11` KMS plugin:
 ```hcl
 plugin "kms" "pkcs11" {
   command = "openbao-plugin-kms-pkcs11"
-  sha256sum = "..."
 }
 
 seal "pkcs11" {

--- a/website/content/docs/plugins/plugin-architecture.mdx
+++ b/website/content/docs/plugins/plugin-architecture.mdx
@@ -99,7 +99,6 @@ plugin_auto_register = true
 plugin "database" "myplugin" {
     command = "myplugin-database-plugin"    
     version = "v0.0.0"
-    sha256sum = "<SHA256 Hex value of the plugin binary>"
 }
 ```
 

--- a/website/content/docs/plugins/plugin-architecture.mdx
+++ b/website/content/docs/plugins/plugin-architecture.mdx
@@ -97,7 +97,6 @@ An example of declarative plugin registration via the configuration file:
 plugin "database" "myplugin" {
     command = "myplugin-database-plugin"    
     version = "v0.0.0"
-    sha256sum = "<SHA256 Hex value of the plugin binary>"
 }
 ```
 

--- a/website/content/docs/plugins/plugin-installation.mdx
+++ b/website/content/docs/plugins/plugin-installation.mdx
@@ -32,16 +32,7 @@ that OpenBao may load and execute (depending on their other access and how OpenB
 
 :::
 
-## Step 2: Obtain the checksum
-
-Obtain the SHA-256 digest for your plugin binary, for example, from the
-[openbao-plugins](https://github.com/openbao/openbao-plugins/releases) releases page
-or by running `sha256sum`.
-
-You will need this checksum later when you register the plugin with OpenBao.
-This allows OpenBao to check the integrity of the plugin before executing it.
-
-## Step 3: Download plugin binary
+## Step 2: Download plugin binary
 
 There are two distribution/packaging mechanisms for external plugins: _raw binaries_ and _OCI artifacts_.
 Depending on which mechanism you choose, the installation process differs.
@@ -65,7 +56,11 @@ The download happens either automatically (if you enable auto-download) or manua
 
 Steps to install the plugin:
 
-1. Define a [`plugin` stanza](../configuration/plugins.mdx) with an `image` field.
+1. Obtain the SHA-256 digest for your plugin binary, for example, from the
+  [openbao-plugins](https://github.com/openbao/openbao-plugins/releases)
+  releases page.
+1. Define a [`plugin` stanza](../configuration/plugins.mdx) with `image` and
+   `sha256sum` fields.
 1. Trigger OpenBao to download the artifact. You have two options:
    1. Run [`bao plugin init`](../commands/plugin/init.mdx), or
    1. Enable auto-download in the config file. Then restart OpenBao or send a SIGHUP.


### PR DESCRIPTION
## Description

This makes specifying the `sha256sum` of a plugin binary optional when registering it via a declarative `plugin` stanza and not using OCI-based distribution. API-based registrations keep enforcing that a checksum is provided in all cases.

## Rationale

~~TODO: Write the rant, then get told to RFC it anyway.~~

Rant is at https://github.com/openbao/openbao/pull/3881.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
