### PR TITLE
Propagate all 'wrapped-requested' requests

### DIFF
--- a/changelog/3790.txt
+++ b/changelog/3790.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Propagate requests with provided wrap info to mitigate 'read-only storage' error on standby nodes. 
+```

--- a/internal/vault/external_tests/standby/read_only_standby_test.go
+++ b/internal/vault/external_tests/standby/read_only_standby_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/openbao/openbao/api/v2"
 	logicalKv "github.com/openbao/openbao/v2/internal/builtin/logical/kv"
 	logicalPki "github.com/openbao/openbao/v2/internal/builtin/logical/pki"
+	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/helper/testhelpers"
 	"github.com/openbao/openbao/v2/internal/helper/testhelpers/teststorage"
 
+	"github.com/openbao/openbao/sdk/v2/helper/consts"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	vaulthttp "github.com/openbao/openbao/v2/internal/http"
 	"github.com/openbao/openbao/v2/internal/vault"
@@ -82,4 +84,62 @@ func TestReadOnlyStandby(t *testing.T) {
 	require.NoError(t, primaryClient.Auth().Token().RevokeTreeWithContext(t.Context(), token.Auth.ClientToken))
 	_, err = standbyClient.KVv2("kv").Get(t.Context(), "foo")
 	require.ErrorContains(t, err, "permission denied", "token was revoked on the primary, should be declined by secondaries")
+}
+
+func TestReadOnlyStandbysForwardingWrapping(t *testing.T) {
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"kv-v2": vault.PassthroughBackendFactory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	leader := cores[0].Core
+	vault.TestWaitActive(t, leader)
+	client := cores[0].Client
+	client.SetToken(cluster.RootToken)
+
+	require.NoError(t, client.Sys().Mount("wraptest", &api.MountInput{Type: "kv-v2"}))
+
+	req := &logical.Request{
+		Path:        "wraptest/secret",
+		ClientToken: cluster.RootToken,
+		Operation:   logical.CreateOperation,
+		Data: map[string]any{
+			"foo": "bar",
+		},
+	}
+
+	resp, err := leader.HandleRequest(namespace.RootContext(t.Context()), req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Standby nodes also handle the wrapping request (standby by forwarding)
+	for _, core := range cores {
+		req = &logical.Request{
+			Path:        "wraptest/secret",
+			ClientToken: cluster.RootToken,
+			Operation:   logical.ReadOperation,
+			WrapInfo: &logical.RequestWrapInfo{
+				TTL: time.Duration(15 * time.Second),
+			},
+		}
+
+		resp, err = core.HandleRequest(namespace.RootContext(t.Context()), req)
+		if core.HAState() == consts.Active {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, time.Duration(15*time.Second), resp.WrapInfo.TTL)
+		} else {
+			require.Error(t, err)
+			require.True(t, logical.ShouldForward(err))
+		}
+	}
 }

--- a/internal/vault/external_tests/token/token_test.go
+++ b/internal/vault/external_tests/token/token_test.go
@@ -452,9 +452,7 @@ path "auth/token/create" {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	client.SetToken(childSecret.Auth.ClientToken)
 	childInfo, err := client.Auth().Token().LookupSelf()
 	if err != nil {

--- a/internal/vault/request_handling.go
+++ b/internal/vault/request_handling.go
@@ -1051,6 +1051,16 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 		if c.standby.Load() && !c.StandbyReadsEnabled() {
 			return nil, ErrCannotForwardLocalOnly
 		}
+
+	// Request wrapping incurs storage (cubbyhole) writes, if the request
+	// is handled on standby node, it doesn't fail and response is not empty
+	// it will ultimately fail to save the wrapping token, and we'd still
+	// have to forward the request.
+	// Preemptively forward the requests with wrapping info provided.
+	case req.WrapInfo != nil && req.WrapInfo.TTL != 0:
+		if c.Standby() {
+			return nil, logical.ErrPerfStandbyPleaseForward
+		}
 	}
 
 	var auth *logical.Auth
@@ -1219,22 +1229,19 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 
 // doRoutingIfApproved will check if the request needs approval before routing
 func (c *Core) doRoutingIfApproved(ctx context.Context, req *logical.Request, auth *logical.Auth) (*logical.Response, error) {
-	var routeErr error
-	var resp *logical.Response
-	if !c.needsApproval(ctx, req, auth) {
-		resp, routeErr = c.doRouting(ctx, req)
+	if !c.needsApproval(req, auth) {
+		return c.doRouting(ctx, req)
 	} else {
-		resp = &logical.Response{}
+		return &logical.Response{}, nil
 	}
-	return resp, routeErr
 }
 
 func (c *Core) isLoginRequest(ctx context.Context, req *logical.Request) bool {
 	return c.router.LoginPath(ctx, req.Path)
 }
 
-// needsApproval will assess if a ControlGroup policy is applicable, so that request is deferred until unwrap
-func (c *Core) needsApproval(ctx context.Context, req *logical.Request, auth *logical.Auth) bool {
+// needsApproval will assess if a ControlGroup policy is applicable, so that request is deferred until unwrap.
+func (c *Core) needsApproval(req *logical.Request, auth *logical.Auth) bool {
 	if auth.PolicyResults != nil &&
 		auth.PolicyResults.ControlGroup != nil &&
 		req.ForwardedFrom != forwardedFromDeferral {
@@ -1418,7 +1425,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 
 		// Set wrapTTL from ControlGroup.TTL if present
-		if c.needsApproval(ctx, req, auth) {
+		if c.needsApproval(req, auth) {
 			cgTTL := auth.PolicyResults.ControlGroup.TTL
 			if cgTTL > 0 {
 				wrapTTL = cgTTL


### PR DESCRIPTION
## Description
This PR adds a `case req.WrapInfo != nil && req.WrapInfo.TTL != 0:` check on `(*Core).handleCancelableRequest()` method to catch the "wrapping requested" requests to propagate before handling on standby nodes as they ultimate fail with `read-only storage` error.

## Rationale
```
    // Request wrapping incurs storage (cubbyhole) writes, if the request
	// is handled on standby node, it doesn't fail and response is not empty
	// it will ultimately fail to save the wrapping token, and we'd still
	// have to forward the request.
```
comment explains the requirement, which otherwise requires the downstream adaptors to always track the current leader node to always direct the wrapping request there.

Resolves: #3026

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
