### PR TITLE
fix error messages in raft snapshot restore cmd

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -254,7 +254,7 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 	}
 
 	r := c.c.NewRequest(http.MethodPost, path)
-	r.Body = snapReader
+	r.Body = io.NopCloser(snapReader)
 
 	resp, err := c.c.httpRequestWithContext(ctx, r)
 	if err != nil {

--- a/changelog/3939.txt
+++ b/changelog/3939.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command/operator: Fix double file close in snapshot restoration.
+```

--- a/internal/command/operator_raft_snapshot_restore.go
+++ b/internal/command/operator_raft_snapshot_restore.go
@@ -88,12 +88,12 @@ func (c *OperatorRaftSnapshotRestoreCommand) Run(args []string) int {
 
 	snapReader, err := os.Open(snapFile)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error opening policy file: %s", err))
+		c.UI.Error(fmt.Sprintf("Error opening snapshot file: %s", err))
 		return 2
 	}
 	defer func() {
 		if err := snapReader.Close(); err != nil {
-			c.UI.Error(fmt.Sprintf("Error properly closing policy file: %s", err))
+			c.UI.Error(fmt.Sprintf("Error properly closing snapshot file: %s", err))
 		}
 	}()
 


### PR DESCRIPTION
## Description

This merge request aims to fix a double closing of the file handler. This comes from [http.NewRequestWithContext](https://pkg.go.dev/net/http#NewRequestWithContext) closing "Closables" when doing the request. While this could be solved with checking for that error and filtering it out, I think passing the responsibility of closing the file handler (in this example) back to the "caller function" is a better design.

While working this out, I also adjusted some error messages

## Rationale

Resolves: #3663

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
