### PR TITLE
Fix backwards-incompatible request forwarding

### DIFF
--- a/changelog/3900.txt
+++ b/changelog/3900.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/ha: Fix broken cross-version request forwarding during rolling upgrades to v2.6.x from an earlier minor version.
+```

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -3907,7 +3907,9 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32),
 			grpc.MaxCallSendMsgSize(math.MaxInt32),
-		))
+		),
+		grpc.WithUnaryInterceptor(forwarding.LegacyPackageFallback),
+	)
 	if err != nil {
 		cancelFunc()
 		c.logger.Error("err setting up forwarding rpc client", "error", err)

--- a/internal/vault/forwarding/request_forwarding_rpc.go
+++ b/internal/vault/forwarding/request_forwarding_rpc.go
@@ -21,6 +21,8 @@ import (
 	"github.com/openbao/openbao/v2/internal/helper/forwarding"
 	"github.com/openbao/openbao/v2/internal/physical/raft"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type forwardedRequestRPCServer struct {
@@ -535,4 +537,27 @@ func (c *Client) StopInvalidations() {
 	}
 
 	c.invalidationsContextCancel()
+}
+
+// LegacyPackageFallback is a [grpc.UnaryClientInterceptor] that ensures
+// backwards-compatibility between OpenBao <= v2.5 and >= 2.6, which changed
+// the Protobuf package name from "vault" to "forwarding". This is achieved by
+// retrying calls with the original method name if the server does not implement
+// the newer one.
+func LegacyPackageFallback(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if status.Code(err) != codes.Unimplemented {
+		return err
+	}
+
+	switch method {
+	case "/forwarding.RequestForwarding/Echo":
+		method = "/vault.RequestForwarding/Echo"
+	case "/forwarding.RequestForwarding/ForwardRequest":
+		method = "/vault.RequestForwarding/ForwardRequest"
+	default:
+		return err
+	}
+
+	return invoker(ctx, method, req, reply, cc, opts...)
 }


### PR DESCRIPTION
## Description

Tested manually by replacing a v2.5.5 node with one built from this patch.

## Rationale

Resolves: #3899

This approach certainly doesn't come with optimal latency, though it should be acceptable for the duration of an upgrade. Alternatively we'd need to mess with config flags or caching so requests can be single-shot most of the time.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
