### PR TITLE
UI: update ember-data to 4.12.x

### DIFF
--- a/changelog/3816.txt
+++ b/changelog/3816.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update ember-data to 4.12.8.
+```

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -34,7 +34,7 @@ module.exports = {
   rules: {
     'no-action': 'off',
     'no-implicit-this': {
-      allow: ['supported-auth-backends'],
+      allow: ['supported-auth-backends', 'current-mount-path'],
     },
     'require-input-label': 'off',
     'no-array-prototype-extensions': 'off',

--- a/ui/app/adapters/capabilities.js
+++ b/ui/app/adapters/capabilities.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import AdapterError from '@ember-data/adapter/error';
+import AdapterError, { ForbiddenError, NotFoundError } from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import ApplicationAdapter from './application';
 
@@ -16,6 +16,10 @@ export default ApplicationAdapter.extend({
     return this.ajax(this.buildURL(type), 'POST', { data: { paths: [id] } }).catch((e) => {
       if (e instanceof AdapterError) {
         set(e, 'policyPath', 'sys/capabilities-self');
+      }
+      // catch 403 and 404 errors
+      if (e instanceof ForbiddenError || e instanceof NotFoundError) {
+        return { data: { path: id } };
       }
       throw e;
     });

--- a/ui/app/adapters/kubernetes/config.js
+++ b/ui/app/adapters/kubernetes/config.js
@@ -34,8 +34,15 @@ export default class KubernetesConfigAdapter extends ApplicationAdapter {
   }
   _saveRecord(store, { modelName }, snapshot) {
     const data = store.serializerFor(modelName).serialize(snapshot);
-    const url = this.getURL(snapshot.attr('backend'));
-    return this.ajax(url, 'POST', { data }).then(() => data);
+    const id = snapshot.id || snapshot.attr('backend');
+    const url = this.getURL(id);
+    return this.ajax(url, 'POST', { data }).then(() => {
+      return {
+        ...data,
+        backend: id,
+        id,
+      };
+    });
   }
   checkConfigVars(backend) {
     return this.ajax(`${this.getURL(backend, 'check')}`, 'GET');

--- a/ui/app/adapters/pki/action.js
+++ b/ui/app/adapters/pki/action.js
@@ -5,6 +5,7 @@
 
 import { assert } from '@ember/debug';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
+import { v4 as uuidv4 } from 'uuid';
 import ApplicationAdapter from '../application';
 
 export default class PkiActionAdapter extends ApplicationAdapter {
@@ -45,7 +46,7 @@ export default class PkiActionAdapter extends ApplicationAdapter {
     return this.ajax(url, 'POST', { data }).then((result) => ({
       // pki/action endpoints don't correspond with a single specific entity,
       // so in ember-data we'll map it to the request ID
-      id: result.request_id,
+      id: result.request_id || uuidv4(),
       ...result,
     }));
   }

--- a/ui/app/adapters/pki/issuer.js
+++ b/ui/app/adapters/pki/issuer.js
@@ -56,7 +56,15 @@ export default class PkiIssuerAdapter extends ApplicationAdapter {
     const backend = this._getBackend(snapshot);
     const data = this.serialize(snapshot);
     const url = this.urlForQuery(backend, issuerId);
-    return this.ajax(url, 'POST', { data });
+    return this.ajax(url, 'POST', { data }).then((resp) => {
+      // keep the id stable if the response omits issuer_id; only set it when
+      // present so `undefined` is never pushed
+      const updatedData = { ...resp.data };
+      if (issuerId) {
+        updatedData.issuer_id = issuerId;
+      }
+      return { ...resp, data: updatedData };
+    });
   }
 
   query(store, type, query) {

--- a/ui/app/adapters/pki/key.js
+++ b/ui/app/adapters/pki/key.js
@@ -25,6 +25,11 @@ export default class PkiKeyAdapter extends ApplicationAdapter {
       url = `${url}/generate/${record.type}`;
     }
     return this.ajax(url, 'POST', { data: this.serialize(snapshot) }).then((resp) => {
+      // import responses always include key_id; generate may omit it, so fall
+      // back to the key name to keep the record id stable
+      if (!adapterOptions.import && !resp.data?.key_id && snapshot.attr('keyName')) {
+        return { ...resp, key_id: snapshot.attr('keyName') };
+      }
       return resp;
     });
   }

--- a/ui/app/adapters/pki/tidy.js
+++ b/ui/app/adapters/pki/tidy.js
@@ -20,8 +20,17 @@ export default class PkiTidyAdapter extends ApplicationAdapter {
       throw new Error('Auto tidy type models are never new, please use findRecord');
     }
 
+    const data = this.serialize(snapshot, tidyType);
     const url = `${this._baseUrl(backend)}/tidy`;
-    return this.ajax(url, 'POST', { data: this.serialize(snapshot, tidyType) });
+    return this.ajax(url, 'POST', { data }).then(() => {
+      return {
+        data: {
+          id: backend,
+          type: 'pki/tidy',
+          attributes: data,
+        },
+      };
+    });
   }
 
   // saving auto-tidy config POST requests will always update

--- a/ui/app/components/auth-config-form/config.js
+++ b/ui/app/components/auth-config-form/config.js
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module AuthConfigForm/Config
@@ -42,7 +43,7 @@ export default class AuthConfigBase extends Component {
       }
       return;
     }
-    this.router.transitionTo('vault.cluster.access.methods').followRedirects();
+    transitionToSafe(this.router, 'vault.cluster.access.methods');
     this.flashMessages.success('The configuration was saved successfully.');
   }
 

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -8,6 +8,7 @@ import AuthConfigComponent from './config';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module AuthConfigForm/Options
@@ -53,7 +54,7 @@ export default AuthConfigComponent.extend({
         }
         return;
       }
-      this.router.transitionTo('vault.cluster.access.methods').followRedirects();
+      transitionToSafe(this.router, 'vault.cluster.access.methods');
       this.flashMessages.success('The configuration was saved successfully.');
     })
   ),

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -221,7 +221,11 @@ export default Component.extend(DEFAULTS, {
           })
         );
         next(() => {
-          store.unloadAll('auth-method');
+          try {
+            store.unloadAll('auth-method');
+          } catch {
+            // unloadAll may fail in ember-data 4.12 if graph is torn down
+          }
         });
       } catch (e) {
         this.set('error', `There was an error fetching Auth Methods: ${e.errors[0]}`);

--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -38,7 +39,7 @@ export default class DatabaseConnectionEdit extends Component {
   }
 
   transitionToRoute() {
-    return this.router.transitionTo(...arguments);
+    return transitionToSafe(this.router, ...arguments);
   }
 
   @action

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -53,7 +54,7 @@ export default class DatabaseRoleEdit extends Component {
 
   @action
   generateCreds(roleId, roleType = '') {
-    this.router.transitionTo('vault.cluster.secrets.backend.credentials', roleId, {
+    transitionToSafe(this.router, 'vault.cluster.secrets.backend.credentials', roleId, {
       queryParams: { roleType },
     });
   }
@@ -66,7 +67,7 @@ export default class DatabaseRoleEdit extends Component {
       .destroyRecord()
       .then(() => {
         try {
-          this.router.transitionTo(LIST_ROOT_ROUTE, backend, { queryParams: { tab: 'role' } });
+          transitionToSafe(this.router, LIST_ROOT_ROUTE, backend, { queryParams: { tab: 'role' } });
         } catch (e) {
           console.debug(e); // eslint-disable-line
         }
@@ -93,7 +94,7 @@ export default class DatabaseRoleEdit extends Component {
       .save()
       .then(() => {
         try {
-          this.router.transitionTo(SHOW_ROUTE, `role/${secretId}`);
+          transitionToSafe(this.router, SHOW_ROUTE, `role/${secretId}`);
         } catch (e) {
           console.debug(e); // eslint-disable-line
         }

--- a/ui/app/components/generate-credentials.js
+++ b/ui/app/components/generate-credentials.js
@@ -6,6 +6,7 @@
 import { inject as service } from '@ember/service';
 import { computed, set } from '@ember/object';
 import Component from '@ember/component';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const MODEL_TYPES = {
   'ssh-sign': {
@@ -49,7 +50,7 @@ export default Component.extend({
       return type.model;
     }
     // if we don't have a mode for that type then redirect them back to the backend list
-    this.router.transitionTo('vault.cluster.secrets.backend.list-root', this.backendPath);
+    transitionToSafe(this.router, 'vault.cluster.secrets.backend.list-root', this.backendPath);
   },
 
   options: computed('action', 'backendType', function () {

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -9,6 +9,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module GeneratedItem
@@ -47,7 +48,9 @@ export default Component.extend({
         }
         return;
       }
-      this.router.transitionTo('vault.cluster.access.method.item.list').followRedirects();
+      // transitionToSafe resolves on the redirect abort, before the list
+      // route's model loads; the flash message needs no model data
+      transitionToSafe(this.router, 'vault.cluster.access.method.item.list');
       this.flashMessages.success(`Successfully saved ${this.itemType} ${this.model.id}.`);
     })
   ),
@@ -84,7 +87,8 @@ export default Component.extend({
     },
     deleteItem() {
       this.model.destroyRecord().then(() => {
-        this.router.transitionTo('vault.cluster.access.method.item.list').followRedirects();
+        // same as saveModel: the flash message needs no list-route model data
+        transitionToSafe(this.router, 'vault.cluster.access.method.item.list');
         this.flashMessages.success(`Successfully deleted ${this.itemType} ${this.model.id}.`);
       });
     },

--- a/ui/app/components/get-credentials-card.js
+++ b/ui/app/components/get-credentials-card.js
@@ -24,6 +24,7 @@
 
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 export default class GetCredentialsCard extends Component {
@@ -57,14 +58,14 @@ export default class GetCredentialsCard extends Component {
     const role = this.role;
     const secret = this.secret;
     if (role) {
-      this.router.transitionTo('vault.cluster.secrets.backend.credentials', role);
+      transitionToSafe(this.router, 'vault.cluster.secrets.backend.credentials', role);
     }
     if (secret) {
       if (secret.endsWith('/')) {
-        this.router.transitionTo('vault.cluster.secrets.backend.list', secret);
+        transitionToSafe(this.router, 'vault.cluster.secrets.backend.list', secret);
         return;
       }
-      this.router.transitionTo('vault.cluster.secrets.backend.show', secret);
+      transitionToSafe(this.router, 'vault.cluster.secrets.backend.show', secret);
     }
   }
 

--- a/ui/app/components/identity/edit-form.js
+++ b/ui/app/components/identity/edit-form.js
@@ -77,7 +77,11 @@ export default Component.extend({
     const model = this.model;
     if (!model) return;
     if ((model.isDirty && !model.isDestroyed) || !model.isDestroying) {
-      model.rollbackAttributes();
+      try {
+        model.rollbackAttributes();
+      } catch {
+        // model's internal graph may already be torn down during destruction
+      }
     }
   },
 

--- a/ui/app/components/identity/lookup-input.js
+++ b/ui/app/components/identity/lookup-input.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { underscore } from 'vault/helpers/underscore';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Component.extend({
   store: service(),
@@ -63,7 +64,7 @@ export default Component.extend({
       return;
     }
     if (response) {
-      return this.router.transitionTo('vault.cluster.access.identity.show', response.id, 'details');
+      return transitionToSafe(this.router, 'vault.cluster.access.identity.show', response.id, 'details');
     } else {
       flash.danger(`We were unable to find an identity ${type} with a "${param}" of "${paramValue}".`);
     }

--- a/ui/app/components/keymgmt/key-edit.js
+++ b/ui/app/components/keymgmt/key-edit.js
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module KeymgmtKeyEdit
@@ -59,7 +60,7 @@ export default class KeymgmtKeyEdit extends Component {
     const { model } = this.args;
     try {
       yield model.save();
-      this.router.transitionTo(SHOW_ROUTE, model.name);
+      transitionToSafe(this.router, SHOW_ROUTE, model.name);
     } catch (error) {
       let errorMessage = error;
       if (error.errors) {
@@ -70,7 +71,7 @@ export default class KeymgmtKeyEdit extends Component {
       if (!error.errors) {
         // If error was custom from save, only partial fail
         // so it's safe to show the key
-        this.router.transitionTo(SHOW_ROUTE, model.name);
+        transitionToSafe(this.router, SHOW_ROUTE, model.name);
       }
     }
   }
@@ -94,7 +95,7 @@ export default class KeymgmtKeyEdit extends Component {
     secret
       .destroyRecord()
       .then(() => {
-        this.router.transitionTo(LIST_ROOT_ROUTE, backend);
+        transitionToSafe(this.router, LIST_ROOT_ROUTE, backend);
       })
       .catch((e) => {
         this.flashMessages.danger(e.errors?.join('. '));

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module KeymgmtProviderEdit
@@ -53,7 +54,7 @@ export default class KeymgmtProviderEdit extends Component {
     const { model } = this.args;
     try {
       yield model.save();
-      this.router.transitionTo('vault.cluster.secrets.backend.show', model.id, {
+      transitionToSafe(this.router, 'vault.cluster.secrets.backend.show', model.id, {
         queryParams: { itemType: 'provider' },
       });
     } catch (error) {
@@ -86,7 +87,7 @@ export default class KeymgmtProviderEdit extends Component {
     try {
       const { model, root } = this.args;
       await model.destroyRecord();
-      this.router.transitionTo(root.path, root.model, { queryParams: { tab: 'provider' } });
+      transitionToSafe(this.router, root.path, root.model, { queryParams: { tab: 'provider' } });
     } catch (error) {
       this.flashMessages.danger(error.errors.join('. '));
     }

--- a/ui/app/components/role-edit.js
+++ b/ui/app/components/role-edit.js
@@ -11,6 +11,7 @@ import Component from '@ember/component';
 import { set } from '@ember/object';
 import { schedule } from '@ember/runloop';
 import keys from 'vault/lib/keycodes';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -61,7 +62,7 @@ export default Component.extend({
     .cancelOn('willDestroyElement'),
 
   transitionToRoute() {
-    this.router.transitionTo(...arguments);
+    return transitionToSafe(this.router, ...arguments);
   },
 
   onEscape(e) {

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -129,6 +129,12 @@ export default class SecretCreateOrUpdate extends Component {
     const changed = secret.changedAttributes();
     const changedKeys = Object.keys(changed);
 
+    // ember-data 4.12 requires created records to have a client id; KV1
+    // secrets are only identified by their (path) id, so set it up front
+    if (!isV2 && secretData && secretData.isNew && !secretData.id && key) {
+      secretData.set('id', key);
+    }
+
     return secretData
       .save()
       .then(() => {

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -33,6 +33,7 @@
 import Component from '@glimmer/component';
 import Ember from 'ember';
 import keys from 'vault/lib/keycodes';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 import { action, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -174,7 +175,7 @@ export default class SecretCreateOrUpdate extends Component {
     callback(key);
   }
   transitionToRoute() {
-    return this.router.transitionTo(...arguments);
+    return transitionToSafe(this.router, ...arguments);
   }
 
   get isCreateNewVersionFromOldVersion() {

--- a/ui/app/components/secret-delete-menu.js
+++ b/ui/app/components/secret-delete-menu.js
@@ -10,6 +10,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { maybeQueryRecord } from 'vault/macros/maybe-query-record';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const getErrorMessage = (errors) => {
   const errorMessage =
@@ -140,7 +141,7 @@ export default class SecretDeleteMenu extends Component {
     }
     if (deleteType === 'destroy-all-versions' || deleteType === 'v1') {
       this.args.model.destroyRecord().then(() => {
-        return this.router.transitionTo('vault.cluster.secrets.backend.list-root');
+        return transitionToSafe(this.router, 'vault.cluster.secrets.backend.list-root');
       });
     } else {
       // if they do not have read access on the metadata endpoint we need to pull the version from modelForData so they can perform delete and undelete operations

--- a/ui/app/components/secret-edit-metadata.js
+++ b/ui/app/components/secret-edit-metadata.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 /**
  * @module SecretEditMetadata
@@ -40,7 +41,7 @@ export default class SecretEditMetadata extends Component {
       this.error = e;
       return;
     }
-    this.router.transitionTo('vault.cluster.secrets.backend.metadata', this.args.model.id);
+    transitionToSafe(this.router, 'vault.cluster.secrets.backend.metadata', this.args.model.id);
   }
 
   @action

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -40,6 +40,10 @@ export default class SecretEdit extends Component {
   // fired on did-insert from render modifier
   @action
   createKvData(elem, [model]) {
+    // the model may not have resolved yet when the component inserts
+    if (!model) {
+      return;
+    }
     if (!model.secretData && model.selectedVersion) {
       this.isV2 = true;
       model.secretData = model.belongsTo('selectedVersion').value().secretData;

--- a/ui/app/components/secret-link.js
+++ b/ui/app/components/secret-link.js
@@ -5,16 +5,22 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default class SecretLink extends Component {
+  @service secretMountPath;
+
   get link() {
     const { mode, secret } = this.args;
     const route = `vault.cluster.secrets.backend.${mode}`;
+    const backend = this.args.backend || this.secretMountPath.currentPath;
     if ((mode !== 'versions' && !secret) || secret === ' ') {
-      return { route: `${route}-root`, models: [] };
+      const models = backend ? [backend] : [];
+      return { route: `${route}-root`, models };
     } else {
-      return { route, models: [encodePath(secret)] };
+      const models = backend ? [backend, encodePath(secret)] : [encodePath(secret)];
+      return { route, models };
     }
   }
   get query() {

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -6,7 +6,7 @@
           <:logo>
             <Sidebar::Header::HomeLink
               @icon="openbao"
-              @route="vault.cluster"
+              @route={{if this.currentCluster.cluster.name "vault.cluster"}}
               @model={{this.currentCluster.cluster.name}}
               @ariaLabel="home link"
               data-test-sidebar-logo

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -1,6 +1,6 @@
 <Hds::AppFrame @hasSidebar={{@showSidebar}} @hasHeader={{false}} @hasFooter={{false}} as |Frame|>
   <Frame.Sidebar data-test-sidebar-nav>
-    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{true}} @a11yRefocusSkipTo="app-main-content">
+    <Hds::SideNav @isResponsive={{true}} @hasA11yRefocus={{@showSidebar}} @a11yRefocusSkipTo="app-main-content">
       <:header>
         <Hds::SideNav::Header>
           <:logo>

--- a/ui/app/components/sidebar/user-menu.js
+++ b/ui/app/components/sidebar/user-menu.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class SidebarUserMenuComponent extends Component {
   @service auth;
@@ -22,7 +23,7 @@ export default class SidebarUserMenuComponent extends Component {
   }
 
   transitionToRoute() {
-    this.router.transitionTo(...arguments);
+    return transitionToSafe(this.router, ...arguments);
   }
 
   @action

--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -12,6 +12,7 @@ import { set } from '@ember/object';
 
 import { schedule } from '@ember/runloop';
 import keys from 'vault/lib/keycodes';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -61,7 +62,7 @@ export default Component.extend({
     .cancelOn('willDestroyElement'),
 
   transitionToRoute() {
-    this.router.transitionTo(...arguments);
+    return transitionToSafe(this.router, ...arguments);
   },
 
   onEscape(e) {

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -149,7 +149,9 @@ export default Component.extend(TRANSIT_PARAMS, {
   },
 
   handleError(e) {
-    this.set('errors', e.errors);
+    if (!this.isDestroyed && !this.isDestroying) {
+      this.set('errors', e.errors);
+    }
   },
 
   clearErrors() {
@@ -163,6 +165,9 @@ export default Component.extend(TRANSIT_PARAMS, {
   },
 
   handleSuccess(resp, options, action) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
     let props = {};
     if (resp && resp.data) {
       if (action === 'export' && resp.data.keys) {
@@ -174,10 +179,8 @@ export default Component.extend(TRANSIT_PARAMS, {
     if (options.wrapTTL) {
       props = assign({}, props, { wrappedToken: resp.wrap_info.token });
     }
-    if (!this.isDestroyed && !this.isDestroying) {
-      this.toggleProperty('isModalActive');
-      this.setProperties(props);
-    }
+    this.toggleProperty('isModalActive');
+    this.setProperties(props);
     if (action === 'rotate') {
       this.onRefresh();
     }

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -11,4 +11,5 @@ export default Controller.extend({
   env: config.environment,
   auth: service(),
   store: service(),
+  currentCluster: service(),
 });

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -10,6 +10,7 @@ import removeRecord from 'vault/utils/remove-record';
 
 export default Controller.extend({
   store: service(),
+  router: service(),
   showRoute: 'vault.cluster.access.identity.show',
   showTab: 'details',
   navAfterSave: task(function* ({ saveType, model }) {
@@ -23,10 +24,15 @@ export default Controller.extend({
     };
     const routeName = listRoutes[type];
     if (!isDelete) {
-      yield this.transitionToRoute(this.showRoute, model.id, this.showTab);
+      yield this.router.transitionTo(this.showRoute, model.id, this.showTab).catch((error) => {
+        if (error?.name !== 'TransitionAborted') throw error;
+      });
       return;
     }
-    yield this.transitionToRoute(routeName);
+
+    yield this.router.transitionTo(routeName).catch((error) => {
+      if (error?.name !== 'TransitionAborted') throw error;
+    });
   }),
 
   cleanupModel() {

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -40,6 +40,11 @@ export default Controller.extend({
       return;
     }
 
+    // Rollback any dirty attributes before unloading to avoid memory leaks
+    if (model.hasDirtyAttributes && typeof model.rollbackAttributes === 'function') {
+      model.rollbackAttributes();
+    }
+
     // controllers are singletons — always unset
     this.model = null;
 

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -7,6 +7,7 @@ import Controller from '@ember/controller';
 import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import removeRecord from 'vault/utils/remove-record';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   store: service(),
@@ -24,15 +25,11 @@ export default Controller.extend({
     };
     const routeName = listRoutes[type];
     if (!isDelete) {
-      yield this.router.transitionTo(this.showRoute, model.id, this.showTab).catch((error) => {
-        if (error?.name !== 'TransitionAborted') throw error;
-      });
+      yield transitionToSafe(this.router, this.showRoute, model.id, this.showTab);
       return;
     }
 
-    yield this.router.transitionTo(routeName).catch((error) => {
-      if (error?.name !== 'TransitionAborted') throw error;
-    });
+    yield transitionToSafe(this.router, routeName);
   }),
 
   cleanupModel() {

--- a/ui/app/controllers/vault/cluster/access/leases/index.js
+++ b/ui/app/controllers/vault/cluster/access/leases/index.js
@@ -5,12 +5,13 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   router: service(),
   actions: {
     lookupLease(id) {
-      this.router.transitionTo('vault.cluster.access.leases.show', id);
+      transitionToSafe(this.router, 'vault.cluster.access.leases.show', id);
     },
   },
 });

--- a/ui/app/controllers/vault/cluster/access/leases/index.js
+++ b/ui/app/controllers/vault/cluster/access/leases/index.js
@@ -4,11 +4,13 @@
  */
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   actions: {
     lookupLease(id) {
-      this.transitionToRoute('vault.cluster.access.leases.show', id);
+      this.router.transitionTo('vault.cluster.access.leases.show', id);
     },
   },
 });

--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -13,6 +13,7 @@ import commonPrefix from 'core/utils/common-prefix';
 export default Controller.extend({
   flashMessages: service(),
   store: service(),
+  router: service(),
   clusterController: controller('vault.cluster'),
 
   backendCrumb: computed('clusterController.model.name', function () {
@@ -100,7 +101,7 @@ export default Controller.extend({
       const fn = adapter[method];
       fn.call(adapter, prefix)
         .then(() => {
-          return this.transitionToRoute('vault.cluster.access.leases.list-root').then(() => {
+          return this.router.transitionTo('vault.cluster.access.leases.list-root').then(() => {
             this.flashMessages.success(`All of the leases under ${prefix} will be revoked.`);
           });
         })

--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -9,6 +9,7 @@ import Controller, { inject as controller } from '@ember/controller';
 import utils from 'vault/lib/key-utils';
 import escapeStringRegexp from 'escape-string-regexp';
 import commonPrefix from 'core/utils/common-prefix';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   flashMessages: service(),
@@ -101,7 +102,7 @@ export default Controller.extend({
       const fn = adapter[method];
       fn.call(adapter, prefix)
         .then(() => {
-          return this.router.transitionTo('vault.cluster.access.leases.list-root').then(() => {
+          return transitionToSafe(this.router, 'vault.cluster.access.leases.list-root').then(() => {
             this.flashMessages.success(`All of the leases under ${prefix} will be revoked.`);
           });
         })

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -11,6 +11,7 @@ import removeRecord from 'vault/utils/remove-record';
 
 export default Controller.extend({
   store: service(),
+  router: service(),
   clusterController: controller('vault.cluster'),
 
   backendCrumb: computed('clusterController.model.name', function () {
@@ -46,7 +47,7 @@ export default Controller.extend({
   actions: {
     revokeLease(model) {
       return model.destroyRecord().then(() => {
-        return this.transitionToRoute('vault.cluster.access.leases.list-root');
+        return this.router.transitionTo('vault.cluster.access.leases.list-root');
       });
     },
 

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 import removeRecord from 'vault/utils/remove-record';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   store: service(),
@@ -47,7 +48,7 @@ export default Controller.extend({
   actions: {
     revokeLease(model) {
       return model.destroyRecord().then(() => {
-        return this.router.transitionTo('vault.cluster.access.leases.list-root');
+        return transitionToSafe(this.router, 'vault.cluster.access.leases.list-root');
       });
     },
 

--- a/ui/app/controllers/vault/cluster/access/method/item/create.js
+++ b/ui/app/controllers/vault/cluster/access/method/item/create.js
@@ -21,6 +21,11 @@ export default Controller.extend({
       return;
     }
 
+    // Rollback any dirty attributes before unloading to avoid memory leaks
+    if (model.hasDirtyAttributes && typeof model.rollbackAttributes === 'function') {
+      model.rollbackAttributes();
+    }
+
     // controllers are singletons — always unset
     this.model = null;
 

--- a/ui/app/controllers/vault/cluster/access/methods.js
+++ b/ui/app/controllers/vault/cluster/access/methods.js
@@ -45,7 +45,7 @@ export default class VaultClusterAccessMethodsController extends Controller {
   get authMethodArrayByType() {
     const arrayOfAllAuthTypes = this.authMethodList.map((modelObject) => modelObject.type);
     // filter out repeated auth types (e.g. [userpass, userpass] => [userpass])
-    const arrayOfUniqueAuthTypes = [...new Set(arrayOfAllAuthTypes)];
+    const arrayOfUniqueAuthTypes = [...new Set(arrayOfAllAuthTypes)].sort();
 
     return arrayOfUniqueAuthTypes.map((authType) => ({
       name: authType,

--- a/ui/app/controllers/vault/cluster/access/mfa/enforcements/enforcement/index.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/enforcements/enforcement/index.js
@@ -7,6 +7,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class MfaLoginEnforcementIndexController extends Controller {
   @service router;
@@ -24,7 +25,7 @@ export default class MfaLoginEnforcementIndexController extends Controller {
       await this.model.destroyRecord();
       this.showDeleteConfirmation = false;
       this.flashMessages.success('MFA login enforcement deleted successfully');
-      this.router.transitionTo('vault.cluster.access.mfa.enforcements');
+      transitionToSafe(this.router, 'vault.cluster.access.mfa.enforcements');
     } catch (error) {
       this.deleteError = error;
     }

--- a/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { capitalize } from '@ember/string';
 import { task } from 'ember-concurrency';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class MfaMethodCreateController extends Controller {
   @service store;
@@ -80,7 +81,7 @@ export default class MfaMethodCreateController extends Controller {
     this.method = null;
     this.enforcement = null;
     this.enforcementPreference = null;
-    this.router.transitionTo('vault.cluster.access.mfa.methods');
+    transitionToSafe(this.router, 'vault.cluster.access.mfa.methods');
   }
   @task
   *save() {
@@ -104,7 +105,7 @@ export default class MfaMethodCreateController extends Controller {
             );
           }
         }
-        this.router.transitionTo('vault.cluster.access.mfa.methods.method', this.method.id);
+        transitionToSafe(this.router, 'vault.cluster.access.mfa.methods.method', this.method.id);
       } catch (error) {
         this.handleError(error, 'Error saving method');
       }

--- a/ui/app/controllers/vault/cluster/access/mfa/methods/method/index.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/method/index.js
@@ -5,6 +5,7 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 import { action } from '@ember/object';
 
 export default class MfaMethodController extends Controller {
@@ -19,7 +20,7 @@ export default class MfaMethodController extends Controller {
     try {
       await this.model.method.destroyRecord();
       this.flashMessages.success('MFA method deleted successfully.');
-      this.router.transitionTo('vault.cluster.access.mfa.methods');
+      transitionToSafe(this.router, 'vault.cluster.access.mfa.methods');
     } catch {
       this.flashMessages.danger(`There was an error deleting this MFA method.`);
     }

--- a/ui/app/controllers/vault/cluster/access/namespaces/create.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/create.js
@@ -10,6 +10,7 @@ import removeRecord from 'vault/utils/remove-record';
 export default Controller.extend({
   namespaceService: service('namespace'),
   store: service(),
+  router: service(),
 
   cleanupModel() {
     const model = this.model;
@@ -35,7 +36,7 @@ export default Controller.extend({
       if (saveType === 'save') {
         // fetch new namespaces for the namespace picker
         this.namespaceService.findNamespacesForUser.perform();
-        return this.transitionToRoute('vault.cluster.access.namespaces.index');
+        return this.router.transitionTo('vault.cluster.access.namespaces.index');
       }
     },
   },

--- a/ui/app/controllers/vault/cluster/access/namespaces/create.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/create.js
@@ -6,6 +6,7 @@
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import removeRecord from 'vault/utils/remove-record';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   namespaceService: service('namespace'),
@@ -36,7 +37,7 @@ export default Controller.extend({
       if (saveType === 'save') {
         // fetch new namespaces for the namespace picker
         this.namespaceService.findNamespacesForUser.perform();
-        return this.router.transitionTo('vault.cluster.access.namespaces.index');
+        return transitionToSafe(this.router, 'vault.cluster.access.namespaces.index');
       }
     },
   },

--- a/ui/app/controllers/vault/cluster/access/oidc/assignments/assignment/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/assignments/assignment/details.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class OidcAssignmentDetailsController extends Controller {
   @service router;
@@ -16,7 +17,7 @@ export default class OidcAssignmentDetailsController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success('Assignment deleted successfully');
-      this.router.transitionTo('vault.cluster.access.oidc.assignments');
+      transitionToSafe(this.router, 'vault.cluster.access.oidc.assignments');
     } catch (error) {
       this.model.rollbackAttributes();
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/access/oidc/clients/client/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/clients/client/details.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class OidcClientDetailsController extends Controller {
   @service router;
@@ -16,7 +17,7 @@ export default class OidcClientDetailsController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success('Application deleted successfully');
-      this.router.transitionTo('vault.cluster.access.oidc.clients');
+      transitionToSafe(this.router, 'vault.cluster.access.oidc.clients');
     } catch (error) {
       this.model.rollbackAttributes();
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class OidcKeyDetailsController extends Controller {
   @service store;
@@ -32,7 +33,7 @@ export default class OidcKeyDetailsController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success('Key deleted successfully');
-      this.router.transitionTo('vault.cluster.access.oidc.keys');
+      transitionToSafe(this.router, 'vault.cluster.access.oidc.keys');
     } catch (error) {
       this.model.rollbackAttributes();
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/access/oidc/providers/provider/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/providers/provider/details.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class OidcProviderDetailsController extends Controller {
   @service router;
@@ -16,7 +17,7 @@ export default class OidcProviderDetailsController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success('Provider deleted successfully');
-      this.router.transitionTo('vault.cluster.access.oidc.providers');
+      transitionToSafe(this.router, 'vault.cluster.access.oidc.providers');
     } catch (error) {
       this.model.rollbackAttributes();
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/access/oidc/scopes/scope/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/scopes/scope/details.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class OidcScopeDetailsController extends Controller {
   @service router;
@@ -16,7 +17,7 @@ export default class OidcScopeDetailsController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success('Scope deleted successfully');
-      this.router.transitionTo('vault.cluster.access.oidc.scopes');
+      transitionToSafe(this.router, 'vault.cluster.access.oidc.scopes');
     } catch (error) {
       this.model.rollbackAttributes();
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   flashMessages: service(),
@@ -33,13 +34,15 @@ export default Controller.extend({
     let transition;
     if (this.redirectTo) {
       // here we don't need the namespace because it will be encoded in redirectTo
-      transition = this.router.transitionTo(this.redirectTo);
+      transition = transitionToSafe(this.router, this.redirectTo);
       // reset the value on the controller because it's bound here
       this.set('redirectTo', '');
     } else {
-      transition = this.router.transitionTo('vault.cluster', { queryParams: { namespace } });
+      transition = transitionToSafe(this.router, 'vault.cluster', { queryParams: { namespace } });
     }
-    transition.followRedirects().then(() => {
+    // transitionToSafe resolves on the redirect abort, before the target
+    // route's model loads; the root-token warning needs no model data
+    transition.then(() => {
       if (isRoot) {
         this.flashMessages.warning(
           'You have logged in with a root token. As a security precaution, this root token will not be stored by your browser and you will need to re-authenticate after the window is closed or refreshed.'

--- a/ui/app/controllers/vault/cluster/policy/edit.js
+++ b/ui/app/controllers/vault/cluster/policy/edit.js
@@ -6,6 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default class PolicyEditController extends Controller {
   @service router;
@@ -17,7 +18,7 @@ export default class PolicyEditController extends Controller {
     try {
       await this.model.destroyRecord();
       this.flashMessages.success(`${policyType.toUpperCase()} policy "${name}" was successfully deleted.`);
-      this.router.transitionTo('vault.cluster.policies', policyType);
+      transitionToSafe(this.router, 'vault.cluster.policies', policyType);
     } catch (error) {
       this.model.rollbackAttributes();
       const errors = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -11,6 +11,7 @@ import utils from 'vault/lib/key-utils';
 import { task } from 'ember-concurrency';
 import escapeStringRegexp from 'escape-string-regexp';
 import commonPrefix from 'core/utils/common-prefix';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   router: service(),
@@ -19,10 +20,18 @@ export default Controller.extend({
     const ancestors = utils.ancestorKeysForKey(key);
     let errored = false;
     let nearest = ancestors.pop();
-    // force a refetch of the current folder when navigating to the same
-    // route/params after a deletion, otherwise the stale cached listing
-    // would make a 404-folder seem like it still contains the deleted key
-    this.store.clearAllDatasets();
+    // Force a refetch of the current folder when navigating to the same
+    // route/params after a deletion: ember-data 4.12 keeps deleted records
+    // in an already-cached lazy page, so a 404-folder would still appear to
+    // contain the deleted key. Only KV listings are cleared here; non-KV
+    // engines list under a different cache key, so clear everything (transit
+    // keys can contain '/', so same-route ancestor transitions do happen).
+    if (['kv', 'generic', 'cubbyhole'].includes(this.backendType)) {
+      this.store.clearDataset('secret');
+      this.store.clearDataset('secret-v2');
+    } else {
+      this.store.clearAllDatasets();
+    }
     while (nearest) {
       try {
         const transition = this.router.transitionTo('vault.cluster.secrets.backend.list', nearest);
@@ -42,9 +51,7 @@ export default Controller.extend({
         errored = false;
       }
     }
-    yield this.router.transitionTo('vault.cluster.secrets.backend.list-root').catch((error) => {
-      if (error?.name !== 'TransitionAborted') throw error;
-    });
+    yield transitionToSafe(this.router, 'vault.cluster.secrets.backend.list-root');
   }),
 
   flashMessages: service(),

--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -13,13 +13,14 @@ import escapeStringRegexp from 'escape-string-regexp';
 import commonPrefix from 'core/utils/common-prefix';
 
 export default Controller.extend({
+  router: service(),
   navToNearestAncestor: task(function* (key) {
     const ancestors = utils.ancestorKeysForKey(key);
     let errored = false;
     let nearest = ancestors.pop();
     while (nearest) {
       try {
-        const transition = this.transitionToRoute('vault.cluster.secrets.backend.list', nearest);
+        const transition = this.router.transitionTo('vault.cluster.secrets.backend.list', nearest);
         transition.data.isDeletion = true;
         yield transition.promise;
       } catch {
@@ -36,7 +37,9 @@ export default Controller.extend({
         errored = false;
       }
     }
-    yield this.transitionToRoute('vault.cluster.secrets.backend.list-root');
+    yield this.router.transitionTo('vault.cluster.secrets.backend.list-root').catch((error) => {
+      if (error?.name !== 'TransitionAborted') throw error;
+    });
   }),
 
   flashMessages: service(),

--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -14,10 +14,15 @@ import commonPrefix from 'core/utils/common-prefix';
 
 export default Controller.extend({
   router: service(),
+  store: service(),
   navToNearestAncestor: task(function* (key) {
     const ancestors = utils.ancestorKeysForKey(key);
     let errored = false;
     let nearest = ancestors.pop();
+    // force a refetch of the current folder when navigating to the same
+    // route/params after a deletion, otherwise the stale cached listing
+    // would make a 404-folder seem like it still contains the deleted key
+    this.store.clearAllDatasets();
     while (nearest) {
       try {
         const transition = this.router.transitionTo('vault.cluster.secrets.backend.list', nearest);
@@ -132,9 +137,10 @@ export default Controller.extend({
         .destroyRecord()
         .then(() => {
           this.flashMessages.success(`${name} was successfully deleted.`);
-          this.send('reload');
           if (type === 'secret') {
             this.navToNearestAncestor.perform(name);
+          } else {
+            this.send('reload');
           }
         })
         .catch((e) => {

--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -51,7 +51,16 @@ export default Controller.extend({
         errored = false;
       }
     }
-    yield transitionToSafe(this.router, 'vault.cluster.secrets.backend.list-root');
+    // A root-level key has no ancestor to navigate to. If we're deleting it
+    // while already on the list page, transitioning to list-root is a
+    // same-route no-op that won't refetch, leaving the stale entry in the
+    // (possibly non-KV, e.g. ssh/transit/aws) listing. Force a reload instead,
+    // which clears every dataset and re-runs the model hook.
+    if (this.router.currentRouteName === 'vault.cluster.secrets.backend.list-root') {
+      this.send('reload');
+    } else {
+      yield transitionToSafe(this.router, 'vault.cluster.secrets.backend.list-root');
+    }
   }),
 
   flashMessages: service(),

--- a/ui/app/controllers/vault/cluster/settings/auth/enable.js
+++ b/ui/app/controllers/vault/cluster/settings/auth/enable.js
@@ -4,11 +4,13 @@
  */
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   actions: {
     onMountSuccess: function (type, path) {
-      const transition = this.transitionToRoute('vault.cluster.settings.auth.configure', path);
+      const transition = this.router.transitionTo('vault.cluster.settings.auth.configure', path);
       return transition.followRedirects();
     },
   },

--- a/ui/app/controllers/vault/cluster/settings/auth/enable.js
+++ b/ui/app/controllers/vault/cluster/settings/auth/enable.js
@@ -5,13 +5,13 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   router: service(),
   actions: {
     onMountSuccess: function (type, path) {
-      const transition = this.router.transitionTo('vault.cluster.settings.auth.configure', path);
-      return transition.followRedirects();
+      return transitionToSafe(this.router, 'vault.cluster.settings.auth.configure', path);
     },
   },
 });

--- a/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
+++ b/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
@@ -8,6 +8,7 @@ import Controller from '@ember/controller';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 import { allEngines } from 'vault/helpers/mountable-secret-engines';
 import { action } from '@ember/object';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 const SUPPORTED_BACKENDS = supportedSecretBackends();
 
@@ -16,21 +17,20 @@ export default class MountSecretBackendController extends Controller {
 
   @action
   onMountSuccess(type, path) {
-    let transition;
+    let route;
     if (SUPPORTED_BACKENDS.includes(type)) {
       const engineInfo = allEngines().find((x) => x.type === type);
       if (engineInfo?.engineRoute) {
-        transition = this.router.transitionTo(
-          `vault.cluster.secrets.backend.${engineInfo.engineRoute}`,
-          path
-        );
+        route = [`vault.cluster.secrets.backend.${engineInfo.engineRoute}`, path];
       } else {
         const queryParams = engineInfo?.routeQueryParams || {};
-        transition = this.router.transitionTo('vault.cluster.secrets.backend.index', path, { queryParams });
+        route = ['vault.cluster.secrets.backend.index', path, { queryParams }];
       }
     } else {
-      transition = this.router.transitionTo('vault.cluster.secrets.backends');
+      route = ['vault.cluster.secrets.backends'];
     }
-    return transition.followRedirects();
+    // transitionToSafe resolves on the redirect abort, before the target
+    // route's model loads; the caller has no side effects after that
+    return transitionToSafe(this.router, ...route);
   }
 }

--- a/ui/app/controllers/vault/cluster/settings/seal.js
+++ b/ui/app/controllers/vault/cluster/settings/seal.js
@@ -8,6 +8,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   auth: service(),
+  router: service(),
 
   actions: {
     seal() {
@@ -17,7 +18,7 @@ export default Controller.extend({
         .then(() => {
           this.model.cluster.leaderNode.set('sealed', true);
           this.auth.deleteCurrentToken();
-          return this.transitionToRoute('vault.cluster.unseal');
+          return this.router.transitionTo('vault.cluster.unseal');
         });
     },
   },

--- a/ui/app/controllers/vault/cluster/settings/seal.js
+++ b/ui/app/controllers/vault/cluster/settings/seal.js
@@ -19,6 +19,9 @@ export default Controller.extend({
           this.model.cluster.leaderNode.set('sealed', true);
           this.auth.deleteCurrentToken();
           return this.router.transitionTo('vault.cluster.unseal');
+        })
+        .catch((error) => {
+          if (error?.name !== 'TransitionAborted') throw error;
         });
     },
   },

--- a/ui/app/controllers/vault/cluster/settings/seal.js
+++ b/ui/app/controllers/vault/cluster/settings/seal.js
@@ -5,6 +5,7 @@
 
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   auth: service(),
@@ -18,10 +19,7 @@ export default Controller.extend({
         .then(() => {
           this.model.cluster.leaderNode.set('sealed', true);
           this.auth.deleteCurrentToken();
-          return this.router.transitionTo('vault.cluster.unseal');
-        })
-        .catch((error) => {
-          if (error?.name !== 'TransitionAborted') throw error;
+          return transitionToSafe(this.router, 'vault.cluster.unseal');
         });
     },
   },

--- a/ui/app/controllers/vault/cluster/unseal.js
+++ b/ui/app/controllers/vault/cluster/unseal.js
@@ -10,9 +10,14 @@ export default Controller.extend({
   router: service(),
   actions: {
     transitionToCluster() {
-      return this.model.reload().then(() => {
-        return this.router.transitionTo('vault.cluster', this.model.name);
-      });
+      return this.model
+        .reload()
+        .then(() => {
+          return this.router.transitionTo('vault.cluster', this.model.name);
+        })
+        .catch((error) => {
+          if (error?.name !== 'TransitionAborted') throw error;
+        });
     },
 
     isUnsealed(data) {

--- a/ui/app/controllers/vault/cluster/unseal.js
+++ b/ui/app/controllers/vault/cluster/unseal.js
@@ -5,19 +5,15 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import transitionToSafe from 'vault/utils/transition-to-safe';
 
 export default Controller.extend({
   router: service(),
   actions: {
     transitionToCluster() {
-      return this.model
-        .reload()
-        .then(() => {
-          return this.router.transitionTo('vault.cluster', this.model.name);
-        })
-        .catch((error) => {
-          if (error?.name !== 'TransitionAborted') throw error;
-        });
+      return this.model.reload().then(() => {
+        return transitionToSafe(this.router, 'vault.cluster', this.model.name);
+      });
     },
 
     isUnsealed(data) {

--- a/ui/app/controllers/vault/cluster/unseal.js
+++ b/ui/app/controllers/vault/cluster/unseal.js
@@ -4,12 +4,14 @@
  */
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   actions: {
     transitionToCluster() {
       return this.model.reload().then(() => {
-        return this.transitionToRoute('vault.cluster', this.model.name);
+        return this.router.transitionTo('vault.cluster', this.model.name);
       });
     },
 

--- a/ui/app/helpers/current-mount-path.js
+++ b/ui/app/helpers/current-mount-path.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
+
+// Returns the path of the currently viewed secret mount
+export default class CurrentMountPathHelper extends Helper {
+  @service secretMountPath;
+
+  compute() {
+    return this.secretMountPath.currentPath;
+  }
+}

--- a/ui/app/helpers/current-mount-path.js
+++ b/ui/app/helpers/current-mount-path.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) HashiCorp, Inc.
+ * Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/ui/app/routes/vault.js
+++ b/ui/app/routes/vault.js
@@ -14,6 +14,7 @@ const SPLASH_DELAY = Ember.testing ? 0 : 300;
 export default Route.extend({
   store: service(),
   version: service(),
+  router: service(),
 
   beforeModel() {
     return this.version.fetchVersion();
@@ -40,7 +41,7 @@ export default Route.extend({
 
   redirect(model, transition) {
     if (model.length === 1 && transition.targetName === 'vault.index') {
-      return this.transitionTo('vault.cluster', model[0].name);
+      return this.router.transitionTo('vault.cluster', model[0].name);
     }
   },
 });

--- a/ui/app/routes/vault/cluster-base.js
+++ b/ui/app/routes/vault/cluster-base.js
@@ -40,9 +40,11 @@ export default Route.extend({
         transition.targetName !== CLUSTER_INDEX &&
         !isExcluded
       ) {
-        return this.transitionTo(targetRoute, { queryParams: { redirect_to: this.router.currentURL } });
+        return this.router.transitionTo(targetRoute, {
+          queryParams: { redirect_to: this.router.currentURL },
+        });
       }
-      return this.transitionTo(targetRoute);
+      return this.router.transitionTo(targetRoute);
     }
 
     return RSVP.resolve();

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -31,6 +31,7 @@ export default ClusterBaseRoute.extend({
   store: service(),
   auth: service(),
   currentCluster: service(),
+  router: service(),
   modelTypes: computed(function () {
     return ['node', 'secret', 'secret-engine'];
   }),
@@ -58,7 +59,7 @@ export default ClusterBaseRoute.extend({
       namespace = storage?.userRootNamespace;
       // only redirect if something other than nothing
       if (namespace) {
-        this.transitionTo({ queryParams: { namespace } });
+        this.router.transitionTo({ queryParams: { namespace } });
       }
     }
     this.namespaceService.setNamespace(namespace);

--- a/ui/app/routes/vault/cluster/access/identity/merge.js
+++ b/ui/app/routes/vault/cluster/access/identity/merge.js
@@ -8,11 +8,12 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
 
   beforeModel() {
     const itemType = this.modelFor('vault.cluster.access.identity');
     if (itemType !== 'entity') {
-      return this.transitionTo('vault.cluster.access.identity');
+      return this.router.transitionTo('vault.cluster.access.identity');
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/identity/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/show.js
@@ -13,6 +13,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
 
   model(params) {
     const { section } = params;
@@ -58,7 +59,7 @@ export default Route.extend({
   afterModel(resolvedModel) {
     const { section, model } = resolvedModel;
     if (model.identityType === 'group' && model.type === 'internal' && section === 'aliases') {
-      return this.transitionTo('vault.cluster.access.identity.show', model.id, 'details');
+      return this.router.transitionTo('vault.cluster.access.identity.show', model.id, 'details');
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/leases/show.js
+++ b/ui/app/routes/vault/cluster/access/leases/show.js
@@ -11,15 +11,16 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
 
   beforeModel() {
     const { lease_id: leaseId } = this.paramsFor(this.routeName);
     const parentKey = utils.parentKeyForKey(leaseId);
     if (utils.keyIsFolder(leaseId)) {
       if (parentKey) {
-        return this.transitionTo('vault.cluster.access.leases.list', parentKey);
+        return this.router.transitionTo('vault.cluster.access.leases.list', parentKey);
       } else {
-        return this.transitionTo('vault.cluster.access.leases.list-root');
+        return this.router.transitionTo('vault.cluster.access.leases.list-root');
       }
     }
   },

--- a/ui/app/routes/vault/cluster/access/method/index.js
+++ b/ui/app/routes/vault/cluster/access/method/index.js
@@ -5,11 +5,14 @@
 
 import Route from '@ember/routing/route';
 import { tabsForAuthSection } from 'vault/helpers/tabs-for-auth-section';
+import { inject as service } from '@ember/service';
+
 export default Route.extend({
+  router: service(),
   beforeModel() {
     let { methodType, paths } = this.modelFor('vault.cluster.access.method');
     paths = paths ? paths.paths.filter((path) => path.navigation === true) : null;
     const activeTab = tabsForAuthSection([methodType, 'authConfig', paths])[0].routeParams;
-    return this.transitionTo(...activeTab);
+    return this.router.transitionTo(...activeTab);
   },
 });

--- a/ui/app/routes/vault/cluster/access/method/item/create.js
+++ b/ui/app/routes/vault/cluster/access/method/item/create.js
@@ -27,9 +27,11 @@ export default Route.extend({
     this._super(...arguments);
     const { item_type: itemType } = this.paramsFor('vault.cluster.access.method.item');
     const { path: method } = this.paramsFor('vault.cluster.access.method');
+    const methodModel = this.modelFor('vault.cluster.access.method');
     controller.set('itemType', singularize(itemType));
     controller.set('mode', 'create');
     controller.set('method', method);
+    controller.set('methodModel', methodModel);
   },
 
   resetController(controller, isExiting) {

--- a/ui/app/routes/vault/cluster/access/method/item/edit.js
+++ b/ui/app/routes/vault/cluster/access/method/item/edit.js
@@ -21,7 +21,9 @@ export default Route.extend({
   setupController(controller) {
     this._super(...arguments);
     const { item_type: itemType } = this.paramsFor('vault.cluster.access.method.item');
+    const methodModel = this.modelFor('vault.cluster.access.method');
     controller.set('itemType', singularize(itemType));
+    controller.set('methodModel', methodModel);
   },
 
   resetController(controller, isExiting) {

--- a/ui/app/routes/vault/cluster/access/method/item/show.js
+++ b/ui/app/routes/vault/cluster/access/method/item/show.js
@@ -22,6 +22,8 @@ export default Route.extend({
   setupController(controller) {
     this._super(...arguments);
     const { item_type: itemType } = this.paramsFor('vault.cluster.access.method.item');
+    const methodModel = this.modelFor('vault.cluster.access.method');
     controller.set('itemType', singularize(itemType));
+    controller.set('methodModel', methodModel);
   },
 });

--- a/ui/app/routes/vault/cluster/access/mfa/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/index.js
@@ -8,13 +8,14 @@ import { inject as service } from '@ember/service';
 
 export default class MfaConfigureRoute extends Route {
   @service store;
+  @service router;
 
   beforeModel() {
     return this.store
       .query('mfa-method', {})
       .then(() => {
         // if response then they should transition to the methods page instead of staying on the configure page.
-        this.transitionTo('vault.cluster.access.mfa.methods.index');
+        this.router.transitionTo('vault.cluster.access.mfa.methods.index');
       })
       .catch(() => {
         // stay on the landing page

--- a/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
@@ -13,4 +13,9 @@ export default class OidcKeyClientsRoute extends Route {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.keys.key');
     return await this.store.query('oidc/client', { paramKey: 'client_id', filterFor: allowedClientIds });
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.set('keyName', this.paramsFor('vault.cluster.access.oidc.keys.key').name);
+  }
 }

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
@@ -13,4 +13,9 @@ export default class OidcProviderClientsRoute extends Route {
     const { allowedClientIds } = this.modelFor('vault.cluster.access.oidc.providers.provider');
     return await this.store.query('oidc/client', { paramKey: 'client_id', filterFor: allowedClientIds });
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.set('providerName', this.paramsFor('vault.cluster.access.oidc.providers.provider').name);
+  }
 }

--- a/ui/app/routes/vault/cluster/index.js
+++ b/ui/app/routes/vault/cluster/index.js
@@ -4,9 +4,11 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  router: service(),
   beforeModel() {
-    return this.transitionTo('vault.cluster.secrets');
+    return this.router.transitionTo('vault.cluster.secrets');
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -37,7 +37,7 @@ export default Route.extend({
     }
     if (Ember.testing) {
       // Don't redirect on the test
-      this.replaceWith('vault.cluster.auth', { queryParams });
+      this.router.replaceWith('vault.cluster.auth', { queryParams });
     } else {
       const { cluster_name } = this.paramsFor('vault.cluster');
       location.assign(this.router.urlFor('vault.cluster.auth', cluster_name, { queryParams }));

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -73,7 +73,7 @@ export default class VaultClusterOidcProviderRoute extends Route {
     if (namespace) {
       queryParams.namespace = namespace;
     }
-    return this.transitionTo(AUTH, cluster_name, { queryParams });
+    return this.router.transitionTo(AUTH, cluster_name, { queryParams });
   }
 
   _buildUrl(urlString, params) {

--- a/ui/app/routes/vault/cluster/policies.js
+++ b/ui/app/routes/vault/cluster/policies.js
@@ -10,11 +10,12 @@ const ALLOWED_TYPES = ['acl', 'egp', 'rgp'];
 
 export default ClusterBaseRoute.extend({
   version: service(),
+  router: service(),
 
   model(params) {
     const policyType = params.type;
     if (!ALLOWED_TYPES.includes(policyType)) {
-      return this.transitionTo(this.routeName, ALLOWED_TYPES[0]);
+      return this.router.transitionTo(this.routeName, ALLOWED_TYPES[0]);
     }
     return {};
   },

--- a/ui/app/routes/vault/cluster/policies/create.js
+++ b/ui/app/routes/vault/cluster/policies/create.js
@@ -9,11 +9,12 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   store: service(),
   version: service(),
+  router: service(),
 
   model() {
     const policyType = this.policyType();
     if (policyType !== 'acl') {
-      return this.transitionTo('vault.cluster.policies', policyType);
+      return this.router.transitionTo('vault.cluster.policies', policyType);
     }
     return this.store.createRecord(`policy/${policyType}`, {});
   },

--- a/ui/app/routes/vault/cluster/policy.js
+++ b/ui/app/routes/vault/cluster/policy.js
@@ -10,13 +10,15 @@ const ALLOWED_TYPES = ['acl', 'egp', 'rgp'];
 
 export default ClusterBaseRoute.extend({
   version: service(),
+  router: service(),
+
   model(params) {
     const policyType = params.type;
     if (!ALLOWED_TYPES.includes(policyType)) {
-      return this.transitionTo('vault.cluster.policies', ALLOWED_TYPES[0]);
+      return this.router.transitionTo('vault.cluster.policies', ALLOWED_TYPES[0]);
     }
     if (policyType !== 'acl') {
-      return this.transitionTo('vault.cluster.policies', policyType);
+      return this.router.transitionTo('vault.cluster.policies', policyType);
     }
     return {};
   },

--- a/ui/app/routes/vault/cluster/policy/index.js
+++ b/ui/app/routes/vault/cluster/policy/index.js
@@ -4,9 +4,11 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  router: service(),
   beforeModel() {
-    return this.transitionTo('vault.cluster.policies', 'acl');
+    return this.router.transitionTo('vault.cluster.policies', 'acl');
   },
 });

--- a/ui/app/routes/vault/cluster/policy/show.js
+++ b/ui/app/routes/vault/cluster/policy/show.js
@@ -9,12 +9,13 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
 
   beforeModel() {
     const params = this.paramsFor(this.routeName);
     const policyType = this.policyType();
     if (policyType === 'acl' && params.policy_name === 'root') {
-      return this.transitionTo('vault.cluster.policies', 'acl');
+      return this.router.transitionTo('vault.cluster.policies', 'acl');
     }
   },
 

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -5,8 +5,10 @@
 
 import EditBase from './secret-edit';
 import utils from 'vault/lib/key-utils';
+import { inject as service } from '@ember/service';
 
 export default EditBase.extend({
+  router: service(),
   queryParams: {
     selectedAction: {
       replace: true,
@@ -21,9 +23,9 @@ export default EditBase.extend({
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
     if (this.backendType(backend) !== 'transit') {
       if (parentKey) {
-        return this.transitionTo('vault.cluster.secrets.backend.show', parentKey);
+        return this.router.transitionTo('vault.cluster.secrets.backend.show', parentKey);
       } else {
-        return this.transitionTo('vault.cluster.secrets.backend.show-root');
+        return this.router.transitionTo('vault.cluster.secrets.backend.show-root');
       }
     }
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -4,12 +4,14 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  router: service(),
   beforeModel() {
     const { secret, initialKey } = this.paramsFor(this.routeName);
     const qp = initialKey || secret;
-    return this.transitionTo('vault.cluster.secrets.backend.create-root', {
+    return this.router.transitionTo('vault.cluster.secrets.backend.create-root', {
       queryParams: { initialKey: qp },
     });
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -13,6 +13,7 @@ export default Route.extend({
   templateName: 'vault/cluster/secrets/backend/credentials',
   pathHelp: service('path-help'),
   store: service(),
+  router: service(),
 
   backendModel() {
     return this.modelFor('vault.cluster.secrets.backend');
@@ -59,7 +60,7 @@ export default Route.extend({
       dbCred = await this.getDatabaseCredential(backendPath, role, roleType);
     }
     if (!SUPPORTED_DYNAMIC_BACKENDS.includes(backendModel.type)) {
-      return this.transitionTo('vault.cluster.secrets.backend.list-root', backendPath);
+      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backendPath);
     }
     return resolve({
       backendPath,

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -202,7 +202,7 @@ export default Route.extend({
 
   handleSecretModelError(capabilities, secretId, modelType, error) {
     // can't read the path and don't have update capability, so re-throw
-    if (!capabilities.canUpdate && modelType === 'secret') {
+    if (capabilities && !capabilities.canUpdate && modelType === 'secret') {
       throw error;
     }
     // don't have access to the metadata for v2 or the secret for v1,

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -16,6 +16,7 @@ export default Route.extend({
   store: service(),
   pathHelp: service('path-help'),
   wizard: service(),
+  router: service(),
 
   secretParam() {
     const { secret } = this.paramsFor(this.routeName);
@@ -83,9 +84,9 @@ export default Route.extend({
       const mode = this.routeName.split('.').pop();
       if (mode === 'edit' && utils.keyIsFolder(secret)) {
         if (parentKey) {
-          return this.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
+          return this.router.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
         } else {
-          return this.transitionTo('vault.cluster.secrets.backend.list-root');
+          return this.router.transitionTo('vault.cluster.secrets.backend.list-root');
         }
       }
     });

--- a/ui/app/routes/vault/cluster/secrets/backend/sign.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/sign.js
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
   templateName: 'vault/cluster/secrets/backend/sign',
 
   backendModel() {
@@ -30,11 +31,11 @@ export default Route.extend({
     const backend = backendModel.id;
 
     if (backendModel.type !== 'ssh') {
-      return this.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
     }
     return this.store.queryRecord('capabilities', this.pathQuery(role, backend)).then((capabilities) => {
       if (!capabilities.canUpdate) {
-        return this.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+        return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
       }
       return this.store.createRecord('ssh-sign', {
         role: {

--- a/ui/app/routes/vault/cluster/secrets/backend/versions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/versions.js
@@ -10,6 +10,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   store: service(),
+  router: service(),
   templateName: 'vault/cluster/secrets/backend/versions',
 
   beforeModel() {
@@ -20,9 +21,9 @@ export default Route.extend({
       return;
     }
     if (parentKey) {
-      return this.transitionTo('vault.cluster.secrets.backend.list', parentKey);
+      return this.router.transitionTo('vault.cluster.secrets.backend.list', parentKey);
     } else {
-      return this.transitionTo('vault.cluster.secrets.backend.list-root');
+      return this.router.transitionTo('vault.cluster.secrets.backend.list-root');
     }
   },
 

--- a/ui/app/routes/vault/cluster/settings/auth/configure/index.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure/index.js
@@ -5,11 +5,13 @@
 
 import Route from '@ember/routing/route';
 import { tabsForAuthSection } from 'vault/helpers/tabs-for-auth-section';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  router: service(),
   beforeModel() {
     const model = this.modelFor('vault.cluster.settings.auth.configure');
     const section = tabsForAuthSection([model])[0].routeParams.lastObject;
-    return this.transitionTo('vault.cluster.settings.auth.configure.section', section);
+    return this.router.transitionTo('vault.cluster.settings.auth.configure.section', section);
   },
 });

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Store from '@ember-data/store';
+import Store from 'ember-data/store';
 import { schedule } from '@ember/runloop';
 import { copy } from 'ember-copy';
 import { resolve, Promise } from 'rsvp';
@@ -205,7 +205,7 @@ export default Store.extend({
 
   unloadAll(modelName) {
     if (this.isDestroying || this.isDestroyed) {
-      return this._super(modelName);
+      return;
     }
 
     const hasMountConfig = ['auth-method', 'secret-engine'];
@@ -218,7 +218,7 @@ export default Store.extend({
 
   unloadRecord(record) {
     if (this.isDestroying || this.isDestroyed) {
-      return this._super(record);
+      return;
     }
 
     const hasMountConfig = ['auth-method', 'secret-engine'];

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -191,11 +191,13 @@ export default Store.extend({
   clearDataset(modelName) {
     const cacheList = this.lazyCaches;
     if (!cacheList.size) return;
-    if (modelName && cacheList.has(modelName)) {
+    if (modelName) {
+      // invalidate only the requested model's cache; don't fall through to
+      // clearing everything when it has no cached dataset
       cacheList.delete(modelName);
-      return;
+    } else {
+      cacheList.clear();
     }
-    cacheList.clear();
     this.set('lazyCaches', cacheList);
   },
 

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<Sidebar::Frame @showSidebar={{this.auth.isActiveSession}}>
+<Sidebar::Frame @showSidebar={{if (and this.auth.isActiveSession this.currentCluster.cluster.name) true false}}>
   <div class="page-container">
     {{outlet}}
   </div>

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -306,7 +306,7 @@
     @message="This database type cannot be viewed in the UI. You will have to use the API or CLI to perform actions here."
     @bottomBorder={{true}}
   >
-    <LinkTo @route="vault.cluster.secrets.backend.list-root" class="link">
+    <LinkTo @route="vault.cluster.secrets.backend.list-root" @model={{(current-mount-path)}} class="link">
       <Chevron @direction="left" />
       Go back
     </LinkTo>

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -24,7 +24,11 @@
         <ul>
           {{#each tabs as |tab|}}
             <li>
-              <LinkTo @route={{get tab.routeParams 0}} @model={{get tab.routeParams 1}} data-test-auth-section-tab={{true}}>
+              <LinkTo
+                @route={{get tab.routeParams 0}}
+                @models={{array @methodModel.id (get tab.routeParams 1)}}
+                data-test-auth-section-tab={{true}}
+              >
                 {{tab.label}}
               </LinkTo>
             </li>
@@ -38,7 +42,7 @@
   <ToolbarActions>
     <ToolbarLink
       @route="vault.cluster.access.method.item.create"
-      @model={{this.itemType}}
+      @models={{array @methodModel.id this.itemType}}
       @type="add"
       data-test-entity-create-link={{this.itemType}}
     >
@@ -51,6 +55,7 @@
   @items={{this.model}}
   @itemNoun={{this.itemType}}
   @paginationRouteName="vault.cluster.access.method.item.list"
+  @paginationModels={{array @methodModel.id this.itemType}}
   as |list|
 >
   {{#if list.empty}}
@@ -60,25 +65,36 @@
         this.itemType
       }} will be listed here. Create your first {{this.itemType}} to get started."
     >
-      <LinkTo @route="vault.cluster.access.method.item.create" @model={{this.itemType}} class="link">
+      <LinkTo @route="vault.cluster.access.method.item.create" @models={{array @methodModel.id this.itemType}} class="link">
         Create
         {{singularize this.itemType}}
       </LinkTo>
     </list.empty>
   {{else if list.item}}
-    <ListItem @linkParams={{array "vault.cluster.access.method.item.show" this.itemType list.item.id}} as |Item|>
+    <ListItem
+      @linkParams={{array "vault.cluster.access.method.item.show" @methodModel.id this.itemType list.item.id}}
+      as |Item|
+    >
       <Item.content>
         <Icon @name="folder" class="has-text-grey-light" />{{list.item.id}}
       </Item.content>
       <Item.menu as |Menu|>
         <li class="action">
-          <LinkTo @route="vault.cluster.access.method.item.show" @model={{list.item.id}} class="is-block">
+          <LinkTo
+            @route="vault.cluster.access.method.item.show"
+            @models={{array @methodModel.id this.itemType list.item.id}}
+            class="is-block"
+          >
             View
             {{singularize this.itemType}}
           </LinkTo>
         </li>
         <li class="action">
-          <LinkTo @route="vault.cluster.access.method.item.edit" @model={{list.item.id}} class="is-block">
+          <LinkTo
+            @route="vault.cluster.access.method.item.edit"
+            @models={{array @methodModel.id this.itemType list.item.id}}
+            class="is-block"
+          >
             Edit
             {{singularize this.itemType}}
           </LinkTo>

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -6,7 +6,7 @@
           <span class="sep">
             /
           </span>
-          <LinkTo @route="vault.cluster.access.method.item.list" @model={{this.itemType}}>
+          <LinkTo @route="vault.cluster.access.method.item.list" @models={{array @methodModelId this.itemType}}>
             {{pluralize this.itemType}}
           </LinkTo>
         </li>
@@ -45,7 +45,7 @@
       <div class="toolbar-separator"></div>
       <ToolbarLink
         @route="vault.cluster.access.method.item.edit"
-        @models={{array this.itemType this.model.id}}
+        @models={{array @methodModelId this.itemType this.model.id}}
         data-test-configure-link="true"
       >
         Edit
@@ -79,13 +79,18 @@
           Save
         </button>
         {{#if (eq this.mode "create")}}
-          <LinkTo @route="vault.cluster.access.method.item.list" class="button" data-test-cancel-link={{true}}>
+          <LinkTo
+            @route="vault.cluster.access.method.item.list"
+            @models={{array @methodModelId this.itemType}}
+            class="button"
+            data-test-cancel-link={{true}}
+          >
             Cancel
           </LinkTo>
         {{else}}
           <LinkTo
             @route="vault.cluster.access.method.item.show"
-            @model={{this.model.id}}
+            @models={{array @methodModelId this.itemType this.model.id}}
             class="button"
             data-test-cancel-link={{true}}
           >

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -91,7 +91,7 @@
           <ToolbarLink
             {{! Always create new version from latest if no metadata read access }}
             @route={{targetRoute}}
-            @model={{@model.id}}
+            @models={{array (current-mount-path) @model.id}}
             @query={{hash version=(if @model.canReadMetadata @modelForData.version "")}}
             @replace={{true}}
             @type="add"
@@ -100,7 +100,12 @@
             Create new version
           </ToolbarLink>
         {{else}}
-          <ToolbarLink @route={{targetRoute}} @model={{@model.id}} @replace={{true}} data-test-secret-edit="true">
+          <ToolbarLink
+            @route={{targetRoute}}
+            @models={{array (current-mount-path) @model.id}}
+            @replace={{true}}
+            data-test-secret-edit="true"
+          >
             Edit secret
           </ToolbarLink>
         {{/if}}

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -28,12 +28,20 @@
     <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
       <nav class="tabs">
         <ul>
-          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@key.id}} data-test-secret-tab>
+          <LinkTo
+            @route="vault.cluster.secrets.backend.show"
+            @models={{array (current-mount-path) @key.id}}
+            data-test-secret-tab
+          >
             Secret
           </LinkTo>
           {{! must have read access to /metadata see tab or update to update metadata}}
           {{#if (or this.canReadSecretMetadata this.canUpdateSecretMetadata)}}
-            <LinkTo @route="vault.cluster.secrets.backend.metadata" @model={{@key.id}} data-test-secret-metadata-tab>
+            <LinkTo
+              @route="vault.cluster.secrets.backend.metadata"
+              @models={{array (current-mount-path) @key.id}}
+              data-test-secret-metadata-tab
+            >
               Metadata
             </LinkTo>
           {{/if}}

--- a/ui/app/templates/components/section-tabs.hbs
+++ b/ui/app/templates/components/section-tabs.hbs
@@ -5,7 +5,11 @@
         <ul>
           {{#each tabs as |tab|}}
             <li>
-              <LinkTo @route={{get tab.routeParams 0}} @model={{get tab.routeParams 1}} data-test-auth-section-tab={{true}}>
+              <LinkTo
+                @route={{get tab.routeParams 0}}
+                @models={{array this.model.id (get tab.routeParams 1)}}
+                data-test-auth-section-tab={{true}}
+              >
                 {{tab.label}}
               </LinkTo>
             </li>

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -10,7 +10,7 @@
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3">
-      <LinkTo @route="vault.cluster.access.leases.list-root">
+      <LinkTo @route="vault.cluster.access.leases.list-root" @model={{this.clusterController.model.name}}>
         Leases
       </LinkTo>
     </h1>

--- a/ui/app/templates/vault/cluster/access/method/item/create.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/create.hbs
@@ -1,1 +1,6 @@
-<GeneratedItem @model={{this.model}} @mode="create" @itemType={{this.model.itemType}} />
+<GeneratedItem
+  @model={{this.model}}
+  @mode="create"
+  @itemType={{this.model.itemType}}
+  @methodModelId={{this.methodModel.id}}
+/>

--- a/ui/app/templates/vault/cluster/access/method/item/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/edit.hbs
@@ -1,1 +1,1 @@
-<GeneratedItem @model={{this.model}} @mode="edit" @itemType={{this.itemType}} />
+<GeneratedItem @model={{this.model}} @mode="edit" @itemType={{this.itemType}} @methodModelId={{this.methodModel.id}} />

--- a/ui/app/templates/vault/cluster/access/method/item/show.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/show.hbs
@@ -1,1 +1,1 @@
-<GeneratedItem @model={{this.model}} @itemType={{this.itemType}} @mode="show" />
+<GeneratedItem @model={{this.model}} @itemType={{this.itemType}} @mode="show" @methodModelId={{this.methodModel.id}} />

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
@@ -7,7 +7,7 @@
     @title="No applications allowed"
     @message="Access to this key has been limited, and no applications are allowed to use it. Edit the key to allow access."
   >
-    <LinkTo @route="vault.cluster.access.oidc.keys.key.edit">
+    <LinkTo @route="vault.cluster.access.oidc.keys.key.edit" @model={{this.keyName}}>
       Edit key
     </LinkTo>
   </EmptyState>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
@@ -7,7 +7,7 @@
     @title="No applications allowed"
     @message="Access to this provider has been limited, and no applications are allowed to use it. Edit the provider to allow access."
   >
-    <LinkTo @route="vault.cluster.access.oidc.providers.provider.edit">
+    <LinkTo @route="vault.cluster.access.oidc.providers.provider.edit" @model={{this.providerName}}>
       Edit provider
     </LinkTo>
   </EmptyState>

--- a/ui/app/templates/vault/cluster/secrets/backend/edit-metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/edit-metadata.hbs
@@ -12,7 +12,11 @@
     @title="You do not have permissions to edit metadata"
     @message="Ask your administrator if you think you should have access."
   >
-    <LinkTo @route="vault.cluster.secrets.backend.metadata" @model={{this.model.id}} class="link">
+    <LinkTo
+      @route="vault.cluster.secrets.backend.metadata"
+      @models={{array (current-mount-path) this.model.id}}
+      class="link"
+    >
       View Metadata
     </LinkTo>
     <DocLink @path="/api-docs/secret/kv/kv-v2#createupdate-metadata">More here</DocLink>

--- a/ui/app/templates/vault/cluster/secrets/backend/error.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/error.hbs
@@ -3,10 +3,17 @@
     <p.top>
       <nav class="breadcrumb">
         <li>
-          <LinkTo @route={{if this.model.backend "vault.cluster.secrets.backend.list-root" "vault.cluster.secrets"}}>
-            <span class="sep">&#x0002f;</span>
-            {{if this.model.backend this.model.backend "secrets"}}
-          </LinkTo>
+          {{#if this.model.backend}}
+            <LinkTo @route="vault.cluster.secrets.backend.list-root" @model={{this.model.backend}}>
+              <span class="sep">&#x0002f;</span>
+              {{this.model.backend}}
+            </LinkTo>
+          {{else}}
+            <LinkTo @route="vault.cluster.secrets">
+              <span class="sep">&#x0002f;</span>
+              secrets
+            </LinkTo>
+          {{/if}}
         </li>
       </nav>
     </p.top>
@@ -27,9 +34,15 @@
       <p data-test-secret-not-found>
         Unable to find secret at
         <code>{{concat this.model.backend "/" this.model.secret}}</code>. Try going back to the
-        <LinkTo @route={{if this.model.backend "vault.cluster.secrets.backend.list-root" "vault.cluster.secrets"}}>
-          root
-        </LinkTo>
+        {{#if this.model.backend}}
+          <LinkTo @route="vault.cluster.secrets.backend.list-root" @model={{this.model.backend}}>
+            root
+          </LinkTo>
+        {{else}}
+          <LinkTo @route="vault.cluster.secrets">
+            root
+          </LinkTo>
+        {{/if}}
         and navigating from there.
       </p>
     {{else if (eq this.model.httpStatus 403)}}
@@ -53,7 +66,7 @@
         </p>
         <p>
           {{#if this.model.secret}}
-            <LinkTo @route="vault.cluster.secrets.backend.list-root">Navigate back to the root</LinkTo>.
+            <LinkTo @route="vault.cluster.secrets.backend.list-root" @model={{this.model.backend}}>Navigate back to the root</LinkTo>.
           {{else}}
             <LinkTo @route="vault.cluster">Go back home</LinkTo>.
           {{/if}}

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -66,7 +66,7 @@
         {{#if this.model.canUpdateMetadata}}
           <LinkTo
             @route="vault.cluster.secrets.backend.edit-metadata"
-            @model={{this.model.id}}
+            @models={{array (current-mount-path) this.id}}
             data-test-add-custom-metadata
           >
             Add metadata

--- a/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/metadata.hbs
@@ -18,10 +18,14 @@
 <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
   <nav class="tabs">
     <ul>
-      <LinkTo @route="vault.cluster.secrets.backend.show" @model={{this.id}} data-test-secret-tab>
+      <LinkTo
+        @route="vault.cluster.secrets.backend.show"
+        @models={{array (current-mount-path) this.id}}
+        data-test-secret-tab
+      >
         Secret
       </LinkTo>
-      <LinkTo @route="vault.cluster.secrets.backend.metadata" @model={{this.id}}>
+      <LinkTo @route="vault.cluster.secrets.backend.metadata" @models={{array (current-mount-path) this.id}}>
         Metadata
       </LinkTo>
     </ul>
@@ -32,7 +36,7 @@
   {{! You must have update on metadata, create is not enough. }}
   {{#if this.model.canUpdateMetadata}}
     <ToolbarActions>
-      <ToolbarLink @route="vault.cluster.secrets.backend.edit-metadata" @model={{this.id}}>
+      <ToolbarLink @route="vault.cluster.secrets.backend.edit-metadata" @models={{array (current-mount-path) this.id}}>
         Edit metadata
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
@@ -16,7 +16,7 @@
         </li>
         <li>
           <span class="sep">&#x0002f;</span>
-          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{this.model.role.name}}>
+          <LinkTo @route="vault.cluster.secrets.backend.show" @models={{array (current-mount-path) this.model.role.name}}>
             {{this.model.role.name}}
           </LinkTo>
         </li>

--- a/ui/app/utils/remove-record.js
+++ b/ui/app/utils/remove-record.js
@@ -3,33 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Unlinks a record from all its relationships and unloads it from
-// the store.
+// Unload a record from the store and catch any errors.
 export default function removeRecord(store, record) {
-  const id = record.path || record.id;
-  if (id) {
-    // Collect relationship property names and types
-    const relationshipMeta = [];
-    record.eachRelationship((key, { kind }) => {
-      relationshipMeta.push({ key, kind });
-    });
-
-    // Push an update to this record with the relationships nulled out.
-    // This unlinks the relationship from the models that aren't about to
-    // be unloaded.
-    store.push({
-      data: {
-        id,
-        type: record.constructor.modelName,
-        relationships: relationshipMeta.reduce((hash, rel) => {
-          hash[rel.key] = { data: rel.kind === 'hasMany' ? [] : null };
-          return hash;
-        }, {}),
-      },
-    });
+  try {
+    store.unloadRecord(record);
+  } catch {
+    // record may already be destroyed
   }
-
-  // Now that the record has no attachments, it can be safely unloaded
-  // from the store.
-  store.unloadRecord(record);
 }

--- a/ui/app/utils/transition-to-safe.js
+++ b/ui/app/utils/transition-to-safe.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) HashiCorp, Inc.
+ * Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/ui/app/utils/transition-to-safe.js
+++ b/ui/app/utils/transition-to-safe.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch aborted transition errors. These are part of normal control flow, but
+// return an error which needs to be handled.
+export default function transitionToSafe(router, ...args) {
+  return router.transitionTo(...args).catch((error) => {
+    if (error?.name !== 'TransitionAborted') {
+      throw error;
+    }
+  });
+}

--- a/ui/lib/core/addon/components/edit-form.js
+++ b/ui/lib/core/addon/components/edit-form.js
@@ -70,7 +70,11 @@ export default Component.extend({
     const { model } = this;
     if (!model) return;
     if ((model.isDirty && !model.isDestroyed) || !model.isDestroying) {
-      model.rollbackAttributes();
+      try {
+        model.rollbackAttributes();
+      } catch {
+        // model's internal graph may already be torn down during destruction
+      }
     }
   },
 });

--- a/ui/lib/core/addon/components/key-value-header.hbs
+++ b/ui/lib/core/addon/components/key-value-header.hbs
@@ -4,10 +4,10 @@
     {{#each this.secretPath as |path index|}}
       <li class={{if (is-active-route path.path path.model isExact=true) "is-active"}}>
         <span class="sep">&#x0002f;</span>
-        {{#if (and this.linkToPaths (not @isEngine))}}
+        {{#if (and this.linkToPaths (not @isEngine) path.models.length)}}
           <LinkTo
             @route={{path.path}}
-            @model={{path.model}}
+            @models={{path.models}}
             data-test-secret-root-link={{if (eq index 0) true false}}
             data-test-secret-breadcrumb={{path.text}}
           >

--- a/ui/lib/core/addon/components/key-value-header.js
+++ b/ui/lib/core/addon/components/key-value-header.js
@@ -44,6 +44,18 @@ export default class KeyValueHeader extends Component {
     return `vault.cluster.secrets.backend.${this.args.mode}`;
   }
 
+  // Supply the breadcrumb models explicitly so the router doesn't have to
+  // infer them from its (possibly mid-transition) state: the leading dynamic
+  // segment comes from the root crumb, the leaf model from the crumb itself.
+  crumbModels(crumb) {
+    const rootModel = this.args.root?.model;
+    const model = crumb.model;
+    if (rootModel !== undefined && rootModel !== null && rootModel !== model) {
+      return [rootModel, model];
+    }
+    return model !== undefined && model !== null ? [model] : [];
+  }
+
   get secretPath() {
     const crumbs = [];
     const root = this.args.root;
@@ -51,7 +63,7 @@ export default class KeyValueHeader extends Component {
     const baseKeyModel = encodePath(this.args.baseKey?.id);
 
     if (root) {
-      crumbs.push(root);
+      crumbs.push({ ...root, models: this.crumbModels(root) });
     }
 
     if (!baseKey) {
@@ -69,6 +81,7 @@ export default class KeyValueHeader extends Component {
         text: this.stripTrailingSlash(baseKey),
         path: currentPath,
         model: baseKeyModel,
+        models: this.crumbModels({ model: baseKeyModel }),
       });
 
       if (!showCurrent) {
@@ -84,6 +97,7 @@ export default class KeyValueHeader extends Component {
         text: this.stripTrailingSlash(parts[index]),
         path: path,
         model: encodePath(ancestor),
+        models: this.crumbModels({ model: encodePath(ancestor) }),
       });
     });
 
@@ -92,6 +106,7 @@ export default class KeyValueHeader extends Component {
       text: this.stripTrailingSlash(utils.keyWithoutParentKey(baseKey)),
       path: currentPath,
       model: baseKeyModel,
+      models: this.crumbModels({ model: baseKeyModel }),
     });
 
     if (!showCurrent) {

--- a/ui/lib/core/addon/components/list-view.hbs
+++ b/ui/lib/core/addon/components/list-view.hbs
@@ -10,6 +10,7 @@
         @page={{@items.meta.currentPage}}
         @lastPage={{@items.meta.lastPage}}
         @link={{@paginationRouteName}}
+        @models={{@paginationModels}}
         data-test-list-view-pagination
       />
     {{/if}}

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -2,15 +2,28 @@
   <div class="is-flex-between is-fullwidth card-details" data-test-selectable-card={{@cardTitle}}>
     <h3 class="title is-5">{{@cardTitle}}</h3>
     {{#if @actionText}}
-      <LinkTo
-        class="has-icon-right is-ghost is-no-underline has-text-weight-semibold"
-        @route={{@actionTo}}
-        @query={{hash @actionQuery}}
-        data-test-action-text={{@actionText}}
-      >
-        {{@actionText}}
-        <Icon @name="chevron-right" />
-      </LinkTo>
+      {{#if @actionModel}}
+        <LinkTo
+          class="has-icon-right is-ghost is-no-underline has-text-weight-semibold"
+          @route={{@actionTo}}
+          @model={{@actionModel}}
+          @query={{hash @actionQuery}}
+          data-test-action-text={{@actionText}}
+        >
+          {{@actionText}}
+          <Icon @name="chevron-right" />
+        </LinkTo>
+      {{else}}
+        <LinkTo
+          class="has-icon-right is-ghost is-no-underline has-text-weight-semibold"
+          @route={{@actionTo}}
+          @query={{hash @actionQuery}}
+          data-test-action-text={{@actionText}}
+        >
+          {{@actionText}}
+          <Icon @name="chevron-right" />
+        </LinkTo>
+      {{/if}}
     {{/if}}
   </div>
   <p class="has-text-grey is-size-8 {{unless @actionText 'has-top-margin-s'}}">{{@subText}}</p>

--- a/ui/lib/core/addon/components/page/breadcrumbs.hbs
+++ b/ui/lib/core/addon/components/page/breadcrumbs.hbs
@@ -6,9 +6,15 @@
         {{#if breadcrumb.linkExternal}}
           <LinkToExternal @route={{breadcrumb.route}}>{{breadcrumb.label}}</LinkToExternal>
         {{else if breadcrumb.route}}
-          <LinkTo @route={{breadcrumb.route}}>
-            {{breadcrumb.label}}
-          </LinkTo>
+          {{#if breadcrumb.models}}
+            <LinkTo @route={{breadcrumb.route}} @models={{breadcrumb.models}}>
+              {{breadcrumb.label}}
+            </LinkTo>
+          {{else}}
+            <LinkTo @route={{breadcrumb.route}} @model={{breadcrumb.model}}>
+              {{breadcrumb.label}}
+            </LinkTo>
+          {{/if}}
         {{else}}
           {{breadcrumb.label}}
         {{/if}}

--- a/ui/lib/core/addon/components/secret-list-header-tab.hbs
+++ b/ui/lib/core/addon/components/secret-list-header-tab.hbs
@@ -1,10 +1,15 @@
 {{#unless this.dontShowTab}}
   {{#if @isEngine}}
-    <LinkTo @route={{@link}} data-test-secret-list-tab={{@label}}>
+    <LinkTo @route={{@link}} @model={{@id}} data-test-secret-list-tab={{@label}}>
       {{@label}}
     </LinkTo>
   {{else}}
-    <LinkTo @route="vault.cluster.secrets.backend.list-root" @query={{hash tab=@tab}} data-test-secret-list-tab={{@label}}>
+    <LinkTo
+      @route="vault.cluster.secrets.backend.list-root"
+      @model={{@id}}
+      @query={{hash tab=@tab}}
+      data-test-secret-list-tab={{@label}}
+    >
       {{@label}}
     </LinkTo>
   {{/if}}

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -53,7 +53,7 @@
         {{else}}
           <ul>
             {{#if options.hasOverview}}
-              <LinkTo @route="vault.cluster.secrets.backend.overview" data-test-tab="overview">
+              <LinkTo @route="vault.cluster.secrets.backend.overview" @model={{@model.id}} data-test-tab="overview">
                 Overview
               </LinkTo>
             {{/if}}
@@ -66,7 +66,11 @@
                 @tab={{or oTab.tab ""}}
               />
             {{/each}}
-            <LinkTo @route="vault.cluster.secrets.backend.configuration" data-test-configuration-tab={{true}}>
+            <LinkTo
+              @route="vault.cluster.secrets.backend.configuration"
+              @model={{@model.id}}
+              data-test-configuration-tab={{true}}
+            >
               Configuration
             </LinkTo>
           </ul>
@@ -81,12 +85,17 @@
           {{#if (includes @model.engineType (supported-secret-backends))}}
             <LinkTo
               @route="vault.cluster.secrets.backend.list-root"
+              @model={{@model.id}}
               @current-when="vault.cluster.secrets.backend.list-root vault.cluster.secrets.backend.list"
             >
               {{capitalize (pluralize options.item)}}
             </LinkTo>
           {{/if}}
-          <LinkTo @route="vault.cluster.secrets.backend.configuration" data-test-configuration-tab={{true}}>
+          <LinkTo
+            @route="vault.cluster.secrets.backend.configuration"
+            @model={{@model.id}}
+            data-test-configuration-tab={{true}}
+          >
             Configuration
           </LinkTo>
         </ul>

--- a/ui/lib/kubernetes/addon/components/config-cta.hbs
+++ b/ui/lib/kubernetes/addon/components/config-cta.hbs
@@ -3,7 +3,7 @@
   @title="Kubernetes not configured"
   @message="Get started by establishing the URL of the Kubernetes API to connect to, along with some additional options."
 >
-  <LinkTo class="has-top-margin-xs" @route="configure">
+  <LinkTo class="has-top-margin-xs" @route="configure" @model={{(current-mount-path)}}>
     Configure Kubernetes
   </LinkTo>
 </EmptyState>

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -1,5 +1,5 @@
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
-  <ToolbarLink @route="configure" data-test-toolbar-config-action>
+  <ToolbarLink @route="configure" data-test-toolbar-config-action @model={{(current-mount-path)}}>
     {{if @config "Edit configuration" "Configure Kubernetes"}}
   </ToolbarLink>
 </TabPageHeader>

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -1,5 +1,5 @@
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
-  <ToolbarLink @route="configure">Configure Kubernetes</ToolbarLink>
+  <ToolbarLink @route="configure" @model={{(current-mount-path)}}>Configure Kubernetes</ToolbarLink>
 </TabPageHeader>
 
 {{#if @promptConfig}}

--- a/ui/lib/kubernetes/addon/components/page/role/details.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/details.hbs
@@ -18,12 +18,16 @@
       <div class="toolbar-separator"></div>
     {{/if}}
     {{#if @model.canGenerateCreds}}
-      <ToolbarLink @route="roles.role.credentials" data-test-generate-credentials>
+      <ToolbarLink
+        @route="roles.role.credentials"
+        @models={{array (current-mount-path) @model.name}}
+        data-test-generate-credentials
+      >
         Generate credentials
       </ToolbarLink>
     {{/if}}
     {{#if @model.canEdit}}
-      <ToolbarLink @route="roles.role.edit" data-test-edit>
+      <ToolbarLink @route="roles.role.edit" @models={{array (current-mount-path) @model.name}} data-test-edit>
         Edit role
       </ToolbarLink>
     {{/if}}

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -5,7 +5,7 @@
   @breadcrumbs={{@breadcrumbs}}
 >
   {{#unless @promptConfig}}
-    <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-roles-action>
+    <ToolbarLink @route="roles.create" @type="add" data-test-toolbar-roles-action @model={{(current-mount-path)}}>
       Create role
     </ToolbarLink>
   {{/unless}}
@@ -22,7 +22,7 @@
       @title="No roles yet"
       @message="When created, roles will be listed here. Create a role to start generating service account tokens."
     >
-      <LinkTo class="has-top-margin-xs" @route="roles.create">
+      <LinkTo class="has-top-margin-xs" @route="roles.create" @model={{(current-mount-path)}}>
         Create role
       </LinkTo>
     </EmptyState>
@@ -48,7 +48,7 @@
                 class="has-text-black has-text-weight-semibold"
                 data-test-details
                 @route="roles.role.details"
-                @model={{role}}
+                @models={{array (current-mount-path) role}}
                 @disabled={{eq role.canRead false}}
               >
                 Details
@@ -59,7 +59,7 @@
                 class="has-text-black has-text-weight-semibold"
                 data-test-edit
                 @route="roles.role.edit"
-                @model={{role}}
+                @models={{array (current-mount-path) role}}
                 @disabled={{not role.canEdit}}
               >
                 Edit

--- a/ui/lib/kubernetes/addon/components/tab-page-header.hbs
+++ b/ui/lib/kubernetes/addon/components/tab-page-header.hbs
@@ -13,9 +13,9 @@
 <div class="tabs-container box is-bottomless is-marginless is-paddingless">
   <nav class="tabs" aria-label="kubernetes tabs">
     <ul>
-      <LinkTo @route="overview" data-test-tab="overview">Overview</LinkTo>
-      <LinkTo @route="roles" data-test-tab="roles">Roles</LinkTo>
-      <LinkTo @route="configuration" data-test-tab="config">Configuration</LinkTo>
+      <LinkTo @route="overview" data-test-tab="overview" @model={{(current-mount-path)}}>Overview</LinkTo>
+      <LinkTo @route="roles" data-test-tab="roles" @model={{(current-mount-path)}}>Roles</LinkTo>
+      <LinkTo @route="configuration" data-test-tab="config" @model={{(current-mount-path)}}>Configuration</LinkTo>
     </ul>
   </nav>
 </div>

--- a/ui/lib/kubernetes/addon/helpers/current-mount-path.js
+++ b/ui/lib/kubernetes/addon/helpers/current-mount-path.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) HashiCorp, Inc.
+ * Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/ui/lib/kubernetes/addon/helpers/current-mount-path.js
+++ b/ui/lib/kubernetes/addon/helpers/current-mount-path.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { inject as service } from '@ember/service';
+import Helper from '@ember/component/helper';
+
+// Returns the path of the currently viewed secret mount
+export default class CurrentMountPathHelper extends Helper {
+  @service secretMountPath;
+
+  compute() {
+    return this.secretMountPath.currentPath;
+  }
+}

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -22,7 +22,7 @@ export default class KubernetesConfigureRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'overview' },
+      { label: resolvedModel.backend, route: 'overview', models: [resolvedModel.backend] },
       { label: 'configure' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/error.js
+++ b/ui/lib/kubernetes/addon/routes/error.js
@@ -13,7 +13,11 @@ export default class KubernetesErrorRoute extends Route {
     super.setupController(...arguments);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
     ];
     controller.backend = this.modelFor('application');
   }

--- a/ui/lib/kubernetes/addon/routes/roles/create.js
+++ b/ui/lib/kubernetes/addon/routes/roles/create.js
@@ -19,8 +19,8 @@ export default class KubernetesRolesCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
+      { label: resolvedModel.backend, route: 'overview', models: [resolvedModel.backend] },
+      { label: 'roles', route: 'roles', models: [resolvedModel.backend] },
       { label: 'create' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
@@ -19,9 +19,13 @@ export default class KubernetesRoleCredentialsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: resolvedModel.roleName, route: 'roles.role.details' },
+      { label: resolvedModel.backend, route: 'overview', models: [resolvedModel.backend] },
+      { label: 'roles', route: 'roles', models: [resolvedModel.backend] },
+      {
+        label: resolvedModel.roleName,
+        route: 'roles.role.details',
+        models: [resolvedModel.backend, resolvedModel.roleName],
+      },
       { label: 'credentials' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/details.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/details.js
@@ -20,8 +20,8 @@ export default class KubernetesRoleDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
+      { label: resolvedModel.backend, route: 'overview', models: [resolvedModel.backend] },
+      { label: 'roles', route: 'roles', models: [resolvedModel.backend] },
       { label: resolvedModel.name },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/edit.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/edit.js
@@ -20,9 +20,9 @@ export default class KubernetesRoleEditRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: resolvedModel.name, route: 'roles.role' },
+      { label: resolvedModel.backend, route: 'overview', models: [resolvedModel.backend] },
+      { label: 'roles', route: 'roles', models: [resolvedModel.backend] },
+      { label: resolvedModel.name, route: 'roles.role', models: [resolvedModel.backend, resolvedModel.name] },
       { label: 'edit' },
     ];
   }

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
@@ -14,7 +14,7 @@
         </button>
         <div class="toolbar-separator"></div>
       {{/if}}
-      <ToolbarLink @route="configuration.edit">
+      <ToolbarLink @route="configuration.edit" @model={{(current-mount-path)}}>
         Edit configuration
       </ToolbarLink>
     </ToolbarActions>
@@ -95,7 +95,7 @@
 {{else}}
   <Toolbar>
     <ToolbarActions>
-      <ToolbarLink @route="configuration.create" data-test-configure-pki-button>
+      <ToolbarLink @route="configuration.create" data-test-configure-pki-button @model={{(current-mount-path)}}>
         Configure
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -12,12 +12,22 @@
       </button>
     {{/if}}
     {{#if @canCrossSign}}
-      <ToolbarLink @route="issuers.issuer.cross-sign" @type="pen-tool" @model={{@issuer.id}} data-test-pki-issuer-cross-sign>
+      <ToolbarLink
+        @route="issuers.issuer.cross-sign"
+        @type="pen-tool"
+        @models={{array (current-mount-path) @issuer.id}}
+        data-test-pki-issuer-cross-sign
+      >
         Cross-sign issuers
       </ToolbarLink>
     {{/if}}
     {{#if @canSignIntermediate}}
-      <ToolbarLink @route="issuers.issuer.sign" @type="pen-tool" @issuer={{@issuer.id}} data-test-pki-issuer-sign-int>
+      <ToolbarLink
+        @route="issuers.issuer.sign"
+        @type="pen-tool"
+        @models={{array (current-mount-path) @issuer.id}}
+        data-test-pki-issuer-sign-int
+      >
         Sign Intermediate
       </ToolbarLink>
     {{/if}}
@@ -68,7 +78,11 @@
     </BasicDropdown>
 
     {{#if @canConfigure}}
-      <ToolbarLink @route="issuers.issuer.edit" @model={{@issuer.id}} data-test-pki-issuer-configure>
+      <ToolbarLink
+        @route="issuers.issuer.edit"
+        @models={{array (current-mount-path) @issuer.id}}
+        data-test-pki-issuer-configure
+      >
         Configure
       </ToolbarLink>
     {{/if}}
@@ -78,7 +92,7 @@
 {{#if @issuer.isDefault}}
   <p class="has-top-margin-m">
     This is your default issuer certificate. You will see it in your
-    <LinkTo @route="issuers.index">
+    <LinkTo @route="issuers.index" @model={{(current-mount-path)}}>
       list of Issuers.
     </LinkTo>
     You may also want to configure its usage and other behaviors.
@@ -106,7 +120,10 @@
           {{else if (eq attr.name "keyId")}}
             <InfoTableRow @label={{or attr.options.label (humanize (dasherize attr.name))}} @value={{get @issuer attr.name}}>
               {{#if @issuer.keyId}}
-                <LinkTo @route="keys.key.details" @model={{@issuer.keyId}}>{{@issuer.keyId}}</LinkTo>
+                <LinkTo
+                  @route="keys.key.details"
+                  @models={{array (current-mount-path) @issuer.keyId}}
+                >{{@issuer.keyId}}</LinkTo>
               {{else}}
                 <Icon @name="minus" />
               {{/if}}

--- a/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
@@ -46,12 +46,12 @@
             <nav class="menu" aria-label="issuer config options">
               <ul class="menu-list">
                 <li data-test-popup-menu-details>
-                  <LinkTo @route="issuers.issuer.details" @model={{pkiIssuer.id}}>
+                  <LinkTo @route="issuers.issuer.details" @models={{array (current-mount-path) pkiIssuer.id}}>
                     Details
                   </LinkTo>
                 </li>
                 <li>
-                  <LinkTo @route="issuers.issuer.edit" @model={{pkiIssuer.id}}>
+                  <LinkTo @route="issuers.issuer.edit" @models={{array (current-mount-path) pkiIssuer.id}}>
                     Edit
                   </LinkTo>
                 </li>

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -15,7 +15,7 @@
       <ToolbarLink
         @route="issuers.issuer.cross-sign"
         @type="pen-tool"
-        @model={{@newRootModel.issuerId}}
+        @models={{array (current-mount-path) @newRootModel.issuerId}}
         data-test-pki-issuer-cross-sign
       >
         Cross-sign issuers
@@ -23,7 +23,7 @@
       <ToolbarLink
         @route="issuers.issuer.sign"
         @type="pen-tool"
-        @model={{@newRootModel.issuerId}}
+        @models={{array (current-mount-path) @newRootModel.issuerId}}
         data-test-pki-issuer-sign-int
       >
         Sign Intermediate
@@ -67,7 +67,11 @@
           </nav>
         </D.Content>
       </BasicDropdown>
-      <ToolbarLink @route="issuers.issuer.edit" @model={{@newRootModel.issuerId}} data-test-pki-issuer-configure>
+      <ToolbarLink
+        @route="issuers.issuer.edit"
+        @models={{array (current-mount-path) @newRootModel.issuerId}}
+        data-test-pki-issuer-configure
+      >
         Configure
       </ToolbarLink>
     </ToolbarActions>
@@ -86,7 +90,11 @@
       If you’re ready, you can begin cross-signing issuers now. If not, the option to cross-sign is available when you use
       this certificate.
       <br />
-      <LinkTo class="is-marginless" @route="issuers.issuer.cross-sign" @model={{@newRootModel.issuerId}}>
+      <LinkTo
+        class="is-marginless"
+        @route="issuers.issuer.cross-sign"
+        @models={{array (current-mount-path) @newRootModel.issuerId}}
+      >
         Cross-sign issuers
       </LinkTo>
     </AlertBanner>

--- a/ui/lib/pki/addon/components/page/pki-key-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-details.hbs
@@ -24,7 +24,7 @@
       </DownloadButton>
     {{/if}}
     {{#if @canEdit}}
-      <ToolbarLink @route="keys.key.edit" @model={{@key.keyId}} data-test-pki-key-edit>
+      <ToolbarLink @route="keys.key.edit" @models={{array (current-mount-path) @key.keyId}} data-test-pki-key-edit>
         Edit key
       </ToolbarLink>
     {{/if}}

--- a/ui/lib/pki/addon/components/page/pki-key-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-list.hbs
@@ -1,12 +1,12 @@
 <Toolbar>
   <ToolbarActions>
     {{#if @canImportKey}}
-      <ToolbarLink @route="keys.import" @type="download" data-test-pki-key-import>
+      <ToolbarLink @route="keys.import" @type="download" data-test-pki-key-import @model={{(current-mount-path)}}>
         Import
       </ToolbarLink>
     {{/if}}
     {{#if @canGenerateKey}}
-      <ToolbarLink @route="keys.create" @type="add" data-test-pki-key-generate>
+      <ToolbarLink @route="keys.create" @type="add" data-test-pki-key-generate @model={{(current-mount-path)}}>
         Generate
       </ToolbarLink>
     {{/if}}
@@ -41,7 +41,7 @@
                   <li>
                     <LinkTo
                       @route="keys.key.details"
-                      @model={{pkiKey.keyId}}
+                      @models={{array (current-mount-path) pkiKey.keyId}}
                       @disabled={{not @canRead}}
                       data-test-key-menu-link="details"
                     >
@@ -51,7 +51,7 @@
                   <li>
                     <LinkTo
                       @route="keys.key.edit"
-                      @model={{pkiKey.keyId}}
+                      @models={{array (current-mount-path) pkiKey.keyId}}
                       @disabled={{not @canEdit}}
                       data-test-key-menu-link="edit"
                     >

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -4,6 +4,7 @@
     @subText="The total number of issuers in this PKI mount. Includes both root and intermediate certificates."
     @actionText="View issuers"
     @actionTo="issuers"
+    @actionModel={{@engine.id}}
   >
     <h2 class="title-number">{{format-number (if (eq @issuers 404) 0 @issuers.length)}}</h2>
   </OverviewCard>
@@ -13,6 +14,7 @@
       @subText="The total number of roles in this PKI mount that have been created to generate certificates."
       @actionText="View roles"
       @actionTo="roles"
+      @actionModel={{@engine.id}}
     >
       <h2 class="title-number">{{format-number (if (eq @roles 404) 0 @roles.length)}}</h2>
     </OverviewCard>

--- a/ui/lib/pki/addon/components/page/pki-role-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-role-details.hbs
@@ -13,19 +13,34 @@
       <div class="toolbar-separator"></div>
     {{/if}}
     {{#if @role.canGenerateCert}}
-      <LinkTo class="toolbar-link" @route="roles.role.generate" @model={{@role.id}} data-test-pki-role-generate-cert>
+      <LinkTo
+        class="toolbar-link"
+        @route="roles.role.generate"
+        @models={{array (current-mount-path) @role.id}}
+        data-test-pki-role-generate-cert
+      >
         Generate Certificate
         <Icon @name="chevron-right" />
       </LinkTo>
     {{/if}}
     {{#if @role.canSign}}
-      <LinkTo class="toolbar-link" @route="roles.role.sign" @model={{@role.id}} data-test-pki-role-sign-cert>
+      <LinkTo
+        class="toolbar-link"
+        @route="roles.role.sign"
+        @models={{array (current-mount-path) @role.id}}
+        data-test-pki-role-sign-cert
+      >
         Sign Certificate
         <Icon @name="chevron-right" />
       </LinkTo>
     {{/if}}
     {{#if @role.canEdit}}
-      <LinkTo class="toolbar-link" @route="roles.role.edit" @model={{@role.id}} data-test-pki-role-edit-link>
+      <LinkTo
+        class="toolbar-link"
+        @route="roles.role.edit"
+        @models={{array (current-mount-path) @role.id}}
+        data-test-pki-role-edit-link
+      >
         Edit
         <Icon @name="chevron-right" />
       </LinkTo>
@@ -45,7 +60,7 @@
             @value={{val}}
             @alwaysRender={{true}}
           >
-            <LinkTo @route="issuers.issuer.details" @model={{val}}>{{val}}</LinkTo>
+            <LinkTo @route="issuers.issuer.details" @models={{array (current-mount-path) val}}>{{val}}</LinkTo>
           </InfoTableRow>
         {{else if (includes attr.name this.arrayAttrs)}}
           <InfoTableRow

--- a/ui/lib/pki/addon/components/page/pki-role-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-role-details.ts
@@ -24,8 +24,12 @@ export default class DetailsPage extends Component<Args> {
   get breadcrumbs() {
     return [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
       { label: this.args.role.id },
     ];
   }

--- a/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
@@ -11,7 +11,12 @@
 
 <Toolbar>
   <ToolbarActions>
-    <LinkTo @route="tidy.auto.configure" class="toolbar-link" data-test-pki-edit-tidy-auto-link>
+    <LinkTo
+      @route="tidy.auto.configure"
+      class="toolbar-link"
+      data-test-pki-edit-tidy-auto-link
+      @model={{(current-mount-path)}}
+    >
       Edit auto-tidy
       <Icon @name="chevron-right" />
     </LinkTo>

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -2,10 +2,10 @@
   <ToolbarActions>
     <div class="toolbar-separator"></div>
     {{#if @autoTidyConfig.enabled}}
-      <ToolbarLink @route="tidy.auto" data-test-pki-auto-tidy-config>
+      <ToolbarLink @route="tidy.auto" data-test-pki-auto-tidy-config @model={{(current-mount-path)}}>
         Auto-tidy configuration
       </ToolbarLink>
-      <ToolbarLink @route="tidy.manual" data-test-pki-manual-tidy-config>
+      <ToolbarLink @route="tidy.manual" data-test-pki-manual-tidy-config @model={{(current-mount-path)}}>
         Perform manual tidy
       </ToolbarLink>
     {{else}}

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -21,7 +21,7 @@
               {{#if (and attr.options.masked value)}}
                 <MaskedInput @value={{value}} @displayOnly={{true}} @allowCopy={{true}} />
               {{else if (eq attr.name "keyId")}}
-                <LinkTo @route="keys.key.details" @model={{@model.keyId}}>
+                <LinkTo @route="keys.key.details" @models={{array (current-mount-path) @model.keyId}}>
                   {{@model.keyId}}
                 </LinkTo>
               {{else}}

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -9,7 +9,9 @@
             @value={{get @model attr.name}}
             @addCopyButton={{or (eq attr.name "issuerId") (eq attr.name "keyId")}}
           >
-            <LinkTo @route={{attr.options.detailLinkTo}} @model={{get @model attr.name}}>{{get @model attr.name}}</LinkTo>
+            <LinkTo @route={{attr.options.detailLinkTo}} @models={{array (current-mount-path) (get @model attr.name)}}>
+              {{get @model attr.name}}
+            </LinkTo>
           </InfoTableRow>
         {{else if attr.options.masked}}
           <InfoTableRow

--- a/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
+++ b/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
@@ -20,7 +20,7 @@
         <div class="is-flex-start">
           <div class="is-flex-1 basis-0 has-bottom-margin-xs" data-test-imported-issuer>
             {{#if imported.issuer}}
-              <LinkTo @route="issuers.issuer.details" @model={{imported.issuer}}>
+              <LinkTo @route="issuers.issuer.details" @models={{array (current-mount-path) imported.issuer}}>
                 {{imported.issuer}}
               </LinkTo>
             {{else}}
@@ -29,7 +29,7 @@
           </div>
           <div class="is-flex-1 basis-0 has-bottom-margin-xs" data-test-imported-key>
             {{#if imported.key}}
-              <LinkTo @route="keys.key.details" @model={{imported.key}}>
+              <LinkTo @route="keys.key.details" @models={{array (current-mount-path) imported.key}}>
                 {{imported.key}}
               </LinkTo>
             {{else}}

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
@@ -17,7 +17,7 @@
             {{else if (eq attr.name "serialNumber")}}
               <LinkTo
                 @route="certificates.certificate.details"
-                @model={{@model.serialNumber}}
+                @models={{array (current-mount-path) @model.serialNumber}}
               >{{@model.serialNumber}}</LinkTo>
             {{else}}
               <Icon @name="minus" />

--- a/ui/lib/pki/addon/helpers/current-mount-path.js
+++ b/ui/lib/pki/addon/helpers/current-mount-path.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) HashiCorp, Inc.
+ * Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/ui/lib/pki/addon/helpers/current-mount-path.js
+++ b/ui/lib/pki/addon/helpers/current-mount-path.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { inject as service } from '@ember/service';
+import Helper from '@ember/component/helper';
+
+// Returns the path of the currently viewed secret mount
+export default class CurrentMountPathHelper extends Helper {
+  @service secretMountPath;
+
+  compute() {
+    return this.secretMountPath.currentPath;
+  }
+}

--- a/ui/lib/pki/addon/routes/certificates/certificate/details.js
+++ b/ui/lib/pki/addon/routes/certificates/certificate/details.js
@@ -18,8 +18,12 @@ export default class PkiCertificateDetailsRoute extends Route {
     super.setupController(controller, model);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'certificates', route: 'certificates.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'certificates', route: 'certificates.index', models: [this.secretMountPath.currentPath] },
       { label: model.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -24,7 +24,11 @@ export default class PkiConfigurationCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
       { label: 'configure' },
     ];
   }

--- a/ui/lib/pki/addon/routes/configuration/edit.js
+++ b/ui/lib/pki/addon/routes/configuration/edit.js
@@ -26,8 +26,12 @@ export default class PkiConfigurationEditRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'configuration', route: 'configuration.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'configuration', route: 'configuration.index', models: [this.secretMountPath.currentPath] },
       { label: 'edit' },
     ];
   }

--- a/ui/lib/pki/addon/routes/error.js
+++ b/ui/lib/pki/addon/routes/error.js
@@ -13,7 +13,11 @@ export default class PkiRolesErrorRoute extends Route {
     super.setupController(...arguments);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
     ];
     controller.tabs = [
       { label: 'Overview', route: 'overview' },

--- a/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
@@ -20,8 +20,12 @@ export default class PkiIssuersGenerateIntermediateRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
       { label: 'generate CSR' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -20,7 +20,11 @@ export default class PkiIssuersGenerateRootRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
       { label: 'generate root' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/import.js
+++ b/ui/lib/pki/addon/routes/issuers/import.js
@@ -20,8 +20,12 @@ export default class PkiIssuersImportRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
       { label: 'import' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -30,8 +30,12 @@ export default class PkiIssuersListRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
     ];
     controller.notConfiguredMessage = PKI_DEFAULT_EMPTY_STATE_MSG;
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer.js
@@ -22,8 +22,12 @@ export default class PkiIssuerIndexRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
@@ -21,9 +21,17 @@ export default class PkiIssuerCrossSignRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
-      { label: resolvedModel.id, route: 'issuers.issuer.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
+      {
+        label: resolvedModel.id,
+        route: 'issuers.issuer.details',
+        models: [this.secretMountPath.currentPath, resolvedModel.id],
+      },
       { label: 'cross-sign' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/details.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/details.js
@@ -26,8 +26,12 @@ export default class PkiIssuerDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
       { label: resolvedModel.issuer.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/edit.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/edit.js
@@ -24,9 +24,17 @@ export default class PkiIssuerEditRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
-      { label: resolvedModel.id, route: 'issuers.issuer.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
+      {
+        label: resolvedModel.id,
+        route: 'issuers.issuer.details',
+        models: [this.secretMountPath.currentPath, resolvedModel.id],
+      },
       { label: 'update' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
@@ -39,9 +39,17 @@ export default class PkiIssuerRotateRootRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
-      { label: resolvedModel.oldRoot.id, route: 'issuers.issuer.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
+      {
+        label: resolvedModel.oldRoot.id,
+        route: 'issuers.issuer.details',
+        models: [this.secretMountPath.currentPath, resolvedModel.oldRoot.id],
+      },
       { label: 'rotate root' },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/sign.js
@@ -20,9 +20,17 @@ export default class PkiIssuerSignRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'issuers', route: 'issuers.index' },
-      { label: resolvedModel.issuerRef, route: 'issuers.issuer.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'issuers', route: 'issuers.index', models: [this.secretMountPath.currentPath] },
+      {
+        label: resolvedModel.issuerRef,
+        route: 'issuers.issuer.details',
+        models: [this.secretMountPath.currentPath, resolvedModel.issuerRef],
+      },
       { label: 'sign intermediate' },
     ];
   }

--- a/ui/lib/pki/addon/routes/keys/create.js
+++ b/ui/lib/pki/addon/routes/keys/create.js
@@ -20,8 +20,12 @@ export default class PkiKeysCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'keys', route: 'keys.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'keys', route: 'keys.index', models: [this.secretMountPath.currentPath] },
       { label: 'generate' },
     ];
   }

--- a/ui/lib/pki/addon/routes/keys/import.js
+++ b/ui/lib/pki/addon/routes/keys/import.js
@@ -20,8 +20,12 @@ export default class PkiKeysImportRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'keys', route: 'keys.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'keys', route: 'keys.index', models: [this.secretMountPath.currentPath] },
       { label: 'import' },
     ];
   }

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -32,8 +32,12 @@ export default class PkiKeysIndexRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'keys', route: 'keys.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'keys', route: 'keys.index', models: [this.secretMountPath.currentPath] },
     ];
     controller.notConfiguredMessage = PKI_DEFAULT_EMPTY_STATE_MSG;
   }

--- a/ui/lib/pki/addon/routes/keys/key/details.js
+++ b/ui/lib/pki/addon/routes/keys/key/details.js
@@ -16,8 +16,12 @@ export default class PkiKeyDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'keys', route: 'keys.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'keys', route: 'keys.index', models: [this.secretMountPath.currentPath] },
       { label: resolvedModel.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/keys/key/edit.js
+++ b/ui/lib/pki/addon/routes/keys/key/edit.js
@@ -19,8 +19,12 @@ export default class PkiKeyEditRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'keys', route: 'keys.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'keys', route: 'keys.index', models: [this.secretMountPath.currentPath] },
       { label: resolvedModel.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/roles/create.js
+++ b/ui/lib/pki/addon/routes/roles/create.js
@@ -31,8 +31,12 @@ export default class PkiRolesCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
       { label: 'create' },
     ];
   }

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -23,8 +23,12 @@ export default class RolesRoleDetailsRoute extends Route {
     const { id } = resolvedModel;
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
       { label: id },
     ];
   }

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -39,9 +39,13 @@ export default class PkiRoleEditRoute extends Route {
     } = resolvedModel;
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
-      { label: id, route: 'roles.role.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
+      { label: id, route: 'roles.role.details', models: [this.secretMountPath.currentPath, id] },
       { label: 'edit' },
     ];
   }

--- a/ui/lib/pki/addon/routes/roles/role/generate.js
+++ b/ui/lib/pki/addon/routes/roles/role/generate.js
@@ -24,9 +24,13 @@ export default class PkiRoleGenerateRoute extends Route {
     const { role } = this.paramsFor('roles/role');
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
-      { label: role, route: 'roles.role.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
+      { label: role, route: 'roles.role.details', models: [this.secretMountPath.currentPath, role] },
       { label: 'generate certificate' },
     ];
     // This is updated on successful generate in the controller

--- a/ui/lib/pki/addon/routes/roles/role/sign.js
+++ b/ui/lib/pki/addon/routes/roles/role/sign.js
@@ -24,9 +24,13 @@ export default class PkiRoleSignRoute extends Route {
     const { role } = this.paramsFor('roles/role');
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'roles', route: 'roles.index' },
-      { label: role, route: 'roles.role.details' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'roles', route: 'roles.index', models: [this.secretMountPath.currentPath] },
+      { label: role, route: 'roles.role.details', models: [this.secretMountPath.currentPath, role] },
       { label: 'sign certificate' },
     ];
     // This is updated on successful generate in the controller

--- a/ui/lib/pki/addon/routes/tidy/auto/configure.js
+++ b/ui/lib/pki/addon/routes/tidy/auto/configure.js
@@ -13,10 +13,14 @@ export default class PkiTidyAutoConfigureRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'configuration', route: 'configuration.index' },
-      { label: 'tidy', route: 'tidy' },
-      { label: 'auto', route: 'tidy.auto' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'configuration', route: 'configuration.index', models: [this.secretMountPath.currentPath] },
+      { label: 'tidy', route: 'tidy', models: [this.secretMountPath.currentPath] },
+      { label: 'auto', route: 'tidy.auto', models: [this.secretMountPath.currentPath] },
       { label: 'configure' },
     ];
   }

--- a/ui/lib/pki/addon/routes/tidy/auto/index.js
+++ b/ui/lib/pki/addon/routes/tidy/auto/index.js
@@ -11,8 +11,12 @@ export default class TidyAutoIndexRoute extends Route {
     super.setupController(...arguments);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'tidy', route: 'tidy.index' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'tidy', route: 'tidy.index', models: [this.secretMountPath.currentPath] },
       { label: 'auto' },
     ];
     controller.title = this.secretMountPath.currentPath;

--- a/ui/lib/pki/addon/routes/tidy/manual.js
+++ b/ui/lib/pki/addon/routes/tidy/manual.js
@@ -20,9 +20,13 @@ export default class PkiTidyManualRoute extends Route {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
       { label: 'secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
-      { label: 'configuration', route: 'configuration.index' },
-      { label: 'tidy', route: 'tidy' },
+      {
+        label: this.secretMountPath.currentPath,
+        route: 'overview',
+        models: [this.secretMountPath.currentPath],
+      },
+      { label: 'configuration', route: 'configuration.index', models: [this.secretMountPath.currentPath] },
+      { label: 'tidy', route: 'tidy', models: [this.secretMountPath.currentPath] },
       { label: 'manual' },
     ];
   }

--- a/ui/lib/pki/addon/templates/certificates/index.hbs
+++ b/ui/lib/pki/addon/templates/certificates/index.hbs
@@ -42,7 +42,10 @@
                 <nav class="menu">
                   <ul class="menu-list">
                     <li>
-                      <LinkTo @route="certificates.certificate.details" @model={{pkiCertificate.id}}>
+                      <LinkTo
+                        @route="certificates.certificate.details"
+                        @models={{array (current-mount-path) pkiCertificate.id}}
+                      >
                         Details
                       </LinkTo>
                     </li>
@@ -60,7 +63,7 @@
       <div>
         <p>When created, certificates will be listed here. Select a role to start generating certificates.</p>
         <div class="has-top-margin-m">
-          <LinkTo @route="roles.index">
+          <LinkTo @route="roles.index" @model={{(current-mount-path)}}>
             View roles
           </LinkTo>
         </div>
@@ -69,7 +72,7 @@
   {{/if}}
 {{else}}
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/lib/pki/addon/templates/error.hbs
+++ b/ui/lib/pki/addon/templates/error.hbs
@@ -13,7 +13,7 @@
   <nav class="tabs" aria-label="secret tabs">
     <ul>
       {{#each this.tabs as |oTab|}}
-        <LinkTo @route={{oTab.route}} data-test-tab={{oTab.route}}>
+        <LinkTo @route={{oTab.route}} @model={{(current-mount-path)}} data-test-tab={{oTab.route}}>
           {{oTab.label}}
         </LinkTo>
       {{/each}}

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -10,7 +10,7 @@
 />
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @route="issuers.import" data-test-generate-issuer="import">
+    <ToolbarLink @route="issuers.import" data-test-generate-issuer="import" @model={{(current-mount-path)}}>
       Import
     </ToolbarLink>
     <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
@@ -26,7 +26,12 @@
         <nav class="box menu" aria-label="generate options">
           <ul class="menu-list">
             <li class="action">
-              <LinkTo @route="issuers.generate-root" {{on "click" (fn this.onLinkClick D)}} data-test-generate-issuer="root">
+              <LinkTo
+                @route="issuers.generate-root"
+                {{on "click" (fn this.onLinkClick D)}}
+                data-test-generate-issuer="root"
+                @model={{(current-mount-path)}}
+              >
                 Root
               </LinkTo>
             </li>
@@ -35,6 +40,7 @@
                 @route="issuers.generate-intermediate"
                 {{on "click" (fn this.onLinkClick D)}}
                 data-test-generate-issuer="intermediate"
+                @model={{(current-mount-path)}}
               >
                 Intermediate CSR
               </LinkTo>
@@ -50,7 +56,7 @@
   <Page::PkiIssuerList @issuers={{this.model.issuersModel}} @mountPoint={{this.mountPoint}} />
 {{else}}
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/lib/pki/addon/templates/keys/index.hbs
+++ b/ui/lib/pki/addon/templates/keys/index.hbs
@@ -20,7 +20,7 @@
 {{else}}
   <Toolbar />
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/lib/pki/addon/templates/overview.hbs
+++ b/ui/lib/pki/addon/templates/overview.hbs
@@ -11,7 +11,7 @@
 <Toolbar>
   <ToolbarActions>
     {{#unless this.model.hasConfig}}
-      <ToolbarLink @route="configuration.create">
+      <ToolbarLink @route="configuration.create" @model={{(current-mount-path)}}>
         Configure PKI
       </ToolbarLink>
     {{/unless}}
@@ -22,7 +22,7 @@
   <Page::PkiOverview @issuers={{this.model.issuers}} @roles={{this.model.roles}} @engine={{this.model.engine}} />
 {{else}}
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -12,7 +12,7 @@
 {{#if this.model.hasConfig}}
   <Toolbar>
     <ToolbarActions>
-      <ToolbarLink @type="add" @route="roles.create" data-test-pki-role-create-link>
+      <ToolbarLink @type="add" @route="roles.create" data-test-pki-role-create-link @model={{(current-mount-path)}}>
         Create role
       </ToolbarLink>
     </ToolbarActions>
@@ -36,12 +36,12 @@
                 <nav class="menu">
                   <ul class="menu-list">
                     <li>
-                      <LinkTo @route="roles.role.details" @model={{pkiRole.id}}>
+                      <LinkTo @route="roles.role.details" @models={{array (current-mount-path) pkiRole.id}}>
                         Details
                       </LinkTo>
                     </li>
                     <li>
-                      <LinkTo @route="roles.role.edit" @model={{pkiRole.id}}>
+                      <LinkTo @route="roles.role.edit" @models={{array (current-mount-path) pkiRole.id}}>
                         Edit
                       </LinkTo>
                     </li>
@@ -58,7 +58,7 @@
       <div>
         <p>When created, roles will be listed here. Create a role to start generating certificates.</p>
         <div class="has-top-margin-m">
-          <LinkTo @route="roles.create">
+          <LinkTo @route="roles.create" @model={{(current-mount-path)}}>
             Create role
           </LinkTo>
         </div>
@@ -68,7 +68,7 @@
 {{else}}
   <Toolbar />
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/lib/pki/addon/templates/tidy/index.hbs
+++ b/ui/lib/pki/addon/templates/tidy/index.hbs
@@ -13,7 +13,7 @@
 {{else}}
   <Toolbar />
   <EmptyState @title="PKI not configured" @message={{this.notConfiguredMessage}}>
-    <LinkTo @route="configuration.create">
+    <LinkTo @route="configuration.create" @model={{(current-mount-path)}}>
       Configure PKI
     </LinkTo>
   </EmptyState>

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,17 +33,9 @@
     "openbao:cluster": "BAO_REDIRECT_ADDR=http://127.0.0.1:8202 bao server -log-level=error -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8202 -dev-ha"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --config .prettierrc.js --write",
-      "eslint --quiet"
-    ],
-    "*.hbs": [
-      "prettier --config .prettierrc.js --write",
-      "ember-template-lint --quiet"
-    ],
-    "*.scss": [
-      "prettier --write"
-    ]
+    "*.js": ["prettier --config .prettierrc.js --write", "eslint --quiet"],
+    "*.hbs": ["prettier --config .prettierrc.js --write", "ember-template-lint --quiet"],
+    "*.scss": ["prettier --write"]
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.27.0",
@@ -55,6 +47,7 @@
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "2.9.3",
     "@ember/test-waiters": "^3.0.0",
+    "@ember-data/legacy-compat": "4.12.8",
     "@eslint/js": "^9.24.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
@@ -120,7 +113,7 @@
     "ember-composable-helpers": "5.0.0",
     "ember-concurrency": "2.3.4",
     "ember-copy": "2.0.1",
-    "ember-data": "4.11.3",
+    "ember-data": "4.12.8",
     "ember-engines": "^0.9.0",
     "ember-fetch": "^8.1.2",
     "ember-inflector": "4.0.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.25.9
         version: 7.29.0(@babel/core@7.29.0)
+      '@ember-data/legacy-compat':
+        specifier: 4.12.8
+        version: 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
       '@ember/app-tsconfig':
         specifier: ^2.0.0
         version: 2.0.0
@@ -237,7 +240,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: 3.0.4
-        version: 3.0.4(cfde6af724c1b31c42f6f1dafc755bc0)
+        version: 3.0.4(d1beff066f772f350d0854b785578bf8)
       ember-cli-page-object:
         specifier: 1.17.10
         version: 1.17.10(@babel/core@7.29.0)
@@ -266,8 +269,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       ember-data:
-        specifier: 4.11.3
-        version: 4.11.3(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
+        specifier: 4.12.8
+        version: 4.12.8(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
       ember-engines:
         specifier: ^0.9.0
         version: 0.9.0(@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4)))(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
@@ -1322,76 +1325,110 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^6.0.13
 
-  '@ember-data/adapter@4.11.3':
-    resolution: {integrity: sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/adapter@4.12.8':
+    resolution: {integrity: sha512-HIwLGUkAXPbOfCw/vt1Xi5a3/J/sV4tT0LVsB/HPo+m0h/ztSmrfCQVRJCzZUP3ACeOL+eGeMQt4zyz8RfZazw==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/store': 4.11.3
+      '@ember-data/store': 4.12.8
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
 
-  '@ember-data/canary-features@4.11.3':
-    resolution: {integrity: sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
-
-  '@ember-data/debug@4.11.3':
-    resolution: {integrity: sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/debug@4.12.8':
+    resolution: {integrity: sha512-dA2VXsO8OPddZ723oQxLbjQVoWMpVuqhskBgaf8kRNmJI9ru8AxhR6KWJaF2LMeJ3VhI5ujo1rNfOC2Y1t/chw==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
+      '@ember-data/store': 4.12.8
       '@ember/string': ^3.0.1
 
-  '@ember-data/model@4.11.3':
-    resolution: {integrity: sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/graph@4.12.8':
+    resolution: {integrity: sha512-Nm297TOVsOvIqnzRPclW3YL+ILgpz00Rc5Z5KNk1Je3RP8+02uA7Sh39p5WG9YQr6rz3+xY5jd1VbmIoLOQiaA==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/record-data': 4.11.3
-      '@ember-data/store': 4.11.3
-      '@ember-data/tracking': 4.11.3
+      '@ember-data/store': 4.12.8
+
+  '@ember-data/json-api@4.12.8':
+    resolution: {integrity: sha512-A5ann76wOeRXeRPOG8wrWQn4BK+yb7T1l6Ybm1eSgkFQeNVvVc/eM6ejcRospQInSRZnOJZCPHYd+wggZgpXGA==}
+    engines: {node: 16.* || >= 18.*}
+    peerDependencies:
+      '@ember-data/graph': 4.12.8
+      '@ember-data/store': 4.12.8
+
+  '@ember-data/legacy-compat@4.12.8':
+    resolution: {integrity: sha512-sMC+QWdA+oMFtGH1UvwK2UU/iua29s298SSftRP9M84JAqr7t8AWfZd73m1CWe9aboyYKe1KXOCfPUsgrSICCg==}
+    engines: {node: 16.* || >= 18}
+    peerDependencies:
+      '@ember-data/graph': 4.12.8
+      '@ember-data/json-api': 4.12.8
+      '@ember/string': ^3.0.1
+    peerDependenciesMeta:
+      '@ember-data/graph':
+        optional: true
+      '@ember-data/json-api':
+        optional: true
+
+  '@ember-data/model@4.12.8':
+    resolution: {integrity: sha512-rJQVri/mrZIdwmonVqbHVsCI+xLvW5CClnlXLiHCBDpoq/klXJ6u5FMglH64GAEpjuIfWKiygdOvMGiaYFJt+A==}
+    engines: {node: 16.* || >= 18.*}
+    peerDependencies:
+      '@ember-data/debug': 4.12.8
+      '@ember-data/graph': 4.12.8
+      '@ember-data/json-api': 4.12.8
+      '@ember-data/legacy-compat': 4.12.8
+      '@ember-data/store': 4.12.8
+      '@ember-data/tracking': 4.12.8
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
     peerDependenciesMeta:
-      '@ember-data/record-data':
+      '@ember-data/debug':
+        optional: true
+      '@ember-data/graph':
+        optional: true
+      '@ember-data/json-api':
         optional: true
 
-  '@ember-data/private-build-infra@4.11.3':
-    resolution: {integrity: sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/private-build-infra@4.12.8':
+    resolution: {integrity: sha512-acOT5m5Bnq78IYcCjRoP9Loh65XNODFor+nThvH4IDmfaxNfKfr8Qheu4f23r5oPOXmHbcDBWRjsjs2dkaKTAw==}
+    engines: {node: 16.* || >= 18.*}
 
-  '@ember-data/record-data@4.11.3':
-    resolution: {integrity: sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
-    peerDependencies:
-      '@ember-data/store': 4.11.3
+  '@ember-data/request@4.12.8':
+    resolution: {integrity: sha512-aTn+Cd5b901MGhLKRJdd/+xXrkp1GAmJEn55F8W2ojYk82rt2ZbO/Ppe2DWhTRMujj6vKclYhWJt0NNafnUobQ==}
+    engines: {node: 16.* || >= 18}
 
   '@ember-data/rfc395-data@0.0.4':
     resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
 
-  '@ember-data/serializer@4.11.3':
-    resolution: {integrity: sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/serializer@4.12.8':
+    resolution: {integrity: sha512-XKjSnq8jR1C8sFCZmdd1cTfV5THt1ykYDcDNo80pLoZaIosYtt1QVIVLq0puTjNXO/B8GyQl8DN2p/AS9fwbaw==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/store': 4.11.3
+      '@ember-data/store': 4.12.8
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
 
-  '@ember-data/store@4.11.3':
-    resolution: {integrity: sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  '@ember-data/store@4.12.8':
+    resolution: {integrity: sha512-pI+c/ZtRO5T02JcQ+yvUQsRZIIw/+fVUUnxa6mHiiNkjOJZaK8/2resdskSgV3SFGI82icanV7Ve5LJj9EzscA==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/model': 4.11.3
-      '@ember-data/record-data': 4.11.3
-      '@ember-data/tracking': 4.11.3
+      '@ember-data/graph': 4.12.8
+      '@ember-data/json-api': 4.12.8
+      '@ember-data/legacy-compat': 4.12.8
+      '@ember-data/model': 4.12.8
+      '@ember-data/tracking': 4.12.8
       '@ember/string': ^3.0.1
       '@glimmer/tracking': ^1.1.2
     peerDependenciesMeta:
+      '@ember-data/graph':
+        optional: true
+      '@ember-data/json-api':
+        optional: true
+      '@ember-data/legacy-compat':
+        optional: true
       '@ember-data/model':
         optional: true
-      '@ember-data/record-data':
-        optional: true
 
-  '@ember-data/tracking@4.11.3':
-    resolution: {integrity: sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==}
-    engines: {node: 14.* || 16.* || >= 18}
+  '@ember-data/tracking@4.12.8':
+    resolution: {integrity: sha512-CczHOsEbInbVg4WF2UQhV89gCnSfH+8ZR1WinPFQ8PaY6e1KSlPULuTXhC03NhAo8GaJzHlvc3KfATt5qgBplg==}
+    engines: {node: 16.* || >= 18}
 
   '@ember-decorators/utils@6.1.1':
     resolution: {integrity: sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==}
@@ -4298,9 +4335,9 @@ packages:
     resolution: {integrity: sha512-N/XFvZszrzyyX4IcNoeK4mJvIItNuONumhPLqi64T8NDjJkxBj4Pq61rvMkJx/9eZ8alzE4I8vYKOLxT0FvRuQ==}
     engines: {node: 10.* || >= 12}
 
-  ember-data@4.11.3:
-    resolution: {integrity: sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==}
-    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+  ember-data@4.12.8:
+    resolution: {integrity: sha512-fK9mp+chqXGWYx6lal/azBKP4AtW8E6u3xUUWet6henO2zPN4S5lRs6iBfaynPkmhW5DK5bvaxNmFvSzmPOghw==}
+    engines: {node: 16.* || >= 18.*}
     peerDependencies:
       '@ember/string': ^3.0.1
 
@@ -9677,33 +9714,23 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@ember-data/adapter@4.11.3(@ember-data/store@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(webpack@5.105.4)':
+  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)':
     dependencies:
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/store': 4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember/edition-utils': 1.2.0
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
-      ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.105.4)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
-      - webpack
 
-  '@ember-data/canary-features@4.11.3(@glint/template@1.7.7)':
+  '@ember-data/debug@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.105.4)':
     dependencies:
-      '@embroider/macros': 1.20.2(@glint/template@1.7.7)
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/debug@4.11.3(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.105.4)':
-    dependencies:
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
@@ -9714,38 +9741,72 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@4.11.3(@babel/core@7.29.0)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)':
+  '@ember-data/graph@4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)':
     dependencies:
-      '@ember-data/canary-features': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/store': 4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember-data/tracking': 4.11.3
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.20.2(@glint/template@1.7.7)
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/json-api@4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)':
+    dependencies:
+      '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.20.2(@glint/template@1.7.7)
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)':
+    dependencies:
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember/string': 3.1.1
+      '@embroider/macros': 1.20.2(@glint/template@1.7.7)
+      ember-cli-babel: 7.26.11
+    optionalDependencies:
+      '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))':
+    dependencies:
+      '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
+      '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
-      ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.105.4)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.29.0)
       ember-inflector: 4.0.2
       inflection: 2.0.1
     optionalDependencies:
-      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(@glint/template@1.7.7)(webpack@5.105.4)
+      '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.105.4)
+      '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - ember-source
       - supports-color
-      - webpack
 
-  '@ember-data/private-build-infra@4.11.3(@glint/template@1.7.7)':
+  '@ember-data/private-build-infra@4.12.8(@glint/template@1.7.7)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      '@ember-data/canary-features': 4.11.3(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
       babel-import-util: 1.4.1
@@ -9764,72 +9825,66 @@ snapshots:
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
       git-repo-info: 2.1.1
-      glob: 8.1.0
+      glob: 9.3.5
       npm-git-info: 1.0.3
-      rimraf: 3.0.2
-      rsvp: 4.8.5
       semver: 7.7.4
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/record-data@4.11.3(@ember-data/store@4.11.3)(@glint/template@1.7.7)(webpack@5.105.4)':
+  '@ember-data/request@4.12.8(@glint/template@1.7.7)':
     dependencies:
-      '@ember-data/canary-features': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/store': 4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember/edition-utils': 1.2.0
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
-      ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.105.4)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
-      - webpack
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@4.11.3(@ember-data/store@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(webpack@5.105.4)':
+  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)':
     dependencies:
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/store': 4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
-      ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.105.4)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
-      - webpack
 
-  '@ember-data/store@4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)':
+  '@ember-data/store@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))':
     dependencies:
-      '@ember-data/canary-features': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/tracking': 4.11.3
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.105.4)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       ember-cli-babel: 7.26.11
     optionalDependencies:
-      '@ember-data/model': 4.11.3(@babel/core@7.29.0)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(@glint/template@1.7.7)(webpack@5.105.4)
+      '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - ember-source
       - supports-color
-      - webpack
 
-  '@ember-data/tracking@4.11.3':
+  '@ember-data/tracking@4.12.8(@glint/template@1.7.7)':
     dependencies:
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@embroider/macros': 1.20.2(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@ember-decorators/utils@6.1.1':
@@ -13888,7 +13943,7 @@ snapshots:
 
   ember-cli-lodash-subset@2.0.1: {}
 
-  ember-cli-mirage@3.0.4(cfde6af724c1b31c42f6f1dafc755bc0):
+  ember-cli-mirage@3.0.4(d1beff066f772f350d0854b785578bf8):
     dependencies:
       '@babel/core': 7.29.0
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
@@ -13902,9 +13957,9 @@ snapshots:
       ember-source: 4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 4.11.3(@babel/core@7.29.0)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
       '@ember/test-helpers': 2.9.3(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
-      ember-data: 4.11.3(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
+      ember-data: 4.12.8(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
       ember-qunit: 6.2.0(@ember/test-helpers@2.9.3(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4)))(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(qunit@2.25.0)(webpack@5.105.4)
     transitivePeerDependencies:
       - '@glint/template'
@@ -14328,16 +14383,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-data@4.11.3(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4):
+  ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4):
     dependencies:
-      '@ember-data/adapter': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(webpack@5.105.4)
-      '@ember-data/debug': 4.11.3(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.105.4)
-      '@ember-data/model': 4.11.3(@babel/core@7.29.0)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember-data/private-build-infra': 4.11.3(@glint/template@1.7.7)
-      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(@glint/template@1.7.7)(webpack@5.105.4)
-      '@ember-data/serializer': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(webpack@5.105.4)
-      '@ember-data/store': 4.11.3(@babel/core@7.29.0)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))(webpack@5.105.4)
-      '@ember-data/tracking': 4.11.3
+      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)
+      '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.105.4)
+      '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
+      '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
+      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/request': 4.12.8(@glint/template@1.7.7)
+      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.2)
+      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@4.12.0(@babel/core@7.29.0)(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(webpack@5.105.4))
+      '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)

--- a/ui/tests/acceptance/access/methods-test.js
+++ b/ui/tests/acceptance/access/methods-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, settled } from '@ember/test-helpers';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -48,6 +48,7 @@ module('Acceptance | auth-methods list view', function (hooks) {
 
     await clickTrigger('#filter-by-auth-type');
     await searchSelect.options[1].click();
+    await settled();
 
     const rows = document.querySelectorAll('[data-test-auth-backend-link]');
     const rowsUserpass = Array.from(rows).filter((row) => row.innerText.includes('userpass'));
@@ -58,6 +59,7 @@ module('Acceptance | auth-methods list view', function (hooks) {
     await clickTrigger('#filter-by-auth-name');
     const firstItemToSelect = searchSelect.options[0].text;
     await searchSelect.options[0].click();
+    await settled();
     const singleRow = document.querySelectorAll('[data-test-auth-backend-link]');
 
     assert.strictEqual(singleRow.length, 1, 'returns only one row');

--- a/ui/tests/acceptance/init-test.js
+++ b/ui/tests/acceptance/init-test.js
@@ -8,6 +8,7 @@ import { setupApplicationTest } from 'ember-qunit';
 
 import initPage from 'vault/tests/pages/init';
 import Pretender from 'pretender';
+import { waitUntil, settled } from '@ember/test-helpers';
 
 const HEALTH_RESPONSE = {
   initialized: false,
@@ -107,8 +108,11 @@ module('Acceptance | init', function (hooks) {
 
     setInitResponse(this.server, CLOUD_SEAL_RESPONSE);
     setStatusResponse(this.server, CLOUD_SEAL_STATUS_RESPONSE);
-
     await initPage.init(5, 3);
+    await waitUntil(() => initPage.keys.length === CLOUD_SEAL_RESPONSE.recovery_keys.length, {
+      timeout: 2000,
+      timeoutMessage: 'Timeout waiting for recovery keys to render',
+    });
 
     assert.strictEqual(
       initPage.keys.length,
@@ -121,6 +125,7 @@ module('Acceptance | init', function (hooks) {
       assert,
       true
     );
+    await settled();
   });
 
   test('shamir seal init', async function (assert) {
@@ -130,6 +135,10 @@ module('Acceptance | init', function (hooks) {
     setStatusResponse(this.server, SEAL_STATUS_RESPONSE);
 
     await initPage.init(3, 2);
+    await waitUntil(() => initPage.keys.length === SEAL_RESPONSE.keys.length, {
+      timeout: 2000,
+      timeoutMessage: 'Timeout waiting for recovery keys to render',
+    });
 
     assert.strictEqual(initPage.keys.length, SEAL_RESPONSE.keys.length, 'shows all of the recovery keys');
     assert.strictEqual(initPage.buttonText, 'Continue to Unseal', 'links to unseal');
@@ -138,5 +147,6 @@ module('Acceptance | init', function (hooks) {
       assert,
       false
     );
+    await settled();
   });
 });

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, currentRouteName, fillIn, visit, settled } from '@ember/test-helpers';
+import { click, currentRouteName, fillIn, visit, settled, waitUntil, findAll } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
@@ -110,6 +110,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await visit('/vault/access/mfa/enforcements');
     const enforcement = this.server.db.mfaLoginEnforcements.where({})[0];
     await click(`[data-test-list-item="${enforcement.name}"]`);
+    await waitUntil(() => findAll('[data-test-target]').length >= 4);
     // heading
     assert.dom('h1').includesText(enforcement.name, 'Name renders in title');
     assert.dom('h1 svg').hasClass('flight-icon-lock', 'Lock icon renders in title');
@@ -210,6 +211,8 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await click('[data-test-mlef-remove-target="Group"]');
     await click('[data-test-mlef-remove-target="Authentication method"]');
     await click('[data-test-mlef-save]');
+
+    await waitUntil(() => findAll('[data-test-target]').length >= 1);
 
     assert.strictEqual(
       currentRouteName(),

--- a/ui/tests/acceptance/mfa-login-test.js
+++ b/ui/tests/acceptance/mfa-login-test.js
@@ -5,7 +5,16 @@
 
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, currentRouteName, fillIn, visit, waitUntil, find } from '@ember/test-helpers';
+import {
+  click,
+  currentRouteName,
+  fillIn,
+  visit,
+  waitUntil,
+  find,
+  settled,
+  findAll,
+} from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
 import { validationHandler } from '../../mirage/handlers/mfa-login';
@@ -34,6 +43,7 @@ module('Acceptance | mfa-login', function (hooks) {
     await fillIn('[data-test-username]', user);
     await fillIn('[data-test-password]', 'test');
     await click('[data-test-auth-submit]');
+    await settled(); // eslint-disable-line ember/no-settled-after-test-helper
   };
   const didLogin = (assert) => {
     assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backends', 'Route transitions after login');
@@ -44,6 +54,7 @@ module('Acceptance | mfa-login', function (hooks) {
       await fillIn('[data-test-mfa-passcode="1"]', 'test');
     }
     await click('[data-test-mfa-validate]');
+    await settled(); // eslint-disable-line ember/no-settled-after-test-helper
   };
 
   test('it should handle single mfa constraint with passcode method', async function (assert) {
@@ -58,6 +69,10 @@ module('Acceptance | mfa-login', function (hooks) {
     assert.dom('[data-test-mfa-select]').doesNotExist('Select is hidden for single method');
     assert.dom('[data-test-mfa-passcode]').exists({ count: 1 }, 'Single passcode input renders');
     await validate();
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -84,6 +99,10 @@ module('Acceptance | mfa-login', function (hooks) {
     });
 
     await login('mfa-b');
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -99,6 +118,10 @@ module('Acceptance | mfa-login', function (hooks) {
     assert.dom('[data-test-mfa-passcode]').doesNotExist('Passcode input hidden until selection is made');
     await this.select();
     await validate();
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -107,6 +130,10 @@ module('Acceptance | mfa-login', function (hooks) {
     await login('mfa-d');
     await this.select();
     await click('[data-test-mfa-validate]');
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -118,6 +145,10 @@ module('Acceptance | mfa-login', function (hooks) {
     await this.select();
     assert.dom('[data-test-mfa-passcode]').doesNotExist('Passcode input is hidden for push method');
     await click('[data-test-mfa-validate]');
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -132,12 +163,20 @@ module('Acceptance | mfa-login', function (hooks) {
       );
     assert.dom('[data-test-mfa-select]').doesNotExist('Selects do not render for single methods');
     await validate(true);
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
   test('it should handle multi mfa constraint with 1 push method each', async function (assert) {
     assert.expect(1);
     await login('mfa-g');
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -153,6 +192,10 @@ module('Acceptance | mfa-login', function (hooks) {
     assert.dom('[data-test-mfa-select]').doesNotExist('Select is hidden for single method');
     assert.dom('[data-test-mfa-passcode]').exists({ count: 1 }, 'Passcode input renders');
     await validate();
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
@@ -168,11 +211,16 @@ module('Acceptance | mfa-login', function (hooks) {
     await this.select();
     await fillIn('[data-test-mfa-passcode="1"]', 'test');
     await click('[data-test-mfa-validate]');
+    await waitUntil(() => {
+      const h1 = find('h1');
+      return h1 && h1.textContent.trim() === 'Secrets Engines';
+    });
     didLogin(assert);
   });
 
   test('it should render unauthorized message for push failure', async function (assert) {
     await login('mfa-j');
+    await waitUntil(() => findAll('[data-test-empty-state-title]'));
     assert.dom('[data-test-auth-form]').doesNotExist('Auth form hidden when mfa fails');
     assert.dom('[data-test-empty-state-title]').hasText('Unauthorized', 'Error title renders');
     assert

--- a/ui/tests/acceptance/mfa-setup-test.js
+++ b/ui/tests/acceptance/mfa-setup-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { create } from 'ember-cli-page-object';
 import { v4 as uuidv4 } from 'uuid';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, settled } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/auth/enable';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
@@ -20,6 +20,7 @@ const POLICY_NAME = 'identity_policy';
 
 const writePolicy = async function (path) {
   await enablePage.enable('userpass', path);
+  await settled(); // eslint-disable-line ember/no-settled-after-test-helper
   const identityPolicy = `path "identity/*" {
     capabilities = ["create", "read", "update", "delete", "list"]
   }`;
@@ -77,9 +78,11 @@ module('Acceptance | mfa-setup', function (hooks) {
     });
     await fillIn('[data-test-input="uuid"]', 123);
     await click('[data-test-verify]');
+    await settled(); // eslint-disable-line ember/no-settled-after-test-helper
     assert.dom('[data-test-qrcode]').exists('the qrCode is shown.');
     assert.dom('[data-test-mfa-enabled-warning]').doesNotExist('warning does not show.');
     await click('[data-test-restart]');
+    await settled(); // eslint-disable-line ember/no-settled-after-test-helper
     assert.dom('[data-test-step-one]').exists('back to step one.');
   });
 
@@ -95,6 +98,7 @@ module('Acceptance | mfa-setup', function (hooks) {
 
     await fillIn('[data-test-input="uuid"]', 123);
     await click('[data-test-verify]');
+    await settled(); // eslint-disable-line ember/no-settled-after-test-helper
     assert.dom('[data-test-qrcode]').doesNotExist('the qrCode is not shown.');
     assert.dom('[data-test-mfa-enabled-warning]').exists('the mfa-enabled warning shows.');
   });

--- a/ui/tests/acceptance/pki/pki-configuration-test.js
+++ b/ui/tests/acceptance/pki/pki-configuration-test.js
@@ -65,6 +65,7 @@ module('Acceptance | pki configuration test', function (hooks) {
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).exists();
       await fillIn(SELECTORS.configuration.deleteAllIssuerInput, 'delete-all');
       await click(SELECTORS.configuration.deleteAllIssuerButton);
+      await waitUntil(() => !find(SELECTORS.configuration.deleteAllIssuerModal));
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).doesNotExist();
       assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/configuration`);
     });
@@ -87,7 +88,7 @@ module('Acceptance | pki configuration test', function (hooks) {
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).exists();
       await fillIn(SELECTORS.configuration.deleteAllIssuerInput, 'delete-all');
       await click(SELECTORS.configuration.deleteAllIssuerButton);
-      await isSettled();
+      await waitUntil(() => !find(SELECTORS.configuration.deleteAllIssuerModal));
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).doesNotExist();
       assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/configuration`);
       await isSettled();
@@ -154,7 +155,7 @@ module('Acceptance | pki configuration test', function (hooks) {
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).exists();
       await fillIn(SELECTORS.configuration.deleteAllIssuerInput, 'delete-all');
       await click(SELECTORS.configuration.deleteAllIssuerButton);
-      await isSettled();
+      await waitUntil(() => !find(SELECTORS.configuration.deleteAllIssuerModal));
       assert.dom(SELECTORS.configuration.deleteAllIssuerModal).doesNotExist();
       assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/configuration`);
       await isSettled();
@@ -211,7 +212,7 @@ module('Acceptance | pki configuration test', function (hooks) {
       await fillIn(SELECTORS.configuration.inputByName('keyType'), 'ed25519');
       await click(SELECTORS.configuration.generateRootSave);
 
-      const issuerId = find(SELECTORS.configuration.saved.issuerLink).innerHTML;
+      const issuerId = find(SELECTORS.configuration.saved.issuerLink).innerHTML.trim();
       await visit(`/vault/secrets/${this.mountPath}/pki/issuers`);
       assert.dom(SELECTORS.issuerListItem(issuerId)).exists();
       assert

--- a/ui/tests/acceptance/pki/pki-tidy-test.js
+++ b/ui/tests/acceptance/pki/pki-tidy-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, currentRouteName, fillIn, visit, settled } from '@ember/test-helpers';
+import { click, currentRouteName, fillIn, visit, settled, waitUntil, find } from '@ember/test-helpers';
 
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { v4 as uuidv4 } from 'uuid';
@@ -57,6 +57,7 @@ module('Acceptance | pki tidy', function (hooks) {
     await click(SELECTORS.tidyForm.inputByAttr('tidyCertStore'));
     await fillIn(SELECTORS.tidyForm.tidyPauseDuration, '10');
     await click(SELECTORS.tidyForm.tidySave);
+    await waitUntil(() => find(SELECTORS.cancelTidyAction));
     await click(SELECTORS.cancelTidyAction);
     assert.dom(SELECTORS.cancelTidyModalBackground).exists('Confirm cancel tidy modal exits');
     await click(SELECTORS.tidyConfigureModal.tidyModalCancelButton);

--- a/ui/tests/acceptance/secrets/backend/kv/diff-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/diff-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { click, settled, fillIn } from '@ember/test-helpers';
+import { click, settled, fillIn, waitUntil } from '@ember/test-helpers';
 import { create } from 'ember-cli-page-object';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -60,6 +60,7 @@ module('Acceptance | kv2 diff view', function (hooks) {
     assert.dom('[data-test-view-diff]').exists('does show diff view with two versions');
 
     await click('[data-test-view-diff]');
+    await waitUntil(() => document.querySelector('.jsondiffpatch-added'));
 
     const diffBetweenVersion2and1 = document.querySelector('.jsondiffpatch-added').innerText;
     assert.strictEqual(diffBetweenVersion2and1, 'version2"world!"', 'shows the correct added part');
@@ -67,6 +68,7 @@ module('Acceptance | kv2 diff view', function (hooks) {
     await click('[data-test-popup-menu-trigger="right-version"]');
 
     await click('[data-test-rightSide-version="2"]');
+    await waitUntil(() => document.querySelector('.diff-status'));
 
     assert.dom('.diff-status').exists('shows States Match');
   });

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -169,6 +169,7 @@ module('Acceptance | tools', function (hooks) {
     await fillIn('[data-test-tools-input="wrapping-token"]', 'sometoken');
     await click('[data-test-tools-submit]');
 
+    await waitUntil(() => findAll('.CodeMirror')[0]?.CodeMirror);
     assert.deepEqual(
       JSON.parse(findAll('.CodeMirror')[0].CodeMirror.getValue()),
       AUTH_RESPONSE.auth,

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -260,12 +260,13 @@ const testConvergentEncryption = async function (assert, keyName) {
     await click('[data-test-button-encrypt]');
 
     if (testCase.assertAfterEncrypt) {
-      await settled();
+      await waitUntil(() => find('.modal.is-active'));
       testCase.assertAfterEncrypt(keyName);
     }
     // store ciphertext for decryption step
     const copiedCiphertext = find('[data-test-encrypted-value="ciphertext"]').innerText;
     await click('.modal.is-active [data-test-modal-background]');
+    await waitUntil(() => !find('.modal.is-active'));
 
     assert.dom('.modal.is-active').doesNotExist(`${name}: Modal closes after background clicked`);
     await click('[data-test-transit-action-link="decrypt"]');
@@ -279,11 +280,12 @@ const testConvergentEncryption = async function (assert, keyName) {
     await click('[data-test-button-decrypt]');
 
     if (testCase.assertAfterDecrypt) {
-      await settled();
+      await waitUntil(() => find('.modal.is-active'));
       testCase.assertAfterDecrypt(keyName);
     }
 
     await click('.modal.is-active [data-test-modal-background]');
+    await waitUntil(() => !find('.modal.is-active'));
 
     assert.dom('.modal.is-active').doesNotExist(`${name}: Modal closes after background clicked`);
   }
@@ -328,7 +330,7 @@ module('Acceptance | transit', function (hooks) {
 
       await click('[data-test-confirm-button]');
       // wait for rotate call
-      await waitUntil(() => findAll('[data-test-transit-key-version-row]').length >= 2);
+      await waitUntil(() => findAll('[data-test-transit-key-version-row]').length >= 2, { timeout: 20000 });
       assert
         .dom('[data-test-transit-key-version-row]')
         .exists({ count: 2 }, `${name}: two key versions after rotate`);

--- a/ui/tests/integration/components/auth-config-form/options-test.js
+++ b/ui/tests/integration/components/auth-config-form/options-test.js
@@ -27,6 +27,12 @@ module('Integration | Component | auth-config-form options', function (hooks) {
           followRedirects() {
             return resolve();
           },
+          then() {
+            return resolve();
+          },
+          catch() {
+            return resolve();
+          },
         };
       },
       replaceWith() {

--- a/ui/tests/integration/components/get-credentials-card-test.js
+++ b/ui/tests/integration/components/get-credentials-card-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | get-credentials-card', function (hooks) {
 
   hooks.beforeEach(function () {
     this.router = this.owner.lookup('service:router');
-    this.router.transitionTo = sinon.stub();
+    this.router.transitionTo = sinon.stub().resolves();
 
     this.owner.unregister('service:store');
     this.owner.register('service:store', storeService);

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -69,7 +69,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       return {};
     });
     this.owner.lookup('service:router').reopen({
-      transitionTo(path, model, { queryParams: { tab } }) {
+      async transitionTo(path, model, { queryParams: { tab } }) {
         assert.strictEqual(path, root.path, 'Root path sent in transitionTo on delete');
         assert.strictEqual(model, root.model, 'Root model sent in transitionTo on delete');
         assert.deepEqual(tab, 'provider', 'Correct query params sent in transitionTo on delete');
@@ -134,7 +134,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       return {};
     });
     this.owner.lookup('service:router').reopen({
-      transitionTo(path, model, { queryParams: { itemType } }) {
+      async transitionTo(path, model, { queryParams: { itemType } }) {
         assert.strictEqual(
           path,
           'vault.cluster.secrets.backend.show',

--- a/ui/tests/integration/components/mfa/method-form-test.js
+++ b/ui/tests/integration/components/mfa/method-form-test.js
@@ -44,7 +44,11 @@ module('Integration | Component | mfa-method-form', function (hooks) {
 
     this.server.post('/identity/mfa/method/totp', () => {
       assert.ok(true, 'create request sent to server');
-      return {};
+      return {
+        data: {
+          method_id: '123',
+        },
+      };
     });
 
     await render(hbs`

--- a/ui/tests/integration/components/sidebar/user-menu-test.js
+++ b/ui/tests/integration/components/sidebar/user-menu-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | sidebar-user-menu', function (hooks) {
 
   test('it should render conditional menu items', async function (assert) {
     const router = this.owner.lookup('service:router');
-    const transitionStub = sinon.stub(router, 'transitionTo');
+    const transitionStub = sinon.stub(router, 'transitionTo').resolves();
     const renewStub = sinon.stub(this.auth, 'renew').resolves();
     const revokeStub = sinon.stub(this.auth, 'revokeCurrentToken').resolves();
     const date = new Date();

--- a/ui/tests/pages/components/calendar-widget.js
+++ b/ui/tests/pages/components/calendar-widget.js
@@ -12,7 +12,7 @@ export default create({
   customEndMonthBtn: clickable('[data-test-show-calendar]'),
   menuToggle: clickable('[data-test-calendar-widget-trigger]'),
   showsCalendar: isPresent('[data-test-calendar-widget-container]'),
-  dateRangeTrigger: '[data-test-show-calendar]',
+  dateRangeTrigger: clickable('[data-test-show-calendar]'),
   async openCalendar() {
     await this.menuToggle();
     await this.customEndMonthBtn();

--- a/ui/tests/pages/components/console/ui-panel.js
+++ b/ui/tests/pages/components/console/ui-panel.js
@@ -5,7 +5,7 @@
 
 import { text, triggerable, clickable, collection, fillable, value, isPresent } from 'ember-cli-page-object';
 import { getter } from 'ember-cli-page-object/macros';
-import { settled } from '@ember/test-helpers';
+import { settled, waitUntil } from '@ember/test-helpers';
 
 import keys from 'vault/lib/keycodes';
 
@@ -49,9 +49,15 @@ export default {
   runCommands: async function (commands) {
     const toExecute = Array.isArray(commands) ? commands : [commands];
     for (const command of toExecute) {
+      const priorOutputItems = this.logOutputItems.length;
       await this.consoleInput(command);
       await this.enter();
       await settled();
+      // The console only logs the command and its output once the request has
+      // responded, so waiting for the log to grow also waits for the response
+      // to render (which `settled()` no longer covers after the ember-data
+      // upgrade).
+      await waitUntil(() => this.logOutputItems.length > priorOutputItems, { timeout: 10000 });
     }
   },
 };

--- a/ui/tests/pages/components/console/ui-panel.js
+++ b/ui/tests/pages/components/console/ui-panel.js
@@ -57,7 +57,12 @@ export default {
       // responded, so waiting for the log to grow also waits for the response
       // to render (which `settled()` no longer covers after the ember-data
       // upgrade).
-      await waitUntil(() => this.logOutputItems.length > priorOutputItems, { timeout: 10000 });
+      if (command === 'clear') {
+        // the clear command clears the log instead of growing it
+        await waitUntil(() => this.logOutputItems.length === 0, { timeout: 10000 });
+      } else {
+        await waitUntil(() => this.logOutputItems.length > priorOutputItems, { timeout: 10000 });
+      }
     }
   },
 };


### PR DESCRIPTION
## Description

Update `ember-data` to the special LTS version `4.12.x`. This should be one of the last major blockers before we can hopefully upgrade the rest of our EmberJS dependencies to a supported LTS release.

## Rationale

Newer EmberJs releases do not work with `ember-data` below `4.12.x`.

Part-Of: #2386

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
