### PR TITLE
add 'show internal engines' toggle

### DIFF
--- a/changelog/3794.txt
+++ b/changelog/3794.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui/secrets: Add 'Show internal engines' button to, by default, hide the `cubbyhole` secret engine
+```

--- a/changelog/3794.txt
+++ b/changelog/3794.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui/secrets: Add 'Show internal engines' button to, by default, hide the `cubbyhole` secret engine
+ui/secrets: Add 'Show internal engines' button to, by default, hide the `cubbyhole` secret engine.
 ```

--- a/ui/app/controllers/vault/cluster/secrets/backends.js
+++ b/ui/app/controllers/vault/cluster/secrets/backends.js
@@ -15,10 +15,18 @@ export default class VaultClusterSecretsBackendController extends Controller {
   @tracked secretEngineOptions = [];
   @tracked selectedEngineType = null;
   @tracked selectedEngineName = null;
+  @tracked showInternalEngines = false;
 
-  #displayableBackendsCache = createCache(() => this.model.filter((be) => be.shouldIncludeInList));
+  #displayableBackendsCache = createCache(() =>
+    this.model.filter((be) => be.shouldIncludeInList && (this.showInternalEngines || !be.isInternal))
+  );
   get displayableBackends() {
     return getValue(this.#displayableBackendsCache);
+  }
+
+  @action
+  toggleShowInternalEngines(checked) {
+    this.showInternalEngines = checked;
   }
 
   get sortedDisplayableBackends() {

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -133,6 +133,10 @@ export default class SecretEngineModel extends Model {
     return !LIST_EXCLUDED_BACKENDS.includes(this.engineType);
   }
 
+  get isInternal() {
+    return this.engineType === 'cubbyhole';
+  }
+
   get isSupportedBackend() {
     return LINKED_BACKENDS.includes(this.engineType);
   }

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -134,7 +134,7 @@ export default class SecretEngineModel extends Model {
   }
 
   get isInternal() {
-    return this.engineType === 'cubbyhole';
+    return this.path === 'cubbyhole/';
   }
 
   get isSupportedBackend() {

--- a/ui/app/styles/core/toggle.scss
+++ b/ui/app/styles/core/toggle.scss
@@ -100,7 +100,7 @@
 .toggle[type='checkbox'].is-small + label::after {
   will-change: left;
 }
-.toggle[type='checkbox']:focus + label {
+.toggle[type='checkbox']:focus + label::before {
   box-shadow: 0 0 1px $blue;
 }
 .toggle[type='checkbox'].is-success:checked + label::before {

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -33,6 +33,16 @@
       @inputValue={{if this.selectedEngineName (array this.selectedEngineName)}}
       class="is-marginless has-left-padding-s"
     />
+    <Toggle
+      @name="show-internal-engines"
+      @status="success"
+      @size="small"
+      @checked={{this.showInternalEngines}}
+      @onChange={{this.toggleShowInternalEngines}}
+      data-test-show-internal-engines-toggle
+    >
+      <span class="has-text-grey">Show internal engines</span>
+    </Toggle>
   </ToolbarFilters>
   <ToolbarActions>
     <ToolbarLink @route="vault.cluster.settings.mount-secret-backend" @type="add" data-test-enable-engine>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -33,16 +33,18 @@
       @inputValue={{if this.selectedEngineName (array this.selectedEngineName)}}
       class="is-marginless has-left-padding-s"
     />
-    <Toggle
-      @name="show-internal-engines"
-      @status="success"
-      @size="small"
-      @checked={{this.showInternalEngines}}
-      @onChange={{this.toggleShowInternalEngines}}
-      data-test-show-internal-engines-toggle
-    >
-      <span class="has-text-grey">Show internal engines</span>
-    </Toggle>
+    <span class="is-marginless has-left-padding-xs">
+      <Toggle
+        @name="show-internal-engines"
+        @status="success"
+        @size="small"
+        @checked={{this.showInternalEngines}}
+        @onChange={{this.toggleShowInternalEngines}}
+        data-test-show-internal-engines-toggle
+      >
+        <span class="has-text-grey">Show internal engines</span>
+      </Toggle>
+    </span>
   </ToolbarFilters>
   <ToolbarActions>
     <ToolbarLink @route="vault.cluster.settings.mount-secret-backend" @type="add" data-test-enable-engine>

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -65,7 +65,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await settled();
     // filter by type
     await clickTrigger('#filter-by-engine-type');
-    await searchSelect.options[1].click();
+    await searchSelect.options[0].click();
 
     const rows = document.querySelectorAll('[data-test-auth-backend-link]');
     const rowsAws = Array.from(rows).filter((row) => row.innerText.includes('database'));

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -87,4 +87,32 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await consoleComponent.runCommands([`delete sys/mounts/${enginePath1}`]);
     await consoleComponent.runCommands([`delete sys/mounts/${enginePath2}`]);
   });
+
+  test('it hides internal engines by default and shows them when toggled', async function (assert) {
+    assert.expect(3);
+
+    await backendsPage.visit();
+    await settled();
+    assert.strictEqual(
+      backendsPage.rows.filterBy('path', 'cubbyhole/').length,
+      0,
+      'does not show the internal cubbyhole engine by default'
+    );
+
+    await backendsPage.showInternalEngines();
+    await settled();
+    assert.strictEqual(
+      backendsPage.rows.filterBy('path', 'cubbyhole/').length,
+      1,
+      'shows the internal cubbyhole engine once toggled on'
+    );
+
+    await backendsPage.showInternalEngines();
+    await settled();
+    assert.strictEqual(
+      backendsPage.rows.filterBy('path', 'cubbyhole/').length,
+      0,
+      'hides the internal cubbyhole engine again once toggled off'
+    );
+  });
 });

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -9,6 +9,7 @@ import uiPanel from 'vault/tests/pages/components/console/ui-panel';
 export default create({
   consoleToggle: clickable('[data-test-console-toggle]'),
   visit: visitable('/vault/secrets'),
+  showInternalEngines: clickable('[data-test-show-internal-engines-toggle]'),
   rows: collection('[data-test-auth-backend-link]', {
     path: text('[data-test-secret-path]'),
     menu: clickable('[data-test-popup-menu-trigger]'),

--- a/ui/tests/pages/settings/mount-secret-backend.js
+++ b/ui/tests/pages/settings/mount-secret-backend.js
@@ -17,7 +17,6 @@ export default create({
   maxTTLUnit: fillable('[data-test-ttl-unit="Max Lease TTL"] [data-test-select="ttl-unit"]'),
   enableDefaultTtl: clickable('[data-test-toggle-input="Default Lease TTL"]'),
   enableEngine: clickable('[data-test-enable-engine]'),
-  showInternalEngines: clickable('[data-test-show-internal-engines-toggle]'),
   secretList: clickable('[data-test-sidebar-nav-link="Secrets engines"]'),
   defaultTTLVal: fillable('input[data-test-ttl-value="Default Lease TTL"]'),
   defaultTTLUnit: fillable('[data-test-ttl-unit="Default Lease TTL"] [data-test-select="ttl-unit"]'),

--- a/ui/tests/pages/settings/mount-secret-backend.js
+++ b/ui/tests/pages/settings/mount-secret-backend.js
@@ -17,6 +17,7 @@ export default create({
   maxTTLUnit: fillable('[data-test-ttl-unit="Max Lease TTL"] [data-test-select="ttl-unit"]'),
   enableDefaultTtl: clickable('[data-test-toggle-input="Default Lease TTL"]'),
   enableEngine: clickable('[data-test-enable-engine]'),
+  showInternalEngines: clickable('[data-test-show-internal-engines-toggle]'),
   secretList: clickable('[data-test-sidebar-nav-link="Secrets engines"]'),
   defaultTTLVal: fillable('input[data-test-ttl-value="Default Lease TTL"]'),
   defaultTTLUnit: fillable('[data-test-ttl-unit="Default Lease TTL"] [data-test-select="ttl-unit"]'),


### PR DESCRIPTION
## Description

Adds a toggle to show/hide internal engines (right now this is only the cubbyhole engine type, could be including the other two hidden by default)

<img width="1085" height="198" alt="Screenshot 2026-08-13 224933" src="https://github.com/user-attachments/assets/22be984f-ae8a-4b59-93d4-65c73358f477" />

## Rationale

Resolves: #3754 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
