### PR TITLE
PKI ML-DSA: 44 as default, UI, Documentation, and Changelog

### DIFF
--- a/changelog/3903.txt
+++ b/changelog/3903.txt
@@ -1,0 +1,5 @@
+```release-note:feature
+**ML-DSA Support in PKI**: Introduces support for the ML-DSA (NIST's FIPS 204) signature algorithm for all CA, CSR, and leaf actions.
+  - ML-DSA is a widely standardized post-quantum cryptography (PQC) algorithm resistant against attacks from quantum computers.
+  - Note that Go's OCSP protocol code does not support ML-DSA so will be unusable with ML-DSA typed issuers.
+```

--- a/internal/builtin/logical/pki/backend_test.go
+++ b/internal/builtin/logical/pki/backend_test.go
@@ -5413,8 +5413,8 @@ func TestBackend_Roles_KeySizeRegression(t *testing.T) {
 		/* 15 */ {"mldsa", []int{44}, []int{0}, false, []string{"mldsa", "mldsa", "mldsa"}, []int{44, 65, 87}, false},
 		/* 16 */ {"mldsa", []int{0, 65}, []int{0}, false, []string{"mldsa", "mldsa"}, []int{65, 87}, false},
 		/* 17 */ {"mldsa", []int{87}, []int{0}, false, []string{"mldsa"}, []int{87}, false},
-		// ML-DSA 65 should reject RSA, EC, Ed25519, and ML-DSA 44 keys
-		/* 18 */ {"mldsa", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519", "mldsa"}, []int{2048, 256, 0, 44}, true},
+		// ML-DSA 44 should reject RSA, EC, Ed25519
+		/* 18 */ {"mldsa", []int{0}, []int{0}, false, []string{"rsa", "ec", "ed25519"}, []int{2048, 256, 0}, true},
 	}
 
 	if len(testCases) != 19 {

--- a/internal/builtin/logical/pki/fields.go
+++ b/internal/builtin/logical/pki/fields.go
@@ -330,7 +330,7 @@ the private key!`,
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},

--- a/internal/builtin/logical/pki/path_issue_sign.go
+++ b/internal/builtin/logical/pki/path_issue_sign.go
@@ -50,7 +50,7 @@ func pathCelIssue(b *backend) *framework.Path {
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},
@@ -229,7 +229,7 @@ func buildPathIssue(b *backend, pattern string, displayAttrs *framework.DisplayA
 		Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: 0,
 		},

--- a/internal/builtin/logical/pki/path_manage_keys.go
+++ b/internal/builtin/logical/pki/path_manage_keys.go
@@ -47,7 +47,7 @@ func pathGenerateKey(b *backend) *framework.Path {
 				Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 			},
 			externalKeyRefParam: {
 				Type:        framework.TypeString,

--- a/internal/builtin/logical/pki/path_roles.go
+++ b/internal/builtin/logical/pki/path_roles.go
@@ -262,7 +262,7 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 			Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 		},
 		"signature_bits": {
 			Type:     framework.TypeInt,
@@ -674,7 +674,7 @@ protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.`,
 				Description: `The number of bits to use. Allowed values are
 0 (universal default); with rsa key_type: 2048 (default), 3072, or
 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
-ed25519; with mldsa key_type: 44, 65 (default), or 87.`,
+ed25519; with mldsa key_type: 44 (default), 65, or 87.`,
 			},
 
 			"signature_bits": {

--- a/internal/command/pki_reissue_intermediate.go
+++ b/internal/command/pki_reissue_intermediate.go
@@ -5,9 +5,7 @@ package command
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
@@ -20,6 +18,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/openbao/openbao/sdk/v2/helper/certutil"
 	"github.com/posener/complete"
 )
 
@@ -237,25 +236,8 @@ func findBitLength(publicKey any) int {
 	if publicKey == nil {
 		return 0
 	}
-	switch pub := publicKey.(type) {
-	case *rsa.PublicKey:
-		return pub.N.BitLen()
-	case *ecdsa.PublicKey:
-		switch pub.Curve {
-		case elliptic.P224():
-			return 224
-		case elliptic.P256():
-			return 256
-		case elliptic.P384():
-			return 384
-		case elliptic.P521():
-			return 521
-		default:
-			return 0
-		}
-	default:
-		return 0
-	}
+
+	return certutil.GetPublicKeySize(publicKey.(crypto.PublicKey))
 }
 
 func findSignatureBits(algo x509.SignatureAlgorithm) int {
@@ -268,7 +250,7 @@ func findSignatureBits(algo x509.SignatureAlgorithm) int {
 		return 384
 	case x509.SHA512WithRSA, x509.SHA512WithRSAPSS, x509.ECDSAWithSHA512:
 		return 512
-	case x509.PureEd25519:
+	case x509.PureEd25519, x509.MLDSA44, x509.MLDSA65, x509.MLDSA87:
 		return 0
 	default:
 		return -1

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -41,7 +41,7 @@ const rsaMinimumSecureKeySize = 2048
 var defaultAlgorithmKeyBits = map[string]int{
 	"rsa":   2048,
 	"ec":    256,
-	"mldsa": 65,
+	"mldsa": 44,
 }
 
 // Mapping of NIST P-Curve's key length to expected signature bits.

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -60,12 +60,13 @@ type PrivateKeyType string
 
 // Well-known PrivateKeyTypes
 const (
-	UnknownPrivateKey  PrivateKeyType = ""
-	RSAPrivateKey      PrivateKeyType = "rsa"
-	ECPrivateKey       PrivateKeyType = "ec"
-	Ed25519PrivateKey  PrivateKeyType = "ed25519"
+	UnknownPrivateKey PrivateKeyType = ""
+	RSAPrivateKey     PrivateKeyType = "rsa"
+	ECPrivateKey      PrivateKeyType = "ec"
+	Ed25519PrivateKey PrivateKeyType = "ed25519"
+	MLDSAPrivateKey   PrivateKeyType = "mldsa"
+
 	ExternalPrivateKey PrivateKeyType = "external-key"
-	MLDSAPrivateKey    PrivateKeyType = "mldsa"
 )
 
 // TLSUsage controls whether the intended usage of a *tls.Config

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -126,7 +126,7 @@ export default class PkiActionModel extends Model {
 
   @attr('string', {
     defaultValue: 'rsa',
-    possibleValues: ['rsa', 'ed25519', 'ec'],
+    possibleValues: ['rsa', 'ed25519', 'ec', 'mldsa'],
   })
   keyType;
 

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -103,6 +103,9 @@ export default class PkiIssuerModel extends Model {
       'sha512withrsa',
       'ecdsawithsha256',
       'ecdsawithsha512',
+      'mldsa44',
+      'mldsa65',
+      'mldsa87',
     ],
   })
   revocationSignatureAlgorithm;

--- a/ui/app/models/pki/key.js
+++ b/ui/app/models/pki/key.js
@@ -43,8 +43,8 @@ export default class PkiKeyModel extends Model {
   type;
   @attr('string', {
     noDefault: true,
-    possibleValues: ['rsa', 'ec', 'ed25519'],
-    subText: 'The type of key that will be generated. Must be rsa, ed25519, or ec. ',
+    possibleValues: ['rsa', 'ec', 'ed25519', 'mldsa'],
+    subText: 'The type of key that will be generated. Must be rsa, ed25519, ec, or mldsa. ',
   })
   keyType;
   @attr('string', {

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -174,7 +174,7 @@ export default class PkiRoleModel extends Model {
   /* Overriding OpenApi Key parameters options */
   @attr('string', {
     label: 'Key type',
-    possibleValues: ['rsa', 'ec', 'ed25519', 'any'],
+    possibleValues: ['rsa', 'ec', 'ed25519', 'mldsa', 'any'],
     defaultValue: 'rsa',
   })
   keyType;

--- a/website/content/docs/api/secret/pki.mdx
+++ b/website/content/docs/api/secret/pki.mdx
@@ -697,14 +697,15 @@ key from the response, you will need to request a new certificate.
   the role.
 
 - `key_type` `(string: "")` - Specifies the desired key type when the role
-  allows any key type; must be `rsa`, `ed25519`, or `ec`. Use the literal
-  empty string when the role's key type should be respected.
+  allows any key type; must be `rsa`, `ed25519`, `ec`, or `mldsa`. Use the
+  literal empty string when the role's key type should be respected.
 
 - `key_bits` `(int: 0)` - Specifies the number of bits to use for the
   generated keys when the role allows any key type. Allowed values are
   0 (universal default); with `key_type=rsa`, allowed values are:
   2048 (default), 3072, or 4096; with `key_type=ec`, allowed values are:
-  224, 256 (default), 384, or 521; ignored with `key_type=ed25519`. Ignored
+  224, 256 (default), 384, or 521; with `key_type=mldsa`, allowed values are:
+  44 (default), 65, 87; ignored with `key_type=ed25519`. Ignored
   when the role has an explicit key type specified.
 
 #### Sample payload
@@ -1021,9 +1022,9 @@ operators.
 
   :::warning
 
-  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-  `signature_bits` value; only RSA issuers will change signature types based on
-  this parameter.
+  **Note**: ECDSA, Ed25519, and ML-DSA issuers do not follow configuration of
+  the `signature_bits` value; only RSA issuers will change signature types
+  based on this parameter.
 
   :::
 
@@ -1299,9 +1300,9 @@ have access.**
 
   :::warning
 
-  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-  `signature_bits` value; only RSA issuers will change signature types based on
-  this parameter.
+  **Note**: ECDSA, Ed25519, and ML-DSA issuers do not follow configuration of
+  the `signature_bits` value; only RSA issuers will change signature types
+  based on this parameter.
 
   :::
 
@@ -2333,8 +2334,8 @@ be retrieved later_.
   optionally specifies the name for this. The global ref `default` may not
   be used as a name.
 
-- `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
-  or `ec`. Ignored when `type=kms`.
+- `key_type` `(string: "rsa")` - Specifies the desired key type; must be
+  `rsa`, `ed25519`, `ec`, or `mldsa`. Ignored when `type=kms`.
 
   :::warning
 
@@ -2347,7 +2348,8 @@ be retrieved later_.
   generated keys. Allowed values are 0 (universal default); with
   `key_type=rsa`, allowed values are: 2048 (default), 3072, or
   4096; with `key_type=ec`, allowed values are: 224, 256 (default),
-  384, or 521; ignored with `key_type=ed25519`. Ignored when `type=kms`.
+  384, or 521; with `key_type=mldsa`, allowed values are 44 (default),
+  65, or 87; ignored with `key_type=ed25519`. Ignored when `type=kms`.
 
 - `external_key_ref` `(string: "")` - When `type=kms`, this specifies the
   reference to the external key to use for operations. This takes the
@@ -2489,8 +2491,8 @@ everything](#delete-all-issuers-and-keys).
 
   :::
 
-- `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
-  or `ec`. Ignored when `type=kms` or `type=existing`.
+- `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`,
+  `ed25519`, `ec`, or `mldsa`. Ignored when `type=kms` or `type=existing`.
 
   :::warning
 
@@ -2503,7 +2505,8 @@ everything](#delete-all-issuers-and-keys).
   generated keys. Allowed values are 0 (universal default); with
   `key_type=rsa`, allowed values are: 2048 (default), 3072, or
   4096; with `key_type=ec`, allowed values are: 224, 256 (default),
-  384, or 521; ignored with `key_type=ed25519`. Ignored when `type=kms` or
+  384, or 521; with `key_type=mldsa`, allowed values are 44 (default), 65, or
+  87; ignored with `key_type=ed25519`. Ignored when `type=kms` or
   `type=existing`.
 
 - `max_path_length` `(int: -1)` - Specifies the maximum path length to encode in
@@ -2734,8 +2737,9 @@ CSR and complete the signing before the signed intermediate certificate is
 
   :::
 
-- `key_type` `(string: "rsa")` - Specifies the desired key type; must be `rsa`, `ed25519`
-  or `ec`. Ignored when `type=kms` or `type=existing`.
+- `key_type` `(string: "rsa")` - Specifies the desired key type; must be
+  `rsa`, `ed25519`, `ec`, or `mldsa`. Ignored when `type=kms` or
+  `type=existing`.
 
   :::warning
 
@@ -2748,7 +2752,8 @@ CSR and complete the signing before the signed intermediate certificate is
   generated keys. Allowed values are 0 (universal default); with
   `key_type=rsa`, allowed values are: 2048 (default), 3072, or
   4096; with `key_type=ec`, allowed values are: 224, 256 (default),
-  384, or 521; ignored with `key_type=ed25519`. Ignored when `type=kms` or
+  384, or 521; with `key_type=mldsa`, allowed values are 44 (default),
+  65, or 87; ignored with `key_type=ed25519`. Ignored when `type=kms` or
   `type=existing`.
 
 - `key_name` `(string: "")` - When a new key is created with this request,
@@ -2771,9 +2776,9 @@ CSR and complete the signing before the signed intermediate certificate is
 
   :::warning
 
-  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-  `signature_bits` value; only RSA issuers will change signature types based on
-  this parameter.
+  **Note**: ECDSA, Ed25519, and ML-DSA issuers do not follow configuration of
+  the `signature_bits` value; only RSA issuers will change signature types
+  based on this parameter.
 
   :::
 
@@ -3776,11 +3781,11 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
 
 - `key_type` `(string: "rsa")` - Specifies the type of key to generate for
   generated private keys and the type of key expected for submitted CSRs.
-  Currently, `rsa`, `ec`, and `ed25519` are supported, or when signing
-  existing CSRs, `any` can be specified to allow keys of either type
-  and with any bit size (subject to >=2048 bits for RSA keys or >= 224 for EC keys).
-  When `any` is used, this role cannot generate certificates and can only
-  be used to sign CSRs.
+  Currently, `rsa`, `ec`, `ed25519`, and `mldsa` are supported, or when
+  signing existing CSRs, `any` can be specified to allow keys of either type
+  and with any bit size (subject to >=2048 bits for RSA keys or >= 224 for EC
+  keys). When `any` is used, this role cannot generate certificates and can
+  only be used to sign CSRs.
 
   :::warning
 
@@ -3793,7 +3798,8 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
   generated keys. Allowed values are 0 (universal default); with
   `key_type=rsa`, allowed values are: 2048 (default), 3072, or
   4096; with `key_type=ec`, allowed values are: 224, 256 (default),
-  384, or 521; ignored with `key_type=ed25519` or in signing operations
+  384, or 521; with `key_type=mldsa`, allowed values are 44 (default), 65, or
+  87; ignored with `key_type=ed25519` or in signing operations
   when `key_type=any`.
 
 - `signature_bits` `(int: 0)` - Specifies the number of bits to use in
@@ -3804,9 +3810,9 @@ allowing update of specific fields. Note that `bao write` uses `POST`.
 
   :::warning
 
-  **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
-  `signature_bits` value; only RSA issuers will change signature types based on
-  this parameter.
+  **Note**: ECDSA, Ed25519, and ML-DSA issuers do not follow configuration of
+  the `signature_bits` value; only RSA issuers will change signature types
+  based on this parameter.
 
   :::
 

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -42,6 +42,7 @@ generating the CA to use with this secrets engine.
  - [Role-Based Access](#role-based-access)
  - [Cluster Scalability](#cluster-scalability)
  - [PSS Support](#pss-support)
+ - [OCSP](#ocsp)
 
 ## Be careful with root CAs
 
@@ -813,12 +814,15 @@ the active node.
 As of OpenBao v2.7, most places where CSRs, CRLs, or certificates are signed
 with PSS should be compatible.
 
-However, Go lacks support for creating OCSP responses with the PSS signature
-algorithm. OpenBao will automatically downgrade issuers with PSS-based
-revocation signature algorithms to PKCS#1v1.5, but note that certain KMS
-devices (like HSMs and GCP) may not support this with the same key. As a
-result, the OCSP responder may fail to sign responses, returning an internal
-error.
+## OCSP
+
+Go lacks support for creating OCSP responses with the PSS signature algorithm
+or when the key type is ML-DSA. OpenBao will automatically downgrade issuers
+with PSS-based revocation signature algorithms to PKCS#1v1.5, but note that
+certain KMS devices (like HSMs and GCP) may not support this with the same
+key. As a result, the OCSP responder may fail to sign responses, returning an
+internal error. This will occur with ML-DSA typed issuing certificates as
+well.
 
 ## API
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

- Sets the default to ML-DSA 44
- Updates the UI to support ML-DSA in PKI
- Adds documentation on ML-DSA support to PKI docs
- Adds a feature changleog entry.

<img width="833" height="908" alt="image" src="https://github.com/user-attachments/assets/873a42f0-5d81-4621-90fa-d68488277a21" />


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Related: #3756 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
