### PR TITLE
Limit parallel transactions in PostgreSQL

### DIFF
--- a/changelog/3913.txt
+++ b/changelog/3913.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/postgresql: Set transaction limit to one less than max_parallel, ensuring HA lock renewal and non-transaction operations can always proceed.
+```

--- a/internal/physical/postgresql/postgresql.go
+++ b/internal/physical/postgresql/postgresql.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -80,6 +81,7 @@ type PostgreSQLBackend struct {
 	haEnabled     bool
 	logger        log.Logger
 	txnPermitPool *physical.PermitPool
+	txnLeakCount  atomic.Uint64
 
 	fenceLock sync.RWMutex
 	fence     *PostgreSQLLock
@@ -139,6 +141,11 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		logger.Debug("transaction_max_parallel set", "transaction_max_parallel", txnMaxParInt)
 	} else {
 		txnMaxParInt = physical.DefaultParallelTransactions
+	}
+
+	if txnMaxParInt >= maxParInt && maxParInt >= 3 {
+		// Leave one for lock renewal.
+		txnMaxParInt = maxParInt - 1
 	}
 
 	maxIdleConnsStr, maxIdleConnsIsSet := conf["max_idle_connections"]

--- a/internal/physical/postgresql/transaction.go
+++ b/internal/physical/postgresql/transaction.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -20,6 +21,8 @@ type PostgreSQLBackendTransaction struct {
 	readOnly       bool
 	haveWritten    bool
 	haveFinishedTx bool
+
+	cleanup runtime.Cleanup
 }
 
 func (b *PostgreSQLBackend) newTransaction(ctx context.Context, readOnly bool) (physical.Transaction, error) {
@@ -36,11 +39,34 @@ func (b *PostgreSQLBackend) newTransaction(ctx context.Context, readOnly bool) (
 		return nil, fmt.Errorf("failed to start underlying postgresql transaction: %w", err)
 	}
 
-	return &PostgreSQLBackendTransaction{
+	txn := &PostgreSQLBackendTransaction{
 		b:        b,
 		tx:       tx,
 		readOnly: readOnly,
-	}, nil
+	}
+
+	trace := make([]byte, 2*1024)
+	bytes := runtime.Stack(trace, false)
+	trace = trace[0:bytes]
+
+	txn.cleanup = runtime.AddCleanup(txn, func(_ any) {
+		log := b.logger.Debug
+		if b.txnLeakCount.Add(1) == 1 {
+			log = b.logger.Error
+		}
+		log(
+			"transaction was leaked",
+			// Stack is the only information we retain in this existing implementation.
+			"stack", string(trace),
+			"read_only", readOnly,
+			"leaked_transactions", b.txnLeakCount.Load(),
+		)
+
+		b.txnPermitPool.Release()
+		_ = tx.Rollback() // ignore the error, not much we can do about this
+	}, true)
+
+	return txn, nil
 }
 
 func (b *PostgreSQLBackend) BeginTx(ctx context.Context) (physical.Transaction, error) {
@@ -200,6 +226,7 @@ func (t *PostgreSQLBackendTransaction) Commit(ctx context.Context) error {
 	defer func() {
 		t.b.txnPermitPool.Release()
 		t.haveFinishedTx = true
+		t.cleanup.Stop()
 	}()
 
 	if err := t.b.validateFence(ctx); err != nil {
@@ -224,6 +251,7 @@ func (t *PostgreSQLBackendTransaction) Rollback(ctx context.Context) error {
 	defer func() {
 		t.b.txnPermitPool.Release()
 		t.haveFinishedTx = true
+		t.cleanup.Stop()
 	}()
 
 	if err := t.tx.Rollback(); err != nil {


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Most of the time, transaction acquisition is limited by the underlying capacity of the PostgreSQL server; we recommend operators tune max_parallel to a reasonable level (5ish from earlier testing at a prior employer). However, the transaction parallelism is limited to 64 by default, which exceeds this substantially, causing a lock renewal failure when long-lived transactions occur (or, if they simply win connection acquisition).

At the same time, let's take the opportunity to add the same global transaction leak detection logic to PostgreSQL for us. This uses a reasonable (2kb) stack trace as we have no other information to go on.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

fyi: @fcat

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
