### PR TITLE
Fix malformed Packages.gz, fix GOARM in nFPM

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -46,14 +46,33 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSWORD }}
 
-      - name: Install reprepro from Debian experimental
+      # This installs reprepro from source to pin it to a version that we know
+      # works given our constraints:
+      #
+      # - Versions lower than 5.4.0 don't support "Limit: 0"
+      # - Version 5.5.1 (latest as of writing this comment) creates bad gzip
+      #   outputs (See https://github.com/openbao/openbao/issues/3799)
+      #
+      # Debian/Ubuntu only distribute versions within 5.3.x and 5.5.x across
+      # stable and unstable repos at this time, and this is the quickest exit
+      # out of dependency hell.
+      - name: Install reprepro
+        env:
+          REPREPRO_VERSION: 5.4.8
+          REPREPRO_SHA256: 4a55ecabb962d11aa32553606b2ff4449dad6c673e4cd0e0741cd8b992a1b1a3
         run: |
-          sudo apt update && sudo apt install -y debian-archive-keyring
-          # Required for reprepro with "Limit" support.
-          echo "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://ftp.debian.org/debian experimental main" | sudo tee /etc/apt/sources.list.d/debian-experimental.list > /dev/null
-          # Required for libgpgme45 >= 1.23.2.
-          echo "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://ftp.debian.org/debian sid main" | sudo tee /etc/apt/sources.list.d/debian-trixie.list > /dev/null
-          sudo apt update && sudo apt install -t experimental -y reprepro
+          cd "$(mktemp -d)"
+          sudo apt install -y libarchive-dev libgpgme-dev libdb-dev
+          SOURCE="reprepro-reprepro-${REPREPRO_VERSION}"
+          ARCHIVE="${SOURCE}.tar.gz"
+          curl -LO \
+            "https://salsa.debian.org/debian/reprepro/-/archive/reprepro-${REPREPRO_VERSION}/${ARCHIVE}" \
+            && sha256sum -c - <<< "${REPREPRO_SHA256}  ${ARCHIVE}" \
+            && tar xvf "$ARCHIVE" && cd "$SOURCE"
+          ./autogen.sh
+          ./configure
+          make -j$(nproc)
+          sudo make install
 
       - name: Download db and dists
         run: |

--- a/scripts/release/nfpm.sh
+++ b/scripts/release/nfpm.sh
@@ -28,6 +28,13 @@ case "${NFPM_PACKAGER}" in
         exit 1
 esac
 
+# nFPM mostly takes GOOS/GOARCH as-is but has no GOARM equivalent, which must
+# effectively be appended to GOARCH. Note that nFPM will *happily* take a plain
+# GOARCH=arm and produce complete nonsense that no downstream tool can work
+# with, so removing this line won't break here but later.
+# Also see: https://nfpm.goreleaser.com/docs/arch-mapping
+export GOARCH="${GOARCH}${GOARM}"
+
 nfpm package \
     --config ./.release/nfpm.yaml \
     --packager "$NFPM_PACKAGER" \


### PR DESCRIPTION
## Description

This has two fixes:

1. Propagate GOARM to nFPM, I missed this initially because the documentation was rather conflicting. No need to backport this, it's unreleased.
2. Fix https://github.com/openbao/openbao/issues/3799 and the associated dependency hell. I also verified that publishing a new release via reprepro 5.4.8 fixes up bad `Package.gz` files previously pushed by 5.5.1 without data loss, which saves us a ton of trouble. This part needs backporting to v2.6.x.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3799

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
