### PR TITLE
auth/jwt: allow multiple JWKS URLs

### DIFF
--- a/changelog/3825.txt
+++ b/changelog/3825.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/jwt: Add `jwks_urls` for multiple JWKS URLs while retaining `jwks_url` as a deprecated single-URL alias.
+auth/jwt: Allow `jwks_url` to configure multiple JWKS URLs while retaining support for single-string values.
 ```

--- a/changelog/3825.txt
+++ b/changelog/3825.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/jwt: Add `jwks_pairs` support so a single JWT auth mount can validate tokens against multiple JWKS endpoints in configured order.
+auth/jwt: The `jwks_url` config option now accepts multiple JWKS URLs, which are tried in order during login.
 ```

--- a/changelog/3825.txt
+++ b/changelog/3825.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/jwt: Add `jwks_pairs` support so a single JWT auth mount can validate tokens against multiple JWKS endpoints in configured order.
+```

--- a/changelog/3825.txt
+++ b/changelog/3825.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth/jwt: The `jwks_url` config option now accepts multiple JWKS URLs, which are tried in order during login.
+auth/jwt: Add `jwks_urls` for multiple JWKS URLs while retaining `jwks_url` as a deprecated single-URL alias.
 ```

--- a/internal/builtin/credential/jwt/backend.go
+++ b/internal/builtin/credential/jwt/backend.go
@@ -149,22 +149,41 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 	}
 
 	var err error
-	var keySet jwt.KeySet
+	var keySets []jwt.KeySet
 
-	// Configure the key set for the validator
+	// Configure the key sets for the validator
 	switch config.authType() {
 	case JWKS:
+		var keySet jwt.KeySet
 		keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, config.JWKSURL, config.JWKSCAPEM)
+		keySets = append(keySets, keySet)
+	case JWKSPairs:
+		for _, pair := range config.JWKSPairs {
+			jwksURL, _ := pair["jwks_url"].(string)
+			jwksCAPEM, _ := pair["jwks_ca_pem"].(string)
+			var keySet jwt.KeySet
+			keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, jwksURL, jwksCAPEM)
+			if err != nil {
+				break
+			}
+			keySets = append(keySets, keySet)
+		}
 	case StaticKeys:
+		var keySet jwt.KeySet
 		keySet, err = jwt.NewStaticKeySet(config.ParsedJWTPubKeys)
+		keySets = append(keySets, keySet)
 	case OIDCDiscovery, OIDCFlow:
+		var keySet jwt.KeySet
 		keySet, err = jwt.NewOIDCDiscoveryKeySet(b.providerCtx, config.OIDCDiscoveryURL, config.OIDCDiscoveryCAPEM)
+		keySets = append(keySets, keySet)
 	case CustomProviderDiscovery:
 		pConfig, initErr := NewProviderConfig(b.providerCtx, config, ProviderMap())
 		if initErr != nil {
 			return nil, initErr
 		}
+		var keySet jwt.KeySet
 		keySet, err = pConfig.(KeySetDiscovery).NewKeySet(b.providerCtx)
+		keySets = append(keySets, keySet)
 	default:
 		return nil, errors.New("unsupported config type")
 	}
@@ -173,7 +192,7 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 		return nil, fmt.Errorf("keyset configuration error: %w", err)
 	}
 
-	validator, err := jwt.NewValidator(keySet)
+	validator, err := jwt.NewValidator(keySets...)
 	if err != nil {
 		return nil, fmt.Errorf("JWT validator configuration error: %w", err)
 	}

--- a/internal/builtin/credential/jwt/backend.go
+++ b/internal/builtin/credential/jwt/backend.go
@@ -154,7 +154,7 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 	// Configure the key sets for the validator
 	switch config.authType() {
 	case JWKS:
-		for _, jwksURL := range config.JWKSURL {
+		for _, jwksURL := range config.JWKSURLs {
 			var keySet jwt.KeySet
 			keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, jwksURL, config.JWKSCAPEM)
 			if err != nil {

--- a/internal/builtin/credential/jwt/backend.go
+++ b/internal/builtin/credential/jwt/backend.go
@@ -154,15 +154,9 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 	// Configure the key sets for the validator
 	switch config.authType() {
 	case JWKS:
-		var keySet jwt.KeySet
-		keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, config.JWKSURL, config.JWKSCAPEM)
-		keySets = append(keySets, keySet)
-	case JWKSPairs:
-		for _, pair := range config.JWKSPairs {
-			jwksURL, _ := pair["jwks_url"].(string)
-			jwksCAPEM, _ := pair["jwks_ca_pem"].(string)
+		for _, jwksURL := range config.JWKSURL {
 			var keySet jwt.KeySet
-			keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, jwksURL, jwksCAPEM)
+			keySet, err = jwt.NewJSONWebKeySet(b.providerCtx, jwksURL, config.JWKSCAPEM)
 			if err != nil {
 				break
 			}

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -86,7 +86,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
-				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. If not set, system certificates are used.",
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates. The same CA certificates are used for all jwks_url values. If not set, system certificates are used.",
 			},
 			"default_role": {
 				Type:        framework.TypeLowerCaseString,
@@ -434,7 +434,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 
 			if !strings.Contains(err.Error(), "failed to verify id token signature") {
 				if !skipJwksValidation {
-					b.Logger().Error("error checking jwks URL", "error", err, "jwks_url_index", i)
+					b.Logger().Error("error checking jwks URL", "jwks_url_index", i)
 					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i)), nil
 				}
 

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -4,7 +4,6 @@
 package jwtauth
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -55,7 +54,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"oidc_discovery_url": {
 				Type:        framework.TypeString,
-				Description: `The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".`,
+				Description: `The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url", "jwks_urls", or "jwt_validation_pubkeys".`,
 			},
 			"oidc_discovery_ca_pem": {
 				Type:        framework.TypeString,
@@ -81,12 +80,17 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Description: "The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'.",
 			},
 			"jwks_url": {
+				Type:        framework.TypeString,
+				Description: `Deprecated: Please use "jwks_urls" instead. The single JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
+				Deprecated:  true,
+			},
+			"jwks_urls": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: `JWKS URLs to use to authenticate signatures. A single URL may be specified as a string, or multiple URLs may be specified as a list. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
+				Description: `JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
 			},
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
-				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates. The same CA certificates are used for all jwks_url values. If not set, system certificates are used.",
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates. The same CA certificates are used for all jwks_urls values. If not set, system certificates are used.",
 			},
 			"default_role": {
 				Type:        framework.TypeLowerCaseString,
@@ -94,7 +98,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".`,
+				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url", "jwks_urls", or "oidc_discovery_url".`,
 			},
 			"jwt_supported_algs": {
 				Type:        framework.TypeCommaStringSlice,
@@ -125,7 +129,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"skip_jwks_validation": {
 				Type:        framework.TypeBool,
-				Description: "When true and oidc_discovery_url or jwks_url are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint.",
+				Description: "When true and oidc_discovery_url, jwks_url, or jwks_urls are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint.",
 			},
 		},
 
@@ -172,6 +176,15 @@ func (b *jwtAuthBackend) config(ctx context.Context, s logical.Storage) (*jwtCon
 	config := &jwtConfig{}
 	if err := entry.DecodeJSON(config); err != nil {
 		return nil, err
+	}
+
+	// Migrate the legacy single URL in memory. The next config write stores the
+	// canonical jwks_urls field; reads do not write back to storage.
+	if config.DeprecatedJWKSURL != "" {
+		if len(config.JWKSURLs) == 0 {
+			config.JWKSURLs = []string{config.DeprecatedJWKSURL}
+		}
+		config.DeprecatedJWKSURL = ""
 	}
 
 	for _, v := range config.JWTValidationPubKeys {
@@ -293,7 +306,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 		}
 	}
 
-	jwksURLs := config.JWKSURL
+	jwksURLs := config.JWKSURLs
 	if jwksURLs == nil {
 		jwksURLs = []string{}
 	}
@@ -308,7 +321,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"default_role":                  config.DefaultRole,
 			"jwt_validation_pubkeys":        config.JWTValidationPubKeys,
 			"jwt_supported_algs":            config.JWTSupportedAlgs,
-			"jwks_url":                      jwksURLs,
+			"jwks_urls":                     jwksURLs,
 			"jwks_ca_pem":                   config.JWKSCAPEM,
 			"bound_issuer":                  config.BoundIssuer,
 			"provider_config":               providerConfig,
@@ -337,14 +350,24 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		OIDCClientSecret:           d.Get("oidc_client_secret").(string),
 		OIDCResponseMode:           d.Get("oidc_response_mode").(string),
 		OIDCResponseTypes:          d.Get("oidc_response_types").([]string),
-		JWKSURL:                    d.Get("jwks_url").([]string),
 		JWKSCAPEM:                  d.Get("jwks_ca_pem").(string),
+		JWKSURLs:                   []string{},
 		DefaultRole:                d.Get("default_role").(string),
 		JWTValidationPubKeys:       d.Get("jwt_validation_pubkeys").([]string),
 		JWTSupportedAlgs:           d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:                d.Get("bound_issuer").(string),
 		ProviderConfig:             d.Get("provider_config").(map[string]any),
 		OverrideAllowedServerNames: d.Get("override_allowed_server_names").([]string),
+	}
+	if jwksURLs, ok := d.GetFirst("jwks_urls", "jwks_url"); ok {
+		switch value := jwksURLs.(type) {
+		case []string:
+			config.JWKSURLs = value
+		case string:
+			if value != "" {
+				config.JWKSURLs = []string{value}
+			}
+		}
 	}
 
 	skipJwksValidation := d.Get("skip_jwks_validation").(bool)
@@ -380,7 +403,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	if len(config.JWTValidationPubKeys) != 0 {
 		methodCount++
 	}
-	if len(config.JWKSURL) != 0 {
+	if len(config.JWKSURLs) != 0 {
 		methodCount++
 	}
 	if config.hasCustomProviderDiscovery() {
@@ -390,7 +413,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	resp := &logical.Response{}
 	switch {
 	case methodCount != 1:
-		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'oidc_discovery_url', or 'provider_config' must be set"), nil
+		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_urls', 'oidc_discovery_url', or 'provider_config' must be set"), nil
 
 	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":
@@ -417,12 +440,12 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	case config.OIDCClientID != "" && config.OIDCDiscoveryURL == "":
 		return logical.ErrorResponse("'oidc_discovery_url' must be set for OIDC"), nil
 
-	case len(config.JWKSURL) != 0:
-		for i, jwksURL := range config.JWKSURL {
+	case len(config.JWKSURLs) != 0:
+		for i, jwksURL := range config.JWKSURLs {
 			keyset, err := jwt.NewJSONWebKeySet(ctx, jwksURL, config.JWKSCAPEM)
 			if err != nil {
 				b.Logger().Error("error checking jwks_ca_pem", "error", err, "jwks_url_index", i)
-				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_url[%d]", i)), nil
+				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_urls[%d]", i)), nil
 			}
 
 			// Try to verify a correctly formatted JWT. The signature will fail to match, but other
@@ -435,10 +458,10 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 			if !strings.Contains(err.Error(), "failed to verify id token signature") {
 				if !skipJwksValidation {
 					b.Logger().Error("error checking jwks URL", "jwks_url_index", i)
-					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i)), nil
+					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_urls[%d]", i)), nil
 				}
 
-				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i))
+				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_urls[%d]", i))
 			}
 		}
 
@@ -630,7 +653,8 @@ type jwtConfig struct {
 	OIDCClientSecret           string         `json:"oidc_client_secret"`
 	OIDCResponseMode           string         `json:"oidc_response_mode"`
 	OIDCResponseTypes          []string       `json:"oidc_response_types"`
-	JWKSURL                    []string       `json:"jwks_url"`
+	DeprecatedJWKSURL          string         `json:"jwks_url"`
+	JWKSURLs                   []string       `json:"jwks_urls"`
 	JWKSCAPEM                  string         `json:"jwks_ca_pem"`
 	JWTValidationPubKeys       []string       `json:"jwt_validation_pubkeys"`
 	JWTSupportedAlgs           []string       `json:"jwt_supported_algs"`
@@ -644,44 +668,6 @@ type jwtConfig struct {
 	// These are looked up from OIDCDiscoveryURL when needed
 	OIDCDeviceAuthURL string `json:"-"`
 	OIDCTokenURL      string `json:"-"`
-}
-
-// UnmarshalJSON decodes a stored jwtConfig, accepting the legacy string form
-// of "jwks_url" for backwards compatibility.
-func (c *jwtConfig) UnmarshalJSON(data []byte) error {
-	type alias jwtConfig
-	aux := &struct {
-		JWKSURL json.RawMessage `json:"jwks_url"`
-		*alias
-	}{
-		alias: (*alias)(c),
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	if err := dec.Decode(aux); err != nil {
-		return err
-	}
-
-	if len(aux.JWKSURL) == 0 {
-		return nil
-	}
-
-	var urls []string
-	if err := json.Unmarshal(aux.JWKSURL, &urls); err != nil {
-		var single string
-		if err := json.Unmarshal(aux.JWKSURL, &single); err != nil {
-			return fmt.Errorf("invalid 'jwks_url' value: %w", err)
-		}
-		if single != "" {
-			urls = []string{single}
-		} else {
-			urls = []string{}
-		}
-	}
-	c.JWKSURL = urls
-
-	return nil
 }
 
 const (
@@ -698,7 +684,7 @@ func (c jwtConfig) authType() int {
 	switch {
 	case len(c.ParsedJWTPubKeys) > 0:
 		return StaticKeys
-	case len(c.JWKSURL) > 0:
+	case len(c.JWKSURLs) > 0:
 		return JWKS
 	case c.OIDCDiscoveryURL != "":
 		if c.OIDCClientID != "" && c.OIDCClientSecret != "" {

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -4,6 +4,7 @@
 package jwtauth
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -80,16 +81,12 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Description: "The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'.",
 			},
 			"jwks_url": {
-				Type:        framework.TypeString,
-				Description: `JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
+				Type:        framework.TypeCommaStringSlice,
+				Description: `JWKS URLs to use to authenticate signatures. A single URL may be specified as a string, or multiple URLs may be specified as a list. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
 			},
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
-				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.",
-			},
-			"jwks_pairs": {
-				Type:        framework.TypeSlice,
-				Description: `List of JWKS URL and optional CA certificate pairs. CA certificates must be in PEM format. Must be a list of JSON objects with format [{"jwks_url": "", "jwks_ca_pem": ""}]. Cannot be used with "jwks_url" or "jwks_ca_pem".`,
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. If not set, system certificates are used.",
 			},
 			"default_role": {
 				Type:        framework.TypeLowerCaseString,
@@ -296,9 +293,9 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 		}
 	}
 
-	jwksPairs := config.JWKSPairs
-	if jwksPairs == nil {
-		jwksPairs = []map[string]any{}
+	jwksURLs := config.JWKSURL
+	if jwksURLs == nil {
+		jwksURLs = []string{}
 	}
 
 	resp := &logical.Response{
@@ -311,9 +308,8 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"default_role":                  config.DefaultRole,
 			"jwt_validation_pubkeys":        config.JWTValidationPubKeys,
 			"jwt_supported_algs":            config.JWTSupportedAlgs,
-			"jwks_url":                      config.JWKSURL,
+			"jwks_url":                      jwksURLs,
 			"jwks_ca_pem":                   config.JWKSCAPEM,
-			"jwks_pairs":                    jwksPairs,
 			"bound_issuer":                  config.BoundIssuer,
 			"provider_config":               providerConfig,
 			"override_allowed_server_names": config.OverrideAllowedServerNames,
@@ -341,7 +337,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		OIDCClientSecret:           d.Get("oidc_client_secret").(string),
 		OIDCResponseMode:           d.Get("oidc_response_mode").(string),
 		OIDCResponseTypes:          d.Get("oidc_response_types").([]string),
-		JWKSURL:                    d.Get("jwks_url").(string),
+		JWKSURL:                    d.Get("jwks_url").([]string),
 		JWKSCAPEM:                  d.Get("jwks_ca_pem").(string),
 		DefaultRole:                d.Get("default_role").(string),
 		JWTValidationPubKeys:       d.Get("jwt_validation_pubkeys").([]string),
@@ -349,15 +345,6 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		BoundIssuer:                d.Get("bound_issuer").(string),
 		ProviderConfig:             d.Get("provider_config").(map[string]any),
 		OverrideAllowedServerNames: d.Get("override_allowed_server_names").([]string),
-	}
-
-	rawPairs := d.Get("jwks_pairs").([]any)
-	if len(rawPairs) > 0 {
-		pairs, err := parseJWKSPairs(rawPairs)
-		if err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-		config.JWKSPairs = pairs
 	}
 
 	skipJwksValidation := d.Get("skip_jwks_validation").(bool)
@@ -393,10 +380,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	if len(config.JWTValidationPubKeys) != 0 {
 		methodCount++
 	}
-	if config.JWKSURL != "" {
-		methodCount++
-	}
-	if len(config.JWKSPairs) != 0 {
+	if len(config.JWKSURL) != 0 {
 		methodCount++
 	}
 	if config.hasCustomProviderDiscovery() {
@@ -406,13 +390,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	resp := &logical.Response{}
 	switch {
 	case methodCount != 1:
-		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_pairs', 'oidc_discovery_url', or 'provider_config' must be set"), nil
-
-	case len(config.JWKSPairs) > 0 && config.JWKSCAPEM != "":
-		return logical.ErrorResponse("'jwks_ca_pem' cannot be used with 'jwks_pairs'"), nil
-
-	case len(config.JWKSPairs) > 0 && config.BoundIssuer != "":
-		return logical.ErrorResponse("'bound_issuer' cannot be used with 'jwks_pairs'"), nil
+		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'oidc_discovery_url', or 'provider_config' must be set"), nil
 
 	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":
@@ -439,37 +417,12 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	case config.OIDCClientID != "" && config.OIDCDiscoveryURL == "":
 		return logical.ErrorResponse("'oidc_discovery_url' must be set for OIDC"), nil
 
-	case config.JWKSURL != "":
-		keyset, err := jwt.NewJSONWebKeySet(ctx, config.JWKSURL, config.JWKSCAPEM)
-		if err != nil {
-			b.Logger().Error("error checking jwks_ca_pem", "error", err)
-			return logical.ErrorResponse("error checking jwks_ca_pem"), nil
-		}
-
-		// Try to verify a correctly formatted JWT. The signature will fail to match, but other
-		// errors with fetching the remote keyset should be reported.
-		_, err = keyset.VerifySignature(ctx, testJWT)
-		if err == nil {
-			err = errors.New("unexpected verification of JWT")
-		}
-
-		if !strings.Contains(err.Error(), "failed to verify id token signature") {
-			if !skipJwksValidation {
-				b.Logger().Error("error checking jwks URL", "error", err)
-				return logical.ErrorResponse("error checking jwks URL"), nil
-			}
-
-			resp.AddWarning("error checking jwks URL")
-		}
-
-	case len(config.JWKSPairs) != 0:
-		for i, pair := range config.JWKSPairs {
-			jwksURL, _ := pair["jwks_url"].(string)
-			jwksCAPEM, _ := pair["jwks_ca_pem"].(string)
-			keyset, err := jwt.NewJSONWebKeySet(ctx, jwksURL, jwksCAPEM)
+	case len(config.JWKSURL) != 0:
+		for i, jwksURL := range config.JWKSURL {
+			keyset, err := jwt.NewJSONWebKeySet(ctx, jwksURL, config.JWKSCAPEM)
 			if err != nil {
-				b.Logger().Error("error checking jwks_ca_pem", "error", err, "jwks_pairs_index", i)
-				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_pairs[%d]", i)), nil
+				b.Logger().Error("error checking jwks_ca_pem", "error", err, "jwks_url_index", i)
+				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_url[%d]", i)), nil
 			}
 
 			// Try to verify a correctly formatted JWT. The signature will fail to match, but other
@@ -481,11 +434,11 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 
 			if !strings.Contains(err.Error(), "failed to verify id token signature") {
 				if !skipJwksValidation {
-					b.Logger().Error("error checking jwks URL", "error", err, "jwks_pairs_index", i)
-					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_pairs[%d]", i)), nil
+					b.Logger().Error("error checking jwks URL", "error", err, "jwks_url_index", i)
+					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i)), nil
 				}
 
-				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_pairs[%d]", i))
+				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i))
 			}
 		}
 
@@ -671,27 +624,64 @@ func (b *jwtAuthBackend) OverrideAllowedServerNames(config *tls.Config, allowedS
 }
 
 type jwtConfig struct {
-	OIDCDiscoveryURL           string           `json:"oidc_discovery_url"`
-	OIDCDiscoveryCAPEM         string           `json:"oidc_discovery_ca_pem"`
-	OIDCClientID               string           `json:"oidc_client_id"`
-	OIDCClientSecret           string           `json:"oidc_client_secret"`
-	OIDCResponseMode           string           `json:"oidc_response_mode"`
-	OIDCResponseTypes          []string         `json:"oidc_response_types"`
-	JWKSURL                    string           `json:"jwks_url"`
-	JWKSCAPEM                  string           `json:"jwks_ca_pem"`
-	JWKSPairs                  []map[string]any `json:"jwks_pairs"`
-	JWTValidationPubKeys       []string         `json:"jwt_validation_pubkeys"`
-	JWTSupportedAlgs           []string         `json:"jwt_supported_algs"`
-	BoundIssuer                string           `json:"bound_issuer"`
-	DefaultRole                string           `json:"default_role"`
-	ProviderConfig             map[string]any   `json:"provider_config"`
-	OverrideAllowedServerNames []string         `json:"override_allowed_server_names"`
-	NamespaceInState           bool             `json:"namespace_in_state"`
+	OIDCDiscoveryURL           string         `json:"oidc_discovery_url"`
+	OIDCDiscoveryCAPEM         string         `json:"oidc_discovery_ca_pem"`
+	OIDCClientID               string         `json:"oidc_client_id"`
+	OIDCClientSecret           string         `json:"oidc_client_secret"`
+	OIDCResponseMode           string         `json:"oidc_response_mode"`
+	OIDCResponseTypes          []string       `json:"oidc_response_types"`
+	JWKSURL                    []string       `json:"jwks_url"`
+	JWKSCAPEM                  string         `json:"jwks_ca_pem"`
+	JWTValidationPubKeys       []string       `json:"jwt_validation_pubkeys"`
+	JWTSupportedAlgs           []string       `json:"jwt_supported_algs"`
+	BoundIssuer                string         `json:"bound_issuer"`
+	DefaultRole                string         `json:"default_role"`
+	ProviderConfig             map[string]any `json:"provider_config"`
+	OverrideAllowedServerNames []string       `json:"override_allowed_server_names"`
+	NamespaceInState           bool           `json:"namespace_in_state"`
 
 	ParsedJWTPubKeys []crypto.PublicKey `json:"-"`
 	// These are looked up from OIDCDiscoveryURL when needed
 	OIDCDeviceAuthURL string `json:"-"`
 	OIDCTokenURL      string `json:"-"`
+}
+
+// UnmarshalJSON decodes a stored jwtConfig, accepting the legacy string form
+// of "jwks_url" for backwards compatibility.
+func (c *jwtConfig) UnmarshalJSON(data []byte) error {
+	type alias jwtConfig
+	aux := &struct {
+		JWKSURL json.RawMessage `json:"jwks_url"`
+		*alias
+	}{
+		alias: (*alias)(c),
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(aux); err != nil {
+		return err
+	}
+
+	if len(aux.JWKSURL) == 0 {
+		return nil
+	}
+
+	var urls []string
+	if err := json.Unmarshal(aux.JWKSURL, &urls); err != nil {
+		var single string
+		if err := json.Unmarshal(aux.JWKSURL, &single); err != nil {
+			return fmt.Errorf("invalid 'jwks_url' value: %w", err)
+		}
+		if single != "" {
+			urls = []string{single}
+		} else {
+			urls = []string{}
+		}
+	}
+	c.JWKSURL = urls
+
+	return nil
 }
 
 const (
@@ -701,7 +691,6 @@ const (
 	OIDCFlow
 	CustomProviderDiscovery
 	unconfigured
-	JWKSPairs
 )
 
 // authType classifies the authorization type/flow based on config parameters.
@@ -709,10 +698,8 @@ func (c jwtConfig) authType() int {
 	switch {
 	case len(c.ParsedJWTPubKeys) > 0:
 		return StaticKeys
-	case c.JWKSURL != "":
+	case len(c.JWKSURL) > 0:
 		return JWKS
-	case len(c.JWKSPairs) > 0:
-		return JWKSPairs
 	case c.OIDCDiscoveryURL != "":
 		if c.OIDCClientID != "" && c.OIDCClientSecret != "" {
 			return OIDCFlow
@@ -755,43 +742,6 @@ func (c jwtConfig) hasCustomProviderDiscovery() bool {
 
 	_, ok = newCustomProvider.(KeySetDiscovery)
 	return ok
-}
-
-// parseJWKSPairs validates each pair and normalizes the raw "jwks_pairs"
-// request value into ordered {"jwks_url", "jwks_ca_pem"} maps.
-func parseJWKSPairs(rawPairs []any) ([]map[string]any, error) {
-	pairs := make([]map[string]any, 0, len(rawPairs))
-	for i, rawPair := range rawPairs {
-		pair, ok := rawPair.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("invalid jwks_pairs[%d]: each pair must be a JSON object", i)
-		}
-
-		urlRaw, ok := pair["jwks_url"]
-		if !ok {
-			return nil, fmt.Errorf("invalid jwks_pairs[%d]: missing 'jwks_url'", i)
-		}
-		url, ok := urlRaw.(string)
-		if !ok || strings.TrimSpace(url) == "" {
-			return nil, fmt.Errorf("invalid jwks_pairs[%d]: 'jwks_url' must be a non-empty string", i)
-		}
-
-		caPEM := ""
-		if caRaw, ok := pair["jwks_ca_pem"]; ok {
-			ca, ok := caRaw.(string)
-			if !ok {
-				return nil, fmt.Errorf("invalid jwks_pairs[%d]: 'jwks_ca_pem' must be a string", i)
-			}
-			caPEM = ca
-		}
-
-		pairs = append(pairs, map[string]any{
-			"jwks_url":    url,
-			"jwks_ca_pem": caPEM,
-		})
-	}
-
-	return pairs, nil
 }
 
 // Adapted from similar code in https://github.com/golang/go/blob/86fca3dcb63157b8e45e565e821e7fb098fcf368/src/crypto/tls/handshake_client.go#L1160-L1181

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -54,7 +54,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"oidc_discovery_url": {
 				Type:        framework.TypeString,
-				Description: `The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url", "jwks_urls", or "jwt_validation_pubkeys".`,
+				Description: `The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".`,
 			},
 			"oidc_discovery_ca_pem": {
 				Type:        framework.TypeString,
@@ -80,17 +80,12 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Description: "The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'.",
 			},
 			"jwks_url": {
-				Type:        framework.TypeString,
-				Description: `Deprecated: Please use "jwks_urls" instead. The single JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
-				Deprecated:  true,
-			},
-			"jwks_urls": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: `JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
+				Description: `JWKS URL or comma-separated list of URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
 			},
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
-				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates. The same CA certificates are used for all jwks_urls values. If not set, system certificates are used.",
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates. The same CA certificates are used for all jwks_url values. If not set, system certificates are used.",
 			},
 			"default_role": {
 				Type:        framework.TypeLowerCaseString,
@@ -98,7 +93,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url", "jwks_urls", or "oidc_discovery_url".`,
+				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".`,
 			},
 			"jwt_supported_algs": {
 				Type:        framework.TypeCommaStringSlice,
@@ -129,7 +124,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"skip_jwks_validation": {
 				Type:        framework.TypeBool,
-				Description: "When true and oidc_discovery_url, jwks_url, or jwks_urls are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint.",
+				Description: "When true and oidc_discovery_url or jwks_url are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint.",
 			},
 		},
 
@@ -321,7 +316,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"default_role":                  config.DefaultRole,
 			"jwt_validation_pubkeys":        config.JWTValidationPubKeys,
 			"jwt_supported_algs":            config.JWTSupportedAlgs,
-			"jwks_urls":                     jwksURLs,
+			"jwks_url":                      jwksURLs,
 			"jwks_ca_pem":                   config.JWKSCAPEM,
 			"bound_issuer":                  config.BoundIssuer,
 			"provider_config":               providerConfig,
@@ -351,7 +346,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		OIDCResponseMode:           d.Get("oidc_response_mode").(string),
 		OIDCResponseTypes:          d.Get("oidc_response_types").([]string),
 		JWKSCAPEM:                  d.Get("jwks_ca_pem").(string),
-		JWKSURLs:                   []string{},
+		JWKSURLs:                   d.Get("jwks_url").([]string),
 		DefaultRole:                d.Get("default_role").(string),
 		JWTValidationPubKeys:       d.Get("jwt_validation_pubkeys").([]string),
 		JWTSupportedAlgs:           d.Get("jwt_supported_algs").([]string),
@@ -359,17 +354,6 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		ProviderConfig:             d.Get("provider_config").(map[string]any),
 		OverrideAllowedServerNames: d.Get("override_allowed_server_names").([]string),
 	}
-	if jwksURLs, ok := d.GetFirst("jwks_urls", "jwks_url"); ok {
-		switch value := jwksURLs.(type) {
-		case []string:
-			config.JWKSURLs = value
-		case string:
-			if value != "" {
-				config.JWKSURLs = []string{value}
-			}
-		}
-	}
-
 	skipJwksValidation := d.Get("skip_jwks_validation").(bool)
 
 	txRollback, err := logical.StartTxStorage(ctx, req)
@@ -413,7 +397,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	resp := &logical.Response{}
 	switch {
 	case methodCount != 1:
-		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_urls', 'oidc_discovery_url', or 'provider_config' must be set"), nil
+		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'oidc_discovery_url', or 'provider_config' must be set"), nil
 
 	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":
@@ -445,7 +429,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 			keyset, err := jwt.NewJSONWebKeySet(ctx, jwksURL, config.JWKSCAPEM)
 			if err != nil {
 				b.Logger().Error("error checking jwks_ca_pem", "error", err, "jwks_url_index", i)
-				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_urls[%d]", i)), nil
+				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_url[%d]", i)), nil
 			}
 
 			// Try to verify a correctly formatted JWT. The signature will fail to match, but other
@@ -458,10 +442,10 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 			if !strings.Contains(err.Error(), "failed to verify id token signature") {
 				if !skipJwksValidation {
 					b.Logger().Error("error checking jwks URL", "jwks_url_index", i)
-					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_urls[%d]", i)), nil
+					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i)), nil
 				}
 
-				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_urls[%d]", i))
+				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_url[%d]", i))
 			}
 		}
 

--- a/internal/builtin/credential/jwt/path_config.go
+++ b/internal/builtin/credential/jwt/path_config.go
@@ -38,6 +38,11 @@ const (
 	responseTypeIDToken  = "id_token"  // ID Token for form post
 	responseModeQuery    = "query"     // Response as a redirect with query parameters
 	responseModeFormPost = "form_post" // Response as an HTML Form
+
+	// testJWT is a correctly formatted JWT whose signature will not match any
+	// configured key set. It is used to detect key set loading errors that are
+	// distinct from a signature mismatch.
+	testJWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
 )
 
 func pathConfig(b *jwtAuthBackend) *framework.Path {
@@ -81,6 +86,10 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
 				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.",
+			},
+			"jwks_pairs": {
+				Type:        framework.TypeSlice,
+				Description: `List of JWKS URL and optional CA certificate pairs. CA certificates must be in PEM format. Must be a list of JSON objects with format [{"jwks_url": "", "jwks_ca_pem": ""}]. Cannot be used with "jwks_url" or "jwks_ca_pem".`,
 			},
 			"default_role": {
 				Type:        framework.TypeLowerCaseString,
@@ -287,6 +296,11 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 		}
 	}
 
+	jwksPairs := config.JWKSPairs
+	if jwksPairs == nil {
+		jwksPairs = []map[string]any{}
+	}
+
 	resp := &logical.Response{
 		Data: map[string]any{
 			"oidc_discovery_url":            config.OIDCDiscoveryURL,
@@ -299,6 +313,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"jwt_supported_algs":            config.JWTSupportedAlgs,
 			"jwks_url":                      config.JWKSURL,
 			"jwks_ca_pem":                   config.JWKSCAPEM,
+			"jwks_pairs":                    jwksPairs,
 			"bound_issuer":                  config.BoundIssuer,
 			"provider_config":               providerConfig,
 			"override_allowed_server_names": config.OverrideAllowedServerNames,
@@ -334,6 +349,15 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		BoundIssuer:                d.Get("bound_issuer").(string),
 		ProviderConfig:             d.Get("provider_config").(map[string]any),
 		OverrideAllowedServerNames: d.Get("override_allowed_server_names").([]string),
+	}
+
+	rawPairs := d.Get("jwks_pairs").([]any)
+	if len(rawPairs) > 0 {
+		pairs, err := parseJWKSPairs(rawPairs)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+		config.JWKSPairs = pairs
 	}
 
 	skipJwksValidation := d.Get("skip_jwks_validation").(bool)
@@ -372,6 +396,9 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	if config.JWKSURL != "" {
 		methodCount++
 	}
+	if len(config.JWKSPairs) != 0 {
+		methodCount++
+	}
 	if config.hasCustomProviderDiscovery() {
 		methodCount++
 	}
@@ -380,6 +407,12 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	switch {
 	case methodCount != 1:
 		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_pairs', 'oidc_discovery_url', or 'provider_config' must be set"), nil
+
+	case len(config.JWKSPairs) > 0 && config.JWKSCAPEM != "":
+		return logical.ErrorResponse("'jwks_ca_pem' cannot be used with 'jwks_pairs'"), nil
+
+	case len(config.JWKSPairs) > 0 && config.BoundIssuer != "":
+		return logical.ErrorResponse("'bound_issuer' cannot be used with 'jwks_pairs'"), nil
 
 	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":
@@ -415,7 +448,6 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 
 		// Try to verify a correctly formatted JWT. The signature will fail to match, but other
 		// errors with fetching the remote keyset should be reported.
-		testJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
 		_, err = keyset.VerifySignature(ctx, testJWT)
 		if err == nil {
 			err = errors.New("unexpected verification of JWT")
@@ -428,6 +460,33 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 			}
 
 			resp.AddWarning("error checking jwks URL")
+		}
+
+	case len(config.JWKSPairs) != 0:
+		for i, pair := range config.JWKSPairs {
+			jwksURL, _ := pair["jwks_url"].(string)
+			jwksCAPEM, _ := pair["jwks_ca_pem"].(string)
+			keyset, err := jwt.NewJSONWebKeySet(ctx, jwksURL, jwksCAPEM)
+			if err != nil {
+				b.Logger().Error("error checking jwks_ca_pem", "error", err, "jwks_pairs_index", i)
+				return logical.ErrorResponse(fmt.Sprintf("error checking jwks_ca_pem for jwks_pairs[%d]", i)), nil
+			}
+
+			// Try to verify a correctly formatted JWT. The signature will fail to match, but other
+			// errors with fetching the remote keyset should be reported.
+			_, err = keyset.VerifySignature(ctx, testJWT)
+			if err == nil {
+				err = errors.New("unexpected verification of JWT")
+			}
+
+			if !strings.Contains(err.Error(), "failed to verify id token signature") {
+				if !skipJwksValidation {
+					b.Logger().Error("error checking jwks URL", "error", err, "jwks_pairs_index", i)
+					return logical.ErrorResponse(fmt.Sprintf("error checking jwks URL for jwks_pairs[%d]", i)), nil
+				}
+
+				resp.AddWarning(fmt.Sprintf("error checking jwks URL for jwks_pairs[%d]", i))
+			}
 		}
 
 	case len(config.JWTValidationPubKeys) != 0:
@@ -612,21 +671,22 @@ func (b *jwtAuthBackend) OverrideAllowedServerNames(config *tls.Config, allowedS
 }
 
 type jwtConfig struct {
-	OIDCDiscoveryURL           string         `json:"oidc_discovery_url"`
-	OIDCDiscoveryCAPEM         string         `json:"oidc_discovery_ca_pem"`
-	OIDCClientID               string         `json:"oidc_client_id"`
-	OIDCClientSecret           string         `json:"oidc_client_secret"`
-	OIDCResponseMode           string         `json:"oidc_response_mode"`
-	OIDCResponseTypes          []string       `json:"oidc_response_types"`
-	JWKSURL                    string         `json:"jwks_url"`
-	JWKSCAPEM                  string         `json:"jwks_ca_pem"`
-	JWTValidationPubKeys       []string       `json:"jwt_validation_pubkeys"`
-	JWTSupportedAlgs           []string       `json:"jwt_supported_algs"`
-	BoundIssuer                string         `json:"bound_issuer"`
-	DefaultRole                string         `json:"default_role"`
-	ProviderConfig             map[string]any `json:"provider_config"`
-	OverrideAllowedServerNames []string       `json:"override_allowed_server_names"`
-	NamespaceInState           bool           `json:"namespace_in_state"`
+	OIDCDiscoveryURL           string           `json:"oidc_discovery_url"`
+	OIDCDiscoveryCAPEM         string           `json:"oidc_discovery_ca_pem"`
+	OIDCClientID               string           `json:"oidc_client_id"`
+	OIDCClientSecret           string           `json:"oidc_client_secret"`
+	OIDCResponseMode           string           `json:"oidc_response_mode"`
+	OIDCResponseTypes          []string         `json:"oidc_response_types"`
+	JWKSURL                    string           `json:"jwks_url"`
+	JWKSCAPEM                  string           `json:"jwks_ca_pem"`
+	JWKSPairs                  []map[string]any `json:"jwks_pairs"`
+	JWTValidationPubKeys       []string         `json:"jwt_validation_pubkeys"`
+	JWTSupportedAlgs           []string         `json:"jwt_supported_algs"`
+	BoundIssuer                string           `json:"bound_issuer"`
+	DefaultRole                string           `json:"default_role"`
+	ProviderConfig             map[string]any   `json:"provider_config"`
+	OverrideAllowedServerNames []string         `json:"override_allowed_server_names"`
+	NamespaceInState           bool             `json:"namespace_in_state"`
 
 	ParsedJWTPubKeys []crypto.PublicKey `json:"-"`
 	// These are looked up from OIDCDiscoveryURL when needed
@@ -641,6 +701,7 @@ const (
 	OIDCFlow
 	CustomProviderDiscovery
 	unconfigured
+	JWKSPairs
 )
 
 // authType classifies the authorization type/flow based on config parameters.
@@ -650,6 +711,8 @@ func (c jwtConfig) authType() int {
 		return StaticKeys
 	case c.JWKSURL != "":
 		return JWKS
+	case len(c.JWKSPairs) > 0:
+		return JWKSPairs
 	case c.OIDCDiscoveryURL != "":
 		if c.OIDCClientID != "" && c.OIDCClientSecret != "" {
 			return OIDCFlow
@@ -692,6 +755,43 @@ func (c jwtConfig) hasCustomProviderDiscovery() bool {
 
 	_, ok = newCustomProvider.(KeySetDiscovery)
 	return ok
+}
+
+// parseJWKSPairs validates each pair and normalizes the raw "jwks_pairs"
+// request value into ordered {"jwks_url", "jwks_ca_pem"} maps.
+func parseJWKSPairs(rawPairs []any) ([]map[string]any, error) {
+	pairs := make([]map[string]any, 0, len(rawPairs))
+	for i, rawPair := range rawPairs {
+		pair, ok := rawPair.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid jwks_pairs[%d]: each pair must be a JSON object", i)
+		}
+
+		urlRaw, ok := pair["jwks_url"]
+		if !ok {
+			return nil, fmt.Errorf("invalid jwks_pairs[%d]: missing 'jwks_url'", i)
+		}
+		url, ok := urlRaw.(string)
+		if !ok || strings.TrimSpace(url) == "" {
+			return nil, fmt.Errorf("invalid jwks_pairs[%d]: 'jwks_url' must be a non-empty string", i)
+		}
+
+		caPEM := ""
+		if caRaw, ok := pair["jwks_ca_pem"]; ok {
+			ca, ok := caRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid jwks_pairs[%d]: 'jwks_ca_pem' must be a string", i)
+			}
+			caPEM = ca
+		}
+
+		pairs = append(pairs, map[string]any{
+			"jwks_url":    url,
+			"jwks_ca_pem": caPEM,
+		})
+	}
+
+	return pairs, nil
 }
 
 // Adapted from similar code in https://github.com/golang/go/blob/86fca3dcb63157b8e45e565e821e7fb098fcf368/src/crypto/tls/handshake_client.go#L1160-L1181

--- a/internal/builtin/credential/jwt/path_config_test.go
+++ b/internal/builtin/credential/jwt/path_config_test.go
@@ -43,7 +43,7 @@ func TestConfig_JWT_Read(t *testing.T) {
 		"default_role":                  "",
 		"jwt_validation_pubkeys":        []string{testJWTPubKey},
 		"jwt_supported_algs":            []string{},
-		"jwks_urls":                     []string{},
+		"jwks_url":                      []string{},
 		"jwks_ca_pem":                   "",
 		"bound_issuer":                  "http://vault.example.com/",
 		"provider_config":               map[string]any{},
@@ -259,15 +259,14 @@ func TestConfig_JWKS_Update(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	// Reads return the new list format regardless of the input form.
-	delete(data, "jwks_url")
-	data["jwks_urls"] = []string{s.server.URL + "/certs"}
+	// Reads return the list format regardless of the input form.
+	data["jwks_url"] = []string{s.server.URL + "/certs"}
 	if diff := deep.Equal(resp.Data, data); diff != nil {
 		t.Fatalf("Expected did not equal actual: %v", diff)
 	}
 }
 
-func TestConfig_JWKS_NewFieldTakesPrecedence(t *testing.T) {
+func TestConfig_JWKS_CommaSeparatedURLs(t *testing.T) {
 	b, storage := getBackend(t)
 
 	s := newOIDCProvider(t)
@@ -278,10 +277,8 @@ func TestConfig_JWKS_NewFieldTakesPrecedence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// When both names are supplied, the replacement field is authoritative.
 	data := map[string]any{
-		"jwks_url":             s.server.URL + "/certs_missing",
-		"jwks_urls":            []string{s.server.URL + "/certs"},
+		"jwks_url":             s.server.URL + "/certs_wrong," + s.server.URL + "/certs",
 		"jwks_ca_pem":          cert,
 		"skip_jwks_validation": false,
 	}
@@ -302,8 +299,9 @@ func TestConfig_JWKS_NewFieldTakesPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(conf.JWKSURLs, []string{s.server.URL + "/certs"}) {
-		t.Fatalf("expected jwks_urls to take precedence, got: %#v", conf.JWKSURLs)
+	expectedURLs := []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"}
+	if !reflect.DeepEqual(conf.JWKSURLs, expectedURLs) {
+		t.Fatalf("expected comma-separated jwks_url to be stored as a list, got: %#v", conf.JWKSURLs)
 	}
 }
 
@@ -1082,7 +1080,7 @@ func TestConfig_JWKS_MultiURL_WriteRead(t *testing.T) {
 	}
 
 	data := map[string]any{
-		"jwks_urls":                     []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"},
+		"jwks_url":                      []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"},
 		"jwks_ca_pem":                   cert,
 		"oidc_discovery_url":            "",
 		"oidc_discovery_ca_pem":         "",
@@ -1155,7 +1153,7 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_urls":   []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_url":    []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
 				"jwks_ca_pem": cert,
 			},
 		}
@@ -1178,7 +1176,7 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_urls":            []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_url":             []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
 				"jwks_ca_pem":          cert,
 				"skip_jwks_validation": true,
 			},
@@ -1194,8 +1192,8 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 		if len(resp.Warnings) == 0 {
 			t.Fatal("expected at least one verification warning")
 		}
-		if !strings.Contains(resp.Warnings[0], "jwks_urls[0]") {
-			t.Fatalf("expected warning to reference jwks_urls[0], got: %v", resp.Warnings)
+		if !strings.Contains(resp.Warnings[0], "jwks_url[0]") {
+			t.Fatalf("expected warning to reference jwks_url[0], got: %v", resp.Warnings)
 		}
 
 		conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
@@ -1245,11 +1243,8 @@ func TestConfig_JWKSURLs_LegacyStringStorage(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
-	if got := resp.Data["jwks_urls"]; !reflect.DeepEqual(got, []string{"https://example.com/certs"}) {
-		t.Fatalf("expected read to return jwks_urls list, got: %#v", got)
-	}
-	if _, ok := resp.Data["jwks_url"]; ok {
-		t.Fatal("expected read not to return deprecated jwks_url")
+	if got := resp.Data["jwks_url"]; !reflect.DeepEqual(got, []string{"https://example.com/certs"}) {
+		t.Fatalf("expected read to return jwks_url list, got: %#v", got)
 	}
 }
 

--- a/internal/builtin/credential/jwt/path_config_test.go
+++ b/internal/builtin/credential/jwt/path_config_test.go
@@ -45,6 +45,7 @@ func TestConfig_JWT_Read(t *testing.T) {
 		"jwt_supported_algs":            []string{},
 		"jwks_url":                      "",
 		"jwks_ca_pem":                   "",
+		"jwks_pairs":                    []map[string]any{},
 		"bound_issuer":                  "http://vault.example.com/",
 		"provider_config":               map[string]any{},
 		"namespace_in_state":            false,
@@ -210,6 +211,7 @@ func TestConfig_JWKS_Update(t *testing.T) {
 	data := map[string]any{
 		"jwks_url":                      s.server.URL + "/certs",
 		"jwks_ca_pem":                   cert,
+		"jwks_pairs":                    []map[string]any{},
 		"oidc_discovery_url":            "",
 		"oidc_discovery_ca_pem":         "",
 		"oidc_client_id":                "",
@@ -1005,6 +1007,289 @@ func getCertificate(hostname string) (serverTLSConf *tls.Config, caPEM *bytes.Bu
 	}
 
 	return serverTLSConf, caPEM, err
+}
+
+func TestConfig_JWKSPairs_WriteRead(t *testing.T) {
+	b, storage := getBackend(t)
+
+	s := newOIDCProvider(t)
+	defer s.server.Close()
+
+	cert, err := s.getTLSCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := map[string]any{
+		"jwks_pairs": []map[string]any{
+			{
+				"jwks_url":    s.server.URL + "/certs_wrong",
+				"jwks_ca_pem": cert,
+			},
+			{
+				"jwks_url":    s.server.URL + "/certs",
+				"jwks_ca_pem": cert,
+			},
+		},
+		"oidc_discovery_url":            "",
+		"oidc_discovery_ca_pem":         "",
+		"oidc_client_id":                "",
+		"oidc_response_mode":            "",
+		"oidc_response_types":           []string{},
+		"override_allowed_server_names": []string{},
+		"default_role":                  "",
+		"jwt_validation_pubkeys":        []string{},
+		"jwt_supported_algs":            []string{},
+		"jwks_url":                      "",
+		"jwks_ca_pem":                   "",
+		"bound_issuer":                  "",
+		"provider_config":               map[string]any{},
+		"namespace_in_state":            false,
+		"status":                        "valid",
+	}
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, err := b.HandleRequest(t.Context(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      nil,
+	}
+
+	resp, err = b.HandleRequest(t.Context(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if diff := deep.Equal(resp.Data, data); diff != nil {
+		t.Fatalf("Expected did not equal actual: %v", diff)
+	}
+
+	// Order must be preserved across a write/read round trip.
+	conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conf.JWKSPairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(conf.JWKSPairs))
+	}
+	if conf.JWKSPairs[0]["jwks_url"] != s.server.URL+"/certs_wrong" || conf.JWKSPairs[1]["jwks_url"] != s.server.URL+"/certs" {
+		t.Fatalf("pair order not preserved: %#v", conf.JWKSPairs)
+	}
+}
+
+func TestConfig_JWKSPairs_MutuallyExclusive(t *testing.T) {
+	b, storage := getBackend(t)
+
+	s := newOIDCProvider(t)
+	defer s.server.Close()
+
+	cert, err := s.getTLSCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pairs := []map[string]any{
+		{"jwks_url": s.server.URL + "/certs", "jwks_ca_pem": cert},
+	}
+
+	tests := []struct {
+		name    string
+		data    map[string]any
+		errText string
+	}{
+		{
+			"with jwks_url",
+			map[string]any{
+				"jwks_url":   s.server.URL + "/certs",
+				"jwks_pairs": pairs,
+			},
+			"exactly one of",
+		},
+		{
+			"with jwks_ca_pem",
+			map[string]any{
+				"jwks_ca_pem": cert,
+				"jwks_pairs":  pairs,
+			},
+			"'jwks_ca_pem' cannot be used with 'jwks_pairs'",
+		},
+		{
+			"with bound_issuer",
+			map[string]any{
+				"bound_issuer": "https://team-vault.auth0.com/",
+				"jwks_pairs":   pairs,
+			},
+			"'bound_issuer' cannot be used with 'jwks_pairs'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      test.data,
+			}
+
+			resp, err := b.HandleRequest(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp == nil || !resp.IsError() {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(resp.Error().Error(), test.errText) {
+				t.Fatalf("got unexpected error: %v", resp.Error())
+			}
+		})
+	}
+}
+
+func TestConfig_JWKSPairs_Malformed(t *testing.T) {
+	b, storage := getBackend(t)
+
+	tests := []struct {
+		name string
+		data map[string]any
+	}{
+		{
+			"element not an object",
+			map[string]any{
+				"jwks_pairs": []any{"not-an-object"},
+			},
+		},
+		{
+			"missing jwks_url",
+			map[string]any{
+				"jwks_pairs": []any{
+					map[string]any{"jwks_ca_pem": "abc"},
+				},
+			},
+		},
+		{
+			"empty jwks_url",
+			map[string]any{
+				"jwks_pairs": []any{
+					map[string]any{"jwks_url": "", "jwks_ca_pem": "abc"},
+				},
+			},
+		},
+		{
+			"non-string jwks_ca_pem",
+			map[string]any{
+				"jwks_pairs": []any{
+					map[string]any{"jwks_url": "https://example.com/certs", "jwks_ca_pem": 123},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      test.data,
+			}
+
+			resp, err := b.HandleRequest(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp == nil || !resp.IsError() {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(resp.Error().Error(), "invalid jwks_pairs[0]") {
+				t.Fatalf("got unexpected error: %v", resp.Error())
+			}
+		})
+	}
+}
+
+func TestConfig_JWKSPairs_SkipValidation(t *testing.T) {
+	b, storage := getBackend(t)
+
+	s := newOIDCProvider(t)
+	defer s.server.Close()
+
+	cert, err := s.getTLSCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pairs := []map[string]any{
+		{"jwks_url": s.server.URL + "/certs_missing", "jwks_ca_pem": cert},
+	}
+
+	t.Run("skip false fails", func(t *testing.T) {
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data: map[string]any{
+				"jwks_pairs": pairs,
+			},
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil || !resp.IsError() {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(resp.Error().Error(), "error checking jwks URL") {
+			t.Fatalf("got unexpected error: %v", resp.Error())
+		}
+	})
+
+	t.Run("skip true warns and saves", func(t *testing.T) {
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data: map[string]any{
+				"jwks_pairs":           pairs,
+				"skip_jwks_validation": true,
+			},
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("unexpected error; expected warning: %v", err)
+		}
+		if resp.IsError() {
+			t.Fatalf("unexpected error; expected warning: %#v", resp)
+		}
+		if len(resp.Warnings) == 0 {
+			t.Fatal("expected at least one verification warning")
+		}
+		if !strings.Contains(resp.Warnings[0], "jwks_pairs[0]") {
+			t.Fatalf("expected warning to reference jwks_pairs[0], got: %v", resp.Warnings)
+		}
+
+		conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(conf.JWKSPairs) != 1 {
+			t.Fatalf("expected 1 pair to be saved, got %d", len(conf.JWKSPairs))
+		}
+	})
 }
 
 const (

--- a/internal/builtin/credential/jwt/path_config_test.go
+++ b/internal/builtin/credential/jwt/path_config_test.go
@@ -43,9 +43,8 @@ func TestConfig_JWT_Read(t *testing.T) {
 		"default_role":                  "",
 		"jwt_validation_pubkeys":        []string{testJWTPubKey},
 		"jwt_supported_algs":            []string{},
-		"jwks_url":                      "",
+		"jwks_url":                      []string{},
 		"jwks_ca_pem":                   "",
-		"jwks_pairs":                    []map[string]any{},
 		"bound_issuer":                  "http://vault.example.com/",
 		"provider_config":               map[string]any{},
 		"namespace_in_state":            false,
@@ -155,6 +154,7 @@ func TestConfig_JWT_Write(t *testing.T) {
 		ParsedJWTPubKeys:           []crypto.PublicKey{pubkey},
 		JWTValidationPubKeys:       []string{testJWTPubKey},
 		JWTSupportedAlgs:           []string{},
+		JWKSURL:                    []string{},
 		OIDCResponseTypes:          []string{},
 		OverrideAllowedServerNames: []string{},
 		BoundIssuer:                "http://vault.example.com/",
@@ -208,10 +208,10 @@ func TestConfig_JWKS_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The old single-string form of jwks_url must still be accepted.
 	data := map[string]any{
 		"jwks_url":                      s.server.URL + "/certs",
 		"jwks_ca_pem":                   cert,
-		"jwks_pairs":                    []map[string]any{},
 		"oidc_discovery_url":            "",
 		"oidc_discovery_ca_pem":         "",
 		"oidc_client_id":                "",
@@ -239,6 +239,14 @@ func TestConfig_JWKS_Update(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
+	conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(conf.JWKSURL, []string{s.server.URL + "/certs"}) {
+		t.Fatalf("expected single-string jwks_url to be stored as a list, got: %#v", conf.JWKSURL)
+	}
+
 	req = &logical.Request{
 		Operation: logical.ReadOperation,
 		Path:      configPath,
@@ -251,6 +259,8 @@ func TestConfig_JWKS_Update(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
+	// Reads return the new list format regardless of the input form.
+	data["jwks_url"] = []string{s.server.URL + "/certs"}
 	if diff := deep.Equal(resp.Data, data); diff != nil {
 		t.Fatalf("Expected did not equal actual: %v", diff)
 	}
@@ -394,6 +404,7 @@ func TestConfig_OIDC_Write(t *testing.T) {
 	expected := &jwtConfig{
 		JWTValidationPubKeys:       []string{},
 		JWTSupportedAlgs:           []string{},
+		JWKSURL:                    []string{},
 		OIDCResponseTypes:          []string{},
 		OverrideAllowedServerNames: []string{},
 		OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -501,6 +512,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 		expected := &jwtConfig{
 			JWTValidationPubKeys:       []string{},
 			JWTSupportedAlgs:           []string{},
+			JWKSURL:                    []string{},
 			OIDCResponseTypes:          []string{},
 			OverrideAllowedServerNames: []string{},
 			OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -562,6 +574,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 		expected := &jwtConfig{
 			JWTValidationPubKeys:       []string{},
 			JWTSupportedAlgs:           []string{},
+			JWKSURL:                    []string{},
 			OIDCResponseTypes:          []string{},
 			OverrideAllowedServerNames: []string{},
 			OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -596,6 +609,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -611,6 +625,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -626,6 +641,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -674,6 +690,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				NamespaceInState:           true,
 				OIDCResponseTypes:          []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
@@ -695,6 +712,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -714,6 +732,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -734,6 +753,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
+				JWKSURL:                    []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -1009,7 +1029,7 @@ func getCertificate(hostname string) (serverTLSConf *tls.Config, caPEM *bytes.Bu
 	return serverTLSConf, caPEM, err
 }
 
-func TestConfig_JWKSPairs_WriteRead(t *testing.T) {
+func TestConfig_JWKS_MultiURL_WriteRead(t *testing.T) {
 	b, storage := getBackend(t)
 
 	s := newOIDCProvider(t)
@@ -1021,16 +1041,8 @@ func TestConfig_JWKSPairs_WriteRead(t *testing.T) {
 	}
 
 	data := map[string]any{
-		"jwks_pairs": []map[string]any{
-			{
-				"jwks_url":    s.server.URL + "/certs_wrong",
-				"jwks_ca_pem": cert,
-			},
-			{
-				"jwks_url":    s.server.URL + "/certs",
-				"jwks_ca_pem": cert,
-			},
-		},
+		"jwks_url":                      []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"},
+		"jwks_ca_pem":                   cert,
 		"oidc_discovery_url":            "",
 		"oidc_discovery_ca_pem":         "",
 		"oidc_client_id":                "",
@@ -1040,8 +1052,6 @@ func TestConfig_JWKSPairs_WriteRead(t *testing.T) {
 		"default_role":                  "",
 		"jwt_validation_pubkeys":        []string{},
 		"jwt_supported_algs":            []string{},
-		"jwks_url":                      "",
-		"jwks_ca_pem":                   "",
 		"bound_issuer":                  "",
 		"provider_config":               map[string]any{},
 		"namespace_in_state":            false,
@@ -1081,15 +1091,13 @@ func TestConfig_JWKSPairs_WriteRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(conf.JWKSPairs) != 2 {
-		t.Fatalf("expected 2 pairs, got %d", len(conf.JWKSPairs))
-	}
-	if conf.JWKSPairs[0]["jwks_url"] != s.server.URL+"/certs_wrong" || conf.JWKSPairs[1]["jwks_url"] != s.server.URL+"/certs" {
-		t.Fatalf("pair order not preserved: %#v", conf.JWKSPairs)
+	expectedURLs := []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"}
+	if !reflect.DeepEqual(conf.JWKSURL, expectedURLs) {
+		t.Fatalf("URL order not preserved: %#v", conf.JWKSURL)
 	}
 }
 
-func TestConfig_JWKSPairs_MutuallyExclusive(t *testing.T) {
+func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 	b, storage := getBackend(t)
 
 	s := newOIDCProvider(t)
@@ -1098,141 +1106,6 @@ func TestConfig_JWKSPairs_MutuallyExclusive(t *testing.T) {
 	cert, err := s.getTLSCert()
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	pairs := []map[string]any{
-		{"jwks_url": s.server.URL + "/certs", "jwks_ca_pem": cert},
-	}
-
-	tests := []struct {
-		name    string
-		data    map[string]any
-		errText string
-	}{
-		{
-			"with jwks_url",
-			map[string]any{
-				"jwks_url":   s.server.URL + "/certs",
-				"jwks_pairs": pairs,
-			},
-			"exactly one of",
-		},
-		{
-			"with jwks_ca_pem",
-			map[string]any{
-				"jwks_ca_pem": cert,
-				"jwks_pairs":  pairs,
-			},
-			"'jwks_ca_pem' cannot be used with 'jwks_pairs'",
-		},
-		{
-			"with bound_issuer",
-			map[string]any{
-				"bound_issuer": "https://team-vault.auth0.com/",
-				"jwks_pairs":   pairs,
-			},
-			"'bound_issuer' cannot be used with 'jwks_pairs'",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req := &logical.Request{
-				Operation: logical.UpdateOperation,
-				Path:      configPath,
-				Storage:   storage,
-				Data:      test.data,
-			}
-
-			resp, err := b.HandleRequest(t.Context(), req)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resp == nil || !resp.IsError() {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(resp.Error().Error(), test.errText) {
-				t.Fatalf("got unexpected error: %v", resp.Error())
-			}
-		})
-	}
-}
-
-func TestConfig_JWKSPairs_Malformed(t *testing.T) {
-	b, storage := getBackend(t)
-
-	tests := []struct {
-		name string
-		data map[string]any
-	}{
-		{
-			"element not an object",
-			map[string]any{
-				"jwks_pairs": []any{"not-an-object"},
-			},
-		},
-		{
-			"missing jwks_url",
-			map[string]any{
-				"jwks_pairs": []any{
-					map[string]any{"jwks_ca_pem": "abc"},
-				},
-			},
-		},
-		{
-			"empty jwks_url",
-			map[string]any{
-				"jwks_pairs": []any{
-					map[string]any{"jwks_url": "", "jwks_ca_pem": "abc"},
-				},
-			},
-		},
-		{
-			"non-string jwks_ca_pem",
-			map[string]any{
-				"jwks_pairs": []any{
-					map[string]any{"jwks_url": "https://example.com/certs", "jwks_ca_pem": 123},
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req := &logical.Request{
-				Operation: logical.UpdateOperation,
-				Path:      configPath,
-				Storage:   storage,
-				Data:      test.data,
-			}
-
-			resp, err := b.HandleRequest(t.Context(), req)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resp == nil || !resp.IsError() {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(resp.Error().Error(), "invalid jwks_pairs[0]") {
-				t.Fatalf("got unexpected error: %v", resp.Error())
-			}
-		})
-	}
-}
-
-func TestConfig_JWKSPairs_SkipValidation(t *testing.T) {
-	b, storage := getBackend(t)
-
-	s := newOIDCProvider(t)
-	defer s.server.Close()
-
-	cert, err := s.getTLSCert()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pairs := []map[string]any{
-		{"jwks_url": s.server.URL + "/certs_missing", "jwks_ca_pem": cert},
 	}
 
 	t.Run("skip false fails", func(t *testing.T) {
@@ -1241,7 +1114,8 @@ func TestConfig_JWKSPairs_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_pairs": pairs,
+				"jwks_url":    []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_ca_pem": cert,
 			},
 		}
 
@@ -1263,7 +1137,8 @@ func TestConfig_JWKSPairs_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_pairs":           pairs,
+				"jwks_url":             []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_ca_pem":          cert,
 				"skip_jwks_validation": true,
 			},
 		}
@@ -1278,18 +1153,115 @@ func TestConfig_JWKSPairs_SkipValidation(t *testing.T) {
 		if len(resp.Warnings) == 0 {
 			t.Fatal("expected at least one verification warning")
 		}
-		if !strings.Contains(resp.Warnings[0], "jwks_pairs[0]") {
-			t.Fatalf("expected warning to reference jwks_pairs[0], got: %v", resp.Warnings)
+		if !strings.Contains(resp.Warnings[0], "jwks_url[0]") {
+			t.Fatalf("expected warning to reference jwks_url[0], got: %v", resp.Warnings)
 		}
 
 		conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(conf.JWKSPairs) != 1 {
-			t.Fatalf("expected 1 pair to be saved, got %d", len(conf.JWKSPairs))
+		if len(conf.JWKSURL) != 2 {
+			t.Fatalf("expected 2 URLs to be saved, got %d", len(conf.JWKSURL))
 		}
 	})
+}
+
+func TestConfig_JWKSURL_LegacyStringStorage(t *testing.T) {
+	b, storage := getBackend(t)
+
+	// A legacy config stored "jwks_url" as a single string; it must still decode.
+	entry := &logical.StorageEntry{
+		Key: configPath,
+		Value: []byte(`{
+			"oidc_discovery_url": "",
+			"jwks_url": "https://example.com/certs",
+			"jwks_ca_pem": ""
+		}`),
+	}
+	if err := storage.Put(t.Context(), entry); err != nil {
+		t.Fatal(err)
+	}
+
+	conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(conf.JWKSURL, []string{"https://example.com/certs"}) {
+		t.Fatalf("expected legacy single-string jwks_url to decode as a list, got: %#v", conf.JWKSURL)
+	}
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      nil,
+	}
+	resp, err := b.HandleRequest(t.Context(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+	if got := resp.Data["jwks_url"]; !reflect.DeepEqual(got, []string{"https://example.com/certs"}) {
+		t.Fatalf("expected read to return jwks_url list, got: %#v", got)
+	}
+}
+
+func TestConfig_JWKSURL_LegacyEmptyStorage(t *testing.T) {
+	// A legacy config could store an empty "jwks_url" string, which must not
+	// be treated as a JWKS configuration after upgrade.
+	tests := map[string]string{
+		"legacy empty string": `{
+			"oidc_discovery_url": "https://team-vault.auth0.com/",
+			"oidc_discovery_ca_pem": "",
+			"oidc_client_id": "",
+			"oidc_client_secret": "",
+			"jwks_url": "",
+			"jwks_ca_pem": ""
+		}`,
+		"null": `{
+			"oidc_discovery_url": "https://team-vault.auth0.com/",
+			"oidc_discovery_ca_pem": "",
+			"oidc_client_id": "",
+			"oidc_client_secret": "",
+			"jwks_url": null,
+			"jwks_ca_pem": ""
+		}`,
+		"missing field": `{
+			"oidc_discovery_url": "https://team-vault.auth0.com/",
+			"oidc_discovery_ca_pem": "",
+			"oidc_client_id": "",
+			"oidc_client_secret": "",
+			"jwks_ca_pem": ""
+		}`,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+
+			entry := &logical.StorageEntry{
+				Key:   configPath,
+				Value: []byte(raw),
+			}
+			if err := storage.Put(t.Context(), entry); err != nil {
+				t.Fatal(err)
+			}
+
+			conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(conf.JWKSURL) != 0 {
+				t.Fatalf("expected zero-length JWKSURL, got: %#v", conf.JWKSURL)
+			}
+			if conf.authType() == JWKS {
+				t.Fatal("expected config not to be classified as JWKS")
+			}
+			if conf.authType() != OIDCDiscovery {
+				t.Fatalf("expected OIDCDiscovery auth type, got: %d", conf.authType())
+			}
+		})
+	}
 }
 
 const (

--- a/internal/builtin/credential/jwt/path_config_test.go
+++ b/internal/builtin/credential/jwt/path_config_test.go
@@ -43,7 +43,7 @@ func TestConfig_JWT_Read(t *testing.T) {
 		"default_role":                  "",
 		"jwt_validation_pubkeys":        []string{testJWTPubKey},
 		"jwt_supported_algs":            []string{},
-		"jwks_url":                      []string{},
+		"jwks_urls":                     []string{},
 		"jwks_ca_pem":                   "",
 		"bound_issuer":                  "http://vault.example.com/",
 		"provider_config":               map[string]any{},
@@ -154,7 +154,7 @@ func TestConfig_JWT_Write(t *testing.T) {
 		ParsedJWTPubKeys:           []crypto.PublicKey{pubkey},
 		JWTValidationPubKeys:       []string{testJWTPubKey},
 		JWTSupportedAlgs:           []string{},
-		JWKSURL:                    []string{},
+		JWKSURLs:                   []string{},
 		OIDCResponseTypes:          []string{},
 		OverrideAllowedServerNames: []string{},
 		BoundIssuer:                "http://vault.example.com/",
@@ -243,8 +243,8 @@ func TestConfig_JWKS_Update(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(conf.JWKSURL, []string{s.server.URL + "/certs"}) {
-		t.Fatalf("expected single-string jwks_url to be stored as a list, got: %#v", conf.JWKSURL)
+	if !reflect.DeepEqual(conf.JWKSURLs, []string{s.server.URL + "/certs"}) {
+		t.Fatalf("expected single-string jwks_url to be stored as a list, got: %#v", conf.JWKSURLs)
 	}
 
 	req = &logical.Request{
@@ -260,9 +260,50 @@ func TestConfig_JWKS_Update(t *testing.T) {
 	}
 
 	// Reads return the new list format regardless of the input form.
-	data["jwks_url"] = []string{s.server.URL + "/certs"}
+	delete(data, "jwks_url")
+	data["jwks_urls"] = []string{s.server.URL + "/certs"}
 	if diff := deep.Equal(resp.Data, data); diff != nil {
 		t.Fatalf("Expected did not equal actual: %v", diff)
+	}
+}
+
+func TestConfig_JWKS_NewFieldTakesPrecedence(t *testing.T) {
+	b, storage := getBackend(t)
+
+	s := newOIDCProvider(t)
+	defer s.server.Close()
+
+	cert, err := s.getTLSCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When both names are supplied, the replacement field is authoritative.
+	data := map[string]any{
+		"jwks_url":             s.server.URL + "/certs_missing",
+		"jwks_urls":            []string{s.server.URL + "/certs"},
+		"jwks_ca_pem":          cert,
+		"skip_jwks_validation": false,
+	}
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, err := b.HandleRequest(t.Context(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(conf.JWKSURLs, []string{s.server.URL + "/certs"}) {
+		t.Fatalf("expected jwks_urls to take precedence, got: %#v", conf.JWKSURLs)
 	}
 }
 
@@ -404,7 +445,7 @@ func TestConfig_OIDC_Write(t *testing.T) {
 	expected := &jwtConfig{
 		JWTValidationPubKeys:       []string{},
 		JWTSupportedAlgs:           []string{},
-		JWKSURL:                    []string{},
+		JWKSURLs:                   []string{},
 		OIDCResponseTypes:          []string{},
 		OverrideAllowedServerNames: []string{},
 		OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -512,7 +553,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 		expected := &jwtConfig{
 			JWTValidationPubKeys:       []string{},
 			JWTSupportedAlgs:           []string{},
-			JWKSURL:                    []string{},
+			JWKSURLs:                   []string{},
 			OIDCResponseTypes:          []string{},
 			OverrideAllowedServerNames: []string{},
 			OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -574,7 +615,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 		expected := &jwtConfig{
 			JWTValidationPubKeys:       []string{},
 			JWTSupportedAlgs:           []string{},
-			JWKSURL:                    []string{},
+			JWKSURLs:                   []string{},
 			OIDCResponseTypes:          []string{},
 			OverrideAllowedServerNames: []string{},
 			OIDCDiscoveryURL:           "https://team-vault.auth0.com/",
@@ -609,7 +650,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -625,7 +666,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -641,7 +682,7 @@ func TestConfig_OIDC_Create_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -690,7 +731,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				NamespaceInState:           true,
 				OIDCResponseTypes:          []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
@@ -712,7 +753,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -732,7 +773,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -753,7 +794,7 @@ func TestConfig_OIDC_Update_Namespace(t *testing.T) {
 				OIDCResponseTypes:          []string{},
 				OverrideAllowedServerNames: []string{},
 				JWTSupportedAlgs:           []string{},
-				JWKSURL:                    []string{},
+				JWKSURLs:                   []string{},
 				JWTValidationPubKeys:       []string{},
 				ProviderConfig:             map[string]any{},
 			},
@@ -1041,7 +1082,7 @@ func TestConfig_JWKS_MultiURL_WriteRead(t *testing.T) {
 	}
 
 	data := map[string]any{
-		"jwks_url":                      []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"},
+		"jwks_urls":                     []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"},
 		"jwks_ca_pem":                   cert,
 		"oidc_discovery_url":            "",
 		"oidc_discovery_ca_pem":         "",
@@ -1092,8 +1133,8 @@ func TestConfig_JWKS_MultiURL_WriteRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedURLs := []string{s.server.URL + "/certs_wrong", s.server.URL + "/certs"}
-	if !reflect.DeepEqual(conf.JWKSURL, expectedURLs) {
-		t.Fatalf("URL order not preserved: %#v", conf.JWKSURL)
+	if !reflect.DeepEqual(conf.JWKSURLs, expectedURLs) {
+		t.Fatalf("URL order not preserved: %#v", conf.JWKSURLs)
 	}
 }
 
@@ -1114,7 +1155,7 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_url":    []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_urls":   []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
 				"jwks_ca_pem": cert,
 			},
 		}
@@ -1137,7 +1178,7 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 			Path:      configPath,
 			Storage:   storage,
 			Data: map[string]any{
-				"jwks_url":             []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
+				"jwks_urls":            []string{s.server.URL + "/certs_missing", s.server.URL + "/certs"},
 				"jwks_ca_pem":          cert,
 				"skip_jwks_validation": true,
 			},
@@ -1153,21 +1194,21 @@ func TestConfig_JWKS_MultiURL_SkipValidation(t *testing.T) {
 		if len(resp.Warnings) == 0 {
 			t.Fatal("expected at least one verification warning")
 		}
-		if !strings.Contains(resp.Warnings[0], "jwks_url[0]") {
-			t.Fatalf("expected warning to reference jwks_url[0], got: %v", resp.Warnings)
+		if !strings.Contains(resp.Warnings[0], "jwks_urls[0]") {
+			t.Fatalf("expected warning to reference jwks_urls[0], got: %v", resp.Warnings)
 		}
 
 		conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(conf.JWKSURL) != 2 {
-			t.Fatalf("expected 2 URLs to be saved, got %d", len(conf.JWKSURL))
+		if len(conf.JWKSURLs) != 2 {
+			t.Fatalf("expected 2 URLs to be saved, got %d", len(conf.JWKSURLs))
 		}
 	})
 }
 
-func TestConfig_JWKSURL_LegacyStringStorage(t *testing.T) {
+func TestConfig_JWKSURLs_LegacyStringStorage(t *testing.T) {
 	b, storage := getBackend(t)
 
 	// A legacy config stored "jwks_url" as a single string; it must still decode.
@@ -1187,8 +1228,11 @@ func TestConfig_JWKSURL_LegacyStringStorage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(conf.JWKSURL, []string{"https://example.com/certs"}) {
-		t.Fatalf("expected legacy single-string jwks_url to decode as a list, got: %#v", conf.JWKSURL)
+	if !reflect.DeepEqual(conf.JWKSURLs, []string{"https://example.com/certs"}) {
+		t.Fatalf("expected legacy single-string jwks_url to migrate to a list, got: %#v", conf.JWKSURLs)
+	}
+	if conf.DeprecatedJWKSURL != "" {
+		t.Fatalf("expected deprecated jwks_url to be cleared after migration, got: %q", conf.DeprecatedJWKSURL)
 	}
 
 	req := &logical.Request{
@@ -1201,12 +1245,41 @@ func TestConfig_JWKSURL_LegacyStringStorage(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
-	if got := resp.Data["jwks_url"]; !reflect.DeepEqual(got, []string{"https://example.com/certs"}) {
-		t.Fatalf("expected read to return jwks_url list, got: %#v", got)
+	if got := resp.Data["jwks_urls"]; !reflect.DeepEqual(got, []string{"https://example.com/certs"}) {
+		t.Fatalf("expected read to return jwks_urls list, got: %#v", got)
+	}
+	if _, ok := resp.Data["jwks_url"]; ok {
+		t.Fatal("expected read not to return deprecated jwks_url")
 	}
 }
 
-func TestConfig_JWKSURL_LegacyEmptyStorage(t *testing.T) {
+func TestConfig_JWKSURLs_StoragePrefersNewValue(t *testing.T) {
+	b, storage := getBackend(t)
+
+	entry := &logical.StorageEntry{
+		Key: configPath,
+		Value: []byte(`{
+			"jwks_url": "https://example.com/old-certs",
+			"jwks_urls": ["https://example.com/new-certs"]
+		}`),
+	}
+	if err := storage.Put(t.Context(), entry); err != nil {
+		t.Fatal(err)
+	}
+
+	conf, err := b.(*jwtAuthBackend).config(t.Context(), storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(conf.JWKSURLs, []string{"https://example.com/new-certs"}) {
+		t.Fatalf("expected existing jwks_urls to be preserved, got: %#v", conf.JWKSURLs)
+	}
+	if conf.DeprecatedJWKSURL != "" {
+		t.Fatalf("expected deprecated jwks_url to be cleared, got: %q", conf.DeprecatedJWKSURL)
+	}
+}
+
+func TestConfig_JWKSURLs_LegacyEmptyStorage(t *testing.T) {
 	// A legacy config could store an empty "jwks_url" string, which must not
 	// be treated as a JWKS configuration after upgrade.
 	tests := map[string]string{
@@ -1251,8 +1324,8 @@ func TestConfig_JWKSURL_LegacyEmptyStorage(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(conf.JWKSURL) != 0 {
-				t.Fatalf("expected zero-length JWKSURL, got: %#v", conf.JWKSURL)
+			if len(conf.JWKSURLs) != 0 {
+				t.Fatalf("expected zero-length JWKSURLs, got: %#v", conf.JWKSURLs)
 			}
 			if conf.authType() == JWKS {
 				t.Fatal("expected config not to be classified as JWKS")

--- a/internal/builtin/credential/jwt/path_login_test.go
+++ b/internal/builtin/credential/jwt/path_login_test.go
@@ -1748,7 +1748,7 @@ func TestLogin_MultiJWKSURL(t *testing.T) {
 		// The first JWKS endpoint serves a valid but wrong key; the second
 		// serves the key that matches the signing key.
 		data := map[string]any{
-			"jwks_urls":   []string{p.server.URL + "/certs_wrong", p.server.URL + "/certs"},
+			"jwks_url":    []string{p.server.URL + "/certs_wrong", p.server.URL + "/certs"},
 			"jwks_ca_pem": cert,
 		}
 
@@ -1779,7 +1779,7 @@ func TestLogin_MultiJWKSURL(t *testing.T) {
 		b, storage, p, cert := newBackend(t)
 
 		data := map[string]any{
-			"jwks_urls":   []string{p.server.URL + "/certs_wrong"},
+			"jwks_url":    []string{p.server.URL + "/certs_wrong"},
 			"jwks_ca_pem": cert,
 		}
 

--- a/internal/builtin/credential/jwt/path_login_test.go
+++ b/internal/builtin/credential/jwt/path_login_test.go
@@ -1661,6 +1661,152 @@ func TestResolveRole_RoleDoesNotExist(t *testing.T) {
 	}
 }
 
+func TestLogin_JWKSPairs(t *testing.T) {
+	newBackend := func(t *testing.T) (logical.Backend, logical.Storage, *oidcProvider, string) {
+		b, storage := getBackend(t)
+		p := newOIDCProvider(t)
+		t.Cleanup(p.server.Close)
+
+		cert, err := p.getTLSCert()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return b, storage, p, cert
+	}
+
+	createRole := func(t *testing.T, b logical.Backend, storage logical.Storage) {
+		data := map[string]any{
+			"role_type":       "jwt",
+			"bound_subject":   "r3qXcK2bix9eFECzsU3Sbmh0K16fatW6@clients",
+			"bound_audiences": []string{"https://vault.plugin.auth.jwt.test"},
+			"user_claim":      "https://vault/user",
+			"groups_claim":    "https://vault/groups",
+			"policies":        "test",
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/plugin-test",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+	}
+
+	loginRequest := func(t *testing.T, b logical.Backend, storage logical.Storage, jwtData string) *logical.Response {
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "login",
+			Storage:   storage,
+			Data: map[string]any{
+				"role": "plugin-test",
+				"jwt":  jwtData,
+			},
+			Connection: &logical.Connection{
+				RemoteAddr: "127.0.0.1",
+			},
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("got nil response")
+		}
+		return resp
+	}
+
+	signJWT := func(t *testing.T) string {
+		cl := sqjwt.Claims{
+			Subject:   "r3qXcK2bix9eFECzsU3Sbmh0K16fatW6@clients",
+			Issuer:    "https://team-vault.auth0.com/",
+			NotBefore: sqjwt.NewNumericDate(time.Now().Add(-5 * time.Second)),
+			Audience:  sqjwt.Audience{"https://vault.plugin.auth.jwt.test"},
+		}
+
+		privateCl := struct {
+			User   string   `json:"https://vault/user"`
+			Groups []string `json:"https://vault/groups"`
+		}{
+			"jeff",
+			[]string{"foo", "bar"},
+		}
+
+		jwtData, _ := getTestJWT(t, ecdsaPrivKey, cl, privateCl)
+		return jwtData
+	}
+
+	t.Run("first pair fails signature, second succeeds", func(t *testing.T) {
+		b, storage, p, cert := newBackend(t)
+
+		// The first JWKS endpoint serves a valid but wrong key; the second
+		// serves the key that matches the signing key.
+		data := map[string]any{
+			"jwks_pairs": []map[string]any{
+				{"jwks_url": p.server.URL + "/certs_wrong", "jwks_ca_pem": cert},
+				{"jwks_url": p.server.URL + "/certs", "jwks_ca_pem": cert},
+			},
+		}
+
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		createRole(t, b, storage)
+
+		resp = loginRequest(t, b, storage, signJWT(t))
+		if resp.IsError() {
+			t.Fatalf("expected successful login via second JWKS endpoint, got: %v", resp.Error())
+		}
+		if resp.Auth == nil {
+			t.Fatal("expected auth response")
+		}
+	})
+
+	t.Run("only wrong key fails", func(t *testing.T) {
+		b, storage, p, cert := newBackend(t)
+
+		data := map[string]any{
+			"jwks_pairs": []map[string]any{
+				{"jwks_url": p.server.URL + "/certs_wrong", "jwks_ca_pem": cert},
+			},
+		}
+
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(t.Context(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		createRole(t, b, storage)
+
+		resp = loginRequest(t, b, storage, signJWT(t))
+		if !resp.IsError() {
+			t.Fatal("expected login to fail when no pair holds the matching key")
+		}
+	})
+}
+
 const (
 	ecdsaPrivKey string = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIKfldwWLPYsHjRL9EVTsjSbzTtcGRu6icohNfIqcb6A+oAoGCCqGSM49

--- a/internal/builtin/credential/jwt/path_login_test.go
+++ b/internal/builtin/credential/jwt/path_login_test.go
@@ -1661,7 +1661,7 @@ func TestResolveRole_RoleDoesNotExist(t *testing.T) {
 	}
 }
 
-func TestLogin_JWKSPairs(t *testing.T) {
+func TestLogin_MultiJWKSURL(t *testing.T) {
 	newBackend := func(t *testing.T) (logical.Backend, logical.Storage, *oidcProvider, string) {
 		b, storage := getBackend(t)
 		p := newOIDCProvider(t)
@@ -1742,16 +1742,14 @@ func TestLogin_JWKSPairs(t *testing.T) {
 		return jwtData
 	}
 
-	t.Run("first pair fails signature, second succeeds", func(t *testing.T) {
+	t.Run("first URL fails signature, second succeeds", func(t *testing.T) {
 		b, storage, p, cert := newBackend(t)
 
 		// The first JWKS endpoint serves a valid but wrong key; the second
 		// serves the key that matches the signing key.
 		data := map[string]any{
-			"jwks_pairs": []map[string]any{
-				{"jwks_url": p.server.URL + "/certs_wrong", "jwks_ca_pem": cert},
-				{"jwks_url": p.server.URL + "/certs", "jwks_ca_pem": cert},
-			},
+			"jwks_url":    []string{p.server.URL + "/certs_wrong", p.server.URL + "/certs"},
+			"jwks_ca_pem": cert,
 		}
 
 		req := &logical.Request{
@@ -1770,20 +1768,19 @@ func TestLogin_JWKSPairs(t *testing.T) {
 
 		resp = loginRequest(t, b, storage, signJWT(t))
 		if resp.IsError() {
-			t.Fatalf("expected successful login via second JWKS endpoint, got: %v", resp.Error())
+			t.Fatalf("expected successful login via second JWKS URL, got: %v", resp.Error())
 		}
 		if resp.Auth == nil {
 			t.Fatal("expected auth response")
 		}
 	})
 
-	t.Run("only wrong key fails", func(t *testing.T) {
+	t.Run("single URL with wrong key fails", func(t *testing.T) {
 		b, storage, p, cert := newBackend(t)
 
 		data := map[string]any{
-			"jwks_pairs": []map[string]any{
-				{"jwks_url": p.server.URL + "/certs_wrong", "jwks_ca_pem": cert},
-			},
+			"jwks_url":    []string{p.server.URL + "/certs_wrong"},
+			"jwks_ca_pem": cert,
 		}
 
 		req := &logical.Request{
@@ -1802,7 +1799,7 @@ func TestLogin_JWKSPairs(t *testing.T) {
 
 		resp = loginRequest(t, b, storage, signJWT(t))
 		if !resp.IsError() {
-			t.Fatal("expected login to fail when no pair holds the matching key")
+			t.Fatal("expected login to fail when no JWKS URL holds the matching key")
 		}
 	})
 }

--- a/internal/builtin/credential/jwt/path_login_test.go
+++ b/internal/builtin/credential/jwt/path_login_test.go
@@ -1748,7 +1748,7 @@ func TestLogin_MultiJWKSURL(t *testing.T) {
 		// The first JWKS endpoint serves a valid but wrong key; the second
 		// serves the key that matches the signing key.
 		data := map[string]any{
-			"jwks_url":    []string{p.server.URL + "/certs_wrong", p.server.URL + "/certs"},
+			"jwks_urls":   []string{p.server.URL + "/certs_wrong", p.server.URL + "/certs"},
 			"jwks_ca_pem": cert,
 		}
 
@@ -1779,7 +1779,7 @@ func TestLogin_MultiJWKSURL(t *testing.T) {
 		b, storage, p, cert := newBackend(t)
 
 		data := map[string]any{
-			"jwks_url":    []string{p.server.URL + "/certs_wrong"},
+			"jwks_urls":   []string{p.server.URL + "/certs_wrong"},
 			"jwks_ca_pem": cert,
 		}
 

--- a/internal/builtin/credential/jwt/path_oidc_test.go
+++ b/internal/builtin/credential/jwt/path_oidc_test.go
@@ -1613,6 +1613,12 @@ func (o *oidcProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			o.t.Fatal(err)
 		}
+	case "/certs_wrong":
+		a := getTestJWKS(o.t, privateKeyToPublicKeyPEM(o.t, badPrivKey))
+		_, err := w.Write(a)
+		if err != nil {
+			o.t.Fatal(err)
+		}
 	case "/certs_missing":
 		w.WriteHeader(404)
 	case "/certs_invalid":
@@ -1740,6 +1746,28 @@ func getQueryParam(t *testing.T, inputURL, param string) string {
 		t.Fatalf("query param %q not found", param)
 	}
 	return v[0]
+}
+
+// privateKeyToPublicKeyPEM derives the PEM-encoded public key from a
+// PEM-encoded EC private key.
+func privateKeyToPublicKeyPEM(t *testing.T, privKey string) string {
+	t.Helper()
+
+	block, _ := pem.Decode([]byte(privKey))
+	if block == nil {
+		t.Fatal("unable to decode private key")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}))
 }
 
 // getTestJWKS converts a pem-encoded public key into JWKS data suitable

--- a/internal/builtin/credential/jwt/provider_kubernetes.go
+++ b/internal/builtin/credential/jwt/provider_kubernetes.go
@@ -46,7 +46,7 @@ func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error 
 	}
 
 	if len(jc.JWKSURLs) != 0 {
-		return errors.New("jwks_urls must not be set when using the kubernetes provider")
+		return errors.New("jwks_url must not be set when using the kubernetes provider")
 	}
 
 	if jc.JWKSCAPEM != "" {

--- a/internal/builtin/credential/jwt/provider_kubernetes.go
+++ b/internal/builtin/credential/jwt/provider_kubernetes.go
@@ -45,7 +45,7 @@ func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error 
 		return errors.New("oidc_discovery_ca_pem must not be set when using the kubernetes provider")
 	}
 
-	if jc.JWKSURL != "" {
+	if len(jc.JWKSURL) != 0 {
 		return errors.New("jwks_url must not be set when using the kubernetes provider")
 	}
 

--- a/internal/builtin/credential/jwt/provider_kubernetes.go
+++ b/internal/builtin/credential/jwt/provider_kubernetes.go
@@ -45,8 +45,8 @@ func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error 
 		return errors.New("oidc_discovery_ca_pem must not be set when using the kubernetes provider")
 	}
 
-	if len(jc.JWKSURL) != 0 {
-		return errors.New("jwks_url must not be set when using the kubernetes provider")
+	if len(jc.JWKSURLs) != 0 {
+		return errors.New("jwks_urls must not be set when using the kubernetes provider")
 	}
 
 	if jc.JWKSCAPEM != "" {

--- a/website/content/docs/api/auth/jwt.mdx
+++ b/website/content/docs/api/auth/jwt.mdx
@@ -35,7 +35,7 @@ set.
 - `oidc_response_types` `(comma-separated string, or array of strings: <optional>)` - The response types to request. Allowed values are "code" and "id_token". Defaults to "code".
   Note: "id_token" may only be used if "oidc_response_mode" is set to "form_post".
 - `jwks_url` `(comma-separated string, or array of strings: <optional>)` - JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
-- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. The same CA trust material is used for all configured `jwks_url` values. If not set, system certificates are used.
+- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates, which are shared across all `jwks_url` values. If not set, system certificates are used.
 - `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.

--- a/website/content/docs/api/auth/jwt.mdx
+++ b/website/content/docs/api/auth/jwt.mdx
@@ -18,7 +18,7 @@ at any location, please update your API calls accordingly.
 ## Configure
 
 Configures the validation information to be used globally across all roles. One
-(and only one) of `oidc_discovery_url`, `jwks_url`, and `jwt_validation_pubkeys` must be
+(and only one) of `oidc_discovery_url`, `jwks_url`, `jwks_pairs`, and `jwt_validation_pubkeys` must be
 set.
 
 | Method | Path               |
@@ -34,16 +34,17 @@ set.
 - `oidc_response_mode` `(string: <optional>)` <a name="oidc_response_mode"></a> - The response mode to be used in the OAuth2 request. Allowed values are "query" and "form_post". Defaults to "query".
 - `oidc_response_types` `(comma-separated string, or array of strings: <optional>)` - The response types to request. Allowed values are "code" and "id_token". Defaults to "code".
   Note: "id_token" may only be used if "oidc_response_mode" is set to "form_post".
-- `jwks_url` `(string: <optional>)` - JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
-- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.
+- `jwks_url` `(string: <optional>)` - JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url", "jwks_pairs", or "jwt_validation_pubkeys".
+- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used. Cannot be used with "jwks_pairs".
+- `jwks_pairs` `(list of JSON object: <optional>)` - List of JWKS URL and optional CA certificate pairs. CA certificates must be in PEM format. Must be a list of JSON objects with format `[{"jwks_url": "", "jwks_ca_pem": ""}]`. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "jwks_url" or "jwks_ca_pem".
 - `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
-- `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
+- `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT. Cannot be configured when `jwks_pairs` is set.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth, IBM ISAM. The options are described in each provider's section in [OIDC Provider Setup](../../auth/jwt/oidc-providers/index.mdx).
 - `override_allowed_server_names` `(comma-separated string, or array of strings: <optional>)` - A list of hostnames to accept when performing TLS validation, which applies both to OIDC and JWKS. This overrides default checks that expect the TLS subject to match the hostname specified in the connection URL.
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in OpenBao and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
-- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url` or `jwks_url` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
+- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url`, `jwks_url`, or `jwks_pairs` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
 
 ### Sample payload
 

--- a/website/content/docs/api/auth/jwt.mdx
+++ b/website/content/docs/api/auth/jwt.mdx
@@ -18,9 +18,9 @@ at any location, please update your API calls accordingly.
 ## Configure
 
 Configures the validation information to be used globally across all roles. One
-(and only one) of `oidc_discovery_url`, `jwks_urls`, and `jwt_validation_pubkeys` must be
-set. The deprecated `jwks_url` parameter is accepted as a single-URL alias for
-`jwks_urls`.
+(and only one) of `oidc_discovery_url`, `jwks_url`, and `jwt_validation_pubkeys` must be
+set. The `jwks_url` parameter accepts a single URL, a comma-separated string of
+URLs, or an array of strings.
 
 | Method | Path               |
 | :----- | :----------------- |
@@ -28,24 +28,28 @@ set. The deprecated `jwks_url` parameter is accepted as a single-URL alias for
 
 ### Parameters
 
-- `oidc_discovery_url` `(string: <optional>)` - The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url", "jwks_urls", or "jwt_validation_pubkeys".
+- `oidc_discovery_url` `(string: <optional>)` - The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".
 - `oidc_discovery_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used.
 - `oidc_client_id` `(string: <optional>)` - The OAuth Client ID from the provider for OIDC roles.
 - `oidc_client_secret` `(string: <optional>)` - The OAuth Client Secret from the provider for OIDC roles.
 - `oidc_response_mode` `(string: <optional>)` <a name="oidc_response_mode"></a> - The response mode to be used in the OAuth2 request. Allowed values are "query" and "form_post". Defaults to "query".
 - `oidc_response_types` `(comma-separated string, or array of strings: <optional>)` - The response types to request. Allowed values are "code" and "id_token". Defaults to "code".
   Note: "id_token" may only be used if "oidc_response_mode" is set to "form_post".
-- `jwks_url` `(string: <optional>)` - Deprecated alias for `jwks_urls` that accepts a single JWKS URL. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
-- `jwks_urls` `(comma-separated string, or array of strings: <optional>)` - JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
-- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates, which are shared across all `jwks_urls` values. If not set, system certificates are used.
-- `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url", "jwks_urls", or "oidc_discovery_url".
+- `jwks_url` `(string, comma-separated string, or array of strings: <optional>)` - A JWKS URL or list of JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys". GET requests return the configured URLs as an array.
+- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates, which are shared across all `jwks_url` values. If not set, system certificates are used.
+- `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth, IBM ISAM. The options are described in each provider's section in [OIDC Provider Setup](../../auth/jwt/oidc-providers/index.mdx).
 - `override_allowed_server_names` `(comma-separated string, or array of strings: <optional>)` - A list of hostnames to accept when performing TLS validation, which applies both to OIDC and JWKS. This overrides default checks that expect the TLS subject to match the hostname specified in the connection URL.
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in OpenBao and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
-- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url`, `jwks_url`, or `jwks_urls` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
+- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url` or `jwks_url` is specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
+
+The multi-value `jwks_url` form supports the same migration use case as Vault's
+`jwks_pairs` feature: trusting multiple JWKS endpoints from one JWT auth mount.
+OpenBao continues to use one shared `jwks_ca_pem` bundle for all configured
+endpoints rather than configuring a separate CA pair for each endpoint.
 
 ### Sample payload
 

--- a/website/content/docs/api/auth/jwt.mdx
+++ b/website/content/docs/api/auth/jwt.mdx
@@ -18,7 +18,7 @@ at any location, please update your API calls accordingly.
 ## Configure
 
 Configures the validation information to be used globally across all roles. One
-(and only one) of `oidc_discovery_url`, `jwks_url`, `jwks_pairs`, and `jwt_validation_pubkeys` must be
+(and only one) of `oidc_discovery_url`, `jwks_url`, and `jwt_validation_pubkeys` must be
 set.
 
 | Method | Path               |
@@ -34,17 +34,16 @@ set.
 - `oidc_response_mode` `(string: <optional>)` <a name="oidc_response_mode"></a> - The response mode to be used in the OAuth2 request. Allowed values are "query" and "form_post". Defaults to "query".
 - `oidc_response_types` `(comma-separated string, or array of strings: <optional>)` - The response types to request. Allowed values are "code" and "id_token". Defaults to "code".
   Note: "id_token" may only be used if "oidc_response_mode" is set to "form_post".
-- `jwks_url` `(string: <optional>)` - JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url", "jwks_pairs", or "jwt_validation_pubkeys".
-- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used. Cannot be used with "jwks_pairs".
-- `jwks_pairs` `(list of JSON object: <optional>)` - List of JWKS URL and optional CA certificate pairs. CA certificates must be in PEM format. Must be a list of JSON objects with format `[{"jwks_url": "", "jwks_ca_pem": ""}]`. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "jwks_url" or "jwks_ca_pem".
+- `jwks_url` `(comma-separated string, or array of strings: <optional>)` - JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
+- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. The same CA trust material is used for all configured `jwks_url` values. If not set, system certificates are used.
 - `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
-- `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT. Cannot be configured when `jwks_pairs` is set.
+- `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth, IBM ISAM. The options are described in each provider's section in [OIDC Provider Setup](../../auth/jwt/oidc-providers/index.mdx).
 - `override_allowed_server_names` `(comma-separated string, or array of strings: <optional>)` - A list of hostnames to accept when performing TLS validation, which applies both to OIDC and JWKS. This overrides default checks that expect the TLS subject to match the hostname specified in the connection URL.
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in OpenBao and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
-- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url`, `jwks_url`, or `jwks_pairs` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
+- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url` or `jwks_url` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
 
 ### Sample payload
 

--- a/website/content/docs/api/auth/jwt.mdx
+++ b/website/content/docs/api/auth/jwt.mdx
@@ -18,8 +18,9 @@ at any location, please update your API calls accordingly.
 ## Configure
 
 Configures the validation information to be used globally across all roles. One
-(and only one) of `oidc_discovery_url`, `jwks_url`, and `jwt_validation_pubkeys` must be
-set.
+(and only one) of `oidc_discovery_url`, `jwks_urls`, and `jwt_validation_pubkeys` must be
+set. The deprecated `jwks_url` parameter is accepted as a single-URL alias for
+`jwks_urls`.
 
 | Method | Path               |
 | :----- | :----------------- |
@@ -27,23 +28,24 @@ set.
 
 ### Parameters
 
-- `oidc_discovery_url` `(string: <optional>)` - The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url" or "jwt_validation_pubkeys".
+- `oidc_discovery_url` `(string: <optional>)` - The base URL of the OIDC Discovery URL without ".well-known/openid-configuration" component. Cannot be used with "jwks_url", "jwks_urls", or "jwt_validation_pubkeys".
 - `oidc_discovery_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used.
 - `oidc_client_id` `(string: <optional>)` - The OAuth Client ID from the provider for OIDC roles.
 - `oidc_client_secret` `(string: <optional>)` - The OAuth Client Secret from the provider for OIDC roles.
 - `oidc_response_mode` `(string: <optional>)` <a name="oidc_response_mode"></a> - The response mode to be used in the OAuth2 request. Allowed values are "query" and "form_post". Defaults to "query".
 - `oidc_response_types` `(comma-separated string, or array of strings: <optional>)` - The response types to request. Allowed values are "code" and "id_token". Defaults to "code".
   Note: "id_token" may only be used if "oidc_response_mode" is set to "form_post".
-- `jwks_url` `(comma-separated string, or array of strings: <optional>)` - JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
-- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates, which are shared across all `jwks_url` values. If not set, system certificates are used.
-- `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
+- `jwks_url` `(string: <optional>)` - Deprecated alias for `jwks_urls` that accepts a single JWKS URL. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
+- `jwks_urls` `(comma-separated string, or array of strings: <optional>)` - JWKS URLs to use to authenticate signatures. During login, the JWT signature is verified against each JWKS in the order configured until a match is found. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
+- `jwks_ca_pem` `(string: <optional>)` - The contents of a CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URLs. May contain multiple concatenated CA certificates, which are shared across all `jwks_urls` values. If not set, system certificates are used.
+- `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url", "jwks_urls", or "oidc_discovery_url".
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/cap/blob/main/jwt/algs.go) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google, SecureAuth, IBM ISAM. The options are described in each provider's section in [OIDC Provider Setup](../../auth/jwt/oidc-providers/index.mdx).
 - `override_allowed_server_names` `(comma-separated string, or array of strings: <optional>)` - A list of hostnames to accept when performing TLS validation, which applies both to OIDC and JWKS. This overrides default checks that expect the TLS subject to match the hostname specified in the connection URL.
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in OpenBao and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
-- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url` or `jwks_url` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
+- `skip_jwks_validation` `(bool: false)` - When `true` and `oidc_discovery_url`, `jwks_url`, or `jwks_urls` are specified, if the connection fails to load, a warning will be issued and status can be checked later by reading the config endpoint. When `false`, configuration save will fail if issuer validation cannot complete successfully.
 
 ### Sample payload
 


### PR DESCRIPTION
## Description

The JWT auth method now supports multiple JWKS endpoints through the existing `jwks_url` configuration parameter.

`jwks_url` now uses `TypeCommaStringSlice`, so existing single-string configurations continue to work, while comma-separated strings and string arrays can be used to configure multiple endpoints.

During login, the configured JWKS endpoints are checked in order until one contains a key that verifies the JWT signature.

Internally, the configuration represents the URLs using `JWKSURLs`. Existing stored configurations containing a single `jwks_url` remain compatible and are handled as a list internally.

Configuration reads return `jwks_url` as a string array, including when only one endpoint is configured.

The existing `jwks_ca_pem` setting remains a shared CA bundle for all configured JWKS endpoints and continues to support concatenated PEM certificates.

## Rationale

Some deployments need a single JWT auth mount to validate tokens from multiple Kubernetes clusters or other JWKS providers.

Allowing multiple values through the existing `jwks_url` parameter avoids adding another public configuration field while preserving compatibility with existing single-URL configurations.

This also covers the Vault `jwks_pairs` migration use case where multiple JWKS endpoints need to be trusted from one auth mount. OpenBao continues to use a shared `jwks_ca_pem` bundle rather than configuring a separate CA for each endpoint.

Resolves: #3761

## Testing

* Single-string `jwks_url`
* Comma-separated `jwks_url`
* String-array `jwks_url`
* Configuration reads returning `jwks_url` as an array
* Multiple JWKS endpoints with order preservation
* Login succeeding when a later JWKS endpoint contains the matching key
* Login failing when no configured JWKS endpoint matches
* `skip_jwks_validation`
* Legacy single-string storage compatibility

```text
go test ./internal/builtin/credential/jwt -run 'TestConfig_|TestLogin_MultiJWKSURL' -count=1
go vet ./internal/builtin/credential/jwt
```

The full JWT package test still has the existing Windows-specific failure in `TestOIDC_Callback/no_response_from_provider`, caused by the platform-specific connection-refused error wording.

## Acknowledgements

- [x] By contributing this change, I certify I have not used generative AI
  (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
  filling out the pull request description or associated issue.
- [x] By contributing this change, I certify I have signed-off on the
  [DCO ownership](https://developercertificate.org/) statement
  and this change did not use post-BUSL-licensed code from HashiCorp.
  Existing MPL-licensed code is still allowed, subject to attribution.
  Code authored by yourself and submitted to HashiCorp for inclusion is
  also allowed.