### PR TITLE
Only provision file backend for migration

### DIFF
--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -36,7 +36,6 @@ import (
 	logicalDb "github.com/openbao/openbao/v2/internal/builtin/logical/database"
 	logicalKv "github.com/openbao/openbao/v2/internal/builtin/logical/kv"
 
-	physFile "github.com/openbao/openbao/sdk/v2/physical/file"
 	physInmem "github.com/openbao/openbao/v2/internal/physical/inmem"
 	physPebble "github.com/openbao/openbao/v2/internal/physical/pebbledb"
 	physPostgresql "github.com/openbao/openbao/v2/internal/physical/postgresql"
@@ -144,7 +143,6 @@ var (
 	}
 
 	physicalBackends = map[string]physical.Factory{
-		"file":       physFile.NewFileBackend,
 		"inmem_ha":   physInmem.NewInmemHA,
 		"inmem":      physInmem.NewInmem,
 		"raft":       physRaft.NewRaftBackend,

--- a/internal/command/operator_migrate.go
+++ b/internal/command/operator_migrate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/hclutil"
 	"github.com/openbao/openbao/sdk/v2/helper/logging"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	physFile "github.com/openbao/openbao/sdk/v2/physical/file"
 	"github.com/openbao/openbao/v2/internal/command/server"
 	"github.com/openbao/openbao/v2/internal/physical/raft"
 	"github.com/openbao/openbao/v2/internal/vault"
@@ -164,6 +165,8 @@ func (c *OperatorMigrateCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error loading configuration from %s: %s", c.flagConfig, err))
 		return 1
 	}
+
+	c.PhysicalBackends["file"] = physFile.NewFileBackend
 
 	if err := c.migrate(config); err != nil {
 		if err == errAbort {

--- a/internal/command/operator_migrate_test.go
+++ b/internal/command/operator_migrate_test.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/openbao/openbao/sdk/v2/physical"
+	physFile "github.com/openbao/openbao/sdk/v2/physical/file"
 	"github.com/openbao/openbao/v2/internal/command/server"
 	"github.com/openbao/openbao/v2/internal/vault"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestMigration(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		data := generateData()
 
-		fromFactory := physicalBackends["file"]
+		fromFactory := physFile.NewFileBackend
 
 		folder := t.TempDir()
 
@@ -69,7 +70,7 @@ func TestMigration(t *testing.T) {
 	t.Run("Concurrent migration", func(t *testing.T) {
 		data := generateData()
 
-		fromFactory := physicalBackends["file"]
+		fromFactory := physFile.NewFileBackend
 
 		folder := t.TempDir()
 
@@ -117,7 +118,7 @@ func TestMigration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		toFactory := physicalBackends["file"]
+		toFactory := physFile.NewFileBackend
 		folder := t.TempDir()
 		confTo := map[string]string{
 			"path": folder,
@@ -156,7 +157,7 @@ func TestMigration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		toFactory := physicalBackends["file"]
+		toFactory := physFile.NewFileBackend
 		folder := t.TempDir()
 		confTo := map[string]string{
 			"path": folder,


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This completes the deprecation and prevents file's use for server operations going forward. As OpenBao still supports one-shot upgrades (barring deprecations and removals), we'll likely keep the file backend around in sdk/ indefinitely as doesn't have any unique dependencies of its own.


## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #2846

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
