### PR TITLE
add workflow command family

### DIFF
--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -83,3 +83,20 @@ func (c *Sys) GetWorkflowWithContext(ctx context.Context, path string) (*GetWork
 	}
 	return result.Data, err
 }
+
+func (c *Sys) DeleteWorkflow(path string) error {
+	return c.DeleteWorkflowWithContext(context.Background(), path)
+}
+
+func (c *Sys) DeleteWorkflowWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/workflows/manage/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err == nil {
+		defer resp.Body.Close() //nolint:errcheck
+	}
+	return err
+}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -11,11 +11,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 )
 
-func (c *Sys) ListWorkflows() ([]string, error) {
-	return c.ListWorkflowsWithContext(context.Background())
-}
-
-func (c *Sys) ListWorkflowsWithContext(ctx context.Context) ([]string, error) {
+func (c *Sys) ListWorkflows(ctx context.Context) ([]string, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -58,11 +54,7 @@ type GetWorkflowResponse struct {
 	Version              int    `json:"version"`
 }
 
-func (c *Sys) GetWorkflow(path string) (*GetWorkflowResponse, error) {
-	return c.GetWorkflowWithContext(context.Background(), path)
-}
-
-func (c *Sys) GetWorkflowWithContext(ctx context.Context, path string) (*GetWorkflowResponse, error) {
+func (c *Sys) GetWorkflow(ctx context.Context, path string) (*GetWorkflowResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -92,11 +84,7 @@ type PutWorkflowInput struct {
 	CAS                  *int   `json:"cas,omitempty"`
 }
 
-func (c *Sys) PutWorkflow(path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
-	return c.PutWorkflowWithContext(context.Background(), path, input)
-}
-
-func (c *Sys) PutWorkflowWithContext(ctx context.Context, path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
+func (c *Sys) PutWorkflow(ctx context.Context, path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -121,11 +109,7 @@ func (c *Sys) PutWorkflowWithContext(ctx context.Context, path string, input Put
 	return result.Data, err
 }
 
-func (c *Sys) DeleteWorkflow(path string) error {
-	return c.DeleteWorkflowWithContext(context.Background(), path)
-}
-
-func (c *Sys) DeleteWorkflowWithContext(ctx context.Context, path string) error {
+func (c *Sys) DeleteWorkflow(ctx context.Context, path string) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -138,11 +122,7 @@ func (c *Sys) DeleteWorkflowWithContext(ctx context.Context, path string) error 
 	return err
 }
 
-func (c *Sys) CallWorkflow(path string, data map[string]any) (*Secret, error) {
-	return c.CallWorkflowWithContext(context.Background(), path, data)
-}
-
-func (c *Sys) CallWorkflowWithContext(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+func (c *Sys) CallWorkflow(ctx context.Context, path string, data map[string]any) (*Secret, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -66,7 +66,7 @@ func (c *Sys) GetWorkflowWithContext(ctx context.Context, path string) (*GetWork
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policies/acl/%s", path))
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/workflows/manage/%s", path))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -100,3 +100,30 @@ func (c *Sys) DeleteWorkflowWithContext(ctx context.Context, path string) error 
 	}
 	return err
 }
+
+func (c *Sys) CallWorkflow(path string, data map[string]any) (*Secret, error) {
+	return c.CallWorkflowWithContext(context.Background(), path, data)
+}
+
+func (c *Sys) CallWorkflowWithContext(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/execute/%s", path))
+	if err := r.SetJSONBody(data); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -84,6 +84,43 @@ func (c *Sys) GetWorkflowWithContext(ctx context.Context, path string) (*GetWork
 	return result.Data, err
 }
 
+type PutWorkflowInput struct {
+	Workflow             string `json:"workflow"`
+	Description          string `json:"description,omitempty"`
+	AllowUnauthenticated bool   `json:"allow_unauthenticated,omitempty"`
+	CASRequired          bool   `json:"cas_required,omitempty"`
+	CAS                  *int   `json:"cas,omitempty"`
+}
+
+func (c *Sys) PutWorkflow(path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
+	return c.PutWorkflowWithContext(context.Background(), path, input)
+}
+
+func (c *Sys) PutWorkflowWithContext(ctx context.Context, path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/manage/%s", path))
+	if err := r.SetJSONBody(input); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *GetWorkflowResponse
+	}
+	err = resp.DecodeJSON(&result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Data, err
+}
+
 func (c *Sys) DeleteWorkflow(path string) error {
 	return c.DeleteWorkflowWithContext(context.Background(), path)
 }

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -46,8 +46,8 @@ func (c *Sys) ListWorkflows(ctx context.Context) ([]string, error) {
 }
 
 type GetWorkflowResponse struct {
-	AllowUnauthenticated bool   `json:"allow_unauthenticated"`
-	CasRequired          bool   `json:"cas_required"`
+	AllowUnauthenticated bool   `json:"allow_unauthenticated" mapstructure:"allow_unauthenticated"`
+	CasRequired          bool   `json:"cas_required" mapstructure:"cas_required"`
 	Description          string `json:"description"`
 	Path                 string `json:"path"`
 	Workflow             string `json:"workflow"`
@@ -66,14 +66,19 @@ func (c *Sys) GetWorkflow(ctx context.Context, path string) (*GetWorkflowRespons
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	var result struct {
-		Data *GetWorkflowResponse
-	}
-	err = resp.DecodeJSON(&result)
+	secret, err := ParseSecret(resp.Body)
 	if err != nil {
 		return nil, err
 	}
-	return result.Data, err
+	if secret == nil || secret.Data == nil {
+		return nil, nil
+	}
+
+	var result GetWorkflowResponse
+	if err := mapstructure.Decode(secret.Data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 type PutWorkflowInput struct {
@@ -99,14 +104,19 @@ func (c *Sys) PutWorkflow(ctx context.Context, path string, input PutWorkflowInp
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	var result struct {
-		Data *GetWorkflowResponse
-	}
-	err = resp.DecodeJSON(&result)
+	secret, err := ParseSecret(resp.Body)
 	if err != nil {
 		return nil, err
 	}
-	return result.Data, err
+	if secret == nil || secret.Data == nil {
+		return nil, nil
+	}
+
+	var result GetWorkflowResponse
+	if err := mapstructure.Decode(secret.Data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 func (c *Sys) DeleteWorkflow(ctx context.Context, path string) error {

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -45,7 +45,7 @@ func (c *Sys) ListWorkflows(ctx context.Context) ([]string, error) {
 	return results, err
 }
 
-type GetWorkflowResponse struct {
+type WorkflowResponse struct {
 	AllowUnauthenticated bool   `json:"allow_unauthenticated" mapstructure:"allow_unauthenticated"`
 	CasRequired          bool   `json:"cas_required" mapstructure:"cas_required"`
 	Description          string `json:"description"`
@@ -54,7 +54,7 @@ type GetWorkflowResponse struct {
 	Version              int    `json:"version"`
 }
 
-func (c *Sys) GetWorkflow(ctx context.Context, path string) (*GetWorkflowResponse, error) {
+func (c *Sys) GetWorkflow(ctx context.Context, path string) (*WorkflowResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -74,14 +74,14 @@ func (c *Sys) GetWorkflow(ctx context.Context, path string) (*GetWorkflowRespons
 		return nil, nil
 	}
 
-	var result GetWorkflowResponse
+	var result WorkflowResponse
 	if err := mapstructure.Decode(secret.Data, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-type PutWorkflowInput struct {
+type WorkflowInput struct {
 	Workflow             string `json:"workflow"`
 	Description          string `json:"description,omitempty"`
 	AllowUnauthenticated bool   `json:"allow_unauthenticated,omitempty"`
@@ -89,7 +89,7 @@ type PutWorkflowInput struct {
 	CAS                  *int   `json:"cas,omitempty"`
 }
 
-func (c *Sys) PutWorkflow(ctx context.Context, path string, input PutWorkflowInput) (*GetWorkflowResponse, error) {
+func (c *Sys) PutWorkflow(ctx context.Context, path string, input WorkflowInput) (*WorkflowResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -112,7 +112,7 @@ func (c *Sys) PutWorkflow(ctx context.Context, path string, input PutWorkflowInp
 		return nil, nil
 	}
 
-	var result GetWorkflowResponse
+	var result WorkflowResponse
 	if err := mapstructure.Decode(secret.Data, &result); err != nil {
 		return nil, err
 	}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+func (c *Sys) ListWorkflows() ([]string, error) {
+	return c.ListWorkflowsWithContext(context.Background())
+}
+
+func (c *Sys) ListWorkflowsWithContext(ctx context.Context) ([]string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest("LIST", "/v1/sys/workflows/manage")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if resp != nil {
+		defer resp.Body.Close() //nolint:errcheck
+	}
+	if resp != nil && resp.StatusCode == 404 {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return []string{}, nil
+	}
+
+	var results []string
+	err = mapstructure.Decode(secret.Data["keys"], &results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, err
+}
+
+type GetWorkflowResponse struct {
+	AllowUnauthenticated bool   `json:"allow_unauthenticated"`
+	CasRequired          bool   `json:"cas_required"`
+	Description          string `json:"description"`
+	Path                 string `json:"path"`
+	Workflow             string `json:"workflow"`
+	Version              int    `json:"version"`
+}
+
+func (c *Sys) GetWorkflow(path string) (*GetWorkflowResponse, error) {
+	return c.GetWorkflowWithContext(context.Background(), path)
+}
+
+func (c *Sys) GetWorkflowWithContext(ctx context.Context, path string) (*GetWorkflowResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policies/acl/%s", path))
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var result struct {
+		Data *GetWorkflowResponse
+	}
+	err = resp.DecodeJSON(&result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Data, err
+}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -141,7 +141,7 @@ func (c *Sys) CallWorkflow(ctx context.Context, path string, unauthed bool, data
 		prefix = "unauthed-execute"
 	}
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/workflows/%s/%s", prefix, path))
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/%s/%s", prefix, path))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -154,3 +154,26 @@ func (c *Sys) CallWorkflow(ctx context.Context, path string, data map[string]any
 
 	return secret, nil
 }
+
+func (c *Sys) CallUnauthedWorkflow(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/unauthed-execute/%s", path))
+	if err := r.SetJSONBody(data); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/api/sys_workflow.go
+++ b/api/sys_workflow.go
@@ -132,11 +132,16 @@ func (c *Sys) DeleteWorkflow(ctx context.Context, path string) error {
 	return err
 }
 
-func (c *Sys) CallWorkflow(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+func (c *Sys) CallWorkflow(ctx context.Context, path string, unauthed bool, data map[string]any) (*Secret, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/execute/%s", path))
+	prefix := "execute"
+	if unauthed {
+		prefix = "unauthed-execute"
+	}
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/workflows/%s/%s", prefix, path))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
@@ -155,14 +160,24 @@ func (c *Sys) CallWorkflow(ctx context.Context, path string, data map[string]any
 	return secret, nil
 }
 
-func (c *Sys) CallUnauthedWorkflow(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+type WorkflowInfo struct {
+	Path           string   `json:"path" mapstructure:"path"`
+	Description    string   `json:"description" mapstructure:"description"`
+	Inputs         []string `json:"inputs" mapstructure:"inputs"`
+	OutputHeaders  []string `json:"output_headers" mapstructure:"output_headers"`
+	OutputDataKeys []string `json:"output_data_keys" mapstructure:"output_data_keys"`
+}
+
+func (c *Sys) DescribeWorkflow(ctx context.Context, path string, unauthed bool) (*WorkflowInfo, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/workflows/unauthed-execute/%s", path))
-	if err := r.SetJSONBody(data); err != nil {
-		return nil, err
+	prefix := "execute"
+	if unauthed {
+		prefix = "unauthed-execute"
 	}
+
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/workflows/%s/%s", prefix, path))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -174,6 +189,13 @@ func (c *Sys) CallUnauthedWorkflow(ctx context.Context, path string, data map[st
 	if err != nil {
 		return nil, err
 	}
+	if secret == nil || secret.Data == nil {
+		return nil, nil
+	}
 
-	return secret, nil
+	var result WorkflowInfo
+	if err := mapstructure.Decode(secret.Data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }

--- a/changelog/3871.txt
+++ b/changelog/3871.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command/workflow: Add `bao workflow` command family to manage and call workflows.
+```

--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	github.com/openbao/openbao/sdk/v2 v2.6.2
 	github.com/ory/dockertest/v4 v4.0.0
 	github.com/pires/go-proxyproto v0.14.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/posener/complete v1.2.3
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-autopilot v0.3.0
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
@@ -111,7 +112,6 @@ require (
 	github.com/openbao/openbao/sdk/v2 v2.6.2
 	github.com/ory/dockertest/v4 v4.0.0
 	github.com/pires/go-proxyproto v0.14.0
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/posener/complete v1.2.3
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -430,6 +430,8 @@ github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyu
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/command/base_predict.go
+++ b/internal/command/base_predict.go
@@ -166,6 +166,11 @@ func (b *BaseCommand) PredictVaultPolicies() complete.Predictor {
 	return NewPredict().VaultPolicies()
 }
 
+// PredictVaultWorkflows returns a predictor for workflows.
+func (b *BaseCommand) PredictVaultWorkflows() complete.Predictor {
+	return NewPredict().VaultWorkflows()
+}
+
 func (b *BaseCommand) PredictVaultDebugTargets() complete.Predictor {
 	return complete.PredictSet(
 		"config",
@@ -233,6 +238,13 @@ func (p *Predict) VaultPlugins(pluginTypes ...api.PluginType) complete.Predictor
 // instead.
 func (p *Predict) VaultPolicies() complete.Predictor {
 	return p.filterFunc(p.policies)
+}
+
+// VaultWorkflows returns a predictor for workflows. This is a public
+// API for consumers, but you probably want BaseCommand.PredictVaultPolicies
+// instead.
+func (p *Predict) VaultWorkflows() complete.Predictor {
+	return p.filterFunc(p.workflows)
 }
 
 // vaultPaths parses the CLI options and returns the "best" list of possible
@@ -506,6 +518,33 @@ func (p *Predict) namespaces() []string {
 	list := make([]string, 0, len(namespaces))
 	for _, n := range namespaces {
 		s, ok := n.(string)
+		if !ok {
+			continue
+		}
+		list = append(list, s)
+	}
+	sort.Strings(list)
+	return list
+}
+
+func (p *Predict) workflows() []string {
+	client := p.Client()
+	if client == nil {
+		return nil
+	}
+
+	secret, err := client.Logical().List("sys/workflows/manage")
+	if err != nil {
+		return nil
+	}
+	workflows, ok := extractListData(secret)
+	if !ok {
+		return nil
+	}
+
+	list := make([]string, 0, len(workflows))
+	for _, w := range workflows {
+		s, ok := w.(string)
 		if !ok {
 			continue
 		}

--- a/internal/command/base_predict.go
+++ b/internal/command/base_predict.go
@@ -241,7 +241,7 @@ func (p *Predict) VaultPolicies() complete.Predictor {
 }
 
 // VaultWorkflows returns a predictor for workflows. This is a public
-// API for consumers, but you probably want BaseCommand.PredictVaultPolicies
+// API for consumers, but you probably want BaseCommand.PredictVaultWorkflows
 // instead.
 func (p *Predict) VaultWorkflows() complete.Predictor {
 	return p.filterFunc(p.workflows)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -753,6 +753,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow": func() (cli.Command, error) {
+			return &WorkflowCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"workflow list": func() (cli.Command, error) {
 			return &WorkflowListCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -758,6 +758,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow call": func() (cli.Command, error) {
+			return &WorkflowCallCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"workflow delete": func() (cli.Command, error) {
 			return &WorkflowDeleteCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -753,6 +753,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow list": func() (cli.Command, error) {
+			return &WorkflowListCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"write": func() (cli.Command, error) {
 			return &WriteCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -778,6 +778,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow write": func() (cli.Command, error) {
+			return &WorkflowWriteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"write": func() (cli.Command, error) {
 			return &WriteCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -768,6 +768,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow edit": func() (cli.Command, error) {
+			return &WorkflowEditCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"workflow list": func() (cli.Command, error) {
 			return &WorkflowListCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -763,6 +763,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow read": func() (cli.Command, error) {
+			return &WorkflowReadCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"write": func() (cli.Command, error) {
 			return &WriteCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -758,6 +758,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow delete": func() (cli.Command, error) {
+			return &WorkflowDeleteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"workflow list": func() (cli.Command, error) {
 			return &WorkflowListCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -773,6 +773,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"workflow info": func() (cli.Command, error) {
+			return &WorkflowInfoCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"workflow list": func() (cli.Command, error) {
 			return &WorkflowListCommand{
 				BaseCommand: getBaseCommand(),

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -24,7 +24,7 @@ func (c *WorkflowCommand) Help() string {
 Usage: bao workflow <subcommand> [options] [args]
 
   This command groups subcommands are for interacting with workflows.
-  Users can list, read, write, delete and call workflows.
+  Users can list, read, edit, delete and call workflows.
 
   List all workflows:
 

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -24,7 +24,7 @@ func (c *WorkflowCommand) Help() string {
 Usage: bao workflow <subcommand> [options] [args]
 
   This command groups subcommands are for interacting with workflows.
-  Users can list, read, write, delete and call workflows.
+  Users can list, read, write, edit, delete and call workflows.
 
   List all workflows:
 
@@ -37,6 +37,10 @@ Usage: bao workflow <subcommand> [options] [args]
   Create or update a workflow named "my-workflow" from local file:
 
       $ bao workflow write my-workflow ./my-workflow.hcl
+
+  Edit a workflow named "my-workflow" inside your local editor:
+
+      $ bao workflow edit my-workflow
 
   Delete the workflow named "my-workflow":
 

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -24,11 +24,27 @@ func (c *WorkflowCommand) Help() string {
 Usage: bao workflow <subcommand> [options] [args]
 
   This command groups subcommands are for interacting with workflows.
-  Users can list, read, edit, delete and call workflows.
+  Users can list, read, write, delete and call workflows.
 
   List all workflows:
 
       $ bao workflow list
+
+  Read the workflow named "my-workflow":
+
+      $ bao workflow read my-workflow
+
+  Create or update a workflow named "my-workflow" from local file:
+
+      $ bao workflow write my-workflow ./my-workflow.hcl
+
+  Delete the workflow named "my-workflow":
+
+      $ bao workflow delete my-workflow
+
+  Call the workflow named "my-workflow":
+
+      $ bao workflow call my-workflow
 
   Please see the individual subcommand help for detailed usage information.
 `

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+
+	"github.com/hashicorp/cli"
+)
+
+var _ cli.Command = (*TokenCommand)(nil)
+
+type WorkflowCommand struct {
+	*BaseCommand
+}
+
+func (c *WorkflowCommand) Synopsis() string {
+	return "Interact with workflows"
+}
+
+func (c *WorkflowCommand) Help() string {
+	helpText := `
+Usage: bao workflow <subcommand> [options] [args]
+
+  This command groups subcommands are for interacting with workflows.
+  Users can list, read, write, delete and call workflows.
+
+  List all workflows:
+
+      $ bao workflow list
+
+  Please see the individual subcommand help for detailed usage information.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
 // SPDX-License-Identifier: MPL-2.0
 
 package command
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/cli"
 )
 
-var _ cli.Command = (*TokenCommand)(nil)
+var _ cli.Command = (*WorkflowCommand)(nil)
 
 type WorkflowCommand struct {
 	*BaseCommand

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -24,7 +24,7 @@ func (c *WorkflowCommand) Help() string {
 Usage: bao workflow <subcommand> [options] [args]
 
   This command groups subcommands are for interacting with workflows.
-  Users can list, read, write, edit, delete and call workflows.
+  Users can list, read, write, edit, delete, call and inspect workflows.
 
   List all workflows:
 
@@ -33,6 +33,11 @@ Usage: bao workflow <subcommand> [options] [args]
   Read the workflow named "my-workflow":
 
       $ bao workflow read my-workflow
+
+  Show execution relevant information of "my-workflow" without requiring read
+  access to its full definition:
+
+      $ bao workflow info my-workflow
 
   Create or update a workflow named "my-workflow" from local file:
 

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowCallCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowCallCommand)(nil)
+)
+
+type WorkflowCallCommand struct {
+	*BaseCommand
+
+	flagUnauthed bool
+
+	testStdin io.Reader // for tests
+}
+
+func (c *WorkflowCallCommand) Synopsis() string {
+	return "Call a workflow"
+}
+
+func (c *WorkflowCallCommand) Help() string {
+	helpText := `
+Usage: bao workflow call [options] PATH [DATA K=V...]
+
+  Calls a OpenBao workflow, allowing for input data if needed.
+  If a workflow doesn't require authentification, it can be called with the unauthed flag.
+
+  Data is specified as "key=value" pairs. If the value begins with an "@", then
+  it is loaded from a file. If the value is "-", OpenBao will read the value from
+  stdin.
+
+  Call a workflow:
+
+      $ bao workflow call my-workflow
+
+  Call a workflow without authentificaiton:
+
+      $ bao workflow call -unauthed my-workflow
+
+  Call a workflow with input variables:
+
+      $ bao workflow call my-workflow username=tester
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowCallCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:       "unauthed",
+		Target:     &c.flagUnauthed,
+		Default:    false,
+		EnvVar:     "",
+		Completion: complete.PredictNothing,
+		Usage:      "Call a unauthed workflow",
+	})
+
+	return set
+}
+
+func (c *WorkflowCallCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *WorkflowCallCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowCallCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	// Pull our fake stdin if needed
+	stdin := io.Reader(os.Stdin)
+	if c.testStdin != nil {
+		stdin = c.testStdin
+	}
+	if c.flagNonInteractive {
+		stdin = bytes.NewReader(nil)
+	}
+
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
+
+	data, err := parseArgsData(stdin, args[1:])
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	secret, err := client.Logical().Write(path, data)
+	return handleWriteSecretOutput(c.BaseCommand, path, secret, err)
+}

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -121,6 +121,25 @@ func (c *WorkflowCallCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Logical().Write(path, data)
-	return handleWriteSecretOutput(c.BaseCommand, path, secret, err)
+	secret, err := client.Sys().CallWorkflow(path, data)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, err))
+		if secret != nil {
+			OutputSecret(c.UI, secret)
+		}
+		return 2
+	}
+	if secret == nil {
+		// Don't output anything unless using the "table" format
+		if Format(c.UI) == "table" {
+			c.UI.Info(fmt.Sprintf("Success! Called workflow: %s", path))
+		}
+		return 0
+	}
+
+	if c.flagField != "" {
+		return PrintRawField(c.UI, secret, c.flagField)
+	}
+
+	return OutputSecret(c.UI, secret)
 }

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -121,7 +122,7 @@ func (c *WorkflowCallCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Sys().CallWorkflow(path, data)
+	secret, err := client.Sys().CallWorkflow(context.Background(), path, data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, err))
 		if secret != nil {

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
 	"github.com/posener/complete"
 )
 
@@ -122,9 +123,15 @@ func (c *WorkflowCallCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Sys().CallWorkflow(context.Background(), path, data)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, err))
+	var secret *api.Secret
+	var callErr error
+	if c.flagUnauthed {
+		secret, callErr = client.Sys().CallUnauthedWorkflow(context.Background(), path, data)
+	} else {
+		secret, callErr = client.Sys().CallWorkflow(context.Background(), path, data)
+	}
+	if callErr != nil {
+		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, callErr))
 		if secret != nil {
 			OutputSecret(c.UI, secret)
 		}

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -37,7 +37,7 @@ func (c *WorkflowCallCommand) Help() string {
 Usage: bao workflow call [options] PATH [DATA K=V...]
 
   Calls a OpenBao workflow, allowing for input data if needed.
-  If a workflow doesn't require authentification, it can be called with the unauthed flag.
+  If a workflow doesn't require authentication, it can be called with the unauthed flag.
 
   Data is specified as "key=value" pairs. If the value begins with an "@", then
   it is loaded from a file. If the value is "-", OpenBao will read the value from
@@ -47,7 +47,7 @@ Usage: bao workflow call [options] PATH [DATA K=V...]
 
       $ bao workflow call my-workflow
 
-  Call a workflow without authentificaiton:
+  Call a workflow without authentication:
 
       $ bao workflow call -unauthed my-workflow
 

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/internal/command/workflow_call.go
+++ b/internal/command/workflow_call.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/cli"
-	"github.com/openbao/openbao/api/v2"
 	"github.com/posener/complete"
 )
 
@@ -123,15 +122,9 @@ func (c *WorkflowCallCommand) Run(args []string) int {
 		return 2
 	}
 
-	var secret *api.Secret
-	var callErr error
-	if c.flagUnauthed {
-		secret, callErr = client.Sys().CallUnauthedWorkflow(context.Background(), path, data)
-	} else {
-		secret, callErr = client.Sys().CallWorkflow(context.Background(), path, data)
-	}
-	if callErr != nil {
-		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, callErr))
+	secret, err := client.Sys().CallWorkflow(context.Background(), path, c.flagUnauthed, data)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error calling workflow at path %s: %s", path, err))
 		if secret != nil {
 			OutputSecret(c.UI, secret)
 		}

--- a/internal/command/workflow_call_test.go
+++ b/internal/command/workflow_call_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -78,7 +79,7 @@ func TestWorkflowCallCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)
@@ -103,7 +104,7 @@ func TestWorkflowCallCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_call_test.go
+++ b/internal/command/workflow_call_test.go
@@ -79,7 +79,7 @@ func TestWorkflowCallCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)
@@ -104,7 +104,7 @@ func TestWorkflowCallCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_call_test.go
+++ b/internal/command/workflow_call_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+)
+
+func testWorkflowCallCommand(tb testing.TB) (*cli.MockUi, *WorkflowCallCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowCallCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestWorkflowCallCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			nil,
+			"Not enough arguments",
+			1,
+		},
+		{
+			"not_found",
+			[]string{"not-a-real-workflow"},
+			"Error calling workflow at path not-a-real-workflow",
+			2,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowCallCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow: workflow,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowCallCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 0; exp != code {
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			t.Fatalf("expected %d to be %d: %s", code, exp, combined)
+		}
+	})
+
+	t.Run("with_data", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow: workflow,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowCallCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow", "foo=bar",
+		})
+		if exp := 0; exp != code {
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			t.Fatalf("expected %d to be %d: %s", code, exp, combined)
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowCallCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error calling workflow at path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowCallCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/command/workflow_delete.go
+++ b/internal/command/workflow_delete.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -76,7 +77,7 @@ func (c *WorkflowDeleteCommand) Run(args []string) int {
 	}
 
 	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
-	if err := client.Sys().DeleteWorkflow(path); err != nil {
+	if err := client.Sys().DeleteWorkflow(context.Background(), path); err != nil {
 		c.UI.Error(fmt.Sprintf("Error deleting workflow at path %s: %s", path, err))
 		return 2
 	}

--- a/internal/command/workflow_delete.go
+++ b/internal/command/workflow_delete.go
@@ -75,7 +75,7 @@ func (c *WorkflowDeleteCommand) Run(args []string) int {
 		return 2
 	}
 
-	path := strings.TrimSpace(strings.ToLower(args[0]))
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
 	if err := client.Sys().DeleteWorkflow(path); err != nil {
 		c.UI.Error(fmt.Sprintf("Error deleting workflow at path %s: %s", path, err))
 		return 2

--- a/internal/command/workflow_delete.go
+++ b/internal/command/workflow_delete.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowDeleteCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowDeleteCommand)(nil)
+)
+
+type WorkflowDeleteCommand struct {
+	*BaseCommand
+}
+
+func (c *WorkflowDeleteCommand) Synopsis() string {
+	return "Deletes a workflow by path"
+}
+
+func (c *WorkflowDeleteCommand) Help() string {
+	helpText := `
+Usage: bao workflow delete [options] PATH
+
+  Deletes the workflow under the given PATH in the OpenBao server.
+
+  Delete the workflow named "my-workflow":
+
+      $ bao workflow delete my-workflow
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowDeleteCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP)
+}
+
+func (c *WorkflowDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultWorkflows()
+}
+
+func (c *WorkflowDeleteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowDeleteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	path := strings.TrimSpace(strings.ToLower(args[0]))
+	if err := client.Sys().DeleteWorkflow(path); err != nil {
+		c.UI.Error(fmt.Sprintf("Error deleting workflow at path %s: %s", path, err))
+		return 2
+	}
+
+	c.UI.Output(fmt.Sprintf("Success! Deleted workflow at path: %s", path))
+	return 0
+}

--- a/internal/command/workflow_delete.go
+++ b/internal/command/workflow_delete.go
@@ -81,6 +81,6 @@ func (c *WorkflowDeleteCommand) Run(args []string) int {
 		return 2
 	}
 
-	c.UI.Output(fmt.Sprintf("Success! Deleted workflow at path: %s", path))
+	c.UI.Output(fmt.Sprintf("Success! Deleted workflow: %s", path))
 	return 0
 }

--- a/internal/command/workflow_delete_test.go
+++ b/internal/command/workflow_delete_test.go
@@ -79,7 +79,7 @@ func TestWorkflowDeleteCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_delete_test.go
+++ b/internal/command/workflow_delete_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+)
+
+func testWorkflowDeleteCommand(tb testing.TB) (*cli.MockUi, *WorkflowDeleteCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowDeleteCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestWorkflowDeleteCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			nil,
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowDeleteCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("integration", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow: workflow,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowDeleteCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Success! Deleted workflow: my-workflow"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+
+		workflows, err := client.Sys().ListWorkflows()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(workflows) != 0 {
+			t.Errorf("expected no workflows, got %q", workflows)
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowDeleteCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error deleting workflow at path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowDeleteCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/command/workflow_delete_test.go
+++ b/internal/command/workflow_delete_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -78,7 +79,7 @@ func TestWorkflowDeleteCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)
@@ -100,7 +101,7 @@ func TestWorkflowDeleteCommand_Run(t *testing.T) {
 			t.Errorf("expected %q to contain %q", combined, expected)
 		}
 
-		workflows, err := client.Sys().ListWorkflows()
+		workflows, err := client.Sys().ListWorkflows(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -39,7 +39,7 @@ func (c *WorkflowEditCommand) Help() string {
 Usage: bao workflow edit [options] PATH
 
   Edit a existing workflow under the given PATH. The used editor
-  can be defined via a flag or the EDITOR enviorment variable.
+  can be defined via a flag or the EDITOR environment variable.
 
   Edit a workflow:
 

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -123,12 +123,12 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 	}
 	defer os.Remove(tmpFile.Name()) //nolint:errcheck
 
-	if err := os.Chmod(tmpFile.Name(), 0o640); err != nil {
+	if err := os.Chmod(tmpFile.Name(), 0o600); err != nil {
 		c.UI.Error(fmt.Sprintf("Error setting temporary workflow file permissions: %s", err))
 		return 2
 	}
 	currentWorkflowBytes := []byte(workflowResp.Workflow)
-	if err := os.WriteFile(tmpFile.Name(), currentWorkflowBytes, 0o640); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), currentWorkflowBytes, 0o600); err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing temporary workflow file permissions: %s", err))
 		return 2
 	}

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/openbao/openbao/api/v2"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/posener/complete"
 )
 
@@ -37,7 +38,10 @@ func (c *WorkflowEditCommand) Help() string {
 Usage: bao workflow edit [options] PATH
 
   Edit a existing workflow under the given PATH. The used editor
-  can be defined via a flag or the EDITOR environment variable.
+  can be defined via a flag or the EDITOR environment variable. If
+  saving fails, you will be prompted to retry editing, overwrite
+  the latest version on the server, view a diff against the latest
+  version, or discard your changes.
 
   Edit a workflow:
 
@@ -121,61 +125,135 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		c.UI.Error(fmt.Sprintf("Error creating temporary workflow file: %s", err))
 		return 2
 	}
-	defer os.Remove(tmpFile.Name()) //nolint:errcheck
+	defer func() {
+		tmpFile.Close()
+		if retcode == 0 {
+			os.Remove(tmpFile.Name()) //nolint:errcheck
+		}
+	}()
 
 	if err := os.Chmod(tmpFile.Name(), 0o600); err != nil {
 		c.UI.Error(fmt.Sprintf("Error setting temporary workflow file permissions: %s", err))
+		os.Remove(tmpFile.Name()) //nolint:errcheck
 		return 2
 	}
 	currentWorkflowBytes := []byte(workflowResp.Workflow)
 	if err := os.WriteFile(tmpFile.Name(), currentWorkflowBytes, 0o600); err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing temporary workflow file permissions: %s", err))
+		os.Remove(tmpFile.Name()) //nolint:errcheck
 		return 2
 	}
 
-	cmd := exec.Command(c.flagEditor, tmpFile.Name())
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-	err = cmd.Run()
+Edit:
+	for {
+		tmpFileContent, ok, code := c.openInEditor(tmpFile.Name())
+		if !ok {
+			return code
+		}
+
+		if bytes.Equal(currentWorkflowBytes, tmpFileContent) || len(tmpFileContent) == 0 {
+			c.UI.Info("Edit unchanged or empty, aborting.")
+			return 0
+		}
+
+	Retry:
+		for {
+			workflowInput := api.PutWorkflowInput{
+				Workflow:             string(tmpFileContent),
+				Description:          workflowResp.Description,
+				AllowUnauthenticated: workflowResp.AllowUnauthenticated,
+				CASRequired:          workflowResp.CasRequired,
+				CAS:                  &workflowResp.Version,
+			}
+			if _, putErr := client.Sys().PutWorkflow(context.Background(), path, workflowInput); putErr != nil {
+				latest, err := client.Sys().GetWorkflow(context.Background(), path)
+				if err != nil {
+					c.UI.Error(fmt.Sprintf("Error fetching latest workflow under path %s: %s", path, err))
+					c.UI.Error(fmt.Sprintf("Your edits are still available in %s", tmpFile.Name()))
+					return 2
+				}
+				if latest == nil {
+					c.UI.Error(fmt.Sprintf("No workflow found in path %s", path))
+					c.UI.Error(fmt.Sprintf("Your edits are still available in %s", tmpFile.Name()))
+					return 2
+				}
+				c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, putErr))
+
+				for {
+					answer, err := c.UI.Ask("Retry editing, overwrite with the latest version, view a diff, or discard your changes? [edit/overwrite/diff/discard]")
+					if err != nil {
+						c.UI.Error(fmt.Sprintf("Error reading answer: %s", err))
+						c.UI.Error(fmt.Sprintf("Your edits are still available in %s", tmpFile.Name()))
+						return 2
+					}
+					switch strings.ToLower(strings.TrimSpace(answer)) {
+					case "edit":
+						continue Edit
+					case "overwrite":
+						workflowResp = latest
+						continue Retry
+					case "diff":
+						if err := c.diffAgainst(tmpFileContent, []byte(latest.Workflow)); err != nil {
+							c.UI.Error(fmt.Sprintf("Error running diff: %s", err))
+						}
+						continue
+					default:
+						c.UI.Info("Discarded changes.")
+						os.Remove(tmpFile.Name()) //nolint:errcheck
+						return 2
+					}
+				}
+			}
+
+			c.UI.Info(fmt.Sprintf("Success! Edited workflow: %s", path))
+			return 0
+		}
+	}
+}
+
+func (c *WorkflowEditCommand) diffAgainst(localContent, remoteContent []byte) error {
+	text, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(localContent)),
+		B:        difflib.SplitLines(string(remoteContent)),
+		FromFile: "your edit",
+		ToFile:   "online version",
+		Context:  3,
+	})
 	if err != nil {
+		return err
+	}
+	if text == "" {
+		c.UI.Info("No differences.")
+		return nil
+	}
+	c.UI.Output(text)
+	return nil
+}
+
+func (c *WorkflowEditCommand) openInEditor(path string) (content []byte, ok bool, retcode int) {
+	cmd := exec.Command(c.flagEditor, path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
 		exitCode := 2
 
-		if exitError, ok := err.(*exec.ExitError); ok {
+		if exitError, isExitErr := err.(*exec.ExitError); isExitErr {
 			if exitError.Success() {
 				c.UI.Info("User exited edit, aborting.")
-				return 0
+				return nil, false, 0
 			}
-			if ws, ok := exitError.Sys().(syscall.WaitStatus); ok {
+			if ws, isWaitStatus := exitError.Sys().(syscall.WaitStatus); isWaitStatus {
 				exitCode = ws.ExitStatus()
 			}
 		}
 
 		c.UI.Error(fmt.Sprintf("Failed to edit workflow: %s", err))
-		return exitCode
+		return nil, false, exitCode
 	}
 
-	tmpFileContent, err := os.ReadFile(tmpFile.Name())
+	content, err := os.ReadFile(path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error read temporary workflow file after changes: %s", err))
-		return 2
+		return nil, false, 2
 	}
-
-	if bytes.Equal(currentWorkflowBytes, tmpFileContent) || len(tmpFileContent) == 0 {
-		c.UI.Info("Edit unchanged or empty, aborting.")
-		return 0
-	}
-
-	workflowInput := api.PutWorkflowInput{
-		Workflow:             string(tmpFileContent),
-		Description:          workflowResp.Description,
-		AllowUnauthenticated: workflowResp.AllowUnauthenticated,
-		CASRequired:          workflowResp.CasRequired,
-		CAS:                  &workflowResp.Version,
-	}
-	if _, err := client.Sys().PutWorkflow(context.Background(), path, workflowInput); err != nil {
-		c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, err))
-		return 2
-	}
-
-	c.UI.Info(fmt.Sprintf("Success! Edited workflow: %s", path))
-	return 0
+	return content, true, 0
 }

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -159,8 +159,8 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		return 2
 	}
 
-	if bytes.Equal(currentWorkflowBytes, tmpFileContent) {
-		c.UI.Info("Edit unchanged, aborting.")
+	if bytes.Equal(currentWorkflowBytes, tmpFileContent) || len(tmpFileContent) == 0 {
+		c.UI.Info("Edit unchanged or empty, aborting.")
 		return 0
 	}
 
@@ -169,9 +169,7 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		Description:          workflowResp.Description,
 		AllowUnauthenticated: workflowResp.AllowUnauthenticated,
 		CASRequired:          workflowResp.CasRequired,
-	}
-	if workflowResp.CasRequired {
-		workflowInput.CAS = &workflowResp.Version
+		CAS:                  &workflowResp.Version,
 	}
 	if _, err := client.Sys().PutWorkflow(context.Background(), path, workflowInput); err != nil {
 		c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, err))

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -105,7 +106,7 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		return 2
 	}
 
-	workflowResp, err := client.Sys().GetWorkflow(path)
+	workflowResp, err := client.Sys().GetWorkflow(context.Background(), path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error finding workflow to edit under path %s: %s", path, err))
 		return 2
@@ -172,7 +173,7 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 	if workflowResp.CasRequired {
 		workflowInput.CAS = &workflowResp.Version
 	}
-	if _, err := client.Sys().PutWorkflow(path, workflowInput); err != nil {
+	if _, err := client.Sys().PutWorkflow(context.Background(), path, workflowInput); err != nil {
 		c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, err))
 		return 2
 	}

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -6,7 +6,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -26,8 +25,6 @@ type WorkflowEditCommand struct {
 	*BaseCommand
 
 	flagEditor string
-
-	testStdin io.Reader // for tests
 }
 
 func (c *WorkflowEditCommand) Synopsis() string {

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -120,7 +120,7 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		c.UI.Error(fmt.Sprintf("Error creating temporary workflow file: %s", err))
 		return 2
 	}
-	defer os.Remove(tmpFile.Name())
+	defer os.Remove(tmpFile.Name()) //nolint:errcheck
 
 	if err := os.Chmod(tmpFile.Name(), 0o640); err != nil {
 		c.UI.Error(fmt.Sprintf("Error setting temporary workflow file permissions: %s", err))

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -58,9 +58,9 @@ func (c *WorkflowEditCommand) Flags() *FlagSets {
 	f.StringVar(&StringVar{
 		Name:    "editor",
 		Target:  &c.flagEditor,
-		Default: "editor",
+		Default: "vi",
 		EnvVar:  "EDITOR",
-		Usage:   "The editor you want to use. Defaults to 'editor'",
+		Usage:   "The editor you want to use. Defaults to '$EDITOR' and then falls back to 'vi'",
 	})
 
 	return set

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowEditCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowEditCommand)(nil)
+)
+
+type WorkflowEditCommand struct {
+	*BaseCommand
+
+	flagEditor string
+
+	testStdin io.Reader // for tests
+}
+
+func (c *WorkflowEditCommand) Synopsis() string {
+	return "Edit a workflow"
+}
+
+func (c *WorkflowEditCommand) Help() string {
+	helpText := `
+Usage: bao workflow edit [options] PATH
+
+  Edit a existing workflow under the given PATH. The used editor
+  can be defined via a flag or the EDITOR enviorment variable.
+
+  Edit a workflow:
+
+      $ bao workflow edit my-workflow
+
+  Edit a workflow with vim:
+
+      $ bao workflow edit -editor=vim my-workflow
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowEditCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP)
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:    "editor",
+		Target:  &c.flagEditor,
+		Default: "editor",
+		EnvVar:  "EDITOR",
+		Usage:   "The editor you want to use. Defaults to 'editor'",
+	})
+
+	return set
+}
+
+func (c *WorkflowEditCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultWorkflows()
+}
+
+func (c *WorkflowEditCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if c.flagNonInteractive {
+		c.UI.Error(wrapAtLength("Refusing to edit workflow with -non-interactive specified; use bao workflow write"))
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	workflowResp, err := client.Sys().GetWorkflow(path)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error finding workflow to edit under path %s: %s", path, err))
+		return 2
+	}
+	if workflowResp == nil {
+		c.UI.Error(fmt.Sprintf("No workflow found in path %s", path))
+		return 2
+	}
+
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("workflow-%s-*.hcl", strings.ReplaceAll(path, "/", "_")))
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error creating temporary workflow file: %s", err))
+		return 2
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if err := os.Chmod(tmpFile.Name(), 0o640); err != nil {
+		c.UI.Error(fmt.Sprintf("Error setting temporary workflow file permissions: %s", err))
+		return 2
+	}
+	currentWorkflowBytes := []byte(workflowResp.Workflow)
+	if err := os.WriteFile(tmpFile.Name(), currentWorkflowBytes, 0o640); err != nil {
+		c.UI.Error(fmt.Sprintf("Error writing temporary workflow file permissions: %s", err))
+		return 2
+	}
+
+	cmd := exec.Command(c.flagEditor, tmpFile.Name())
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		exitCode := 2
+
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.Success() {
+				c.UI.Info("User exited edit, aborting.")
+				return 0
+			}
+			if ws, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				exitCode = ws.ExitStatus()
+			}
+		}
+
+		c.UI.Error(fmt.Sprintf("Failed to edit workflow: %s", err))
+		return exitCode
+	}
+
+	tmpFileContent, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error read temporary workflow file after changes: %s", err))
+		return 2
+	}
+
+	if bytes.Equal(currentWorkflowBytes, tmpFileContent) {
+		c.UI.Info("Edit unchanged, aborting.")
+		return 0
+	}
+
+	workflowInput := api.PutWorkflowInput{
+		Workflow:             string(tmpFileContent),
+		Description:          workflowResp.Description,
+		AllowUnauthenticated: workflowResp.AllowUnauthenticated,
+		CASRequired:          workflowResp.CasRequired,
+	}
+	if workflowResp.CasRequired {
+		workflowInput.CAS = &workflowResp.Version
+	}
+	if _, err := client.Sys().PutWorkflow(path, workflowInput); err != nil {
+		c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, err))
+		return 2
+	}
+
+	c.UI.Info(fmt.Sprintf("Success! Edited workflow: %s", path))
+	return 0
+}

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -158,7 +158,7 @@ Edit:
 
 	Retry:
 		for {
-			workflowInput := api.PutWorkflowInput{
+			workflowInput := api.WorkflowInput{
 				Workflow:             string(tmpFileContent),
 				Description:          workflowResp.Description,
 				AllowUnauthenticated: workflowResp.AllowUnauthenticated,

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -126,7 +126,7 @@ func (c *WorkflowEditCommand) Run(args []string) (retcode int) {
 		return 2
 	}
 	defer func() {
-		tmpFile.Close()
+		tmpFile.Close() //nolint:errcheck
 		if retcode == 0 {
 			os.Remove(tmpFile.Name()) //nolint:errcheck
 		}

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -13,8 +13,10 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/cli"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
 	"github.com/openbao/openbao/api/v2"
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/posener/complete"
 )
 
@@ -194,9 +196,7 @@ Edit:
 						workflowResp = latest
 						continue Retry
 					case "diff":
-						if err := c.diffAgainst(tmpFileContent, []byte(latest.Workflow)); err != nil {
-							c.UI.Error(fmt.Sprintf("Error running diff: %s", err))
-						}
+						c.diffAgainst(tmpFileContent, []byte(latest.Workflow))
 						continue
 					default:
 						c.UI.Info("Discarded changes.")
@@ -212,23 +212,15 @@ Edit:
 	}
 }
 
-func (c *WorkflowEditCommand) diffAgainst(localContent, remoteContent []byte) error {
-	text, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(localContent)),
-		B:        difflib.SplitLines(string(remoteContent)),
-		FromFile: "your edit",
-		ToFile:   "online version",
-		Context:  3,
-	})
-	if err != nil {
-		return err
-	}
-	if text == "" {
+func (c *WorkflowEditCommand) diffAgainst(localContent, remoteContent []byte) {
+	local, remote := string(localContent), string(remoteContent)
+	if local == remote {
 		c.UI.Info("No differences.")
-		return nil
+		return
 	}
-	c.UI.Output(text)
-	return nil
+
+	edits := myers.ComputeEdits(span.URIFromPath("your edit"), local, remote)
+	c.UI.Output(fmt.Sprint(gotextdiff.ToUnified("your edit", "online version", local, edits)))
 }
 
 func (c *WorkflowEditCommand) openInEditor(path string) (content []byte, ok bool, retcode int) {

--- a/internal/command/workflow_edit.go
+++ b/internal/command/workflow_edit.go
@@ -175,6 +175,7 @@ Edit:
 				if latest == nil {
 					c.UI.Error(fmt.Sprintf("No workflow found in path %s", path))
 					c.UI.Error(fmt.Sprintf("Your edits are still available in %s", tmpFile.Name()))
+					c.UI.Error(fmt.Sprintf("You can create a workflow under that path via:\n'\tbao workflow write %s %s", path, tmpFile.Name()))
 					return 2
 				}
 				c.UI.Error(fmt.Sprintf("Error putting workflow under path %s: %s", path, putErr))

--- a/internal/command/workflow_edit_test.go
+++ b/internal/command/workflow_edit_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -91,7 +92,7 @@ func TestWorkflowEditCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_edit_test.go
+++ b/internal/command/workflow_edit_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+)
+
+func testWorkflowEditCommand(tb testing.TB) (*cli.MockUi, *WorkflowEditCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowEditCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestWorkflowEditCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			nil,
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"non_interactive",
+			[]string{"-non-interactive", "my-workflow"},
+			"Refusing to edit",
+			1,
+		},
+		{
+			"not_found",
+			[]string{"-editor=do-not-matter", "not-a-real-workflow"},
+			"Error finding workflow to edit under path not-a-real-workflow",
+			2,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowEditCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("editor_does_not_exist", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{Workflow: workflow}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowEditCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-editor=" + filepath.Join(t.TempDir(), "does-not-exist"), "my-workflow",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Failed to edit workflow"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowEditCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-editor=i-use-vim-btw", "my-workflow",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error finding workflow to edit under path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowEditCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/command/workflow_edit_test.go
+++ b/internal/command/workflow_edit_test.go
@@ -91,7 +91,9 @@ func TestWorkflowEditCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{Workflow: workflow}); err != nil {
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow: workflow,
+		}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/command/workflow_edit_test.go
+++ b/internal/command/workflow_edit_test.go
@@ -92,7 +92,7 @@ func TestWorkflowEditCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_info.go
+++ b/internal/command/workflow_info.go
@@ -32,7 +32,7 @@ func (c *WorkflowInfoCommand) Help() string {
 Usage: bao workflow info [options] PATH
 
   Prints the information needed to call a OpenBao workflow under the given
-  path: its declared inputs and, its output headers and data keys.
+  path: its declared inputs, output headers and output data keys.
   Unlike "workflow read", this does not require read access to the workflow's full definition.
 
   Show info for the workflow "test-workflow":

--- a/internal/command/workflow_info.go
+++ b/internal/command/workflow_info.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowInfoCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowInfoCommand)(nil)
+)
+
+type WorkflowInfoCommand struct {
+	*BaseCommand
+
+	flagUnauthed bool
+}
+
+func (c *WorkflowInfoCommand) Synopsis() string {
+	return "Prints the execution relevant information of a workflow"
+}
+
+func (c *WorkflowInfoCommand) Help() string {
+	helpText := `
+Usage: bao workflow info [options] PATH
+
+  Prints the information needed to call a OpenBao workflow under the given
+  path: its declared inputs and, its output headers and data keys.
+  Unlike "workflow read", this does not require read access to the workflow's full definition.
+
+  Show info for the workflow "test-workflow":
+
+      $ bao workflow info test-workflow
+
+  Show info for a workflow that allows unauthenticated calls:
+
+      $ bao workflow info -unauthed test-workflow
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowInfoCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:       "unauthed",
+		Target:     &c.flagUnauthed,
+		Default:    false,
+		EnvVar:     "",
+		Completion: complete.PredictNothing,
+		Usage:      "Look up an unauthed workflow",
+	})
+
+	return set
+}
+
+func (c *WorkflowInfoCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultWorkflows()
+}
+
+func (c *WorkflowInfoCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowInfoCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
+	info, err := client.Sys().DescribeWorkflow(context.Background(), path, c.flagUnauthed)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading workflow info under path %s: %s", path, err))
+		return 2
+	}
+	if info == nil {
+		c.UI.Error(fmt.Sprintf("No workflow found in path %s", path))
+		return 2
+	}
+
+	data := map[string]any{
+		"path":             info.Path,
+		"description":      info.Description,
+		"inputs":           info.Inputs,
+		"output_headers":   info.OutputHeaders,
+		"output_data_keys": info.OutputDataKeys,
+	}
+	if c.flagField != "" {
+		return PrintRawField(c.UI, data, c.flagField)
+	}
+	return OutputData(c.UI, data)
+}

--- a/internal/command/workflow_list.go
+++ b/internal/command/workflow_list.go
@@ -77,6 +77,10 @@ func (c *WorkflowListCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error reading workflows: %s", err))
 		return 2
 	}
+	if len(workflows) == 0 {
+		c.UI.Error("No workflows found")
+		return 2
+	}
 
 	switch Format(c.UI) {
 	case "table":

--- a/internal/command/workflow_list.go
+++ b/internal/command/workflow_list.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	_ cli.Command             = (*NamespaceSealCommand)(nil)
-	_ cli.CommandAutocomplete = (*NamespaceSealCommand)(nil)
+	_ cli.Command             = (*WorkflowListCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowListCommand)(nil)
 )
 
 type WorkflowListCommand struct {

--- a/internal/command/workflow_list.go
+++ b/internal/command/workflow_list.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -72,7 +73,7 @@ func (c *WorkflowListCommand) Run(args []string) int {
 		return 2
 	}
 
-	workflows, err := client.Sys().ListWorkflows()
+	workflows, err := client.Sys().ListWorkflows(context.Background())
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading workflows: %s", err))
 		return 2

--- a/internal/command/workflow_list.go
+++ b/internal/command/workflow_list.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*NamespaceSealCommand)(nil)
+	_ cli.CommandAutocomplete = (*NamespaceSealCommand)(nil)
+)
+
+type WorkflowListCommand struct {
+	*BaseCommand
+}
+
+func (c *WorkflowListCommand) Synopsis() string {
+	return "Prints all workflows"
+}
+
+func (c *WorkflowListCommand) Help() string {
+	helpText := `
+Usage: bao workflow list [options]
+
+  This command outputs a list of all workflows created.
+
+  Fetch list of all workflows:
+
+      $ bao workflow list
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowListCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+}
+
+func (c *WorkflowListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *WorkflowListCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowListCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) > 0:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 0, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	workflows, err := client.Sys().ListWorkflows()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading workflows: %s", err))
+		return 2
+	}
+
+	switch Format(c.UI) {
+	case "table":
+		out := []string{"Path"}
+		out = append(out, workflows...)
+		c.UI.Output(tableOutput(out, nil))
+		return 0
+	default:
+		return OutputData(c.UI, workflows)
+	}
+}

--- a/internal/command/workflow_list.go
+++ b/internal/command/workflow_list.go
@@ -29,7 +29,7 @@ func (c *WorkflowListCommand) Help() string {
 	helpText := `
 Usage: bao workflow list [options]
 
-  This command outputs a list of all workflows created.
+  This command outputs a list of all workflows.
 
   Fetch list of all workflows:
 

--- a/internal/command/workflow_list_test.go
+++ b/internal/command/workflow_list_test.go
@@ -94,7 +94,7 @@ func TestWorkflowListCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_list_test.go
+++ b/internal/command/workflow_list_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -93,7 +94,7 @@ func TestWorkflowListCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow: workflow,
 		}); err != nil {
 			t.Fatal(err)

--- a/internal/command/workflow_list_test.go
+++ b/internal/command/workflow_list_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+)
+
+func testWorkflowListCommand(tb testing.TB) (*cli.MockUi, *WorkflowListCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowListCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestWorkflowListCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"too_many_args",
+			[]string{"foo"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowListCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testWorkflowListCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "No workflows found"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow: workflow,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowListCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "my-workflow"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowListCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error reading workflows: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowListCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/command/workflow_read.go
+++ b/internal/command/workflow_read.go
@@ -27,7 +27,7 @@ func (c *WorkflowReadCommand) Synopsis() string {
 
 func (c *WorkflowReadCommand) Help() string {
 	helpText := `
-Usage: bao workflow read [options] [PATH]
+Usage: bao workflow read [options] PATH
 
   Prints the content and metadata of a OpenBao workflow under the given path.
   If the policy does not exist, an error is returned.

--- a/internal/command/workflow_read.go
+++ b/internal/command/workflow_read.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -78,7 +79,7 @@ func (c *WorkflowReadCommand) Run(args []string) int {
 	}
 
 	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
-	workflowResp, err := client.Sys().GetWorkflow(path)
+	workflowResp, err := client.Sys().GetWorkflow(context.Background(), path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading workflow under path %s: %s", path, err))
 		return 2

--- a/internal/command/workflow_read.go
+++ b/internal/command/workflow_read.go
@@ -77,7 +77,7 @@ func (c *WorkflowReadCommand) Run(args []string) int {
 		return 2
 	}
 
-	path := strings.ToLower(strings.TrimSpace(args[0]))
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
 	workflowResp, err := client.Sys().GetWorkflow(path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading workflow under path %s: %s", path, err))

--- a/internal/command/workflow_read.go
+++ b/internal/command/workflow_read.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowReadCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowReadCommand)(nil)
+)
+
+type WorkflowReadCommand struct {
+	*BaseCommand
+}
+
+func (c *WorkflowReadCommand) Synopsis() string {
+	return "Prints the information about a workflow"
+}
+
+func (c *WorkflowReadCommand) Help() string {
+	helpText := `
+Usage: bao workflow read [options] [PATH]
+
+  Prints the content and metadata of a OpenBao workflow under the given path.
+  If the policy does not exist, an error is returned.
+
+  Read the workflow "test-workflow":
+
+      $ bao workflow read test-workflow
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowReadCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+}
+
+func (c *WorkflowReadCommand) AutocompleteArgs() complete.Predictor {
+	return c.PredictVaultWorkflows()
+}
+
+func (c *WorkflowReadCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowReadCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 1:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		return 1
+	case len(args) > 1:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	path := strings.ToLower(strings.TrimSpace(args[0]))
+	workflowResp, err := client.Sys().GetWorkflow(path)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading workflow under path %s: %s", path, err))
+		return 2
+	}
+	if workflowResp == nil {
+		c.UI.Error(fmt.Sprintf("No workflow found in path %s", path))
+		return 2
+	}
+
+	data := structtomap.Map(workflowResp)
+	if c.flagField != "" {
+		return PrintRawField(c.UI, data, c.flagField)
+	}
+	return OutputData(c.UI, data)
+}

--- a/internal/command/workflow_read.go
+++ b/internal/command/workflow_read.go
@@ -31,7 +31,7 @@ func (c *WorkflowReadCommand) Help() string {
 Usage: bao workflow read [options] PATH
 
   Prints the content and metadata of a OpenBao workflow under the given path.
-  If the policy does not exist, an error is returned.
+  If the workflow does not exist, an error is returned.
 
   Read the workflow "test-workflow":
 

--- a/internal/command/workflow_read_test.go
+++ b/internal/command/workflow_read_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+)
+
+func testWorkflowReadCommand(tb testing.TB) (*cli.MockUi, *WorkflowReadCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowReadCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestWorkflowReadCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			nil,
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"not_found",
+			[]string{"not-a-real-workflow"},
+			"Error reading workflow under path not-a-real-workflow",
+			2,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowReadCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		workflow := string(testWorkflowContents(t))
+		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+			Workflow:    workflow,
+			Description: "my description",
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		ui, cmd := testWorkflowReadCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		for _, expected := range []string{"my-workflow", "my description", "sys/seal-status"} {
+			if !strings.Contains(combined, expected) {
+				t.Errorf("expected %q to contain %q", combined, expected)
+			}
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowReadCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error reading workflow under path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowReadCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/command/workflow_read_test.go
+++ b/internal/command/workflow_read_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestWorkflowReadCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow("my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
 			Workflow:    workflow,
 			Description: "my description",
 		}); err != nil {

--- a/internal/command/workflow_read_test.go
+++ b/internal/command/workflow_read_test.go
@@ -85,7 +85,7 @@ func TestWorkflowReadCommand_Run(t *testing.T) {
 		defer closer()
 
 		workflow := string(testWorkflowContents(t))
-		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.PutWorkflowInput{
+		if _, err := client.Sys().PutWorkflow(context.Background(), "my-workflow", api.WorkflowInput{
 			Workflow:    workflow,
 			Description: "my description",
 		}); err != nil {

--- a/internal/command/workflow_write.go
+++ b/internal/command/workflow_write.go
@@ -168,7 +168,7 @@ func (c *WorkflowWriteCommand) Run(args []string) (retcode int) {
 		return 2
 	}
 
-	input := api.PutWorkflowInput{
+	input := api.WorkflowInput{
 		Workflow:             buf.String(),
 		Description:          c.flagDescription,
 		AllowUnauthenticated: c.flagAllowUnauthenticated,

--- a/internal/command/workflow_write.go
+++ b/internal/command/workflow_write.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -175,7 +176,7 @@ func (c *WorkflowWriteCommand) Run(args []string) (retcode int) {
 		CAS:                  cas,
 	}
 
-	workflowResp, err := client.Sys().PutWorkflow(path, input)
+	workflowResp, err := client.Sys().PutWorkflow(context.Background(), path, input)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing workflow at path %s: %s", path, err))
 		return 2

--- a/internal/command/workflow_write.go
+++ b/internal/command/workflow_write.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/openbao/openbao/api/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/structtomap"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*WorkflowWriteCommand)(nil)
+	_ cli.CommandAutocomplete = (*WorkflowWriteCommand)(nil)
+)
+
+type WorkflowWriteCommand struct {
+	*BaseCommand
+
+	flagDescription          string
+	flagAllowUnauthenticated bool
+	flagCASRequired          bool
+	flagCAS                  int
+
+	testStdin io.Reader // for tests
+}
+
+func (c *WorkflowWriteCommand) Synopsis() string {
+	return "Creates or updates a workflow"
+}
+
+func (c *WorkflowWriteCommand) Help() string {
+	helpText := `
+Usage: bao workflow write [options] PATH WORKFLOW_FILE
+
+  Creates a new workflow or updates an existing workflow under the given
+  PATH, using the workflow document read from WORKFLOW_FILE. Like all HCL
+  documents, this may alternatively be JSON encoded. If WORKFLOW_FILE is
+  "-", the workflow is read from stdin.
+
+  Create or update a workflow named "my-workflow" from "./workflow.hcl"
+  on the local disk:
+
+      $ bao workflow write my-workflow ./workflow.hcl
+
+  Create or update a workflow from stdin:
+
+      $ cat my-workflow.hcl | bao workflow write my-workflow -
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkflowWriteCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&StringVar{
+		Name:    "description",
+		Target:  &c.flagDescription,
+		Default: "",
+		Usage:   "Textual description of this workflow for operators.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "allow-unauthenticated",
+		Target:  &c.flagAllowUnauthenticated,
+		Default: false,
+		Usage: "Specifies if this workflow is allowed to be executed by " +
+			"unauthenticated users. Requires setting the " +
+			"allow_unauthenticated_workflows configuration option.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "cas-required",
+		Target:  &c.flagCASRequired,
+		Default: false,
+		Usage:   "Whether check-and-set semantics are required to update this workflow.",
+	})
+
+	f.IntVar(&IntVar{
+		Name:   "cas",
+		Target: &c.flagCAS,
+		Usage: "Last version number for modifications. Set to -1 for creation " +
+			"of a new workflow. Required if the workflow has cas_required set.",
+	})
+
+	return set
+}
+
+func (c *WorkflowWriteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *WorkflowWriteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *WorkflowWriteCommand) Run(args []string) (retcode int) {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	var cas *int
+	f.Visit(func(fl *flag.Flag) {
+		if fl.Name == "cas" {
+			cas = &c.flagCAS
+		}
+	})
+
+	args = f.Args()
+	switch {
+	case len(args) < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+		return 1
+	case len(args) > 2:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+		return 1
+	}
+
+	path := strings.TrimSpace(strings.ToLower(sanitizePath(args[0])))
+	filePath := strings.TrimSpace(args[1])
+
+	// Get the workflow contents, either from stdin or a file
+	var reader io.Reader
+	if filePath == "-" {
+		reader = os.Stdin
+		if c.testStdin != nil {
+			reader = c.testStdin
+		}
+	} else {
+		file, err := os.Open(filePath)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error opening workflow file: %s", err))
+			return 2
+		}
+		defer func() {
+			if err := file.Close(); err != nil {
+				c.UI.Error(fmt.Sprintf("Error closing workflow file: %s", err))
+				retcode = 2
+			}
+		}()
+		reader = file
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading workflow: %s", err))
+		return 2
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	input := api.PutWorkflowInput{
+		Workflow:             buf.String(),
+		Description:          c.flagDescription,
+		AllowUnauthenticated: c.flagAllowUnauthenticated,
+		CASRequired:          c.flagCASRequired,
+		CAS:                  cas,
+	}
+
+	workflowResp, err := client.Sys().PutWorkflow(path, input)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error writing workflow at path %s: %s", path, err))
+		return 2
+	}
+
+	if Format(c.UI) == "table" {
+		c.UI.Output(fmt.Sprintf("Success! Wrote workflow: %s", path))
+		return 0
+	}
+
+	data := structtomap.Map(workflowResp)
+	if c.flagField != "" {
+		return PrintRawField(c.UI, data, c.flagField)
+	}
+	return OutputData(c.UI, data)
+}

--- a/internal/command/workflow_write_test.go
+++ b/internal/command/workflow_write_test.go
@@ -106,7 +106,7 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(f.Name())
+		defer os.Remove(f.Name()) //nolint:errcheck
 
 		client, closer := testVaultServer(t)
 		defer closer()
@@ -148,8 +148,8 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 		stdinR, stdinW := io.Pipe()
 		go func() {
 			workflow := testWorkflowContents(t)
-			stdinW.Write(workflow)
-			stdinW.Close()
+			stdinW.Write(workflow) //nolint:errcheck
+			stdinW.Close()         //nolint:errcheck
 		}()
 
 		client, closer := testVaultServer(t)
@@ -187,7 +187,7 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(f.Name())
+		defer os.Remove(f.Name()) //nolint:errcheck
 
 		client, closer := testVaultServer(t)
 		defer closer()

--- a/internal/command/workflow_write_test.go
+++ b/internal/command/workflow_write_test.go
@@ -258,6 +258,12 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 		if exp := 0; code != exp {
 			t.Errorf("expected %d to be %d", code, exp)
 		}
+
+		expected = "Success! Wrote workflow: my-workflow"
+		combined = ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
 	})
 
 	t.Run("communication_failure", func(t *testing.T) {

--- a/internal/command/workflow_write_test.go
+++ b/internal/command/workflow_write_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -127,7 +128,7 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 			t.Errorf("expected %q to contain %q", combined, expected)
 		}
 
-		resp, err := client.Sys().GetWorkflow("my-workflow")
+		resp, err := client.Sys().GetWorkflow(context.Background(), "my-workflow")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +208,7 @@ func TestWorkflowWriteCommand_Run(t *testing.T) {
 			t.Fatalf("expected %d to be %d: %s", code, exp, combined)
 		}
 
-		resp, err := client.Sys().GetWorkflow("my-workflow")
+		resp, err := client.Sys().GetWorkflow(context.Background(), "my-workflow")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/command/workflow_write_test.go
+++ b/internal/command/workflow_write_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testWorkflowWriteCommand(tb testing.TB) (*cli.MockUi, *WorkflowWriteCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &WorkflowWriteCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func testWorkflowContents(tb testing.TB) []byte {
+	tb.Helper()
+
+	return bytes.TrimSpace([]byte(`
+flow "check" {
+  request "status" {
+    operation = "read"
+    path = "sys/seal-status"
+  }
+}
+	`))
+}
+
+func TestWorkflowWriteCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{"my-workflow"},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar", "baz"},
+			"Too many arguments",
+			1,
+		},
+		{
+			"bad_file",
+			[]string{"my-workflow", "/not/a/real/path.hcl"},
+			"Error opening workflow file",
+			2,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				ui, cmd := testWorkflowWriteCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		t.Parallel()
+
+		workflow := testWorkflowContents(t)
+		f, err := os.CreateTemp("", "vault-workflow-write")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(workflow); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(f.Name())
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testWorkflowWriteCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"my-workflow", f.Name(),
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Success! Wrote workflow: my-workflow"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+
+		resp, err := client.Sys().GetWorkflow("my-workflow")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("expected a workflow response")
+		}
+		if resp.Version != 1 {
+			t.Errorf("expected version %d to be %d", resp.Version, 1)
+		}
+		if strings.TrimSpace(resp.Workflow) != string(workflow) {
+			t.Errorf("expected %q to be %q", resp.Workflow, workflow)
+		}
+	})
+
+	t.Run("stdin", func(t *testing.T) {
+		t.Parallel()
+
+		stdinR, stdinW := io.Pipe()
+		go func() {
+			workflow := testWorkflowContents(t)
+			stdinW.Write(workflow)
+			stdinW.Close()
+		}()
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testWorkflowWriteCommand(t)
+		cmd.client = client
+		cmd.testStdin = stdinR
+
+		code := cmd.Run([]string{
+			"my-workflow", "-",
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Success! Wrote workflow: my-workflow"
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("flags", func(t *testing.T) {
+		t.Parallel()
+
+		workflow := testWorkflowContents(t)
+		f, err := os.CreateTemp("", "vault-workflow-write")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(workflow); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(f.Name())
+
+		client, closer := testVaultServer(t)
+		defer closer()
+
+		ui, cmd := testWorkflowWriteCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"-description", "my description",
+			"-allow-unauthenticated",
+			"-cas-required",
+			"-cas=-1",
+			"my-workflow", f.Name(),
+		})
+		if exp := 0; exp != code {
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			t.Fatalf("expected %d to be %d: %s", code, exp, combined)
+		}
+
+		resp, err := client.Sys().GetWorkflow("my-workflow")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Description != "my description" {
+			t.Errorf("expected description %q to be %q", resp.Description, "my description")
+		}
+		if !resp.AllowUnauthenticated {
+			t.Error("expected allow_unauthenticated to be true")
+		}
+		if !resp.CasRequired {
+			t.Error("expected cas_required to be true")
+		}
+
+		// A second write without -cas should now fail since cas is required.
+		ui, cmd = testWorkflowWriteCommand(t)
+		cmd.client = client
+
+		code = cmd.Run([]string{"my-workflow", f.Name()})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error writing workflow at path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+
+		// A write with an incorrect cas should also fail.
+		ui, cmd = testWorkflowWriteCommand(t)
+		cmd.client = client
+
+		code = cmd.Run([]string{"-cas=99", "my-workflow", f.Name()})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		combined = ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+
+		// A write with the correct cas should succeed.
+		ui, cmd = testWorkflowWriteCommand(t)
+		cmd.client = client
+
+		code = cmd.Run([]string{"-cas=1", "my-workflow", f.Name()})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testWorkflowWriteCommand(t)
+		cmd.client = client
+		cmd.testStdin = bytes.NewReader(testWorkflowContents(t))
+
+		code := cmd.Run([]string{
+			"my-workflow", "-",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error writing workflow at path my-workflow: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testWorkflowWriteCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}

--- a/internal/vault/logical_system_workflows.go
+++ b/internal/vault/logical_system_workflows.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -49,6 +50,31 @@ func (b *SystemBackend) workflowPaths() []*framework.Path {
 			Type:        framework.TypeBool,
 			Required:    true,
 			Description: "Whether this workflow can be accessed unauthenticated.",
+		},
+	}
+
+	workflowExecutionReadSchema := map[string]*framework.FieldSchema{
+		"path": {
+			Type:        framework.TypeString,
+			Required:    true,
+			Description: "Path of the workflow.",
+		},
+		"description": {
+			Type:        framework.TypeString,
+			Required:    true,
+			Description: "Workflow description.",
+		},
+		"inputs": {
+			Type:        framework.TypeStringSlice,
+			Description: "Declared input fields, as \"name <type>\".",
+		},
+		"output_headers": {
+			Type:        framework.TypeStringSlice,
+			Description: "Names of headers declared in the workflow's output headers block.",
+		},
+		"output_data_keys": {
+			Type:        framework.TypeStringSlice,
+			Description: "Names of keys declared in the workflow's output data block.",
 		},
 	}
 
@@ -202,6 +228,13 @@ func (b *SystemBackend) workflowPaths() []*framework.Path {
 					},
 					Summary: "Execute the given workflow.",
 				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleWorkflowsExecutionRead(false /* we are authenticated */),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: "OK", Fields: workflowExecutionReadSchema}},
+					},
+					Summary: "Retrieve information relevant to the execution of the given workflow.",
+				},
 			},
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["exec-workflows"][0]),
@@ -264,6 +297,13 @@ func (b *SystemBackend) workflowPaths() []*framework.Path {
 					},
 					Summary: "Execute the given workflow without authentication.",
 				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleWorkflowsExecutionRead(true /* we are unauthenticated */),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{Description: "OK", Fields: workflowExecutionReadSchema}},
+					},
+					Summary: "Retrieve information relevant to the execution of the given workflow.",
+				},
 			},
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["exec-workflows"][0]),
@@ -272,6 +312,45 @@ func (b *SystemBackend) workflowPaths() []*framework.Path {
 	}
 
 	return paths
+}
+
+func createWorkflowExecutionReadResponse(we *WorkflowEntry, ctx context.Context) (map[string]any, error) {
+	inputs, _, outputs, err := we.Parse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workflowData := map[string]any{
+		"path":        we.Path,
+		"description": we.Description,
+	}
+
+	if inputs != nil {
+		inputInfos := make([]string, len(inputs.Fields))
+		for i, input := range inputs.Fields {
+			inputInfo := fmt.Sprintf("%s <%s>", input.Name, input.Type.String())
+			inputInfos[i] = inputInfo
+		}
+		workflowData["inputs"] = inputInfos
+	}
+
+	if outputs != nil {
+		headerNames := make([]string, 0, len(outputs.Headers))
+		for name := range outputs.Headers {
+			headerNames = append(headerNames, name)
+		}
+		workflowData["output_headers"] = headerNames
+
+		if m, ok := outputs.Data.(map[string]any); ok {
+			dataKeys := make([]string, 0, len(m))
+			for k := range m {
+				dataKeys = append(dataKeys, k)
+			}
+			workflowData["output_data_keys"] = dataKeys
+		}
+	}
+
+	return workflowData, nil
 }
 
 func createWorkflowListResponse(we *WorkflowEntry) map[string]any {
@@ -311,7 +390,7 @@ func (b *SystemBackend) handleWorkflowsList(scan bool) framework.OperationFunc {
 		keyInfo := make(map[string]any, len(workflows))
 		for _, entry := range workflows {
 			keys = append(keys, entry.Path)
-			keyInfo[entry.Path] = createWorkflowDataResponse(entry)
+			keyInfo[entry.Path] = createWorkflowListResponse(entry)
 		}
 
 		return logical.ListResponseWithInfo(keys, keyInfo), nil
@@ -385,11 +464,37 @@ func (b *SystemBackend) handleWorkflowsDelete() framework.OperationFunc {
 	}
 }
 
-// handleWorkflowsExecute handles the "/sys/workflow/execute/<path>" and
-// "/sys/workflow/unauthed-execute/<path>" endpoints to execute workflows.
+// handleWorkflowsExecute handles the "/sys/workflow/execute/<path>", "/sys/workflows/trace/<path>"
+// and "/sys/workflow/unauthed-execute/<path>" endpoints to execute workflows.
 func (b *SystemBackend) handleWorkflowsExecute(unauthed bool, trace bool) framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		path := data.Get("path").(string)
 		return b.Core.workflowStore.Execute(ctx, req.ID, path, unauthed, trace, req, data)
+	}
+}
+
+// handleWorkflowsExecutionRead handles the "/sys/workflow/execute/<path>", "/sys/workflows/trace/<path>"
+// and "/sys/workflow/unauthed-execute/<path>" endpoints to read execution relevant information.
+func (b *SystemBackend) handleWorkflowsExecutionRead(unauthed bool) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		path := data.Get("path").(string)
+
+		pe, err := b.Core.workflowStore.Get(ctx, path)
+		if err != nil {
+			return handleError(err)
+		}
+		if unauthed && (pe == nil || !pe.AllowUnauthenticated) {
+			return nil, logical.ErrPermissionDenied
+		}
+		if pe == nil {
+			return nil, nil
+		}
+
+		workflowData, err := createWorkflowExecutionReadResponse(pe, ctx)
+		if err != nil {
+			return handleError(err)
+		}
+
+		return &logical.Response{Data: workflowData}, nil
 	}
 }

--- a/website/content/docs/api/system/workflows.mdx
+++ b/website/content/docs/api/system/workflows.mdx
@@ -77,7 +77,6 @@ $ curl \
     "cas_required": false,
     "description": "create namespace",
     "path": "ns1",
-    "workflow": " ... workflow data elided ...",
     "version": 0
 }
 ```
@@ -151,6 +150,44 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
     http://127.0.0.1:8200/v1/sys/workflows/manage/create-namespace
+```
+
+### Describe workflow execution
+
+This endpoint retrieves the information needed to call a workflow: its
+declared inputs and, its output headers and data keys.
+Unlike [reading a workflow](#read-workflow), this does not require
+read access to the workflow's full definition, so it can be granted to
+callers who are only meant to execute a workflow.
+
+| Method | Path                                     | Requires Authentication |
+| :----- | :--------------------------------------- | :---------------------- |
+| `GET`  | `/sys/workflows/execute/:path`           | yes                     |
+| `GET`  | `/sys/workflows/unauthed-execute/:path`  | no                      |
+
+#### Parameters
+
+- `path` `(string: <required>)` - Specifies the path of the workflow to
+  describe. This is specified as part of the request URL.
+
+#### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/workflows/execute/create-namespace
+```
+
+#### Sample response
+
+```json
+{
+  "path": "create-namespace",
+  "description": "create namespace",
+  "inputs": ["name <string>"],
+  "output_headers": ["X-Namespace-Id"],
+  "output_data_keys": ["namespace_id"]
+}
 ```
 
 ## Execute workflows

--- a/website/content/docs/api/system/workflows.mdx
+++ b/website/content/docs/api/system/workflows.mdx
@@ -154,8 +154,8 @@ $ curl \
 
 ### Describe workflow execution
 
-This endpoint retrieves the information needed to call a workflow: its
-declared inputs and, its output headers and data keys.
+This endpoint retrieves the information needed to call a workflow:
+its declared inputs, output headers and output data keys.
 Unlike [reading a workflow](#read-workflow), this does not require
 read access to the workflow's full definition, so it can be granted to
 callers who are only meant to execute a workflow.

--- a/website/content/docs/commands/workflow/call.mdx
+++ b/website/content/docs/commands/workflow/call.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_label: call
+description: |-
+  The "workflow call" command executes a given workflow with
+  the supplied data.
+---
+
+# workflow call
+
+The `workflow call` command calls a OpenBao workflow, allowing for input data if
+needed. If a workflow doesn't require authentication, it can be called with the
+`-unauthed` flag.
+
+Data is specified as `key=value` pairs. If the value begins with an `@`, then it
+is loaded from a file. If the value is `-`, OpenBao will read the value from
+stdin.
+
+Use [`workflow info`](info.mdx) to see the inputs a workflow declares.
+
+## Examples
+
+Call a workflow:
+
+```shell-session
+$ bao workflow call my-workflow
+Success! Called workflow: my-workflow
+```
+
+Call a workflow without authentication:
+
+```shell-session
+$ bao workflow call -unauthed my-workflow
+```
+
+Call a workflow with input variables:
+
+```shell-session
+$ bao workflow call my-workflow username=tester
+```
+
+Call a workflow with an input read from a file:
+
+```shell-session
+$ bao workflow call my-workflow policy=@my-policy.hcl
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Output options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `BAO_FORMAT` environment variable.
+
+### Command options
+
+- `-unauthed` `(bool: false)` - Call a unauthed workflow. This uses the
+  `sys/workflows/unauthed-execute` endpoint, which does not require
+  authentication.

--- a/website/content/docs/commands/workflow/delete.mdx
+++ b/website/content/docs/commands/workflow/delete.mdx
@@ -1,0 +1,24 @@
+---
+sidebar_label: delete
+description: |-
+  The "workflow delete" command deletes a given workflow.
+---
+
+# workflow delete
+
+The `workflow delete` command deletes the workflow under the given path in the
+OpenBao server.
+
+## Examples
+
+Delete the workflow named "my-workflow":
+
+```shell-session
+$ bao workflow delete my-workflow
+Success! Deleted workflow: my-workflow
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](../index.mdx) included on
+all commands.

--- a/website/content/docs/commands/workflow/edit.mdx
+++ b/website/content/docs/commands/workflow/edit.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_label: edit
+description: |-
+  The "workflow edit" command allows edits to a given workflow
+  via the provided editor of choice. If saving fails,
+  you will be prompted to retry editing, overwrite  the latest version on the server,
+  view a diff against the latest version, or discard your changes.
+---
+
+# workflow edit
+
+The `workflow edit` command edits an existing workflow under the given PATH.
+The used editor can be defined via a flag or the `EDITOR` environment variable.
+
+The workflow is written back with the version it was read at, so a concurrent
+update on the server is detected instead of silently overwritten. If saving
+fails, you will be prompted to retry editing, overwrite the latest version on
+the server, view a diff against the latest version, or discard your changes.
+
+If the editor exits without changes, or leaves the workflow empty, the edit is
+aborted. When saving fails and the edits are not discarded, they remain
+available in the temporary file whose path is printed.
+
+This command requires an interactive terminal; with `-non-interactive` it
+refuses to run. Use [`workflow write`](write.mdx) instead.
+
+## Examples
+
+Edit a workflow:
+
+```shell-session
+$ bao workflow edit my-workflow
+Success! Edited workflow: my-workflow
+```
+
+Edit a workflow with vim:
+
+```shell-session
+$ bao workflow edit -editor=vim my-workflow
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Command options
+
+- `-editor` `(string: "vi")` - The editor you want to use. Defaults to `$EDITOR`
+  and then falls back to `vi`.

--- a/website/content/docs/commands/workflow/index.mdx
+++ b/website/content/docs/commands/workflow/index.mdx
@@ -1,0 +1,80 @@
+---
+sidebar_label: Overview
+description: |-
+  The "workflow" command groups subcommands for interacting with workflows. Users can
+  call, delete, edit, info, list, read and write workflows.
+---
+
+# workflow
+
+The `workflow` command groups subcommands for interacting with workflows. Users
+can list, read, write, edit, delete, call and inspect workflows.
+
+For more information about the contents of workflows, please see the [profile
+engine documentation](../../concepts/profiles.mdx). For the underlying API, see
+the [`sys/workflows`](../../api/system/workflows.mdx) documentation.
+
+## Examples
+
+List all workflows:
+
+```shell-session
+$ bao workflow list
+```
+
+Read the workflow named "my-workflow":
+
+```shell-session
+$ bao workflow read my-workflow
+```
+
+Show execution relevant information of "my-workflow" without requiring read
+access to its full definition:
+
+```shell-session
+$ bao workflow info my-workflow
+```
+
+Create or update a workflow named "my-workflow" from a local file:
+
+```shell-session
+$ bao workflow write my-workflow ./my-workflow.hcl
+```
+
+Edit a workflow named "my-workflow" inside your local editor:
+
+```shell-session
+$ bao workflow edit my-workflow
+```
+
+Delete the workflow named "my-workflow":
+
+```shell-session
+$ bao workflow delete my-workflow
+```
+
+Call the workflow named "my-workflow":
+
+```shell-session
+$ bao workflow call my-workflow
+```
+
+## Usage
+
+```text
+Usage: bao workflow <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    call      Call a workflow
+    delete    Deletes a workflow by path
+    edit      Edit a workflow
+    info      Prints the execution relevant information of a workflow
+    list      Prints all workflows
+    read      Prints the information about a workflow
+    write     Creates or updates a workflow
+```
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar.

--- a/website/content/docs/commands/workflow/info.mdx
+++ b/website/content/docs/commands/workflow/info.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_label: info
+description: |-
+  The "workflow info" command prints the information needed to call a OpenBao workflow under the given
+  path: its declared inputs and, its output headers and data keys.
+  Unlike "workflow read", this does not require read access to the workflow's full definition.
+---
+
+# workflow info
+
+The `workflow info` command prints the information needed to call a OpenBao
+workflow under the given path: its declared inputs and, its output headers and
+data keys.
+
+Unlike [`workflow read`](read.mdx), this does not require read access to the
+workflow's full definition, so it can be granted to callers who are only meant
+to execute a workflow.
+
+## Examples
+
+Show info for the workflow "test-workflow":
+
+```shell-session
+$ bao workflow info test-workflow
+Key                 Value
+---                 -----
+path                test-workflow
+description         create namespace
+inputs              [name <string>]
+output_headers      [X-Namespace-Id]
+output_data_keys    [namespace_id]
+```
+
+Show info for a workflow that allows unauthenticated calls:
+
+```shell-session
+$ bao workflow info -unauthed test-workflow
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Output options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `BAO_FORMAT` environment variable.
+
+### Command options
+
+- `-unauthed` `(bool: false)` - Look up an unauthed workflow. This uses the
+  `sys/workflows/unauthed-execute` endpoint, which does not require
+  authentication.

--- a/website/content/docs/commands/workflow/list.mdx
+++ b/website/content/docs/commands/workflow/list.mdx
@@ -1,0 +1,32 @@
+---
+sidebar_label: list
+description: |-
+  The "workflow list" command outputs a list of all workflows.
+---
+
+# workflow list
+
+The `workflow list` command outputs a list of all workflows.
+
+## Examples
+
+Fetch list of all workflows:
+
+```shell-session
+$ bao workflow list
+Path
+----
+create-namespace
+reset-admin
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `BAO_FORMAT` environment variable.

--- a/website/content/docs/commands/workflow/read.mdx
+++ b/website/content/docs/commands/workflow/read.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_label: read
+description: |-
+  The "workflow read" command prints the content and metadata
+  of a OpenBao workflow under the given path.
+  If the workflow does not exist, an error is returned.
+---
+
+# workflow read
+
+The `workflow read` command prints the content and metadata of a OpenBao
+workflow under the given path. If the workflow does not exist, an error is
+returned.
+
+Reading a workflow requires read access to its full definition. To only fetch
+the information needed to execute a workflow, use [`workflow
+info`](info.mdx) instead.
+
+## Examples
+
+Read the workflow "test-workflow":
+
+```shell-session
+$ bao workflow read test-workflow
+Key                      Value
+---                      -----
+allow_unauthenticated    false
+cas_required             false
+description              create namespace
+path                     test-workflow
+version                  0
+workflow                 inputs { ... }
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Output options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `BAO_FORMAT` environment variable.

--- a/website/content/docs/commands/workflow/write.mdx
+++ b/website/content/docs/commands/workflow/write.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_label: write
+description: |-
+  The "workflow write" command creates or updates a workflow
+  under the given path. The workflow content can be defined via a HCL file
+  or read from the stdin.
+---
+
+# workflow write
+
+The `workflow write` command creates a new workflow or updates an existing
+workflow under the given PATH, using the workflow document read from
+WORKFLOW_FILE. Like all HCL documents, this may alternatively be JSON encoded.
+If WORKFLOW_FILE is `-`, the workflow is read from stdin.
+
+For details on the workflow syntax, please see the [profile engine
+documentation](../../concepts/profiles.mdx).
+
+## Examples
+
+Create or update a workflow named "my-workflow" from "./workflow.hcl" on the
+local disk:
+
+```shell-session
+$ bao workflow write my-workflow ./workflow.hcl
+Success! Wrote workflow: my-workflow
+```
+
+Create or update a workflow from stdin:
+
+```shell-session
+$ cat my-workflow.hcl | bao workflow write my-workflow -
+Success! Wrote workflow: my-workflow
+```
+
+Create a new workflow, failing if it already exists:
+
+```shell-session
+$ bao workflow write -cas=-1 my-workflow ./workflow.hcl
+```
+
+## Usage
+
+The following flags are available in addition to the [standard set of
+flags](../index.mdx) included on all commands.
+
+### Output options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `BAO_FORMAT` environment variable.
+
+### Command options
+
+- `-description` `(string: "")` - Textual description of this workflow for
+  operators.
+
+- `-allow-unauthenticated` `(bool: false)` - Specifies if this workflow is
+  allowed to be executed by unauthenticated users. Requires setting the
+  `allow_unauthenticated_workflows` configuration option.
+
+- `-cas-required` `(bool: false)` - Whether check-and-set semantics are required
+  to update this workflow.
+
+- `-cas` `(int: <optional>)` - Last version number for modifications. Set to
+  `-1` for creation of a new workflow. Required if the workflow has
+  `cas_required` set.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -283,6 +283,18 @@ const sidebars: SidebarsConfig = {
                 "commands/version",
                 "commands/version-history",
                 "commands/write",
+                {
+                    workflow: [
+                        "commands/workflow/index",
+                        "commands/workflow/call",
+                        "commands/workflow/delete",
+                        "commands/workflow/edit",
+                        "commands/workflow/info",
+                        "commands/workflow/list",
+                        "commands/workflow/read",
+                        "commands/workflow/write",
+                    ],
+                },
                 "commands/token-helper",
             ],
             "OpenBao Agent and Proxy": [


### PR DESCRIPTION
## Description

Add the following commands:
- bao workflow call -> call a workflow with given inputs
- bao workflow delete -> delete a workflow
- bao workflow edit -> edit a existing workflow in a editor of his choosing
- bao workflow list -> lists all workflows
- bao workflow read -> read all infos about a workflow
- bao workflow write -> create/update a workflow from a file or stdin

Also adds simple test for each command, ~~these will partially fail when #3870 isn't applied~~.

## Rationale

Resolves: #3331 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
