### PR TITLE
Fix when to issue sleep

### DIFF
--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -596,7 +596,7 @@ func (c *Core) leadershipLoop(manualStepDownCh, stopCh <-chan struct{}, isReadEn
 // become leader and potentially running a read-enabled standby in the
 // interim.
 func (c *Core) waitForLeadership(iteration int, manualStepDown *bool, manualStepDownCh, stopCh <-chan struct{}, isReadEnabled bool) (stop bool) {
-	if iteration == 0 && !*manualStepDown {
+	if iteration > 0 && !*manualStepDown {
 		// If we restarted the for loop due to an error, wait a second
 		// so that we don't busy loop if the error persists.
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Startup on all horizontally scalable engines was artificially delayed on initial startup due to an inverted condition around the sleep.

See also: #3736

fyi @JanMa 

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
