### PR TITLE
Fix listing of namespaces in recovery mode

### DIFF
--- a/changelog/3925.txt
+++ b/changelog/3925.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/recovery: Avoid panic during listing of namespace contents due to uninitialized namespace store.
+```

--- a/internal/vault/external_tests/misc/recovery_test.go
+++ b/internal/vault/external_tests/misc/recovery_test.go
@@ -27,6 +27,7 @@ func TestRecovery(t *testing.T) {
 
 	var keys [][]byte
 	var secretUUID string
+	var nsUUID string
 	var rootToken string
 	{
 		conf := vault.CoreConfig{
@@ -65,6 +66,12 @@ func TestRecovery(t *testing.T) {
 			t.Fatalf("secret mount not found, mounts: %v", mounts)
 		}
 		secretUUID = secretMount.UUID
+
+		// Create a namespace.
+		nsOutput, err := cluster.Cores[0].Client.Sys().CreateNamespace("ns1", nil)
+		require.NoError(t, err)
+		nsUUID = nsOutput.UUID
+
 		cluster.EnsureCoresSealed(t)
 		keys = cluster.BarrierKeys
 	}
@@ -126,6 +133,13 @@ func TestRecovery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Check our namespace entry.
+		values, err := client.Logical().List(path.Join("sys/raw/namespaces/", nsUUID))
+		require.NoError(t, err)
+		require.Contains(t, values.Data, "keys")
+		require.Contains(t, values.Data["keys"], "core/")
+
 		cluster.EnsureCoresSealed(t)
 	}
 

--- a/internal/vault/namespace_store.go
+++ b/internal/vault/namespace_store.go
@@ -1747,6 +1747,13 @@ func (ns *NamespaceStore) LockNamespace(ctx context.Context, path string) (strin
 // NamespaceByStoragePath parses an absolute storage path and returns the
 // matching namespace that the path belongs to.
 func (c *Core) NamespaceByStoragePath(ctx context.Context, path string) (*namespace.Namespace, string, error) {
+	if c.recoveryMode {
+		// In recovery mode, we do not have a namespace store so treat
+		// everything as relative to the root namespace. This means that
+		// sealed namespaces will not function.
+		return namespace.RootNamespace, path, nil
+	}
+
 	rest, ok := strings.CutPrefix(path, barrier.NamespacePrefix)
 	if !ok || rest == "" {
 		return namespace.RootNamespace, path, nil


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

When introducing namespace sealing, a call to namespace store was done unconditionally; this lead to OpenBao panicking in recovery mode because namespace store is not set up.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

Resolves: [#openssf-openbao-support > Recover broken openbao :/ @ 💬](https://linuxfoundation.zulipchat.com/#narrow/channel/530381-openssf-openbao-support/topic/Recover.20broken.20openbao.20.3A.2F/near/621172827) 

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
