### PR TITLE
Fix incorrect entity count metrics when `unsafeCrossNamespaceIdentity` flag is present

### DIFF
--- a/changelog/3846.txt
+++ b/changelog/3846.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Fixed incorrect 'identity.num_entities', 'identity.entity.count' and 'identity.entity.alias.count' metrics values when running OpenBao with `unsafe_cross_namespace_identity` enabled.
+```

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -1344,16 +1344,16 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 		identityLogger := logger.Named("identity")
 		c.AddLogger(identityLogger)
 		identityStoreConfig := &ident.IdentityStoreConfig{
-			Logger:        c.Logger(),
-			Router:        c.router,
-			RedirectAddr:  c.redirectAddr,
-			LocalNode:     c,
-			Namespacer:    c,
-			MetricsSink:   c.metricSink,
-			TOTPPersister: c,
-			TokenStorer:   c,
-			MFABackend:    c.loginMFABackend,
-			LoggerAdder:   c,
+			LocalNode:                    c,
+			Namespacer:                   c,
+			TOTPPersister:                c,
+			TokenStorer:                  c,
+			LoggerAdder:                  c,
+			Router:                       c.router,
+			MetricsSink:                  c.metricSink,
+			RedirectAddr:                 c.redirectAddr,
+			MFABackend:                   c.loginMFABackend,
+			UnsafeCrossNamespaceIdentity: c.unsafeCrossNamespaceIdentity,
 		}
 		return ident.NewIdentityStore(ctx, identityStoreConfig, config, identityLogger)
 	}
@@ -1364,7 +1364,7 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 				return nil, err
 			}
 
-			if err := c.identityStore.AddNamespaceView(c, ns, config.StorageView); err != nil {
+			if err := c.identityStore.AddNamespaceView(c, ns, config.StorageView, c.unsafeCrossNamespaceIdentity); err != nil {
 				return nil, fmt.Errorf("failed to register namespace to identity store: %w", err)
 			}
 			return c.identityStore, nil

--- a/internal/vault/core_metrics_test.go
+++ b/internal/vault/core_metrics_test.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"errors"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -16,8 +15,8 @@ import (
 	logicalKv "github.com/openbao/openbao/v2/internal/builtin/logical/kv"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	be "github.com/openbao/openbao/v2/internal/vault/backend"
-	ident "github.com/openbao/openbao/v2/internal/vault/identity"
 	"github.com/openbao/openbao/v2/internal/vault/routing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoreMetrics_KvSecretGauge(t *testing.T) {
@@ -248,50 +247,48 @@ func TestCoreMetrics_KvSecretGaugeError(t *testing.T) {
 	}
 }
 
-func metricLabelsMatch(t *testing.T, actual []metrics.Label, expected map[string]string) {
-	t.Helper()
-
-	if len(actual) != len(expected) {
-		t.Errorf("Expected %v labels, got %v: %v", len(expected), len(actual), actual)
-	}
-
-	for _, l := range actual {
-		if v, ok := expected[l.Name]; ok {
-			if v != l.Value {
-				t.Errorf("Mismatched value %v=%v, expected %v", l.Name, l.Value, v)
-			}
-		} else {
-			t.Errorf("Unexpected label %v", l.Name)
-		}
-	}
-}
-
 func TestCoreMetrics_EntityGauges(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
+	c := testIdentityStoreCore(t, false)
+	ns := &namespace.Namespace{Path: "ns/"}
+	TestCoreCreateNamespaces(t, c, ns)
 
-	testCoreMetricsEntityGauges(t, ctx, is, approleAccessor, upAccessor, core)
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testCoreCreateEntities(t, ctx, c, approleAccessor, upAccessor)
+
+	approleAccessorNS, upAccessorNS := testEnableAppRoleUserpassAuthMounts(t, namespace.ContextWithNamespace(ctx, ns), c)
+	testCoreCreateEntities(t, namespace.ContextWithNamespace(ctx, ns), c, approleAccessorNS, upAccessorNS)
+
+	testCoreMetricsEntityGauges(t, c)
 }
 
+// This test verifies that we aren't duplicating the amount of reported entities
+// when running with `UnsafeCrossNamespaceIdentity` set to true.
+// See more: https://github.com/openbao/openbao/issues/3840
 func TestCoreMetrics_EntityGaugesUnsafeSharedIdentity(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, core := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
+	c := testIdentityStoreCore(t, true)
+	ns := &namespace.Namespace{Path: "ns/"}
+	TestCoreCreateNamespaces(t, c, ns)
 
-	testCoreMetricsEntityGauges(t, ctx, is, approleAccessor, upAccessor, core)
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testCoreCreateEntities(t, ctx, c, approleAccessor, upAccessor)
+
+	approleAccessorNS, upAccessorNS := testEnableAppRoleUserpassAuthMounts(t, namespace.ContextWithNamespace(ctx, ns), c)
+	testCoreCreateEntities(t, namespace.ContextWithNamespace(ctx, ns), c, approleAccessorNS, upAccessorNS)
+
+	testCoreMetricsEntityGauges(t, c)
 }
 
-func testCoreMetricsEntityGauges(t *testing.T, ctx context.Context, is *ident.IdentityStore, approleAccessor string, upAccessor string, core *Core) {
-	// Create an entity
-	alias1 := &logical.Alias{
+func testCoreCreateEntities(t *testing.T, ctx context.Context, core *Core, approleAccessor, upAccessor string) {
+	alias := &logical.Alias{
 		MountType:     "approle",
 		MountAccessor: approleAccessor,
 		Name:          "approleuser",
 	}
 
-	entity, _, err := is.CreateOrFetchEntity(ctx, alias1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	entity, _, err := core.identityStore.CreateOrFetchEntity(ctx, alias)
+	require.NoError(t, err)
 
 	// Create a second alias for the same entity
 	registerReq := &logical.Request{
@@ -303,66 +300,35 @@ func testCoreMetricsEntityGauges(t *testing.T, ctx context.Context, is *ident.Id
 			"mount_accessor": upAccessor,
 		},
 	}
-	resp, err := is.HandleRequest(ctx, registerReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
+	resp, err := core.identityStore.HandleRequest(ctx, registerReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func testCoreMetricsEntityGauges(t *testing.T, core *Core) {
+	glv, err := core.entityGaugeCollector(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, glv, 2)
+	for _, metric := range glv {
+		require.Equal(t, float32(1.0), metric.Value)
+		require.Len(t, metric.Labels, 1)
+		require.Equal(t, "namespace", metric.Labels[0].Name)
+		require.Contains(t, []string{"root", "ns"}, metric.Labels[0].Value)
 	}
 
-	glv, err := core.entityGaugeCollector(ctx)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	glv, err = core.entityGaugeCollectorByMount(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, glv, 4)
+	for _, metric := range glv {
+		require.Equal(t, float32(1.0), metric.Value)
+		require.Len(t, metric.Labels, 3)
+		require.Equal(t, "namespace", metric.Labels[0].Name)
+		require.Contains(t, []string{"root", "ns"}, metric.Labels[0].Value)
+		require.Equal(t, "auth_method", metric.Labels[1].Name)
+		require.Contains(t, []string{"userpass", "approle"}, metric.Labels[1].Value)
+		require.Equal(t, "mount_point", metric.Labels[2].Name)
+		require.Contains(t, []string{"auth/userpass/", "auth/approle/"}, metric.Labels[2].Value)
 	}
-
-	if len(glv) != 1 {
-		t.Fatalf("Wrong number of gauges %v, expected %v", len(glv), 1)
-	}
-
-	if glv[0].Value != 1.0 {
-		t.Errorf("Entity count %v, expected %v", glv[0].Value, 1.0)
-	}
-
-	metricLabelsMatch(t, glv[0].Labels,
-		map[string]string{
-			"namespace": "root",
-		})
-
-	glv, err = core.entityGaugeCollectorByMount(ctx)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if len(glv) != 2 {
-		t.Fatalf("Wrong number of gauges %v, expected %v", len(glv), 1)
-	}
-
-	if glv[0].Value != 1.0 {
-		t.Errorf("Alias count %v, expected %v", glv[0].Value, 1.0)
-	}
-
-	if glv[1].Value != 1.0 {
-		t.Errorf("Alias count %v, expected %v", glv[0].Value, 1.0)
-	}
-
-	// Sort both metrics.Label slices by Name, causing the Label
-	// with Name auth_method to be first in both arrays
-	sort.Slice(glv[0].Labels, func(i, j int) bool { return glv[0].Labels[i].Name < glv[0].Labels[j].Name })
-	sort.Slice(glv[1].Labels, func(i, j int) bool { return glv[1].Labels[i].Name < glv[1].Labels[j].Name })
-
-	// Sort the GaugeLabelValues slice by the Value of the first metric,
-	// in this case auth_method, in each metrics.Label slice
-	sort.Slice(glv, func(i, j int) bool { return glv[i].Labels[0].Value < glv[j].Labels[0].Value })
-
-	metricLabelsMatch(t, glv[0].Labels,
-		map[string]string{
-			"namespace":   "root",
-			"auth_method": "approle",
-			"mount_point": "auth/approle/",
-		})
-
-	metricLabelsMatch(t, glv[1].Labels,
-		map[string]string{
-			"namespace":   "root",
-			"auth_method": "userpass",
-			"mount_point": "auth/userpass/",
-		})
 }

--- a/internal/vault/identity/store.go
+++ b/internal/vault/identity/store.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -39,27 +40,28 @@ var (
 )
 
 func (i *IdentityStore) ResetDB(ctx context.Context) error {
-	var err error
+	var merr *multierror.Error
 
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
 
+		// If we are running unsafeCrossNamespaceIdentity and it's not root namespace, skip.
+		if i.unsafeCrossNamespaceIdentity() && uuidRaw != namespace.RootNamespaceUUID {
+			return false
+		}
+
+		var err error
 		views.db, err = memdb.NewMemDB(identityStoreSchema(!i.disableLowerCasedNames))
 		if err != nil {
-			err = fmt.Errorf("error resetting database for namespace %v: %w", uuid, err)
+			merr = multierror.Append(merr, fmt.Errorf("error resetting database for namespace %v: %w", uuid, err))
 			return false
 		}
 
 		return true
 	})
 
-	return err
-}
-
-type LoggerAdder interface {
-	AddLogger(log.Logger)
-	UnsafeCrossNamespaceIdentity() bool
+	return merr.ErrorOrNil()
 }
 
 type IdentityStoreConfig struct {
@@ -77,15 +79,16 @@ type IdentityStoreConfig struct {
 
 func NewIdentityStore(ctx context.Context, identityStoreConfig *IdentityStoreConfig, config *logical.BackendConfig, logger log.Logger) (*IdentityStore, error) {
 	iStore := &IdentityStore{
-		logger:        identityStoreConfig.Logger,
-		router:        identityStoreConfig.Router,
-		redirectAddr:  identityStoreConfig.RedirectAddr,
-		localNode:     identityStoreConfig.LocalNode,
-		namespacer:    identityStoreConfig.Namespacer,
-		metrics:       identityStoreConfig.MetricsSink,
-		totpPersister: identityStoreConfig.TOTPPersister,
-		tokenStorer:   identityStoreConfig.TokenStorer,
-		mfaBackend:    identityStoreConfig.MFABackend,
+		logger:                       identityStoreConfig.Logger,
+		router:                       identityStoreConfig.Router,
+		redirectAddr:                 identityStoreConfig.RedirectAddr,
+		localNode:                    identityStoreConfig.LocalNode,
+		namespacer:                   identityStoreConfig.Namespacer,
+		metrics:                      identityStoreConfig.MetricsSink,
+		totpPersister:                identityStoreConfig.TOTPPersister,
+		tokenStorer:                  identityStoreConfig.TokenStorer,
+		mfaBackend:                   identityStoreConfig.MFABackend,
+		unsafeCrossNamespaceIdentity: identityStoreConfig.LoggerAdder.UnsafeCrossNamespaceIdentity,
 	}
 
 	if err := iStore.AddNamespaceView(identityStoreConfig.LoggerAdder, namespace.RootNamespace, config.StorageView); err != nil {

--- a/internal/vault/identity/store.go
+++ b/internal/vault/identity/store.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -39,63 +40,70 @@ var (
 )
 
 func (i *IdentityStore) ResetDB(ctx context.Context) error {
-	var err error
+	var merr *multierror.Error
 
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
 
+		// If we've enabled unsafeCrossNamespaceIdentity and it's not root namespace, skip.
+		if i.unsafeCrossNamespaceIdentity && uuidRaw != namespace.RootNamespaceUUID {
+			return false
+		}
+
+		var err error
 		views.db, err = memdb.NewMemDB(identityStoreSchema(!i.disableLowerCasedNames))
 		if err != nil {
-			err = fmt.Errorf("error resetting database for namespace %v: %w", uuid, err)
+			merr = multierror.Append(merr, fmt.Errorf("error resetting database for namespace %v: %w", uuid, err))
 			return false
 		}
 
 		return true
 	})
 
-	return err
-}
-
-type LoggerAdder interface {
-	AddLogger(log.Logger)
-	UnsafeCrossNamespaceIdentity() bool
+	return merr.ErrorOrNil()
 }
 
 type IdentityStoreConfig struct {
-	Logger        log.Logger
-	Router        *routing.Router
-	RedirectAddr  string
-	LocalNode     LocalNode
-	Namespacer    Namespacer
-	MetricsSink   metricsutil.Metrics
-	TOTPPersister TOTPPersister
-	TokenStorer   TokenStorer
-	MFABackend    MFABackend
-	LoggerAdder   LoggerAdder
+	Router                       *routing.Router
+	RedirectAddr                 string
+	LocalNode                    LocalNode
+	Namespacer                   Namespacer
+	MetricsSink                  metricsutil.Metrics
+	TOTPPersister                TOTPPersister
+	TokenStorer                  TokenStorer
+	MFABackend                   MFABackend
+	LoggerAdder                  LoggerAdder
+	UnsafeCrossNamespaceIdentity bool
 }
 
 func NewIdentityStore(ctx context.Context, identityStoreConfig *IdentityStoreConfig, config *logical.BackendConfig, logger log.Logger) (*IdentityStore, error) {
 	iStore := &IdentityStore{
-		logger:        identityStoreConfig.Logger,
-		router:        identityStoreConfig.Router,
-		redirectAddr:  identityStoreConfig.RedirectAddr,
-		localNode:     identityStoreConfig.LocalNode,
-		namespacer:    identityStoreConfig.Namespacer,
-		metrics:       identityStoreConfig.MetricsSink,
-		totpPersister: identityStoreConfig.TOTPPersister,
-		tokenStorer:   identityStoreConfig.TokenStorer,
-		mfaBackend:    identityStoreConfig.MFABackend,
+		logger:                       logger,
+		router:                       identityStoreConfig.Router,
+		redirectAddr:                 identityStoreConfig.RedirectAddr,
+		localNode:                    identityStoreConfig.LocalNode,
+		namespacer:                   identityStoreConfig.Namespacer,
+		metrics:                      identityStoreConfig.MetricsSink,
+		totpPersister:                identityStoreConfig.TOTPPersister,
+		tokenStorer:                  identityStoreConfig.TokenStorer,
+		mfaBackend:                   identityStoreConfig.MFABackend,
+		unsafeCrossNamespaceIdentity: identityStoreConfig.UnsafeCrossNamespaceIdentity,
 	}
 
-	if err := iStore.AddNamespaceView(identityStoreConfig.LoggerAdder, namespace.RootNamespace, config.StorageView); err != nil {
+	if err := iStore.AddNamespaceView(
+		identityStoreConfig.LoggerAdder,
+		namespace.RootNamespace,
+		config.StorageView,
+		iStore.unsafeCrossNamespaceIdentity,
+	); err != nil {
 		return nil, err
 	}
 
 	iStore.Backend = &framework.Backend{
 		BackendType:    logical.TypeLogical,
 		Paths:          iStore.paths(),
-		Invalidate:     iStore.Invalidate,
+		Invalidate:     iStore.invalidate,
 		InitializeFunc: iStore.initialize,
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
@@ -125,7 +133,7 @@ func NewIdentityStore(ctx context.Context, identityStoreConfig *IdentityStoreCon
 	return iStore, nil
 }
 
-func (i *IdentityStore) AddNamespaceView(la LoggerAdder, ns *namespace.Namespace, view logical.Storage) error {
+func (i *IdentityStore) AddNamespaceView(la LoggerAdder, ns *namespace.Namespace, view logical.Storage, unsafeCrossNSIdentity bool) error {
 	nsView := &identityStoreNamespaceView{
 		view: view,
 	}
@@ -157,7 +165,7 @@ func (i *IdentityStore) AddNamespaceView(la LoggerAdder, ns *namespace.Namespace
 		return fmt.Errorf("failed to create group packer: %w", err)
 	}
 
-	if ns.ID == namespace.RootNamespaceID || !la.UnsafeCrossNamespaceIdentity() {
+	if ns.ID == namespace.RootNamespaceID || !unsafeCrossNSIdentity {
 		nsView.db, err = memdb.NewMemDB(identityStoreSchema(!i.disableLowerCasedNames))
 		if err != nil {
 			return err
@@ -834,11 +842,11 @@ func (i *IdentityStore) initialize(ctx context.Context, req *logical.Initializat
 	return nil
 }
 
-// Invalidate is a callback wherein the backend is informed that the value at
+// invalidate is a callback wherein the backend is informed that the value at
 // the given key is updated. In identity store's case, it would be the entity
 // storage entries that get updated. The value needs to be read and MemDB needs
 // to be updated accordingly.
-func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
+func (i *IdentityStore) invalidate(ctx context.Context, key string) {
 	i.logger.Debug("invalidate notification received", "key", key)
 
 	i.Lock()

--- a/internal/vault/identity/store_structs.go
+++ b/internal/vault/identity/store_structs.go
@@ -95,6 +95,10 @@ type IdentityStore struct {
 	// operated case insensitively
 	disableLowerCasedNames bool
 
+	// unsafeCrossNamespaceIdentity returns back current value of the `unsafe_cross_namespace_identity`
+	// flag indicating whether we use a single global memdb instance for identity
+	unsafeCrossNamespaceIdentity func() bool
+
 	router        *routing.Router
 	redirectAddr  string
 	localNode     LocalNode
@@ -132,4 +136,9 @@ type TOTPPersister interface {
 type TokenStorer interface {
 	LookupToken(context.Context, string) (*logical.TokenEntry, error)
 	CreateToken(context.Context, *logical.TokenEntry, bool) error
+}
+
+type LoggerAdder interface {
+	AddLogger(log.Logger)
+	UnsafeCrossNamespaceIdentity() bool
 }

--- a/internal/vault/identity/store_structs.go
+++ b/internal/vault/identity/store_structs.go
@@ -95,6 +95,10 @@ type IdentityStore struct {
 	// operated case insensitively
 	disableLowerCasedNames bool
 
+	// unsafeCrossNamespaceIdentity is the value of the `unsafe_cross_namespace_identity`
+	// flag indicating whether we use a single global memdb instance for identity
+	unsafeCrossNamespaceIdentity bool
+
 	router        *routing.Router
 	redirectAddr  string
 	localNode     LocalNode
@@ -132,4 +136,8 @@ type TOTPPersister interface {
 type TokenStorer interface {
 	LookupToken(context.Context, string) (*logical.TokenEntry, error)
 	CreateToken(context.Context, *logical.TokenEntry, bool) error
+}
+
+type LoggerAdder interface {
+	AddLogger(log.Logger)
 }

--- a/internal/vault/identity/store_util.go
+++ b/internal/vault/identity/store_util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -2403,19 +2404,58 @@ func (i *IdentityStore) handleAliasListCommon(ctx context.Context, groupAlias bo
 // CountEntities returns the sum of all entities across all namespaces.
 func (i *IdentityStore) CountEntities(ctx context.Context) (int, error) {
 	var count int
-	var outErr error
+	err := i.iterateEntities(ctx, func(uuid string, entity *identity.Entity) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		return -1, err
+	}
 
+	return count, nil
+}
+
+// Sum up the number of entities belonging to each namespace (keyed by ID).
+func (i *IdentityStore) CountEntitiesByNamespace(ctx context.Context) (map[string]int, error) {
+	byNamespace := make(map[string]int)
+	err := i.iterateEntities(ctx, func(uuid string, entity *identity.Entity) error {
+		byNamespace[entity.NamespaceID]++
+		return nil
+	})
+
+	return byNamespace, err
+}
+
+// Sum up the number of entities belonging to each mount point (keyed by accessor).
+func (i *IdentityStore) CountEntitiesByMountAccessor(ctx context.Context) (map[string]int, error) {
+	byMountAccessor := make(map[string]int)
+	err := i.iterateEntities(ctx, func(_ string, entity *identity.Entity) error {
+		for _, alias := range entity.Aliases {
+			byMountAccessor[alias.MountAccessor] = byMountAccessor[alias.MountAccessor] + 1
+		}
+		return nil
+	})
+
+	return byMountAccessor, err
+}
+
+// iterateEntities traverses through views and invokes callback for each entity.
+func (i *IdentityStore) iterateEntities(ctx context.Context, cb func(uuid string, entity *identity.Entity) error) error {
 	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
 	if !ok || rootViewRaw == nil {
-		return -1, fmt.Errorf("failed to load root namespace")
+		return fmt.Errorf("failed to load root namespace")
 	}
 	rootView := rootViewRaw.(*identityStoreNamespaceView)
 
+	var merr *multierror.Error
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
 		db := views.db
 		if db == nil {
+			if i.unsafeCrossNamespaceIdentity() {
+				return true
+			}
 			db = rootView.db
 		}
 
@@ -2423,131 +2463,27 @@ func (i *IdentityStore) CountEntities(ctx context.Context) (int, error) {
 
 		iter, err := txn.Get(entitiesTable, "id")
 		if err != nil {
-			outErr = fmt.Errorf("failed to get entities table for namespace %v: %w", uuid, err)
+			merr = multierror.Append(merr, fmt.Errorf("failed to get entities table for namespace %v: %w", uuid, err))
 			return false
 		}
 
-		val := iter.Next()
-		for val != nil {
-			count++
-			val = iter.Next()
-		}
-
-		return true
-	})
-
-	if outErr != nil {
-		return -1, outErr
-	}
-
-	return count, nil
-}
-
-// Sum up the number of entities belonging to each namespace (keyed by ID)
-func (i *IdentityStore) CountEntitiesByNamespace(ctx context.Context) (map[string]int, error) {
-	byNamespace := make(map[string]int)
-
-	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
-	if !ok || rootViewRaw == nil {
-		return nil, fmt.Errorf("failed to load root namespace")
-	}
-	rootView := rootViewRaw.(*identityStoreNamespaceView)
-
-	var err error
-	i.views.Range(func(uuidRaw, viewsRaw any) bool {
-		uuid := uuidRaw.(string)
-		views := viewsRaw.(*identityStoreNamespaceView)
-		db := views.db
-		if db == nil {
-			db = rootView.db
-		}
-
-		txn := db.Txn(false)
-
-		var iter memdb.ResultIterator
-		iter, err = txn.Get(entitiesTable, "id")
-		if err != nil {
-			return false
-		}
-
-		val := iter.Next()
-		for val != nil {
-			// Check if runtime exceeded.
+		for val := iter.Next(); val != nil; val = iter.Next() {
 			select {
 			case <-ctx.Done():
-				err = fmt.Errorf("context cancelled during namespace %v", uuid)
+				merr = multierror.Append(merr, fmt.Errorf("context cancelled during namespace %v", uuid))
 				return false
 			default:
 			}
 
-			// Count in the namespace attached to the entity.
 			entity := val.(*identity.Entity)
-			byNamespace[entity.NamespaceID] = byNamespace[entity.NamespaceID] + 1
-			val = iter.Next()
-		}
-
-		return true
-	})
-
-	if err == nil || strings.Contains(err.Error(), "context cancelled") {
-		return byNamespace, err
-	}
-
-	return nil, err
-}
-
-// Sum up the number of entities belonging to each mount point (keyed by accessor)
-func (i *IdentityStore) CountEntitiesByMountAccessor(ctx context.Context) (map[string]int, error) {
-	byMountAccessor := make(map[string]int)
-
-	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
-	if !ok || rootViewRaw == nil {
-		return nil, fmt.Errorf("failed to load root namespace")
-	}
-	rootView := rootViewRaw.(*identityStoreNamespaceView)
-
-	var err error
-	i.views.Range(func(uuidRaw, viewsRaw any) bool {
-		uuid := uuidRaw.(string)
-		views := viewsRaw.(*identityStoreNamespaceView)
-		db := views.db
-		if db == nil {
-			db = rootView.db
-		}
-
-		txn := db.Txn(false)
-
-		var iter memdb.ResultIterator
-		iter, err = txn.Get(entitiesTable, "id")
-		if err != nil {
-			return false
-		}
-
-		val := iter.Next()
-		for val != nil {
-			// Check if runtime exceeded.
-			select {
-			case <-ctx.Done():
-				err = fmt.Errorf("context cancelled during namespace %v", uuid)
+			if err := cb(uuid, entity); err != nil {
+				merr = multierror.Append(merr, err)
 				return false
-			default:
 			}
-
-			// Count each alias separately; will translate to mount point and type
-			// in the caller.
-			entity := val.(*identity.Entity)
-			for _, alias := range entity.Aliases {
-				byMountAccessor[alias.MountAccessor] = byMountAccessor[alias.MountAccessor] + 1
-			}
-			val = iter.Next()
 		}
 
 		return true
 	})
 
-	if err == nil || strings.Contains(err.Error(), "context cancelled") {
-		return byMountAccessor, err
-	}
-
-	return nil, err
+	return merr.ErrorOrNil()
 }

--- a/internal/vault/identity/store_util.go
+++ b/internal/vault/identity/store_util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
@@ -2403,19 +2404,58 @@ func (i *IdentityStore) handleAliasListCommon(ctx context.Context, groupAlias bo
 // CountEntities returns the sum of all entities across all namespaces.
 func (i *IdentityStore) CountEntities(ctx context.Context) (int, error) {
 	var count int
-	var outErr error
+	err := i.iterateEntities(ctx, func(uuid string, entity *identity.Entity) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		return -1, err
+	}
 
+	return count, nil
+}
+
+// Sum up the number of entities belonging to each namespace (keyed by ID).
+func (i *IdentityStore) CountEntitiesByNamespace(ctx context.Context) (map[string]int, error) {
+	byNamespace := make(map[string]int)
+	err := i.iterateEntities(ctx, func(uuid string, entity *identity.Entity) error {
+		byNamespace[entity.NamespaceID]++
+		return nil
+	})
+
+	return byNamespace, err
+}
+
+// Sum up the number of entities belonging to each mount point (keyed by accessor).
+func (i *IdentityStore) CountEntitiesByMountAccessor(ctx context.Context) (map[string]int, error) {
+	byMountAccessor := make(map[string]int)
+	err := i.iterateEntities(ctx, func(_ string, entity *identity.Entity) error {
+		for _, alias := range entity.Aliases {
+			byMountAccessor[alias.MountAccessor] = byMountAccessor[alias.MountAccessor] + 1
+		}
+		return nil
+	})
+
+	return byMountAccessor, err
+}
+
+// iterateEntities traverses through views and invokes callback for each entity.
+func (i *IdentityStore) iterateEntities(ctx context.Context, cb func(uuid string, entity *identity.Entity) error) error {
 	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
 	if !ok || rootViewRaw == nil {
-		return -1, fmt.Errorf("failed to load root namespace")
+		return fmt.Errorf("failed to load root namespace")
 	}
 	rootView := rootViewRaw.(*identityStoreNamespaceView)
 
+	var merr *multierror.Error
 	i.views.Range(func(uuidRaw, viewsRaw any) bool {
 		uuid := uuidRaw.(string)
 		views := viewsRaw.(*identityStoreNamespaceView)
 		db := views.db
 		if db == nil {
+			if i.unsafeCrossNamespaceIdentity {
+				return true
+			}
 			db = rootView.db
 		}
 
@@ -2423,131 +2463,27 @@ func (i *IdentityStore) CountEntities(ctx context.Context) (int, error) {
 
 		iter, err := txn.Get(entitiesTable, "id")
 		if err != nil {
-			outErr = fmt.Errorf("failed to get entities table for namespace %v: %w", uuid, err)
+			merr = multierror.Append(merr, fmt.Errorf("failed to get entities table for namespace %v: %w", uuid, err))
 			return false
 		}
 
-		val := iter.Next()
-		for val != nil {
-			count++
-			val = iter.Next()
-		}
-
-		return true
-	})
-
-	if outErr != nil {
-		return -1, outErr
-	}
-
-	return count, nil
-}
-
-// Sum up the number of entities belonging to each namespace (keyed by ID)
-func (i *IdentityStore) CountEntitiesByNamespace(ctx context.Context) (map[string]int, error) {
-	byNamespace := make(map[string]int)
-
-	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
-	if !ok || rootViewRaw == nil {
-		return nil, fmt.Errorf("failed to load root namespace")
-	}
-	rootView := rootViewRaw.(*identityStoreNamespaceView)
-
-	var err error
-	i.views.Range(func(uuidRaw, viewsRaw any) bool {
-		uuid := uuidRaw.(string)
-		views := viewsRaw.(*identityStoreNamespaceView)
-		db := views.db
-		if db == nil {
-			db = rootView.db
-		}
-
-		txn := db.Txn(false)
-
-		var iter memdb.ResultIterator
-		iter, err = txn.Get(entitiesTable, "id")
-		if err != nil {
-			return false
-		}
-
-		val := iter.Next()
-		for val != nil {
-			// Check if runtime exceeded.
+		for val := iter.Next(); val != nil; val = iter.Next() {
 			select {
 			case <-ctx.Done():
-				err = fmt.Errorf("context cancelled during namespace %v", uuid)
+				merr = multierror.Append(merr, fmt.Errorf("context cancelled during namespace %v", uuid))
 				return false
 			default:
 			}
 
-			// Count in the namespace attached to the entity.
 			entity := val.(*identity.Entity)
-			byNamespace[entity.NamespaceID] = byNamespace[entity.NamespaceID] + 1
-			val = iter.Next()
-		}
-
-		return true
-	})
-
-	if err == nil || strings.Contains(err.Error(), "context cancelled") {
-		return byNamespace, err
-	}
-
-	return nil, err
-}
-
-// Sum up the number of entities belonging to each mount point (keyed by accessor)
-func (i *IdentityStore) CountEntitiesByMountAccessor(ctx context.Context) (map[string]int, error) {
-	byMountAccessor := make(map[string]int)
-
-	rootViewRaw, ok := i.views.Load(namespace.RootNamespaceUUID)
-	if !ok || rootViewRaw == nil {
-		return nil, fmt.Errorf("failed to load root namespace")
-	}
-	rootView := rootViewRaw.(*identityStoreNamespaceView)
-
-	var err error
-	i.views.Range(func(uuidRaw, viewsRaw any) bool {
-		uuid := uuidRaw.(string)
-		views := viewsRaw.(*identityStoreNamespaceView)
-		db := views.db
-		if db == nil {
-			db = rootView.db
-		}
-
-		txn := db.Txn(false)
-
-		var iter memdb.ResultIterator
-		iter, err = txn.Get(entitiesTable, "id")
-		if err != nil {
-			return false
-		}
-
-		val := iter.Next()
-		for val != nil {
-			// Check if runtime exceeded.
-			select {
-			case <-ctx.Done():
-				err = fmt.Errorf("context cancelled during namespace %v", uuid)
+			if err := cb(uuid, entity); err != nil {
+				merr = multierror.Append(merr, err)
 				return false
-			default:
 			}
-
-			// Count each alias separately; will translate to mount point and type
-			// in the caller.
-			entity := val.(*identity.Entity)
-			for _, alias := range entity.Aliases {
-				byMountAccessor[alias.MountAccessor] = byMountAccessor[alias.MountAccessor] + 1
-			}
-			val = iter.Next()
 		}
 
 		return true
 	})
 
-	if err == nil || strings.Contains(err.Error(), "context cancelled") {
-		return byMountAccessor, err
-	}
-
-	return nil, err
+	return merr.ErrorOrNil()
 }

--- a/internal/vault/identity_store_aliases_test.go
+++ b/internal/vault/identity_store_aliases_test.go
@@ -657,18 +657,18 @@ func TestIdentityStore_AliasMove_DuplicateAccessor(t *testing.T) {
 // the entity already has an alias
 func TestIdentityStore_AliasUpdate_DuplicateAccessor(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
+	c := testIdentityStoreCore(t, false)
 
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
-
-	testIdentityStoreAliasUpdateDuplicateAccessor(t, ctx, is, approleAccessor, upAccessor)
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreAliasUpdateDuplicateAccessor(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func TestIdentityStore_AliasUpdate_DuplicateAccessor_UnsafeShared(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
+	c := testIdentityStoreCore(t, true)
 
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
-
-	testIdentityStoreAliasUpdateDuplicateAccessor(t, ctx, is, approleAccessor, upAccessor)
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreAliasUpdateDuplicateAccessor(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func testIdentityStoreAliasUpdateDuplicateAccessor(t *testing.T, ctx context.Context, is *ident.IdentityStore, approleAccessor string, upAccessor string) {

--- a/internal/vault/identity_store_entities_test.go
+++ b/internal/vault/identity_store_entities_test.go
@@ -869,14 +869,18 @@ func TestIdentityStore_EntityCRUD(t *testing.T) {
 
 func TestIdentityStore_MergeEntitiesByID(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
-	testIdentityStoreMergeEntitiesById(t, ctx, is, approleAccessor, upAccessor)
+	c := testIdentityStoreCore(t, false)
+
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreMergeEntitiesById(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func TestIdentityStore_MergeEntitiesByID_UnsafeShared(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
-	testIdentityStoreMergeEntitiesById(t, ctx, is, approleAccessor, upAccessor)
+	c := testIdentityStoreCore(t, true)
+
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreMergeEntitiesById(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func testIdentityStoreMergeEntitiesById(t *testing.T, ctx context.Context, is *ident.IdentityStore, approleAccessor string, upAccessor string) {

--- a/internal/vault/identity_store_test.go
+++ b/internal/vault/identity_store_test.go
@@ -263,14 +263,18 @@ func TestIdentityStore_EntityIDPassthrough(t *testing.T) {
 
 func TestIdentityStore_CreateOrFetchEntity(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, false)
-	testIdentityStoreCreateOrFetchEntity(t, ctx, is, approleAccessor, upAccessor)
+	c := testIdentityStoreCore(t, false)
+
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreCreateOrFetchEntity(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func TestIdentityStore_CreateOrFetchEntity_UnsafeShared(t *testing.T) {
 	ctx := namespace.RootContext(t.Context())
-	is, approleAccessor, upAccessor, _ := testIdentityStoreWithAppRoleUserpassAuth(ctx, t, true)
-	testIdentityStoreCreateOrFetchEntity(t, ctx, is, approleAccessor, upAccessor)
+	c := testIdentityStoreCore(t, true)
+
+	approleAccessor, upAccessor := testEnableAppRoleUserpassAuthMounts(t, ctx, c)
+	testIdentityStoreCreateOrFetchEntity(t, ctx, c.identityStore, approleAccessor, upAccessor)
 }
 
 func testIdentityStoreCreateOrFetchEntity(t *testing.T, ctx context.Context, is *ident.IdentityStore, approleAccessor string, upAccessor string) {
@@ -701,17 +705,10 @@ func testIdentityStoreWithAppRoleAuthRoot(ctx context.Context, t *testing.T) (*i
 	return c.identityStore, meGH.Accessor, c, root
 }
 
-func testIdentityStoreWithAppRoleUserpassAuth(ctx context.Context, t *testing.T, unsafeShared bool) (*ident.IdentityStore, string, string, *Core) {
+func testIdentityStoreCore(t *testing.T, unsafeShared bool) *Core {
 	// Setup 2 auth backends, github and userpass
-	err := be.AddTestCredentialBackend("approle", credAppRole.Factory)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	err = be.AddTestCredentialBackend("userpass", credUserpass.Factory)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, be.AddTestCredentialBackend("approle", credAppRole.Factory))
+	require.NoError(t, be.AddTestCredentialBackend("userpass", credUserpass.Factory))
 
 	defer be.ClearTestCredentialBackends()
 
@@ -723,18 +720,17 @@ func testIdentityStoreWithAppRoleUserpassAuth(ctx context.Context, t *testing.T,
 		},
 	}
 	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
+	return c
+}
 
+func testEnableAppRoleUserpassAuthMounts(t *testing.T, ctx context.Context, c *Core) (string, string) {
 	githubMe := &routing.MountEntry{
 		Table:       routing.CredentialTableType,
 		Path:        "approle/",
 		Type:        "approle",
 		Description: "approle auth",
 	}
-
-	err = c.enableCredential(ctx, githubMe)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.enableCredential(ctx, githubMe))
 
 	userpassMe := &routing.MountEntry{
 		Table:       routing.CredentialTableType,
@@ -742,13 +738,9 @@ func testIdentityStoreWithAppRoleUserpassAuth(ctx context.Context, t *testing.T,
 		Type:        "userpass",
 		Description: "userpass",
 	}
+	require.NoError(t, c.enableCredential(ctx, userpassMe))
 
-	err = c.enableCredential(ctx, userpassMe)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return c.identityStore, githubMe.Accessor, userpassMe.Accessor, c
+	return githubMe.Accessor, userpassMe.Accessor
 }
 
 func TestIdentityStore_MetadataKeyRegex(t *testing.T) {


### PR DESCRIPTION
## Description
This PR:
- refactors `CountEntitiesX` code introducing shared `iterateEntities` method
- fixes the bug by skipping namespace views when `unsafeCrossNamespaceIdentity` flag is true
- adds `unsafeCrossNamespaceIdentity bool` flag copied from core config
- adjusts `(*IdentityStore).ResetDB` accumulating the errors while skipping the views when running `unsafeCrossNamespaceIdentity` flag present
- fixes `identity` logger never being used by `identityStore`

## Rationale
```
identity.num_entities
identity.entity.count
identity.entity.alias.count
```
metrics reports are useless when running `unsafe_cross_namespace_identity`, due to faulty logic (correctly identified by @vzdai)

Resolves: #3840

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
