### PR TITLE
RFC: TOTP Self-Enrollment

### DIFF
--- a/website/content/community/rfcs/index.mdx
+++ b/website/content/community/rfcs/index.mdx
@@ -33,6 +33,7 @@ Steering Committee.
  - [GRPC-Based Invalidation](grpc-invalidation.mdx), for providing read
    scalability on non-Raft HA storage backends which expose an underlying
    index consistent between different nodes.
+- [TOTP Self Enrollment](totp-self-enroll.mdx), for adding self enrollment to the TOTP MFA Method.
 
 ## Landed
 

--- a/website/content/community/rfcs/index.mdx
+++ b/website/content/community/rfcs/index.mdx
@@ -39,6 +39,7 @@ Steering Committee.
  - [Plugin Management Improvements](plugin-improvements.mdx), addressing
    several pain points around plugin binary management to improve the operator
    experience that comes with an increasingly plugin-focused OpenBao.
+- [TOTP Self Enrollment](totp-self-enroll.mdx), for adding self enrollment to the TOTP MFA Method.
 
 ## Landed
 

--- a/website/content/community/rfcs/totp-self-enroll.mdx
+++ b/website/content/community/rfcs/totp-self-enroll.mdx
@@ -1,0 +1,150 @@
+---
+sidebar_label: TOTP Self-Enrollment
+description: |-
+  An OpenBao RFC for allowing users to enroll a TOTP MFA method on their own
+---
+
+# TOTP Self-Enrollment
+
+## Summary
+
+Allow a user to setup TOTP as their second factor natively in OpenBao. This should be interactive and require no additional administrative work.
+
+## Problem Statement
+
+When using TOTP as a mandatory second factor, a chicken-egg problem arises. The user can't log in because they can't provide a TOTP code and they can't enroll a TOTP second factor, because they can't log in.
+
+This leads to unnecessary overhead when wanting to enforce TOTP as a second factor with minimal administrative work.
+
+## User-facing description
+
+Current sequence for a user in the UI:
+1. Log in
+2. If a self-enrollable TOTP MFA method is enforced and not yet configured, redirection to the self-enrollemnt page
+3. Show a QR code as well as the TOTP secret to allow easy setup
+4. Confirm the setup with inputting a TOTP code
+5. Log in again, now with the TOTP MFA method configured
+
+## Technical Description
+
+### Configuration of self-enrollment
+
+The `TOTPConfig` controls if a TOTP MFA method allows self-enrollment via a `enable_self_enrollment` boolean option, configurable through the current api.
+This config option is also configurable through the UI, when creating a TOTP MFA method.
+
+### Detecting when to move into self-enrollment
+
+MFA enforcement is evaluated in `internal/vault/request_handling.go`.
+This is where the function `findSelfEnrollableTOTPMethod` checks if the MFA enforcement and its enforced methods can and should be self enrolled.
+
+
+1. If the entity already has an `MFASecrets` entry for *any* method ID in
+   the enforcement config, self-enrollment is skipped entirely, as the enforcement is satisfied.
+2. Otherwise, it returns the first method ID that is both a TOTP method and
+   has `enable_self_enrollment` enabled. Non-TOTP methods in the same constraint are skipped,
+   since there isn't self-enrollment for these methods.
+
+If a self-enrollable method is found, a TOTP key and key url are generated.
+For this `generateTOTPKeyAndQR` (`internal/vault/login_mfa.go`) was extracted out of the existing `HandleMFAGenerateTOTP` enrollment path so both share the same functionality and way of generation.
+This generated TOTP information is not persisted to the user yet, but returned including a mfa request (uu)id through a new response `TOTPSelfEnroll` to be confirmed on the user's end.
+
+### Pending-enrollment queue
+
+The previously generated secret has to survive during the confirmation period on the users end, without getting saved in a more persistent manner.
+This is solved through a new `TOTPSelfEnrollmentQueue` (`internal/vault/mfa_self_enrollment_queue.go`), which uses the already existing priority queue that is also used in `mfaResponseAuthQueue`.
+Entries include the request id, the requesting namespace, entity id, the generated secret, targeted method id and when it was stored.
+
+A background goroutine evicts the oldest entry once it exceeds `defaultTOTPSelfEnrollmentTTL` (currently 5 minutes), limiting how long an unconfirmed enrollment request stays usable.
+This is again similar to `mfaResponseAuthQueue`.
+
+This means queued self-enrollments don't survive an active-node change.
+
+### Confirmation and cancellation endpoints
+
+Two new unauthenticated system paths are added to `SystemBackend` (`internal/vault/login_mfa.go`):
+
+- `POST /v1/sys/mfa/self-enroll/totp` (`request_id`, `totp_code`) -
+  pops the pending entry by ID, verifies the confirming request is in the
+  same namespace it was issued in and rate-limits validation attempts using the same `rateLimits` cache the
+  standard MFA validation path uses (keyed as `<methodID>_<entityID>_selfenroll` to not conflict with it,
+  capped at `MaxValidationAttempts` from the MFA method).
+  On a valid code, it acquires the identity store lock, re-reads the entity,
+  persists the key via the same `Core.PersistTOTPKey` storage path normal
+  TOTP enrollment uses, and writes the `mfa.Secret` into `entity.MFASecrets`.
+  If confirmation fails at any point after popping the
+  entry, it's pushed back onto the queue so the user can retry within the
+  remaining TTL rather than having to restart self-enrollment. This mimics the `mfaResponseAuthQueue` as well
+- `DELETE /v1/sys/mfa/self-enroll/totp` (`request_id`) -
+  pops and discards the pending entry, invalidating it without persisting anything.
+  Used when the user cancels enrollment client-side.
+
+### Finalize the self-enrollment
+
+After self-enrollment is finalized by the user, the server does not hand out a valid token.
+The user is expected to authenticate again afterwards, at which point `findSelfEnrollableTOTPMethod` will see the now-available TOTP method and allow normal MFA authentification.
+
+### Audit logging
+
+`TOTPSelfEnroll.TOTPSecret` and `TOTPSelfEnroll.TOTPURL` are hashed to not be revealed through the audit logs.
+As the confirmation and cancellation are requests the client has to send, these are audited that way.
+
+### UI flow
+
+The auth controller (`ui/app/controllers/vault/cluster/auth.js`, which handles the login) checks for the new `mfa_self_enroll` response field and routes to a new `Mfa::TotpSelfEnroll` component.
+The component renders a QR code client-side (via the `qrcode` package, from the returned `totp_url`) and the raw secret as a fallback, and submits the confirmation or cancellation calls through two new `cluster` adapter methods that wrap the endpoints mentioned above.
+On success, the user is bounced back to the login form with a message asking them to log in again. When cancelled, the success of that is also sent to the user through that way.
+
+## Rationale and alternatives
+
+### One-time token to generate a TOTP secret vs the self-enrollment system
+
+The self-enrollment system is the barrier of entry, when a second factor is required. While OpenBao could just generate a one-time-usage token for the `/identity/mfa/method/totp/generate` endpoint, this would require equally as much work, while also creating a valid token that leaves more surface area to be attacked.
+
+### Completing login vs log in again after enrollment
+
+TOTP self-enrollment currently forces you to sign again. This was partially to quicken the creation of a PoC and on the other hand being sure that the person who finished the self-enrollment wasn't just faster in submitting a TOTP code.
+
+### In-memory queue vs storage-backed record
+
+The self-enrollment requests are currently only saved in memory via the queue.
+This leads to loss of state on failover between nodes, which is intended, as these unfinished MFA secrets shouldn't have persistence above memory.
+
+## Downsides
+
+- The self-enrollment queue silently doesn't survive active node changes or restarts
+- Re-login is a worse experience for the user
+- Confirmation but especially the invalidation of a self-enrollment attempt hinge on the request uuid
+- Loss of admin driven MFA enrollment for TOTP
+
+## Security Implications
+
+### Primary auth leads to full trust
+
+The self-enrollment only requires a username and password. This sounds obvious, but because there are no email notifications or similar to a user, a wrong enrollment by a bad actor won't per-se be noticed.
+While this already requires a valid username and password, this should still be noted.
+
+### Plaintext TOTP secret
+
+The TOTP secret as well as init url (which also includes the secret) are send to the user in a HTTP request as well as stored in memory as plaintext.
+
+### Self-Enrollment confirmation endpoint is unauthenticated
+
+Out of necessity the endpoint to confirm TOTP self-enrollment is unauthenticated and only protected through the request id.
+
+## User/Developer Experience
+
+For developers of OpenBao clients, the new self-enrollment now adds to the steps that have to be checked and completed before login can be done.
+
+## Unresolved Questions
+
+Should TOTP self-enrollment be allowed via the CLI?
+
+Should the user be logged in after self-enrolling?
+
+## Related Issues
+
+- https://github.com/openbao/openbao/issues/3576
+
+## Proof of Concept
+
+

--- a/website/content/community/rfcs/totp-self-enroll.mdx
+++ b/website/content/community/rfcs/totp-self-enroll.mdx
@@ -59,11 +59,26 @@ This is again similar to `mfaResponseAuthQueue`.
 
 This means queued self-enrollments don't survive an active-node change.
 
+### Authorizing confirmation and cancellation
+
+A valid request id alone does not authorize a call to the confirmation or cancellation endpoints.
+When `findSelfEnrollableTOTPMethod` decides to self-enroll the user, `internal/vault/request_handling.go` also mints a token specifically for self enrollment.
+This token:
+
+- carries an inline policy scoped to only `sys/mfa/self-enroll/totp` (`create`, `update`, `delete`) and nothing else
+- is bound to this specific enrollment attempt via `InternalMeta["request_id"]`
+- shares the same TTL and `ExplicitMaxTTL` as the queue entry (`defaultTOTPSelfEnrollmentTTL`)
+
+It is returned to the client as `client_token` alongside the QR code/secret payload, and must be presented on both the confirmation and cancellation calls.
+The token is not single-use: a wrong TOTP code does not consume it, so retries stay bounded by the token's TTL and the rate-limiting than by exhausting the token.
+
 ### Confirmation and cancellation endpoints
 
-Two new unauthenticated system paths are added to `SystemBackend` (`internal/vault/login_mfa.go`):
+Two new system paths are added to `SystemBackend` (`internal/vault/login_mfa.go`), both requiring the token described above:
 
 - `POST /v1/sys/mfa/self-enroll/totp` (`request_id`, `totp_code`) -
+  looks up the presented token and rejects the request if its bound
+  `InternalMeta["request_id"]` does not match the supplied `request_id`, then
   pops the pending entry by ID, verifies the confirming request is in the
   same namespace it was issued in and rate-limits validation attempts using the same `rateLimits` cache the
   standard MFA validation path uses (keyed as `<methodID>_<entityID>_selfenroll` to not conflict with it,
@@ -73,10 +88,14 @@ Two new unauthenticated system paths are added to `SystemBackend` (`internal/vau
   TOTP enrollment uses, and writes the `mfa.Secret` into `entity.MFASecrets`.
   If confirmation fails at any point after popping the
   entry, it's pushed back onto the queue so the user can retry within the
-  remaining TTL rather than having to restart self-enrollment. This mimics the `mfaResponseAuthQueue` as well
+  remaining TTL rather than having to restart self-enrollment. This mimics the `mfaResponseAuthQueue` as well.
+  On success the server revokes the token itself.
 - `DELETE /v1/sys/mfa/self-enroll/totp` (`request_id`) -
-  pops and discards the pending entry, invalidating it without persisting anything.
+  same token and request id check, then pops and discards the pending entry,
+  invalidating it without persisting anything, and revokes the token itself.
   Used when the user cancels enrollment client-side.
+
+Revocation happens server-side in both cases rather than relying on the client to separately call `auth/token/revoke-self`.
 
 ### Finalize the self-enrollment
 
@@ -92,13 +111,16 @@ As the confirmation and cancellation are requests the client has to send, these 
 
 The auth controller (`ui/app/controllers/vault/cluster/auth.js`, which handles the login) checks for the new `mfa_self_enroll` response field and routes to a new `Mfa::TotpSelfEnroll` component.
 The component renders a QR code client-side (via the `qrcode` package, from the returned `totp_url`) and the raw secret as a fallback, and submits the confirmation or cancellation calls through two new `cluster` adapter methods that wrap the endpoints mentioned above.
+The `client_token` returned alongside the enrollment data is threaded through the auth controller and component down to those adapter methods, which use it to authenticate against the endpoints.
 On success, the user is bounced back to the login form with a message asking them to log in again. When cancelled, the success of that is also sent to the user through that way.
 
 ## Rationale and alternatives
 
-### One-time token to generate a TOTP secret vs the self-enrollment system
+### Single use token vs reusable token
 
-The self-enrollment system is the barrier of entry, when a second factor is required. While OpenBao could just generate a one-time-usage token for the `/identity/mfa/method/totp/generate` endpoint, this would require equally as much work, while also creating a valid token that leaves more surface area to be attacked.
+The current minted token is not single use and in effect allows for multiple attempts at self enrollment. While this sounds insecure, the token is scoped, timed and gets forcefully revoked by the server when its purpose has been fulfilled.
+
+While a single use token would theoretically be more secure, the UX impact as well as the actual security gain would need to be weighed against each other.
 
 ### Completing login vs log in again after enrollment
 
@@ -113,7 +135,7 @@ This leads to loss of state on failover between nodes, which is intended, as the
 
 - The self-enrollment queue silently doesn't survive active node changes or restarts
 - Re-login is a worse experience for the user
-- Confirmation but especially the invalidation of a self-enrollment attempt hinge on the request uuid
+- Confirmation and cancellation hinge on possession of the request-scoped token, not on re-proving the enrolling identity - anyone holding both the token and the request id can complete or cancel the enrollment
 - Loss of admin driven MFA enrollment for TOTP
 
 ## Security Implications
@@ -127,9 +149,15 @@ While this already requires a valid username and password, this should still be 
 
 The TOTP secret as well as init url (which also includes the secret) are send to the user in a HTTP request as well as stored in memory as plaintext.
 
-### Self-Enrollment confirmation endpoint is unauthenticated
+### Confirmation and cancellation are authorized by a token minted without a second factor
 
-Out of necessity the endpoint to confirm TOTP self-enrollment is unauthenticated and only protected through the request id.
+The token that authorizes the confirmation and cancellation endpoints (see "Authorizing confirmation and cancellation" above) is itself issued right after first-factor auth, before any second factor is proven - the same trust boundary noted in "Primary auth leads to full trust" applies to it.
+Its possible impact is kept deliberately small:
+
+- it can only call the two self-enrollment paths
+- it is bound to a single request id
+- it lives no longer than the enrollment window
+- the server revokes it as soon as the enrollment is confirmed or cancelled.
 
 ## User/Developer Experience
 

--- a/website/content/community/rfcs/totp-self-enroll.mdx
+++ b/website/content/community/rfcs/totp-self-enroll.mdx
@@ -147,4 +147,5 @@ Should the user be logged in after self-enrolling?
 
 ## Proof of Concept
 
+https://github.com/openbao/openbao/pull/3772
 

--- a/website/content/community/rfcs/totp-self-enroll.mdx
+++ b/website/content/community/rfcs/totp-self-enroll.mdx
@@ -18,7 +18,7 @@ This leads to unnecessary overhead when wanting to enforce TOTP as a second fact
 
 ## User-facing description
 
-Current sequence for a user in the UI:
+Revised sequence for a user in the UI:
 1. Log in
 2. If a self-enrollable TOTP MFA method is enforced and not yet configured, redirection to the self-enrollemnt page
 3. Show a QR code as well as the TOTP secret to allow easy setup

--- a/website/content/community/rfcs/totp-self-enroll.mdx
+++ b/website/content/community/rfcs/totp-self-enroll.mdx
@@ -120,7 +120,7 @@ This leads to loss of state on failover between nodes, which is intended, as the
 
 ### Primary auth leads to full trust
 
-The self-enrollment only requires a username and password. This sounds obvious, but because there are no email notifications or similar to a user, a wrong enrollment by a bad actor won't per-se be noticed.
+The self-enrollment only requires valid first-factor authentication. This sounds obvious, but because there are no email notifications or similar to a user, a wrong enrollment by a bad actor won't per-se be noticed.
 While this already requires a valid username and password, this should still be noted.
 
 ### Plaintext TOTP secret

--- a/website/sidebarsCommunity.ts
+++ b/website/sidebarsCommunity.ts
@@ -103,6 +103,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/control-groups",
                 "rfcs/pqc",
                 "rfcs/index-headers",
+                "rfcs/totp-self-enroll",
             ],
         },
         {

--- a/website/sidebarsCommunity.ts
+++ b/website/sidebarsCommunity.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
                 "rfcs/grpc-invalidation",
                 "rfcs/control-groups",
                 "rfcs/pqc",
+                "rfcs/totp-self-enroll",
             ],
         },
         {


### PR DESCRIPTION
## Description

As discussed on [Zulip](https://linuxfoundation.zulipchat.com/#narrow/channel/529890-openssf-openbao-discussion/topic/TOTP.20self.20enrollment/with/615619356), here is my RFC for adding TOTP self-enrollment.

A PoC can be found in https://github.com/openbao/openbao/pull/3772

## Rationale

Working on resolving: #3576 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
