### PR TITLE
test: Await token revocation

### DIFF
--- a/internal/vault/external_tests/standby/read_only_standby_test.go
+++ b/internal/vault/external_tests/standby/read_only_standby_test.go
@@ -24,6 +24,11 @@ import (
 )
 
 func TestReadOnlyStandby(t *testing.T) {
+	const (
+		timeout = 10 * time.Second
+		tick    = 100 * time.Millisecond
+	)
+
 	conf := vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"pki": logicalPki.Factory,
@@ -38,7 +43,7 @@ func TestReadOnlyStandby(t *testing.T) {
 	cluster := vault.NewTestCluster(t, &conf, &opts)
 
 	cluster.Start()
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
 	require.False(t, cluster.Cores[0].Standby())
@@ -63,27 +68,30 @@ func TestReadOnlyStandby(t *testing.T) {
 				"bar": expectedValue,
 			})
 			require.NoError(collect, err)
-		}, 10*time.Second, 100*time.Millisecond)
+		}, timeout, tick)
 
 		t.Logf("validating expected value on primary %d", i)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			data, err := primaryClient.KVv2("kv").Get(t.Context(), "foo")
 			require.NoError(collect, err)
 			require.Equal(collect, expectedValue, data.Data["bar"])
-		}, 10*time.Second, 100*time.Millisecond)
+		}, timeout, tick)
 
 		t.Logf("validating expected value on standby %d", i)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			data, err := standbyClient.KVv2("kv").Get(t.Context(), "foo")
 			require.NoError(collect, err)
 			require.Equal(collect, expectedValue, data.Data["bar"])
-		}, 10*time.Second, 100*time.Millisecond)
+		}, timeout, tick)
 	}
 
 	t.Log("revoking token")
-	require.NoError(t, primaryClient.Auth().Token().RevokeTreeWithContext(t.Context(), token.Auth.ClientToken))
-	_, err = standbyClient.KVv2("kv").Get(t.Context(), "foo")
-	require.ErrorContains(t, err, "permission denied", "token was revoked on the primary, should be declined by secondaries")
+	errRevoke := primaryClient.Auth().Token().RevokeTreeWithContext(t.Context(), token.Auth.ClientToken)
+	require.NoError(t, errRevoke)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err = standbyClient.KVv2("kv").Get(t.Context(), "foo")
+		require.ErrorContains(collect, err, "permission denied", "token was revoked on the primary, should be declined by secondaries")
+	}, timeout, tick)
 }
 
 func TestReadOnlyStandbysForwardingWrapping(t *testing.T) {


### PR DESCRIPTION
## Description

1. Add _require.EventuallyWithT_ for token revocation.
2. Add constants for the time the test awaits a condition, and the time the test evaluates a condition.
3. Replace a _defer_ with a _t.Cleanup_

```bash
go test github.com/openbao/openbao/v2/internal/vault/external_tests/standby -run '^TestReadOnlyStandby$'
```

## Rationale
_TestReadOnlyStandby_ suffered 12 failures from July 3rd to August 31st this year.

Resolves: contributes towards #2581 

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
