### PR TITLE
Fix signing in Transit with External Keys

### DIFF
--- a/internal/builtin/logical/transit/path_hmac.go
+++ b/internal/builtin/logical/transit/path_hmac.go
@@ -158,7 +158,10 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 		return logical.ErrorResponse("unsupported algorithm %q", hashAlgorithm), nil
 	}
 
-	hashAlg := keysutil.HashFuncMap[hashAlgorithm]
+	hf := keysutil.HashFuncMap[hashAlgorithm]
+	if hf == nil {
+		return logical.ErrorResponse("algorithm cannot be none"), nil
+	}
 
 	batchInputRaw := d.Raw["batch_input"]
 	var batchInputItems []batchRequestHMACItem
@@ -200,7 +203,7 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 			continue
 		}
 
-		hf := hmac.New(hashAlg, key)
+		hf := hmac.New(hf, key)
 		hf.Write(input)
 		retBytes := hf.Sum(nil)
 
@@ -237,15 +240,12 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 
 func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
-	hashAlgorithmStr := d.Get("urlalgorithm").(string)
-	if hashAlgorithmStr == "" {
-		hashAlgorithmStr = d.Get("hash_algorithm").(string)
-		if hashAlgorithmStr == "" {
-			hashAlgorithmStr = d.Get("algorithm").(string)
-			if hashAlgorithmStr == "" {
-				hashAlgorithmStr = defaultHashAlgorithm
-			}
-		}
+
+	// Even if not using an HMAC-typed key, fall back to the default hash
+	// algorithm of the HMAC key type.
+	hashAlgorithm, err := getHashAlgorithm(d, keysutil.KeyType_HMAC)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
@@ -260,12 +260,10 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 	}
 	defer p.Unlock()
 
-	hashAlgorithmType, ok := keysutil.HashTypeMap[hashAlgorithmStr]
-	if !ok {
-		return logical.ErrorResponse("invalid hash algorithm %q", hashAlgorithmStr), logical.ErrInvalidRequest
+	hf := keysutil.HashFuncMap[hashAlgorithm]
+	if hf == nil {
+		return logical.ErrorResponse("algorithm cannot be none"), nil
 	}
-
-	hashAlg := keysutil.HashFuncMap[hashAlgorithmType]
 
 	batchInputRaw := d.Raw["batch_input"]
 	var batchInputItems []batchRequestHMACItem
@@ -366,7 +364,7 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 			continue
 		}
 
-		hf := hmac.New(hashAlg, key)
+		hf := hmac.New(hf, key)
 		hf.Write(input)
 		retBytes := hf.Sum(nil)
 		response[i].Valid = hmac.Equal(retBytes, verBytes)

--- a/internal/builtin/logical/transit/path_hmac_test.go
+++ b/internal/builtin/logical/transit/path_hmac_test.go
@@ -21,6 +21,10 @@ func TestTransit_HMAC(t *testing.T) {
 		Storage:   storage,
 		Operation: logical.UpdateOperation,
 		Path:      "keys/" + keyName,
+		Data: map[string]any{
+			"type":     "hmac",
+			"key_size": 32,
+		},
 	}
 	_, err := b.HandleRequest(t.Context(), req)
 	require.NoError(t, err)
@@ -35,7 +39,6 @@ func TestTransit_HMAC(t *testing.T) {
 	// We don't care as we're the only one using this
 	latestVersion := strconv.Itoa(p.LatestVersion)
 	keyEntry := p.Keys[latestVersion]
-	keyEntry.HMACKey = []byte("01234567890123456789012345678901")
 	keyEntry.Key = []byte("01234567890123456789012345678901")
 	p.Keys[latestVersion] = keyEntry
 	require.NoError(t, p.Persist(t.Context(), storage))
@@ -134,7 +137,7 @@ func TestTransit_HMAC(t *testing.T) {
 	require.NoError(t, p.Rotate(t.Context(), storage, b.GetRandomReader()))
 	keyEntry = p.Keys["2"]
 	// Set to another value we control
-	keyEntry.HMACKey = []byte("12345678901234567890123456789012")
+	keyEntry.Key = []byte("12345678901234567890123456789012")
 	p.Keys["2"] = keyEntry
 	require.NoError(t, p.Persist(t.Context(), storage))
 

--- a/internal/builtin/logical/transit/path_keys.go
+++ b/internal/builtin/logical/transit/path_keys.go
@@ -72,9 +72,11 @@ func (b *backend) pathKeys() *framework.Path {
 				Type:    framework.TypeString,
 				Default: "aes256-gcm96",
 				Description: `
-The type of key to create. Currently, "aes128-gcm96" (symmetric), "aes256-gcm96" (symmetric), "ecdsa-p256"
-(asymmetric), "ecdsa-p384" (asymmetric), "ecdsa-p521" (asymmetric), "ed25519" (asymmetric), "rsa-2048" (asymmetric), "rsa-3072"
-(asymmetric), "rsa-4096" (asymmetric) are supported.  Defaults to "aes256-gcm96".
+The type of key to create. Currently, "aes128-gcm96" (symmetric), "aes256-gcm96"
+(symmetric), "ecdsa-p256" (asymmetric), "ecdsa-p384" (asymmetric), "ecdsa-p521"
+(asymmetric), "ed25519" (asymmetric), "rsa-2048" (asymmetric), "rsa-3072"
+(asymmetric), "rsa-4096" (asymmetric), "external-key" (symmetric or asymmetric)
+are supported. Defaults to "aes256-gcm96".
 `,
 			},
 

--- a/internal/builtin/logical/transit/path_sign_verify.go
+++ b/internal/builtin/logical/transit/path_sign_verify.go
@@ -73,7 +73,26 @@ type batchResponseVerifyItem struct {
 	Reference string `json:"reference" mapstructure:"reference"`
 }
 
-const defaultHashAlgorithm = "sha2-256"
+func getHashAlgorithm(d *framework.FieldData, kt keysutil.KeyType) (keysutil.HashType, error) {
+	hashAlgorithmStr := d.Get("urlalgorithm").(string)
+	if hashAlgorithmStr == "" {
+		hashAlgorithmStr = d.Get("hash_algorithm").(string)
+		if hashAlgorithmStr == "" {
+			hashAlgorithmStr = d.Get("algorithm").(string)
+		}
+	}
+
+	if hashAlgorithmStr == "" {
+		return kt.DefaultHashAlgorithm(), nil
+	}
+
+	hashAlgorithmType, ok := keysutil.HashTypeMap[hashAlgorithmStr]
+	if !ok {
+		return 0, fmt.Errorf("invalid hash algorithm %q", hashAlgorithmStr)
+	}
+
+	return hashAlgorithmType, nil
+}
 
 func (b *backend) pathSign() *framework.Path {
 	return &framework.Path{
@@ -103,8 +122,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 			},
 
 			"hash_algorithm": {
-				Type:    framework.TypeString,
-				Default: defaultHashAlgorithm,
+				Type: framework.TypeString,
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
 * sha1
@@ -118,15 +136,15 @@ derivation is enabled; currently only available with ed25519 keys.`,
 * sha3-512
 * none
 
-Defaults to "sha2-256". Not valid for all key types,
-including ed25519. Using none requires setting prehashed=true and
-signature_algorithm=pkcs1v15, yielding a PKCSv1_5_NoOID instead of
-the usual PKCSv1_5_DERnull signature.`,
+Defaults to "sha2-256" for RSA- and ECDSA-type keys, and "none" otherwise.
+Not valid for all key types, including Ed25519. Using "none" with a key type
+that otherwise requires a hash function requires setting prehashed=true and
+signature_algorithm=pkcs1v15, yielding a PKCSv1_5_NoOID instead of the usual
+PKCSv1_5_DERnull signature.`,
 			},
 
 			"algorithm": {
 				Type:        framework.TypeString,
-				Default:     defaultHashAlgorithm,
 				Description: `Deprecated: use "hash_algorithm" instead.`,
 			},
 
@@ -229,8 +247,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 			},
 
 			"hash_algorithm": {
-				Type:    framework.TypeString,
-				Default: defaultHashAlgorithm,
+				Type: framework.TypeString,
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
 * sha1
@@ -244,13 +261,12 @@ derivation is enabled; currently only available with ed25519 keys.`,
 * sha3-512
 * none
 
-Defaults to "sha2-256". Not valid for all key types. See note about
-none on signing path.`,
+Defaults to "sha2-256" for RSA-, ECDSA-, and HMAC-type keys, and "none"
+otherwise. Not valid for all key types. See note about "none" on signing path.`,
 			},
 
 			"algorithm": {
 				Type:        framework.TypeString,
-				Default:     defaultHashAlgorithm,
 				Description: `Deprecated: use "hash_algorithm" instead.`,
 			},
 
@@ -328,21 +344,6 @@ func (b *backend) getSaltLength(d *framework.FieldData) (int, error) {
 func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 	ver := d.Get("key_version").(int)
-	hashAlgorithmStr := d.Get("urlalgorithm").(string)
-	if hashAlgorithmStr == "" {
-		hashAlgorithmStr = d.Get("hash_algorithm").(string)
-		if hashAlgorithmStr == "" {
-			hashAlgorithmStr = d.Get("algorithm").(string)
-			if hashAlgorithmStr == "" {
-				hashAlgorithmStr = defaultHashAlgorithm
-			}
-		}
-	}
-
-	hashAlgorithm, ok := keysutil.HashTypeMap[hashAlgorithmStr]
-	if !ok {
-		return logical.ErrorResponse("invalid hash algorithm %q", hashAlgorithmStr), logical.ErrInvalidRequest
-	}
 
 	marshalingStr := d.Get("marshaling_algorithm").(string)
 	marshaling, ok := keysutil.MarshalingTypeMap[marshalingStr]
@@ -374,7 +375,12 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		return logical.ErrorResponse("key type %v does not support signing", p.Type), logical.ErrInvalidRequest
 	}
 
-	if hashAlgorithm == keysutil.HashTypeNone && (!prehashed || sigAlgorithm != "pkcs1v15") {
+	hashAlgorithm, err := getHashAlgorithm(d, p.Type)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	if hashAlgorithm == keysutil.HashTypeNone && (!prehashed || sigAlgorithm != "pkcs1v15") && p.Type.HashSignatureInput() {
 		return logical.ErrorResponse("hash_algorithm=none requires both prehashed=true and signature_algorithm=pkcs1v15"), logical.ErrInvalidRequest
 	}
 
@@ -416,11 +422,13 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 			continue
 		}
 
+		prehashed := prehashed
 		if p.Type.HashSignatureInput() && !prehashed {
 			hf := keysutil.HashFuncMap[hashAlgorithm]()
 			if hf != nil {
 				hf.Write(input)
 				input = hf.Sum(nil)
+				prehashed = true
 			}
 		}
 
@@ -437,6 +445,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 
 		sig, err := p.SignWithOptions(ver, context, input, &keysutil.SigningOptions{
 			HashAlgorithm:      hashAlgorithm,
+			Prehashed:          prehashed,
 			Marshaling:         marshaling,
 			SaltLength:         saltLength,
 			SigAlgorithm:       sigAlgorithm,
@@ -562,21 +571,6 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 	}
 
 	name := d.Get("name").(string)
-	hashAlgorithmStr := d.Get("urlalgorithm").(string)
-	if hashAlgorithmStr == "" {
-		hashAlgorithmStr = d.Get("hash_algorithm").(string)
-		if hashAlgorithmStr == "" {
-			hashAlgorithmStr = d.Get("algorithm").(string)
-			if hashAlgorithmStr == "" {
-				hashAlgorithmStr = defaultHashAlgorithm
-			}
-		}
-	}
-
-	hashAlgorithm, ok := keysutil.HashTypeMap[hashAlgorithmStr]
-	if !ok {
-		return logical.ErrorResponse("invalid hash algorithm %q", hashAlgorithmStr), logical.ErrInvalidRequest
-	}
 
 	marshalingStr := d.Get("marshaling_algorithm").(string)
 	marshaling, ok := keysutil.MarshalingTypeMap[marshalingStr]
@@ -608,7 +602,12 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse("key type %v does not support verification", p.Type), logical.ErrInvalidRequest
 	}
 
-	if hashAlgorithm == keysutil.HashTypeNone && (!prehashed || sigAlgorithm != "pkcs1v15") {
+	hashAlgorithm, err := getHashAlgorithm(d, p.Type)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	if hashAlgorithm == keysutil.HashTypeNone && (!prehashed || sigAlgorithm != "pkcs1v15") && p.Type.HashSignatureInput() {
 		return logical.ErrorResponse("hash_algorithm=none requires both prehashed=true and signature_algorithm=pkcs1v15"), logical.ErrInvalidRequest
 	}
 
@@ -637,11 +636,13 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 			continue
 		}
 
+		prehashed := prehashed
 		if p.Type.HashSignatureInput() && !prehashed {
 			hf := keysutil.HashFuncMap[hashAlgorithm]()
 			if hf != nil {
 				hf.Write(input)
 				input = hf.Sum(nil)
+				prehashed = true
 			}
 		}
 
@@ -658,6 +659,7 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 
 		signingOptions := &keysutil.SigningOptions{
 			HashAlgorithm:      hashAlgorithm,
+			Prehashed:          prehashed,
 			Marshaling:         marshaling,
 			SaltLength:         saltLength,
 			SigAlgorithm:       sigAlgorithm,

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -110,6 +110,7 @@ type BackupInfo struct {
 
 type SigningOptions struct {
 	HashAlgorithm      HashType
+	Prehashed          bool
 	Marshaling         MarshalingType
 	SaltLength         int
 	SigAlgorithm       string
@@ -153,7 +154,7 @@ func (kt KeyType) SigningSupported() bool {
 
 func (kt KeyType) HashSignatureInput() bool {
 	switch kt {
-	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096, KeyType_ExternalKey:
+	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 		return true
 	}
 	return false
@@ -189,6 +190,19 @@ func (kt KeyType) ImportPublicKeySupported() bool {
 		return true
 	}
 	return false
+}
+
+func (kt KeyType) DefaultHashAlgorithm() HashType {
+	switch kt {
+	case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
+		return HashTypeSHA2256
+	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521:
+		return HashTypeSHA2256
+	case KeyType_HMAC:
+		return HashTypeSHA2256
+	default:
+		return HashTypeNone
+	}
 }
 
 func (kt KeyType) String() string {
@@ -1155,7 +1169,7 @@ func (p *Policy) DecryptWithFactory(derivationContext, nonce []byte, value strin
 
 		plain, err = key.Decrypt(ctx, opts)
 		if err != nil {
-			return "", fmt.Errorf("call to Decrypt with external key failed: %w", err)
+			return "", fmt.Errorf("failed to decrypt with external key: %w", err)
 		}
 
 	default:
@@ -1391,14 +1405,26 @@ func (p *Policy) SignWithOptions(ver int, derivationContext, input []byte, optio
 		}
 
 		opts := &kms.SignOptions{
-			Data:       input,
-			SignerOpts: algo,
-			Prehashed:  true,
+			Data:      input,
+			Prehashed: options.Prehashed,
+		}
+
+		if sigAlgorithm == "" {
+			sigAlgorithm = "pss"
+		}
+
+		if sigAlgorithm == "pss" {
+			opts.SignerOpts = &rsa.PSSOptions{
+				Hash:       algo,
+				SaltLength: saltLength,
+			}
+		} else {
+			opts.SignerOpts = algo
 		}
 
 		sig, err = key.Sign(ctx, opts)
 		if err != nil {
-			return nil, fmt.Errorf("call to Sign with external key failed: %w", err)
+			return nil, fmt.Errorf("failed to sign with external key: %w", err)
 		}
 
 	default:
@@ -1618,15 +1644,27 @@ func (p *Policy) VerifySignatureWithOptions(derivationContext, input []byte, sig
 		}
 
 		opts := &kms.VerifyOptions{
-			Data:       input,
-			Signature:  sigBytes,
-			SignerOpts: algo,
-			Prehashed:  true,
+			Data:      input,
+			Signature: sigBytes,
+			Prehashed: options.Prehashed,
+		}
+
+		if sigAlgorithm == "" {
+			sigAlgorithm = "pss"
+		}
+
+		if sigAlgorithm == "pss" {
+			opts.SignerOpts = &rsa.PSSOptions{
+				Hash:       algo,
+				SaltLength: saltLength,
+			}
+		} else {
+			opts.SignerOpts = algo
 		}
 
 		err = key.Verify(ctx, opts)
 		if err != nil {
-			return false, fmt.Errorf("call to Verify with external key failed: %w", err)
+			return false, fmt.Errorf("failed to verify with external key: %w", err)
 		}
 
 		return err == nil, nil
@@ -2359,7 +2397,7 @@ func (p *Policy) EncryptWithFactory(ver int, derivationContext []byte, nonce []b
 
 		ciphertext, err = key.Encrypt(ctx, opts)
 		if err != nil {
-			return "", fmt.Errorf("call to Encrypt with external key failed: %w", err)
+			return "", fmt.Errorf("failed to encrypt with external key: %w", err)
 		}
 	default:
 		return "", errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}

--- a/website/content/docs/api/secret/transit.mdx
+++ b/website/content/docs/api/secret/transit.mdx
@@ -1450,9 +1450,10 @@ supports signing.
   signing. If not set, uses the latest version. Must be greater than or equal
   to the key's `min_encryption_version`, if set.
 
-- `hash_algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use for
-  supporting key types (notably, not including `ed25519` which specifies its
-  own hash algorithm). This can also be specified as part of the URL.
+- `hash_algorithm` `(string: <optional>)` – Specifies the hash algorithm to
+  use for supporting key types (notably, not including `ed25519` which specifies
+  its own hash algorithm). Defaults to `sha2-256` for RSA- and ECDSA-type
+  keys, and `none` otherwise. This can also be specified as part of the URL.
   Currently-supported algorithms are:
 
   - `sha1`
@@ -1489,7 +1490,8 @@ supports signing.
 
   :::warning
 
-  **Note**: using `hash_algorithm=none` requires setting `prehashed=true` and
+  **Note**: using `hash_algorithm=none` with a key type that otherwise
+  requires a hash function requires setting `prehashed=true` and
   `signature_algorithm=pkcs1v15`. This generates a `PKCSv1_5_NoOID` signature
   rather than the `PKCSv1_5_DERnull` signature type usually created. See [RFC
   3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
@@ -1644,8 +1646,11 @@ data.
 - `name` `(string: <required>)` – Specifies the name of the encryption key that
   was used to generate the signature or HMAC.
 
-- `hash_algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use. This
-  can also be specified as part of the URL. Currently-supported algorithms are:
+- `hash_algorithm` `(string: <optional>)` – Specifies the hash algorithm to use
+  for supporting key types (notably, not including `ed25519` which specifies its
+  own hash algorithm). Defaults to `sha2-256` for RSA-, ECDSA-, and HMAC-type
+  keys, and `none` otherwise. This can also be specified as part of the URL.
+  Currently-supported algorithms are:
 
   - `sha1`
   - `sha2-224`


### PR DESCRIPTION
## Description

Fixes a couple quirks with signing via external keys in transit:

- Don't pre-hash external key input by default (by defaulting `hash_algorithm=none`) so keys that shouldn't receive pre-hashed input (e.g., Ed25519, MLDSA) don't do so. The plugin can otherwise perform the hashing itself, also allowing for the final remote KMS to see underlying messages if the plugin was configured that way.
  - One caveat here is that signing with RSA/ECDSA external keys will require an explicit `hash_algorithm=xxx` if the underlying provider rejects `crypto.Hash(0)` and does not set its own default. In the Transit->Transit case, this is fine, as the final Transit has a default for its native keys. In the Transit->PKCS#11 case, we haven't implemented a default and see errors if `hash_algorithm=none`. Might be worth adjusting in go-kms-wrapping.

- Correctly pass `rsa.PSSOptions` when `signature_algorithm=pss` and set the default to PSS like documented.

- Unrelated to external keys, but included here: HMAC signing would panic (non-fatally) if `signature_algorithm` was explicitly none.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
