### PR TITLE
UI: Fix invalid CSS class in MFA method create template

### DIFF
--- a/changelog/3885.txt
+++ b/changelog/3885.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix invalid CSS class causing uncentered text on MFA method create page.
+```

--- a/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
@@ -62,7 +62,7 @@
           <div class="radio-card-row is-flex-v-centered">
             <div>
               <Icon @name={{(lowercase methodName)}} @size="24" class={{if (eq methodName "TOTP") "has-text-grey"}} />
-              <p class="has-text-weight-semibold has-text-center">
+              <p class="has-text-weight-semibold has-text-centered">
                 {{methodName}}
               </p>
             </div>


### PR DESCRIPTION
## Description

The MFA method create template used `has-text-center`, which is not a defined CSS class anywhere in the codebase. The correct helper class, `has-text-centered`, is defined in [`openbao/ui/app/styles/helper-classes/typography.scss`](https://github.com/openbao/openbao/blob/90db1b5df834e28a167cf28878532fe14da3bad9/ui/app/styles/helper-classes/typography.scss#L82-L84) and used consistently elsewhere in the app. This typo caused the method name label under each radio card icon to not be centered as intended.

## Rationale

Fixes a minor visual bug where method name labels on the MFA method create page were not centered as intended.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
