### PR TITLE
sdk/helper/cidrutil: use testify require consistently in tests

### DIFF
--- a/sdk/helper/cidrutil/cidr_test.go
+++ b/sdk/helper/cidrutil/cidr_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	sockaddr "github.com/hashicorp/go-sockaddr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCIDRUtil_IPBelongsToCIDR(t *testing.T) {
@@ -14,39 +15,25 @@ func TestCIDRUtil_IPBelongsToCIDR(t *testing.T) {
 	cidr := "192.168.26.30/16"
 
 	belongs, err := IPBelongsToCIDR(ip, cidr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !belongs {
-		t.Fatalf("expected IP %q to belong to CIDR %q", ip, cidr)
-	}
+	require.NoError(t, err)
+	require.True(t, belongs, "expected IP %q to belong to CIDR %q", ip, cidr)
 
 	ip = "10.197.192.6"
 	cidr = "10.197.192.0/18"
 	belongs, err = IPBelongsToCIDR(ip, cidr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !belongs {
-		t.Fatalf("expected IP %q to belong to CIDR %q", ip, cidr)
-	}
+	require.NoError(t, err)
+	require.True(t, belongs, "expected IP %q to belong to CIDR %q", ip, cidr)
 
 	ip = "192.168.25.30"
 	cidr = "192.168.26.30/24"
 	belongs, err = IPBelongsToCIDR(ip, cidr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if belongs {
-		t.Fatalf("expected IP %q to not belong to CIDR %q", ip, cidr)
-	}
+	require.NoError(t, err)
+	require.False(t, belongs, "expected IP %q to not belong to CIDR %q", ip, cidr)
 
 	ip = "192.168.25.30.100"
 	cidr = "192.168.26.30/24"
 	_, err = IPBelongsToCIDR(ip, cidr)
-	if err == nil {
-		t.Fatal("expected an error")
-	}
+	require.Error(t, err, "expected an error")
 }
 
 func TestCIDRUtil_IPBelongsToCIDRBlocksSlice(t *testing.T) {
@@ -54,140 +41,87 @@ func TestCIDRUtil_IPBelongsToCIDRBlocksSlice(t *testing.T) {
 	cidrList := []string{"172.169.100.200/18", "192.168.0.0/16", "10.10.20.20/24"}
 
 	belongs, err := IPBelongsToCIDRBlocksSlice(ip, cidrList)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !belongs {
-		t.Fatalf("expected IP %q to belong to one of the CIDRs in %q", ip, cidrList)
-	}
+	require.NoError(t, err)
+	require.True(t, belongs, "expected IP %q to belong to one of the CIDRs in %q", ip, cidrList)
 
 	ip = "192.168.27.29"
 	cidrList = []string{"172.169.100.200/18", "192.168.0.0.0/16", "10.10.20.20/24"}
 
 	_, err = IPBelongsToCIDRBlocksSlice(ip, cidrList)
-	if err == nil {
-		t.Fatal("expected an error")
-	}
+	require.Error(t, err, "expected an error")
 
 	ip = "30.40.50.60"
 	cidrList = []string{"172.169.100.200/18", "192.168.0.0/16", "10.10.20.20/24"}
 
 	belongs, err = IPBelongsToCIDRBlocksSlice(ip, cidrList)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if belongs {
-		t.Fatalf("expected IP %q to not belong to one of the CIDRs in %q", ip, cidrList)
-	}
+	require.NoError(t, err)
+	require.False(t, belongs, "expected IP %q to not belong to one of the CIDRs in %q", ip, cidrList)
 }
 
 func TestCIDRUtil_ValidateCIDRListString(t *testing.T) {
 	cidrList := "172.169.100.200/18,192.168.0.0/16,10.10.20.20/24"
 
 	valid, err := ValidateCIDRListString(cidrList, ",")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !valid {
-		t.Fatalf("expected CIDR list %q to be valid", cidrList)
-	}
+	require.NoError(t, err)
+	require.True(t, valid, "expected CIDR list %q to be valid", cidrList)
 
 	cidrList = "172.169.100.200,192.168.0.0/16,10.10.20.20/24"
 	valid, err = ValidateCIDRListString(cidrList, ",")
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if valid {
-		t.Fatal("expected valid = false")
-	}
+	require.Error(t, err, "expected an error")
+	require.False(t, valid, "expected valid = false")
 
 	cidrList = "172.169.100.200/18,192.168.0.0.0/16,10.10.20.20/24"
 	valid, err = ValidateCIDRListString(cidrList, ",")
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if valid {
-		t.Fatal("expected valid = false")
-	}
+	require.Error(t, err, "expected an error")
+	require.False(t, valid, "expected valid = false")
 }
 
 func TestCIDRUtil_ValidateCIDRListSlice(t *testing.T) {
 	cidrList := []string{"172.169.100.200/18", "192.168.0.0/16", "10.10.20.20/24"}
 
 	valid, err := ValidateCIDRListSlice(cidrList)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !valid {
-		t.Fatalf("expected CIDR list %q to be valid", cidrList)
-	}
+	require.NoError(t, err)
+	require.True(t, valid, "expected CIDR list %q to be valid", cidrList)
 
 	cidrList = []string{"172.169.100.200", "192.168.0.0/16", "10.10.20.20/24"}
 	valid, err = ValidateCIDRListSlice(cidrList)
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if valid {
-		t.Fatal("expected valid = false")
-	}
+	require.Error(t, err, "expected an error")
+	require.False(t, valid, "expected valid = false")
 
 	cidrList = []string{"172.169.100.200/18", "192.168.0.0.0/16", "10.10.20.20/24"}
 	valid, err = ValidateCIDRListSlice(cidrList)
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if valid {
-		t.Fatal("expected valid = false")
-	}
+	require.Error(t, err, "expected an error")
+	require.False(t, valid, "expected valid = false")
 }
 
 func TestCIDRUtil_Subset(t *testing.T) {
 	cidr1 := "192.168.27.29/24"
 	cidr2 := "192.168.27.29/24"
 	subset, err := Subset(cidr1, cidr2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !subset {
-		t.Fatalf("expected CIDR %q to be a subset of CIDR %q", cidr2, cidr1)
-	}
+	require.NoError(t, err)
+	require.True(t, subset, "expected CIDR %q to be a subset of CIDR %q", cidr2, cidr1)
 
 	cidr1 = "192.168.27.29/16"
 	cidr2 = "192.168.27.29/24"
 	subset, err = Subset(cidr1, cidr2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !subset {
-		t.Fatalf("expected CIDR %q to be a subset of CIDR %q", cidr2, cidr1)
-	}
+	require.NoError(t, err)
+	require.True(t, subset, "expected CIDR %q to be a subset of CIDR %q", cidr2, cidr1)
 
 	cidr1 = "192.168.27.29/24"
 	cidr2 = "192.168.27.29/16"
 	subset, err = Subset(cidr1, cidr2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if subset {
-		t.Fatalf("expected CIDR %q to not be a subset of CIDR %q", cidr2, cidr1)
-	}
+	require.NoError(t, err)
+	require.False(t, subset, "expected CIDR %q to not be a subset of CIDR %q", cidr2, cidr1)
 
 	cidr1 = "192.168.0.128/25"
 	cidr2 = "192.168.0.0/24"
 	subset, err = Subset(cidr1, cidr2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if subset {
-		t.Fatalf("expected CIDR %q to not be a subset of CIDR %q", cidr2, cidr1)
-	}
+	require.NoError(t, err)
+	require.False(t, subset, "expected CIDR %q to not be a subset of CIDR %q", cidr2, cidr1)
+
 	subset, err = Subset(cidr2, cidr1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !subset {
-		t.Fatalf("expected CIDR %q to be a subset of CIDR %q", cidr1, cidr2)
-	}
+	require.NoError(t, err)
+	require.True(t, subset, "expected CIDR %q to be a subset of CIDR %q", cidr1, cidr2)
 }
 
 func TestCIDRUtil_SubsetBlocks(t *testing.T) {
@@ -195,47 +129,31 @@ func TestCIDRUtil_SubsetBlocks(t *testing.T) {
 	cidrBlocks2 := []string{"192.168.27.29/20", "172.245.30.40/25", "10.20.30.40/32"}
 
 	subset, err := SubsetBlocks(cidrBlocks1, cidrBlocks2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !subset {
-		t.Fatalf("expected CIDR blocks %q to be a subset of CIDR blocks %q", cidrBlocks2, cidrBlocks1)
-	}
+	require.NoError(t, err)
+	require.True(t, subset, "expected CIDR blocks %q to be a subset of CIDR blocks %q", cidrBlocks2, cidrBlocks1)
 
 	cidrBlocks1 = []string{"192.168.27.29/16", "172.245.30.40/25", "10.20.30.40/30"}
 	cidrBlocks2 = []string{"192.168.27.29/20", "172.245.30.40/24", "10.20.30.40/32"}
 
 	subset, err = SubsetBlocks(cidrBlocks1, cidrBlocks2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if subset {
-		t.Fatalf("expected CIDR blocks %q to not be a subset of CIDR blocks %q", cidrBlocks2, cidrBlocks1)
-	}
+	require.NoError(t, err)
+	require.False(t, subset, "expected CIDR blocks %q to not be a subset of CIDR blocks %q", cidrBlocks2, cidrBlocks1)
 }
 
 func TestCIDRUtil_RemoteAddrIsOk_NegativeTest(t *testing.T) {
 	addr, err := sockaddr.NewSockAddr("127.0.0.1/8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	boundCIDRs := []*sockaddr.SockAddrMarshaler{
 		{addr},
 	}
-	if RemoteAddrIsOk("123.0.0.1", boundCIDRs) {
-		t.Fatal("remote address of 123.0.0.1/2 should not be allowed for 127.0.0.1/8")
-	}
+	require.False(t, RemoteAddrIsOk("123.0.0.1", boundCIDRs), "remote address of 123.0.0.1/2 should not be allowed for 127.0.0.1/8")
 }
 
 func TestCIDRUtil_RemoteAddrIsOk_PositiveTest(t *testing.T) {
 	addr, err := sockaddr.NewSockAddr("127.0.0.1/8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	boundCIDRs := []*sockaddr.SockAddrMarshaler{
 		{addr},
 	}
-	if !RemoteAddrIsOk("127.0.0.1", boundCIDRs) {
-		t.Fatal("remote address of 127.0.0.1 should be allowed for 127.0.0.1/8")
-	}
+	require.True(t, RemoteAddrIsOk("127.0.0.1", boundCIDRs), "remote address of 127.0.0.1 should be allowed for 127.0.0.1/8")
 }


### PR DESCRIPTION
Part of #2736 - converts `sdk/helper/cidrutil` tests to consistent testify usage.

Changes:

- `if err != nil { t.Fatal(err) }` guards become `require.NoError(t, err)`
- `if err == nil { t.Fatal("expected an error") }` guards become `require.Error(t, err, "expected an error")`
- `if !belongs { t.Fatalf("expected ...") }` boolean blocks become `require.True` / `require.False` with the original messages kept as testify message arguments
- adds the `testify/require` import; no production code changes

Fail-fast semantics are unchanged (`require` calls `t.FailNow`, matching the previous `t.Fatal`), and the `%q`-formatted messages survive as testify format strings with their original arguments.

Validation: `go test ./helper/cidrutil/...` passes; `gofmt` and `go vet` clean. Happy to continue the same conversion for other `sdk/helper` packages in follow-ups if this shape is what #2736 wants.
