### PR TITLE
Clear read-only error on plugin reload

### DIFF
--- a/changelog/3936.txt
+++ b/changelog/3936.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/plugins: Ensure that a mount's storage view is no longer marked read-only following a successful plugin reload.
+```

--- a/internal/vault/audit.go
+++ b/internal/vault/audit.go
@@ -120,13 +120,11 @@ func (c *Core) enableAudit(ctx context.Context, entry *routing.MountEntry, updat
 		return err
 	}
 
-	origViewReadOnlyErr := view.GetReadOnlyErr()
-
-	// Mark the view as read-only until the mounting is complete and
-	// ensure that it is reset after. This ensures that there will be no
-	// writes during the construction of the backend.
+	// Mark the view as read-only until the mounting is complete and ensure that
+	// it is reset after. This ensures that there will be no writes during the
+	// construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-	defer view.SetReadOnlyErr(origViewReadOnlyErr)
+	defer view.SetReadOnlyErr(nil)
 
 	// Lookup the new backend
 	backend, err := c.newAuditBackend(ctx, entry, view, entry.Options)
@@ -462,18 +460,16 @@ func (c *Core) reconcileAudits(req reconcileAuditsRequests) error {
 			return err
 		}
 
-		origViewReadOnlyErr := view.GetReadOnlyErr()
-
 		// Mark the view as read-only until the mounting is complete and
 		// ensure that it is reset after. This ensures that there will be no
 		// writes during the construction of the backend.
 		view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 		if req.isInitial {
 			c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
-				view.SetReadOnlyErr(origViewReadOnlyErr)
+				view.SetReadOnlyErr(nil)
 			})
 		} else {
-			defer view.SetReadOnlyErr(origViewReadOnlyErr)
+			defer view.SetReadOnlyErr(nil)
 		}
 
 		// Initialize the backend

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -141,13 +141,9 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 		return err
 	}
 
-	origViewReadOnlyErr := view.GetReadOnlyErr()
-
-	// Mark the view as read-only until the mounting is complete and
-	// ensure that it is reset after. This ensures that there will be no
-	// writes during the construction of the backend.
+	// Mark the view as read-only until the mounting is complete. This ensures
+	// that there will be no writes during the construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-	defer view.SetReadOnlyErr(origViewReadOnlyErr)
 
 	var backend logical.Backend
 	// Create the new backend
@@ -187,9 +183,9 @@ func (c *Core) enableCredentialInternalWithLock(ctx context.Context, entry *rout
 		return err
 	}
 
-	// restore the original readOnlyErr, so we can write to the view in
-	// Initialize() if necessary
-	view.SetReadOnlyErr(origViewReadOnlyErr)
+	// Mark as writable again and ensure Initialize can write to the view if
+	// necessary.
+	view.SetReadOnlyErr(nil)
 
 	// Initialize, using the core's active context.
 	activeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
@@ -1108,14 +1104,12 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 		return nil, err
 	}
 
-	origViewReadOnlyErr := view.GetReadOnlyErr()
-
-	// Mark the view as read-only until the mounting is complete and
-	// ensure that it is reset after. This ensures that there will be no
-	// writes during the construction of the backend.
+	// Mark the view as read-only until the mounting is complete and ensure that
+	// it is reset after. This ensures that there will be no writes during the
+	// construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 	if slices.Contains(singletonMounts, entry.Type) {
-		defer view.SetReadOnlyErr(origViewReadOnlyErr)
+		defer view.SetReadOnlyErr(nil)
 	}
 
 	// Initialize the backend
@@ -1182,7 +1176,7 @@ func (c *Core) setupCredential(ctx context.Context, entry *routing.MountEntry) (
 			return
 		}
 		if !slices.Contains(singletonMounts, localEntry.Type) {
-			view.SetReadOnlyErr(origViewReadOnlyErr)
+			view.SetReadOnlyErr(nil)
 		}
 
 		if err := backend.Initialize(namespace.ContextWithNamespace(ctx, localEntry.Namespace), &logical.InitializationRequest{Storage: view}); err != nil {

--- a/internal/vault/mount.go
+++ b/internal/vault/mount.go
@@ -274,15 +274,9 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 		return err
 	}
 
-	origReadOnlyErr := view.GetReadOnlyErr()
-
-	// Mark the view as read-only until the mounting is complete and
-	// ensure that it is reset after. This ensures that there will be no
-	// writes during the construction of the backend.
+	// Mark the view as read-only until the mounting is complete. This ensures
+	// that there will be no writes during the construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
-	// We defer this because we're already up and running so we don't need to
-	// time it for after postUnseal
-	defer view.SetReadOnlyErr(origReadOnlyErr)
 
 	var backend logical.Backend
 	// Create the new backend
@@ -328,9 +322,9 @@ func (c *Core) mountInternalWithLock(ctx context.Context, entry *routing.MountEn
 		return err
 	}
 
-	// restore the original readOnlyErr, so we can write to the view in
-	// Initialize() if necessary
-	view.SetReadOnlyErr(origReadOnlyErr)
+	// Mark as writable again and ensure Initialize can write to the view if
+	// necessary.
+	view.SetReadOnlyErr(nil)
 
 	// Initialize, using the core's active context.
 	activeCtx := namespace.ContextWithNamespace(c.activeContext.Load(), ns)
@@ -1490,14 +1484,12 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 		return nil, err
 	}
 
-	origReadOnlyErr := view.GetReadOnlyErr()
-
-	// Mark the view as read-only until the mounting is complete and
-	// ensure that it is reset after. This ensures that there will be no
-	// writes during the construction of the backend.
+	// Mark the view as read-only until the mounting is complete and ensure that
+	// it is reset after. This ensures that there will be no writes during the
+	// construction of the backend.
 	view.SetReadOnlyErr(logical.ErrSetupReadOnly)
 	if slices.Contains(singletonMounts, entry.Type) {
-		defer view.SetReadOnlyErr(origReadOnlyErr)
+		defer view.SetReadOnlyErr(nil)
 	}
 
 	// Create the new backend
@@ -1553,7 +1545,7 @@ func (c *Core) setupMount(ctx context.Context, entry *routing.MountEntry) (func(
 			return
 		}
 		if !slices.Contains(singletonMounts, localEntry.Type) {
-			view.SetReadOnlyErr(origReadOnlyErr)
+			view.SetReadOnlyErr(nil)
 		}
 
 		if err := backend.Initialize(namespace.ContextWithNamespace(ctx, localEntry.Namespace), &logical.InitializationRequest{Storage: view}); err != nil {

--- a/internal/vault/plugin_reload.go
+++ b/internal/vault/plugin_reload.go
@@ -207,6 +207,12 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *routing.MountEntr
 	// Set the backend back
 	re.Backend = backend
 
+	// We may have loaded a nil backend on unseal due to a missing plugin,
+	// leaving the mount's storage view marked read-only. At this point we're
+	// sure we've replaced the backend with a working one, so ensure the storage
+	// view is writable again.
+	re.StorageView.SetReadOnlyErr(nil)
+
 	// Initialize the backend after reload. This is a no-op for backends < v5 which
 	// rely on lazy loading for initialization. v5 backends do not rely on lazy loading
 	// for initialization unless the plugin process is killed. Reload of a v5 backend

--- a/internal/vault/routing/router.go
+++ b/internal/vault/routing/router.go
@@ -67,7 +67,7 @@ type RouteEntry struct {
 	tainted       bool
 	Backend       logical.Backend
 	MountEntry    *MountEntry
-	StorageView   logical.Storage
+	StorageView   barrier.View
 	StoragePrefix string
 	rootPaths     atomic.Pointer[radix.Tree]
 	loginPaths    atomic.Pointer[loginPathsEntry]


### PR DESCRIPTION
## Description

When unsealing, a mount's storage view may remain marked read-only indefinitely beyond the setup phase if the backend did not come up successfully ("nil backend"). This happens when the mount's backing plugin is no longer available, e.g., because it was a builtin that's been removed or the plugin was deregistered.

This change ensures that a mount's storage view is no longer marked read-only when the mount sees a successful plugin reload, unblocking live migrations from builtin->external plugins.

Calling `SetReadOnlyErr(nil)` felt a little awkward since it is never otherwise used this way. Instead, mount setup code always passes the result of a previous `GetReadOnlyErr()` to return back to some theoretical prior error state. I don't however see any scenario where mount setup would restore to a non-nil error, so I've simplified that code by passing `nil` directly, hopefully making it easier to read.

## Rationale

See https://github.com/openbao/openbao/pull/3486#issuecomment-5445870167, https://github.com/openbao/openbao/pull/3710#discussion_r3737017357 for context.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
