### PR TITLE
Fsm perf optimization

### DIFF
--- a/changelog/3844.txt
+++ b/changelog/3844.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Fix performance regression caused by second transaction during batch application to write last applied log index.
+```

--- a/internal/physical/raft/fsm.go
+++ b/internal/physical/raft/fsm.go
@@ -897,8 +897,7 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 		// If we had no error, update our last applied log.
 		if err == nil {
 			if len(logIndex) > 0 {
-				b := tx.Bucket(configBucketName)
-				err = b.Put(latestIndexKey, logIndex)
+				err = configB.Put(latestIndexKey, logIndex)
 				if err != nil {
 					return err
 				}

--- a/internal/physical/raft/fsm.go
+++ b/internal/physical/raft/fsm.go
@@ -894,12 +894,8 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 			}
 		}
 
-		return err
-	})
-
-	// If we had no error, update our last applied log.
-	if err == nil {
-		err = f.db.Update(func(tx *bolt.Tx) error {
+		// If we had no error, update our last applied log.
+		if err == nil {
 			if len(logIndex) > 0 {
 				b := tx.Bucket(configBucketName)
 				err = b.Put(latestIndexKey, logIndex)
@@ -907,10 +903,10 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 					return err
 				}
 			}
+		}
 
-			return nil
-		})
-	}
+		return err
+	})
 
 	if err != nil {
 		f.logger.Error("failed to store data", "error", err)


### PR DESCRIPTION
## Description

the code block for "If we had no error, update our last applied log." may be in the same f.db.Update connection (just above) instead of open a new. I don't know for any impact but for us all seems good and all work.

## Rationale

Resolves: https://github.com/openbao/openbao/issues/3843

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
