### PR TITLE
Fix signature_bits confusion in PKI

### DIFF
--- a/changelog/3858.txt
+++ b/changelog/3858.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+secrets/pki: Fix `use_pss=true` + `signature_bits=0` on a role incorrectly resulting in certificates signed via PKCS#1 v1.5 instead of correctly using PSS.
+```
+```release-note:bug
+secrets/pki: Don't pick a default value for `signature_bits` based on the key type of the certificate being issued as it applies to the issuer's key, not the certificate's key.
+```

--- a/changelog/3858.txt
+++ b/changelog/3858.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+secrets/pki: Fix `use_pss=true` + `signature_bits=0` on a role resulting in certificates signed via PKCS#1 v1.5 instead of PSS.
+```
+```release-note:bug
+secrets/pki: Don't pick a default value for `signature_bits` based on the key type of the certificate being issued as it applies to the issuer's key, not the certificate's key.
+```

--- a/internal/builtin/logical/pki/backend_test.go
+++ b/internal/builtin/logical/pki/backend_test.go
@@ -4027,7 +4027,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 		"client_flag":                        true,
 		"allowed_serial_numbers":             []any{},
 		"generate_lease":                     false,
-		"signature_bits":                     json.Number("256"),
+		"signature_bits":                     json.Number("0"),
 		"use_pss":                            false,
 		"allowed_domains":                    []any{},
 		"allowed_uri_sans_template":          false,
@@ -5405,11 +5405,11 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{2048}, true},
 
 		// We should be able to sign with PSS with any CA key type.
-		/* 12 */ {"rsa", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
-		/* 13 */ {"ec", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
-		/* 14 */ {"ed25519", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
+		/* 12 */ {"any", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
+		/* 13 */ {"any", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
+		/* 14 */ {"any", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
 
-		// ML-DSA should accept same or larger parameters
+		// ML-DSA should accept same or larger parameters.
 		/* 15 */ {"mldsa", []int{44}, []int{0}, false, []string{"mldsa", "mldsa", "mldsa"}, []int{44, 65, 87}, false},
 		/* 16 */ {"mldsa", []int{0, 65}, []int{0}, false, []string{"mldsa", "mldsa"}, []int{65, 87}, false},
 		/* 17 */ {"mldsa", []int{87}, []int{0}, false, []string{"mldsa"}, []int{87}, false},

--- a/internal/builtin/logical/pki/backend_test.go
+++ b/internal/builtin/logical/pki/backend_test.go
@@ -4015,7 +4015,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 		"client_flag":                        true,
 		"allowed_serial_numbers":             []any{},
 		"generate_lease":                     false,
-		"signature_bits":                     json.Number("256"),
+		"signature_bits":                     json.Number("0"),
 		"use_pss":                            false,
 		"allowed_domains":                    []any{},
 		"allowed_uri_sans_template":          false,
@@ -5393,9 +5393,9 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{2048}, true},
 
 		// We should be able to sign with PSS with any CA key type.
-		/* 12 */ {"rsa", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
-		/* 13 */ {"ec", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
-		/* 14 */ {"ed25519", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
+		/* 12 */ {"any", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
+		/* 13 */ {"any", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
+		/* 14 */ {"any", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
 	}
 
 	if len(testCases) != 15 {

--- a/internal/builtin/logical/pki/ca_util.go
+++ b/internal/builtin/logical/pki/ca_util.go
@@ -89,7 +89,7 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 	}
 	*role.AllowWildcardCertificates = true
 
-	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
+	if role.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 

--- a/internal/builtin/logical/pki/ca_util.go
+++ b/internal/builtin/logical/pki/ca_util.go
@@ -88,7 +88,7 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 	}
 	*role.AllowWildcardCertificates = true
 
-	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
+	if role.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 

--- a/internal/builtin/logical/pki/cert_util.go
+++ b/internal/builtin/logical/pki/cert_util.go
@@ -1052,13 +1052,12 @@ func signCert(b *backend,
 		return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unsupported key type value: %s", data.role.KeyType)}
 	}
 
-	// Before validating key lengths, update our KeyBits/SignatureBits based
-	// on the actual CSR key type.
+	// Before validating key lengths, update our KeyBits based on the actual CSR
+	// key type.
 	if data.role.KeyType == "any" {
-		// We update the value of KeyBits and SignatureBits here (from the
-		// role), using the specified key type. This allows us to convert
-		// the default value (0) for SignatureBits and KeyBits to a
-		// meaningful value.
+		// We update the value of KeyBits (from the role), using the specified
+		// key type. This allows us to convert the default value (0) for KeyBits
+		// to a meaningful value.
 		//
 		// We ignore the role's original KeyBits value if the KeyType is any
 		// as legacy (pre-1.10) roles had default values that made sense only
@@ -1066,9 +1065,7 @@ func signCert(b *backend,
 		// set for KeyBits when KeyType was set to any. This also enforces the
 		// docs saying when key_type=any, we only enforce our specified minimums
 		// for signing operations
-		if data.role.KeyBits, data.role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(
-			actualKeyType, 0, data.role.SignatureBits,
-		); err != nil {
+		if data.role.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeLength(actualKeyType, 0); err != nil {
 			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unknown internal error updating default values: %v", err)}
 		}
 
@@ -1085,11 +1082,10 @@ func signCert(b *backend,
 		}
 	}
 
-	// At this point, data.role.KeyBits and data.role.SignatureBits should both
-	// be non-zero, for RSA and ECDSA keys. Validate the actualKeyBits based on
-	// the role's values. If the KeyType was any, and KeyBits was set to 0,
-	// KeyBits should be updated to 2048 unless some other value was chosen
-	// explicitly.
+	// At this point, data.role.KeyBits should be non-zero, for RSA and ECDSA
+	// keys. Validate the actualKeyBits based on the role's values. If the
+	// KeyType was any, and KeyBits was set to 0, KeyBits should be updated to
+	// 2048 unless some other value was chosen explicitly.
 	//
 	// This validation needs to occur regardless of the role's key type, so
 	// that we always validate both RSA and ECDSA key sizes.

--- a/internal/builtin/logical/pki/cert_util.go
+++ b/internal/builtin/logical/pki/cert_util.go
@@ -1020,13 +1020,12 @@ func signCert(b *backend,
 		return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unsupported key type value: %s", data.role.KeyType)}
 	}
 
-	// Before validating key lengths, update our KeyBits/SignatureBits based
-	// on the actual CSR key type.
+	// Before validating key lengths, update our KeyBits based on the actual CSR
+	// key type.
 	if data.role.KeyType == "any" {
-		// We update the value of KeyBits and SignatureBits here (from the
-		// role), using the specified key type. This allows us to convert
-		// the default value (0) for SignatureBits and KeyBits to a
-		// meaningful value.
+		// We update the value of KeyBits (from the role), using the specified
+		// key type. This allows us to convert the default value (0) for KeyBits
+		// to a meaningful value.
 		//
 		// We ignore the role's original KeyBits value if the KeyType is any
 		// as legacy (pre-1.10) roles had default values that made sense only
@@ -1034,9 +1033,7 @@ func signCert(b *backend,
 		// set for KeyBits when KeyType was set to any. This also enforces the
 		// docs saying when key_type=any, we only enforce our specified minimums
 		// for signing operations
-		if data.role.KeyBits, data.role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(
-			actualKeyType, 0, data.role.SignatureBits,
-		); err != nil {
+		if data.role.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeLength(actualKeyType, 0); err != nil {
 			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unknown internal error updating default values: %v", err)}
 		}
 
@@ -1049,11 +1046,10 @@ func signCert(b *backend,
 		}
 	}
 
-	// At this point, data.role.KeyBits and data.role.SignatureBits should both
-	// be non-zero, for RSA and ECDSA keys. Validate the actualKeyBits based on
-	// the role's values. If the KeyType was any, and KeyBits was set to 0,
-	// KeyBits should be updated to 2048 unless some other value was chosen
-	// explicitly.
+	// At this point, data.role.KeyBits should be non-zero, for RSA and ECDSA
+	// keys. Validate the actualKeyBits based on the role's values. If the
+	// KeyType was any, and KeyBits was set to 0, KeyBits should be updated to
+	// 2048 unless some other value was chosen explicitly.
 	//
 	// This validation needs to occur regardless of the role's key type, so
 	// that we always validate both RSA and ECDSA key sizes.

--- a/internal/builtin/logical/pki/path_issue_sign.go
+++ b/internal/builtin/logical/pki/path_issue_sign.go
@@ -571,7 +571,7 @@ func (b *backend) pathIssue(ctx context.Context, req *logical.Request, data *fra
 		// Perform validation of the new role parameters, updating an explicit
 		// zero-valued KeyBits to a useful value.
 		var err error
-		role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits)
+		role.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeLength(role.KeyType, role.KeyBits)
 		if err != nil {
 			return nil, fmt.Errorf("failed to validate role: %w", err)
 		}
@@ -917,7 +917,7 @@ func (b *backend) pathCelIssueSignCert(ctx context.Context, req *logical.Request
 
 		keyBits := int(validationOutput.KeyBits)
 
-		keyBits, signatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(keyType, keyBits, signatureBits)
+		keyBits, err = certutil.ValidateDefaultOrValueKeyTypeLength(keyType, keyBits)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cel response for key type, key bits, or signature bits: %w", err)
 		}
@@ -928,15 +928,6 @@ func (b *backend) pathCelIssueSignCert(ctx context.Context, req *logical.Request
 		evaluationData["use_pss"] = usePSS
 	} else {
 		signingKeyType := string(signingBundle.PrivateKeyType)
-		signingKeyBits, err := signingBundle.GetKeyBits()
-		if err != nil {
-			return nil, fmt.Errorf("unable to get signing key information: %w", err)
-		}
-
-		if signatureBits, err = certutil.DefaultOrValueHashBits(signingKeyType, signingKeyBits, signatureBits); err != nil {
-			return nil, err
-		}
-
 		if err := certutil.ValidateSignatureLength(signingKeyType, signatureBits); err != nil {
 			return nil, err
 		}

--- a/internal/builtin/logical/pki/path_manage_keys.go
+++ b/internal/builtin/logical/pki/path_manage_keys.go
@@ -140,7 +140,7 @@ func (b *backend) pathGenerateKeyHandler(ctx context.Context, req *logical.Reque
 		keyType := data.Get(keyTypeParam).(string)
 		keyBits := data.Get(keyBitsParam).(int)
 
-		keyBits, _, err := certutil.ValidateDefaultOrValueKeyTypeSignatureLength(keyType, keyBits, 0)
+		keyBits, err := certutil.ValidateDefaultOrValueKeyTypeLength(keyType, keyBits)
 		if err != nil {
 			return logical.ErrorResponse("Validation for key_type, key_bits failed: %s", err.Error()), nil
 		}

--- a/internal/builtin/logical/pki/path_roles.go
+++ b/internal/builtin/logical/pki/path_roles.go
@@ -1341,7 +1341,7 @@ func validateRole(b *backend, entry *roleEntry, ctx context.Context, s logical.S
 		), nil
 	}
 
-	if entry.KeyBits, entry.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, entry.SignatureBits); err != nil {
+	if entry.KeyBits, err = certutil.ValidateDefaultOrValueKeyTypeLength(entry.KeyType, entry.KeyBits); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -722,55 +722,40 @@ func DefaultOrValueKeyBits(keyType string, keyBits int) (int, error) {
 	return keyBits, nil
 }
 
-// Returns default signature hash bit length for the specified key type and
-// bits, or the present value if hashBits is non-zero. Returns an error under
-// certain internal circumstances.
-func DefaultOrValueHashBits(keyType string, keyBits int, hashBits int) (int, error) {
-	if keyType == "ec" {
-		// Enforcement of curve moved to selectSignatureAlgorithmForECDSA. See
-		// note there about why.
-	} else if keyType == "rsa" && hashBits == 0 {
-		// To match previous behavior (and ignoring NIST's recommendations for
-		// hash size to align with RSA key sizes), default to SHA-2-256.
-		hashBits = 256
-	} else if keyType == "ed25519" || keyType == "ed448" || keyType == "mldsa" || keyType == "any" {
-		// No-op; ed25519, ed448 and mldsa internally specify their own hash and
-		// we do not need to select one. Double hashing isn't supported in
-		// certificate signing. Additionally, the any key type can't know
-		// what hash algorithm to use yet, so default to zero.
-		return 0, nil
+// ValidateDefaultOrValueKeyTypeSignatureLength validates that the
+// combination of keyType, keyBits, and hashBits are valid together; replaces
+// individual calls to DefaultOrValueKeyBits, ValidateKeyTypeLength and
+// ValidateSignatureLength. Also updates the value of keyBits on return.
+func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, hashBits int) (int, error) {
+	var err error
+
+	if keyBits, err = ValidateDefaultOrValueKeyTypeLength(keyType, keyBits); err != nil {
+		return keyBits, err
 	}
 
-	return hashBits, nil
+	if err = ValidateSignatureLength(keyType, hashBits); err != nil {
+		return keyBits, err
+	}
+
+	return keyBits, nil
 }
 
-// Validates that the combination of keyType, keyBits, and hashBits are
-// valid together; replaces individual calls to ValidateSignatureLength and
-// ValidateKeyTypeLength. Also updates the value of keyBits and hashBits on
-// return.
-func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, hashBits int) (int, int, error) {
+// ValidateDefaultOrValueKeyTypeLength validates that the combination of
+// keyType and keyBits are valid together; replaces individual calls to
+// DefaultOrValueKeyBits and ValidateKeyTypeLength. Also updates the value of
+// keyBits on return.
+func ValidateDefaultOrValueKeyTypeLength(keyType string, keyBits int) (int, error) {
 	var err error
 
 	if keyBits, err = DefaultOrValueKeyBits(keyType, keyBits); err != nil {
-		return keyBits, hashBits, err
+		return keyBits, err
 	}
 
 	if err = ValidateKeyTypeLength(keyType, keyBits); err != nil {
-		return keyBits, hashBits, err
+		return keyBits, err
 	}
 
-	if hashBits, err = DefaultOrValueHashBits(keyType, keyBits, hashBits); err != nil {
-		return keyBits, hashBits, err
-	}
-
-	// Note that this check must come after we've selected a value for
-	// hashBits above, in the event it was left as the default, but we
-	// were allowed to update it.
-	if err = ValidateSignatureLength(keyType, hashBits); err != nil {
-		return keyBits, hashBits, err
-	}
-
-	return keyBits, hashBits, nil
+	return keyBits, nil
 }
 
 // Validates that the length of the hash (in bits) used in the signature
@@ -799,6 +784,7 @@ func ValidateSignatureLength(keyType string, hashBits int) error {
 	}
 
 	switch hashBits {
+	case 0:
 	case 256:
 	case 384:
 	case 512:
@@ -864,48 +850,12 @@ func CreateCertificateWithKeyGenerator(data *CreationBundle, randReader io.Reade
 	return createCertificate(data, randReader, keyGenerator)
 }
 
-// Set correct RSA sig algo
-func certTemplateSetSigAlgo(certTemplate *x509.Certificate, data *CreationBundle) {
-	if data.Params.UsePSS {
-		switch data.Params.SignatureBits {
-		case 256:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-		case 384:
-			certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-		case 512:
-			certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-		}
-	} else {
-		switch data.Params.SignatureBits {
-		case 256:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-		case 384:
-			certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-		case 512:
-			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-		}
-	}
-}
-
-// Set correct RSA sig algo
-func celSetSigAlgo(certTemplate *x509.Certificate, usePSS bool, signatureBits int) {
-	data := CreationBundle{
-		Params: &CreationParameters{
-			UsePSS:        usePSS,
-			SignatureBits: signatureBits,
-		},
-		SigningBundle: nil,
-		CSR:           nil,
-	}
-	certTemplateSetSigAlgo(certTemplate, &data)
-}
-
 // selectSignatureAlgorithmForRSA returns the proper x509.SignatureAlgorithm based on various properties set in the
 // Creation Bundle parameter. This method will default to a SHA256 signature algorithm if the requested signature
 // bits is not set/unknown.
-func selectSignatureAlgorithmForRSA(data *CreationBundle) x509.SignatureAlgorithm {
-	if data.Params.UsePSS {
-		switch data.Params.SignatureBits {
+func selectSignatureAlgorithmForRSA(usePSS bool, signatureBits int) x509.SignatureAlgorithm {
+	if usePSS {
+		switch signatureBits {
 		case 256:
 			return x509.SHA256WithRSAPSS
 		case 384:
@@ -917,7 +867,7 @@ func selectSignatureAlgorithmForRSA(data *CreationBundle) x509.SignatureAlgorith
 		}
 	}
 
-	switch data.Params.SignatureBits {
+	switch signatureBits {
 	case 256:
 		return x509.SHA256WithRSA
 	case 384:
@@ -1029,13 +979,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 		privateKeyType := data.SigningBundle.PrivateKeyType
 		switch privateKeyType {
 		case RSAPrivateKey:
-			certTemplateSetSigAlgo(certTemplate, data)
-		case Ed25519PrivateKey:
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(data.SigningBundle.PrivateKey.Public(), data.Params.SignatureBits)
-		case MLDSAPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(data.SigningBundle.PrivateKey.Public())
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 		}
 
 		caCert := data.SigningBundle.Certificate
@@ -1053,13 +997,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 
 		switch data.Params.KeyType {
 		case "rsa":
-			certTemplateSetSigAlgo(certTemplate, data)
-		case "ed25519":
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case "ec":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
-		case "mldsa":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1169,13 +1107,7 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 		privateKeyType := caSign.PrivateKeyType
 		switch privateKeyType {
 		case RSAPrivateKey:
-			celSetSigAlgo(&certTemplate, usePSS, signatureBits)
-		case Ed25519PrivateKey:
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(caSign.PrivateKey.Public(), signatureBits)
-		case MLDSAPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(caSign.PrivateKey.Public())
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 		}
 
 		caCert := caSign.Certificate
@@ -1190,31 +1122,7 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 
 		switch keyType {
 		case "rsa":
-			if usePSS {
-				switch signatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-				}
-			} else {
-				switch signatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-				}
-			}
-		case "ed25519":
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case "ec":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), signatureBits)
-		case "mldsa":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1253,59 +1161,6 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 	}
 
 	return result, nil
-}
-
-func selectSignatureAlgorithmForMLDSA(pub crypto.PublicKey) x509.SignatureAlgorithm {
-	pubkey, ok := pub.(*mldsa.PublicKey)
-	if !ok {
-		return 0
-	}
-	switch pubkey.Parameters() {
-	case mldsa.MLDSA44():
-		return x509.MLDSA44
-	case mldsa.MLDSA65():
-		return x509.MLDSA65
-	case mldsa.MLDSA87():
-		return x509.MLDSA87
-	default:
-		return 0
-	}
-}
-
-func selectSignatureAlgorithmForECDSA(pub crypto.PublicKey, signatureBits int) x509.SignatureAlgorithm {
-	// Previously we preferred the user-specified signature bits for ECDSA
-	// keys. However, this could result in using a longer hash function than
-	// the underlying NIST P-curve will encode (e.g., a SHA-512 hash with a
-	// P-256 key). This isn't ideal: the hash is implicitly truncated
-	// (effectively turning it into SHA-512/256) and we then need to rely
-	// on the prefix security of the hash. Since both NIST and Mozilla guidance
-	// suggest instead using the correct hash function, we should prefer that
-	// over the operator-specified signatureBits.
-	//
-	// Lastly, note that pub above needs to be the _signer's_ public key;
-	// the issue with DefaultOrValueHashBits is that it is called at role
-	// configuration time, which might _precede_ issuer generation. Thus
-	// it only has access to the desired key type and not the actual issuer.
-	// The reference from that function is reproduced below:
-	//
-	// > To comply with BSI recommendations Section 4.2 and Mozilla root
-	// > store policy section 5.1.2, enforce that NIST P-curves use a hash
-	// > length corresponding to curve length. Note that ed25519 does not
-	// > implement the "ec" key type.
-	key, ok := pub.(*ecdsa.PublicKey)
-	if !ok {
-		return x509.ECDSAWithSHA256
-	}
-	switch key.Curve {
-	case elliptic.P224(), elliptic.P256():
-		return x509.ECDSAWithSHA256
-	case elliptic.P384():
-		return x509.ECDSAWithSHA384
-	case elliptic.P521():
-		return x509.ECDSAWithSHA512
-	default:
-		return x509.ECDSAWithSHA256
-	}
 }
 
 var (
@@ -1378,14 +1233,7 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 
 	switch data.Params.KeyType {
 	case "rsa":
-		// use specified RSA algorithm defaulting to the appropriate SHA256 RSA signature type
-		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data)
-	case "ec":
-		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
-	case "ed25519":
-		csrTemplate.SignatureAlgorithm = x509.PureEd25519
-	case "mldsa":
-		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
+		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 	}
 
 	csr, err := x509.CreateCertificateRequest(randReader, csrTemplate, result.PrivateKey)
@@ -1466,7 +1314,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	privateKeyType := data.SigningBundle.PrivateKeyType
 	switch privateKeyType {
 	case RSAPrivateKey:
-		certTemplateSetSigAlgo(certTemplate, data)
+		certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 	case ECPrivateKey:
 		switch data.Params.SignatureBits {
 		case 256:
@@ -1614,7 +1462,7 @@ func signCertificateWithTemplate(caSign *CAInfoBundle, CSR *x509.CertificateRequ
 	privateKeyType := caSign.PrivateKeyType
 	switch privateKeyType {
 	case RSAPrivateKey:
-		celSetSigAlgo(&certTemplate, usePSS, signatureBits)
+		certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 	case ECPrivateKey:
 		switch signatureBits {
 		case 256:

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -680,55 +680,40 @@ func DefaultOrValueKeyBits(keyType string, keyBits int) (int, error) {
 	return keyBits, nil
 }
 
-// Returns default signature hash bit length for the specified key type and
-// bits, or the present value if hashBits is non-zero. Returns an error under
-// certain internal circumstances.
-func DefaultOrValueHashBits(keyType string, keyBits int, hashBits int) (int, error) {
-	if keyType == "ec" {
-		// Enforcement of curve moved to selectSignatureAlgorithmForECDSA. See
-		// note there about why.
-	} else if keyType == "rsa" && hashBits == 0 {
-		// To match previous behavior (and ignoring NIST's recommendations for
-		// hash size to align with RSA key sizes), default to SHA-2-256.
-		hashBits = 256
-	} else if keyType == "ed25519" || keyType == "ed448" || keyType == "any" {
-		// No-op; ed25519 and ed448 internally specify their own hash and
-		// we do not need to select one. Double hashing isn't supported in
-		// certificate signing. Additionally, the any key type can't know
-		// what hash algorithm to use yet, so default to zero.
-		return 0, nil
+// ValidateDefaultOrValueKeyTypeSignatureLength validates that the
+// combination of keyType, keyBits, and hashBits are valid together; replaces
+// individual calls to DefaultOrValueKeyBits, ValidateKeyTypeLength and
+// ValidateSignatureLength. Also updates the value of keyBits on return.
+func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, hashBits int) (int, error) {
+	var err error
+
+	if keyBits, err = ValidateDefaultOrValueKeyTypeLength(keyType, keyBits); err != nil {
+		return keyBits, err
 	}
 
-	return hashBits, nil
+	if err = ValidateSignatureLength(keyType, hashBits); err != nil {
+		return keyBits, err
+	}
+
+	return keyBits, nil
 }
 
-// Validates that the combination of keyType, keyBits, and hashBits are
-// valid together; replaces individual calls to ValidateSignatureLength and
-// ValidateKeyTypeLength. Also updates the value of keyBits and hashBits on
-// return.
-func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, hashBits int) (int, int, error) {
+// ValidateDefaultOrValueKeyTypeLength validates that the combination of
+// keyType and keyBits are valid together; replaces individual calls to
+// DefaultOrValueKeyBits and ValidateKeyTypeLength. Also updates the value of
+// keyBits on return.
+func ValidateDefaultOrValueKeyTypeLength(keyType string, keyBits int) (int, error) {
 	var err error
 
 	if keyBits, err = DefaultOrValueKeyBits(keyType, keyBits); err != nil {
-		return keyBits, hashBits, err
+		return keyBits, err
 	}
 
 	if err = ValidateKeyTypeLength(keyType, keyBits); err != nil {
-		return keyBits, hashBits, err
+		return keyBits, err
 	}
 
-	if hashBits, err = DefaultOrValueHashBits(keyType, keyBits, hashBits); err != nil {
-		return keyBits, hashBits, err
-	}
-
-	// Note that this check must come after we've selected a value for
-	// hashBits above, in the event it was left as the default, but we
-	// were allowed to update it.
-	if err = ValidateSignatureLength(keyType, hashBits); err != nil {
-		return keyBits, hashBits, err
-	}
-
-	return keyBits, hashBits, nil
+	return keyBits, nil
 }
 
 // Validates that the length of the hash (in bits) used in the signature
@@ -757,6 +742,7 @@ func ValidateSignatureLength(keyType string, hashBits int) error {
 	}
 
 	switch hashBits {
+	case 0:
 	case 256:
 	case 384:
 	case 512:
@@ -814,48 +800,12 @@ func CreateCertificateWithKeyGenerator(data *CreationBundle, randReader io.Reade
 	return createCertificate(data, randReader, keyGenerator)
 }
 
-// Set correct RSA sig algo
-func certTemplateSetSigAlgo(certTemplate *x509.Certificate, data *CreationBundle) {
-	if data.Params.UsePSS {
-		switch data.Params.SignatureBits {
-		case 256:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-		case 384:
-			certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-		case 512:
-			certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-		}
-	} else {
-		switch data.Params.SignatureBits {
-		case 256:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-		case 384:
-			certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-		case 512:
-			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-		}
-	}
-}
-
-// Set correct RSA sig algo
-func celSetSigAlgo(certTemplate *x509.Certificate, usePSS bool, signatureBits int) {
-	data := CreationBundle{
-		Params: &CreationParameters{
-			UsePSS:        usePSS,
-			SignatureBits: signatureBits,
-		},
-		SigningBundle: nil,
-		CSR:           nil,
-	}
-	certTemplateSetSigAlgo(certTemplate, &data)
-}
-
 // selectSignatureAlgorithmForRSA returns the proper x509.SignatureAlgorithm based on various properties set in the
 // Creation Bundle parameter. This method will default to a SHA256 signature algorithm if the requested signature
 // bits is not set/unknown.
-func selectSignatureAlgorithmForRSA(data *CreationBundle) x509.SignatureAlgorithm {
-	if data.Params.UsePSS {
-		switch data.Params.SignatureBits {
+func selectSignatureAlgorithmForRSA(usePSS bool, signatureBits int) x509.SignatureAlgorithm {
+	if usePSS {
+		switch signatureBits {
 		case 256:
 			return x509.SHA256WithRSAPSS
 		case 384:
@@ -867,7 +817,7 @@ func selectSignatureAlgorithmForRSA(data *CreationBundle) x509.SignatureAlgorith
 		}
 	}
 
-	switch data.Params.SignatureBits {
+	switch signatureBits {
 	case 256:
 		return x509.SHA256WithRSA
 	case 384:
@@ -979,11 +929,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 		privateKeyType := data.SigningBundle.PrivateKeyType
 		switch privateKeyType {
 		case RSAPrivateKey:
-			certTemplateSetSigAlgo(certTemplate, data)
-		case Ed25519PrivateKey:
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(data.SigningBundle.PrivateKey.Public(), data.Params.SignatureBits)
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 		}
 
 		caCert := data.SigningBundle.Certificate
@@ -1001,11 +947,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 
 		switch data.Params.KeyType {
 		case "rsa":
-			certTemplateSetSigAlgo(certTemplate, data)
-		case "ed25519":
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case "ec":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1115,11 +1057,7 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 		privateKeyType := caSign.PrivateKeyType
 		switch privateKeyType {
 		case RSAPrivateKey:
-			celSetSigAlgo(&certTemplate, usePSS, signatureBits)
-		case Ed25519PrivateKey:
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(caSign.PrivateKey.Public(), signatureBits)
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 		}
 
 		caCert := caSign.Certificate
@@ -1134,29 +1072,7 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 
 		switch keyType {
 		case "rsa":
-			if usePSS {
-				switch signatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSAPSS
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSAPSS
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSAPSS
-				}
-			} else {
-				switch signatureBits {
-				case 256:
-					certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
-				case 384:
-					certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
-				case 512:
-					certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
-				}
-			}
-		case "ed25519":
-			certTemplate.SignatureAlgorithm = x509.PureEd25519
-		case "ec":
-			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), signatureBits)
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1195,42 +1111,6 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 	}
 
 	return result, nil
-}
-
-func selectSignatureAlgorithmForECDSA(pub crypto.PublicKey, signatureBits int) x509.SignatureAlgorithm {
-	// Previously we preferred the user-specified signature bits for ECDSA
-	// keys. However, this could result in using a longer hash function than
-	// the underlying NIST P-curve will encode (e.g., a SHA-512 hash with a
-	// P-256 key). This isn't ideal: the hash is implicitly truncated
-	// (effectively turning it into SHA-512/256) and we then need to rely
-	// on the prefix security of the hash. Since both NIST and Mozilla guidance
-	// suggest instead using the correct hash function, we should prefer that
-	// over the operator-specified signatureBits.
-	//
-	// Lastly, note that pub above needs to be the _signer's_ public key;
-	// the issue with DefaultOrValueHashBits is that it is called at role
-	// configuration time, which might _precede_ issuer generation. Thus
-	// it only has access to the desired key type and not the actual issuer.
-	// The reference from that function is reproduced below:
-	//
-	// > To comply with BSI recommendations Section 4.2 and Mozilla root
-	// > store policy section 5.1.2, enforce that NIST P-curves use a hash
-	// > length corresponding to curve length. Note that ed25519 does not
-	// > implement the "ec" key type.
-	key, ok := pub.(*ecdsa.PublicKey)
-	if !ok {
-		return x509.ECDSAWithSHA256
-	}
-	switch key.Curve {
-	case elliptic.P224(), elliptic.P256():
-		return x509.ECDSAWithSHA256
-	case elliptic.P384():
-		return x509.ECDSAWithSHA384
-	case elliptic.P521():
-		return x509.ECDSAWithSHA512
-	default:
-		return x509.ECDSAWithSHA256
-	}
 }
 
 var (
@@ -1304,11 +1184,7 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 	switch data.Params.KeyType {
 	case "rsa":
 		// use specified RSA algorithm defaulting to the appropriate SHA256 RSA signature type
-		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data)
-	case "ec":
-		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
-	case "ed25519":
-		csrTemplate.SignatureAlgorithm = x509.PureEd25519
+		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 	}
 
 	csr, err := x509.CreateCertificateRequest(randReader, csrTemplate, result.PrivateKey)
@@ -1389,7 +1265,7 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	privateKeyType := data.SigningBundle.PrivateKeyType
 	switch privateKeyType {
 	case RSAPrivateKey:
-		certTemplateSetSigAlgo(certTemplate, data)
+		certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(data.Params.UsePSS, data.Params.SignatureBits)
 	case ECPrivateKey:
 		switch data.Params.SignatureBits {
 		case 256:
@@ -1537,7 +1413,7 @@ func signCertificateWithTemplate(caSign *CAInfoBundle, CSR *x509.CertificateRequ
 	privateKeyType := caSign.PrivateKeyType
 	switch privateKeyType {
 	case RSAPrivateKey:
-		celSetSigAlgo(&certTemplate, usePSS, signatureBits)
+		certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForRSA(usePSS, signatureBits)
 	case ECPrivateKey:
 		switch signatureBits {
 		case 256:


### PR DESCRIPTION
## Description

This fixes two related bugs:

1. When using an RSA-based issuer, a role with `use_pss=true` + `signature_bits=0` would issue certs signed via PKCS#1 v1.5 due to missing `default` cases in certutil's `x509.SignatureAlgorithm` selection.
2. PKI would pick a default `signature_bits` for a role based on the role's key type, which may often be coincidentally correct but is generally nonsensical. `signature_bits` applies to the operation performed by the issuer which may use an entirely separate key type. Since issuer information is not trivially available e.g., at role creation, fully remove the defaulting logic (as it only applied to RSA to begin with) and defer to the fix for 1).

Combining 1) and 2), an RSA-based issuer used by a role that has `use_pss=true`, `key_type != "rsa"` and no explicit `signature_bits` would always result in issued certificates being signed via PKCS#1 v1.5 as `signature_bits` would default to `0` unless `key_type == "rsa"`.

To reproduce:

```
bao secrets enable pki
bao write pki/root/generate/internal common_name="Root CA" key_type=rsa key_bits=4096
bao write pki/roles/test use_pss=true key_type=ec key_bits=256 allow_any_name=true
bao write pki/issue/test common_name=openbao ttl=600
```

... then inspect the generated leaf.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
