### PR TITLE
fix: `sys/leader` does not contain `is_self` on standbys

### DIFF
--- a/changelog/3932.txt
+++ b/changelog/3932.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: The response of `sys/leader` did not contain `is_self` when it was supposed to be `false`.
+```

--- a/internal/http/sys_leader_test.go
+++ b/internal/http/sys_leader_test.go
@@ -5,29 +5,84 @@ package http
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
+	"time"
 
+	"github.com/openbao/openbao/v2/internal/helper/testhelpers"
 	"github.com/openbao/openbao/v2/internal/vault"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSysLeader_get(t *testing.T) {
-	core, _, _ := vault.TestCoreUnsealed(t)
-	ln, addr := TestServer(t, core)
-	defer ln.Close()
+	requestSysLeader := func(t *testing.T, client *http.Client, addr string) map[string]any {
+		t.Helper()
 
-	resp, err := http.Get(addr + "/v1/sys/leader")
-	if err != nil {
-		t.Fatalf("err: %s", err)
+		resp, err := client.Get(addr + "/v1/sys/leader")
+		require.NoError(t, err)
+
+		var actual map[string]any
+
+		testResponseStatus(t, resp, 200)
+		testResponseBody(t, resp, &actual)
+
+		return actual
 	}
 
-	var actual map[string]any
-	expected := map[string]any{
-		"ha_enabled": false,
-	}
-	testResponseStatus(t, resp, 200)
-	testResponseBody(t, resp, &actual)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v \n%#v", actual, expected)
-	}
+	t.Run("non-ha", func(t *testing.T) {
+		core, _, _ := vault.TestCoreUnsealed(t)
+		ln, addr := TestServer(t, core)
+		defer func() {
+			require.NoError(t, ln.Close())
+		}()
+
+		actual := requestSysLeader(t, http.DefaultClient, addr)
+		require.Equal(t, map[string]any{
+			"ha_enabled": false,
+		}, actual)
+	})
+
+	t.Run("ha", func(t *testing.T) {
+		testStartTime := time.Now()
+		cluster := vault.NewTestCluster(t, nil, &vault.TestClusterOptions{
+			NumCores:    2,
+			HandlerFunc: Handler,
+		})
+		testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
+		t.Cleanup(cluster.Cleanup)
+
+		// primary
+		actual := requestSysLeader(t, &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig:   cluster.Nodes()[0].TLSConfig(),
+				ForceAttemptHTTP2: true,
+			},
+		}, cluster.Cores[0].Client.Address())
+
+		require.Contains(t, actual, "active_time")
+		activeTime, err := time.Parse(time.RFC3339, actual["active_time"].(string))
+		require.NoError(t, err)
+		require.WithinRange(t, activeTime, testStartTime, time.Now())
+		delete(actual, "active_time")
+
+		expected := map[string]any{
+			"ha_enabled":             true,
+			"is_self":                true,
+			"leader_address":         cluster.Cores[0].Client.Address(),
+			"leader_cluster_address": cluster.Cores[0].ClusterAddr(),
+			// "active_time" is tested above and removed from the map
+		}
+		require.Equal(t, expected, actual)
+
+		// standby
+		expected["is_self"] = false
+
+		actual = requestSysLeader(t, &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig:   cluster.Nodes()[1].TLSConfig(),
+				ForceAttemptHTTP2: true,
+			},
+		}, cluster.Cores[1].Client.Address())
+
+		require.Equal(t, expected, actual)
+	})
 }

--- a/internal/vault/logical_system.go
+++ b/internal/vault/logical_system.go
@@ -4523,7 +4523,7 @@ func (c *Core) GetSealStatus(ctx context.Context, lock bool) (*CoreSealStatusRes
 
 type LeaderResponse struct {
 	HAEnabled            bool      `json:"ha_enabled"`
-	IsSelf               bool      `json:"is_self,omitempty"`
+	IsSelf               *bool     `json:"is_self,omitempty"`
 	ActiveTime           time.Time `json:"active_time,omitzero"`
 	LeaderAddress        string    `json:"leader_address,omitempty"`
 	LeaderClusterAddress string    `json:"leader_cluster_address,omitempty"`
@@ -4553,7 +4553,7 @@ func (core *Core) GetLeaderStatusLocked() (*LeaderResponse, error) {
 
 	resp := &LeaderResponse{
 		HAEnabled:            true,
-		IsSelf:               isLeader,
+		IsSelf:               &isLeader,
 		LeaderAddress:        address,
 		LeaderClusterAddress: clusterAddr,
 		ActiveTime:           core.activeTime,


### PR DESCRIPTION
## Description

`omitempty` causes the json marshaller to drop the value if it's "empty" which is `false` for boolean values. Changing it to a bool pointer fixes this (`nil` -> drop, pointer to `false` or `true` -> keep)

## Rationale

This is a regression introduced in https://github.com/openbao/openbao/pull/2383

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
