### PR TITLE
PQC KEM Configuration & Policies

### DIFF
--- a/changelog/3769.txt
+++ b/changelog/3769.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-command/server: Add `tls_curve_preferences` configuration option to support enforcing PQC KEM.
+command/server: Add `tls_key_exchange_preferences` configuration option to support enforcing PQC KEM.
 ```

--- a/changelog/3769.txt
+++ b/changelog/3769.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/server: Add `tls_curve_preferences` configuration option to support enforcing PQC KEM.
+```

--- a/internal/helper/configutil/listener.go
+++ b/internal/helper/configutil/listener.go
@@ -77,6 +77,7 @@ type Listener struct {
 	TLSMaxVersion                    string        `hcl:"tls_max_version"`
 	TLSCipherSuites                  []uint16      `hcl:"-"`
 	TLSCipherSuitesRaw               string        `hcl:"tls_cipher_suites"`
+	TLSCurvePreferences              []string      `hcl:"tls_curve_preferences"`
 	TLSRequireAndVerifyClientCert    bool          `hcl:"-"`
 	TLSRequireAndVerifyClientCertRaw any           `hcl:"tls_require_and_verify_client_cert"`
 	TLSClientCAFile                  string        `hcl:"tls_client_ca_file"`

--- a/internal/helper/configutil/listener.go
+++ b/internal/helper/configutil/listener.go
@@ -77,7 +77,7 @@ type Listener struct {
 	TLSMaxVersion                    string        `hcl:"tls_max_version"`
 	TLSCipherSuites                  []uint16      `hcl:"-"`
 	TLSCipherSuitesRaw               string        `hcl:"tls_cipher_suites"`
-	TLSCurvePreferences              []string      `hcl:"tls_curve_preferences"`
+	TLSKeyExchangePreferences        []string      `hcl:"tls_key_exchange_preferences"`
 	TLSRequireAndVerifyClientCert    bool          `hcl:"-"`
 	TLSRequireAndVerifyClientCertRaw any           `hcl:"tls_require_and_verify_client_cert"`
 	TLSClientCAFile                  string        `hcl:"tls_client_ca_file"`

--- a/internal/helper/listenerutil/listener.go
+++ b/internal/helper/listenerutil/listener.go
@@ -8,9 +8,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	osuser "os/user"
+	"slices"
 	"strconv"
 
 	"github.com/hashicorp/cli"
@@ -47,6 +49,26 @@ func (l *rmListener) Close() error {
 
 	// Remove the file
 	return os.Remove(l.Path)
+}
+
+var curveIDByName = map[string]tls.CurveID{
+	tls.CurveP256.String():          tls.CurveP256,
+	tls.CurveP384.String():          tls.CurveP384,
+	tls.CurveP521.String():          tls.CurveP521,
+	tls.X25519.String():             tls.X25519,
+	tls.X25519MLKEM768.String():     tls.X25519MLKEM768,
+	tls.SecP256r1MLKEM768.String():  tls.SecP256r1MLKEM768,
+	tls.SecP384r1MLKEM1024.String(): tls.SecP384r1MLKEM1024,
+}
+
+var allCurveNames = slices.Sorted(maps.Keys(curveIDByName))
+
+func CurveToCurveID(curve string) (tls.CurveID, error) {
+	id, ok := curveIDByName[curve]
+	if !ok {
+		return 0, fmt.Errorf("%s is an unknown curve", curve)
+	}
+	return id, nil
 }
 
 func UnixSocketListener(path string, unixSocketsConfig *UnixSocketsConfig) (net.Listener, error) {
@@ -92,10 +114,20 @@ func TLSConfig(
 	}
 	l.TLSCertGetter = cg
 
+	curvePreferences := []tls.CurveID{}
+	for _, curvePreference := range l.TLSCurvePreferences {
+		curveID, err := CurveToCurveID(curvePreference)
+		if err != nil {
+			return nil, nil, fmt.Errorf("'tls_curve_preferences' value %q not supported, please select from %v", curvePreference, allCurveNames)
+		}
+		curvePreferences = append(curvePreferences, curveID)
+	}
+
 	tlsConf := &tls.Config{
-		GetCertificate: cg.GetCertificate,
-		NextProtos:     []string{"h2", "http/1.1"},
-		ClientAuth:     tls.RequestClientCert,
+		GetCertificate:   cg.GetCertificate,
+		NextProtos:       []string{"h2", "http/1.1"},
+		ClientAuth:       tls.RequestClientCert,
+		CurvePreferences: curvePreferences,
 	}
 
 	if acg, ok := cg.(*ACMECertGetter); ok {

--- a/internal/helper/listenerutil/listener.go
+++ b/internal/helper/listenerutil/listener.go
@@ -63,14 +63,6 @@ var curveIDByName = map[string]tls.CurveID{
 
 var allCurveNames = slices.Sorted(maps.Keys(curveIDByName))
 
-func CurveToCurveID(curve string) (tls.CurveID, error) {
-	id, ok := curveIDByName[curve]
-	if !ok {
-		return 0, fmt.Errorf("%s is an unknown curve", curve)
-	}
-	return id, nil
-}
-
 func UnixSocketListener(path string, unixSocketsConfig *UnixSocketsConfig) (net.Listener, error) {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove socket file: %v", err)
@@ -116,8 +108,8 @@ func TLSConfig(
 
 	curvePreferences := []tls.CurveID{}
 	for _, curvePreference := range l.TLSCurvePreferences {
-		curveID, err := CurveToCurveID(curvePreference)
-		if err != nil {
+		curveID, ok := curveIDByName[curvePreference]
+		if !ok {
 			return nil, nil, fmt.Errorf("'tls_curve_preferences' value %q not supported, please select from %v", curvePreference, allCurveNames)
 		}
 		curvePreferences = append(curvePreferences, curveID)

--- a/internal/helper/listenerutil/listener.go
+++ b/internal/helper/listenerutil/listener.go
@@ -51,6 +51,8 @@ func (l *rmListener) Close() error {
 	return os.Remove(l.Path)
 }
 
+// curveIDByName translates the valid config parameters to golang
+// standard library CurveIDs.
 var curveIDByName = map[string]tls.CurveID{
 	tls.CurveP256.String():          tls.CurveP256,
 	tls.CurveP384.String():          tls.CurveP384,
@@ -61,7 +63,7 @@ var curveIDByName = map[string]tls.CurveID{
 	tls.SecP384r1MLKEM1024.String(): tls.SecP384r1MLKEM1024,
 }
 
-var allCurveNames = slices.Sorted(maps.Keys(curveIDByName))
+var allKexNames = slices.Sorted(maps.Keys(curveIDByName))
 
 func UnixSocketListener(path string, unixSocketsConfig *UnixSocketsConfig) (net.Listener, error) {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -107,10 +109,10 @@ func TLSConfig(
 	l.TLSCertGetter = cg
 
 	curvePreferences := []tls.CurveID{}
-	for _, curvePreference := range l.TLSCurvePreferences {
-		curveID, ok := curveIDByName[curvePreference]
+	for _, kexPreference := range l.TLSKeyExchangePreferences {
+		curveID, ok := curveIDByName[kexPreference]
 		if !ok {
-			return nil, nil, fmt.Errorf("'tls_curve_preferences' value %q not supported, please select from %v", curvePreference, allCurveNames)
+			return nil, nil, fmt.Errorf("'tls_key_exchange_preferences' value %q not supported, please select from %v", kexPreference, allKexNames)
 		}
 		curvePreferences = append(curvePreferences, curveID)
 	}

--- a/internal/helper/listenerutil/listener.go
+++ b/internal/helper/listenerutil/listener.go
@@ -63,8 +63,6 @@ var curveIDByName = map[string]tls.CurveID{
 	tls.SecP384r1MLKEM1024.String(): tls.SecP384r1MLKEM1024,
 }
 
-var allKexNames = slices.Sorted(maps.Keys(curveIDByName))
-
 func UnixSocketListener(path string, unixSocketsConfig *UnixSocketsConfig) (net.Listener, error) {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove socket file: %v", err)
@@ -112,6 +110,7 @@ func TLSConfig(
 	for _, kexPreference := range l.TLSKeyExchangePreferences {
 		curveID, ok := curveIDByName[kexPreference]
 		if !ok {
+			allKexNames := slices.Sorted(maps.Keys(curveIDByName))
 			return nil, nil, fmt.Errorf("'tls_key_exchange_preferences' value %q not supported, please select from %v", kexPreference, allKexNames)
 		}
 		curvePreferences = append(curvePreferences, curveID)

--- a/internal/helper/listenerutil/listener_test.go
+++ b/internal/helper/listenerutil/listener_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func TestCurveToCurveIDMatchesGoStdLib(t *testing.T) {
+func TestCurveIDsMatchGoStdLib(t *testing.T) {
 	for i := range math.MaxUint16 + 1 {
 		id := tls.CurveID(i)
 		name := id.String()

--- a/internal/helper/listenerutil/listener_test.go
+++ b/internal/helper/listenerutil/listener_test.go
@@ -4,11 +4,40 @@
 package listenerutil
 
 import (
+	"crypto/tls"
+	"math"
 	"os"
 	osuser "os/user"
 	"strconv"
+	"strings"
 	"testing"
 )
+
+func TestCurveToCurveIDMatchesGoStdLib(t *testing.T) {
+	for i := range math.MaxUint16 + 1 {
+		id := tls.CurveID(i)
+		name := id.String()
+
+		supportedCurveID := !strings.HasPrefix(name, "CurveID(")
+
+		got, err := CurveToCurveID(name)
+		switch {
+		// Tripwire in case new Go versions add more CurveIDs we need to support
+		case supportedCurveID && err != nil:
+			t.Errorf("missing mapping in CurveToCurveID, please add new %s (0x%04x)", name, i)
+		case supportedCurveID && got != id:
+			t.Errorf("CurveToCurveID(%q) = 0x%04x, want 0x%04x", name, got, id)
+		case !supportedCurveID && err == nil:
+			t.Errorf("CurveToCurveID(%q) accepts an ID crypto/tls does not define", name)
+		}
+	}
+
+	for name, id := range curveIDByName {
+		if strings.HasPrefix(id.String(), "CurveID(") {
+			t.Errorf("%q maps to an ID (0x%04x) that crypto/tls does not define", name, uint16(id))
+		}
+	}
+}
 
 func TestUnixSocketListener(t *testing.T) {
 	t.Run("ids", func(t *testing.T) {

--- a/internal/helper/listenerutil/listener_test.go
+++ b/internal/helper/listenerutil/listener_test.go
@@ -20,14 +20,14 @@ func TestCurveToCurveIDMatchesGoStdLib(t *testing.T) {
 
 		supportedCurveID := !strings.HasPrefix(name, "CurveID(")
 
-		got, err := CurveToCurveID(name)
+		got, ok := curveIDByName[name]
 		switch {
 		// Tripwire in case new Go versions add more CurveIDs we need to support
-		case supportedCurveID && err != nil:
+		case supportedCurveID && !ok:
 			t.Errorf("missing mapping in CurveToCurveID, please add new %s (0x%04x)", name, i)
 		case supportedCurveID && got != id:
 			t.Errorf("CurveToCurveID(%q) = 0x%04x, want 0x%04x", name, got, id)
-		case !supportedCurveID && err == nil:
+		case !supportedCurveID && ok:
 			t.Errorf("CurveToCurveID(%q) accepts an ID crypto/tls does not define", name)
 		}
 	}

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -206,10 +206,9 @@ default value in the `"/sys/config/ui"` [API endpoint](../../api/system/config-u
 
   :::
 
-- `tls_curve_preferences` `([]string: nil)` - Specifies the list of supported
+- `tls_key_exchange_preferences` `([]string: nil)` - Specifies the list of supported
   key exchange mechanisms. Up to TLS 1.2 this value only specified elliptic curves.
-  In TLS 1.3 it was extended and named to NamedGroup. We keep the legacy field name
-  to align with the Go naming conventions.
+  In TLS 1.3 it was extended and named to NamedGroup.
 
   Accepted values are: "CurveP256", "CurveP384", "CurveP521", "SecP256r1MLKEM768",
   "SecP384r1MLKEM1024", "X25519", and "X25519MLKEM768". They follow the Go standard
@@ -400,7 +399,7 @@ To enforce PQC KEM server-side, use the following configuration.
 listener "tcp" {
   tls_min_version = "tls13"
   tls_max_version = "tls13"
-  tls_curve_preferences = ["X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM10242"]
+  tls_key_exchange_preferences = ["X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM10242"]
 }
 ```
 

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -206,6 +206,15 @@ default value in the `"/sys/config/ui"` [API endpoint](../../api/system/config-u
 
   :::
 
+- `tls_curve_preferences` `([]string: nil)` - Specifies the list of supported
+  key exchange mechanisms. Up to TLS 1.2 this value only specified elliptic curves.
+  In TLS 1.3 it was extended and named to NamedGroup. We keep the legacy field name
+  to align with the Go naming conventions.
+
+  Accepted values are: "CurveP256", "CurveP384", "CurveP521", "SecP256r1MLKEM768",
+  "SecP384r1MLKEM1024", "X25519", and "X25519MLKEM768". They follow the Go standard
+  library [CurveIDs][curve-id].
+
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.
 
@@ -382,6 +391,19 @@ listener "tcp" {
 }
 ```
 
+### Enforce PQC Key Exchange Mechanisms (KEM)
+
+Go will prefer post-quantum cryptography (PQC) key exchange mechanisms (KEM) when both server and client support them.
+To enforce PQC KEM server-side, use the following configuration.
+
+```hcl
+listener "tcp" {
+  tls_min_version = "tls13"
+  tls_max_version = "tls13"
+  tls_curve_preferences = ["X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM10242"]
+}
+```
+
 ### Listening on multiple interfaces
 
 This example shows OpenBao listening on a private interface, as well as localhost.
@@ -534,3 +556,4 @@ cluster_addr = "https://[2001:1c04:90d:1c00:a00:27ff:fefa:58ec]:8201"
 [api-addr]: ../index.mdx#api_addr
 [cluster-addr]: ../index.mdx#cluster_addr
 [go-tls-blog]: https://go.dev/blog/tls-cipher-suites
+[curve-id]: https://pkg.go.dev/crypto/tls#CurveID


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

This pull request will focus on the Key Exchange Mechanism (KEM) portion for TLS listeners, and PQC authentication will follow in a separate one, since it requires Go 1.27 (currently RC), which is [in progress](https://github.com/openbao/openbao/pull/3752).

This pull requests introduces a new configuration option `tls_curve_preferences` to enable PQC KEM policies, i.e., enforce PQC KEMs server side.

### PQC KEM support in OpenBao

Go 1.24 is used since OpenBao 2.2.x, and assuming default TLS config, [automatically supports and prioritizes PQC KEM](https://go.dev/doc/go1.24#cryptotlspkgcryptotls):

```
› cat example.openbao.d/server.hcl 
storage "inmem" {}

listener "tcp" {
  address       = "127.0.0.1:8200"
  tls_cert_file = "example.openbao.d/tls/server.pem"
  tls_key_file  = "example.openbao.d/tls/server-key.pem"
}

api_addr = "https://127.0.0.1:8200"

› ./example.openbao.d/releases/bao-2.2.2 server -config=example.openbao.d/server.hcl

WARNING: storage configured to use "inmem" which should NOT be used in
production

==> OpenBao server configuration:

Administrative Namespace: 
             Api Address: https://127.0.0.1:8200
                     Cgo: disabled
         Cluster Address: https://127.0.0.1:8201
   Environment Variables: COLORTERM, COMMAND_MODE, FPATH, HOME, HOMEBREW_CELLAR, HOMEBREW_PREFIX, HOMEBREW_REPOSITORY, INFOPATH, KITTY_INSTALLATION_DIR, KITTY_PID, KITTY_PUBLIC_KEY, KITTY_WINDOW_ID, LANG, LESS, LOGNAME, LSCOLORS, LS_COLORS, MANPATH, NIX_PROFILES, NIX_SSL_CERT_FILE, NVM_BIN, NVM_CD_FLAGS, NVM_DIR, NVM_INC, OLDPWD, OSLogRateLimit, PAGER, PATH, PWD, SHELL, SHLVL, SSH_AUTH_SOCK, TERM, TERMINFO, TMPDIR, USER, WINDOWID, XDG_DATA_DIRS, XPC_FLAGS, XPC_SERVICE_NAME, ZSH, _, __CFBundleIdentifier, __CF_USER_TEXT_ENCODING, __ETC_PROFILE_NIX_SOURCED
              Go Version: go1.24.3
              Listener 1: tcp (addr: "127.0.0.1:8200", cluster address: "127.0.0.1:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "enabled")
               Log Level: 
           Recovery Mode: false
                 Storage: inmem
                 Version: OpenBao v2.2.2, built 2025-05-29T19:40:39Z
             Version Sha: 8c0322c0423231836a1432fdad29dc2e99640da9

==> OpenBao server started! Log data will stream in below:

2026-08-12T12:19:36.486+0200 [INFO]  proxy environment: http_proxy="" https_proxy="" no_proxy=""
2026-08-12T12:19:36.489+0200 [INFO]  core: Initializing version history cache for core
```

Generic Go TLS client

```
› go run ./client -probe -addr 127.0.0.1:8200                                           
--- client: negotiated connection ---
  version:      TLS 1.3
  cipher suite: TLS_AES_128_GCM_SHA256
  key exchange: X25519MLKEM768 (0x11ec)  [post-quantum hybrid]
```

Still, a client is perfectly capable of 'downgrading' a connection either by using outdated software or explicitly insecure configuration:

```
go run ./client -probe -addr 127.0.0.1:8200 -tls-version 1.2
--- client: negotiated connection ---
  version:      TLS 1.2
  cipher suite: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
  key exchange: X25519 (0x001d)
› go run ./client -probe -addr 127.0.0.1:8200 -curves X25519  
--- client: negotiated connection ---
  version:      TLS 1.3
  cipher suite: TLS_AES_128_GCM_SHA256
  key exchange: X25519 (0x001d)
```

### PQC KEM requires TLS 1.3

[RFC9851](https://datatracker.ietf.org/doc/rfc9851/) states that TLS 1.2 is in maintenance-only mode and "PQC for TLS 1.2 will not be specified".

### Cipher Suites changes in TLS 1.3

In TLS 1.2 we had cipher suites like `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, which define the full set of cryptographic algorithms used.

TLS 1.3 splits this into different parameter sets, where we still have cipher suites, but they focus on symmetric encryption like `TLS_AES_128_GCM_SHA256`, and then a dedicated set of preferences, e.g., for KEM like `X25519` and `X25519MLKEM768` (for a PQC hybrid scheme).

### Impact on OpenBao

Today, OpenBao supports `tls_cipher_suites` as a config parameter. They still exist in TLS 1.3, but are not configurable in Go, as per [this post](https://go.dev/blog/tls-cipher-suites#gos-cryptotls-and-cipher-suites) and [this issue](https://github.com/golang/go/issues/29349#issuecomment-449143820). We can also see in [handshake_server_tls13.go](https://github.com/golang/go/blob/go1.26.5/src/crypto/tls/handshake_server_tls13.go#L179-L196) that Config.CipherSuites is not used.

### Implementation

I introduce `tls_curve_preferences`, backed by [tls.CurveID](https://github.com/golang/go/blob/go1.26.5/src/crypto/tls/common.go#L146-L156).

When new `CurveID`s are introduced in Go, OpenBao needs to add support for the configuration fields and ID mapping. I have added a unit test that will fail in that event with actionable instructions.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Makes progress on https://github.com/openbao/openbao/issues/3755

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
