### PR TITLE
Validate that + wildcards behave like *

### DIFF
--- a/internal/vault/policy/acl_test.go
+++ b/internal/vault/policy/acl_test.go
@@ -996,81 +996,99 @@ func TestACLGrantingPolicies(t *testing.T) {
 	}
 }
 
-func TestACL_ListScanWildcardDeny(t *testing.T) {
+func TestACL_ListScanDeny(t *testing.T) {
 	ns := namespace.RootNamespace
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	tests := []struct {
-		path    string
-		allowed bool
-	}{
-		{
-			path:    "foo",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/test",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/private",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata/private/internal",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata/private/granted",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/private/granted/test",
-			allowed: true,
-		},
+	policies := map[string]string{
+		"wildcard":          listScanDenyWildcardPolicy,
+		"internal_wildcard": listScanDenyInternalWildcardPolicy,
+		"glob":              listScanDenyGlobPolicy,
+		"explicit":          listScanDenyExplicitPolicy,
 	}
 
-	for i, pt := range tests {
-		policy, err := ParseACLPolicy(ns, listScanDenyPolicy)
-		require.NoError(t, err)
-		require.NotNil(t, policy)
+	for name, policy := range policies {
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				path    string
+				allowed bool
+			}{
+				{
+					path:    "foo",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/test",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/private",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata/private/internal",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata/private/internal/elsewhere",
+					allowed: false,
+				},
 
-		acl, err := NewACL(ctx, []*Policy{policy})
-		require.NoError(t, err)
-		require.NotNil(t, acl)
+				{
+					path:    "foo/metadata/private/granted",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/private/granted/test",
+					allowed: true,
+				},
+			}
 
-		for _, operation := range []logical.Operation{
-			logical.ScanOperation,
-			logical.ListOperation,
-		} {
-			request := new(logical.Request)
-			request.Path = pt.path
-			request.Operation = operation
+			for i, pt := range tests {
+				t.Run(strings.ReplaceAll(pt.path, "/", "_"), func(t *testing.T) {
+					policy, err := ParseACLPolicy(ns, policy)
+					require.NoError(t, err)
+					require.NotNil(t, policy)
 
-			require.False(t, strings.HasSuffix(request.Path, "/"))
-			request.Path += "/"
+					acl, err := NewACL(ctx, []*Policy{policy})
+					require.NoError(t, err)
+					require.NotNil(t, acl)
 
-			authResults := acl.AllowOperation(ctx, request, false)
-			require.Equal(
-				t,
-				pt.allowed,
-				authResults.Allowed,
-				"bad:\n"+
-					"case %d\n"+
-					"\t%#v\n"+
-					"operation: %v\n"+
-					"engine: %v != expected: %v",
-				i,
-				pt,
-				operation,
-				authResults.Allowed,
-				pt.allowed,
-			)
-		}
+					for _, operation := range []logical.Operation{
+						logical.ScanOperation,
+						logical.ListOperation,
+					} {
+						request := new(logical.Request)
+						request.Path = pt.path
+						request.Operation = operation
+
+						require.False(t, strings.HasSuffix(request.Path, "/"))
+						request.Path += "/"
+
+						authResults := acl.AllowOperation(ctx, request, false)
+						require.Equal(
+							t,
+							pt.allowed,
+							authResults.Allowed,
+							"bad:\n"+
+								"case %d\n"+
+								"\t%#v\n"+
+								"operation: %v\n"+
+								"engine: %v != expected: %v",
+							i,
+							pt,
+							operation,
+							authResults.Allowed,
+							pt.allowed,
+						)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -1481,8 +1499,34 @@ path "test/star" {
 }
 `
 
-var listScanDenyPolicy = `
+var listScanDenyGlobPolicy = `
 path "foo/metadata/*" { capabilities = ["list","scan"] }
 path "foo/metadata/private/*" { capabilities = ["deny"] }
 path "foo/metadata/private/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyWildcardPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/+" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/+" { capabilities = ["deny"] }
+// While tricky, note that + only matches a single segment. So +/ is
+// necessary to forbid a LIST, as the LIST operation is not on + but
+// on +/ and that's a different path from +.
+path "foo/metadata/private/internal/+/" { capabilities = ["deny"] }
+path "foo/metadata/private/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyInternalWildcardPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/" { capabilities = ["deny"] }
+path "foo/metadata/+/internal/" { capabilities = ["deny"] }
+path "foo/metadata/+/internal/+/" { capabilities = ["deny"] }
+path "foo/metadata/pr+vate/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyExplicitPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/elsewhere/" { capabilities = ["deny"] }
 `

--- a/internal/vault/policy/acl_test.go
+++ b/internal/vault/policy/acl_test.go
@@ -996,81 +996,99 @@ func TestACLGrantingPolicies(t *testing.T) {
 	}
 }
 
-func TestACL_ListScanWildcardDeny(t *testing.T) {
+func TestACL_ListScanDeny(t *testing.T) {
 	ns := namespace.RootNamespace
 	ctx := namespace.ContextWithNamespace(t.Context(), ns)
 
-	tests := []struct {
-		path    string
-		allowed bool
-	}{
-		{
-			path:    "foo",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/test",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/private",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata/private/internal",
-			allowed: false,
-		},
-		{
-			path:    "foo/metadata/private/granted",
-			allowed: true,
-		},
-		{
-			path:    "foo/metadata/private/granted/test",
-			allowed: true,
-		},
+	policies := map[string]string{
+		"wildcard":          listScanDenyWildcardPolicy,
+		"internal_wildcard": listScanDenyInternalWildcardPolicy,
+		"glob":              listScanDenyGlobPolicy,
+		"explicit":          listScanDenyExplicitPolicy,
 	}
 
-	for i, pt := range tests {
-		policy, err := ParseACLPolicy(ns, listScanDenyPolicy)
-		require.NoError(t, err)
-		require.NotNil(t, policy)
+	for name, policy := range policies {
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				path    string
+				allowed bool
+			}{
+				{
+					path:    "foo",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/test",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/private",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata/private/internal",
+					allowed: false,
+				},
+				{
+					path:    "foo/metadata/private/internal/elsewhere",
+					allowed: false,
+				},
 
-		acl, err := NewACL(ctx, []*Policy{policy})
-		require.NoError(t, err)
-		require.NotNil(t, acl)
+				{
+					path:    "foo/metadata/private/granted",
+					allowed: true,
+				},
+				{
+					path:    "foo/metadata/private/granted/test",
+					allowed: true,
+				},
+			}
 
-		for _, operation := range []logical.Operation{
-			logical.ScanOperation,
-			logical.ListOperation,
-		} {
-			request := new(logical.Request)
-			request.Path = pt.path
-			request.Operation = operation
+			for i, pt := range tests {
+				t.Run(strings.ReplaceAll(pt.path, "/", "_"), func(t *testing.T) {
+					policy, err := ParseACLPolicy(ns, policy)
+					require.NoError(t, err)
+					require.NotNil(t, policy)
 
-			require.False(t, strings.HasSuffix(request.Path, "/"))
-			request.Path += "/"
+					acl, err := NewACL(ctx, []*Policy{policy})
+					require.NoError(t, err)
+					require.NotNil(t, acl)
 
-			authResults := acl.AllowOperation(ctx, request, false)
-			require.Equal(
-				t,
-				pt.allowed,
-				authResults.Allowed,
-				"bad:\n"+
-					"case %d\n"+
-					"\t%#v\n"+
-					"operation: %v\n"+
-					"engine: %v != expected: %v",
-				i,
-				pt,
-				operation,
-				authResults.Allowed,
-				pt.allowed,
-			)
-		}
+					for _, operation := range []logical.Operation{
+						logical.ScanOperation,
+						logical.ListOperation,
+					} {
+						request := new(logical.Request)
+						request.Path = pt.path
+						request.Operation = operation
+
+						require.False(t, strings.HasSuffix(request.Path, "/"))
+						request.Path += "/"
+
+						authResults := acl.AllowOperation(ctx, request, false)
+						require.Equal(
+							t,
+							pt.allowed,
+							authResults.Allowed,
+							"bad:\n"+
+								"case %d\n"+
+								"\t%#v\n"+
+								"operation: %v\n"+
+								"engine: %v != expected: %v",
+							i,
+							pt,
+							operation,
+							authResults.Allowed,
+							pt.allowed,
+						)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -1481,8 +1499,37 @@ path "test/star" {
 }
 `
 
-var listScanDenyPolicy = `
+var listScanDenyGlobPolicy = `
 path "foo/metadata/*" { capabilities = ["list","scan"] }
 path "foo/metadata/private/*" { capabilities = ["deny"] }
 path "foo/metadata/private/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyWildcardPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/+" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/+" { capabilities = ["deny"] }
+// While tricky, note that + only matches a single segment. So +/ is
+// necessary to forbid a LIST, as the LIST operation is not on + but
+// on +/ and that's a different path from +.
+path "foo/metadata/private/internal/+/" { capabilities = ["deny"] }
+path "foo/metadata/private/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyInternalWildcardPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private" { capabilities = ["deny"] }
+path "foo/metadata/private/" { capabilities = ["deny"] }
+path "foo/metadata/+/internal" { capabilities = ["deny"] }
+path "foo/metadata/+/internal/" { capabilities = ["deny"] }
+path "foo/metadata/+/internal/+" { capabilities = ["deny"] }
+path "foo/metadata/+/internal/+/" { capabilities = ["deny"] }
+path "foo/metadata/pr+vate/granted/*" { capabilities = ["list","scan"] }
+`
+
+var listScanDenyExplicitPolicy = `
+path "foo/metadata/*" { capabilities = ["list","scan"] }
+path "foo/metadata/private/" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/" { capabilities = ["deny"] }
+path "foo/metadata/private/internal/elsewhere/" { capabilities = ["deny"] }
 `


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Note the rules of ACL policies:

**At the same rule precedence level**, deny takes precedence over any other operation. This does not mean that a deny in a lower-priority rule takes precedence over an approval; it makes that the deny is ignored.

And per https://openbao.org/docs/concepts/policies/#policy-syntax

1. If the first wildcard (`+`) or glob (`*`) occurs earlier in P1, P1 is lower priority
2. If P1 ends in * and P2 doesn't, P1 is lower priority
3. If P1 has more + (wildcard) segments, P1 is lower priority
4. If P1 is shorter, it is lower priority
5. If P1 is smaller lexicographically, it is lower priority

These tests attempt to demonstrate that w.r.t. LIST/SCAN operations. By the above, the following rules are sorted in priority order:

- `path "foo/metadata/*" { capabilities = ["list","scan"] }`
- `path "foo/metadata/+/private/*" { capabilities = ["deny"] }`

And thus a deny would never be processed because it is lower priority than the granting rule. This is hard to detect in general as a rule may exist across two different policies and it would be dependent on an auth method or identity linking the two policies together for this rule to be ignored.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
