### PR TITLE
Flaky postgres scalability

### DIFF
--- a/internal/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/internal/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	EVAR_BINARY = "BAO_BINARY"
+)
+
 func TestPostgreSQL_FencedWrites(t *testing.T) {
 	binary := api.ReadBaoVariable("BAO_BINARY")
 	if binary == "" {
@@ -328,67 +332,71 @@ func TestPostgreSQL_Upgrade(t *testing.T) {
 	require.Equal(t, value.Data["value"], "known-value")
 }
 
-func TestPostgreSQL_Scalability(t *testing.T) {
-	binary := api.ReadBaoVariable("BAO_BINARY")
+func clusterMapper(ctx context.Context, cluster *thpsql.Cluster, index int) (*thpsql.Node, error) {
+	nodesOnPrimary := 2
+	if index < nodesOnPrimary {
+		return cluster.Primary, nil
+	}
+
+	if index == nodesOnPrimary {
+		node, err := cluster.AddNode(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add replica: %w", err)
+		}
+
+		return node, nil
+	}
+
+	return cluster.Nodes[1], nil
+}
+
+type Container struct {
+	Storage *docker.PostgreSQLClusterStorage
+	Cluster *docker.DockerCluster
+}
+
+func erectCluster(t *testing.T) *Container {
+	// Read e-var that identifies the Openbao executable.
+	binary := api.ReadBaoVariable(EVAR_BINARY)
 	if binary == "" {
 		t.Skip("missing $BAO_BINARY")
 	}
 
+	// Setup logging
 	logger := logging.NewVaultLogger(log.Trace).Named(t.Name())
 	pLogger := logger.Named("postgresql-cluster")
 	cLogger := logger.Named("openbao-cluster")
 
-	nodesOnPrimary := 2
-	mapper := func(ctx context.Context, cluster *thpsql.Cluster, index int) (*thpsql.Node, error) {
-		if index < nodesOnPrimary {
-			return cluster.Primary, nil
-		}
-
-		if index == nodesOnPrimary {
-			node, err := cluster.AddNode(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to add replica: %w", err)
-			}
-
-			return node, nil
-		}
-
-		return cluster.Nodes[1], nil
-	}
-
-	pCluster, err := docker.NewPostgreSQLClusterStorage(t.Context(), pLogger, "scalability", "", mapper)
+	// Setup & teardown storage.
+	cStorage, err := docker.NewPostgreSQLClusterStorage(t.Context(), pLogger, "scalability", "", clusterMapper)
 	require.NoError(t, err)
+	t.Cleanup(cStorage.Cluster.Cleanup)
 
-	defer func() { require.NoError(t, pCluster.Cleanup()) }()
+	// Setup & teardown cluster.
+	options := docker.DraftClusterOptions(binary, cStorage, cLogger)
+	options.ClusterOptions.ClusterName = "psql-upgrade"
+	cluster := docker.NewTestDockerCluster(t, options)
+	t.Cleanup(cluster.Cleanup)
 
-	opts := &docker.DockerClusterOptions{
-		ImageRepo:   "quay.io/openbao/openbao",
-		ImageTag:    "latest",
-		Storage:     pCluster,
-		VaultBinary: binary,
-		ClusterOptions: testcluster.ClusterOptions{
-			VaultNodeConfig: &testcluster.VaultNodeConfig{
-				// Audit logs help with debugging.
-				AuditLogStdout:      true,
-				LogLevel:            "TRACE",
-				DisableStandbyReads: false,
-			},
-			ClusterName: "psql-upgrade",
-			NumCores:    3,
-			Logger:      cLogger,
-		},
+	return &Container{
+		Storage: cStorage,
+		Cluster: cluster,
 	}
+}
 
-	cluster := docker.NewTestDockerCluster(t, opts)
-	defer cluster.Cleanup()
+func TestPostgreSQL_Scalability(t *testing.T) {
+	// Erect a docker cluster with storage.
+	virtCluster := erectCluster(t)
+	cluster := virtCluster.Cluster
+	storage := virtCluster.Storage
 
+	// Access the nodes of the cluster with a client.
 	nodes := cluster.Nodes()
 	client := nodes[0].APIClient()
-
 	t.Logf("token: %v vs %v", client.Token(), cluster.GetRootToken())
 
 	// Create some data to test persistence.
-	err = client.Sys().Mount("kv", &api.MountInput{
+	err := client.Sys().Mount("kv", &api.MountInput{
 		Type: "kv",
 		Options: map[string]string{
 			"version": "2",
@@ -403,7 +411,7 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 
 	// Read the key; it should exist.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		for index, node := range cluster.Nodes() {
+		for index, node := range nodes {
 			nodeClientCfg := node.APIClient().CloneConfig()
 
 			// Do not allow redirects from standby->active; force local
@@ -488,7 +496,7 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 
 	// All nodes should have the same data
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		for index, node := range cluster.Nodes() {
+		for index, node := range nodes {
 			nodeClientCfg := node.APIClient().CloneConfig()
 
 			// Do not allow redirects from standby->active; force local
@@ -509,12 +517,12 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 
 	// Taking down the primary PostgreSQL node should cause problems for all
 	// nodes talking to it.
-	require.NoError(t, pCluster.Cluster.RemovePrimary(t.Context()))
+	require.NoError(t, storage.Cluster.RemovePrimary(t.Context()))
 	time.Sleep(2 * time.Second)
 
 	start := time.Now()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		for index, node := range cluster.Nodes()[0:1] {
+		for index, node := range nodes[0:1] {
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 
@@ -530,11 +538,11 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// We should be able to promote the replica and the tertiary should follow.
-	require.NoError(t, pCluster.Cluster.PromoteNode(t.Context(), 0))
+	require.NoError(t, storage.Cluster.PromoteNode(t.Context(), 0))
 	time.Sleep(2 * time.Second)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		for index, node := range cluster.Nodes()[2:] {
+		for index, node := range nodes[2:] {
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -51,7 +51,12 @@ var (
 	_ testcluster.VaultClusterNode = &DockerClusterNode{}
 )
 
-const MaxClusterNameLength = 52
+const (
+	MaxClusterNameLength = 52
+
+	IMG_REPO = "quay.io/openbao/openbao"
+	IMG_TAG  = "latest"
+)
 
 // DockerCluster is used to managing the lifecycle of the test Vault cluster
 type DockerCluster struct {
@@ -1044,6 +1049,31 @@ func DefaultOptions(t *testing.T) *DockerClusterOptions {
 			},
 		},
 	}
+}
+
+func DraftClusterOptions(executable string, storage testcluster.ClusterStorage, cLogger log.Logger) *DockerClusterOptions {
+	nodeOptions := &testcluster.VaultNodeConfig{
+		AuditLogStdout:      true,
+		LogLevel:            "TRACE",
+		DisableStandbyReads: false,
+	}
+
+	clusterOptions := testcluster.ClusterOptions{
+		VaultNodeConfig: nodeOptions,
+		ClusterName:     "test-cluster",
+		NumCores:        3,
+		Logger:          cLogger,
+	}
+
+	options := &DockerClusterOptions{
+		ImageRepo:      IMG_REPO,
+		ImageTag:       IMG_TAG,
+		Storage:        storage,
+		VaultBinary:    executable,
+		ClusterOptions: clusterOptions,
+	}
+
+	return options
 }
 
 func ensureLeaderMatches(ctx context.Context, client *api.Client, ready func(response *api.LeaderResponse) error) error {


### PR DESCRIPTION
## Description

1. Removed lines that setup a container cluster from the actual test func.
2. One function named _DraftClusterOptions_ is generalized enough to belong to the file _sdk/helper/testcluster/docker/environment.go_. It is invoked in the func _erectCluster_ in _internal/vault/external_tests/postgresql_binary/postgresql_test.go_.
3. The actual test _TestPostgreSQL_Scalability_ hasn't been substantially changed.

```bash
BAO_BINARY=/bin/bao go test github.com/openbao/openbao/v2/internal/vault/external_tests/postgresql_binary -run '^TestPostgreSQL_Scalability$'
```

## Rationale
The test _TestPostgreSQL_Scalability_ suffered 9 failures between July 29th & August 13th of this year.

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
