### PR TITLE
Add missing job-level permissions to the workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       # required for all workflows
       security-events: write
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -35,6 +35,7 @@ jobs:
     name: Test Docs
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publiccodeyml-check.yml
+++ b/.github/workflows/publiccodeyml-check.yml
@@ -10,14 +10,13 @@ on:
       - "publiccode.yml"
       - ".github/workflows/publiccodeyml-check.yml"
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   validate:
     name: publiccode.yml validation
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -125,6 +125,7 @@ jobs:
     needs: test-matrix
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
     strategy:
       fail-fast: false
@@ -279,6 +280,7 @@ jobs:
     needs: [test-go, test-matrix]
     runs-on: ubuntu-slim
     permissions:
+      contents: read
       actions: write
     steps:
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -25,6 +25,7 @@ jobs:
     name: Test UI
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -13,6 +13,7 @@ jobs:
     name: Verify Commit Signatures
     runs-on: ubuntu-slim
     permissions:
+      contents: read
       pull-requests: read
     
     steps:


### PR DESCRIPTION
## Description
Adds missing permissions when a more granular job-level `permissions` block was used which does not inherit top-level `permissions` properties

## Rationale
Follow up to #3768, this would surface if you tried to run the actions in a authorization required environment.

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
