### PR TITLE
Wrap all proxyproto errors with ErrInvalidUpstream

### DIFF
--- a/internal/helper/proxyutil/proxyutil.go
+++ b/internal/helper/proxyutil/proxyutil.go
@@ -59,7 +59,7 @@ func WrapInProxyProto(listener net.Listener, config *ProxyProtoConfig) (net.List
 
 				sa, err := sockaddr.NewSockAddr(addr.String())
 				if err != nil {
-					return proxyproto.REJECT, fmt.Errorf("error parsing remote address: %w", err)
+					return proxyproto.REJECT, fmt.Errorf("%w: error parsing remote address: %v", proxyproto.ErrInvalidUpstream, err)
 				}
 
 				for _, authorizedAddr := range config.AuthorizedAddrs {
@@ -72,7 +72,7 @@ func WrapInProxyProto(listener net.Listener, config *ProxyProtoConfig) (net.List
 					return proxyproto.IGNORE, nil
 				}
 
-				return proxyproto.REJECT, errors.New(`upstream connection not trusted proxy_protocol_behavior is "deny_unauthorized"`)
+				return proxyproto.REJECT, fmt.Errorf("%w: upstream connection not trusted proxy_protocol_behavior is 'deny_unauthorized'", proxyproto.ErrInvalidUpstream)
 			},
 		}
 	default:


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

All errors in the ProxyProto wrapper need to be wrapped with ErrInvalidUpstream to prevent propagating the error upwards and thus exiting the proxy handling loop.

The other site was also missed in #3669 fwiw, though is substantially more rare. 

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3664

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
