### PR TITLE
Decrease delay in acquiring HA lock

### DIFF
--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -14,11 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
-	metrics "github.com/hashicorp/go-metrics/compat"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-uuid"
-	"github.com/oklog/run"
 	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
@@ -28,6 +23,13 @@ import (
 	"github.com/openbao/openbao/v2/internal/vault/barrier"
 	"github.com/openbao/openbao/v2/internal/vault/policy"
 	"github.com/openbao/openbao/v2/internal/vault/seal"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/hashicorp/errwrap"
+	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/oklog/run"
 )
 
 const (
@@ -1318,6 +1320,12 @@ func (c *Core) scheduleUpgradeCleanup(ctx context.Context) error {
 
 // acquireLock blocks until the lock is acquired, returning the leaderLostCh
 func (c *Core) acquireLock(lock physical.Lock, stopCh <-chan struct{}) <-chan struct{} {
+	// Use an exponential backoff on errors during lock acquisition. This
+	// ensures transitive failures don't result in 10-second backoffs, at
+	// the expense of more burst-y database traffic.
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 15 * time.Millisecond
+	b.MaxInterval = lockRetryInterval
 	for {
 		// Attempt lock acquisition
 		leaderLostCh, err := lock.Lock(stopCh)
@@ -1327,7 +1335,7 @@ func (c *Core) acquireLock(lock physical.Lock, stopCh <-chan struct{}) <-chan st
 
 		// Retry the acquisition
 		c.logger.Error("failed to acquire lock", "error", err)
-		timer := time.NewTimer(lockRetryInterval)
+		timer := time.NewTimer(b.NextBackOff())
 		select {
 		case <-timer.C:
 		case <-stopCh:


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

On transitive failures on fresh loops, use exponential backoff during lock acquisition to ensure that we don't always blindly block for 10 seconds. This can lead to a burst of database traffic, though, we should eventually go back to 10s+ backoffs. 

## Rationale

15ms initial value seems reasonably safe to support faster local HA setups versus longer network backed setups (with randomization + exponential growth).

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
