### PR TITLE
docs: remove oidc_discovery_url from kubernetes jwt/oidc provider

### DIFF
--- a/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
+++ b/website/content/docs/auth/jwt/oidc-providers/kubernetes.mdx
@@ -36,31 +36,23 @@ Kubernetes cluster requirements:
 
 #### Configuration steps when OpenBao is running in Kubernetes
 
-1. Find the issuer URL of the cluster.
+Enable and configure JWT auth in OpenBao.
 
-   ```bash
-   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
-   ```
-
-1. Enable and configure JWT auth in OpenBao.
-
-   ```bash
-   kubectl exec openbao-0 -- bao auth enable jwt
-   kubectl exec openbao-0 -- bao write auth/jwt/config -<<EOF
-   {
-      "oidc_discovery_url": "https://kubernetes.default.svc.cluster.local",
-      "provider_config": {
-          "provider": "kubernetes"
-      }
+```bash
+kubectl exec openbao-0 -- bao auth enable jwt
+kubectl exec openbao-0 -- bao write auth/jwt/config -<<EOF
+{
+   "provider_config": {
+       "provider": "kubernetes"
    }
-   EOF
-   ```
+}
+EOF
+```
 
-* `provider_config.provider` `(string: <required>)` - Name of the provider.
-   Must be set to "kubernetes".
-
-OpenBao automatically uses the service account token found at `/var/run/secrets/kubernetes.io/serviceaccount/token`
-for authentication with the Kubernetes API server, and the CA certificate at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+OpenBao automatically derives the OIDC discovery URL from the `KUBERNETES_SERVICE_HOST` and
+`KUBERNETES_SERVICE_PORT` environment variables set in every pod, uses the service account token found
+at `/var/run/secrets/kubernetes.io/serviceaccount/token` for authentication with the Kubernetes
+API server, and the CA certificate at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 to verify the server's TLS certificate. It supports short-lived tokens.
 
 No special Kubernetes RBAC permissions are required for the service account token.
@@ -75,6 +67,12 @@ may or may not be reachable. If not, you can configure JWT auth using
 [`jwt_validation_pubkeys`](#using-jwt-validation-public-keys) instead.
 
 :::
+
+1. Find the issuer URL of the cluster.
+
+   ```bash
+   ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
+   ```
 
 1. Ensure OIDC discovery URLs do not require authentication, as detailed
    [here][k8s-sa-issuer-discovery]:


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This PR corrects the configuration doc for the Kubernetes JWT/OIDC provider.

During development of the original PR we removed the ability to set `oidc_discovery_url` for reasons discussed in https://github.com/openbao/openbao/pull/2114#issuecomment-3631805603 but I missed changing the documentation to reflect that. This PR now corrects that.

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->


Resolves: #3920

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
