### PR TITLE
Fix unreadable backed up keys regression

### DIFF
--- a/changelog/3863.txt
+++ b/changelog/3863.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+sys/raw: Allow reading backed up unseal or recovery shares.
+```
+
+```release-note:bug
+sys/rotate: Fix existing unseal/recovery share backups going unreadable after upgrading to v2.6.x from an earlier version.
+```

--- a/internal/vault/logical_raw.go
+++ b/internal/vault/logical_raw.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
@@ -25,6 +26,15 @@ var protectedPaths = []string{
 	barrier.KeyringPath,
 	// Changing the cluster info path can change the cluster ID which can be disruptive
 	coreLocalClusterInfoPath,
+}
+
+// These paths use the "upper" barrier, which is the direct physical layer
+// for the root namespace.
+var specialPaths = []string{
+	barrierSealConfigPath,
+	recoverySealConfigPath,
+	coreBarrierUnsealKeysBackupPath,
+	coreRecoveryUnsealKeysBackupPath,
 }
 
 type RawBackend struct {
@@ -61,9 +71,7 @@ func (b *RawBackend) storageByPath(ctx context.Context, path string) (StorageAcc
 		}
 	}
 
-	// These paths use the "upper" barrier, which is the direct physical layer
-	// for the root namespace.
-	specialPath := rest == barrierSealConfigPath || rest == recoverySealConfigPath
+	specialPath := slices.Contains(specialPaths, rest)
 
 	// Fast-path root or deleted namespaces; we do not need a lookup into the
 	// seal manager.

--- a/internal/vault/logical_system_rotate.go
+++ b/internal/vault/logical_system_rotate.go
@@ -383,7 +383,9 @@ func (b *SystemBackend) rotatePaths() []*framework.Path {
 							},
 						}},
 					},
-					Summary: "Return the backup copy of PGP-encrypted unseal keys.",
+					Summary:                     "Return the backup copy of PGP-encrypted unseal keys.",
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: b.handleRotateBackupDelete(),
@@ -904,7 +906,7 @@ func (b *SystemBackend) handleRotateBackupRetrieve() framework.OperationFunc {
 		}
 
 		recovery := strings.Contains(req.Path, "recovery")
-		backup, err := b.Core.sealManager.RetrieveRotationBackup(ctx, ns.Path, recovery)
+		backup, err := b.Core.sealManager.RetrieveRotationBackup(ctx, ns, recovery)
 		if err != nil {
 			return handleError(fmt.Errorf("unable to look up backed-up keys: %w", err))
 		}

--- a/internal/vault/logical_system_rotate.go
+++ b/internal/vault/logical_system_rotate.go
@@ -904,7 +904,7 @@ func (b *SystemBackend) handleRotateBackupRetrieve() framework.OperationFunc {
 		}
 
 		recovery := strings.Contains(req.Path, "recovery")
-		backup, err := b.Core.sealManager.RetrieveRotationBackup(ctx, ns.Path, recovery)
+		backup, err := b.Core.sealManager.RetrieveRotationBackup(ctx, ns, recovery)
 		if err != nil {
 			return handleError(fmt.Errorf("unable to look up backed-up keys: %w", err))
 		}

--- a/internal/vault/rotate.go
+++ b/internal/vault/rotate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/helper/pgpkeys"
 	"github.com/openbao/openbao/v2/internal/vault/barrier"
@@ -656,8 +657,20 @@ func (sm *SealManager) pgpEncryptShares(ctx context.Context, ns *namespace.Names
 			entry.Key = coreRecoveryUnsealKeysBackupPath
 		}
 
-		barrier := sm.namespaceBarrier(ns.Path)
-		if err = barrier.Put(ctx, entry); err != nil {
+		parentPath, hasParent := ns.ParentPath()
+		if !hasParent {
+			// If we don't have a parent - meaning we are in root namespace
+			// write the backed up keys through physical.
+			err = sm.core.physical.Put(ctx, &physical.Entry{
+				Key:   entry.Key,
+				Value: buf,
+			})
+		} else {
+			barrier := sm.namespaceBarrierByLongestPrefix(parentPath)
+			err = barrier.Put(ctx, entry)
+		}
+
+		if err != nil {
 			sm.logger.Error("failed to save unseal key backup", "error", err)
 			return nil, fmt.Errorf("failed to save unseal key backup: %w", err)
 		}
@@ -802,7 +815,7 @@ func (sm *SealManager) RestartRotationVerification(nsUUID string, recovery bool)
 
 // RetrieveRotationBackup is used to retrieve any backed-up PGP-encrypted
 // unseal keys.
-func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, nsPath string, recovery bool) (*RekeyBackup, error) {
+func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, ns *namespace.Namespace, recovery bool) (*RekeyBackup, error) {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
@@ -811,17 +824,57 @@ func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, nsPath string
 		path = coreRecoveryUnsealKeysBackupPath
 	}
 
-	barrier := sm.namespaceBarrier(nsPath)
-	entry, err := barrier.Get(ctx, path)
+	overwriteKeys := func(sa StorageAccess, path string, value []byte) {
+		if err := sa.Put(ctx, path, value); err != nil {
+			sm.logger.Error("Failed to overwrite backed up keys, please rotate the keys immediately after.")
+		}
+		sm.logger.Info("Overwritten backed up keys.")
+	}
+
+	parentPath, hasParent := ns.ParentPath()
+	var value []byte
+	var err error
+	if !hasParent {
+		storage := secureStorageAccess{sm.core.barrier}
+		// Try to read backed up keys through barrier.
+		value, err = storage.Get(ctx, path)
+		switch {
+		case err != nil:
+			// Fallback to reading through physical if barrier read errors.
+			dirStorage := directStorageAccess{sm.core.physical}
+			value, err = dirStorage.Get(ctx, path)
+			if value != nil && err == nil {
+				defer overwriteKeys(&dirStorage, path, value)
+			}
+		case value == nil:
+			return nil, nil
+		}
+	} else {
+		pBarrier := secureStorageAccess{sm.namespaceBarrierByLongestPrefix(parentPath)}
+		value, err = pBarrier.Get(ctx, path)
+		// Try to read backed up keys through namespace parent's barrier.
+		switch {
+		case err != nil:
+			// Fallback to reading through namespace owned barrier if parent barrier read errors.
+			barrier := secureStorageAccess{sm.namespaceBarrierByLongestPrefix(ns.Path)}
+			value, err = barrier.Get(ctx, path)
+			if value != nil && err == nil {
+				defer overwriteKeys(&barrier, path, value)
+			}
+		case value == nil:
+			return nil, nil
+		}
+	}
+
 	if err != nil {
 		return nil, logical.CodedError(http.StatusInternalServerError, "error getting keys from backup: %w", err)
 	}
-	if entry == nil {
+	if value == nil {
 		return nil, nil
 	}
 
 	ret := &RekeyBackup{}
-	if err = jsonutil.DecodeJSON(entry.Value, ret); err != nil {
+	if err = jsonutil.DecodeJSON(value, ret); err != nil {
 		return nil, logical.CodedError(http.StatusInternalServerError, "error decoding backup keys: %w", err)
 	}
 

--- a/internal/vault/rotate.go
+++ b/internal/vault/rotate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/helper/pgpkeys"
 	"github.com/openbao/openbao/v2/internal/vault/barrier"
@@ -656,8 +657,20 @@ func (sm *SealManager) pgpEncryptShares(ctx context.Context, ns *namespace.Names
 			entry.Key = coreRecoveryUnsealKeysBackupPath
 		}
 
-		barrier := sm.namespaceBarrier(ns.Path)
-		if err = barrier.Put(ctx, entry); err != nil {
+		parentPath, hasParent := ns.ParentPath()
+		if !hasParent {
+			// If we don't have a parent - meaning we are in root namespace
+			// write the backed up keys through physical.
+			err = sm.core.physical.Put(ctx, &physical.Entry{
+				Key:   entry.Key,
+				Value: buf,
+			})
+		} else {
+			barrier := sm.namespaceBarrierByLongestPrefix(parentPath)
+			err = barrier.Put(ctx, entry)
+		}
+
+		if err != nil {
 			sm.logger.Error("failed to save unseal key backup", "error", err)
 			return nil, fmt.Errorf("failed to save unseal key backup: %w", err)
 		}
@@ -802,7 +815,7 @@ func (sm *SealManager) RestartRotationVerification(nsUUID string, recovery bool)
 
 // RetrieveRotationBackup is used to retrieve any backed-up PGP-encrypted
 // unseal keys.
-func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, nsPath string, recovery bool) (*RekeyBackup, error) {
+func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, ns *namespace.Namespace, recovery bool) (*RekeyBackup, error) {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
@@ -811,8 +824,41 @@ func (sm *SealManager) RetrieveRotationBackup(ctx context.Context, nsPath string
 		path = coreRecoveryUnsealKeysBackupPath
 	}
 
-	barrier := sm.namespaceBarrier(nsPath)
-	entry, err := barrier.Get(ctx, path)
+	parentPath, hasParent := ns.ParentPath()
+	var entry *logical.StorageEntry
+	var err error
+	if !hasParent {
+		entry, err = sm.core.barrier.Get(ctx, path)
+		switch {
+		case err != nil:
+			var pEntry *physical.Entry
+			pEntry, err = sm.core.physical.Get(ctx, path)
+			entry = &logical.StorageEntry{
+				Key:   pEntry.Key,
+				Value: pEntry.Value,
+			}
+		case entry == nil:
+			return nil, nil
+		}
+	} else {
+		barrier := sm.namespaceBarrierByLongestPrefix(parentPath)
+		entry, err = barrier.Get(ctx, path)
+		switch {
+		case err != nil:
+			entry, err = sm.namespaceBarrierByLongestPrefix(ns.Path).Get(ctx, path)
+			if entry != nil && err == nil {
+				defer func() {
+					if err := barrier.Put(ctx, entry); err != nil {
+						sm.logger.Error("Failed to overwrite backed up keys, please rotate the keys immediately after.")
+					}
+					sm.logger.Info("Overwritten backed up keys.")
+				}()
+			}
+		case entry == nil:
+			return nil, nil
+		}
+	}
+
 	if err != nil {
 		return nil, logical.CodedError(http.StatusInternalServerError, "error getting keys from backup: %w", err)
 	}

--- a/internal/vault/rotate_test.go
+++ b/internal/vault/rotate_test.go
@@ -4,6 +4,8 @@
 package vault
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
@@ -11,9 +13,11 @@ import (
 
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
+	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
+	"github.com/openbao/openbao/v2/internal/helper/pgpkeys"
 	vaultseal "github.com/openbao/openbao/v2/internal/vault/seal"
 )
 
@@ -490,4 +494,117 @@ func testRotateBarrierRootKey(t *testing.T, c *Core, ns *namespace.Namespace, un
 		require.NoError(t, c.UnsealWithStoredKeys(ctx))
 	}
 	require.False(t, c.NamespaceSealed(ns))
+}
+
+func TestRotationBackedUpKeys(t *testing.T) {
+	config := &SealConfig{
+		SecretShares:    3,
+		SecretThreshold: 2,
+	}
+
+	t.Run("root namespace barrier keys", func(t *testing.T) {
+		c, barrierKeys, _, _ := TestCoreUnsealedWithConfigs(t, config, nil)
+		testRotationBackedUpKeys(t, c, namespace.RootNamespace, barrierKeys, false)
+	})
+
+	t.Run("root namespace recovery keys", func(t *testing.T) {
+		c, _, recoveryKeys, _ := TestCoreUnsealedWithConfigs(t, config, config)
+		testRotationBackedUpKeys(t, c, namespace.RootNamespace, recoveryKeys, true)
+	})
+
+	t.Run("child namespace barrier keys", func(t *testing.T) {
+		c, _, _, _ := TestCoreUnsealedWithConfigs(t, config, nil)
+		ns := &namespace.Namespace{Path: "ns1/"}
+		keys := TestCoreCreateUnsealedNamespaces(t, c, ns)
+		testRotationBackedUpKeys(t, c, ns, keys["ns1/"], false)
+	})
+}
+
+func testRotationBackedUpKeys(t *testing.T, c *Core, ns *namespace.Namespace, keys [][]byte, recovery bool) {
+	ctx := namespace.ContextWithNamespace(t.Context(), ns)
+	seal := c.sealManager.NamespaceSeal(ns.UUID)
+	require.NotNil(t, seal)
+
+	var expType string
+	if recovery {
+		expType = seal.RecoveryType()
+	} else {
+		expType = seal.BarrierType().String()
+	}
+
+	newConf := &SealConfig{
+		Type:            expType,
+		SecretThreshold: 1,
+		SecretShares:    1,
+		Backup:          true,
+		PGPKeys:         []string{pgpkeys.TestPubKey1},
+	}
+	rotationResult, err := c.sealManager.InitRotation(ctx, ns, newConf, recovery)
+	require.NoError(t, err)
+	require.Empty(t, rotationResult)
+
+	// Fetch new config with generated nonce
+	rotConfig := c.sealManager.RotationConfig(ns.UUID, recovery)
+	require.NotNil(t, rotConfig)
+
+	// Provide the root/recovery keys
+	var result *RekeyResult
+	for _, key := range keys {
+		result, err = c.sealManager.UpdateRotation(ctx, ns, key, rotConfig.Nonce, recovery)
+		require.NoError(t, err)
+		if result != nil {
+			break
+		}
+	}
+	require.NotNil(t, result)
+
+	// Should be no config
+	require.Nil(t, c.sealManager.RotationConfig(ns.UUID, recovery))
+
+	// SealConfig should update
+	var sealConf *SealConfig
+	if recovery {
+		sealConf, err = seal.RecoveryConfig(ctx)
+	} else {
+		sealConf, err = seal.BarrierConfig(ctx)
+	}
+	require.NoError(t, err)
+	require.NotNil(t, sealConf)
+	require.Equal(t, sealConf, newConf)
+
+	// Verify we can read backed up keys.
+	backedKeys, err := c.sealManager.RetrieveRotationBackup(ctx, ns, recovery)
+	require.NoError(t, err)
+
+	decodedKey, err := hex.DecodeString(backedKeys.Keys[result.PGPFingerprints[0]][0])
+	require.NoError(t, err)
+	require.Equal(t, result.SecretShares[0], decodedKey)
+
+	// Verify fallback path.
+	barrier := c.sealManager.NamespaceBarrier(ns.Path)
+	eKey := coreBarrierUnsealKeysBackupPath
+	if recovery {
+		eKey = coreRecoveryUnsealKeysBackupPath
+	}
+
+	buf, err := json.Marshal(backedKeys)
+	require.NoError(t, err)
+
+	require.NoError(t, barrier.Put(ctx, &logical.StorageEntry{
+		Key:   eKey,
+		Value: buf,
+	}))
+
+	backedKeys, err = c.sealManager.RetrieveRotationBackup(ctx, ns, recovery)
+	require.NoError(t, err)
+
+	decodedKey, err = hex.DecodeString(backedKeys.Keys[result.PGPFingerprints[0]][0])
+	require.NoError(t, err)
+	require.Equal(t, result.SecretShares[0], decodedKey)
+
+	// Verify deletion works as intended.
+	require.NoError(t, c.sealManager.DeleteRotationBackup(ctx, ns.Path, recovery))
+	backedKeys, err = c.sealManager.RetrieveRotationBackup(ctx, ns, recovery)
+	require.NoError(t, err)
+	require.Nil(t, backedKeys)
 }

--- a/internal/vault/seal.go
+++ b/internal/vault/seal.go
@@ -295,7 +295,8 @@ type SealConfig struct {
 	Nonce string `json:"nonce" mapstructure:"nonce"`
 
 	// Backup indicates whether or not a backup of PGP-encrypted unseal keys
-	// should be stored at coreUnsealKeysBackupPath after successful rotation.
+	// should be stored at coreUnsealKeysBackupPath or coreRecoveryUnsealKeysBackupPath
+	// after successful rotation.
 	Backup bool `json:"backup" mapstructure:"backup"`
 
 	// Stores the progress of the rotation (key shares).


### PR DESCRIPTION
## Description
This PR:
- Changed backed up unseal shares write and store methods, now using parent's barrier (or physical in case of root)
- Introduced fallback read of the backed up unseal shares 
   - for root namespace we are checking root namespace barrier, then falling back to physical
   - for other namespaces we are checking namespace barrier, then namespace parent's barrier
- Added unconditional forwarding for backed up unseal shares read requests due to introduced writes in the handler
- Adjusted sys/raw read call for backed up unseal shares, allowing for reads using parent's barrier (or physical in root namespace case)

## Rationale
With v2.6+ and introduction of per-namespace seals, which for feature parity's with root namespace (global seal) required support of storing pgp encrypted unseal shares in the OpenBao after (recovery/barrier) key rotation. This introduced a regression within how the encrypted unseal shares were stored and read. Previously they were stored as-is directly to the OpenBao storage without additional layer of encryption (which made sense, as they are already encrypted with pgp shares). That was changed to the namespace barrier, which introduced regression when upgrading from versions before v2.6. This PR aims at fixing that gap through fallback reads.

A change to the `sys/raw` endpoints require a key rotation of the v2.6 unseal shares saved to the storage before this change makes it to the release. Reads through the `sys/rotate/<recovery|barrier>/backup` endpoint are going to work without rotation requirement.

Resolves: #3857

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
