### PR TITLE
Only attempt to change file sink ownership in agent when explicitly requested (#3733)

### DIFF
--- a/changelog/3733.txt
+++ b/changelog/3733.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/agent: Fix file sink chown failing unconditionally on Windows.
+```

--- a/command/agentproxyshared/sink/file/file_sink.go
+++ b/command/agentproxyshared/sink/file/file_sink.go
@@ -147,9 +147,11 @@ func (f *fileSink) WriteToken(token string) error {
 		return nil
 	}
 
-	// adjust file ownership if the sink has a none-default uid or gid configuration
-	if err := os.Chown(tmpFile.Name(), f.uid, f.gid); err != nil {
-		return fmt.Errorf("error changing file ownership of %s to uid %d and gid %d: %w", tmpFile.Name(), f.uid, f.gid, err)
+	// Only attempt to change ownership if uid/gid were explicitly configured
+	if f.uid != -1 || f.gid != -1 {
+		if err := os.Chown(tmpFile.Name(), f.uid, f.gid); err != nil {
+			return fmt.Errorf("error changing file ownership of %s to uid %d and gid %d: %w", tmpFile.Name(), f.uid, f.gid, err)
+		}
 	}
 
 	err = os.Rename(tmpFile.Name(), f.path)


### PR DESCRIPTION
Backport of #3733.

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3730

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
