### PR TITLE
test(namespace): Await deletion operation

### DIFF
--- a/internal/vault/namespace_store_test.go
+++ b/internal/vault/namespace_store_test.go
@@ -189,24 +189,15 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "in-progress", status)
 
-	maxRetries := 50
-	for range maxRetries {
-		status, err := s.DeleteNamespace(ctx, "test")
-		require.NoError(t, err)
-		if status == "in-progress" {
-			time.Sleep(1 * time.Millisecond)
-			continue
-		}
-		break
-	}
-
 	// verify namespace deletion
-	nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
-		Recursive:     true,
-		IncludeSealed: true,
-	})
-	require.NoError(t, err)
-	require.Empty(t, nsList)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		nsList, err := s.ListNamespaces(ctx, ListNamespaceOpts{
+			Recursive:     true,
+			IncludeSealed: true,
+		})
+		require.NoError(collect, err)
+		require.Empty(collect, nsList)
+	}, time.Second*10, time.Millisecond*10)
 
 	keys, err := s.storage.List(ctx, namespaceStoreSubPath)
 	require.NoError(t, err)
@@ -240,19 +231,11 @@ func TestNamespaceStore_DeleteNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "in-progress", status)
 
-	for range maxRetries {
-		status, err := s.DeleteNamespace(parentCtx, "child")
-		require.NoError(t, err)
-		if status == "in-progress" {
-			time.Sleep(1 * time.Millisecond)
-			continue
-		}
-		break
-	}
-
-	keys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, parentNamespace.UUID, namespaceStoreSubPath)+"/")
-	require.NoError(t, err)
-	require.Empty(t, keys, "Expected empty namespace store on storage level")
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		keys, err = s.storage.List(ctx, path.Join(barrier.NamespacePrefix, parentNamespace.UUID, namespaceStoreSubPath)+"/")
+		require.NoError(collect, err)
+		require.Empty(collect, keys, "Expected empty namespace store on storage level")
+	}, time.Second*10, time.Millisecond*10)
 }
 
 func TestNamespaceStore_DeleteSealedNamespace(t *testing.T) {
@@ -1027,7 +1010,6 @@ func TestNamespaceStorage(t *testing.T) {
 }
 
 func TestNamespaceDeletionSealingInteraction(t *testing.T) {
-
 	t.Run("cannot seal tainted namespace", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Description

1. Erase two loops that inspected the status of a deletion operation.
2. Add the _require.EventuallyWithT_ func to test the disappearance of a namespace from a list.

```bash
go test github.com/openbao/openbao/v2/internal/vault -run '^TestNamespaceStore_DeleteNamespace$'
```

## Rationale
_TestNamespaceStore_DeleteNamespace_ suffered 11 failures between April 20th and August 27th of this year.

Related: #2581 

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
