### PR TITLE
fix cas for workflow update

### DIFF
--- a/changelog/3870.txt
+++ b/changelog/3870.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sys/workflows: Fix `cas` variable getting discarded.
+```

--- a/changelog/3870.txt
+++ b/changelog/3870.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-sys/workflows: Fix `cas` variable getting discarded.
+sys/workflows: Fix Check-And-Set in workflow API.  
 ```

--- a/internal/vault/logical_system_workflows.go
+++ b/internal/vault/logical_system_workflows.go
@@ -345,7 +345,7 @@ func (b *SystemBackend) handleWorkflowsUpdate() framework.OperationFunc {
 		var cas *int
 		casRaw, ok := data.GetOk("cas")
 		if ok {
-			cas := new(int)
+			cas = new(int)
 			*cas = casRaw.(int)
 		}
 


### PR DESCRIPTION
## Description

While working on the workflow command family, I noticed that the cas flag did not work. This seems to be caused by the reassignment of the variable inside the if block, so it is discarded and never actually set for the workflowStore.Set call.

Without the fix:
```
$ bao write sys/workflows/manage/test cas=-1 cas_required=true workflow='flow "check" {
  request "status" {
    operation = "read"
    path = "sys/seal-status"
  }
}'
Error writing data to sys/workflows/manage/test: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/workflows/manage/test
Code: 400. Errors:

* check-and-set parameter required for this call
```

With the fix applied:
```
$ bao write sys/workflows/manage/test cas=-1 cas_required=true workflow='flow "check" {
  request "status" {
    operation = "read"
    path = "sys/seal-status"
  }
}'
Key                      Value
---                      -----
allow_unauthenticated    false
cas_required             true
description              n/a
path                     test
version                  1
workflow                 flow "check" {
  request "status" {
    operation = "read"
    path = "sys/seal-status"
  }
}
```

## Rationale

Resolves: N/A

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
