### PR TITLE
Group go.opentelemetry.io dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,9 @@ updates:
       google-golang:
         patterns:
           - "google.golang.org/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
     ignore:
       # armon/go-metrics was moved to hashicorp/go-metrics, but we cannot
       # drop the indirect dependency on it just yet. This causes errors in


### PR DESCRIPTION
## Description
This PR introduces grouping for `"go.opentelemetry.io/otel*"` dependencies

## Rationale
So next time https://github.com/openbao/openbao/pull/3851, https://github.com/openbao/openbao/pull/3852 and https://github.com/openbao/openbao/pull/3850 are gonna be one PR

Resolves: no issue

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
