### PR TITLE
Enable ML-DSA support in PKI

### DIFF
--- a/internal/builtin/logical/pki/backend_test.go
+++ b/internal/builtin/logical/pki/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -724,6 +725,17 @@ func generateCSR(t *testing.T, csrTemplate *x509.CertificateRequest, keyType str
 		}
 	case "ed25519":
 		_, priv, err = ed25519.GenerateKey(rand.Reader)
+	case "mldsa":
+		switch keyBits {
+		case 44:
+			priv, err = mldsa.GenerateKey(mldsa.MLDSA44())
+		case 65:
+			priv, err = mldsa.GenerateKey(mldsa.MLDSA65())
+		case 87:
+			priv, err = mldsa.GenerateKey(mldsa.MLDSA87())
+		default:
+			t.Fatalf("Got unknown ML-DSA size: %v", keyBits)
+		}
 	}
 
 	if err != nil {
@@ -5276,7 +5288,7 @@ type KeySizeRegression struct {
 
 func (k KeySizeRegression) KeyTypeValues() []string {
 	if k.RoleKeyType == "any" {
-		return []string{"rsa", "ec", "ed25519"}
+		return []string{"rsa", "ec", "ed25519", "mldsa"}
 	}
 
 	return []string{k.RoleKeyType}
@@ -5363,14 +5375,14 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 	// Regression testing of role's issuance policy.
 	testCases := []KeySizeRegression{
 		// RSA with default parameters should fail to issue smaller RSA keys
-		// and any size ECDSA/Ed25519 keys.
-		/*  0 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, false, []string{"rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{1024, 224, 256, 384, 521, 0}, true},
+		// and any size ECDSA/Ed25519/MLDSA keys.
+		/*  0 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, false, []string{"rsa", "ec", "ec", "ec", "ec", "ed25519", "mldsa"}, []int{1024, 224, 256, 384, 521, 0, 65}, true},
 		// But it should work to issue larger RSA keys.
 		/*  1 */ {"rsa", []int{0, 2048}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa"}, []int{2048, 3072}, false},
 
 		// EC with default parameters should fail to issue smaller EC keys
-		// and any size RSA/Ed25519 keys.
-		/*  2 */ {"ec", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519"}, []int{2048, 224, 0}, true},
+		// and any size RSA/Ed25519/MLDSA keys.
+		/*  2 */ {"ec", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519", "mldsa"}, []int{2048, 224, 0, 65}, true},
 		// But it should work to issue larger EC keys. Note that we should be
 		// independent of signature bits as that's computed from the issuer
 		// type (for EC based issuers).
@@ -5379,15 +5391,15 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/*  5 */ {"ec", []int{384}, []int{0, 256, 384, 521}, false, []string{"ec", "ec"}, []int{384, 521}, false},
 		/*  6 */ {"ec", []int{521}, []int{0, 256, 384, 512}, false, []string{"ec"}, []int{521}, false},
 
-		// Ed25519 should reject RSA and EC keys.
-		/*  7 */ {"ed25519", []int{0}, []int{0}, false, []string{"rsa", "ec", "ec"}, []int{2048, 256, 521}, true},
+		// Ed25519 should reject RSA, EC, and MLDSA keys.
+		/*  7 */ {"ed25519", []int{0}, []int{0}, false, []string{"rsa", "ec", "ec", "mldsa"}, []int{2048, 256, 521, 65}, true},
 		// But it should work to issue Ed25519 keys.
 		/*  8 */ {"ed25519", []int{0}, []int{0}, false, []string{"ed25519"}, []int{0}, false},
 
 		// Any key type should reject insecure RSA key sizes.
 		/*  9 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{1024}, true},
 		// But work for everything else.
-		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519"}, []int{2048, 3072, 224, 256, 384, 521, 0}, false},
+		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519", "mldsa"}, []int{2048, 3072, 224, 256, 384, 521, 0, 65}, false},
 
 		// RSA with larger than default key size should reject smaller ones.
 		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{2048}, true},
@@ -5396,9 +5408,13 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/* 12 */ {"rsa", []int{0}, []int{0, 256, 384, 512}, true, []string{"rsa"}, []int{2048}, false},
 		/* 13 */ {"ec", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
 		/* 14 */ {"ed25519", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
+
+		/* 15 */ {"mldsa", []int{0, 44, 65, 87}, []int{0}, false, []string{"mldsa"}, []int{65}, false},
+		// ML-DSA should reject RSA, EC, and Ed25519 keys
+		/* 16 */ {"mldsa", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519"}, []int{2048, 256, 0}, true},
 	}
 
-	if len(testCases) != 15 {
+	if len(testCases) != 17 {
 		t.Fatalf("misnumbered test case entries will make it hard to find bugs: %v", len(testCases))
 	}
 
@@ -7819,6 +7835,7 @@ func TestPKI_IssueKeyTypeAny(t *testing.T) {
 		"rsa":     {0, 2048, 3072, 4096},
 		"ec":      {0, 256, 384, 521},
 		"ed25519": {0},
+		"mldsa":   {0, 44, 65, 87},
 	}
 
 	resp, err := CBWrite(b, s, "root/generate/internal", map[string]any{

--- a/internal/builtin/logical/pki/backend_test.go
+++ b/internal/builtin/logical/pki/backend_test.go
@@ -5399,7 +5399,7 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		// Any key type should reject insecure RSA key sizes.
 		/*  9 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{1024}, true},
 		// But work for everything else.
-		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519", "mldsa"}, []int{2048, 3072, 224, 256, 384, 521, 0, 65}, false},
+		/* 10 */ {"any", []int{0}, []int{0, 256, 384, 512}, false, []string{"rsa", "rsa", "ec", "ec", "ec", "ec", "ed25519", "mldsa", "mldsa"}, []int{2048, 3072, 224, 256, 384, 521, 0, 44, 65}, false},
 
 		// RSA with larger than default key size should reject smaller ones.
 		/* 11 */ {"rsa", []int{3072}, []int{0, 256, 384, 512}, false, []string{"rsa"}, []int{2048}, true},
@@ -5409,12 +5409,15 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/* 13 */ {"ec", []int{0}, []int{0}, true, []string{"ec"}, []int{256}, false},
 		/* 14 */ {"ed25519", []int{0}, []int{0}, true, []string{"ed25519"}, []int{0}, false},
 
-		/* 15 */ {"mldsa", []int{0, 44, 65, 87}, []int{0}, false, []string{"mldsa"}, []int{65}, false},
-		// ML-DSA should reject RSA, EC, and Ed25519 keys
-		/* 16 */ {"mldsa", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519"}, []int{2048, 256, 0}, true},
+		// ML-DSA should accept same or larger parameters
+		/* 15 */ {"mldsa", []int{44}, []int{0}, false, []string{"mldsa", "mldsa", "mldsa"}, []int{44, 65, 87}, false},
+		/* 16 */ {"mldsa", []int{0, 65}, []int{0}, false, []string{"mldsa", "mldsa"}, []int{65, 87}, false},
+		/* 17 */ {"mldsa", []int{87}, []int{0}, false, []string{"mldsa"}, []int{87}, false},
+		// ML-DSA 65 should reject RSA, EC, Ed25519, and ML-DSA 44 keys
+		/* 18 */ {"mldsa", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519", "mldsa"}, []int{2048, 256, 0, 44}, true},
 	}
 
-	if len(testCases) != 17 {
+	if len(testCases) != 19 {
 		t.Fatalf("misnumbered test case entries will make it hard to find bugs: %v", len(testCases))
 	}
 

--- a/internal/builtin/logical/pki/ca_util.go
+++ b/internal/builtin/logical/pki/ca_util.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -232,6 +233,8 @@ func getKeyTypeAndBitsFromPublicKeyForRole(pubKey crypto.PublicKey) (certutil.Pr
 		keyType = certutil.ECPrivateKey
 	case ed25519.PublicKey:
 		keyType = certutil.Ed25519PrivateKey
+	case *mldsa.PublicKey:
+		keyType = certutil.MLDSAPrivateKey
 	default:
 		return certutil.UnknownPrivateKey, 0, fmt.Errorf("unsupported public key: %#v", pubKey)
 	}

--- a/internal/builtin/logical/pki/cert_util.go
+++ b/internal/builtin/logical/pki/cert_util.go
@@ -1072,12 +1072,16 @@ func signCert(b *backend,
 			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unknown internal error updating default values: %v", err)}
 		}
 
+		switch actualKeyType {
 		// We're using the KeyBits field as a minimum value below, and P-224 is safe
 		// and a previously allowed value. However, the above call defaults
 		// to P-256 as that's a saner default than P-224 (w.r.t. generation), so
 		// override it here to allow 224 as the smallest size we permit.
-		if actualKeyType == "ec" {
+		case "ec":
 			data.role.KeyBits = 224
+		// same reasoning as above for "ec": we allow 44 instead of 65 parameter set
+		case "mldsa":
+			data.role.KeyBits = 44
 		}
 	}
 
@@ -1104,7 +1108,7 @@ func signCert(b *backend,
 				actualKeyBits,
 			)}
 		}
-	case "ec":
+	case "ec", "mldsa":
 		if actualKeyBits < data.role.KeyBits {
 			return nil, nil, errutil.UserError{Err: fmt.Sprintf(
 				"role requires a minimum of a %d-bit key, but CSR's key is %d bits",
@@ -1112,7 +1116,6 @@ func signCert(b *backend,
 				actualKeyBits,
 			)}
 		}
-		// TODO: How do we want to handle mldsa here? Do we require exact parameter set match?
 	}
 
 	creation, warnings, err := generateCreationBundle(b, data, caSign, csr)

--- a/internal/builtin/logical/pki/cert_util.go
+++ b/internal/builtin/logical/pki/cert_util.go
@@ -7,6 +7,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -982,6 +983,25 @@ func signCert(b *backend,
 
 		actualKeyType = "ed25519"
 		actualKeyBits = 0
+	case "mldsa":
+		if csr.PublicKeyAlgorithm != x509.MLDSA {
+			return nil, nil, errutil.UserError{Err: fmt.Sprintf(
+				"role requires keys of type %s",
+				data.role.KeyType,
+			)}
+		}
+
+		pubkey, ok := csr.PublicKey.(*mldsa.PublicKey)
+		if !ok {
+			return nil, nil, errutil.UserError{Err: "could not parse CSR's public key"}
+		}
+
+		actualKeyType = "mldsa"
+		label := certutil.GetMLDSAParameterSetLabel(pubkey)
+		if label == -1 {
+			return nil, nil, errutil.UserError{Err: fmt.Sprintf("Unknown key size for ML-DSA: %v", pubkey.Parameters().String())}
+		}
+		actualKeyBits = label
 	case "any":
 		// We need to compute the actual key type and key bits, to correctly
 		// validate minimums and SignatureBits below.
@@ -1013,6 +1033,18 @@ func signCert(b *backend,
 
 			actualKeyType = "ed25519"
 			actualKeyBits = 0
+		case x509.MLDSA:
+			pubkey, ok := csr.PublicKey.(*mldsa.PublicKey)
+			if !ok {
+				return nil, nil, errutil.UserError{Err: "could not parse CSR's public key"}
+			}
+
+			actualKeyType = "mldsa"
+			label := certutil.GetMLDSAParameterSetLabel(pubkey)
+			if label == -1 {
+				return nil, nil, errutil.UserError{Err: fmt.Sprintf("Unknown key size for ML-DSA: %v", pubkey.Parameters().String())}
+			}
+			actualKeyBits = label
 		default:
 			return nil, nil, errutil.UserError{Err: "Unknown key type in CSR: " + csr.PublicKeyAlgorithm.String()}
 		}
@@ -1080,6 +1112,7 @@ func signCert(b *backend,
 				actualKeyBits,
 			)}
 		}
+		// TODO: How do we want to handle mldsa here? Do we require exact parameter set match?
 	}
 
 	creation, warnings, err := generateCreationBundle(b, data, caSign, csr)
@@ -1880,7 +1913,7 @@ func convertRespToPKCS8(resp *logical.Response) error {
 		signer, err = x509.ParsePKCS1PrivateKey(keyData)
 	case certutil.ECPrivateKey:
 		signer, err = x509.ParseECPrivateKey(keyData)
-	case certutil.Ed25519PrivateKey:
+	case certutil.Ed25519PrivateKey, certutil.MLDSAPrivateKey:
 		k, err := x509.ParsePKCS8PrivateKey(keyData)
 		if err != nil {
 			return fmt.Errorf("error converting response to pkcs8: error parsing previous key: %w", err)

--- a/internal/builtin/logical/pki/crl_test.go
+++ b/internal/builtin/logical/pki/crl_test.go
@@ -167,6 +167,9 @@ func TestBackend_CRL_AllKeyTypeSigAlgos(t *testing.T) {
 		{"ec", 384, 384, false, "ECDSAWithSHA384"},
 		{"ec", 521, 521, false, "ECDSAWithSHA512"},
 		{"ed25519", 0, 0, false, "Ed25519"},
+		{"mldsa", 44, 0, false, "MLDSA44"},
+		{"mldsa", 65, 0, false, "MLDSA65"},
+		{"mldsa", 87, 0, false, "MLDSA87"},
 	}
 
 	for index, tc := range testCases {

--- a/internal/builtin/logical/pki/fields.go
+++ b/internal/builtin/logical/pki/fields.go
@@ -330,7 +330,7 @@ the private key!`,
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},
@@ -358,9 +358,9 @@ RSA key-type issuer. Defaults to false.`,
 	fields["key_type"] = &framework.FieldSchema{
 		Type:    framework.TypeString,
 		Default: "rsa",
-		Description: `The type of key to use; defaults to RSA. "rsa"
-"ec" and "ed25519" are the only valid values.`,
-		AllowedValues: []any{"rsa", "ec", "ed25519"},
+		Description: `The type of key to use; defaults to RSA. "rsa",
+"ec", "ed25519", and "mldsa" are the only valid values.`,
+		AllowedValues: []any{"rsa", "ec", "ed25519", "mldsa"},
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: "rsa",
 		},
@@ -509,16 +509,16 @@ in most operational scenarios).`,
 	fields["tidy_acme"] = &framework.FieldSchema{
 		Type: framework.TypeBool,
 		Description: `Set to true to enable tidying ACME accounts,
-orders and authorizations.  ACME orders are tidied (deleted) 
+orders and authorizations.  ACME orders are tidied (deleted)
 safety_buffer after the certificate associated with them expires,
-or after the order and relevant authorizations have expired if no 
-certificate was produced.  Authorizations are tidied with the 
+or after the order and relevant authorizations have expired if no
+certificate was produced.  Authorizations are tidied with the
 corresponding order.
 
 When a valid ACME Account is at least acme_account_safety_buffer
 old, and has no remaining orders associated with it, the account is
-marked as revoked.  After another acme_account_safety_buffer has 
-passed from the revocation or deactivation date, a revoked or 
+marked as revoked.  After another acme_account_safety_buffer has
+passed from the revocation or deactivation date, a revoked or
 deactivated ACME account is deleted.`,
 		Default: false,
 	}
@@ -560,10 +560,10 @@ after being marked revoked or deactivated.`,
 
 	fields["page_size"] = &framework.FieldSchema{
 		Type: framework.TypeInt,
-		Description: `The number of certificates to process per page during list 
+		Description: `The number of certificates to process per page during list
 pagination. This setting enables tidy to handle certificates in smaller increments,
-rather than loading the entire set into memory at once. 
-Defaults to 1000 certificates, with a minimum of 5 certificates per page. To 
+rather than loading the entire set into memory at once.
+Defaults to 1000 certificates, with a minimum of 5 certificates per page. To
 revert to the old behavior, set page size to any value less than zero.`,
 		Default: int(defaultTidyConfig.PageSize),
 	}

--- a/internal/builtin/logical/pki/integration_test.go
+++ b/internal/builtin/logical/pki/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -340,6 +341,9 @@ func TestIntegration_CSRGeneration(t *testing.T) {
 		{"ec", false, 521, 0, &ecdsa.PublicKey{}, x509.ECDSAWithSHA512},
 		{"ec", false, 521, 224, &ecdsa.PublicKey{}, x509.ECDSAWithSHA512}, // We ignore signature_bits for ec
 		{"ed25519", false, 0, 0, ed25519.PublicKey{}, x509.PureEd25519},   // We ignore both fields for ed25519
+		{"mldsa", false, 44, 0, &mldsa.PublicKey{}, x509.MLDSA44},
+		{"mldsa", false, 65, 0, &mldsa.PublicKey{}, x509.MLDSA65},
+		{"mldsa", false, 87, 0, &mldsa.PublicKey{}, x509.MLDSA87},
 	}
 	for _, tc := range testCases {
 		keyTypeName := tc.keyType

--- a/internal/builtin/logical/pki/path_fetch.go
+++ b/internal/builtin/logical/pki/path_fetch.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
+	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/openbao/openbao/sdk/v2/helper/errutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"golang.org/x/crypto/ed25519"
@@ -379,6 +381,13 @@ func (b *backend) pathFetchCertListDetailed(ctx context.Context, req *logical.Re
 		case ed25519.PublicKey:
 			keyBits = 256 // Fixed size for Ed25519
 			keyType = "ed25519"
+		case *mldsa.PublicKey:
+			keyType = "mldsa"
+			label := certutil.GetMLDSAParameterSetLabel(pubKey)
+			if label == -1 {
+				return nil, fmt.Errorf("unknown ML-DSA parameter set: %s", pubKey.Parameters().String())
+			}
+			keyBits = label
 		default:
 			keyBits = 0 // Unknown key type
 			keyType = "unknown"

--- a/internal/builtin/logical/pki/path_issue_sign.go
+++ b/internal/builtin/logical/pki/path_issue_sign.go
@@ -50,7 +50,7 @@ func pathCelIssue(b *backend) *framework.Path {
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},
@@ -60,9 +60,9 @@ ed25519.`,
 		Type:    framework.TypeString,
 		Default: "",
 		Description: `The type of key to use; defaults to the empty string
-to use whatever is specified by the role. "rsa", "ec", and "ed25519" are the
-only valid values outside of the empty string.`,
-		AllowedValues: []any{"", "rsa", "ec", "ed25519"},
+to use whatever is specified by the role. "rsa", "ec", "ed25519", and "mldsa"
+are the only valid values outside of the empty string.`,
+		AllowedValues: []any{"", "rsa", "ec", "ed25519", "mldsa"},
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: "",
 		},
@@ -229,7 +229,7 @@ func buildPathIssue(b *backend, pattern string, displayAttrs *framework.DisplayA
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},
@@ -239,9 +239,9 @@ ed25519.`,
 		Type:    framework.TypeString,
 		Default: "",
 		Description: `The type of key to use; defaults to the empty string
-to use whatever is specified by the role. "rsa","ec", and "ed25519" are the
-only valid values outside of the empty string.`,
-		AllowedValues: []any{"", "rsa", "ec", "ed25519"},
+to use whatever is specified by the role. "rsa","ec", "ed25519", and "mldsa"
+are the only valid values outside of the empty string.`,
+		AllowedValues: []any{"", "rsa", "ec", "ed25519", "mldsa"},
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: "",
 		},

--- a/internal/builtin/logical/pki/path_manage_keys.go
+++ b/internal/builtin/logical/pki/path_manage_keys.go
@@ -35,8 +35,8 @@ func pathGenerateKey(b *backend) *framework.Path {
 				Type:    framework.TypeString,
 				Default: "rsa",
 				Description: `The type of key to use; defaults to RSA. "rsa"
-"ec" and "ed25519" are the only valid values.`,
-				AllowedValues: []any{"rsa", "ec", "ed25519"},
+"ec", "ed25519", and "mldsa" are the only valid values.`,
+				AllowedValues: []any{"rsa", "ec", "ed25519", "mldsa"},
 				DisplayAttrs: &framework.DisplayAttributes{
 					Value: "rsa",
 				},
@@ -47,7 +47,7 @@ func pathGenerateKey(b *backend) *framework.Path {
 				Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 			},
 			externalKeyRefParam: {
 				Type:        framework.TypeString,

--- a/internal/builtin/logical/pki/path_manage_keys_test.go
+++ b/internal/builtin/logical/pki/path_manage_keys_test.go
@@ -33,6 +33,7 @@ func TestPKI_PathManageKeys_GenerateInternalKeys(t *testing.T) {
 		{"rsa", "rsa", []int{0, 2048, 3072, 4096}, false},
 		{"ec", "ec", []int{0, 224, 256, 384, 521}, false},
 		{"ed25519", "ed25519", []int{0}, false},
+		{"mldsa", "mldsa", []int{0, 44, 65, 87}, false},
 		{"error-rsa", "rsa", []int{-1, 343444}, true},
 		{"error-ec", "ec", []int{-1, 3434324}, true},
 		{"error-bad-type", "dskjfkdsfjdkf", []int{0}, true},

--- a/internal/builtin/logical/pki/path_revoke.go
+++ b/internal/builtin/logical/pki/path_revoke.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"crypto/subtle"
 	"crypto/x509"
@@ -453,6 +454,14 @@ func validatePublicKeyMatchesCert(verifier crypto.PublicKey, certReference *x509
 			return errutil.UserError{Err: "provided private key type does not match certificate's public key type"}
 		}
 		if subtle.ConstantTimeCompare(privPub, certPub) == 0 {
+			return errutil.UserError{Err: "provided private key does not match certificate's public key"}
+		}
+	case *mldsa.PublicKey:
+		privPub, ok := verifier.(*mldsa.PublicKey)
+		if !ok {
+			return errutil.UserError{Err: "provided private key type does not match certificate's public key type"}
+		}
+		if !privPub.Equal(certPub) {
 			return errutil.UserError{Err: "provided private key does not match certificate's public key"}
 		}
 	default:

--- a/internal/builtin/logical/pki/path_roles.go
+++ b/internal/builtin/logical/pki/path_roles.go
@@ -184,7 +184,7 @@ Allowed IP ranges can be further restricted using allowed_ip_sans_cidr.`,
 			Type:     framework.TypeCommaStringSlice,
 			Required: true,
 			Description: `Specifies the IP CIDRs this role is allowed
-to issue certificates for. This is used with the allow_ip_sans to 
+to issue certificates for. This is used with the allow_ip_sans to
 determine matches for the common name, and IP-typed SAN entries of
 certificates. See the documentation for more information. This parameter
 accepts a comma-separated string or list of CIDR notated IPs.
@@ -252,8 +252,8 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 		"key_type": {
 			Type:     framework.TypeString,
 			Required: true,
-			Description: `The type of key to use; defaults to RSA. "rsa"
-"ec", "ed25519" and "any" are the only valid values.`,
+			Description: `The type of key to use; defaults to RSA. "rsa",
+"ec", "ed25519", "mldsa" and "any" are the only valid values.`,
 		},
 
 		"key_bits": {
@@ -262,7 +262,7 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 			Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 		},
 		"signature_bits": {
 			Type:     framework.TypeInt,
@@ -384,7 +384,7 @@ leases adversely affect the startup time of OpenBao.`,
 			Type: framework.TypeBool,
 			Description: `
 If set, certificates issued/signed against this role will not be stored in the
-storage backend. This can improve performance when issuing large numbers of 
+storage backend. This can improve performance when issuing large numbers of
 certificates. However, certificates issued in this way cannot be enumerated
 or revoked, so this option is recommended only for certificates that are
 non-sensitive, or extremely short-lived. This option implies a value of "false"
@@ -410,7 +410,7 @@ non-Hostname, non-Email address CNs.`,
 		"policy_identifiers": {
 			Type: framework.TypeCommaStringSlice,
 			Description: `A comma-separated string or list of policy OIDs, or a JSON list of qualified policy
-information, which must include an oid, and may include a notice and/or cps url, using the form 
+information, which must include an oid, and may include a notice and/or cps url, using the form
 [{"oid"="1.3.6.1.4.1.7.8","notice"="I am a user Notice"}, {"oid"="1.3.6.1.4.1.32473.1.2.4 ","cps"="https://example.com"}].`,
 		},
 
@@ -588,7 +588,7 @@ Allowed IP ranges can be further restricted using allowed_ip_sans_cidr.`,
 			"allowed_ip_sans_cidr": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Specifies the IP CIDRs this role is allowed
-to issue certificates for. This is used with the allow_ip_sans to 
+to issue certificates for. This is used with the allow_ip_sans to
 determine matches for the common name, and IP-typed SAN entries of
 certificates. See the documentation for more information. This parameter
 accepts a comma-separated string or list of CIDR notated IPs.`,
@@ -664,8 +664,8 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 				Type:    framework.TypeString,
 				Default: "rsa",
 				Description: `The type of key to use; defaults to RSA. "rsa"
-"ec", "ed25519" and "any" are the only valid values.`,
-				AllowedValues: []any{"rsa", "ec", "ed25519", "any"},
+"ec", "ed25519", "mldsa" and "any" are the only valid values.`,
+				AllowedValues: []any{"rsa", "ec", "ed25519", "mldsa", "any"},
 			},
 
 			"key_bits": {
@@ -674,7 +674,7 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 				Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519.`,
+ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
 			},
 
 			"signature_bits": {
@@ -824,7 +824,7 @@ leases adversely affect the startup time of OpenBao.`,
 				Type: framework.TypeBool,
 				Description: `
 If set, certificates issued/signed against this role will not be stored in the
-storage backend. This can improve performance when issuing large numbers of 
+storage backend. This can improve performance when issuing large numbers of
 certificates. However, certificates issued in this way cannot be enumerated
 or revoked, so this option is recommended only for certificates that are
 non-sensitive, or extremely short-lived. This option implies a value of "false"
@@ -858,7 +858,7 @@ non-Hostname, non-Email address CNs.`,
 			"policy_identifiers": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `A comma-separated string or list of policy OIDs, or a JSON list of qualified policy
-information, which must include an oid, and may include a notice and/or cps url, using the form 
+information, which must include an oid, and may include a notice and/or cps url, using the form
 [{"oid"="1.3.6.1.4.1.7.8","notice"="I am a user Notice"}, {"oid"="1.3.6.1.4.1.32473.1.2.4 ","cps"="https://example.com"}].`,
 			},
 

--- a/internal/builtin/logical/pki/path_root.go
+++ b/internal/builtin/logical/pki/path_root.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -653,8 +654,20 @@ func publicKeyType(pub crypto.PublicKey) (pubType x509.PublicKeyAlgorithm, sigAl
 	case ed25519.PublicKey:
 		pubType = x509.Ed25519
 		sigAlgo = x509.PureEd25519
+	case *mldsa.PublicKey:
+		pubType = x509.MLDSA
+		switch pub.Parameters() {
+		case mldsa.MLDSA44():
+			sigAlgo = x509.MLDSA44
+		case mldsa.MLDSA65():
+			sigAlgo = x509.MLDSA65
+		case mldsa.MLDSA87():
+			sigAlgo = x509.MLDSA87
+		default:
+			err = errors.New("x509: unknown ML-DSA parameters")
+		}
 	default:
-		err = errors.New("x509: only RSA, ECDSA and Ed25519 keys supported")
+		err = errors.New("x509: only RSA, ECDSA, Ed25519, and ML-DSA keys supported")
 	}
 	return pubType, sigAlgo, err
 }

--- a/internal/builtin/logical/pki/storage.go
+++ b/internal/builtin/logical/pki/storage.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/mldsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -609,6 +610,25 @@ func (i issuerEntry) CanMaybeSignWithAlgo(algo x509.SignatureAlgorithm) error {
 		switch algo {
 		case x509.PureEd25519:
 			return nil
+		}
+	case x509.MLDSA:
+		pubk, ok := cert.PublicKey.(*mldsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("unable to parse ML-DSA public key")
+		}
+		switch pubk.Parameters() {
+		case mldsa.MLDSA44():
+			if algo == x509.MLDSA44 {
+				return nil
+			}
+		case mldsa.MLDSA65():
+			if algo == x509.MLDSA65 {
+				return nil
+			}
+		case mldsa.MLDSA87():
+			if algo == x509.MLDSA87 {
+				return nil
+			}
 		}
 	}
 

--- a/internal/builtin/logical/pki/storage.go
+++ b/internal/builtin/logical/pki/storage.go
@@ -629,6 +629,8 @@ func (i issuerEntry) CanMaybeSignWithAlgo(algo x509.SignatureAlgorithm) error {
 			if algo == x509.MLDSA87 {
 				return nil
 			}
+		default:
+			return fmt.Errorf("unable to use issuer of type %v to sign with %v key type", pubk.Parameters().String(), algo.String())
 		}
 	}
 

--- a/internal/command/pki_reissue_intermediate.go
+++ b/internal/command/pki_reissue_intermediate.go
@@ -283,6 +283,8 @@ func getKeyType(goKeyType string) string {
 		return "ec"
 	case "Ed25519":
 		return "ed25519"
+	case "ML-DSA":
+		return "mldsa"
 	default:
 		return ""
 	}

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -523,7 +523,6 @@ func TestGetPublicKeySize(t *testing.T) {
 	if GetPublicKeySize(ed25519) != 256 {
 		t.Fatal("unexpected ed25519 key size")
 	}
-	// Skipping DSA as too slow
 	mldsakey, err := mldsa.GenerateKey(mldsa.MLDSA65())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -523,6 +524,13 @@ func TestGetPublicKeySize(t *testing.T) {
 		t.Fatal("unexpected ed25519 key size")
 	}
 	// Skipping DSA as too slow
+	mldsakey, err := mldsa.GenerateKey(mldsa.MLDSA65())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if GetPublicKeySize(mldsakey.PublicKey()) != 65 {
+		t.Fatal("unexpected mldsa key size")
+	}
 }
 
 func refreshRSA8CertBundle() *CertBundle {

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1748,6 +1748,8 @@ func GetPublicKeyType(pub crypto.PublicKey) PrivateKeyType {
 		return ECPrivateKey
 	case ed25519.PublicKey:
 		return Ed25519PrivateKey
+	case *mldsa.PublicKey:
+		return MLDSAPrivateKey
 	default:
 		return UnknownPrivateKey
 	}

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -38,8 +39,9 @@ const rsaMinimumSecureKeySize = 2048
 
 // Mapping of key types to default key lengths
 var defaultAlgorithmKeyBits = map[string]int{
-	"rsa": 2048,
-	"ec":  256,
+	"rsa":   2048,
+	"ec":    256,
+	"mldsa": 65,
 }
 
 // Mapping of NIST P-Curve's key length to expected signature bits.
@@ -63,6 +65,9 @@ var SignatureAlgorithmNames = map[string]x509.SignatureAlgorithm{
 	"sha512withrsapss": x509.SHA512WithRSAPSS,
 	"pureed25519":      x509.PureEd25519,
 	"ed25519":          x509.PureEd25519, // Duplicated for clarity; most won't expect the "Pure" prefix.
+	"mldsa44":          x509.MLDSA44,
+	"mldsa65":          x509.MLDSA65,
+	"mldsa87":          x509.MLDSA87,
 }
 
 // Mapping of constant values<->constant names for SignatureAlgorithm
@@ -77,6 +82,9 @@ var InvSignatureAlgorithmNames = map[x509.SignatureAlgorithm]string{
 	x509.SHA384WithRSAPSS: "SHA384WithRSAPSS",
 	x509.SHA512WithRSAPSS: "SHA512WithRSAPSS",
 	x509.PureEd25519:      "Ed25519",
+	x509.MLDSA44:          "MLDSA44",
+	x509.MLDSA65:          "MLDSA65",
+	x509.MLDSA87:          "MLDSA87",
 }
 
 // OID for RFC 5280 CRL Number extension.
@@ -167,6 +175,8 @@ func GetSubjectKeyID(pub any) ([]byte, error) {
 		}
 	case ed25519.PublicKey:
 		publicKeyBytes = pub
+	case *mldsa.PublicKey:
+		publicKeyBytes = pub.Bytes()
 	default:
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unsupported public key type: %T", pub)}
 	}
@@ -231,6 +241,8 @@ func ParseDERKey(privateKeyBytes []byte) (signer crypto.Signer, format BlockType
 		case *ecdsa.PrivateKey:
 			signer = rawSigner
 		case ed25519.PrivateKey:
+			signer = rawSigner
+		case *mldsa.PrivateKey:
 			signer = rawSigner
 		default:
 			return nil, UnknownBlock, errutil.InternalError{Err: "unknown type for parsed PKCS8 Private Key"}
@@ -387,6 +399,27 @@ func generatePrivateKey(keyType string, keyBits int, container ParsedPrivateKeyC
 		if err != nil {
 			return errutil.InternalError{Err: fmt.Sprintf("error marshalling Ed25519 private key: %v", err)}
 		}
+	case "mldsa":
+		privateKeyType = MLDSAPrivateKey
+		var params mldsa.Parameters
+		switch keyBits {
+		case 44:
+			params = mldsa.MLDSA44()
+		case 65:
+			params = mldsa.MLDSA65()
+		case 87:
+			params = mldsa.MLDSA87()
+		default:
+			return errutil.UserError{Err: fmt.Sprintf("unsupported bit length for mldsa key: %d", keyBits)}
+		}
+		privateKey, err = mldsa.GenerateKey(params)
+		if err != nil {
+			return errutil.InternalError{Err: fmt.Sprintf("error generating mldsa private key: %v", err)}
+		}
+		privateKeyBytes, err = x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return errutil.InternalError{Err: fmt.Sprintf("error marshalling mldsa private key: %v", err)}
+		}
 	default:
 		return errutil.UserError{Err: fmt.Sprintf("unknown key type: %s", keyType)}
 	}
@@ -474,6 +507,13 @@ func ComparePublicKeys(key1Iface, key2Iface crypto.PublicKey) (bool, error) {
 			return false, nil
 		}
 		return true, nil
+	case *mldsa.PublicKey:
+		key1 := key1Iface.(*mldsa.PublicKey)
+		key2, ok := key2Iface.(*mldsa.PublicKey)
+		if !ok {
+			return false, fmt.Errorf("key types do not match: %T and %T", key1Iface, key2Iface)
+		}
+		return key1.Equal(key2), nil
 	default:
 		return false, fmt.Errorf("cannot compare key with type %T", key1Iface)
 	}
@@ -502,6 +542,8 @@ func ParsePublicKeyPEM(data []byte) (crypto.PublicKey, error) {
 		case *ecdsa.PublicKey:
 			return key, nil
 		case ed25519.PublicKey:
+			return key, nil
+		case *mldsa.PublicKey:
 			return key, nil
 		}
 	}
@@ -691,8 +733,8 @@ func DefaultOrValueHashBits(keyType string, keyBits int, hashBits int) (int, err
 		// To match previous behavior (and ignoring NIST's recommendations for
 		// hash size to align with RSA key sizes), default to SHA-2-256.
 		hashBits = 256
-	} else if keyType == "ed25519" || keyType == "ed448" || keyType == "any" {
-		// No-op; ed25519 and ed448 internally specify their own hash and
+	} else if keyType == "ed25519" || keyType == "ed448" || keyType == "mldsa" || keyType == "any" {
+		// No-op; ed25519, ed448 and mldsa internally specify their own hash and
 		// we do not need to select one. Double hashing isn't supported in
 		// certificate signing. Additionally, the any key type can't know
 		// what hash algorithm to use yet, so default to zero.
@@ -734,7 +776,7 @@ func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, h
 // Validates that the length of the hash (in bits) used in the signature
 // calculation is a known, approved value.
 func ValidateSignatureLength(keyType string, hashBits int) error {
-	if keyType == "any" || keyType == "ec" || keyType == "ed25519" || keyType == "ed448" {
+	if keyType == "any" || keyType == "ec" || keyType == "ed25519" || keyType == "ed448" || keyType == "mldsa" {
 		// ed25519 and ed448 include built-in hashing and is not externally
 		// configurable. There are three modes for each of these schemes:
 		//
@@ -788,6 +830,14 @@ func ValidateKeyTypeLength(keyType string, keyBits int) error {
 			return fmt.Errorf("unsupported bit length for EC key: %d", keyBits)
 		}
 	case "any", "ed25519", "external-key":
+	case "mldsa":
+		switch keyBits {
+		case 44:
+		case 65:
+		case 87:
+		default:
+			return fmt.Errorf("unsupported bit length for ML-DSA key: %d", keyBits)
+		}
 	default:
 		return fmt.Errorf("unknown key type %s", keyType)
 	}
@@ -984,6 +1034,8 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case ECPrivateKey:
 			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(data.SigningBundle.PrivateKey.Public(), data.Params.SignatureBits)
+		case MLDSAPrivateKey:
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(data.SigningBundle.PrivateKey.Public())
 		}
 
 		caCert := data.SigningBundle.Certificate
@@ -1006,6 +1058,8 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case "ec":
 			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
+		case "mldsa":
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1120,6 +1174,8 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case ECPrivateKey:
 			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(caSign.PrivateKey.Public(), signatureBits)
+		case MLDSAPrivateKey:
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(caSign.PrivateKey.Public())
 		}
 
 		caCert := caSign.Certificate
@@ -1157,6 +1213,8 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 			certTemplate.SignatureAlgorithm = x509.PureEd25519
 		case "ec":
 			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), signatureBits)
+		case "mldsa":
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -1195,6 +1253,23 @@ func createCertificateWithTemplate(caSign *CAInfoBundle, evaluationData map[stri
 	}
 
 	return result, nil
+}
+
+func selectSignatureAlgorithmForMLDSA(pub crypto.PublicKey) x509.SignatureAlgorithm {
+	pubkey, ok := pub.(*mldsa.PublicKey)
+	if !ok {
+		return 0
+	}
+	switch pubkey.Parameters() {
+	case mldsa.MLDSA44():
+		return x509.MLDSA44
+	case mldsa.MLDSA65():
+		return x509.MLDSA65
+	case mldsa.MLDSA87():
+		return x509.MLDSA87
+	default:
+		return 0
+	}
 }
 
 func selectSignatureAlgorithmForECDSA(pub crypto.PublicKey, signatureBits int) x509.SignatureAlgorithm {
@@ -1309,6 +1384,8 @@ func createCSR(data *CreationBundle, addBasicConstraints bool, randReader io.Rea
 		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public(), data.Params.SignatureBits)
 	case "ed25519":
 		csrTemplate.SignatureAlgorithm = x509.PureEd25519
+	case "mldsa":
+		csrTemplate.SignatureAlgorithm = selectSignatureAlgorithmForMLDSA(result.PrivateKey.Public())
 	}
 
 	csr, err := x509.CreateCertificateRequest(randReader, csrTemplate, result.PrivateKey)
@@ -1653,6 +1730,9 @@ func GetPublicKeySize(key crypto.PublicKey) int {
 	if key, ok := key.(dsa.PublicKey); ok {
 		return key.Y.BitLen()
 	}
+	if key, ok := key.(*mldsa.PublicKey); ok {
+		return GetMLDSAParameterSetLabel(key)
+	}
 
 	return -1
 }
@@ -1670,6 +1750,21 @@ func GetPublicKeyType(pub crypto.PublicKey) PrivateKeyType {
 		return Ed25519PrivateKey
 	default:
 		return UnknownPrivateKey
+	}
+}
+
+// GetMLDSAParameterSetLabel returns the integer label suffix defined in FIPS 204. The
+// only valid return values are 44, 65, 87, or -1 (for unknown parameter set label).
+func GetMLDSAParameterSetLabel(k *mldsa.PublicKey) int {
+	switch k.Parameters() {
+	case mldsa.MLDSA44():
+		return 44
+	case mldsa.MLDSA65():
+		return 65
+	case mldsa.MLDSA87():
+		return 87
+	default:
+		return -1
 	}
 }
 

--- a/sdk/helper/certutil/helpers_test.go
+++ b/sdk/helper/certutil/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -341,6 +342,51 @@ func TestParsePKIMap(t *testing.T) {
 				assert.Equal(t, parsedCertBundle.Certificate.Subject.CommonName, validCommonName)
 			}
 		})
+	}
+}
+
+func TestGetMLDSAParameterSetLabel(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc      string
+		params    mldsa.Parameters
+		wantLabel int
+		wantErr   bool
+	}{
+		{
+			desc:      "ML-DSA-44",
+			params:    mldsa.MLDSA44(),
+			wantLabel: 44,
+			wantErr:   false,
+		},
+		{
+			desc:      "ML-DSA-65",
+			params:    mldsa.MLDSA65(),
+			wantLabel: 65,
+			wantErr:   false,
+		},
+		{
+			desc:      "ML-DSA-87",
+			params:    mldsa.MLDSA87(),
+			wantLabel: 87,
+			wantErr:   false,
+		},
+		{
+			desc:    "Unknown params",
+			params:  mldsa.Parameters{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		privKey, err := mldsa.GenerateKey(tc.params)
+		if tc.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantLabel, GetMLDSAParameterSetLabel(privKey.PublicKey()))
+		}
 	}
 }
 

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -16,6 +16,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/mldsa"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -64,6 +65,7 @@ const (
 	ECPrivateKey       PrivateKeyType = "ec"
 	Ed25519PrivateKey  PrivateKeyType = "ed25519"
 	ExternalPrivateKey PrivateKeyType = "external-key"
+	MLDSAPrivateKey    PrivateKeyType = "mldsa"
 )
 
 // TLSUsage controls whether the intended usage of a *tls.Config
@@ -158,6 +160,8 @@ func GetPrivateKeyTypeFromSigner(signer crypto.Signer) PrivateKeyType {
 		return ECPrivateKey
 	case ed25519.PublicKey:
 		return Ed25519PrivateKey
+	case *mldsa.PublicKey:
+		return MLDSAPrivateKey
 	}
 	return UnknownPrivateKey
 }
@@ -300,6 +304,8 @@ func extractAndSetPrivateKey(c *CertBundle, parsedBundle *ParsedCertBundle) erro
 			c.PrivateKeyType = RSAPrivateKey
 		case Ed25519PrivateKey:
 			c.PrivateKeyType = Ed25519PrivateKey
+		case MLDSAPrivateKey:
+			c.PrivateKeyType = MLDSAPrivateKey
 		}
 	default:
 		return errutil.UserError{Err: fmt.Sprintf("Unsupported key block type: %s", pemBlock.Type)}
@@ -350,6 +356,8 @@ func (p *ParsedCertBundle) ToCertBundle() (*CertBundle, error) {
 			case RSAPrivateKey:
 				block.Type = string(PKCS1Block)
 			case Ed25519PrivateKey:
+				block.Type = string(PKCS8Block)
+			case MLDSAPrivateKey:
 				block.Type = string(PKCS8Block)
 			}
 		}
@@ -445,7 +453,7 @@ func (p *ParsedCertBundle) getSigner() (crypto.Signer, error) {
 	case PKCS8Block:
 		if k, err := x509.ParsePKCS8PrivateKey(p.PrivateKeyBytes); err == nil {
 			switch k := k.(type) {
-			case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey:
+			case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey, *mldsa.PrivateKey:
 				return k.(crypto.Signer), nil
 			default:
 				return nil, errutil.UserError{Err: "Found unknown private key type in pkcs#8 wrapping"}
@@ -453,7 +461,7 @@ func (p *ParsedCertBundle) getSigner() (crypto.Signer, error) {
 		}
 		return nil, errutil.UserError{Err: fmt.Sprintf("Failed to parse pkcs#8 key: %v", err)}
 	default:
-		return nil, errutil.UserError{Err: "Unable to determine type of private key; only RSA and EC are supported"}
+		return nil, errutil.UserError{Err: "Unable to determine type of private key; only RSA, EC, Ed25519, and ML-DSA are supported"}
 	}
 	return signer, nil
 }
@@ -496,6 +504,16 @@ func (p *ParsedCertBundle) GetKeyBits() (int, error) {
 		}
 	case x509.Ed25519:
 		return 0, nil
+	case x509.MLDSA:
+		pub, ok := p.Certificate.PublicKey.(*mldsa.PublicKey)
+		if !ok {
+			return -1, fmt.Errorf("unable to cast mldsa type certificate's key to mldsa.PublicKey: actually of type %T", p.Certificate.PublicKey)
+		}
+		label := GetMLDSAParameterSetLabel(pub)
+		if label == -1 {
+			return -1, fmt.Errorf("unknown size for ML-DSA Public Key: %v", pub.Parameters().String())
+		}
+		return label, nil
 	default:
 		return -1, fmt.Errorf("unknown public key algorithm on bundle: %v", p.Certificate.PublicKeyAlgorithm)
 	}
@@ -514,6 +532,8 @@ func getPKCS8Type(bs []byte) (PrivateKeyType, error) {
 		return RSAPrivateKey, nil
 	case ed25519.PrivateKey:
 		return Ed25519PrivateKey, nil
+	case *mldsa.PrivateKey:
+		return MLDSAPrivateKey, nil
 	default:
 		return UnknownPrivateKey, errutil.UserError{Err: "Found unknown private key type in pkcs#8 wrapping"}
 	}
@@ -546,9 +566,16 @@ func (c *CSRBundle) ToParsedCSRBundle() (*ParsedCSRBundle, error) {
 			} else if _, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes); err == nil {
 				result.PrivateKeyType = RSAPrivateKey
 				c.PrivateKeyType = "rsa"
-			} else if _, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes); err == nil {
-				result.PrivateKeyType = Ed25519PrivateKey
-				c.PrivateKeyType = "ed25519"
+			} else if privKeyType, err := getPKCS8Type(pemBlock.Bytes); err == nil {
+				result.PrivateKeyType = privKeyType
+				switch privKeyType {
+				case Ed25519PrivateKey:
+					c.PrivateKeyType = "ed25519"
+				case MLDSAPrivateKey:
+					c.PrivateKeyType = "mldsa"
+				default:
+					return nil, errutil.UserError{Err: fmt.Sprintf("Unknown private key type in bundle: %s", c.PrivateKeyType)}
+				}
 			} else {
 				return nil, errutil.UserError{Err: fmt.Sprintf("Unknown private key type in bundle: %s", c.PrivateKeyType)}
 			}
@@ -600,6 +627,9 @@ func (p *ParsedCSRBundle) ToCSRBundle() (*CSRBundle, error) {
 		case Ed25519PrivateKey:
 			result.PrivateKeyType = "ed25519"
 			block.Type = "PRIVATE KEY"
+		case MLDSAPrivateKey:
+			result.PrivateKeyType = "mldsa"
+			block.Type = "PRIVATE KEY"
 		default:
 			return nil, errutil.InternalError{Err: "Could not determine private key type when creating block"}
 		}
@@ -636,13 +666,20 @@ func (p *ParsedCSRBundle) getSigner() (crypto.Signer, error) {
 
 	case Ed25519PrivateKey:
 		signerd, err := x509.ParsePKCS8PrivateKey(p.PrivateKeyBytes)
-		signer = signerd.(ed25519.PrivateKey)
 		if err != nil {
 			return nil, errutil.UserError{Err: fmt.Sprintf("Unable to parse CA's private Ed25519 key: %s", err)}
 		}
+		signer = signerd.(ed25519.PrivateKey)
+
+	case MLDSAPrivateKey:
+		signerd, err := x509.ParsePKCS8PrivateKey(p.PrivateKeyBytes)
+		if err != nil {
+			return nil, errutil.UserError{Err: fmt.Sprintf("Unable to parse CA's private ML-DSA key: %s", err)}
+		}
+		signer = signerd.(*mldsa.PrivateKey)
 
 	default:
-		return nil, errutil.UserError{Err: "Unable to determine type of private key; only RSA, Ed25519 and EC are supported"}
+		return nil, errutil.UserError{Err: "Unable to determine type of private key; only RSA, Ed25519, EC, and ML-DSA are supported"}
 	}
 	return signer, nil
 }


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

I have put the commands I used to end-2-end test this with openssl below. Since I am rather new to the OpenBao code base, and pki side of things in particular, I would appreciate any pointers on this I might have missed or where I didn't follow project conventions.

I went light on the unit tests, just to get some confirmation on direction, before spending too much time here. Happy to work on coverage once the first feedback is in.

~~Note this is still based on #3752, since Go 1.27 was released today (Aug 20), we should be good to merge it and up versions to 1.27.~~

~~Note the CI will mostly break until we have moved to Go 1.27.~~

## Test Environment

### Install Go RC and Build OpenBao

```sh
go install golang.org/dl/go1.27rc3@latest && go1.27rc3 download
go1.27rc3 version
go1.27rc3 build -o bin/bao . && ./bin/bao version
```

### Setup Server

```sh
./bin/bao server -dev -dev-root-token-id=root
```

### Setup PKI

```sh
export BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=root
bao secrets enable pki
```

### ML-DSA Tests

#### Generate an ML-DSA-65 root CA

```sh
bao write -field=certificate pki/root/generate/internal \
    common_name=ml-dsa-ca key_type=mldsa key_bits=65 > ca.pem
openssl x509 -in ca.pem -noout -text | grep -E 'Public Key Algorithm|Signature Algorithm'
```

#### Issue a leaf certificate (key generated by OpenBao)

```sh
bao write pki/roles/ml-dsa-role \
    key_type=mldsa key_bits=65 \
    allow_any_name=true enforce_hostnames=false ttl=1h

bao write -field=certificate pki/issue/ml-dsa-role common_name=leaf.test > leaf.pem
openssl verify -CAfile ca.pem leaf.pem
```

#### Sign an external CSR (key generated by OpenSSL)

```sh
# Note: seed-only is required, Go rejects OpenSSL's default
openssl genpkey -algorithm ML-DSA-65 \
    -provparam ml-dsa.output_formats=seed-only -out csr-key.pem
openssl req -new -key csr-key.pem -subj "/CN=csr.test" -out ml-dsa.csr

bao write -field=certificate pki/sign/ml-dsa-role csr=@ml-dsa.csr > signed.pem
openssl verify -CAfile ca.pem signed.pem
```

#### CRL is signed with ML-DSA

```sh
curl -s http://127.0.0.1:8200/v1/pki/crl \
    | openssl crl -inform DER -noout -text | grep 'Signature Algorithm'
```

#### revocation_signature_algorithm must match the issuer's parameter set

```sh
bao write pki/issuer/default revocation_signature_algorithm=MLDSA65
bao read pki/crl/rotate

# Cross parameter set: rejected
bao write pki/issuer/default revocation_signature_algorithm=MLDSA87

# Wrong algorithm family: rejected
bao write pki/issuer/default revocation_signature_algorithm=SHA256WithRSA
```

## Open questions

### role key_bits does not constrain signed CSRs

The role's `key_bits` selects the parameter set for keys generated via `pki/issue`, but `pki/sign` currently accepts CSRs of any ML-DSA parameter

```sh
openssl genpkey -algorithm ML-DSA-87 \
    -provparam ml-dsa.output_formats=seed-only -out csr87-key.pem
openssl req -new -key csr87-key.pem -subj "/CN=csr87.test" -out ml-dsa-87.csr

# Signs successfully despite the role's key_bits=65, see TODO in cert_util.go
bao write pki/sign/ml-dsa-role csr=@ml-dsa-87.csr
```

### What is the right default value?

I chose 65, which corresponds to category 3, but go mldsa.go says: `Most applications should use [MLDSA44].`, which would be category 2.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #3756

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
