### PR TITLE
Allow read-enabled standby on leaderless cluster

### DIFF
--- a/changelog/3904.txt
+++ b/changelog/3904.txt
@@ -1,6 +1,6 @@
 ```release-note:feature
 **PostgreSQL Horizontal Scalability**: Enable read scalability on the PostgreSQL storage backend similar to existing Raft support.
-  - Requires `ha_enabled = true` to be set and an active GRPC connection from standbys to the primary.
+  - Requires `ha_enabled = true` to be set and `cluster_addr` to be reachable (establishing a forwarding RPC connection) from standbys to the primary.
   - In the event of extended leadership loss, standby nodes will come up as read-enabled.
   - Only works with PostgreSQL physical replication; will not work with logical replication.
 ```

--- a/changelog/3904.txt
+++ b/changelog/3904.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+**PostgreSQL Horizontal Scalability**: Enable read scalability on the PostgreSQL storage backend similar to existing Raft support.
+  - Requires `ha_enabled = true` to be set and an active GRPC connection from standbys to the primary.
+  - In the event of extended leadership loss, standby nodes will come up as read-enabled.
+  - Only works with PostgreSQL physical replication; will not work with logical replication.
+```

--- a/internal/vault/core.go
+++ b/internal/vault/core.go
@@ -457,6 +457,9 @@ type Core struct {
 	clusterPeerClusterAddrsCache *zcache.Cache[string, forwarding.NodeHAConnectionInfo]
 	// The UUID used to hold the leader lock. Only set on active node
 	leaderUUID string
+	// When the first time a GRPC invalidation node discovered it did not have
+	// any active leader.
+	firstMissingLeader time.Time
 
 	// Request forwarding information
 	// The context for the client
@@ -649,7 +652,7 @@ type Core struct {
 func (c *Core) HAState() consts.HAState {
 	switch {
 	case c.standby.Load():
-		if c.StandbyReadsEnabled() {
+		if !c.activeContext.Load().IsNil() {
 			return consts.PerfStandby
 		}
 
@@ -1948,7 +1951,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	// validation and the operation should be performed. But for now, just
 	// returning with an error and recommending a vault restart, which
 	// essentially does the same thing.
-	if c.standby.Load() && !c.StandbyReadsEnabled() {
+	if c.standby.Load() && c.activeContext.Load().IsNil() {
 		c.logger.Error("vault cannot seal when in standby mode; please restart instead")
 		return errors.New("vault cannot seal when in standby mode; please restart instead")
 	}
@@ -2241,8 +2244,6 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 type readonlyUnsealStrategy struct{}
 
 func (s readonlyUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c *Core) error {
-	c.logger.Debug("read-only unseal starting")
-
 	// Start tracking invalidations.
 	c.invalidations.Track()
 

--- a/internal/vault/external_tests/postgresql_binary/postgresql_test.go
+++ b/internal/vault/external_tests/postgresql_binary/postgresql_test.go
@@ -456,7 +456,7 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 		require.NoError(collect, err, "failed writing k/v key")
 	}, 15*time.Second, 100*time.Millisecond)
 
-	// This should eventually be visible on the secondary node.
+	// This should eventually be visible on the third node.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		nodeClientCfg := nodes[2].APIClient().CloneConfig()
 
@@ -480,9 +480,11 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 	err = nodes[1].APIClient().Sys().Seal()
 	require.NoError(t, err)
 
-	resp, err := nodes[2].APIClient().KVv2("kv").Get(t.Context(), "a/key")
-	require.Error(t, err)
-	require.Nil(t, resp)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp, err := nodes[2].APIClient().KVv2("kv").Get(t.Context(), "a/key")
+		require.ErrorContains(collect, err, "local node not active but active cluster node not found")
+		require.Nil(collect, resp)
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// Unsealing should work.
 	err = testcluster.UnsealAllNodes(t.Context(), cluster)
@@ -509,6 +511,12 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 		}
 	}, 15*time.Second, 100*time.Millisecond)
 
+	// Write one last value before shutting down.
+	_, err = nodes[0].APIClient().KVv2("kv").Put(t.Context(), "a/key", map[string]any{
+		"value": "one-last-value",
+	})
+	require.NoError(t, err, "failed writing k/v key")
+
 	// Taking down the primary PostgreSQL node should cause problems for all
 	// nodes talking to it.
 	require.NoError(t, pCluster.Cluster.RemovePrimary(t.Context()))
@@ -530,6 +538,18 @@ func TestPostgreSQL_Scalability(t *testing.T) {
 			require.Nil(collect, resp, "on node %v / duration: %v", index, time.Since(start))
 		}
 	}, 30*time.Second, 100*time.Millisecond)
+
+	// After a great period of time, the tertiary should be able to read
+	// because it will know that there is no primary.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+		defer cancel()
+
+		resp, err := nodes[2].APIClient().KVv2("kv").Get(ctx, "a/key")
+		require.NoError(collect, err)
+		require.NotNil(collect, resp)
+		require.Equal(collect, resp.Data["value"], "one-last-value")
+	}, 60*time.Second, 100*time.Millisecond)
 
 	// We should be able to promote the replica and the tertiary should follow.
 	require.NoError(t, pCluster.Cluster.PromoteNode(t.Context(), 0))

--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -153,6 +153,12 @@ func (c *Core) LeaderLocked() (isLeader bool, leaderAddr, clusterAddr string, er
 		return false, "", "", err
 	}
 	if !held {
+		// Since we don't have a lock, no point keeping around a stale
+		// forwarding connection.
+		if c.rpcForwardingClient.Load() != nil {
+			c.clearForwardingClients()
+		}
+
 		return false, "", "", nil
 	}
 
@@ -656,7 +662,7 @@ func (c *Core) runReadStandby(stopCh <-chan struct{}, sharedStandbyCtx *atomic.P
 		return false, true
 	}
 
-	c.logger.Info("entering read-enabled standby mode")
+	c.logger.Trace("entering read-enabled standby mode")
 	defer c.logger.Trace("done with read-enabled standby loop iteration")
 
 	// Create the standby context (this becomes activeCtx on core, oh well).
@@ -1016,23 +1022,133 @@ func (c *Core) waitForLeadership(manualStepDown *bool, manualStepDownCh, stopCh 
 	return false, false
 }
 
-func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) bool {
+func (c *Core) maybeBypassGRPCRequirement(ctx context.Context) bool {
+	// We can enter read-only mode without having an active GRPC forwarding
+	// because we have (mostly) synchronized storage. When the underlying lock
+	// is not held with an active reservation, it means there is no active
+	// leader and other nodes may be competing for that value. When one wins,
+	// we'll restart and wait for the active lock requirement again.
+	lock, err := c.ha.LockWith(CoreLockPath, "read")
+	if err != nil {
+		c.firstMissingLeader = time.Time{}
+		c.logger.Debug("unable to create ha lock to validate leadership status", "error", err)
+		return false
+	}
+
+	held, _, err := lock.Value()
+	if err != nil {
+		c.firstMissingLeader = time.Time{}
+		c.logger.Debug("unable to check ha lock to validate leadership status", "error", err)
+		return false
+	}
+
+	if held {
+		c.firstMissingLeader = time.Time{}
+		// This means that we are unable to connect to the leader, but (per
+		// storage) they definitely exist.
+		return false
+	}
+
+	if c.firstMissingLeader.IsZero() {
+		// This is our first time missing a leader; wait until two lock
+		// retry intervals have passed so we don't prematurely enter read-only
+		// mode if a new leader has been found.
+		c.firstMissingLeader = time.Now()
+		return false
+	}
+
+	if time.Since(c.firstMissingLeader) < 2*lockRetryInterval {
+		// We've not yet found a leader but our time hasn't elapsed.
+		return false
+	}
+
+	// We're good to start as read-only, given we haven't found a leader. If we
+	// get restarted though, make sure we start from scratch.
+	c.firstMissingLeader = time.Time{}
+
+	// Periodically check this lock. If we error or find a leader, we exit and
+	// restart the core.
+	go func() {
+		c.logger.Trace("starting polling to ensure lock remains unheld")
+		defer c.logger.Trace("done polling to ensure lock remains unheld")
+
+		restart := true
+		defer func() {
+			if restart {
+				c.logger.Info("restarting due to discovered active node")
+				c.Restart()
+			}
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				// Do not restart the core because of a cancelled context;
+				// we're likely already restarting or have experienced a
+				// state change.
+				restart = false
+				return
+			case <-time.After(lockRetryInterval):
+			}
+
+			held, _, err := lock.Value()
+			if err != nil {
+				c.logger.Debug("unable to check ha lock to validate missing leadership status", "error", err)
+				return
+			}
+
+			if held {
+				return
+			}
+		}
+	}()
+
+	return true
+}
+
+// setupGRPCStandbyInvalidations returns (bypass, isOk):
+//
+//   - bypass means that GRPC invalidation was bypassed and we still want to
+//     stand up as read-enabled,
+//   - isOk means a fatal error occurred
+func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) (bool, bool) {
 	// Potentially refresh replication information before we get
 	// too far. This ensures we do not attempt to contact a stale
 	// leader.
 	if _, _, _, err := c.LeaderLocked(); err != nil {
 		c.logger.Error("skipping invalidation streaming as unable to read leader information", "err", err)
-		return false
+		return false, false
 	}
 
-	if c.rpcForwardingClient.Load() == nil {
+	client := c.rpcForwardingClient.Load()
+	if client == nil {
 		// When the active node has not indicated a cluster address
 		// or there's a problem connecting, we may not have a
 		// forwarding client. This renders us unable to perform any
 		// invalidations so we're unable to start-up in read-enabled
 		// mode.
-		c.logger.Error("skipping invalidation streaming as no RPC client is present")
-		return false
+		//
+		// Treat this as an error most of the time.
+		//
+		// However, we bypass this error if we can prove that there is no
+		// leader.
+		wasZero := c.firstMissingLeader.IsZero()
+		bypass := c.maybeBypassGRPCRequirement(ctx)
+		isNoLongerZero := !c.firstMissingLeader.IsZero()
+
+		if !bypass && wasZero && isNoLongerZero {
+			// Reduce the number of errors we spew.
+			c.logger.Error("skipping invalidation streaming as no GRPC client is present; this is required for read-only standby node operation; ensure valid cluster_addr and connectivity")
+		} else if bypass {
+			c.logger.Info("bypassing GRPC leader requirements as no leader lock found")
+		}
+
+		// Callers expect (bypass, ok): when we don't want to bypass, we
+		// aren't ok and so want the parent to treat this as an error and
+		// stop setup accordingly. However, when we do want to bypass
+		// GRPC invalidation and start as a read-enabled standby anyways,
+		// we want to continue on, so ok == bypass.
+		return bypass, bypass
 	}
 
 	// Start tracking any invalidations; we won't begin processing
@@ -1050,18 +1166,12 @@ func (c *Core) setupGRPCStandbyInvalidations(ctx context.Context) bool {
 	c.LocalGRPCDispatching()
 
 	// Start streaming invalidation events from the primary.
-	client := c.rpcForwardingClient.Load()
-	if client == nil {
-		c.logger.Error("unexpectedly nil replication forwarding client")
-		return false
-	}
-
 	if err := client.StreamInvalidations(ctx); err != nil {
 		c.logger.Error("failed to begin streaming invalidations", "err", err)
-		return false
+		return false, false
 	}
 
-	return true
+	return false, true
 }
 
 // runReadEnabledStandby grabs the state lock and unseals in read-only mode. It
@@ -1077,7 +1187,7 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 		return false, true
 	}
 
-	c.logger.Info("enabling horizontal scalability (reads)")
+	c.logger.Trace("attempting enabling horizontal scalability (reads)")
 
 	if err := c.runStandbyGrabStateLock(stopCh); err != nil {
 		c.logger.Error("unable to grab state lock for standby", "err", err)
@@ -1098,19 +1208,15 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 	// ensures we don't conflict with waitForLeadership(...).
 	c.barrier.SetReadOnly(true)
 
-	// Wipe any existing state.
-	if err := c.preSeal(); err != nil {
-		c.logger.Error("pre-seal teardown failed", "error", err)
-	}
-
-	c.drainPendingRestarts()
-
-	// Before unseal, check if we need to do GRPC based invalidation;
-	// if so, start streaming invalidations.
+	// Before preSeal, check if we need to do GRPC based invalidation;
+	// if so, start streaming invalidations. While it is overkill to do so
+	// before preSeal, this ensures we get fewer log messages if we end up
+	// not being able to start up.
 	if shouldUseGRPCInvalidation(c.underlyingPhysical) {
 		c.logger.Debug("setting up GRPC-backed streaming of invalidations")
 
-		if ok := c.setupGRPCStandbyInvalidations(ctx); !ok {
+		bypass, ok := c.setupGRPCStandbyInvalidations(ctx)
+		if !ok {
 			// Clear any events we might have received.
 			c.CleanupInvalidationPeers()
 			c.invalidations.Stop()
@@ -1119,16 +1225,25 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 			return false, true
 		}
 
-		// Wait for our initial invalidation checkpoint.
-		if err := c.AwaitReplication(ctx); err != nil {
-			// Clear any events we might have received.
-			c.CleanupInvalidationPeers()
-			c.invalidations.Stop()
+		if !bypass {
+			// Wait for our initial invalidation checkpoint.
+			if err := c.AwaitReplication(ctx); err != nil {
+				// Clear any events we might have received.
+				c.CleanupInvalidationPeers()
+				c.invalidations.Stop()
 
-			c.logger.Error("failed to await replication", "err", err)
-			return false, true
+				c.logger.Error("failed to await replication", "err", err)
+				return false, true
+			}
 		}
 	}
+
+	// Wipe any existing state.
+	if err := c.preSeal(); err != nil {
+		c.logger.Error("pre-seal teardown failed", "error", err)
+	}
+
+	c.drainPendingRestarts()
 
 	// Bail if we're told we should cancel.
 	if ctx.Err() != nil || !runStandby.Load() {
@@ -1136,6 +1251,9 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 		// We want to retry eventually.
 		return false, true
 	}
+
+	// Notify that we're most likely to be successful
+	c.logger.Info("attempting enabling horizontal scalability (reads)")
 
 	// Unseal, holding the state lock.
 	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))
@@ -1571,18 +1689,15 @@ func (c *Core) shouldHookInvalidate(phys physical.Backend) bool {
 
 // StandbyReadsEnabled returns true iff standby read are enabled, supported,
 // and likely immediately usable by the physical backend.
-//
-// Notably, when GRPC-based invalidation is in use and the underlying GRPC
-// client is not connected, we return false here.
 func (c *Core) StandbyReadsEnabled() bool {
-	return c.standbyReadsAllowed() &&
+	return c.standbyReadsAllowed() && !c.activeContext.Load().IsNil() &&
 		(isCacheInvalidationBackend(c.underlyingPhysical) ||
-			(isReplicationIndexBackend(c.underlyingPhysical) && c.haveForwardingClient()))
+			isReplicationIndexBackend(c.underlyingPhysical))
 }
 
 // MaybeStandbyReadsEnabled is like StandbyReadsEnabled but returns true in
 // the case of a disconnected GRPC forwarding client when GRPC invalidations
-// are in use.
+// are in use or when read-request handling is not yet set up.
 //
 // In the context of runHALoop, we want runReadStandby to execute if the GRPC
 // forwarding client is not connected because it will opportunistically

--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -1187,7 +1187,7 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 		return false, true
 	}
 
-	c.logger.Trace("attempting enabling horizontal scalability (reads)")
+	c.logger.Trace("attempting state lock acquisition before read-enabled standby setup")
 
 	if err := c.runStandbyGrabStateLock(stopCh); err != nil {
 		c.logger.Error("unable to grab state lock for standby", "err", err)
@@ -1677,10 +1677,6 @@ func (c *Core) standbyReadsAllowed() bool {
 		return !conf.DisableStandbyReads
 	}
 	return false
-}
-
-func (c *Core) haveForwardingClient() bool {
-	return c.rpcForwardingClient.Load() != nil
 }
 
 func (c *Core) shouldHookInvalidate(phys physical.Backend) bool {

--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -662,7 +662,7 @@ func (c *Core) runReadStandby(stopCh <-chan struct{}, sharedStandbyCtx *atomic.P
 		return false, true
 	}
 
-	c.logger.Trace("entering read-enabled standby mode")
+	c.logger.Trace("starting read-enabled standby loop iteration")
 	defer c.logger.Trace("done with read-enabled standby loop iteration")
 
 	// Create the standby context (this becomes activeCtx on core, oh well).
@@ -1253,7 +1253,7 @@ func (c *Core) runReadEnabledStandby(ctx context.Context, ctxCancel context.Canc
 	}
 
 	// Notify that we're most likely to be successful
-	c.logger.Info("attempting enabling horizontal scalability (reads)")
+	c.logger.Info("entering read-enabled standby mode")
 
 	// Unseal, holding the state lock.
 	c.replicationState.Store(uint32(consts.ReplicationDRDisabled | consts.ReplicationPerformanceStandby))

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -148,9 +148,18 @@ scalability. This requires an active cluster GRPC connection; ensure
 log messages like:
 
 > [DEBUG] setting up GRPC-backed streaming of invalidations
-> [DEBUG] read-only unseal starting
+> [INFO] attempting enabling horizontal scalability (reads)
 
 will be visible on standby nodes.
+
+:::warning
+
+Use of horizontal (read) scalability requires physical replication. If using
+logical replication, you **must** set `disable_standby_reads` in the storage
+configuration as LSN Index values differ across PostgreSQL nodes and OpenBao
+will not be able to use them for tracking invalidations.
+
+:::
 
 [golang_setmaxidleconns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 [postgresql]: https://www.postgresql.org/

--- a/website/content/docs/configuration/storage/postgresql.mdx
+++ b/website/content/docs/configuration/storage/postgresql.mdx
@@ -148,7 +148,7 @@ scalability. This requires an active cluster GRPC connection; ensure
 log messages like:
 
 > [DEBUG] setting up GRPC-backed streaming of invalidations
-> [INFO] attempting enabling horizontal scalability (reads)
+> [INFO] entering read-enabled standby mode
 
 will be visible on standby nodes.
 


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

When using GRPC invalidation, we previously always required that the
leader be present and reachable. While we don't loosen that restriction
when a leader does exist (but is not reachable), we do loosen that
restriction when we can prove (within storage) there is no leader and
there may not have been a leader for some time. We want to handle
read-only requests in this window to avoid unnecessarily long outages
and loss of availability. (Though, writes will obviously still be
encumbered).

We ensure that we monitor the lock throughout being leaderless-ly
read-enabled to ensure no other node acquires the lock in the interim.
This (coupled with restarts on announcement) should guarantee that we
never falsely believe that we lack a leader when there is indeed a valid
leader.

This holds as long as `lockRetryInterval` is less than the validity period
of the lock in each underlying HA backend. This holds true of
PostgreSQL (which has `PostgreSQLLockTTLSeconds = 15s` while
`lockRetryInterval = 10s`).

As part of this, `StandbyReadsEnabled(...)` has been refactored (again) to
give a more precise definition for `internal/http`'s usage: we care about
whether we've:

1. Not disabled reads.
2. Are horizontally read-scalable.
3. Actually have started up core i.e., assigned an active context.

This is made possible by the atomic active context refactor.

Some additional log messages have been refactored as part of this to
reduce verbosity of logging in certain backoff-retry scenarios. The
ordering of GRPC invalidation checking w.r.t. `preSeal` has been adjusted
for the same reason.


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
