### PR TITLE
Drop github.com/coreos/go-systemd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/containerd/platforms v0.2.1
-	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/duosecurity/duo_api_golang v0.2.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/
 github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
-github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/command/agent.go
+++ b/internal/command/agent.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	systemd "github.com/coreos/go-systemd/v22/daemon"
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
@@ -49,6 +48,7 @@ import (
 	"github.com/openbao/openbao/v2/internal/helper/listenerutil"
 	"github.com/openbao/openbao/v2/internal/helper/logging"
 	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
+	"github.com/openbao/openbao/v2/internal/helper/systemd"
 	"github.com/openbao/openbao/v2/internal/helper/useragent"
 	"github.com/openbao/openbao/v2/internal/version"
 )
@@ -790,7 +790,7 @@ func (c *AgentCommand) Run(args []string) int {
 	}
 
 	// Notify systemd that the server is ready (if applicable)
-	c.notifySystemd(systemd.SdNotifyReady)
+	c.notifySystemd(systemd.Ready)
 
 	defer func() {
 		if err := c.removePidFile(config.PidFile); err != nil {
@@ -813,7 +813,7 @@ func (c *AgentCommand) Run(args []string) int {
 		}
 	}
 
-	c.notifySystemd(systemd.SdNotifyStopping)
+	c.notifySystemd(systemd.Stopping)
 
 	return exitCode
 }
@@ -902,7 +902,7 @@ func verifyRequestHeader(handler http.Handler) http.Handler {
 }
 
 func (c *AgentCommand) notifySystemd(status string) {
-	sent, err := systemd.SdNotify(false, status)
+	sent, err := systemd.Notify(status)
 	if err != nil {
 		c.logger.Error("error notifying systemd", "error", err)
 	} else {
@@ -1135,8 +1135,8 @@ func (c *AgentCommand) loadConfig(paths []string) (*agentConfig.Config, error) {
 // * TLS config for the upstream vault connection (ca_cert, ca_path, client_cert, client_key)
 func (c *AgentCommand) reloadConfig(paths []string) error {
 	// Notify systemd that the server is reloading
-	c.notifySystemd(systemd.SdNotifyReloading)
-	defer c.notifySystemd(systemd.SdNotifyReady)
+	c.notifySystemd(systemd.Reloading)
+	defer c.notifySystemd(systemd.Ready)
 
 	var errors error
 

--- a/internal/command/proxy.go
+++ b/internal/command/proxy.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	systemd "github.com/coreos/go-systemd/v22/daemon"
 	"github.com/hashicorp/cli"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
@@ -42,6 +41,7 @@ import (
 	"github.com/openbao/openbao/v2/internal/helper/listenerutil"
 	"github.com/openbao/openbao/v2/internal/helper/logging"
 	"github.com/openbao/openbao/v2/internal/helper/metricsutil"
+	"github.com/openbao/openbao/v2/internal/helper/systemd"
 	"github.com/openbao/openbao/v2/internal/helper/useragent"
 	"github.com/openbao/openbao/v2/internal/version"
 	"github.com/posener/complete"
@@ -714,7 +714,7 @@ func (c *ProxyCommand) Run(args []string) int {
 	}
 
 	// Notify systemd that the server is ready (if applicable)
-	c.notifySystemd(systemd.SdNotifyReady)
+	c.notifySystemd(systemd.Ready)
 
 	defer func() {
 		if err := c.removePidFile(config.PidFile); err != nil {
@@ -728,7 +728,7 @@ func (c *ProxyCommand) Run(args []string) int {
 		c.UI.Error("Error encountered during run, refer to logs for more details.")
 		exitCode = 1
 	}
-	c.notifySystemd(systemd.SdNotifyStopping)
+	c.notifySystemd(systemd.Stopping)
 	return exitCode
 }
 
@@ -801,7 +801,7 @@ func (c *ProxyCommand) applyConfigOverrides(f *FlagSets, config *proxyConfig.Con
 }
 
 func (c *ProxyCommand) notifySystemd(status string) {
-	sent, err := systemd.SdNotify(false, status)
+	sent, err := systemd.Notify(status)
 	if err != nil {
 		c.logger.Error("error notifying systemd", "error", err)
 	} else {
@@ -1033,8 +1033,8 @@ func (c *ProxyCommand) loadConfig(paths []string) (*proxyConfig.Config, error) {
 // * TLS certs for listeners
 func (c *ProxyCommand) reloadConfig(paths []string) error {
 	// Notify systemd that the server is reloading
-	c.notifySystemd(systemd.SdNotifyReloading)
-	defer c.notifySystemd(systemd.SdNotifyReady)
+	c.notifySystemd(systemd.Reloading)
+	defer c.notifySystemd(systemd.Ready)
 
 	var errors error
 

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -24,7 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	systemd "github.com/coreos/go-systemd/v22/daemon"
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
@@ -52,6 +51,7 @@ import (
 	"github.com/openbao/openbao/v2/internal/helper/osutil"
 	"github.com/openbao/openbao/v2/internal/helper/pluginutil/oci"
 	"github.com/openbao/openbao/v2/internal/helper/profiles"
+	"github.com/openbao/openbao/v2/internal/helper/systemd"
 	"github.com/openbao/openbao/v2/internal/helper/testhelpers/teststorage"
 	"github.com/openbao/openbao/v2/internal/helper/useragent"
 	vaulthttp "github.com/openbao/openbao/v2/internal/http"
@@ -1408,7 +1408,7 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	// Notify systemd that the server is ready (if applicable)
-	c.notifySystemd(systemd.SdNotifyReady)
+	c.notifySystemd(systemd.Ready)
 
 	// Output the header that the server has started
 	if !c.logFlags.flagCombineLogs {
@@ -1475,7 +1475,7 @@ func (c *ServerCommand) Run(args []string) int {
 			c.UI.Output("==> OpenBao reload triggered")
 
 			// Notify systemd that the server is reloading config
-			c.notifySystemd(systemd.SdNotifyReloading)
+			c.notifySystemd(systemd.Reloading)
 
 			// Check for new log level
 			var config *server.Config
@@ -1552,7 +1552,7 @@ func (c *ServerCommand) Run(args []string) int {
 			}
 
 			// Notify systemd that the server has completed reloading config
-			c.notifySystemd(systemd.SdNotifyReady)
+			c.notifySystemd(systemd.Ready)
 
 		case <-c.SigUSR2Ch:
 			logWriter := c.logger.StandardWriter(&hclog.StandardLoggerOptions{})
@@ -1640,7 +1640,7 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 	// Notify systemd that the server is shutting down
-	c.notifySystemd(systemd.SdNotifyStopping)
+	c.notifySystemd(systemd.Stopping)
 
 	// Stop the listeners so that we don't process further client requests.
 	c.cleanupGuard.Do(listenerCloseFunc)
@@ -1691,7 +1691,7 @@ func (c *ServerCommand) configureLogging(config *server.Config) (hclog.Intercept
 }
 
 func (c *ServerCommand) notifySystemd(status string) {
-	sent, err := systemd.SdNotify(false, status)
+	sent, err := systemd.Notify(status)
 	if err != nil {
 		c.logger.Error("error notifying systemd", "error", err)
 	} else {

--- a/internal/helper/systemd/notify.go
+++ b/internal/helper/systemd/notify.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package systemd
+
+import (
+	"net"
+	"os"
+)
+
+const (
+	Ready     = "READY=1"
+	Stopping  = "STOPPING=1"
+	Reloading = "RELOADING=1"
+)
+
+// Notify implements systemd's NOTIFY_SOCKET protocol.
+// See also: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
+func Notify(state string) (bool, error) {
+	socket := os.Getenv("NOTIFY_SOCKET")
+	if socket == "" {
+		return false, nil
+	}
+
+	addr := &net.UnixAddr{
+		Name: socket,
+		Net:  "unixgram",
+	}
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	if _, err = conn.Write([]byte(state)); err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
## Description

Replaces github.com/coreos/go-systemd with a tiny helper package that reimplements `sd_notify` functionality.

## Rationale

Systemd's `NOTIFY_SOCKET` is a very simple protocol that we don't need a larger dependency to implement for us.

We've also ran into troubles with this library previously, see https://github.com/openbao/openbao/pull/2588. This still prevents us from upgrading, though there hasn't been a reason to.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
