### PR TITLE
Update `update_time` timestamp on KVv2 deletion operations

### DIFF
--- a/changelog/3963.txt
+++ b/changelog/3963.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/kv: Delete, undelete and destroy operations update the `update_time` timestamp of the version metadata.
+```

--- a/internal/builtin/logical/kv/path_data.go
+++ b/internal/builtin/logical/kv/path_data.go
@@ -654,10 +654,10 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			}
 		}
 
-		lv.DeletionTime = timestamppb.Now()
-
-		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		if err != nil {
+		now := timestamppb.Now()
+		lv.DeletionTime = now
+		meta.UpdatedTime = now
+		if err := b.writeKeyMetadata(ctx, req.Storage, meta); err != nil {
 			return nil, err
 		}
 

--- a/internal/builtin/logical/kv/path_data_test.go
+++ b/internal/builtin/logical/kv/path_data_test.go
@@ -383,6 +383,27 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	if !parsed.After(time.Now().Add(-1*time.Minute)) || !parsed.Before(time.Now()) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
+
+	// Read the key metadata directly to verify it was refreshed by the delete.
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "metadata/foo",
+		Storage:   storage,
+	}
+
+	resp, err = b.HandleRequest(t.Context(), req)
+	if err != nil || resp == nil || resp.IsError() {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	updatedTime, err := time.Parse(time.RFC3339Nano, resp.Data["updated_time"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !updatedTime.After(time.Now().Add(-1*time.Minute)) || !updatedTime.Before(time.Now()) {
+		t.Fatalf("Bad response: %#v", resp)
+	}
 }
 
 func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {

--- a/internal/builtin/logical/kv/path_delete.go
+++ b/internal/builtin/logical/kv/path_delete.go
@@ -103,12 +103,15 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 			return nil, nil
 		}
 
+		persistChanges := false
 		for _, verNum := range versions {
 			// If there is no version or the version is destroyed continue
 			lv := meta.Versions[uint64(verNum)]
 			if lv == nil || lv.Destroyed {
 				continue
 			}
+
+			persistChanges = true
 			lv.DeletionTime = nil
 
 			if !config.IsDeleteVersionAfterDisabled() {
@@ -120,8 +123,14 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 				}
 			}
 		}
-		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		if err != nil {
+
+		// no-op
+		if !persistChanges {
+			return nil, nil
+		}
+
+		meta.UpdatedTime = timestamppb.Now()
+		if err := b.writeKeyMetadata(ctx, req.Storage, meta); err != nil {
 			return nil, err
 		}
 
@@ -172,6 +181,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 			return nil, nil
 		}
 
+		persistChanges := false
 		for _, verNum := range versions {
 			// If there is no latest version, or the latest version is already
 			// deleted or destroyed continue
@@ -191,11 +201,17 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 				}
 			}
 
+			persistChanges = true
 			lv.DeletionTime = timestamppb.Now()
 		}
 
-		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		if err != nil {
+		// no-op
+		if !persistChanges {
+			return nil, nil
+		}
+
+		meta.UpdatedTime = timestamppb.Now()
+		if err := b.writeKeyMetadata(ctx, req.Storage, meta); err != nil {
 			return nil, err
 		}
 

--- a/internal/builtin/logical/kv/path_delete_test.go
+++ b/internal/builtin/logical/kv/path_delete_test.go
@@ -102,6 +102,15 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	if !parsed.After(time.Now().Add(-1*time.Minute)) || !parsed.Before(time.Now()) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
+
+	updatedTime, err := time.Parse(time.RFC3339Nano, resp.Data["updated_time"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !updatedTime.After(time.Now().Add(-1*time.Minute)) || !updatedTime.Before(time.Now()) {
+		t.Fatalf("Bad response: %#v", resp)
+	}
 }
 
 func TestVersionedKV_Undelete_Put(t *testing.T) {
@@ -202,6 +211,15 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
 	if resp.Data["versions"].(map[string]any)["2"].(map[string]any)["deletion_time"].(string) != "" {
+		t.Fatalf("Bad response: %#v", resp)
+	}
+
+	updatedTime, err := time.Parse(time.RFC3339Nano, resp.Data["updated_time"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !updatedTime.After(time.Now().Add(-1*time.Minute)) || !updatedTime.Before(time.Now()) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
 }

--- a/internal/builtin/logical/kv/path_destroy.go
+++ b/internal/builtin/logical/kv/path_destroy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/logical"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // pathDestroy returns the path configuration for the destroy endpoint
@@ -69,6 +70,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 			return nil, nil
 		}
 
+		persistChanges := false
 		for _, verNum := range versions {
 			// If there is no version, or the version is already destroyed,
 			// continue
@@ -77,12 +79,18 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				continue
 			}
 
+			persistChanges = true
 			lv.Destroyed = true
 		}
 
+		// no-op
+		if !persistChanges {
+			return nil, nil
+		}
+
 		// Write the metadata key before deleting the versions
-		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		if err != nil {
+		meta.UpdatedTime = timestamppb.Now()
+		if err := b.writeKeyMetadata(ctx, req.Storage, meta); err != nil {
 			return nil, err
 		}
 
@@ -93,8 +101,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				return nil, err
 			}
 
-			err = req.Storage.Delete(ctx, versionKey)
-			if err != nil {
+			if err = req.Storage.Delete(ctx, versionKey); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/builtin/logical/kv/path_destroy_test.go
+++ b/internal/builtin/logical/kv/path_destroy_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"testing"
+	"time"
 
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
@@ -88,6 +89,15 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
 	if resp.Data["versions"].(map[string]any)["2"].(map[string]any)["destroyed"].(bool) != true {
+		t.Fatalf("Bad response: %#v", resp)
+	}
+
+	updatedTime, err := time.Parse(time.RFC3339Nano, resp.Data["updated_time"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !updatedTime.After(time.Now().Add(-1*time.Minute)) || !updatedTime.Before(time.Now()) {
 		t.Fatalf("Bad response: %#v", resp)
 	}
 }


### PR DESCRIPTION
## Description
Following KV operations will now update the `update_time` timestamp on the version metadata
- `DELETE /data/{path}`
- `PUT /delete/{path}`
- `PUT /undelete/{path}`
- `PUT /destroy/{path}`

with an assumption that the operation did pass (deletion attempt of already deleted secret will result in no-op).

Additionally changed the logic of the `pathUndeleteWrite`, `pathDeleteWrite` and `pathDestroyWrite` to return immediately after validating that the request doesn't cause any changes to the storage reducing unnecessary writes.

## Rationale
We've got `creation_time` which is immutable, we've got `deletion_time` which gets updated (nulled) after undeletion operation. Both of these fields do not help if someone were to investigate the timeline of a secret version which was deleted and later undeleted by someone, the secret got updated in a particular way, but this wouldn't be surfaced with `update_time` of the version metadata.

Resolves: #3897

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
