### PR TITLE
fix allow unauthenticated workflows

### DIFF
--- a/changelog/3785.txt
+++ b/changelog/3785.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sys/workflows: Allow unauthenticated workflow execution without authentification
+```

--- a/internal/vault/external_tests/workflows/workflow_test.go
+++ b/internal/vault/external_tests/workflows/workflow_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestWorkflow(t *testing.T) {
 	coreConfig := &vault.CoreConfig{
-		DisableCache: true,
+		DisableCache:                  true,
+		AllowUnauthenticatedWorkflows: true,
 		CredentialBackends: map[string]logical.Factory{
 			"userpass": userpass.Factory,
 		},
@@ -64,6 +65,14 @@ func TestWorkflow(t *testing.T) {
 
 		client := client.WithNamespace("mfa")
 		testWorkflowLoginMFA(t, client)
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		_, err := client.Logical().Write("sys/namespaces/unauthenticated", map[string]any{})
+		require.NoError(t, err)
+
+		client := client.WithNamespace("unauthenticated")
+		testWorkflowUnauthenticatedExecute(t, client)
 	})
 }
 
@@ -169,6 +178,41 @@ func testWorkflowLoginMFA(t *testing.T, client *api.Client) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
+
+func testWorkflowUnauthenticatedExecute(t *testing.T, client *api.Client) {
+	// Create a unauthed workflow
+	_, err := client.Logical().Write("sys/workflows/manage/unauthed-check", map[string]any{
+		"workflow":              sealStatusWorkflow,
+		"allow_unauthenticated": true,
+	})
+	require.NoError(t, err)
+
+	// Create a normal, authed workflow
+	_, err = client.Logical().Write("sys/workflows/manage/authed-check", map[string]any{
+		"workflow":              sealStatusWorkflow,
+		"allow_unauthenticated": false,
+	})
+	require.NoError(t, err)
+
+	unauthClient, err := client.CloneWithHeaders()
+	require.NoError(t, err)
+	unauthClient.ClearToken()
+
+	_, err = unauthClient.Logical().Write("sys/workflows/unauthed-execute/authed-check", nil)
+	require.Error(t, err)
+
+	_, err = unauthClient.Logical().Write("sys/workflows/unauthed-execute/unauthed-check", nil)
+	require.NoError(t, err)
+}
+
+const sealStatusWorkflow = `
+flow "check" {
+  request "status" {
+    operation = "read"
+    path = "sys/seal-status"
+  }
+}
+`
 
 const createNamespaceWorkflow = `
 input {

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -172,7 +172,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	}
 
 	if core.allowUnauthedWorkflows {
-		b.Backend.PathsSpecial.Unauthenticated = append(b.Backend.PathsSpecial.Unauthenticated, "workflows/unauthed-execute/+")
+		b.PathsSpecial.Unauthenticated = append(b.PathsSpecial.Unauthenticated, "workflows/unauthed-execute/+")
 	}
 
 	return b

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -171,6 +171,10 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 		b.Paths = append(b.Paths, b.raftStoragePaths()...)
 	}
 
+	if core.allowUnauthedWorkflows {
+		b.Backend.PathsSpecial.Unauthenticated = append(b.Backend.PathsSpecial.Unauthenticated, "workflows/unauthed-execute/+")
+	}
+
 	return b
 }
 

--- a/internal/vault/testing.go
+++ b/internal/vault/testing.go
@@ -1551,6 +1551,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.MetricSink = base.MetricSink
 		coreConfig.DisableSentinelTrace = base.DisableSentinelTrace
 		coreConfig.ClusterName = base.ClusterName
+		coreConfig.AllowUnauthenticatedWorkflows = base.AllowUnauthenticatedWorkflows
 		coreConfig.DisableAutopilot = base.DisableAutopilot
 		coreConfig.ServiceRegistration = base.ServiceRegistration
 		coreConfig.ImpreciseLeaseRoleTracking = base.ImpreciseLeaseRoleTracking


### PR DESCRIPTION
## Description

Add `workflows/unauthed-execute` to the unauthenticated paths, when these are allowed by the config

## Rationale

Resolves: #3784

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
