### PR TITLE
Make semgrep timer rule happy

### DIFF
--- a/internal/vault/ha.go
+++ b/internal/vault/ha.go
@@ -1080,6 +1080,7 @@ func (c *Core) maybeBypassGRPCRequirement(ctx context.Context) bool {
 			}
 		}()
 
+		t := time.NewTimer(lockRetryInterval)
 		for {
 			select {
 			case <-ctx.Done():
@@ -1088,7 +1089,7 @@ func (c *Core) maybeBypassGRPCRequirement(ctx context.Context) bool {
 				// state change.
 				restart = false
 				return
-			case <-time.After(lockRetryInterval):
+			case <-t.C:
 			}
 
 			held, _, err := lock.Value()
@@ -1100,6 +1101,8 @@ func (c *Core) maybeBypassGRPCRequirement(ctx context.Context) bool {
 			if held {
 				return
 			}
+
+			t.Reset(lockRetryInterval)
 		}
 	}()
 


### PR DESCRIPTION
## Description

See semgrep failures on pushes to main.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
