### PR TITLE
Provide independent resources to three sub-tests

### DIFF
--- a/internal/vault/namespace_store_test.go
+++ b/internal/vault/namespace_store_test.go
@@ -1027,20 +1027,20 @@ func TestNamespaceStorage(t *testing.T) {
 }
 
 func TestNamespaceDeletionSealingInteraction(t *testing.T) {
-	t.Parallel()
-
-	c, keys, _ := TestCoreUnsealed(t)
-	s := c.namespaceStore
-	ctx := namespace.RootContext(t.Context())
-
-	namespaces := []*namespace.Namespace{
-		{Path: "ns1/"},
-		{Path: "ns2/"},
-		{Path: "ns3/"},
-	}
-	nsKeys := TestCoreCreateUnsealedNamespaces(t, c, namespaces...)
 
 	t.Run("cannot seal tainted namespace", func(t *testing.T) {
+		t.Parallel()
+
+		c, _, _ := TestCoreUnsealed(t)
+		s := c.namespaceStore
+		ctx := namespace.RootContext(t.Context())
+		namespaces := []*namespace.Namespace{
+			{Path: "ns1/"},
+			{Path: "ns2/"},
+			{Path: "ns3/"},
+		}
+		TestCoreCreateUnsealedNamespaces(t, c, namespaces...)
+
 		_, err := s.DeleteNamespace(ctx, "ns1")
 		require.NoError(t, err)
 
@@ -1059,6 +1059,18 @@ func TestNamespaceDeletionSealingInteraction(t *testing.T) {
 	})
 
 	t.Run("seal core while deleting namespace", func(t *testing.T) {
+		t.Parallel()
+
+		c, keys, _ := TestCoreUnsealed(t)
+		s := c.namespaceStore
+		ctx := namespace.RootContext(t.Context())
+		namespaces := []*namespace.Namespace{
+			{Path: "ns1/"},
+			{Path: "ns2/"},
+			{Path: "ns3/"},
+		}
+		nsKeys := TestCoreCreateUnsealedNamespaces(t, c, namespaces...)
+
 		_, err := s.DeleteNamespace(ctx, "ns2")
 		require.NoError(t, err)
 
@@ -1097,6 +1109,18 @@ func TestNamespaceDeletionSealingInteraction(t *testing.T) {
 	})
 
 	t.Run("cannot delete currently sealed namespace", func(t *testing.T) {
+		t.Parallel()
+
+		c, _, _ := TestCoreUnsealed(t)
+		s := c.namespaceStore
+		ctx := namespace.RootContext(t.Context())
+		namespaces := []*namespace.Namespace{
+			{Path: "ns1/"},
+			{Path: "ns2/"},
+			{Path: "ns3/"},
+		}
+		TestCoreCreateUnsealedNamespaces(t, c, namespaces...)
+
 		require.NoError(t, s.SealNamespace(ctx, "ns3"))
 
 		_, err := s.DeleteNamespace(ctx, "ns3")


### PR DESCRIPTION
## Description

Provide each of the three sub-tests of _TestNamespaceDeletionSealingInteraction_ their own Test Core. Previously, the three sub-tests shared a resource while running sequentially.

```bash
go test github.com/openbao/openbao/v2/internal/vault -run '^TestNamespaceDeletionSealingInteraction$'
```

## Rationale
This test suffered five failures from June 22nd to July 8th of this year, and earned a place on the list of Flaky Tests.

Addresses part of: #2581

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.