### PR TITLE
Fix recovery token generation via CLI

### DIFF
--- a/changelog/3924.txt
+++ b/changelog/3924.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/recovery: Fix generation of recovery token via `bao operator generate-root` by allowing status checks.
+```

--- a/internal/helper/testhelpers/testhelpers.go
+++ b/internal/helper/testhelpers/testhelpers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/openbao/openbao/api/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/consts"
-	"github.com/openbao/openbao/sdk/v2/helper/xor"
+	"github.com/openbao/openbao/sdk/v2/helper/roottoken"
 	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
 	"github.com/openbao/openbao/v2/internal/physical/raft"
@@ -100,15 +100,26 @@ func GenerateRootWithError(t testing.T, cluster *vault.TestCluster, kind Generat
 		return "", fmt.Errorf("generate root operation did not end successfully: %d / %d", status.Progress, status.Required)
 	}
 
-	tokenBytes, err := base64.RawStdEncoding.DecodeString(status.EncodedToken)
+	encoded := status.EncodedToken
+
+	// The CLI (`bao operator generate-root`) calls status before decoding the
+	// token to know the length.
+	switch kind {
+	case GenerateRootRegular:
+		status, err = client.Sys().GenerateRootStatus()
+	case GenerateRecovery:
+		status, err = client.Sys().GenerateRecoveryOperationTokenStatus()
+	}
 	if err != nil {
 		return "", err
 	}
-	tokenBytes, err = xor.XORBytes(tokenBytes, []byte(otp))
+
+	token, err := roottoken.DecodeToken(encoded, otp, status.OTPLength)
 	if err != nil {
 		return "", err
 	}
-	return string(tokenBytes), nil
+
+	return token, nil
 }
 
 // RandomWithPrefix is used to generate a unique name with a prefix, for

--- a/internal/vault/generate_root.go
+++ b/internal/vault/generate_root.go
@@ -100,10 +100,6 @@ func (c *Core) lockRootGeneration() (func(), error) {
 		c.stateLock.RUnlock()
 		return nil, consts.ErrStandby
 	}
-	if !c.barrier.Sealed() && c.recoveryMode {
-		c.stateLock.RUnlock()
-		return nil, errors.New("attempted to generate recovery operation token when already unsealed")
-	}
 
 	return c.stateLock.RUnlock, nil
 }
@@ -175,6 +171,10 @@ func (c *Core) GenerateRootInit(ctx context.Context, otp, pgpKey string, strateg
 		return err
 	}
 	defer unlock()
+
+	if !c.barrier.Sealed() && c.recoveryMode {
+		return errors.New("attempted to generate recovery operation token when already unsealed")
+	}
 
 	return c.lockedGenerateRootInit(ctx, otp, pgpKey, strategy)
 }
@@ -265,6 +265,10 @@ func (c *Core) GenerateRootUpdate(ctx context.Context, key []byte, nonce string,
 		return nil, err
 	}
 	defer unlock()
+
+	if !c.barrier.Sealed() && c.recoveryMode {
+		return nil, errors.New("attempted to generate recovery operation token when already unsealed")
+	}
 
 	return c.lockedGenerateRootUpdate(ctx, key, nonce, strategy)
 }


### PR DESCRIPTION

<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

When decoding a recovery token, the CLI does not remember OTP length and queries the server for it again. At this point, because the server is unsealed, it thinks it is already done generating the token and refuses to give status back.

Allow status operations but deny init/update.

Using `encoded` and `otp` on the CLI, a hack like the following python script would decode this on any broken versions:

```python
import os, base64
otp=bytes(os.getenv("otp"), "utf8")
encoded = base64.decodebytes(bytes(os.getenv("encoded") + "==", "utf8"))
print(bytes(map(lambda a: a[1] ^ otp[a[0]], enumerate(encoded))).decode("utf8"))
```

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: [#openssf-openbao-support > Recover broken openbao :/ @ 💬](https://linuxfoundation.zulipchat.com/#narrow/channel/530381-openssf-openbao-support/topic/Recover.20broken.20openbao.20.3A.2F/near/621166496)

fyi @wslabosz-reply 

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
