### PR TITLE
fix acme using defaults for renew config

### DIFF
--- a/changelog/3872.txt
+++ b/changelog/3872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+listener/tcp: Set ACME cache path according to `tls_acme_cache_path`.
+```

--- a/internal/helper/listenerutil/tls_acme.go
+++ b/internal/helper/listenerutil/tls_acme.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/caddyserver/certmagic"
@@ -40,6 +41,18 @@ type ACMECertGetter struct {
 
 	Magic *certmagic.Config
 	ACME  *certmagic.ACMEIssuer
+
+	certCache *certmagic.Cache
+	closeOnce sync.Once
+}
+
+func (cg *ACMECertGetter) Close() error {
+	cg.closeOnce.Do(func() {
+		if cg.certCache != nil {
+			cg.certCache.Stop()
+		}
+	})
+	return nil
 }
 
 func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger) (ReloadableCertGetter, error) {
@@ -168,6 +181,7 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 		},
 		Logger: zapLogger,
 	})
+	acg.certCache = cache
 
 	acg.Magic = certmagic.New(cache, magicCfg)
 

--- a/internal/helper/listenerutil/tls_acme.go
+++ b/internal/helper/listenerutil/tls_acme.go
@@ -75,15 +75,17 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 	if logger == nil {
 		zapLogger = zap.NewNop()
 	}
-	certmagic.Default.Logger = zapLogger
 
 	acg := &ACMECertGetter{
 		Listener: l,
-		Magic:    certmagic.NewDefault(),
 	}
 
-	acg.Magic.OnDemand = new(certmagic.OnDemandConfig)
-	acg.Magic.OnDemand.DecisionFunc = func(ctx context.Context, name string) error {
+	magicCfg := certmagic.Config{
+		Logger: zapLogger,
+	}
+
+	onDemand := new(certmagic.OnDemandConfig)
+	onDemand.DecisionFunc = func(ctx context.Context, name string) error {
 		if len(l.TLSACMEDomains) == 0 {
 			return nil
 		}
@@ -103,11 +105,13 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 		return nil
 	}
 
+	magicCfg.OnDemand = onDemand
+
 	if err := adjustCachePath(l); err != nil {
 		return nil, err
 	}
 
-	acg.Magic.Storage = &certmagic.FileStorage{
+	magicCfg.Storage = &certmagic.FileStorage{
 		Path: l.TLSACMECachePath,
 	}
 
@@ -118,12 +122,12 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 			return nil, fmt.Errorf("unknown value for tls_acme_key_type (`%v`); allowed values are `%v`, `%v`, `%v`, `%v`, `%v`, `%v`", l.TLSACMEKeyType, certmagic.ED25519, certmagic.P256, certmagic.P384, certmagic.RSA2048, certmagic.RSA4096, certmagic.RSA8192)
 		}
 
-		acg.Magic.KeySource = certmagic.StandardKeyGenerator{
+		magicCfg.KeySource = certmagic.StandardKeyGenerator{
 			KeyType: certmagic.KeyType(l.TLSACMEKeyType),
 		}
 	}
 
-	template := certmagic.ACMEIssuer{
+	issuerTemplate := certmagic.ACMEIssuer{
 		CA:                      l.TLSACMECADirectory,
 		TestCA:                  l.TLSACMETestCADirectory,
 		Email:                   l.TLSACMEEmail,
@@ -145,17 +149,29 @@ func NewCertificateGetter(l *configutil.Listener, ui cli.Ui, logger hclog.Logger
 			return nil, fmt.Errorf("failed to parse ACME CA certificate")
 		}
 
-		template.TrustedRoots = caPool
+		issuerTemplate.TrustedRoots = caPool
 	}
 
 	if l.TLSACMEEABKeyId != "" {
-		template.ExternalAccount = &acme.EAB{
+		issuerTemplate.ExternalAccount = &acme.EAB{
 			KeyID:  l.TLSACMEEABKeyId,
 			MACKey: l.TLSACMEEABMacKey,
 		}
 	}
 
-	acg.ACME = certmagic.NewACMEIssuer(acg.Magic, template)
+	cache := certmagic.NewCache(certmagic.CacheOptions{
+		GetConfigForCert: func(certmagic.Certificate) (*certmagic.Config, error) {
+			if acg.Magic == nil {
+				return nil, errors.New("ACME certificate config isn't initialized yet")
+			}
+			return acg.Magic, nil
+		},
+		Logger: zapLogger,
+	})
+
+	acg.Magic = certmagic.New(cache, magicCfg)
+
+	acg.ACME = certmagic.NewACMEIssuer(acg.Magic, issuerTemplate)
 	acg.Magic.Issuers = []certmagic.Issuer{acg.ACME}
 
 	return acg, nil

--- a/internal/helper/listenerutil/tls_acme_test.go
+++ b/internal/helper/listenerutil/tls_acme_test.go
@@ -24,6 +24,9 @@ func TestACMECertGetter(t *testing.T) {
 
 		acg, ok := cg.(*ACMECertGetter)
 		require.True(t, ok, "expected *ACMECertGetter, got %T", cg)
+		t.Cleanup(func() {
+			acg.Close() //nolint:errcheck
+		})
 		return acg
 	}
 

--- a/internal/helper/listenerutil/tls_acme_test.go
+++ b/internal/helper/listenerutil/tls_acme_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package listenerutil
+
+import (
+	"testing"
+
+	"github.com/caddyserver/certmagic"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openbao/openbao/v2/internal/helper/configutil"
+)
+
+func TestACMECertGetter(t *testing.T) {
+	const caDirectory = "http://127.0.0.1:9999/v1/pki/acme/directory"
+
+	newTestACMECertGetter := func(t *testing.T, l *configutil.Listener) *ACMECertGetter {
+		t.Helper()
+
+		cg, err := NewCertificateGetter(l, nil, hclog.NewNullLogger())
+		require.NoError(t, err)
+
+		acg, ok := cg.(*ACMECertGetter)
+		require.True(t, ok, "expected *ACMECertGetter, got %T", cg)
+		return acg
+	}
+
+	t.Run("listener config correctly setup", func(t *testing.T) {
+		dir := t.TempDir()
+
+		acg := newTestACMECertGetter(t, &configutil.Listener{
+			TLSACMECADirectory: caDirectory,
+			TLSACMECachePath:   dir,
+			TLSACMEKeyType:     string(certmagic.RSA4096),
+		})
+
+		require.Equal(t, dir, acg.Magic.Storage.(*certmagic.FileStorage).Path)
+		require.NotNil(t, acg.Magic.OnDemand)
+		require.Equal(t, caDirectory, acg.ACME.CA)
+		require.Equal(t, certmagic.StandardKeyGenerator{KeyType: certmagic.RSA4096}, acg.Magic.KeySource)
+	})
+}


### PR DESCRIPTION
## Description

As reported in #1232, when a tcp listener gets his certificate via ACME, the `tls_acme_cache_path` isn't respected. This comes from the default magic not having the config set for the cache, which is used to renew certificates.

This PR aims to fix this via not using the default but building our own.

## Rationale

Resolves: #1232 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
