### PR TITLE
Fix busy-loop when renewing a revoked-but-renewable token (#3747)

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -346,8 +346,16 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 
 		if errorBackoff == nil {
 			sleepDuration = r.calculateSleepDuration(remainingLeaseDuration, priorDuration)
-		} else if errorBackoff.NextBackOff() == backoff.Stop || remainingLeaseDuration < 0 {
-			return err
+		} else {
+			// A renewal error is in flight: sleep for the backoff interval
+			// rather than busy-looping. NextBackOff both advances the backoff
+			// state and returns the next interval; if it reports Stop (or the
+			// original lease has fully expired) give up and surface the error.
+			nextBackoff := errorBackoff.NextBackOff()
+			if nextBackoff == backoff.Stop || remainingLeaseDuration < 0 {
+				return err
+			}
+			sleepDuration = nextBackoff
 		}
 
 		// remainingLeaseDuration becomes the priorDuration for the next loop

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/rand"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"testing/quick"
 	"time"
@@ -280,5 +281,63 @@ func TestCalcSleepPeriod(t *testing.T) {
 		return lw.calculateSleepDuration(remainingLeaseDuration, priorDuration) < remainingLeaseDuration
 	}, &c); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestLifetimeWatcher_RenewErrorsBackOff guards against a busy-loop regression:
+// when renew keeps failing (e.g. the cached token was revoked but is still
+// marked renewable), the watcher must honor the error backoff between attempts
+// instead of retrying with a zero sleep. Before the fix, the errorBackoff branch
+// evaluated NextBackOff() only to compare against Stop and discarded the
+// returned interval, leaving sleepDuration at 0 — so the loop hammered
+// renew-self as fast as the CPU allowed. Here we assert the number of renew
+// attempts in a short window stays small (a few backed-off retries), not the
+// thousands a tight loop would produce. See openbao/openbao#3747.
+func TestLifetimeWatcher_RenewErrorsBackOff(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var attempts int64
+	renew := func(_ string, _ int) (*Secret, error) {
+		atomic.AddInt64(&attempts, 1)
+		return nil, errors.New("renew failure: token revoked")
+	}
+
+	v, err := client.NewLifetimeWatcher(&LifetimeWatcherInput{
+		Secret:    &Secret{LeaseDuration: 60},
+		Increment: 60,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doneCh := make(chan error, 1)
+	go func() {
+		// initialRetryInterval of 100ms: with backoff honored, a 1s window
+		// permits only a handful of attempts (100ms, 200ms, 400ms, ...). A
+		// zero-sleep busy loop would rack up thousands.
+		doneCh <- v.doRenewWithOptions(false, false, 60, "myleaseID", renew, 100*time.Millisecond)
+	}()
+
+	time.Sleep(time.Second)
+	v.Stop()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop")
+	}
+
+	n := atomic.LoadInt64(&attempts)
+	if n == 0 {
+		t.Fatal("expected at least one renew attempt")
+	}
+	// Generously bounded: exponential backoff from 100ms over ~1s yields well
+	// under 50 attempts; a busy loop would be in the thousands/millions.
+	if n > 50 {
+		t.Fatalf("renew was retried %d times in ~1s — backoff is not being honored (busy loop)", n)
 	}
 }

--- a/changelog/3813.txt
+++ b/changelog/3813.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api/lifetime_watcher: Fix a busy-loop that hammered the leader with `renew-self` requests when a cached, revoked-but-renewable token kept failing to renew; the renewal error backoff interval was computed but never applied.
+```


### PR DESCRIPTION
## Description

Fixes #3747.

When the auto-auth / proxy `LifetimeWatcher` renews a cached token whose `renew-self` keeps failing — e.g. the token was revoked out from under the proxy but is still marked `renewable` — it entered a tight retry loop that hammered the leader node with `renew-self` requests (the load described in the issue).

### Root cause

In `api/lifetime_watcher.go`, the error-backoff branch evaluated `NextBackOff()` only to compare it against `backoff.Stop`, and **discarded the returned interval**:

```go
if errorBackoff == nil {
    sleepDuration = r.calculateSleepDuration(...)
} else if errorBackoff.NextBackOff() == backoff.Stop || remainingLeaseDuration < 0 {
    return err
}
```

On a renewal error under the default `RenewBehaviorIgnoreErrors`, `sleepDuration` was left at its zero value, so `time.NewTimer(0)` fired immediately and the loop retried `renew` as fast as the CPU allowed — no backoff at all.

### Fix

Capture the interval `NextBackOff()` returns and use it as the sleep duration, still bailing out when it reports `Stop` or the original lease has fully expired:

```go
} else {
    nextBackoff := errorBackoff.NextBackOff()
    if nextBackoff == backoff.Stop || remainingLeaseDuration < 0 {
        return err
    }
    sleepDuration = nextBackoff
}
```

## Test

Adds `TestLifetimeWatcher_RenewErrorsBackOff` (`api/renewer_test.go`): a renew func that always errors, asserting the number of attempts in a ~1 s window stays small (backoff honored) rather than spinning.

**RED→GREEN, verified locally (Go 1.26.0):**
- Against the pre-fix code the test observed **1,798,812 renew attempts in ~1 s** — the busy loop, reproduced.
- With the fix it drops to a handful, and the test passes.

```
$ go test -run 'TestLifetimeWatcher|TestRenewer|TestCalcSleepPeriod' ./
ok  github.com/openbao/openbao/api/v2
```

`go build ./...`, `gofmt`, and the existing renewer suite all stay green. Only `api/lifetime_watcher.go` and `api/renewer_test.go` change. (The pre-existing `go vet` lock-copy notices in `client.go` are untouched and outside this diff.)

First-time contributor here — happy to adjust the backoff bounds in the test or the wording. I'll add the `changelog/<pr>.txt` entry once this PR has a number.
