### PR TITLE
Control group authorization

### DIFF
--- a/internal/vault/control_group.go
+++ b/internal/vault/control_group.go
@@ -264,9 +264,20 @@ func (c *Core) addAuthorization(ctx context.Context, token string, approver *log
 
 	addingAuthorization := false
 	for i, factor := range cg.Factors {
-		identityGroups := factor.Identity.GroupNames
+		// For each group listed in the control group factor identity, get its ID
+		identityGroupIDs := []string{}
+		for _, name := range factor.Identity.GroupNames {
+			group, err := c.identityStore.MemDBGroupByName(ctx, name, false)
+			if err != nil {
+				return err
+			}
+			if group != nil {
+				identityGroupIDs = append(identityGroupIDs, group.ID)
+			}
+		}
+
 		for _, group := range approver.GroupAliases {
-			if slices.Contains(identityGroups, group.Name) {
+			if slices.Contains(identityGroupIDs, group.ID) {
 				// make sure token doesn't have same identity as approver
 				if !cg.SelfAuthorizationAllowed && originalEntity.ID == approver.EntityID {
 					return fmt.Errorf("token owner cannot be approver")
@@ -403,9 +414,10 @@ func (c *Core) handleControlGroupAuthorize(ctx context.Context, req *logical.Req
 	authorizerGroupAliases := []*logical.Alias{}
 	for _, group := range authorizerGroups {
 		authorizerGroupAliases = append(authorizerGroupAliases, &logical.Alias{
-			Name: group.Name,
+			ID: group.ID,
 		})
 	}
+
 	authorizerAuth := logical.Auth{
 		EntityID:     authorizerIdentity.GetID(),
 		DisplayName:  authorizerToken.DisplayName,

--- a/internal/vault/control_group.go
+++ b/internal/vault/control_group.go
@@ -393,10 +393,13 @@ func (c *Core) handleControlGroupAuthorize(ctx context.Context, req *logical.Req
 	if authorizerToken == nil {
 		return nil, &logical.StatusBadRequest{Err: "missing auth"}
 	}
-	authorizerGroups, err := c.identityStore.MemDBGroupsByMemberEntityID(ctx, authorizerToken.EntityID, false, false)
+
+	groups, inheritedGroups, err := c.identityStore.GroupsByEntityID(ctx, authorizerToken.EntityID)
 	if err != nil {
 		return nil, err
 	}
+	authorizerGroups := append(groups, inheritedGroups...)
+
 	authorizerGroupAliases := []*logical.Alias{}
 	for _, group := range authorizerGroups {
 		authorizerGroupAliases = append(authorizerGroupAliases, &logical.Alias{

--- a/internal/vault/control_group_test.go
+++ b/internal/vault/control_group_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/v2/internal/helper/identity"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/vault/policy"
 	"github.com/stretchr/testify/require"
@@ -136,6 +137,7 @@ func TestControlGroup_setControlGroup(t *testing.T) {
 
 func TestControlGroup_addAuthorization(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
+	i := c.identityStore
 
 	creationTime := time.Now()
 	wrappingTokenEntry := &logical.TokenEntry{
@@ -156,6 +158,19 @@ func TestControlGroup_addAuthorization(t *testing.T) {
 	require.NotEmpty(t, wrappingTokenEntry.ID)                          // id has been created
 	require.Empty(t, wrappingTokenEntry.InternalMeta["control_group"])  // no control group
 	require.Empty(t, wrappingTokenEntry.InternalMeta["request_entity"]) // no request data
+
+	// Create group for approver membership
+	secOpsGroup := identity.Group{
+		ID:          "secops-id",
+		Name:        "secops",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   i.EntityPacker(ctx).BucketKey("secops-id"),
+	}
+
+	txn := i.Txn(ctx, true)
+	err := i.MemDBUpsertGroupInTxn(txn, &secOpsGroup)
+	require.NoError(t, err)
+	txn.Commit()
 
 	cg := logical.ControlGroup{
 		TTL: time.Duration(14440),
@@ -190,7 +205,7 @@ func TestControlGroup_addAuthorization(t *testing.T) {
 	}
 
 	// Set control group in token
-	err := c.setControlGroupInTokenEntry(ctx, wrappingTokenEntry, &cg)
+	err = c.setControlGroupInTokenEntry(ctx, wrappingTokenEntry, &cg)
 	require.Nil(t, err)
 
 	// Set request entity in token
@@ -200,13 +215,14 @@ func TestControlGroup_addAuthorization(t *testing.T) {
 	// addAuthorzation
 	var groups []*logical.Alias
 	groups = append(groups, &logical.Alias{
-		Name: "secops",
+		ID: "secops-id",
 	})
 	auth := logical.Auth{
 		EntityID:     "approving-user-id",
 		DisplayName:  "user@example.com",
 		GroupAliases: groups,
 	}
+	// addAuthorization converts the control group factor identity group names to IDs.
 	err = c.addAuthorization(ctx, wrappingTokenEntry.ID, &auth)
 	require.Nil(t, err)
 
@@ -245,6 +261,7 @@ func TestControlGroup_addAuthorization(t *testing.T) {
 
 func TestControlGroup_validateControlGroup(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
+	i := c.identityStore
 
 	creationTime := time.Now()
 	te := &logical.TokenEntry{
@@ -308,11 +325,25 @@ func TestControlGroup_validateControlGroup(t *testing.T) {
 	err = c.setEntityInTokenEntry(ctx, te, &requestEntity)
 	require.Nil(t, err)
 
+	// Create group for approver membership
+	secOpsGroup := identity.Group{
+		ID:          "secops-id",
+		Name:        "secops",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   i.EntityPacker(ctx).BucketKey("secops-id"),
+	}
+
+	txn := i.Txn(ctx, true)
+	err = i.MemDBUpsertGroupInTxn(txn, &secOpsGroup)
+	require.NoError(t, err)
+	txn.Commit()
+
 	// addAuthorzation
 	var groups []*logical.Alias
 	groups = append(groups, &logical.Alias{
-		Name: "secops",
+		ID: "secops-id",
 	})
+
 	entityID, err := uuid.GenerateUUID()
 	require.Nil(t, err)
 	auth := logical.Auth{

--- a/internal/vault/token_store_test.go
+++ b/internal/vault/token_store_test.go
@@ -1031,14 +1031,6 @@ path "sys/control-group/request" {
 	err = c.setControlGroupInTokenEntry(ctx, wrapped, &cg)
 	require.Nil(t, err)
 
-	// addAuthorzation
-	var groups []*logical.Alias
-	groups = append(groups, &logical.Alias{
-		Name: "secops",
-	})
-	req.Auth = &logical.Auth{
-		GroupAliases: groups,
-	}
 	resp, err = c.HandleRequest(ctx, req)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1205,6 +1197,153 @@ path "sys/control-group/request" {
 	require.Nil(t, err)
 
 	require.Equal(t, true, resp.Data["approved"])
+}
+
+// Test the behaviour of control group accessor approvals across namespaces.
+func TestTokenStore_HandleRequest_ApproveAccessorCrossNamespace(t *testing.T) {
+	c := TestCoreWithConfig(t, &CoreConfig{
+		UnsafeCrossNamespaceIdentity: true,
+	})
+	c, _, _ = testCoreUnsealed(t, c)
+	ts := c.tokenStore
+	is := c.identityStore
+	ctx := namespace.RootContext(context.Background())
+
+	policyHCL := `
+path "sys/control-group/authorize" {
+  capabilities = ["update"]
+}
+
+path "sys/control-group/request" {
+  capabilities = ["update"]
+}
+`
+	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, policyHCL)
+	require.NoError(t, err)
+	pol.Name = "control-group-approver"
+	err = c.policyStore.SetPolicy(ctx, pol, nil)
+	require.NoError(t, err)
+
+	// Create a namespace.
+	TestCoreCreateNamespaces(t, c, &namespace.Namespace{Path: "abc"})
+	childNamespace, err := c.namespaceStore.GetNamespaceByPath(ctx, "abc/")
+	require.Nil(t, err)
+
+	// Alice is the requesting entity
+	requestingEntity := identity.Entity{
+		ID:          "alice-entity-id",
+		Name:        "alice",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   is.EntityPacker(ctx).BucketKey("alice-entity-id"),
+	}
+
+	// Bob is an invalid approver. He is in a group called "admin1", however this group
+	// is in the namespace "abc" - not the root namespace, where the control
+	// group policy is defined.
+	invalidApproverEntity := identity.Entity{
+		ID:          "bob-entity-id",
+		Name:        "bob",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   is.EntityPacker(ctx).BucketKey("bob-entity-id"),
+	}
+
+	namespaceAdminGroup := identity.Group{
+		ID:              "abc-admin1-id",
+		Name:            "admin1",
+		NamespaceID:     childNamespace.ID,
+		MemberEntityIDs: []string{"bob-entity-id"},
+		BucketKey:       is.EntityPacker(ctx).BucketKey("abc-admin1-id"),
+	}
+
+	// This is a root-level group called "admin1". It will be the control group factor.
+	rootAdminGroup := identity.Group{
+		ID:              "admin1-id",
+		Name:            "admin1",
+		NamespaceID:     namespace.RootNamespaceID,
+		MemberEntityIDs: []string{},
+		BucketKey:       is.EntityPacker(ctx).BucketKey("admin1-id"),
+	}
+
+	txn := is.Txn(ctx, true)
+	require.NoError(t, is.MemDBUpsertEntityInTxn(txn, &requestingEntity))
+	require.NoError(t, is.MemDBUpsertEntityInTxn(txn, &invalidApproverEntity))
+	require.NoError(t, is.MemDBUpsertGroupInTxn(txn, &rootAdminGroup))
+	require.NoError(t, is.MemDBUpsertGroupInTxn(txn, &namespaceAdminGroup))
+	txn.Commit()
+
+	// Alice tries to access a control-group gated KV path in the root namespace,
+	// and receives a wrapped token, and a wrapping accessor.
+
+	// The following constructs the wrapping accessor.
+
+	// Encode the `request`
+	req := logical.TestRequest(t, logical.ReadOperation, "kv/data/secret")
+	reqPb, err := pb.LogicalRequestToProtoRequest(req)
+	require.Nil(t, err)
+	reqPbBytes, err := proto.Marshal(reqPb)
+	require.Nil(t, err)
+	reqPbBytesEncoded := base64.StdEncoding.EncodeToString(reqPbBytes)
+
+	// Encode the `request_entity`
+	reqEntity, err := jsonutil.EncodeJSON(&requestingEntity)
+	require.Nil(t, err)
+
+	// Control Group
+	cg := logical.ControlGroup{
+		TTL: time.Second * 600,
+		Factors: []logical.ControlGroupFactor{
+			{
+				Name: "approvers",
+				Identity: logical.ControlGroupIdentity{
+					GroupNames: []string{"admin1"},
+					Approvals:  1,
+				},
+			},
+		},
+	}
+
+	cgEncoded, err := jsonutil.EncodeJSON(cg)
+	require.Nil(t, err)
+
+	te := logical.TokenEntry{
+		TTL:         time.Hour,
+		NamespaceID: namespace.RootNamespaceID,
+		InternalMeta: map[string]string{
+			"control_group":  string(cgEncoded),
+			"request":        reqPbBytesEncoded,
+			"request_entity": string(reqEntity),
+		},
+	}
+
+	testMakeTokenDirectly(t, ctx, ts, &te)
+
+	accessor, err := ts.Lookup(ctx, te.ID)
+	require.Nil(t, err)
+
+	// Attempt to authorize the wrapping accessor.
+
+	// Bob generates a token
+	tbob := logical.TokenEntry{
+		EntityID: "bob-entity-id",
+		Policies: []string{"control-group-approver"},
+		TTL:      time.Minute,
+	}
+	testMakeTokenDirectly(t, ctx, ts, &tbob)
+	approverBob, err := ts.Lookup(ctx, tbob.ID)
+	require.Nil(t, err)
+
+	// Bob makes a request to authorize the control group request
+	req = logical.TestRequest(t, logical.UpdateOperation, "sys/control-group/authorize")
+	req.Data = map[string]any{
+		"accessor": accessor.Accessor,
+	}
+	req.ClientToken = approverBob.ID
+
+	// Bob is not considered an approver for the "admin1" group in the root namespace.
+	resp, err := c.HandleRequest(ctx, req)
+	require.Nil(t, err)
+
+	require.Equal(t, false, resp.Data["approved"])
 }
 
 func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {

--- a/internal/vault/token_store_test.go
+++ b/internal/vault/token_store_test.go
@@ -1073,6 +1073,140 @@ path "sys/control-group/request" {
 	require.Equal(t, approverEntityID, auths[0]["entity_id"])
 }
 
+// Test the approval of control group accessors when approvers are indirectly
+// members of the approval group.
+func TestTokenStore_HandleRequest_ApproveAccessorIndirectGroups(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ts := c.tokenStore
+	is := c.identityStore
+	ctx := namespace.RootContext(context.Background())
+
+	// Control group approver policy
+	policyHCL := `
+path "sys/control-group/authorize" {
+  capabilities = ["update"]
+}
+
+path "sys/control-group/request" {
+  capabilities = ["update"]
+}
+`
+	pol, err := policy.ParseACLPolicy(namespace.RootNamespace, policyHCL)
+	require.NoError(t, err)
+	pol.Name = "control-group-approver"
+	err = c.policyStore.SetPolicy(ctx, pol, nil)
+	require.NoError(t, err)
+
+	// Alice is the requesting entity
+	requestingEntity := identity.Entity{
+		ID:          "alice-entity-id",
+		Name:        "alice",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   is.EntityPacker(ctx).BucketKey("alice-entity-id"),
+	}
+
+	// Jane is a valid control group approver. She is an indirect member of
+	// "admin1", as she is a member of "admin2".
+	approverEntity := identity.Entity{
+		ID:          "jane-entity-id",
+		Name:        "jane",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   is.EntityPacker(ctx).BucketKey("jane-entity-id"),
+	}
+
+	admin1Group := identity.Group{
+		ID:          "admin1-id",
+		Name:        "admin1",
+		NamespaceID: namespace.RootNamespaceID,
+		BucketKey:   is.EntityPacker(ctx).BucketKey("admin1-id"),
+	}
+
+	admin2Group := identity.Group{
+		ID:              "admin2-id",
+		Name:            "admin2",
+		NamespaceID:     namespace.RootNamespaceID,
+		MemberEntityIDs: []string{"jane-entity-id"},
+		ParentGroupIDs:  []string{"admin1-id"},
+		BucketKey:       is.EntityPacker(ctx).BucketKey("admin2-id"),
+	}
+
+	txn := is.Txn(ctx, true)
+	require.NoError(t, is.MemDBUpsertEntityInTxn(txn, &requestingEntity))
+	require.NoError(t, is.MemDBUpsertEntityInTxn(txn, &approverEntity))
+	require.NoError(t, is.MemDBUpsertGroupInTxn(txn, &admin1Group))
+	require.NoError(t, is.MemDBUpsertGroupInTxn(txn, &admin2Group))
+	txn.Commit()
+
+	// Alice tries to access a control-group gated KV path in the root namespace,
+	// and receives a wrapped token, and a wrapping accessor.
+
+	// The following constructs the wrapping accessor.
+
+	// Encode the `request`
+	req := logical.TestRequest(t, logical.ReadOperation, "kv/data/secret")
+	reqPb, err := pb.LogicalRequestToProtoRequest(req)
+	require.Nil(t, err)
+	reqPbBytes, err := proto.Marshal(reqPb)
+	require.Nil(t, err)
+	reqPbBytesEncoded := base64.StdEncoding.EncodeToString(reqPbBytes)
+
+	// Encode the `request_entity`
+	reqEntity, err := jsonutil.EncodeJSON(&requestingEntity)
+	require.Nil(t, err)
+
+	// Control Group
+	cg := logical.ControlGroup{
+		TTL: time.Second * 600,
+		Factors: []logical.ControlGroupFactor{
+			{
+				Name: "approvers",
+				Identity: logical.ControlGroupIdentity{
+					GroupNames: []string{"admin1"},
+					Approvals:  1,
+				},
+			},
+		},
+	}
+
+	cgEncoded, err := jsonutil.EncodeJSON(cg)
+	require.Nil(t, err)
+
+	te := logical.TokenEntry{
+		TTL:         time.Hour,
+		NamespaceID: namespace.RootNamespaceID,
+		InternalMeta: map[string]string{
+			"control_group":  string(cgEncoded),
+			"request":        reqPbBytesEncoded,
+			"request_entity": string(reqEntity),
+		},
+	}
+
+	testMakeTokenDirectly(t, ctx, ts, &te)
+	accessor, err := ts.Lookup(ctx, te.ID)
+	require.Nil(t, err)
+
+	// Jane attempts to authorize the wrapping accessor.
+	tjane := logical.TokenEntry{
+		EntityID: "jane-entity-id",
+		Policies: []string{"control-group-approver"},
+		TTL:      time.Minute,
+	}
+	testMakeTokenDirectly(t, ctx, ts, &tjane)
+	approverJane, err := ts.Lookup(ctx, tjane.ID)
+	require.Nil(t, err)
+
+	// Jane makes a request to authorize the control group request
+	req = logical.TestRequest(t, logical.UpdateOperation, "sys/control-group/authorize")
+	req.Data = map[string]any{
+		"accessor": accessor.Accessor,
+	}
+	req.ClientToken = approverJane.ID
+	resp, err := c.HandleRequest(ctx, req)
+	require.Nil(t, err)
+
+	require.Equal(t, true, resp.Data["approved"])
+}
+
 func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	ts := c.tokenStore


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This PR enables entities in indirect groups mentioned by a control group factor
to be correctly recognised as valid approvers.

This PR additionally proposes the use of group IDs as the identifier for groups 
during control group authorization.

The use of a group ID ensures uniqueness across namespaces, and addresses a 
bug where entities could incorrectly approve control group requests, if they 
belonged to a group of the same name, in a different namespace.

Converting group names to group IDs would also more readily enable the 
addition of `group_ids` on the control group factor in the future :)

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: 
https://github.com/openbao/openbao/issues/3814
https://github.com/openbao/openbao/issues/3815

It follows from the addition of control groups: https://github.com/openbao/openbao/pull/2241, https://github.com/openbao/openbao/pull/3609.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
