### PR TITLE
fix: UpdateDNPassword should not discard explicit DN when userattr=userPrincipalName

### DIFF
--- a/internal/builtin/logical/openldap/client.go
+++ b/internal/builtin/logical/openldap/client.go
@@ -48,10 +48,17 @@ func (c *Client) UpdateDNPassword(conf *client.Config, dn string, newPassword st
 	}
 
 	if field == client.FieldRegistry.UserPrincipalName {
-		scope = ldap.ScopeWholeSubtree
-		bindUser := fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)
-		filters[field] = []string{bindUser}
-		dn = conf.UserDN
+		// If the provided dn is a fully-qualified LDAP DN (e.g. an explicitly
+		// configured static-role DN), operate on that object directly with a
+		// base-object search instead of re-resolving it via the userPrincipalName
+		// attribute. Re-resolution would construct a malformed UPN from the DN and
+		// discard the caller-provided DN, causing a "No Such Object" failure.
+		if _, parseErr := ldap.ParseDN(dn); parseErr != nil {
+			scope = ldap.ScopeWholeSubtree
+			bindUser := fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)
+			filters[field] = []string{bindUser}
+			dn = conf.UserDN
+		}
 	}
 
 	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)

--- a/internal/builtin/logical/openldap/client_test.go
+++ b/internal/builtin/logical/openldap/client_test.go
@@ -110,3 +110,49 @@ func Test_UpdateDNPassword_AD_DN(t *testing.T) {
 	err = c.UpdateDNPassword(config, "CN=Bob,CN=Users,DC=example,DC=net", newPassword)
 	assert.NoError(t, err)
 }
+
+// UpdateDNPassword with an explicit DN while the UserAttr is "userPrincipalName"
+// (the AD schema default). The explicit DN must be used directly with a
+// base-object search instead of being discarded in favor of UPN re-resolution.
+func Test_UpdateDNPassword_AD_UserPrincipalName_ExplicitDN(t *testing.T) {
+	newPassword := "newpassword"
+	conn := &ldapifc.FakeLDAPConnection{
+		ModifyRequestToExpect: &ldap.ModifyRequest{
+			DN: "CN=svc-example,OU=Users,DC=example,DC=net",
+		},
+		SearchRequestToExpect: &ldap.SearchRequest{
+			BaseDN: "CN=svc-example,OU=Users,DC=example,DC=net",
+			Scope:  ldap.ScopeBaseObject,
+			Filter: "(objectClass=*)",
+		},
+		SearchResultToReturn: &ldap.SearchResult{
+			Entries: []*ldap.Entry{
+				{
+					DN: "CN=svc-example,OU=Users,DC=example,DC=net",
+				},
+			},
+		},
+	}
+
+	c := GetTestClient(conn)
+	config := &client.Config{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			Url:          "ldaps://ldap:386",
+			UserDN:       "cn=users",
+			UPNDomain:    "example.net",
+			BindDN:       "username",
+			BindPassword: "password",
+		},
+		Schema: client.SchemaAD,
+	}
+
+	// depending on the schema, the password may be formatted, so we leverage this helper function
+	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	assert.NoError(t, err)
+	for k, v := range fields {
+		conn.ModifyRequestToExpect.Replace(k.String(), v)
+	}
+
+	err = c.UpdateDNPassword(config, "CN=svc-example,OU=Users,DC=example,DC=net", newPassword)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## What

Fixes #3862

When a static role has an explicitly configured DN, `UpdateDNPassword` must search and modify directly against that DN using `ScopeBaseObject` instead of attempting UPN-based re-resolution, which would construct a malformed UPN from the DN value (e.g. `CN=svc-example,OU=Users,DC=example,DC=net@domain`) and overwrite `dn` with `conf.UserDN`, causing a `"No Such Object"` failure.

## Root cause

In `client.go`, the `UpdateDNPassword` function enters a UPN re-resolution branch when `userattr=userPrincipalName` (AD schema default). This branch:
1. Constructs `bindUser = fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)` — treating the DN as a UPN prefix
2. Overwrites `dn = conf.UserDN` — discarding the caller-provided explicit DN

When the caller passes a full DN (e.g. `CN=svc-example,OU=Users,DC=example,DC=net`), the filter becomes `userPrincipalName=CN=svc-example,...@example.com` which matches nothing, and the search base is changed to `conf.UserDN` instead of the explicit DN.

## Fix

Use `ldap.ParseDN` to detect whether the `dn` argument is a fully-qualified LDAP DN. If it is, skip the UPN re-resolution and use `ScopeBaseObject` directly against the provided DN. If it is a plain username (ParseDN fails), keep the existing UPN re-resolution behavior.

## Test

Added `Test_UpdateDNPassword_AD_UserPrincipalName_ExplicitDN` — verifies that an explicit DN with `userattr=userPrincipalName` (AD default) results in:
- BaseDN: the explicit DN
- Scope: `ScopeBaseObject`
- Filter: `(objectClass=*)`

Existing tests `Test_UpdateDNPassword_AD_UserPrincipalName` and `Test_UpdateDNPassword_AD_DN` remain unchanged.

Signed-off-by: waterWang <waterwang@proton.me>