### PR TITLE
Allow pinning OCI-based plugins by manifest digest

### DIFF
--- a/changelog/3915.txt
+++ b/changelog/3915.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/plugins: Allow pinning OCI-based plugins by manifest digest (e.g., `ghcr.io/openbao/openbao-plugin-secrets-aws@sha256:<digest>`) instead of providing the `sha256sum` of the inner plugin binary.
+```

--- a/internal/command/server/config.go
+++ b/internal/command/server/config.go
@@ -307,21 +307,17 @@ func (b *ServiceRegistration) GoString() string {
 // PluginConfig represents the configuration for a single OCI-based plugin
 type PluginConfig struct {
 	UnusedKeys configutil.UnusedKeyMap `hcl:",unusedKeyPositions"`
-	RawConfig  map[string]any
 
 	Type       string
 	Name       string
-	Image      string   `hcl:"image"`
-	Version    string   `hcl:"version"`
-	BinaryName string   `hcl:"binary_name"`
-	SHA256Sum  string   `hcl:"sha256sum"`
-	Command    string   `hcl:"command"`
-	Args       []string `hcl:"args"`
-	Env        []string `hcl:"env"`
-}
-
-func (p *PluginConfig) URL() string {
-	return fmt.Sprintf("%s:%s", p.Image, p.Version)
+	Image      name.Reference `hcl:"-"`
+	RawImage   string         `hcl:"image"`
+	Version    string         `hcl:"version"`
+	BinaryName string         `hcl:"binary_name"`
+	SHA256Sum  string         `hcl:"sha256sum"`
+	Command    string         `hcl:"command"`
+	Args       []string       `hcl:"args"`
+	Env        []string       `hcl:"env"`
 }
 
 func (p *PluginConfig) Slug() string {
@@ -333,7 +329,7 @@ func (p *PluginConfig) FullName() string {
 }
 
 func (p *PluginConfig) CommandPath() string {
-	if p.Image != "" {
+	if p.Image != nil {
 		return p.FullName()
 	}
 
@@ -370,28 +366,17 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 	}
 
 	// Validate Image is not empty
-	if p.Image == "" && p.Command == "" {
+	if p.Image == nil && p.Command == "" {
 		results = append(results, configutil.ConfigError{
 			Problem: fmt.Sprintf("plugin %q: image and command cannot both be empty", p.Slug()),
 		})
-	} else if p.Image != "" && p.Command != "" {
+	} else if p.Image != nil && p.Command != "" {
 		results = append(results, configutil.ConfigError{
 			Problem: fmt.Sprintf("plugin %q: command must be empty if image is specified", p.Slug()),
 		})
 	}
 
-	isOCI := p.Image != ""
-
-	if isOCI {
-		// Ensure Image:Version is a valid image reference
-		if _, err := name.ParseReference(p.URL()); err != nil {
-			results = append(results, configutil.ConfigError{
-				Problem: fmt.Sprintf("plugin %q: image and version do not form a valid image reference. %v", p.Slug(), err),
-			})
-		}
-	}
-
-	if isOCI || typ != consts.PluginTypeKMS {
+	if p.Image != nil || typ != consts.PluginTypeKMS {
 		// Validate version is not empty. KMS plugins do not require or enforce
 		// that a version is set. OCI-based plugins however require a version be
 		// set at all times.
@@ -403,9 +388,16 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 	}
 
 	switch {
-	case len(p.SHA256Sum) == 0 && !isOCI:
-		// sha256sum may be omitted unless OCI images are used, where they are
-		// required as cache sentinels.
+	case len(p.SHA256Sum) == 0 && p.Image != nil:
+		// SHA256Sum may be omitted in OCI image mode if the image reference is
+		// a digest reference.
+		if _, ok := p.Image.(name.Digest); !ok {
+			results = append(results, configutil.ConfigError{
+				Problem: fmt.Sprintf("plugin %q: sha256sum must be set if image is not pinned by digest, prefer pinning the image directly", p.Slug()),
+			})
+		}
+	case len(p.SHA256Sum) == 0:
+		// SHA256Sum may generally be omitted outside of OCI image mode.
 	case len(p.SHA256Sum) != 64:
 		// Unless omitted, validate sha256sum is exactly 64 hex characters.
 		results = append(results, configutil.ConfigError{
@@ -432,37 +424,64 @@ func (p *PluginConfig) Validate(sourceFilePath string) []configutil.ConfigError 
 	return results
 }
 
-func parsePlugins(name string, list *ast.ObjectList) ([]*PluginConfig, error) {
+func parsePlugins(block string, list *ast.ObjectList) ([]*PluginConfig, error) {
 	result := make([]*PluginConfig, 0, len(list.Items))
 	for index, item := range list.Items {
-		var i PluginConfig
-		if err := hcl.DecodeObject(&i, item.Val); err != nil {
-			return result, fmt.Errorf("%v.%d: %w", name, index, err)
-		}
-
-		var m map[string]any
-		if err := hcl.DecodeObject(&m, item.Val); err != nil {
-			return result, fmt.Errorf("%v.%d: %w", name, index, err)
-		}
-		i.RawConfig = m
-
-		switch {
-		case i.Type != "":
-		case len(item.Keys) == 2:
-			i.Type = item.Keys[0].Token.Value().(string)
-		default:
-			return result, fmt.Errorf("%v.%d: %v type must be specified: %#v", name, index, name, item)
+		var p PluginConfig
+		if err := hcl.DecodeObject(&p, item.Val); err != nil {
+			return result, fmt.Errorf("%v.%d: %w", block, index, err)
 		}
 
 		switch {
-		case i.Name != "":
+		case p.Type != "":
 		case len(item.Keys) == 2:
-			i.Name = item.Keys[1].Token.Value().(string)
+			p.Type = item.Keys[0].Token.Value().(string)
 		default:
-			return result, fmt.Errorf("%v.%d: %v name must be specified: %#v", name, index, name, item)
+			return result, fmt.Errorf("%v.%d: %v type must be specified: %#v", block, index, block, item)
 		}
 
-		result = append(result, &i)
+		switch {
+		case p.Name != "":
+		case len(item.Keys) == 2:
+			p.Name = item.Keys[1].Token.Value().(string)
+		default:
+			return result, fmt.Errorf("%v.%d: %v name must be specified: %#v", block, index, block, item)
+		}
+
+		if p.RawImage != "" {
+			// Figure out if this is a digest-based or tag-based reference. We
+			// need to know this ahead of passing over to go-containerregistry's
+			// parsing as it discards the tag component on digest references,
+			// but we'd like to substitute any empty version fields with that.
+			parts := strings.SplitN(p.RawImage, "@", 2)
+
+			// Begin by parsing a tag reference.
+			tag, err := name.NewTag(parts[0], name.WithDefaultTag(p.Version))
+			if err != nil {
+				return result, fmt.Errorf("%v.%d: invalid image reference: %w", block, index, err)
+			}
+
+			if len(parts) > 1 {
+				// If the image reference has an '@', also parse and a digest
+				// reference and use that instead.
+				p.Image, err = name.NewDigest(p.RawImage)
+			} else {
+				// Otherwise, just use the tag reference.
+				p.Image = tag
+			}
+
+			if err != nil {
+				return result, fmt.Errorf("%v.%d: invalid image reference: %w", block, index, err)
+			}
+
+			if p.Version == "" {
+				// Regardless of the reference we ultimately used above, try to
+				// replace an unset Version field with the tag reference's tag.
+				p.Version = tag.Identifier()
+			}
+		}
+
+		result = append(result, &p)
 	}
 
 	return result, nil

--- a/internal/command/server/config_plugin_test.go
+++ b/internal/command/server/config_plugin_test.go
@@ -6,6 +6,9 @@ package server
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPluginConfigParsing(t *testing.T) {
@@ -29,55 +32,64 @@ plugin "secret" "aws" {
 plugin "auth" "gcp" {
   image = "ghcr.io/openbao/openbao-plugin-auth-gcp"
   version = "v0.21.0"
-  binary_name = "openbao-plugin-auth-gcp"
   sha256sum = "f586717376b20763b3ecef0412cdd6cbb4f8295b9679da4bfa4e1f75b8e00a63"
+}
+
+plugin "kms" "pkcs11" {
+  image = "ghcr.io/openbao/openbao-plugin-kms-pkcs11@sha256:ba3229ef91ab1040122d1389f9d015f3f211076835cf6914977c09d3697b4697"
+  version = "v0.1.0"
+}
+
+plugin "kms" "ovhcloud" {
+  image = "ghcr.io/openbao/openbao-plugin-kms-ovhcloud:v0.0.1@sha256:0ac993bbd5589845ef0b60f9b106ebadf82903de8bccaafce8abb04d7094d9ed"
 }
 
 plugin_download_behavior = "fail"
 `
 
 	config, err := ParseConfig(configData, "test")
-	if err != nil {
-		t.Fatalf("Error parsing config: %v", err)
+	require.NoError(t, err)
+
+	require.Equal(t, "/opt/openbao/plugins", config.PluginDirectory)
+	require.Equal(t, config.PluginDownloadBehavior, "fail")
+
+	for _, c := range config.Plugins {
+		c.RawImage = ""
 	}
 
-	// Test plugin directory
-	if config.PluginDirectory != "/opt/openbao/plugins" {
-		t.Errorf("Expected plugin directory '/opt/openbao/plugins', got '%s'", config.PluginDirectory)
-	}
+	require.Equal(t, config.Plugins, []*PluginConfig{
+		{
+			Type:       "secret",
+			Name:       "aws",
+			Version:    "v0.0.1",
+			BinaryName: "openbao-plugin-secrets-aws",
+			SHA256Sum:  "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c",
+			Image:      name.MustParseReference("ghcr.io/openbao/openbao-plugin-secrets-aws", name.WithDefaultTag("v0.0.1")),
+		},
+		{
+			Type:      "auth",
+			Name:      "gcp",
+			Version:   "v0.21.0",
+			SHA256Sum: "f586717376b20763b3ecef0412cdd6cbb4f8295b9679da4bfa4e1f75b8e00a63",
+			Image:     name.MustParseReference("ghcr.io/openbao/openbao-plugin-auth-gcp", name.WithDefaultTag("v0.21.0")),
+		},
+		{
+			Type:    "kms",
+			Name:    "pkcs11",
+			Version: "v0.1.0",
+			Image:   name.MustParseReference("ghcr.io/openbao/openbao-plugin-kms-pkcs11@sha256:ba3229ef91ab1040122d1389f9d015f3f211076835cf6914977c09d3697b4697"),
+		},
+		{
+			Type:    "kms",
+			Name:    "ovhcloud",
+			Version: "v0.0.1",
+			Image:   name.MustParseReference("ghcr.io/openbao/openbao-plugin-kms-ovhcloud:v0.0.1@sha256:0ac993bbd5589845ef0b60f9b106ebadf82903de8bccaafce8abb04d7094d9ed"),
+		},
+	})
 
-	// Test plugin download behavior
-	if config.PluginDownloadBehavior != "fail" {
-		t.Errorf("Expected plugin download behavior 'fail', got '%s'", config.PluginDownloadBehavior)
-	}
-
-	// Test plugins
-	if len(config.Plugins) != 2 {
-		t.Fatalf("Expected 2 plugins, got %d", len(config.Plugins))
-	}
-
-	awsPlugin := config.Plugins[0]
-	if awsPlugin.Slug() != "secret-aws" {
-		t.Fatal("secret-aws plugin not found")
-	}
-
-	if awsPlugin.URL() != "ghcr.io/openbao/openbao-plugin-secrets-aws:v0.0.1" {
-		t.Errorf("Expected AWS plugin URL 'ghcr.io/openbao/openbao-plugin-secrets-aws:v0.0.1', got '%s'", awsPlugin.URL())
-	}
-	if awsPlugin.BinaryName != "openbao-plugin-secrets-aws" {
-		t.Errorf("Expected AWS plugin binary 'openbao-plugin-secrets-aws', got '%s'", awsPlugin.BinaryName)
-	}
-	if awsPlugin.SHA256Sum != "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c" {
-		t.Errorf("Expected AWS plugin SHA256 '9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c', got '%s'", awsPlugin.SHA256Sum)
-	}
-
-	// Test validation
 	errors := config.Validate("test")
-	if len(errors) > 0 {
-		t.Errorf("Validation failed with errors:")
-		for _, err := range errors {
-			t.Errorf("  %s", err.String())
-		}
+	for _, err := range errors {
+		require.NoError(t, err)
 	}
 }
 
@@ -89,7 +101,7 @@ func TestPluginConfigValidation(t *testing.T) {
 		errorMsg    string
 	}{
 		{
-			name: "valid config",
+			name: "valid config with sha256sum",
 			configData: `
 storage "inmem" {}
 listener "tcp" { 
@@ -105,12 +117,26 @@ plugin "secret" "aws" {
 			expectError: false,
 		},
 		{
+			name: "valid config with manifest digest",
+			configData: `
+storage "inmem" {}
+listener "tcp" {
+  address = "127.0.0.1:8200"
+  tls_disable = true
+}
+plugin "secret" "aws" {
+  image = "ghcr.io/openbao/openbao-plugin-secrets-aws@sha256:9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"
+  version = "v0.0.1"
+}`,
+			expectError: false,
+		},
+		{
 			name: "missing url",
 			configData: `
 storage "inmem" {}
-listener "tcp" { 
+listener "tcp" {
   address = "127.0.0.1:8200"
-  tls_disable = true 
+  tls_disable = true
 }
 plugin "secret" "aws" {
   version = "v0.0.1"
@@ -121,7 +147,7 @@ plugin "secret" "aws" {
 			errorMsg:    "image and command cannot both be empty",
 		},
 		{
-			name: "invalid url",
+			name: "missing sha256sum or manifest digest",
 			configData: `
 storage "inmem" {}
 listener "tcp" {
@@ -130,20 +156,18 @@ listener "tcp" {
 }
 plugin "secret" "aws" {
   image = "ghcr.io/openbao/openbao-plugin-secrets-aws"
-  version = "v0.0.1:v0.0.1"
-  binary_name = "openbao-plugin-secrets-aws"
-  sha256sum = "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"
+  version = "v0.0.1"
 }`,
 			expectError: true,
-			errorMsg:    "image and version do not form a valid image reference",
+			errorMsg:    "sha256sum must be set if image is not pinned by digest",
 		},
 		{
 			name: "invalid sha256sum length",
 			configData: `
 storage "inmem" {}
-listener "tcp" { 
+listener "tcp" {
   address = "127.0.0.1:8200"
-  tls_disable = true 
+  tls_disable = true
 }
 plugin "secret" "aws" {
   image = "ghcr.io/openbao/openbao-plugin-secrets-aws"
@@ -158,9 +182,9 @@ plugin "secret" "aws" {
 			name: "invalid sha256sum characters",
 			configData: `
 storage "inmem" {}
-listener "tcp" { 
+listener "tcp" {
   address = "127.0.0.1:8200"
-  tls_disable = true 
+  tls_disable = true
 }
 plugin "secret" "aws" {
   image = "ghcr.io/openbao/openbao-plugin-secrets-aws"
@@ -175,9 +199,9 @@ plugin "secret" "aws" {
 			name: "invalid download behavior",
 			configData: `
 storage "inmem" {}
-listener "tcp" { 
+listener "tcp" {
   address = "127.0.0.1:8200"
-  tls_disable = true 
+  tls_disable = true
 }
 plugin_download_behavior = "invalid_value"`,
 			expectError: true,

--- a/internal/helper/kmsplugin/catalog.go
+++ b/internal/helper/kmsplugin/catalog.go
@@ -237,13 +237,12 @@ func (c *Catalog) checkFilePath(plugin *server.PluginConfig) error {
 		return fmt.Errorf("error while validating the command path: %w", err)
 	}
 
-	var ok bool
-	if plugin.Image == "" {
-		// Declarative, manual plugin.
-		ok = filepath.Dir(path) == c.pluginDirectory
-	} else {
-		// Declarative, OCI-based plugin.
-		ok = filepath.Dir(path) == filepath.Join(
+	dir := filepath.Dir(path)
+	ok := dir == c.pluginDirectory
+	if !ok && plugin.Image != nil {
+		ok = dir == filepath.Join(
+			c.pluginDirectory, oci.PluginCacheDir,
+		) || dir == filepath.Join(
 			c.pluginDirectory, oci.PluginCacheDir, plugin.Slug(), plugin.SHA256Sum[:8],
 		)
 	}

--- a/internal/helper/pluginutil/oci/downloader.go
+++ b/internal/helper/pluginutil/oci/downloader.go
@@ -61,7 +61,7 @@ func (d *PluginDownloader) ReconcilePlugins(ctx context.Context) error {
 
 	for _, pluginConfig := range plugins {
 		// Skip plugins which are manually downloaded but defined declaratively.
-		if pluginConfig.Image == "" {
+		if pluginConfig.Image == nil {
 			continue
 		}
 
@@ -81,8 +81,6 @@ func (d *PluginDownloader) ReconcilePlugins(ctx context.Context) error {
 				continue
 			}
 		}
-
-		pluginLogger.Debug("processing plugin", "url", pluginConfig.URL())
 
 		// Fast path: check if plugin already exists and matches expected SHA256
 		if d.IsPluginCacheValid(pluginConfig) {
@@ -123,66 +121,70 @@ func (d *PluginDownloader) maxPluginSize() int64 {
 	return PluginMaxSizeBytes
 }
 
-// IsPluginCacheValid checks if the plugin already exists in the plugin directory
-// and matches the expected SHA256 hash (fast path)
+// IsPluginCacheValid checks if the plugin already exists in the plugin
+// directory.
 func (d *PluginDownloader) IsPluginCacheValid(config *server.PluginConfig) bool {
 	if d.pluginDirectory == "" {
 		return false
 	}
 
-	// Check if the symlink exists in the plugin directory
-	symlinkPath := filepath.Join(d.pluginDirectory, config.FullName())
+	// Check if the symlink exists in the plugin directory.
+	pluginPath := filepath.Join(d.pluginDirectory, config.FullName())
 
-	// Check if symlink exists and is a symlink
-	linkInfo, err := os.Lstat(symlinkPath)
+	// Check if symlink exists and is a symlink.
+	linkInfo, err := os.Lstat(pluginPath)
 	if err != nil {
 		return false
 	}
 
-	if linkInfo.Mode()&os.ModeSymlink == 0 {
-		// If it's not a symlink, it might be a regular file from manual installation
-		// Let's validate it directly
-		actualHash, err := osutil.FileSha256Sum(symlinkPath)
+	if linkInfo.Mode()&os.ModeSymlink != 0 {
+		// Follow the symlink to get the actual cached file.
+		cachedFilePath, err := os.Readlink(pluginPath)
 		if err != nil {
 			return false
 		}
-		return strings.EqualFold(actualHash, config.SHA256Sum)
+
+		// Make sure it's an absolute path.
+		if !filepath.IsAbs(cachedFilePath) {
+			cachedFilePath = filepath.Join(d.pluginDirectory, cachedFilePath)
+		}
+
+		// Check if the cached file exists.
+		if _, err := os.Stat(cachedFilePath); os.IsNotExist(err) {
+			return false
+		}
+
+		pluginPath = cachedFilePath
 	}
 
-	// Follow the symlink to get the actual cached file
-	cachedFilePath, err := os.Readlink(symlinkPath)
-	if err != nil {
-		return false
+	// Conservatively default to false and enforce that one of the below checks
+	// must run such that true can be returned.
+	var valid bool
+
+	// Validate the file name of the cache entry if we have a digest reference.
+	if digest, ok := config.Image.(name.Digest); ok {
+		if valid = filepath.Base(pluginPath) == digest.Identifier(); !valid {
+			return false
+		}
 	}
 
-	// Make sure it's an absolute path
-	if !filepath.IsAbs(cachedFilePath) {
-		cachedFilePath = filepath.Join(d.pluginDirectory, cachedFilePath)
+	// Validate the SHA-256 digest of the plugin binary if one is specified.
+	if len(config.SHA256Sum) > 0 {
+		actualHash, err := osutil.FileSha256Sum(pluginPath)
+		if err != nil {
+			return false
+		}
+		if valid = strings.EqualFold(actualHash, config.SHA256Sum); !valid {
+			return false
+		}
 	}
 
-	// Check if the cached file exists
-	if _, err := os.Stat(cachedFilePath); os.IsNotExist(err) {
-		return false
-	}
-
-	// Validate SHA256 of the cached file
-	actualHash, err := osutil.FileSha256Sum(cachedFilePath)
-	if err != nil {
-		d.logger.Debug("failed to calculate plugin hash", "plugin", config.Slug(), "error", err)
-		return false
-	}
-
-	return strings.EqualFold(actualHash, config.SHA256Sum)
+	return valid
 }
 
 // DownloadPlugin downloads a plugin from an OCI registry
 func (d *PluginDownloader) DownloadPlugin(ctx context.Context, config *server.PluginConfig, logger hclog.Logger) error {
-	if d.pluginDirectory == "" {
-		return errors.New("plugin directory is not configured")
-	}
-
-	logger.Info("downloading plugin from OCI registry",
-		"url", config.URL())
+	logger.Info("downloading plugin from OCI registry", "reference", config.Image.String())
 
 	// Detect local platform to download correct image variant
 	localSpec := platforms.DefaultString()
@@ -192,16 +194,18 @@ func (d *PluginDownloader) DownloadPlugin(ctx context.Context, config *server.Pl
 	}
 	logger.Debug("local platform", "platform", platform.String())
 
-	// Parse the OCI reference
-	ref, err := name.ParseReference(config.URL())
+	// Look up the descriptor instead of directly calling Image(), this lets us
+	// record the first manifest digest that we encounter (such as multi-arch
+	// index manifests) instead of the final image manifest digest only.
+	desc, err := remote.Get(config.Image, remote.WithContext(ctx), remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(*platform))
 	if err != nil {
-		return fmt.Errorf("invalid OCI reference %q: %w", config.URL(), err)
+		return fmt.Errorf("failed to fetch OCI descriptor: %w", err)
 	}
 
-	// Download the image
-	img, err := remote.Image(ref, remote.WithContext(ctx), remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(*platform))
+	// Then step down to the image.
+	img, err := desc.Image()
 	if err != nil {
-		return fmt.Errorf("failed to download OCI image: %w", err)
+		return fmt.Errorf("failed to fetch OCI image: %w", err)
 	}
 
 	binaryName := config.BinaryName
@@ -230,36 +234,36 @@ func (d *PluginDownloader) DownloadPlugin(ctx context.Context, config *server.Pl
 		return fmt.Errorf("invalid binary name: %q", binaryName)
 	}
 
-	// Extract the plugin binary from the image using hidden cache path
-	// Format: <plugin_directory>/.oci-cache/<plugin_slug>/<sha256_prefix>/<binary_name>
-	sha256Prefix := config.SHA256Sum[:8]
-	cacheDir := filepath.Join(d.pluginDirectory, PluginCacheDir, config.Slug(), sha256Prefix)
-	cachedPluginPath := filepath.Join(cacheDir, binaryName)
+	// Extract the plugin binary from the image using hidden cache path.
+	// Format: <plugin_directory>/.oci-cache/<digest>
+	cachedPluginPath := filepath.Join(d.pluginDirectory, PluginCacheDir, desc.Digest.String())
 
 	if err := d.ExtractPluginFromImage(img, cachedPluginPath, binaryName, logger); err != nil {
 		return fmt.Errorf("failed to extract plugin from OCI image: %w", err)
 	}
 
-	// Verify the SHA256 hash of the cached file
-	actualHash, err := osutil.FileSha256Sum(cachedPluginPath)
-	if err != nil {
-		// Clean up the cached file if hash verification fails
-		removeErr := os.Remove(cachedPluginPath)
-		if removeErr != nil {
-			return errors.Join(fmt.Errorf("failed to calculate plugin hash: %w", err),
-				fmt.Errorf("failed to remove cached file: %w", removeErr))
+	if len(config.SHA256Sum) > 0 {
+		// Verify the SHA256 hash of the cached file
+		actualHash, err := osutil.FileSha256Sum(cachedPluginPath)
+		if err != nil {
+			// Clean up the cached file if hash verification fails
+			removeErr := os.Remove(cachedPluginPath)
+			if removeErr != nil {
+				return errors.Join(fmt.Errorf("failed to calculate plugin hash: %w", err),
+					fmt.Errorf("failed to remove cached file: %w", removeErr))
+			}
+			return fmt.Errorf("failed to calculate plugin hash: %w", err)
 		}
-		return fmt.Errorf("failed to calculate plugin hash: %w", err)
-	}
 
-	if !strings.EqualFold(actualHash, config.SHA256Sum) {
-		// Clean up the cached file if hash doesn't match
-		removeErr := os.Remove(cachedPluginPath)
-		if removeErr != nil {
-			return errors.Join(fmt.Errorf("plugin hash mismatch: expected %s, got %s", config.SHA256Sum, actualHash),
-				fmt.Errorf("failed to remove cached file: %w", removeErr))
+		if !strings.EqualFold(actualHash, config.SHA256Sum) {
+			// Clean up the cached file if hash doesn't match
+			removeErr := os.Remove(cachedPluginPath)
+			if removeErr != nil {
+				return errors.Join(fmt.Errorf("plugin hash mismatch: expected %s, got %s", config.SHA256Sum, actualHash),
+					fmt.Errorf("failed to remove cached file: %w", removeErr))
+			}
+			return fmt.Errorf("plugin hash mismatch: expected %s, got %s", config.SHA256Sum, actualHash)
 		}
-		return fmt.Errorf("plugin hash mismatch: expected %s, got %s", config.SHA256Sum, actualHash)
 	}
 
 	// Create symlink in the plugin directory pointing to the cached file
@@ -283,10 +287,7 @@ func (d *PluginDownloader) DownloadPlugin(ctx context.Context, config *server.Pl
 		return fmt.Errorf("failed to create plugin symlink: %w", err)
 	}
 
-	logger.Info("successfully downloaded and validated plugin",
-		"cached_path", cachedPluginPath,
-		"symlink_path", symlinkPath,
-		"hash", actualHash)
+	logger.Info("downloaded plugin", "cached_path", cachedPluginPath, "symlink_path", symlinkPath)
 
 	return nil
 }

--- a/internal/vault/plugin_catalog.go
+++ b/internal/vault/plugin_catalog.go
@@ -340,8 +340,8 @@ func (c *PluginCatalog) registerDeclarativePlugins(ctx context.Context, plugins 
 				update = !slices.Equal(plugin.Args, pluginInfo.Args) ||
 					!slices.Equal(plugin.Env, pluginInfo.Env) ||
 					!bytes.Equal(sha256, pluginInfo.Sha256) ||
-					(plugin.Image != "") != pluginInfo.Oci ||
-					(plugin.Image == "" && plugin.Command != pluginInfo.Command)
+					(plugin.Image != nil) != pluginInfo.Oci ||
+					(plugin.Image == nil && plugin.Command != pluginInfo.Command)
 				if update {
 					c.logger.Info("updating existing plugin", "name", plugin.Name, "type", plugin.Type, "version", plugin.Version, "sha256", plugin.SHA256Sum)
 				}
@@ -356,7 +356,7 @@ func (c *PluginCatalog) registerDeclarativePlugins(ctx context.Context, plugins 
 					return nil
 				}
 
-				_, err = c.setInternal(ctx, plugin.Name, pluginType, plugin.Version, plugin.CommandPath(), plugin.Args, plugin.Env, sha256, plugin.Image != "" /* OCI */, true /* declarative */)
+				_, err = c.setInternal(ctx, plugin.Name, pluginType, plugin.Version, plugin.CommandPath(), plugin.Args, plugin.Env, sha256, plugin.Image != nil /* OCI */, true /* declarative */)
 				if err != nil {
 					return fmt.Errorf("failed to register new plugin: %w", err)
 				}
@@ -1160,22 +1160,18 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 		return nil, fmt.Errorf("error while validating the command path: %w", err)
 	}
 
-	switch isOci {
-	case true:
-		if len(sha256) < 8 {
-			return nil, errors.New("valid sha256 must be provided when registering OCI plugins")
+	ok := symAbs == c.directory
+	if !ok && isOci {
+		ok = symAbs == filepath.Join(c.directory, oci.PluginCacheDir)
+		if !ok && len(sha256) > 0 {
+			ok = symAbs == filepath.Join(
+				c.directory, oci.PluginCacheDir, fmt.Sprintf("%s-%s", pluginType.String(), name), hex.EncodeToString(sha256)[:8],
+			)
 		}
+	}
 
-		// Format: <plugin_directory>/.oci-cache/<plugin_slug>/<sha256_prefix>
-		shaPrefix := hex.EncodeToString(sha256)[:8]
-		ociCachePath := filepath.Join(c.directory, oci.PluginCacheDir, fmt.Sprintf("%s-%s", pluginType.String(), name), shaPrefix)
-		if symAbs != ociCachePath {
-			return nil, errors.New("cannot execute files outside of configured plugin directory")
-		}
-	case false:
-		if symAbs != c.directory {
-			return nil, errors.New("cannot execute files outside of configured plugin directory")
-		}
+	if !ok {
+		return nil, errors.New("cannot execute files outside of configured plugin directory")
 	}
 
 	// entryTmp should only be used for the below type and version checks, it uses the

--- a/internal/vault/plugin_catalog_oci_test.go
+++ b/internal/vault/plugin_catalog_oci_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -175,7 +176,7 @@ func TestReconcileOCIPlugins(t *testing.T) {
 			{
 				Type:       "secret",
 				Name:       "nomad",
-				Image:      "ghcr.io/openbao/openbao-plugin-secrets-nomad",
+				Image:      name.MustParseReference("ghcr.io/openbao/openbao-plugin-secrets-nomad:v0.1.4"),
 				Version:    "v0.1.4",
 				BinaryName: "openbao-plugin-secrets-nomad",
 				SHA256Sum:  nomadPluginSHA256,
@@ -219,8 +220,8 @@ func TestReconcileOCIPlugins(t *testing.T) {
 		t.Fatalf("Failed to read symlink: %v", err)
 	}
 
-	// Should point to .oci-cache/secret-nomad/{sha256_prefix}/openbao-plugin-secrets-nomad
-	expectedPrefix := ".oci-cache/secret-nomad/"
+	// Should point to .oci-cache/
+	expectedPrefix := ".oci-cache/"
 	if !strings.HasPrefix(target, expectedPrefix) {
 		t.Errorf("Symlink target should start with %q, got %q", expectedPrefix, target)
 	}
@@ -281,14 +282,14 @@ func TestReconcileOCIPlugins(t *testing.T) {
 			{
 				Type:      "secret",
 				Name:      "nomad",
-				Image:     "ghcr.io/openbao/openbao-plugin-secrets-nomad",
+				Image:     name.MustParseReference("ghcr.io/openbao/openbao-plugin-secrets-nomad:v0.1.4"),
 				Version:   "v0.1.4",
 				SHA256Sum: nomadPluginSHA256,
 			},
 			{
 				Type:      "secret",
 				Name:      "aws",
-				Image:     "ghcr.io/openbao/openbao-plugin-secrets-aws",
+				Image:     name.MustParseReference("ghcr.io/openbao/openbao-plugin-secrets-aws:v0.0.1"),
 				Version:   "v0.0.1",
 				SHA256Sum: awsPluginSHA256,
 			},
@@ -368,7 +369,7 @@ func TestPluginCacheStructure(t *testing.T) {
 
 	// Test plugin configuration
 	pluginConfig := &server.PluginConfig{
-		Image:      "docker.io/test/plugin",
+		Image:      name.MustParseReference("docker.io/test/plugin:latest"),
 		Version:    "latest",
 		Type:       "test",
 		Name:       "plugin",

--- a/website/content/docs/configuration/plugins.mdx
+++ b/website/content/docs/configuration/plugins.mdx
@@ -50,9 +50,7 @@ A `plugin` block defines an OCI-based plugin to download:
 
 ```hcl
 plugin "type" "name" {
-  image       = "registry.example.com/org/plugin"
-  version     = "v0.0.0"
-  sha256sum   = "sha256-checksum"
+  image = "registry.example.com/org/plugin:v0.0.0@sha256:digest"
 }
 ```
 
@@ -60,10 +58,8 @@ Or it specifies a plugin to automatically register that was manually downloaded:
 
 ```hcl
 plugin "type" "name" {
-  command     = "plugin-binary-name"
-  version     = "v0.0.0"
-  env         = ["MY_ENV=value"]
-  args        = ["-some-argument"]
+  command = "plugin-binary-name"
+  version = "v0.0.0"
 }
 ```
 
@@ -78,26 +74,32 @@ plugin versions.
 ### Parameters
 
 - `image` `(string: required)` - OCI artifact/image URL including registry and
-  repository. Conflicts with the `command` value. One of `image` or `command` is
-  required.
+  repository. Conflicts with the `command` value. One of `image` or `command`
+  is required. `image` may be pinned by digest and directly specify the plugin
+  version via its tag. See notes on `version` and several examples below.
 
 - `command` `(string: required)` - Command name of the plugin that has been
   manually downloaded. Conflicts with the `image` value. One of `image` or
   `command` is required.
 
 - `version` `(string: required)` - The (semantic) version of the plugin. When
-  `image` is set, this doubles as the image tag on the registry.
-
-- `sha256sum` `(string: optional)` - Expected SHA-256 digest of the plugin
-  binary. Must be a 64-character hexadecimal string. This is **required**
-  when `image` is set, but **optional** otherwise. When set, OpenBao will
-  revalidate the digest of the plugin binary on disk against what was configured
-  before executing the plugin, though note that the check is subject to a
-  [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) problem.
+  `image` is set and does not contain a tag, this doubles as the image tag on
+  the registry. When `image` is set and contains a tag but `version` is unset,
+  the image's tag doubles as the version. Unless image tag and the plugin's
+  embedded version differ, prefer leaving this field unset and embed the version
+  within `image` instead.
 
 - `args` `([]string: optional)` - Any arguments to pass to the running plugin.
 
 - `env` `([]string: optional)` - Any environment variables to pass to the running plugin.
+
+- `sha256sum` `(string: optional)` - Expected SHA-256 digest of the plugin
+  binary (read: not an OCI image digest). Must be a 64-character hexadecimal
+  string if set. This is only required when `image` is set but not pinned by
+  image digest, and **optional** otherwise. When set, OpenBao will revalidate
+  the digest of the plugin binary on disk against what was configured
+  before executing the plugin, though note that the check is subject to a
+  [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) problem.
 
 - `binary_name` `(string: optional)` - Name of the plugin binary file
   within the OCI image. Only applies when `image` is set. If unset, OpenBao
@@ -117,9 +119,7 @@ plugin versions.
     {
       "secret": {
         "aws": {
-          "image": "ghcr.io/openbao/openbao-plugin-secrets-aws",
-          "version": "v1.0.0",
-          "sha256sum": "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"
+          "image": "ghcr.io/openbao/openbao-plugin-secrets-aws:v0.1.0@sha256:ffff79125690e9a1f4cfd3e6d851657386a97c2e96e8d66a82adddb53e0b7359"
         }
       }
     }
@@ -132,9 +132,7 @@ plugin versions.
 
 ```hcl
 plugin "secret" "aws" {
-  image       = "ghcr.io/openbao/openbao-plugin-secrets-aws"
-  version     = "v1.0.0"
-  sha256sum   = "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"
+  image = "ghcr.io/openbao/openbao-plugin-secrets-aws:v0.1.0@sha256:ffff79125690e9a1f4cfd3e6d851657386a97c2e96e8d66a82adddb53e0b7359"
 }
 ```
 
@@ -217,9 +215,7 @@ plugin_directory = "/opt/openbao/plugins"
 plugin_download_behavior = "fail"
 
 plugin "secret" "aws" {
-  image       = "ghcr.io/openbao/openbao-plugin-secrets-aws"
-  version     = "v1.0.0"
-  sha256sum   = "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"
+  image = "ghcr.io/openbao/openbao-plugin-secrets-aws:v0.1.0@sha256:ffff79125690e9a1f4cfd3e6d851657386a97c2e96e8d66a82adddb53e0b7359"
 }
 ```
 


### PR DESCRIPTION
## Description

Works as demonstrated in the RFC.

## Rationale

See https://github.com/openbao/openbao/pull/3881.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
