### PR TITLE
Increase timeout for mysql container startup

### DIFF
--- a/internal/builtin/database/mysql/connection_producer_test.go
+++ b/internal/builtin/database/mysql/connection_producer_test.go
@@ -117,7 +117,8 @@ func startMySQLWithTLS(t *testing.T, version, confDir string) string {
 		return os.Getenv("MYSQL_URL")
 	}
 
-	pool := dockertest.NewPoolT(t, "", dockertest.WithMaxWait(30*time.Second))
+	timeout := 60 * time.Second
+	pool := dockertest.NewPoolT(t, "", dockertest.WithMaxWait(timeout))
 	username := "root"
 	password := "x509test"
 
@@ -139,8 +140,7 @@ func startMySQLWithTLS(t *testing.T, version, confDir string) string {
 		"username": username,
 		"password": password,
 	})
-	// exponential backoff-retry
-	err := pool.Retry(t.Context(), 15*time.Second, func() error {
+	err := pool.Retry(t.Context(), timeout, func() error {
 		db, err := sql.Open("mysql", url)
 		if err != nil {
 			t.Logf("err: %s", err)


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

The new MySQL v9 image seems to come up a lot slower than the previous v8 version. 

Also removed outdated comment, retry uses fixed 1s: https://github.com/ory/dockertest/blob/v4.0.0/retry.go#L65


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves flaky test in #3859

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
