### PR TITLE
Refactor paginated listing into common module

### DIFF
--- a/internal/physical/raft/fsm.go
+++ b/internal/physical/raft/fsm.go
@@ -581,58 +581,32 @@ func (f *FSM) ListPage(ctx context.Context, prefix string, after string, limit i
 }
 
 func listPageInner(ctx context.Context, tx *bolt.Tx, prefix string, after string, limit int) ([]string, error) {
-	var keys []string
-
-	prefixBytes := []byte(prefix)
-	seekPrefix := []byte(filepath.Join(prefix, after))
-	if after == "" {
-		seekPrefix = prefixBytes
-	} else if !bytes.HasPrefix(seekPrefix, prefixBytes) {
-		// filepath.Join has the very unfortunate behavior of trimming the
-		// trailing slash when after=".". When e.g., prefix=foo/, this gives
-		// us seekPrefix=foo, which fails the initial HasPrefix check,
-		// skipping all results.
-		seekPrefix = prefixBytes
+	lister := &physical.Lister{
+		Prefix: prefix,
+		After:  after,
+		Limit:  limit,
 	}
 
-	// Assume bucket exists and has keys
-	c := tx.Bucket(dataBucketName).Cursor()
+	var key []byte
+	cursor := tx.Bucket(dataBucketName).Cursor()
 
-	// By seeking relative to the after location, we can save looking
-	// at unnecessary entries before our expected entry.
-	for k, _ := c.Seek(seekPrefix); k != nil && bytes.HasPrefix(k, prefixBytes); k, _ = c.Next() {
-		if limit > 0 && len(keys) >= limit {
-			// We've seen enough entries; exit early.
-			return keys, nil
-		}
-
-		// Note that we push the comparison of 'key' with 'after'
-		// until we add in the directory suffix, if necessary.
-		key := string(k)
-		key = strings.TrimPrefix(key, prefix)
-		if i := strings.Index(key, "/"); i == -1 {
-			if after != "" && key <= after {
-				// Still prior to our cut-off point, so retry.
-				continue
-			}
-
-			// Add objects only from the current 'folder'
-			keys = append(keys, key)
-		} else {
-			// Add truncated 'folder' paths
-			if len(keys) == 0 || keys[len(keys)-1] != key[:i+1] {
-				folder := string(key[:i+1])
-				if after != "" && folder <= after {
-					// Still prior to our cut-off point, so retry.
-					continue
-				}
-
-				keys = append(keys, folder)
-			}
-		}
+	lister.Start = func() error {
+		_, seekPrefix := lister.SeekPrefix()
+		key, _ = cursor.Seek(seekPrefix)
+		return nil
 	}
 
-	return keys, nil
+	lister.Next = func() error {
+		key, _ = cursor.Next()
+		return nil
+	}
+
+	lister.Key = func() (string, bool, error) {
+		return string(key), key != nil, nil
+	}
+
+	results, _, err := lister.ListPage(ctx)
+	return results, err
 }
 
 // Within ApplyBatch, applies non-transactional operations.
@@ -906,7 +880,6 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []any {
 
 		return err
 	})
-
 	if err != nil {
 		f.logger.Error("failed to store data", "error", err)
 		panic("failed to store data")

--- a/internal/physical/raft/transaction.go
+++ b/internal/physical/raft/transaction.go
@@ -4,19 +4,17 @@
 package raft
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"hash"
+	"iter"
 	"maps"
 	"math"
-	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -468,158 +466,68 @@ func listShouldIncludeEntry(prefix string, after string, key string) (string, bo
 }
 
 func (t *RaftTransaction) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
-	// List differs from Get in that the latter is a single entry: if an
-	// put or delete has occurred in the transaction, it supersedes the
-	// value we would've gotten from the underlying data store. Here however,
-	// we always want to execute the list and remove entries if there have
-	// been writes that affect it.
-	//
-	// This is complex to do efficiently. We might have deleted an entire
-	// subtree that might show up in a list. We could've also added more
-	// entries, such that the list is unnecessary.
-	//
-	// We do this in two steps: perform the underlying list, ignoring results
-	// that have been deleted and merging any new writes that occur prior to
-	// a given iteration's entry.. Finally after the loop, we merge in results
-	// that have been added after the last key in the pending list, trimming
-	// it down to size.
 	t.l.Lock()
 	defer t.l.Unlock()
+
 	if t.haveFinishedTx {
 		return nil, physical.ErrTransactionAlreadyCommitted
 	}
 
-	prefixBytes := []byte(prefix)
-	fullAfter := filepath.Join(prefix, after)
-	seekPrefix := []byte(fullAfter)
-	if after == "" {
-		seekPrefix = prefixBytes
+	lister := &physical.Lister{
+		Prefix: prefix,
+		After:  after,
+		Limit:  limit,
 	}
 
-	// Assume the bucket exists and has keys.
-	c := t.tx.Bucket(dataBucketName).Cursor()
+	var key []byte
+	cursor := t.tx.Bucket(dataBucketName).Cursor()
 
-	// Build a map of updates and deletions (in the prefix!) for fast lookup.
-	deletions := map[string]struct{}{}
-	updates := map[string]struct{}{}
-	for key := range t.updates {
-		// Modified key is not in the correct path prefix.
-		if !strings.HasPrefix(key, prefix) {
-			continue
-		}
-
-		// Check whether we should visit this entry.
-		entry, _, visit := listShouldIncludeEntry(prefix, after, key)
-		if !visit {
-			continue
-		}
-
-		// If we'd keep this entry, track it appropriately.
-		if t.updates[key].Contents == nil {
-			deletions[key] = struct{}{}
-		} else {
-			updates[entry] = struct{}{}
-		}
+	lister.Start = func() error {
+		_, seekPrefix := lister.SeekPrefix()
+		key, _ = cursor.Seek(seekPrefix)
+		return nil
 	}
 
-	// We do verifications off of the contents actually in the underlying
-	// storage, not from pre-commit writes. This means we need two entries:
-	//
-	// 1. Things we've seen in the course of this list.
-	// 2. The immediate next list entry, if any.
-	var presentKeys []string
-	var nextPresentEntry string
+	lister.Next = func() error {
+		key, _ = cursor.Next()
+		return nil
+	}
 
-	// Iterate through the results of list and see if the underlying data
-	// store already had entries for this list operation. Merge in any
-	// updated keys in the process.
-	var keys []string
-	for k, _ := c.Seek(seekPrefix); k != nil && bytes.HasPrefix(k, prefixBytes); k, _ = c.Next() {
-		key := string(k)
-		entry, isFolder, shouldVisit := listShouldIncludeEntry(prefix, after, key)
+	lister.Key = func() (string, bool, error) {
+		return string(key), key != nil, nil
+	}
 
-		if limit > 0 && len(keys) >= limit {
-			// We've seen enough entries; exit.
-			nextPresentEntry = entry
-			break
+	lister.Deleted = func(path string) bool {
+		entry, present := t.updates[path]
+		if !present {
+			return false
 		}
 
-		if _, deleted := deletions[key]; deleted {
-			// This key was deleted; we don't need to include it in our list,
-			// but because it was deleted, it will show up in our underlying
-			// list.
-			presentKeys = append(presentKeys, key)
-			continue
-		}
+		return entry.Contents == nil
+	}
 
-		if !shouldVisit {
-			// Skip this entry.
-			continue
-		}
+	lister.Inserted = func() iter.Seq[string] {
+		return func(yield func(K string) bool) {
+			for key, entry := range t.updates {
+				if entry.Contents == nil {
+					// Skip deletes.
+					continue
+				}
 
-		// Before we add this entry, see if there's any updates to add instead.
-		lastKey := ""
-		if len(keys) > 0 {
-			lastKey = keys[len(keys)-1]
-		}
-		var mergedEntries []string
-		for updateEntry := range updates {
-			if updateEntry < entry && updateEntry > lastKey {
-				mergedEntries = append(mergedEntries, updateEntry)
-				delete(updates, updateEntry)
+				if !yield(key) {
+					return
+				}
 			}
 		}
-		sort.Strings(mergedEntries)
-		keys = append(keys, mergedEntries...)
-		if len(keys) > 0 {
-			lastKey = keys[len(keys)-1]
-		}
-
-		if isFolder && len(keys) > 0 && lastKey == entry {
-			// This folder was already seen; don't revisit it.
-			if len(presentKeys) > 0 && presentKeys[len(presentKeys)-1] != key {
-				presentKeys = append(presentKeys, key)
-			}
-			continue
-		}
-
-		// Otherwise, include the entry.
-		keys = append(keys, entry)
-		presentKeys = append(presentKeys, entry)
-		delete(updates, entry)
 	}
 
-	// Finally, attempt to merge newly added entries one more time. This
-	// handles the case when there were no on-disk entries, or when there
-	// were too few and subsequent entries were added here.
-	lastKey := ""
-	if len(keys) > 0 {
-		lastKey = keys[len(keys)-1]
-	}
-	var mergedEntries []string
-	for updateEntry := range updates {
-		if updateEntry > lastKey {
-			mergedEntries = append(mergedEntries, updateEntry)
-			delete(updates, updateEntry)
-		}
-	}
-	sort.Strings(mergedEntries)
-	keys = append(keys, mergedEntries...)
-
-	// We may end up with extra keys as a result of adding all locally
-	// updated ones; if we have too many, trim it down.
-	if limit > 0 && len(keys) > limit {
-		keys = keys[:limit]
+	keys, presentKeys, err := lister.ListPage(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	// Now that we have the results, create a fake version for verification:
-	// we append the next key (in storage) to the iterated list for iteration,
-	// to ensure we didn't miss any entries. This is guaranteed to be at most
-	// one more than the requested entries, if no writes occurred within this
-	// transaction.
-	if nextPresentEntry != "" {
-		presentKeys = append(presentKeys, nextPresentEntry)
-	}
+	// Now that we have the results, create a fake version for verification
+	// using all read entries (presentKeys) from above.
 	verifyLimit := len(presentKeys)
 	listParams, contentsHash, err := createListVerificationEntry(prefix, after, verifyLimit, presentKeys)
 	if err != nil {

--- a/sdk/physical/listing.go
+++ b/sdk/physical/listing.go
@@ -1,0 +1,308 @@
+package physical
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
+)
+
+// Lister allows an ordered, seeking backend to implement ListPage in a
+// uniform manner without handling the specifics of paginated list
+// themselves.
+type Lister struct {
+	// Prefix is as given to physical.Backend.ListPage(...).
+	Prefix string
+
+	// After is as given to physical.Backend.ListPage(...).
+	After string
+
+	// Limit is as given to physical.Backend.ListPage(...).
+	Limit int
+
+	// Start is a function which begins iteration, setting the initial value
+	// returned by Key(...).
+	Start func() error
+
+	// Next is a function which continues iteration, updating the next value
+	// returned by Key(...).
+	Next func() error
+
+	// Key returns the key at the current iteration position.
+	Key func() (string, bool, error)
+
+	// Deleted returns whether the given fully resolved path has been deleted.
+	//
+	// This is used with reconciling read-write transactions: those which
+	// maintain written/updated state in memory but use a consistent read-only
+	// snapshot as the backing layer. In this case, the above Start(...),
+	// Next(...), and Key(...) functions return the state as of the read-only
+	// storage view and Lister.ListPage(...) will resolve the discrepancies.
+	Deleted func(path string) bool
+
+	// Inserted returns an iterator over all insertions in the given
+	// transaction. See note about Delete(...) above.
+	Inserted func() iter.Seq[string]
+}
+
+// SeekPrefix returns the joined prefix of the first element, assuming a strict
+// greater-than seek logic. Lister handles both greater-than and
+// greater-than-equal seek logic.
+func (l *Lister) SeekPrefix() (string, []byte) {
+	slash := "/"
+
+	// This is a quirk of how listing works not exercised by our test suite:
+	// if you list a specific entry under certain backends, you'd end up with
+	// a single result, the entry itself. This is because no subsequent keys
+	// were checked by virtue of there being an actual slash and after was
+	// empty. As a side effect, ClearView(...) on such a path would actually
+	// function and would remove the path. This seems reasonable enough to
+	// keep the behavior of, even though the list operation (which enabled
+	// this) probably shouldn't have.
+	if l.Prefix == "" || l.After == "" || l.Prefix[len(l.Prefix)-1] == '/' || l.After[0] == '/' {
+		slash = ""
+	}
+
+	result := l.Prefix + slash + l.After
+	return result, []byte(result)
+}
+
+func (l *Lister) validate() error {
+	if l.Start == nil || l.Next == nil || l.Key == nil {
+		return errors.New("missing implementation helpers")
+	}
+
+	if (l.Deleted != nil) != (l.Inserted != nil) {
+		return errors.New("missing reconciling implementation helpers")
+	}
+
+	if l.Limit < 0 {
+		// Ensure uniformity of limits.
+		l.Limit = 0
+	}
+
+	return nil
+}
+
+func (l *Lister) while(ctx context.Context, listerErr *error, key *string, start *bool, keys []string) bool {
+	if ctx.Err() != nil {
+		// Context cancelled.
+		*listerErr = ctx.Err()
+		return false
+	}
+
+	if l.Limit > 0 && len(keys) >= l.Limit {
+		// Enough keys, can return early.
+		return false
+	}
+
+	// Progress through the loop.
+	increment := l.Next
+	if !*start {
+		increment = l.Start
+		*start = true
+	}
+
+	if err := increment(); err != nil {
+		*listerErr = err
+		return false
+	}
+
+	var ok bool
+	*key, ok, *listerErr = l.Key()
+	if *listerErr != nil {
+		return false
+	}
+
+	// Otherwise, validate we haven't gone too far.
+	return ok && strings.HasPrefix(*key, l.Prefix)
+}
+
+// shouldIncludeEntry returns (entryName, isFolder, shouldVisit)
+func (l *Lister) shouldIncludeEntry(key string) (string, bool, bool) {
+	subKey, ok := strings.CutPrefix(key, l.Prefix)
+	if !ok {
+		return subKey, false, false
+	}
+
+	i := strings.Index(subKey, "/")
+	if i == -1 {
+		// Not a folder; check if we can skip this entry by suffix.
+		if l.After != "" && subKey <= l.After {
+			return subKey, false, false
+		}
+
+		return subKey, false, true
+	}
+
+	// Check if we need to visit the truncated folder path.
+	folder := subKey[:i+1]
+	if l.After != "" && folder <= l.After {
+		return folder, true, false
+	}
+
+	return folder, true, true
+}
+
+func (l *Lister) inserts() []string {
+	var entries []string
+
+	if l.Inserted == nil {
+		return entries
+	}
+
+	for path := range l.Inserted() {
+		entry, _, include := l.shouldIncludeEntry(path)
+		if !include {
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	slices.Sort(entries)
+	return slices.Compact(entries)
+}
+
+func (l *Lister) ListPage(ctx context.Context) ([]string, []string, error) {
+	// List differs from Get in that the latter is a single entry: if an
+	// put or delete has occurred in the transaction, it supersedes the
+	// value we would've gotten from the underlying data store. Here however,
+	// we always want to execute the list and remove entries if there have
+	// been writes that affect it.
+	//
+	// This is complex to do efficiently. We might have deleted an entire
+	// subtree that might show up in a list. We could've also added more
+	// entries, such that the list is unnecessary.
+	//
+	// We do this in two steps: perform the underlying list, ignoring results
+	// that have been deleted and merging any new writes that occur prior to
+	// a given iteration's entry. Finally after the loop, we merge in results
+	// that have been added after the last key in the pending list, trimming
+	// it down to size.
+
+	if err := l.validate(); err != nil {
+		return nil, nil, fmt.Errorf("error validating list parameters: %w", err)
+	}
+
+	// We remain two lists of keys: those we expect to be returned to the
+	// caller (i.e., the reconciled list), and the list of keys present in
+	// storage from our underlying view. This lets callers know what was
+	// actually read and use it for conflict detection.
+	var keys []string
+	var presentKeys []string
+
+	// Because inserts is sorted, we can maintain a single iterator over it.
+	inserts := l.inserts()
+	offset := 0
+
+	// We track errors and keys explicitly here so that Start(...), Next(...),
+	// and Key(...) are allowed to error.
+	var listerErr error
+	var key string
+	var start bool
+
+	// We assume the backend supports seeking around after, however, we'll
+	// gracefully handle and skip entries which occur before/at the after
+	// point in case this is ambiguous or different. This is only true if
+	// prefix is respected though: if we seek before prefix, we'll skip this
+	// loop entirely.
+	for l.while(ctx, &listerErr, &key, &start, keys) {
+		entry, isFolder, shouldVisit := l.shouldIncludeEntry(key)
+
+		// Always track this key as it was present in storage.
+		presentKeys = append(presentKeys, key)
+
+		if l.Deleted != nil && l.Deleted(key) {
+			// Key was deleted in this transaction so we should skip it.
+			continue
+		}
+
+		if !shouldVisit {
+			// Skip this entry as it doesn't have the correct prefix.
+			continue
+		}
+
+		// lastKey holds the last key in the keys list for comparison.
+		lastKey := ""
+		if len(keys) > 0 {
+			lastKey = keys[len(keys)-1]
+		}
+
+		// Check if we need to add any items inserted in this transaction
+		// before we process the item from underlying storage.
+		for offset < len(inserts) {
+			candidate := inserts[offset]
+			if candidate < entry && candidate > lastKey {
+				// Item existed in storage.
+				keys = append(keys, candidate)
+				offset += 1
+				lastKey = candidate
+				continue
+			}
+
+			if candidate == entry {
+				// It doesn't really matter which copy we insert, so skip this
+				// one and insert the outer loop's one.
+				offset += 1
+				break
+			}
+
+			// Since our current item isn't yet slated for insert, skip it. We
+			// know now that offset will be correct:
+			//
+			// On first loop iteration, we have an empty keys list and thus it
+			// holds that lastKey == "". We then insert any candidates up to
+			// entry.
+			//
+			// If entry is present both in storage and in our candidate list,
+			// we increment offset again. Thus it holds that
+			// candidate > lastKey is maintained.
+			break
+		}
+
+		// When this key represents a folder that already exists, we should skip it.
+		if isFolder && len(keys) > 0 && lastKey == entry {
+			continue
+		}
+
+		// Finally, include this entry. It is not present in the list.
+		keys = append(keys, entry)
+	}
+
+	// Loop exit may occur on context cancellation, so check that rather than
+	// returning partial results.
+	if listerErr != nil {
+		return nil, nil, listerErr
+	}
+
+	// Now, merge in any newly-added entries one more time. This handles the
+	// case where there were no on-disk entries, or when there were too few and
+	// subsequent entries were added here.
+	lastKey := ""
+	if len(keys) > 0 {
+		lastKey = keys[len(keys)-1]
+	}
+	for offset < len(inserts) {
+		candidate := inserts[offset]
+		offset += 1
+
+		if candidate > lastKey {
+			// Item existed in storage.
+			keys = append(keys, candidate)
+			continue
+		}
+	}
+
+	// Trim keys up to our limit; don't go over: the above final update
+	// reconciling logic means we might accidentally go over even though
+	// the main loop validates the limit.
+	actualLimit := len(keys)
+	if l.Limit > 0 && l.Limit < actualLimit {
+		actualLimit = l.Limit
+	}
+
+	return keys[:actualLimit], presentKeys, nil
+}


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Raft's implementation of paginated lists should be the reference for all backends. Rather than copying the logic, this is now refactored into a common, iteration-based approach for easier reuse in other storage backends. This also modularize's Raft's approach to transactional listing.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

This significantly helps with PebbleDB implementation, in support of #2846. The actual new LoC is probably small, but the commentary is useful. 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
