### PR TITLE
fix: Resolve control group authorization for indirect group members

### DIFF
--- a/internal/vault/control_group.go
+++ b/internal/vault/control_group.go
@@ -393,7 +393,11 @@ func (c *Core) handleControlGroupAuthorize(ctx context.Context, req *logical.Req
 	if authorizerToken == nil {
 		return nil, &logical.StatusBadRequest{Err: "missing auth"}
 	}
-	authorizerGroups, err := c.identityStore.MemDBGroupsByMemberEntityID(ctx, authorizerToken.EntityID, false, false)
+	authorizerGroups, authorizerAncestorGroups, err := c.identityStore.GroupsByEntityID(ctx, authorizerToken.EntityID)
+	if err != nil {
+		return nil, err
+	}
+	authorizerGroups = append(authorizerGroups, authorizerAncestorGroups...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Indirect group members (members of a group that is a member of the control group factor's group) were not recognized as valid authorizers for control group requests.

The `handleControlGroupAuthorize` function used `MemDBGroupsByMemberEntityID` which only returns direct group membership. Changed to `GroupsByEntityID` which also resolves nested/indirect group memberships via `collectGroupsReverseDFS`.

## How to reproduce

Use the reproduction script in the issue: Bob is a member of `admin1`, which is a member of `admin2`. The control group factor refers to `admin2`. Bob should be able to authorize the control group request, but is rejected.

## Root cause

In `internal/vault/control_group.go`, line 396:
```go
authorizerGroups, err := c.identityStore.MemDBGroupsByMemberEntityID(ctx, authorizerToken.EntityID, false, false)
```

`MemDBGroupsByMemberEntityID` only queries the memdb index `"member_entity_ids"` which returns groups where the entity is directly listed as a member. It does not resolve nested/indirect group membership.

The `GroupsByEntityID` method (already used elsewhere in the codebase) calls `collectGroupsReverseDFS` to recursively resolve all ancestor groups, providing the full set of groups the entity belongs to.

## Fix

Changed the call to use `GroupsByEntityID` and combined the two return values (direct groups + ancestor groups).

Fixes #3814
