### PR TITLE
Add initial support to PKI for external keys

### DIFF
--- a/internal/builtin/logical/pki/ca_util.go
+++ b/internal/builtin/logical/pki/ca_util.go
@@ -34,6 +34,19 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		return exported, format, role, errorResp
 	}
 
+	if exportedStr == "kms" && getExternalKeyRef(data) == "" {
+		errorResp = logical.ErrorResponse(
+			`must specify "external_key_ref" on "kms"-typed generation requests`,
+		)
+		return exported, format, role, errorResp
+	} else if exportedStr != "kms" && getExternalKeyRef(data) != "" {
+		errorResp = logical.ErrorResponse(
+			`cannot specify "external_key_ref" on %q-typed generation requests`,
+			exportedStr,
+		)
+		return exported, format, role, errorResp
+	}
+
 	format = getFormat(data)
 	if format == "" {
 		errorResp = logical.ErrorResponse(
@@ -83,6 +96,8 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 }
 
 func generateCABundle(sc *storageContext, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
+	var generator certutil.KeyGenerator
+
 	if existingKeyRequested(input) {
 		keyRef, err := getKeyRefWithErr(input.apiData)
 		if err != nil {
@@ -94,10 +109,33 @@ func generateCABundle(sc *storageContext, input *inputBundle, data *certutil.Cre
 			return nil, err
 		}
 
-		return certutil.CreateCertificateWithKeyGenerator(data, randomSource, existingKeyGeneratorFromBytes(keyEntry))
+		generator = existingKeyGeneratorFromBytes(keyEntry)
 	}
 
-	return certutil.CreateCertificateWithRandomSource(data, randomSource)
+	if externalKeyRequested(input) {
+		keyRef, err := getExternalKeyRefWithErr(input.apiData)
+		if err != nil {
+			return nil, err
+		}
+
+		signer, err := sc.getExternalSigner(keyRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get external key: %w", err)
+		}
+
+		pubType := certutil.GetPrivateKeyTypeFromSigner(signer)
+
+		generator = func(keyType string, keyBits int, container certutil.ParsedPrivateKeyContainer, entropyReader io.Reader) error {
+			if keyType != string(pubType) && keyType != "" && keyType != "external-key" {
+				return fmt.Errorf("external key of type %v does not match generation expectations %v", pubType, keyType)
+			}
+
+			container.SetParsedPrivateKey(signer, certutil.ExternalPrivateKey, []byte(keyRef))
+			return nil
+		}
+	}
+
+	return certutil.CreateCertificateWithKeyGenerator(data, randomSource, generator)
 }
 
 func generateCSRBundle(sc *storageContext, input *inputBundle, data *certutil.CreationBundle, addBasicConstraints bool, randomSource io.Reader) (*certutil.ParsedCSRBundle, error) {
@@ -147,6 +185,19 @@ func (sc *storageContext) getKeyTypeAndBitsForRole(data *framework.FieldData) (s
 			return "", 0, errors.New("failed to lookup public key from existing key: " + err.Error())
 		}
 		pubKey = existingPubKey
+	}
+	if externalKeyRequestedFromFieldData(data) {
+		keyRef, err := getExternalKeyRefWithErr(data)
+		if err != nil {
+			return "", 0, err
+		}
+
+		signer, err := sc.getExternalSigner(keyRef)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to get external key: %w", err)
+		}
+
+		pubKey = signer.Public()
 	}
 
 	privateKeyType, keyBits, err := getKeyTypeAndBitsFromPublicKeyForRole(pubKey)

--- a/internal/builtin/logical/pki/cert_util.go
+++ b/internal/builtin/logical/pki/cert_util.go
@@ -137,7 +137,7 @@ func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuerID, usage issuerU
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error while attempting to use issuer %v: %v", issuerId, err)}
 	}
 
-	parsedBundle, err := bundle.ToParsedCertBundle()
+	parsedBundle, err := bundle.ToParsedCertBundleWithExtractor(certutil.OptionalExternalKeyExtractor(sc.externalKeyExtractor))
 	if err != nil {
 		return nil, errutil.InternalError{Err: err.Error()}
 	}

--- a/internal/builtin/logical/pki/crl_util.go
+++ b/internal/builtin/logical/pki/crl_util.go
@@ -476,7 +476,7 @@ func fetchIssuerMapForRevocationChecking(sc *storageContext) (map[issuerID]*x509
 			return nil, fmt.Errorf("faulty reference: %v - CA info not found", issuer)
 		}
 
-		parsedBundle, err := bundle.ToParsedCertBundle()
+		parsedBundle, err := bundle.ToParsedCertBundleWithExtractor(certutil.OptionalExternalKeyExtractor(sc.externalKeyExtractor))
 		if err != nil {
 			return nil, errutil.InternalError{Err: err.Error()}
 		}

--- a/internal/builtin/logical/pki/fields.go
+++ b/internal/builtin/logical/pki/fields.go
@@ -10,14 +10,20 @@ import (
 )
 
 const (
-	issuerRefParam = "issuer_ref"
-	keyNameParam   = "key_name"
-	keyRefParam    = "key_ref"
-	keyIdParam     = "key_id"
-	keyTypeParam   = "key_type"
-	keyBitsParam   = "key_bits"
-	skidParam      = "subject_key_id"
+	issuerRefParam      = "issuer_ref"
+	keyNameParam        = "key_name"
+	keyRefParam         = "key_ref"
+	keyIdParam          = "key_id"
+	keyTypeParam        = "key_type"
+	keyBitsParam        = "key_bits"
+	externalKeyRefParam = "external_key_ref"
+	skidParam           = "subject_key_id"
 )
+
+const externalKeyRefDesc = `Reference to the external key to use. This follows
+the format <config name>:<key name>, uniquely identifying the key configured
+under sys/external-keys/configs/<config name>/keys/<key name>. Must be an
+asymmetric key.`
 
 // addIssueAndSignCommonFields adds fields common to both CA and non-CA issuing
 // and signing
@@ -358,6 +364,11 @@ RSA key-type issuer. Defaults to false.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: "rsa",
 		},
+	}
+
+	fields[externalKeyRefParam] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Description: externalKeyRefDesc,
 	}
 
 	fields = addKeyRefNameFields(fields)

--- a/internal/builtin/logical/pki/key_util.go
+++ b/internal/builtin/logical/pki/key_util.go
@@ -23,6 +23,10 @@ func comparePublicKey(key *keyEntry, publicKey crypto.PublicKey) (bool, error) {
 }
 
 func getPublicKey(key *keyEntry) (crypto.PublicKey, error) {
+	if key.PrivateKeyType == certutil.ExternalPrivateKey {
+		return certutil.ParsePublicKeyPEM([]byte(key.PublicKey))
+	}
+
 	signer, _, _, err := getSignerFromKeyEntryBytes(key)
 	if err != nil {
 		return nil, err

--- a/internal/builtin/logical/pki/path_fetch_issuers.go
+++ b/internal/builtin/logical/pki/path_fetch_issuers.go
@@ -192,7 +192,7 @@ signing CRLs. This parameter allows differentiation between PKCS#1v1.5
 and PSS keys and choice of signature hash algorithm. The default (empty
 string) value is for Go to select the signature algorithm. This can fail
 if the underlying key does not support the requested signature algorithm,
-which may not be known at modification time (such as with PKCS#11 managed
+which may not be known at modification time (such as with PKCS#11-managed
 RSA keys).`,
 		Default: "",
 	}

--- a/internal/builtin/logical/pki/path_fetch_keys.go
+++ b/internal/builtin/logical/pki/path_fetch_keys.go
@@ -256,7 +256,7 @@ func (b *backend) pathGetKeyHandler(ctx context.Context, req *logical.Request, d
 		keyTypeParam: string(key.PrivateKeyType),
 	}
 
-	pkForSkid, err := getPublicKeyFromBytes([]byte(key.PrivateKey))
+	pkForSkid, err := getPublicKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/builtin/logical/pki/path_manage_issuers.go
+++ b/internal/builtin/logical/pki/path_manage_issuers.go
@@ -99,6 +99,11 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 								Description: `The private key if exported was specified.`,
 								Required:    false,
 							},
+							externalKeyRefParam: {
+								Type:        framework.TypeString,
+								Description: externalKeyRefDesc,
+								Required:    false,
+							},
 						},
 					}},
 				},
@@ -172,6 +177,11 @@ func buildPathGenerateIntermediate(b *backend, pattern string, displayAttrs *fra
 							"private_key_type": {
 								Type:        framework.TypeString,
 								Description: `Specifies the format used for marshaling the private key.`,
+								Required:    false,
+							},
+							externalKeyRefParam: {
+								Type:        framework.TypeString,
+								Description: externalKeyRefDesc,
 								Required:    false,
 							},
 						},

--- a/internal/builtin/logical/pki/path_manage_keys.go
+++ b/internal/builtin/logical/pki/path_manage_keys.go
@@ -49,6 +49,10 @@ func pathGenerateKey(b *backend) *framework.Path {
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
 ed25519.`,
 			},
+			externalKeyRefParam: {
+				Type:        framework.TypeString,
+				Description: externalKeyRefDesc,
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -77,6 +81,11 @@ ed25519.`,
 							"private_key": {
 								Type:        framework.TypeString,
 								Description: `The private key string`,
+								Required:    false,
+							},
+							externalKeyRefParam: {
+								Type:        framework.TypeString,
+								Description: externalKeyRefDesc,
 								Required:    false,
 							},
 						},
@@ -116,12 +125,18 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 
 	exportPrivateKey := false
 	var keyBundle certutil.KeyBundle
-	var actualPrivateKeyType certutil.PrivateKeyType
+	var privateKeyPemString string
+
+	externalKeyRef := data.Get(externalKeyRefParam).(string)
 	switch {
 	case strings.HasSuffix(req.Path, "/exported"):
 		exportPrivateKey = true
 		fallthrough
 	case strings.HasSuffix(req.Path, "/internal"):
+		if getExternalKeyRef(data) != "" {
+			return logical.ErrorResponse("cannot specify %q on non-kms typed key generation request", externalKeyRefParam), nil
+		}
+
 		keyType := data.Get(keyTypeParam).(string)
 		keyBits := data.Get(keyBitsParam).(int)
 
@@ -136,20 +151,31 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 			return nil, err
 		}
 
-		actualPrivateKeyType = keyBundle.PrivateKeyType
+		privateKeyPemString, err = keyBundle.ToPrivateKeyPemString()
+		if err != nil {
+			return nil, err
+		}
+	case strings.HasSuffix(req.Path, "/kms"):
+		if len(externalKeyRef) == 0 {
+			return logical.ErrorResponse("%q is required for kms typed key generation", externalKeyRefParam), nil
+		}
+
+		keyBundle.PrivateKeyType = certutil.ExternalPrivateKey
+		privateKeyPemString = externalKeyRef
 	default:
 		return logical.ErrorResponse("Unknown type of key to generate"), nil
-	}
-
-	privateKeyPemString, err := keyBundle.ToPrivateKeyPemString()
-	if err != nil {
-		return nil, err
 	}
 
 	key, _, err := sc.importKey(privateKeyPemString, keyName, keyBundle.PrivateKeyType)
 	if err != nil {
 		return nil, err
 	}
+
+	actualPrivateKeyType := keyBundle.PrivateKeyType
+	if keyBundle.PrivateKeyType == certutil.ExternalPrivateKey {
+		actualPrivateKeyType = key.ExternalKeyType
+	}
+
 	responseData := map[string]any{
 		keyIdParam:   key.ID,
 		keyNameParam: key.Name,
@@ -157,6 +183,9 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 	}
 	if exportPrivateKey {
 		responseData["private_key"] = privateKeyPemString
+	}
+	if keyBundle.PrivateKeyType == certutil.ExternalPrivateKey {
+		responseData[externalKeyRefParam] = externalKeyRef
 	}
 	return &logical.Response{
 		Data: responseData,

--- a/internal/builtin/logical/pki/path_ocsp.go
+++ b/internal/builtin/logical/pki/path_ocsp.go
@@ -379,7 +379,7 @@ func getOcspIssuerParsedBundle(sc *storageContext, issuerId issuerID) (*certutil
 		return nil, nil, ErrIssuerHasNoKey
 	}
 
-	caBundle, err := bundle.ToParsedCertBundle()
+	caBundle, err := bundle.ToParsedCertBundleWithExtractor(certutil.OptionalExternalKeyExtractor(sc.externalKeyExtractor))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/builtin/logical/pki/storage.go
+++ b/internal/builtin/logical/pki/storage.go
@@ -6,7 +6,9 @@ package pki
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"sort"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -75,6 +78,14 @@ type keyEntry struct {
 	Name           string                  `json:"name"`
 	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type"`
 	PrivateKey     string                  `json:"private_key"`
+	PublicKey      string                  `json:"public_key"`
+
+	// ExternalKeyRef is the reference to use for this key when PrivateKeyType
+	// is ExternalPrivateKey. This is not stored in PrivateKey as a defense
+	// against accidentally returning the PrivateKey field on non-external key
+	// types.
+	ExternalKeyRef  string                  `json:"external_key_ref"`
+	ExternalKeyType certutil.PrivateKeyType `json:"external_key_type"`
 }
 
 type issuerUsage uint
@@ -349,18 +360,17 @@ func (sc *storageContext) deleteKey(id keyID) (bool, error) {
 	return wasDefault, sc.Storage.Delete(sc.Context, keyPrefix+id.String())
 }
 
+// importKey imports the specified PEM-format key (from keyValue) into
+// the new PKI storage format. The first return field is a reference to
+// the new key; the second is whether or not the key already existed
+// during import (in which case, *key points to the existing key reference
+// and identifier); the last return field is whether or not an error
+// occurred.
 func (sc *storageContext) importKey(keyValue string, keyName string, keyType certutil.PrivateKeyType) (*keyEntry, bool, error) {
-	// importKey imports the specified PEM-format key (from keyValue) into
-	// the new PKI storage format. The first return field is a reference to
-	// the new key; the second is whether or not the key already existed
-	// during import (in which case, *key points to the existing key reference
-	// and identifier); the last return field is whether or not an error
-	// occurred.
-	//
 	// Normalize whitespace before beginning.  See note in importIssuer as to
 	// why we do this.
 	keyValue = strings.TrimSpace(keyValue) + "\n"
-	//
+
 	// Before we can import a known key, we first need to know if the key
 	// exists in storage already. This means iterating through all known
 	// keys and comparing their private value against this value.
@@ -370,9 +380,18 @@ func (sc *storageContext) importKey(keyValue string, keyName string, keyType cer
 	}
 
 	// Get our public key from the current inbound key, to compare against all the other keys.
-	pkForImportingKey, err := getPublicKeyFromBytes([]byte(keyValue))
+	var pkForImportingKey crypto.PublicKey
+	if keyType != certutil.ExternalPrivateKey {
+		pkForImportingKey, err = getPublicKeyFromBytes([]byte(keyValue))
+	} else {
+		pkForImportingKey, err = sc.getExternalPublicKey(keyValue)
+	}
 	if err != nil {
 		return nil, false, err
+	}
+
+	if certutil.GetPublicKeyType(pkForImportingKey) == certutil.UnknownPrivateKey {
+		return nil, false, fmt.Errorf("unknown type for public key: %T", pkForImportingKey)
 	}
 
 	foundExistingKeyWithName := false
@@ -387,6 +406,10 @@ func (sc *storageContext) importKey(keyValue string, keyName string, keyType cer
 		}
 
 		if areEqual {
+			if existingKey.PrivateKeyType != keyType {
+				return nil, false, fmt.Errorf("cannot import existing key with different type, e.g., as external key")
+			}
+
 			// Here, we don't need to stitch together the issuer entries,
 			// because the last run should've done that for us (or, when
 			// importing an issuer).
@@ -410,6 +433,28 @@ func (sc *storageContext) importKey(keyValue string, keyName string, keyType cer
 	result.Name = keyName
 	result.PrivateKey = keyValue
 	result.PrivateKeyType = keyType
+
+	if keyType == certutil.ExternalPrivateKey {
+		// Marshal public key.
+		derBytes, err := x509.MarshalPKIXPublicKey(pkForImportingKey)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to encode exported public counterpart of external key: %w", err)
+		}
+
+		pemBlock := &pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: derBytes,
+		}
+		pemBytes := pem.EncodeToMemory(pemBlock)
+		if len(pemBytes) == 0 {
+			return nil, false, errors.New("error PEM-encoding public key")
+		}
+
+		result.PrivateKey = ""
+		result.ExternalKeyRef = keyValue
+		result.PublicKey = string(pemBytes)
+		result.ExternalKeyType = certutil.GetPublicKeyType(pkForImportingKey)
+	}
 
 	// Finally, we can write the key to storage.
 	if err := sc.writeKey(result); err != nil {
@@ -1225,6 +1270,10 @@ func (sc *storageContext) fetchCertBundleByIssuerId(id issuerID, loadKey bool) (
 
 		bundle.PrivateKeyType = key.PrivateKeyType
 		bundle.PrivateKey = key.PrivateKey
+
+		if key.PrivateKeyType == certutil.ExternalPrivateKey {
+			bundle.PrivateKey = key.ExternalKeyRef
+		}
 	}
 
 	return issuer, &bundle, nil
@@ -1233,7 +1282,7 @@ func (sc *storageContext) fetchCertBundleByIssuerId(id issuerID, loadKey bool) (
 func (sc *storageContext) writeCaBundle(caBundle *certutil.CertBundle, issuerName string, keyName string) (*issuerEntry, *keyEntry, error) {
 	myKey, _, err := sc.importKey(caBundle.PrivateKey, keyName, caBundle.PrivateKeyType)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("error importing key: %w", err)
 	}
 
 	// We may have existing mounts that only contained a key with no certificate yet as a signed CSR
@@ -1482,4 +1531,48 @@ func (sc *storageContext) fetchRevocationInfo(serial string) (*revocationInfo, e
 	}
 
 	return revInfo, nil
+}
+
+func (sc *storageContext) getExternalKey(ref string) (kms.Key, error) {
+	// We embed a newline here due to storage in importKey. Trim it.
+	return sc.Backend.System().GetExternalKey(sc.Context, strings.TrimSpace(ref))
+}
+
+func (sc *storageContext) getExternalSigner(ref string) (crypto.Signer, error) {
+	key, err := sc.getExternalKey(strings.TrimSpace(ref))
+	if err != nil {
+		return nil, fmt.Errorf("error getting external key (%q): %w", ref, err)
+	}
+
+	signer, err := kms.NewSigner(sc.Context, key)
+	if err != nil {
+		return nil, fmt.Errorf("error building signer: %w", err)
+	}
+
+	return signer, nil
+}
+
+func (sc *storageContext) getExternalPublicKey(ref string) (crypto.PublicKey, error) {
+	signer, err := sc.getExternalSigner(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer.Public(), nil
+}
+
+func (sc *storageContext) externalKeyExtractor(c *certutil.CertBundle, parsedBundle *certutil.ParsedCertBundle) error {
+	if len(c.PrivateKey) == 0 {
+		return nil
+	}
+
+	signer, err := sc.getExternalSigner(c.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to get external key signer: %w", err)
+	}
+
+	parsedBundle.PrivateKey = signer
+	parsedBundle.PrivateKeyType = certutil.GetPrivateKeyTypeFromSigner(signer)
+
+	return nil
 }

--- a/internal/builtin/logical/pki/util.go
+++ b/internal/builtin/logical/pki/util.go
@@ -76,6 +76,28 @@ func getKeyRefWithErr(data *framework.FieldData) (string, error) {
 	return keyRef, nil
 }
 
+func externalKeyRequested(input *inputBundle) bool {
+	return externalKeyRequestedFromFieldData(input.apiData)
+}
+
+func externalKeyRequestedFromFieldData(data *framework.FieldData) bool {
+	exportedStr, ok := data.GetOk("exported")
+	if !ok {
+		return false
+	}
+	return exportedStr.(string) == "kms"
+}
+
+func getExternalKeyRefWithErr(data *framework.FieldData) (string, error) {
+	keyRef := getExternalKeyRef(data)
+
+	if len(keyRef) == 0 {
+		return "", errutil.UserError{Err: "missing argument external_key_ref for external type"}
+	}
+
+	return keyRef, nil
+}
+
 func getIssuerName(sc *storageContext, data *framework.FieldData) (string, error) {
 	issuerName := ""
 	issuerNameIface, ok := data.GetOk("issuer_name")
@@ -133,6 +155,10 @@ func getIssuerRef(data *framework.FieldData) string {
 
 func getKeyRef(data *framework.FieldData) string {
 	return extractRef(data, keyRefParam)
+}
+
+func getExternalKeyRef(data *framework.FieldData) string {
+	return extractRef(data, externalKeyRefParam)
 }
 
 func extractRef(data *framework.FieldData, paramName string) string {

--- a/internal/helper/versions/version.go
+++ b/internal/helper/versions/version.go
@@ -17,9 +17,7 @@ const (
 	BuiltinMetadata = "builtin"
 )
 
-var (
-	DefaultBuiltinVersion = fmt.Sprintf("v%s+%s.bao", version.GetVersion().Version, BuiltinMetadata)
-)
+var DefaultBuiltinVersion = fmt.Sprintf("v%s+%s.bao", version.GetVersion().Version, BuiltinMetadata)
 
 func GetBuiltinVersion(pluginType consts.PluginType, pluginName string) string {
 	// pluginType and pluginName are ignored as of now.

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -787,7 +787,7 @@ func ValidateKeyTypeLength(keyType string, keyBits int) error {
 		if !present {
 			return fmt.Errorf("unsupported bit length for EC key: %d", keyBits)
 		}
-	case "any", "ed25519":
+	case "any", "ed25519", "external-key":
 	default:
 		return fmt.Errorf("unknown key type %s", keyType)
 	}
@@ -798,13 +798,13 @@ func ValidateKeyTypeLength(keyType string, keyBits int) error {
 // CreateCertificate uses CreationBundle and the default rand.Reader to
 // generate a cert/keypair.
 func CreateCertificate(data *CreationBundle) (*ParsedCertBundle, error) {
-	return createCertificate(data, rand.Reader, generatePrivateKey)
+	return createCertificate(data, rand.Reader, nil)
 }
 
 // CreateCertificateWithRandomSource uses CreationBundle and a custom
 // io.Reader for randomness to generate a cert/keypair.
 func CreateCertificateWithRandomSource(data *CreationBundle, randReader io.Reader) (*ParsedCertBundle, error) {
-	return createCertificate(data, randReader, generatePrivateKey)
+	return createCertificate(data, randReader, nil)
 }
 
 // KeyGenerator Allow us to override how/what generates the private key
@@ -886,6 +886,10 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 	serialNumber, err := GenerateSerialNumber()
 	if err != nil {
 		return nil, err
+	}
+
+	if privateKeyGenerator == nil {
+		privateKeyGenerator = generatePrivateKey
 	}
 
 	if err := privateKeyGenerator(data.Params.KeyType,
@@ -1046,7 +1050,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 }
 
 func CreateCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[string]any, certTemplate x509.Certificate, randReader io.Reader) (*ParsedCertBundle, error) {
-	return createCertificateWithTemplate(caSign, evaluationData, certTemplate, randReader, generatePrivateKey)
+	return createCertificateWithTemplate(caSign, evaluationData, certTemplate, randReader, nil)
 }
 
 func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[string]any, certTemplate x509.Certificate, randReader io.Reader, privateKeyGenerator KeyGenerator) (*ParsedCertBundle, error) {
@@ -1075,6 +1079,10 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 	}
 	if v, ok := evaluationData["signature_bits"].(int); ok {
 		signatureBits = v
+	}
+
+	if privateKeyGenerator == nil {
+		privateKeyGenerator = generatePrivateKey
 	}
 
 	result := &ParsedCertBundle{}
@@ -1234,13 +1242,13 @@ var (
 // generate a cert/keypair. This is currently only meant
 // for use when generating an intermediate certificate.
 func CreateCSR(data *CreationBundle, addBasicConstraints bool) (*ParsedCSRBundle, error) {
-	return createCSR(data, addBasicConstraints, rand.Reader, generatePrivateKey)
+	return createCSR(data, addBasicConstraints, rand.Reader, nil)
 }
 
 // CreateCSRWithRandomSource creates a CSR with a custom io.Reader
 // for randomness to generate a cert/keypair.
 func CreateCSRWithRandomSource(data *CreationBundle, addBasicConstraints bool, randReader io.Reader) (*ParsedCSRBundle, error) {
-	return createCSR(data, addBasicConstraints, randReader, generatePrivateKey)
+	return createCSR(data, addBasicConstraints, randReader, nil)
 }
 
 // CreateCSRWithKeyGenerator creates a CSR with a custom io.Reader
@@ -1252,6 +1260,10 @@ func CreateCSRWithKeyGenerator(data *CreationBundle, addBasicConstraints bool, r
 func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Reader, keyGenerator KeyGenerator) (*ParsedCSRBundle, error) {
 	var err error
 	result := &ParsedCSRBundle{}
+
+	if keyGenerator == nil {
+		keyGenerator = generatePrivateKey
+	}
 
 	if err := keyGenerator(data.Params.KeyType,
 		data.Params.KeyBits,
@@ -1645,16 +1657,36 @@ func GetPublicKeySize(key crypto.PublicKey) int {
 	return -1
 }
 
+// GetPublicKeyType yields the corresponding PrivateKeyType for this
+// crypto.PublicKey instance; useful for decoding the type of an external
+// key.
+func GetPublicKeyType(pub crypto.PublicKey) PrivateKeyType {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return RSAPrivateKey
+	case *ecdsa.PublicKey:
+		return ECPrivateKey
+	case ed25519.PublicKey:
+		return Ed25519PrivateKey
+	default:
+		return UnknownPrivateKey
+	}
+}
+
 // CreateKeyBundle create a KeyBundle struct object which includes a generated key
 // of keyType with keyBits leveraging the randomness from randReader.
 func CreateKeyBundle(keyType string, keyBits int, randReader io.Reader) (KeyBundle, error) {
-	return CreateKeyBundleWithKeyGenerator(keyType, keyBits, randReader, generatePrivateKey)
+	return CreateKeyBundleWithKeyGenerator(keyType, keyBits, randReader, nil)
 }
 
 // CreateKeyBundleWithKeyGenerator create a KeyBundle struct object which includes
 // a generated key of keyType with keyBits leveraging the randomness from randReader and
 // delegates the actual key generation to keyGenerator
 func CreateKeyBundleWithKeyGenerator(keyType string, keyBits int, randReader io.Reader, keyGenerator KeyGenerator) (KeyBundle, error) {
+	if keyGenerator == nil {
+		keyGenerator = generatePrivateKey
+	}
+
 	result := KeyBundle{}
 	if err := keyGenerator(keyType, keyBits, &result, randReader); err != nil {
 		return result, err

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -59,10 +59,11 @@ type PrivateKeyType string
 
 // Well-known PrivateKeyTypes
 const (
-	UnknownPrivateKey PrivateKeyType = ""
-	RSAPrivateKey     PrivateKeyType = "rsa"
-	ECPrivateKey      PrivateKeyType = "ec"
-	Ed25519PrivateKey PrivateKeyType = "ed25519"
+	UnknownPrivateKey  PrivateKeyType = ""
+	RSAPrivateKey      PrivateKeyType = "rsa"
+	ECPrivateKey       PrivateKeyType = "ec"
+	Ed25519PrivateKey  PrivateKeyType = "ed25519"
+	ExternalPrivateKey PrivateKeyType = "external-key"
 )
 
 // TLSUsage controls whether the intended usage of a *tls.Config
@@ -258,6 +259,16 @@ func (c *CertBundle) ToParsedCertBundleWithExtractor(privateKeyExtractor Private
 	return result, nil
 }
 
+func OptionalExternalKeyExtractor(externalKeyExtractor PrivateKeyExtractor) PrivateKeyExtractor {
+	return func(c *CertBundle, parsedBundle *ParsedCertBundle) error {
+		if c.PrivateKeyType == ExternalPrivateKey {
+			return externalKeyExtractor(c, parsedBundle)
+		}
+
+		return extractAndSetPrivateKey(c, parsedBundle)
+	}
+}
+
 func extractAndSetPrivateKey(c *CertBundle, parsedBundle *ParsedCertBundle) error {
 	if len(c.PrivateKey) == 0 {
 		return nil
@@ -343,7 +354,11 @@ func (p *ParsedCertBundle) ToCertBundle() (*CertBundle, error) {
 			}
 		}
 
-		result.PrivateKey = strings.TrimSpace(string(pem.EncodeToMemory(&block)))
+		if result.PrivateKeyType != ExternalPrivateKey {
+			result.PrivateKey = strings.TrimSpace(string(pem.EncodeToMemory(&block)))
+		} else {
+			result.PrivateKey = strings.TrimSpace(string(p.PrivateKeyBytes))
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Like earlier support for Transit, we support the external_key_ref parameter on CA (including intermediate CSR) generation. This is not relevant for leaf issuance as we don't keep leaf certificate key material within this engine (see Transit for that).


<details>

<summary> Test scripts </summary>

```
#!/bin/bash

set -euxo pipefail

( killall bao && sleep 1 ) || true

devbao node start --force --initialize --unseal --profiles secret,userpass,pki,transit --audit --seals static:// --ui

. <(devbao node env prod)

bao write transit/keys/pki-signing type=rsa-2048

bao write sys/external-keys/configs/transit plugin=transit token=$VAULT_TOKEN address=$VAULT_ADDR mount_path=transit
bao write sys/external-keys/configs/transit/keys/signing-key name=pki-signing version=1
bao write -f sys/external-keys/configs/transit/keys/signing-key/grants/pki

bao secrets enable pki

bao write pki/root/generate/kms external_key_ref=transit:signing-key common_name="Root R1" use_pss=true

bao list -detailed pki/issuers
bao read pki/issuer/default
bao read pki/key/default

bao write pki/roles/testing allow_any_name=true key_type=rsa generate_lease=true use_pss=true
bao write pki/issue/testing common_name=alex ttl=900s
```

</details>

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
