### PR TITLE
Ensure signatures are verified on creation

### DIFF
--- a/scripts/release/checksums.sh
+++ b/scripts/release/checksums.sh
@@ -2,6 +2,8 @@
 
 # This script creates a checksums.txt for all artifacts in dist/ and signs the
 # checksums via cosign and gpg.
+#
+# We verify each signature after creation to ensure it is valid.
 
 set -euo pipefail
 
@@ -19,6 +21,12 @@ cosign sign-blob \
     --bundle=checksums.txt.sigstore.json \
     checksums.txt
 
+cosign verify-blob \
+    --bundle=checksums.txt.sigstore.json \
+    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+    --certificate-identity-regexp='https://github.com/openbao/openbao/.github/workflows/release.yml@refs/heads/(main|release/)' \
+    checksums.txt
+
 # Sign with gpg:
 gpg \
     --batch \
@@ -26,3 +34,9 @@ gpg \
     --default-key="$GPG_FINGERPRINT" \
     --output=checksums.txt.gpgsig \
     checksums.txt <<< "$GPG_PASSWORD"
+
+gpg \
+    --batch\
+    --verify \
+    checksums.txt.gpgsig \
+    checksums.txt

--- a/scripts/release/sign.sh
+++ b/scripts/release/sign.sh
@@ -3,6 +3,8 @@
 # This script signs release artifacts (Tarballs with binaries, Linux packages,
 # SBOMs) via cosign and gpg. Checksums are separately signed as part of
 # checksums.sh.
+#
+# We verify each signature after creation to ensure it is valid.
 
 set -euo pipefail
 
@@ -20,6 +22,12 @@ while read -r f; do
         --default-key="$GPG_FINGERPRINT" \
         --output="${f}.gpgsig" \
         "$f" <<< "$GPG_PASSWORD"
+
+    gpg \
+        --batch\
+        --verify \
+        "${f}.gpgsig" \
+        "$f"
 done <<< "$artifacts"
 
 echo "Signing w/ cosign..."
@@ -28,5 +36,11 @@ while read -r f; do
     cosign sign-blob \
         --yes \
         --bundle="${f}.sigstore.json" \
+        "$f"
+
+    cosign verify-blob \
+        --bundle="${f}.sigstore.json" \
+        --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+        --certificate-identity-regexp='https://github.com/openbao/openbao/.github/workflows/release.yml@refs/heads/(main|release/)' \
         "$f"
 done <<< "$artifacts"

--- a/website/content/community/policies/release.mdx
+++ b/website/content/community/policies/release.mdx
@@ -63,18 +63,16 @@ a better release process going forward.
        will stage a draft release on GitHub and upload release artifacts to it.
  - [ ] Spot-check stage-one release artifacts:
       - [ ] Binaries work.
-      - [ ] CoSign and GPG signatures on artifacts are valid.
 -  [ ] On failure, delete the draft release, merge necessary adjustments, and
        retry the above two steps.
  - [ ] Attach release notes to the release draft.
  - [ ] Publish the release draft. This pushes the release tag and triggers
        workflows to build & publish container images and to update repos hosted
-       on pkgs.openbao.org.
+       on `pkgs.openbao.org`. Check the box to create the discussion.
  - [ ] Spot-check stage-two release artifacts:
       - [ ] Container images work and have valid CoSign signatures.
  - [ ] Share release notification announcement:
       - [ ] OpenBao Core mailing list (cc TSC mailing list)
-      - [ ] GitHub Discussions
       - [ ] Link from Zulip
       - [ ] Mention in next community meeting & TSC meetings.
  - [ ] Publish any security advisory drafts fixed in this release.


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

This mirrors what Go does e.g., in crypto/x509, ensuring each certificate created has a valid signature by verifying it with the corresponding public key.

This should let us drop the corresponding entry out of the release scripts.


<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
