### PR TITLE
Allow none compression type in sys/raw

### DIFF
--- a/changelog/3933.txt
+++ b/changelog/3933.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sys/raw: Allow creating new entries via sys/raw; when doing so without compression, `compression_type="none"` must be specified.
+```

--- a/internal/vault/logical_raw.go
+++ b/internal/vault/logical_raw.go
@@ -202,23 +202,29 @@ func (b *RawBackend) handleRawWrite(ctx context.Context, req *logical.Request, d
 		if err != nil {
 			return handleError(err)
 		}
-		if valueBytes == nil {
+		if valueBytes == nil && compressionType == "" {
 			err := "cannot figure out compression type because entry does not exist"
 			return logical.ErrorResponse(err), logical.ErrInvalidRequest
 		}
 
-		// For cases where DecompressWithCanary errored, treat entry as non-compressed data.
-		_, existingCompressionType, _, _ := compressutil.DecompressWithCanary(valueBytes)
-
-		// Ensure compression_type matches existing entries' compression
-		// except allow writing non-compressed data over compressed data
-		if existingCompressionType != compressionType && compressionType != "" {
-			err := "the entry uses a different compression scheme then compression_type"
-			return logical.ErrorResponse(err), logical.ErrInvalidRequest
+		if compressionType == "none" {
+			compressionType = ""
 		}
 
-		if !compressionTypeOk {
-			compressionType = existingCompressionType
+		if valueBytes != nil {
+			// For cases where DecompressWithCanary errored, treat entry as non-compressed data.
+			_, existingCompressionType, _, _ := compressutil.DecompressWithCanary(valueBytes)
+
+			// Ensure compression_type matches existing entries' compression
+			// except allow writing non-compressed data over compressed data
+			if existingCompressionType != compressionType && compressionType != "" {
+				err := "the entry uses a different compression scheme then compression_type"
+				return logical.ErrorResponse(err), logical.ErrInvalidRequest
+			}
+
+			if !compressionTypeOk {
+				compressionType = existingCompressionType
+			}
 		}
 	}
 

--- a/website/content/docs/api/system/raw.mdx
+++ b/website/content/docs/api/system/raw.mdx
@@ -64,9 +64,12 @@ mount system.
 - `value` `(string: <required>)` – Specifies the value of the key.
 
 - `compression_type` `(string: "")` - Create/update using the compressed form
-  of `value`. Supported `compression_type` values are `gzip`, `snappy`, or `""`.
-  `""` means no compression is used. If omitted and key already exists, update
-  uses the same compression (or no compression) as the existing value.
+  of `value`. Supported `compression_type` values are `gzip`, `snappy`, `""`,
+  or `none`. `""` means no compression is used but the existing entry is
+  checked to ensure types align. `none` is used for no compression without
+  checking an existing entry (required for creating an entry with no
+  compression). If omitted and the key already exists, update uses the same
+  compression (or no compression) as the existing value.
 
 - `encoding` `(string: "")` - Specifies the encoding of `value`. Defaults to no
   encoding. Use "base64" if `value` is encoded in base64.


### PR DESCRIPTION


<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

When specified on the `sys/raw` update API, this allows creation of new entries which do not have compression, versus inferring against a currently existing entry.

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Related: [#openssf-openbao-support > Recover broken openbao :/ @ 💬](https://linuxfoundation.zulipchat.com/#narrow/channel/530381-openssf-openbao-support/topic/Recover.20broken.20openbao.20.3A.2F/near/621187163)

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
