### PR TITLE
Allow mounts to request the "latest" plugin version

### DIFF
--- a/changelog/3914.txt
+++ b/changelog/3914.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/plugins: Allow auth & secret mounts to automatically request the latest installed version of the underlying external plugin via `plugin_version=latest`.
+```

--- a/internal/command/auth_enable.go
+++ b/internal/command/auth_enable.go
@@ -206,7 +206,8 @@ func (c *AuthEnableCommand) Flags() *FlagSets {
 		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
-		Usage:   "Select the semantic version of the plugin to enable.",
+		Usage: "Select the semantic version of the plugin to enable. " +
+			`Set to "latest" to automatically pick the latest available plugin version whenever the mount is (re-)loaded.`,
 	})
 
 	return set

--- a/internal/command/auth_tune.go
+++ b/internal/command/auth_tune.go
@@ -192,7 +192,8 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
-			"the plugin catalog and will not start running until the plugin is reloaded.",
+			"the plugin catalog and will not start running until the plugin is reloaded. " +
+			`Can also be set to "latest" to automatically pick the latest available plugin version on reload.`,
 	})
 
 	return set

--- a/internal/command/secrets_enable.go
+++ b/internal/command/secrets_enable.go
@@ -179,7 +179,8 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 		Name:    flagNamePluginVersion,
 		Target:  &c.flagPluginVersion,
 		Default: "",
-		Usage:   "Select the semantic version of the plugin to enable.",
+		Usage: "Select the semantic version of the plugin to enable. " +
+			`Set to "latest" to automatically pick the latest available plugin version whenever the mount is (re-)loaded.`,
 	})
 
 	f.StringMapVar(&StringMapVar{

--- a/internal/command/secrets_tune.go
+++ b/internal/command/secrets_tune.go
@@ -146,7 +146,8 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 		Target:  &c.flagPluginVersion,
 		Default: "",
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
-			"the plugin catalog and will not start running until the plugin is reloaded.",
+			"the plugin catalog and will not start running until the plugin is reloaded. " +
+			`Can also be set to "latest" to automatically pick the latest available plugin version on reload.`,
 	})
 
 	return set

--- a/internal/vault/external_plugin_test.go
+++ b/internal/vault/external_plugin_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"cmp"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -101,12 +102,13 @@ func TestCore_EnableExternalPlugin(t *testing.T) {
 
 func TestCore_EnableExternalPlugin_MultipleVersions(t *testing.T) {
 	for name, tc := range map[string]struct {
-		pluginType       consts.PluginType
-		registerVersions []string
-		mountVersion     string
-		expectedVersion  string
-		routerPath       string
-		expectedMatch    string
+		pluginType             consts.PluginType
+		registerVersions       []string
+		mountVersion           string
+		expectedVersion        string
+		expectedRunningVersion string
+		routerPath             string
+		expectedMatch          string
 	}{
 		"enable external credential plugin, multiple versions available": {
 			pluginType:       consts.PluginTypeCredential,
@@ -156,6 +158,24 @@ func TestCore_EnableExternalPlugin_MultipleVersions(t *testing.T) {
 			routerPath:       "foo/bar",
 			expectedMatch:    "foo/",
 		},
+		"enable external credential plugin, selects moving latest when version is latest": {
+			pluginType:             consts.PluginTypeCredential,
+			registerVersions:       []string{"v1.0.0", "v1.0.1"},
+			mountVersion:           "latest",
+			expectedVersion:        "latest",
+			expectedRunningVersion: "v1.0.1",
+			routerPath:             "auth/foo/bar",
+			expectedMatch:          "auth/foo/",
+		},
+		"enable external secrets plugin, selects moving latest when version is latest": {
+			pluginType:             consts.PluginTypeSecrets,
+			registerVersions:       []string{"v1.0.0", "v1.0.1"},
+			mountVersion:           "latest",
+			expectedVersion:        "latest",
+			expectedRunningVersion: "v1.0.1",
+			routerPath:             "foo/bar",
+			expectedMatch:          "foo/",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			c, plugins := testCoreWithPlugins(t, tc.pluginType, "")
@@ -175,7 +195,7 @@ func TestCore_EnableExternalPlugin_MultipleVersions(t *testing.T) {
 				t.Errorf("Expected mount to be version %s but got %s", tc.expectedVersion, re.MountEntry.Version)
 			}
 
-			if re.MountEntry.RunningVersion != tc.expectedVersion {
+			if re.MountEntry.RunningVersion != cmp.Or(tc.expectedRunningVersion, tc.expectedVersion) {
 				t.Errorf("Expected mount running version to be %s but got %s", tc.expectedVersion, re.MountEntry.RunningVersion)
 			}
 

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -1733,11 +1733,13 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 
 	if rawVal, ok := data.GetOk("plugin_version"); ok {
 		version := rawVal.(string)
-		semanticVersion, err := semver.NewVersion(version)
-		if err != nil {
-			return logical.ErrorResponse("version %q is not a valid semantic version: %s", version, err), nil
+		if version != versionLatest {
+			semanticVersion, err := semver.NewVersion(version)
+			if err != nil {
+				return logical.ErrorResponse("version %q is not a valid semantic version: %s", version, err), nil
+			}
+			version = "v" + semanticVersion.String()
 		}
-		version = "v" + semanticVersion.String()
 
 		pluginType := consts.PluginTypeSecrets
 		if isAuth {
@@ -1745,7 +1747,7 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		}
 
 		// Lookup the version to ensure it exists in the catalog before committing.
-		if _, err = b.System().LookupPluginVersion(ctx, mountEntry.Type, pluginType, version); err != nil {
+		if _, err := b.System().LookupPluginVersion(ctx, mountEntry.Type, pluginType, version); err != nil {
 			return handleError(err)
 		}
 
@@ -2366,6 +2368,11 @@ func (b *SystemBackend) validateVersion(ctx context.Context, version string, plu
 		if version != "" {
 			b.logger.Debug("pinning plugin version", "plugin type", pluginType.String(), "plugin name", pluginName, "plugin version", version)
 		}
+	case versionLatest:
+		// If set to "latest", we derive the latest plugin version dynamically
+		// when setting up the backend. This is distinct from the above case
+		// (empty string) where we derive the latest version on the spot and
+		// then pin it.
 	default:
 		semanticVersion, err := semver.NewVersion(version)
 		if err != nil {
@@ -5477,7 +5484,7 @@ Each entry is of the form "key=value".`,
 		"",
 	},
 	"plugin-catalog_version": {
-		"The semantic version of the plugin to use.",
+		`The semantic version of the plugin to use, or "latest".`,
 		"",
 	},
 	"leases": {

--- a/internal/vault/plugin_catalog.go
+++ b/internal/vault/plugin_catalog.go
@@ -39,6 +39,8 @@ import (
 
 const pluginCatalogPath = "core/plugin-catalog/"
 
+const versionLatest = "latest"
+
 var (
 	ErrDirectoryNotConfigured       = errors.New("could not set plugin, plugin directory is not configured")
 	ErrPluginNotFound               = errors.New("plugin not found in the catalog")
@@ -980,62 +982,105 @@ func (c *PluginCatalog) Get(ctx context.Context, name string, pluginType consts.
 func (c *PluginCatalog) get(ctx context.Context, name string, pluginType consts.PluginType, version string) (*pluginutil.PluginRunner, error) {
 	// If the directory isn't set only look for builtin plugins.
 	if c.directory != "" {
-		// Look for external plugins in the barrier
-		storageKey := path.Join(pluginType.String(), name)
-		if version != "" {
-			storageKey = path.Join(storageKey, version)
+		// Look for external plugins in the barrier.
+		runner, err := c.getExternal(ctx, name, pluginType, version)
+		switch {
+		case err != nil:
+			return nil, err
+		case runner != nil:
+			return runner, err
 		}
-		out, err := c.catalogView.Get(ctx, storageKey)
+	}
+
+	return c.getBuiltin(ctx, name, pluginType, version), nil
+}
+
+func (c *PluginCatalog) getExternal(ctx context.Context, name string, pluginType consts.PluginType, version string) (*pluginutil.PluginRunner, error) {
+	storageKey := path.Join(pluginType.String(), name)
+
+	if version == versionLatest {
+		versions, err := c.catalogView.List(ctx, storageKey+"/")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list available plugin versions: %w", err)
+		}
+
+		// Find the latest available version.
+		version = ""
+		var latest *semver.Version
+
+		for _, v := range versions {
+			sv, err := semver.NewSemver(v)
+			switch {
+			case err != nil:
+				return nil, fmt.Errorf("bad plugin version in storage: %w", err)
+			case latest == nil, sv.GreaterThan(latest):
+				latest, version = sv, v
+			}
+		}
+	}
+
+	if version != "" {
+		storageKey = path.Join(storageKey, version)
+	}
+
+	out, err := c.catalogView.Get(ctx, storageKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve plugin %q: %w", name, err)
+	}
+	if out == nil && version == "" {
+		// Also look for external plugins under what their name would have been if they
+		// were registered before plugin types existed.
+		out, err = c.catalogView.Get(ctx, name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve plugin %q: %w", name, err)
 		}
-		if out == nil && version == "" {
-			// Also look for external plugins under what their name would have been if they
-			// were registered before plugin types existed.
-			out, err = c.catalogView.Get(ctx, name)
-			if err != nil {
-				return nil, fmt.Errorf("failed to retrieve plugin %q: %w", name, err)
-			}
-		}
-		if out != nil {
-			entry := new(pluginutil.PluginRunner)
-			if err := jsonutil.DecodeJSON(out.Value, entry); err != nil {
-				return nil, fmt.Errorf("failed to decode plugin entry: %w", err)
-			}
-			if entry.Type != pluginType && entry.Type != consts.PluginTypeUnknown {
-				return nil, nil
-			}
-
-			// prepend the plugin directory to the command
-			entry.Command = filepath.Join(c.directory, entry.Command)
-
-			return entry, nil
-		}
+	}
+	if out == nil {
+		return nil, nil
 	}
 
+	entry := new(pluginutil.PluginRunner)
+	if err := jsonutil.DecodeJSON(out.Value, entry); err != nil {
+		return nil, fmt.Errorf("failed to decode plugin entry: %w", err)
+	}
+	if entry.Type != pluginType && entry.Type != consts.PluginTypeUnknown {
+		return nil, nil
+	}
+
+	// Prepend the plugin directory to the command.
+	entry.Command = filepath.Join(c.directory, entry.Command)
+
+	return entry, nil
+}
+
+func (c *PluginCatalog) getBuiltin(ctx context.Context, name string, pluginType consts.PluginType, version string) *pluginutil.PluginRunner {
 	builtinVersion := versions.GetBuiltinVersion(pluginType, name)
-	if version == "" || version == builtinVersion {
-		if version == builtinVersion {
-			// Don't return the builtin if it's shadowed by an unversioned plugin.
-			unversioned, err := c.get(ctx, name, pluginType, "")
-			if err == nil && unversioned != nil && !unversioned.Builtin {
-				return nil, nil
-			}
-		}
 
-		// Look for builtin plugins
-		if factory, ok := c.builtinRegistry.Get(name, pluginType); ok {
-			return &pluginutil.PluginRunner{
-				Name:           name,
-				Type:           pluginType,
-				Builtin:        true,
-				BuiltinFactory: factory,
-				Version:        builtinVersion,
-			}, nil
+	switch version {
+	case "":
+	case builtinVersion:
+		// Don't return the builtin if it's shadowed by an unversioned plugin.
+		unversioned, err := c.getExternal(ctx, name, pluginType, "")
+		if err == nil && unversioned != nil {
+			return nil
 		}
+	default:
+		return nil
 	}
 
-	return nil, nil
+	// Look for builtin plugins.
+	factory, ok := c.builtinRegistry.Get(name, pluginType)
+	if !ok {
+		return nil
+	}
+
+	return &pluginutil.PluginRunner{
+		Name:           name,
+		Type:           pluginType,
+		Builtin:        true,
+		BuiltinFactory: factory,
+		Version:        builtinVersion,
+	}
 }
 
 // Get the plugin types associated with a plugin name

--- a/website/content/docs/commands/auth/enable.mdx
+++ b/website/content/docs/commands/auth/enable.mdx
@@ -87,6 +87,8 @@ flags](../index.mdx) included on all commands.
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
   returned by the auth method.
 
-- `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
-  to use. If unspecified, implies the built-in or any matching unversioned plugin
-  that may have been registered.
+- `-plugin-version` `(string: "")` - Configures the semantic version of
+  the plugin to use. If unspecified, implies the built-in or any matching
+  unversioned plugin that may have been registered. Set to "latest" to
+  automatically pick the latest available plugin version whenever the mount is
+  (re-)loaded.

--- a/website/content/docs/commands/auth/tune.mdx
+++ b/website/content/docs/commands/auth/tune.mdx
@@ -154,9 +154,10 @@ flags](../index.mdx) included on all commands.
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
   returned by the auth method.
 
-- `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
-  to use. The new version will not start running until the mount is
-  [reloaded](../plugin/reload.mdx).
+- `-plugin-version` `(string: "")` - Configures the semantic version of the
+  plugin to use. The new version will not start running until the mount is
+  [reloaded](../plugin/reload.mdx). Can also be set to "latest" to automatically
+  pick the latest available plugin version on reload.
 
 - `-user-lockout-threshold` `(string: "")` - Specifies the number of failed login attempts
   after which the user is locked out.

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -106,6 +106,8 @@ flags](../index.mdx) included on all commands.
   engine will be allowed to set. Note that multiple keys may be
   specified by providing this option multiple times, each time with 1 key.
 
-- `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
-  to use. If unspecified, implies the built-in or any matching unversioned plugin
-  that may have been registered.
+- `-plugin-version` `(string: "")` - Configures the semantic version of
+  the plugin to use. If unspecified, implies the built-in or any matching
+  unversioned plugin that may have been registered. Set to "latest" to
+  automatically pick the latest available plugin version whenever the mount is
+  (re-)loaded.

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -88,6 +88,7 @@ flags](../index.mdx) included on all commands.
   be sent to the secrets engine. Note that multiple keys may be
   specified by providing this option multiple times, each time with 1 key.
 
-- `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
-  to use. The new version will not start running until the mount is
-  [reloaded](../plugin/reload.mdx).
+- `-plugin-version` `(string: "")` - Configures the semantic version of the
+  plugin to use. The new version will not start running until the mount is
+  [reloaded](../plugin/reload.mdx). Can also be set to "latest" to automatically
+  pick the latest available plugin version on reload.

--- a/website/content/docs/guides/upgrade/plugins.mdx
+++ b/website/content/docs/guides/upgrade/plugins.mdx
@@ -54,6 +54,15 @@ an auth plugin, just replace all usages of `secrets` or `secret` with `auth`.
    $ bao secrets tune -plugin-version=v1.0.1 my-secret-plugin
    ```
 
+   Alternatively, opt into the special "latest" plugin version such that future
+   upgrades automatically pick the latest installed plugin version. This lets
+   you skip this step in the future, assuming a simple upgrade to the latest
+   installed plugin version is desired.
+
+   ```shell-session
+   $ bao secrets tune -plugin-version=latest my-secret-plugin
+   ```
+
 1. If you wish, you can check the updated configuration. Notice the "Version" is
    now different from the "Running Version".
 


### PR DESCRIPTION
## Description

As title states!

## Rationale

See #3881.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
