### PR TITLE
Fix flaky final second test to land predictably in last second

### DIFF
--- a/internal/vault/expiration_test.go
+++ b/internal/vault/expiration_test.go
@@ -2106,7 +2106,9 @@ func TestExpiration_Renew_FinalSecond(t *testing.T) {
 		},
 	}
 
-	time.Sleep(1000 * time.Millisecond)
+	// Follow CalculateTTL truncation to predictably land in final second bucket
+	finalBucket := le.IssueTime.Truncate(time.Second).Add(time.Second)
+	time.Sleep(time.Until(finalBucket))
 	_, err = exp.Renew(ctx, id, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -2168,7 +2170,9 @@ func TestExpiration_Renew_FinalSecond_Lease(t *testing.T) {
 	}
 	exp.persistEntry(ctx, le)
 
-	time.Sleep(1000 * time.Millisecond)
+	// Follow CalculateTTL truncation to predictably land in final second bucket
+	finalBucket := le.IssueTime.Truncate(time.Second).Add(time.Second)
+	time.Sleep(time.Until(finalBucket))
 	_, err = exp.Renew(ctx, id, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

See #3786 for background information. The modified sleep will always wait until the beginning of the final second, giving the test more time to succeed within it's allotted bucket. 

I noticed that the same flakiness also exists in `TestExpiration_Renew_FinalSecond_Lease` so I added the same fix there.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3786 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
