### PR TITLE
Allow for lease and `sys/raw` requests propagation to leader node

### DIFF
--- a/changelog/3766.txt
+++ b/changelog/3766.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+sys/leases: Propagate renew, revoke and revoke-prefix requests to active node by default. 
+```
+
+```release-note:bug
+sys/raw: Propagate delete and write requests to active node.
+```

--- a/internal/vault/logical_raw.go
+++ b/internal/vault/logical_raw.go
@@ -104,7 +104,7 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 
 	storage, _, err := b.storageByPath(ctx, path)
 	if err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	valueBytes, err := storage.Get(ctx, path)
@@ -115,7 +115,7 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 	case err != nil && strings.HasSuffix(err.Error(), "cipher: message authentication failed"):
 		return nil, barrier.ErrNamespaceSealed
 	case err != nil:
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	case valueBytes == nil:
 		return nil, nil
 	}
@@ -127,7 +127,7 @@ func (b *RawBackend) handleRawRead(ctx context.Context, req *logical.Request, da
 		// will be nil.
 		decompData, _, err := compressutil.Decompress(valueBytes)
 		if err != nil {
-			return handleErrorNoReadOnlyForward(err)
+			return handleError(err)
 		}
 
 		// `decompData` is nil if the input is uncompressed.
@@ -180,7 +180,7 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 
 	storage, allowWrites, err := b.storageByPath(ctx, path)
 	if err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	if !allowWrites {
@@ -192,7 +192,7 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 		// If so, use the same compression (or no compression)
 		valueBytes, err := storage.Get(ctx, path)
 		if err != nil {
-			return handleErrorNoReadOnlyForward(err)
+			return handleError(err)
 		}
 		if valueBytes == nil {
 			err := "cannot figure out compression type because entry does not exist"
@@ -254,11 +254,11 @@ func (b *RawBackend) handleRawDelete(ctx context.Context, req *logical.Request, 
 
 	barrier, _, err := b.storageByPath(ctx, path)
 	if err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	if err := barrier.Delete(ctx, path); err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 	return nil, nil
 }
@@ -282,12 +282,12 @@ func (b *RawBackend) handleRawList(ctx context.Context, req *logical.Request, da
 
 	barrier, _, err := b.storageByPath(ctx, path)
 	if err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	keys, err := barrier.ListPage(ctx, path, after, limit)
 	if err != nil {
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 	return logical.ListResponse(keys), nil
 }

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -1195,22 +1195,6 @@ func handleError(
 	}
 }
 
-// Performs a similar function to handleError, but upon seeing a ReadOnlyError
-// will actually strip it out to prevent forwarding
-func handleErrorNoReadOnlyForward(
-	err error,
-) (*logical.Response, error) {
-	if logical.ShouldForward(err) {
-		return nil, errors.New("operation could not be completed as storage is read-only")
-	}
-	switch err.(type) {
-	case logical.HTTPCodedError:
-		return logical.ErrorResponse(err.Error()), err
-	default:
-		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
-	}
-}
-
 // handleUnmount is used to unmount a path
 func (b *SystemBackend) handleUnmount(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	path := data.Get("path").(string)
@@ -2008,10 +1992,11 @@ func (b *SystemBackend) handleLeaseLookupList(ctx context.Context, req *logical.
 	if err != nil {
 		return nil, err
 	}
+
 	keys, err := b.Core.expiration.leaseView(ns).List(ctx, prefix)
 	if err != nil {
 		b.Backend.Logger().Error("error listing leases", "prefix", prefix, "error", err)
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 	return logical.ListResponse(keys), nil
 }
@@ -2036,7 +2021,7 @@ func (b *SystemBackend) handleRenew(ctx context.Context, req *logical.Request, d
 	resp, err := b.Core.expiration.Renew(ctx, leaseID, increment)
 	if err != nil {
 		b.Backend.Logger().Error("lease renewal failed", "lease_id", leaseID, "error", err)
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 	return resp, err
 }
@@ -2062,7 +2047,7 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 		// Invoke the expiration manager directly
 		if err := b.Core.expiration.Revoke(revokeCtx, leaseID); err != nil {
 			b.Backend.Logger().Error("lease revocation failed", "lease_id", leaseID, "error", err)
-			return handleErrorNoReadOnlyForward(err)
+			return handleError(err)
 		}
 
 		return nil, nil
@@ -2070,7 +2055,7 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 
 	if err := b.Core.expiration.LazyRevoke(revokeCtx, leaseID); err != nil {
 		b.Backend.Logger().Error("lease revocation failed", "lease_id", leaseID, "error", err)
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
@@ -2107,7 +2092,7 @@ func (b *SystemBackend) handleRevokePrefixCommon(ctx context.Context,
 	}
 	if err != nil {
 		b.Backend.Logger().Error("revoke prefix failed", "prefix", prefix, "error", err)
-		return handleErrorNoReadOnlyForward(err)
+		return handleError(err)
 	}
 
 	if sync {

--- a/internal/vault/logical_system_paths.go
+++ b/internal/vault/logical_system_paths.go
@@ -2709,10 +2709,12 @@ func (b *SystemBackend) leasePaths() []*framework.Path {
 					Callback: b.handleRenew,
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
-							Description: "OK",
+							Description: http.StatusText(http.StatusNoContent),
 						}},
 					},
-					Summary: "Renews a lease, requesting to extend the lease.",
+					Summary:                     "Renews a lease, requesting to extend the lease.",
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 			},
 
@@ -2753,7 +2755,9 @@ func (b *SystemBackend) leasePaths() []*framework.Path {
 							Description: "OK",
 						}},
 					},
-					Summary: "Revokes a lease immediately.",
+					Summary:                     "Revokes a lease immediately.",
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 			},
 
@@ -2785,8 +2789,10 @@ func (b *SystemBackend) leasePaths() []*framework.Path {
 							Description: "OK",
 						}},
 					},
-					Summary:     "Revokes all secrets or tokens generated under a given prefix immediately",
-					Description: "Unlike `/sys/leases/revoke-prefix`, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.\n\nBy ignoring these errors, OpenBao abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.",
+					Summary:                     "Revokes all secrets or tokens generated under a given prefix immediately",
+					Description:                 "Unlike `/sys/leases/revoke-prefix`, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.\n\nBy ignoring these errors, OpenBao abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.",
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 			},
 
@@ -2823,7 +2829,9 @@ func (b *SystemBackend) leasePaths() []*framework.Path {
 							Description: "OK",
 						}},
 					},
-					Summary: "Revokes all secrets (via a lease ID prefix) or tokens (via the tokens' path property) generated under a given prefix immediately.",
+					Summary:                     "Revokes all secrets (via a lease ID prefix) or tokens (via the tokens' path property) generated under a given prefix immediately.",
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 			},
 
@@ -2844,10 +2852,12 @@ func (b *SystemBackend) leasePaths() []*framework.Path {
 					Callback: b.handleTidyLeases,
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
-							Description: "OK",
+							Description: http.StatusText(http.StatusNoContent),
 							Fields:      map[string]*framework.FieldSchema{},
 						}},
 					},
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 			},
 


### PR DESCRIPTION
## Description
This PR removes `handleErrorNoReadOnlyForward` as a special "read-only" error catching mechanism from the `sys/raw` and lease handling operations. Additionally makes all "write-incurring" lease operations forwarded by default, leaving read requests untouched.

## Rationale
Lease renewal was failing when routed to the standby node with following error:
```
[ERROR] secrets.system.system_da598944: lease renewal failed: lease_id=-path-/<id>error="failed to persist lease entry: cannot write to readonly storage"
```
lease operations were never retried on the leader due to usage of `handleErrorNoReadOnlyForward` (removed with this PR) which was swallowing the "read-only error" category  nor they were propagated on the router level. This PR should allow seamless lease operation handling without manually directing the requests to the leader node.

_I think the reason it was implemented without propagation was due to the existence of `secondary performance clusters` within VE, where you could have "locally" mounted backend with their own set of leases, which also meant possible diverging storages between one clusters. With that setup, sys/raw or lease operations could be propagated to the node without knowledge of the requested entity_

This also matches the explanation in the original code commit message of:

```
commit f3656e80f072b7ef9335e2cb84bc2cbd7017d8fb
Author: Jeff Mitchell <jeff@hashicorp.com>
Date:   Sat Mar 17 21:29:17 2018 -0400

    Properly forward (or specifically don't) sys calls that result in read only errors (#4129)

    Prior to this policy writes against a performance secondary would not
    succeed because the read-only error was swallowed by handleError. In
    addition to fixing this, it adds a similar function that explicitly
    doesn't trigger forwarding. This is useful for things that are local to
    the secondary such as raw operations and lease management.
```

Resolves: #3709

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
