### PR TITLE
fix(openldap): use explicit DN in static-role rotation with AD schema

### DIFF
--- a/internal/builtin/logical/openldap/client.go
+++ b/internal/builtin/logical/openldap/client.go
@@ -48,10 +48,17 @@ func (c *Client) UpdateDNPassword(conf *client.Config, dn string, newPassword st
 	}
 
 	if field == client.FieldRegistry.UserPrincipalName {
-		scope = ldap.ScopeWholeSubtree
-		bindUser := fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)
-		filters[field] = []string{bindUser}
-		dn = conf.UserDN
+		// If the provided dn is a fully-qualified LDAP DN (e.g. an explicitly
+		// configured static-role DN), operate on that object directly with a
+		// base-object search instead of re-resolving it via the userPrincipalName
+		// attribute. Re-resolution would construct a malformed UPN from the DN and
+		// discard the caller-provided DN, causing a "No Such Object" failure.
+		if _, parseErr := ldap.ParseDN(dn); parseErr != nil {
+			scope = ldap.ScopeWholeSubtree
+			bindUser := fmt.Sprintf("%s@%s", ldap.EscapeFilter(dn), conf.UPNDomain)
+			filters[field] = []string{bindUser}
+			dn = conf.UserDN
+		}
 	}
 
 	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)

--- a/internal/builtin/logical/openldap/client_test.go
+++ b/internal/builtin/logical/openldap/client_test.go
@@ -110,3 +110,49 @@ func Test_UpdateDNPassword_AD_DN(t *testing.T) {
 	err = c.UpdateDNPassword(config, "CN=Bob,CN=Users,DC=example,DC=net", newPassword)
 	assert.NoError(t, err)
 }
+
+// UpdateDNPassword with an explicit DN while the UserAttr is "userPrincipalName"
+// (the AD schema default). The explicit DN must be used directly with a
+// base-object search instead of being discarded in favor of UPN re-resolution.
+func Test_UpdateDNPassword_AD_UserPrincipalName_ExplicitDN(t *testing.T) {
+	newPassword := "newpassword"
+	conn := &ldapifc.FakeLDAPConnection{
+		ModifyRequestToExpect: &ldap.ModifyRequest{
+			DN: "CN=svc-example,OU=Users,DC=example,DC=net",
+		},
+		SearchRequestToExpect: &ldap.SearchRequest{
+			BaseDN: "CN=svc-example,OU=Users,DC=example,DC=net",
+			Scope:  ldap.ScopeBaseObject,
+			Filter: "(objectClass=*)",
+		},
+		SearchResultToReturn: &ldap.SearchResult{
+			Entries: []*ldap.Entry{
+				{
+					DN: "CN=svc-example,OU=Users,DC=example,DC=net",
+				},
+			},
+		},
+	}
+
+	c := GetTestClient(conn)
+	config := &client.Config{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			Url:          "ldaps://ldap:386",
+			UserDN:       "cn=users",
+			UPNDomain:    "example.net",
+			BindDN:       "username",
+			BindPassword: "password",
+		},
+		Schema: client.SchemaAD,
+	}
+
+	// depending on the schema, the password may be formatted, so we leverage this helper function
+	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	assert.NoError(t, err)
+	for k, v := range fields {
+		conn.ModifyRequestToExpect.Replace(k.String(), v)
+	}
+
+	err = c.UpdateDNPassword(config, "CN=svc-example,OU=Users,DC=example,DC=net", newPassword)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #3862

**Bug**: When `schema=ad` and `userattr` defaults to `userPrincipalName` (AD default), `UpdateDNPassword` treats the caller-provided DN as a UPN username, escapes it into a `userPrincipalName` search filter, and then overwrites the base DN with `conf.UserDN`. For static roles with an explicit `dn`, this constructs a malformed UPN from the full DN and discards the caller's DN (`dn = conf.UserDN`), so the LDAP search runs against the wrong base and fails with `LDAP Result Code 32 "No Such Object"`.

**Fix**: Use `ldap.ParseDN` to detect whether the caller passed a fully-qualified LDAP DN. When the value is a real DN, keep the base-object search directly against that DN (`ScopeBaseObject`), matching the behavior for any other `userattr` value (e.g. `dn`). Only fall back to UPN re-resolution when the value is not a DN (e.g. a bare username, which occurs in a legacy test path).

**Test**: Added `Test_UpdateDNPassword_AD_UserPrincipalName_ExplicitDN` — verifies that an explicit DN with `schema=ad` is searched directly with `ScopeBaseObject` instead of UPN re-resolution.