### PR TITLE
CLI: accept raw and PEM key files in Transit import

### DIFF
--- a/changelog/3982.txt
+++ b/changelog/3982.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add explicit raw and private-key PEM file input formats to transit import and transit import-version while retaining base64 as the default.
+```

--- a/internal/command/transit_import_key.go
+++ b/internal/command/transit_import_key.go
@@ -34,6 +34,7 @@ var (
 
 type TransitImportCommand struct {
 	*BaseCommand
+	keyFormat string
 }
 
 func (c *TransitImportCommand) Synopsis() string {
@@ -42,13 +43,15 @@ func (c *TransitImportCommand) Synopsis() string {
 
 func (c *TransitImportCommand) Help() string {
 	helpText := `
-Usage: bao transit import PATH KEY [options...]
+Usage: bao transit import [flags] PATH KEY [options...]
 
   Using the Transit key wrapping system, imports key material from
   the base64 encoded KEY (either directly on the CLI or via @path notation),
-  into a new key whose API path is PATH.  To import a new version into an
-  existing key, use import_version.  The remaining options after KEY (key=value
-  style) are passed on to the Transit create key endpoint.  If your
+  into a new key whose API path is PATH. Use -key-format=raw or -key-format=pem
+  with @path to read binary key material or an unencrypted private-key PEM file.
+  To import a new version into an existing key, use import-version. The remaining
+  options after KEY (key=value style) are passed on to the Transit create key
+  endpoint. If your
   system or device natively supports the RSA AES key wrap mechanism (such as
   the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it directly
   rather than this command.
@@ -59,7 +62,22 @@ Usage: bao transit import PATH KEY [options...]
 }
 
 func (c *TransitImportCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP)
+	return transitImportFlags(c.BaseCommand, &c.keyFormat)
+}
+
+func transitImportFlags(c *BaseCommand, keyFormat *string) *FlagSets {
+	set := c.flagSet(FlagSetHTTP)
+	f := set.NewFlagSet("Import Options")
+	f.StringVar(&StringVar{
+		Name:       "key-format",
+		Target:     keyFormat,
+		Default:    "base64",
+		Completion: complete.PredictSet("base64", "raw", "pem"),
+		Usage: "Format of the source key: base64, raw, or pem. Raw and PEM require " +
+			"@path notation. Raw reads binary key material unchanged; PEM converts " +
+			"an unencrypted PKCS#8, PKCS#1 RSA, or SEC1 EC private key to PKCS#8 DER.",
+	})
+	return set
 }
 
 func (c *TransitImportCommand) AutocompleteArgs() complete.Predictor {
@@ -71,7 +89,7 @@ func (c *TransitImportCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *TransitImportCommand) Run(args []string) int {
-	return ImportKey(c.BaseCommand, "import", transitImportKeyPath, c.Flags(), args)
+	return ImportKey(c.BaseCommand, "import", transitImportKeyPath, c.Flags(), &c.keyFormat, args)
 }
 
 func transitImportKeyPath(s string, operation string) (path string, apiPath string, err error) {
@@ -90,7 +108,7 @@ func transitImportKeyPath(s string, operation string) (path string, apiPath stri
 type ImportKeyFunc func(s string, operation string) (path string, apiPath string, err error)
 
 // error codes: 1: user error, 2: internal computation error, 3: remote api call error
-func ImportKey(c *BaseCommand, operation string, pathFunc ImportKeyFunc, flags *FlagSets, args []string) int {
+func ImportKey(c *BaseCommand, operation string, pathFunc ImportKeyFunc, flags *FlagSets, keyFormat *string, args []string) int {
 	// Parse and validate the arguments.
 	if err := flags.Parse(args); err != nil {
 		c.UI.Error(err.Error())
@@ -119,20 +137,9 @@ func ImportKey(c *BaseCommand, operation string, pathFunc ImportKeyFunc, flags *
 		c.UI.Error(err.Error())
 		return 1
 	}
-	keyMaterial := args[1]
-	if keyMaterial[0] == '@' {
-		keyMaterialBytes, err := os.ReadFile(keyMaterial[1:])
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("error reading key material file: %v", err))
-			return 1
-		}
-
-		keyMaterial = string(keyMaterialBytes)
-	}
-
-	key, err := base64.StdEncoding.DecodeString(keyMaterial)
+	key, err := readTransitImportKey(args[1], *keyFormat)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("error base64 decoding source key material: %v", err))
+		c.UI.Error(err.Error())
 		return 1
 	}
 	// Fetch the wrapping key

--- a/internal/command/transit_import_key_material.go
+++ b/internal/command/transit_import_key_material.go
@@ -1,0 +1,100 @@
+// Copyright (c) OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func readTransitImportKey(source, format string) ([]byte, error) {
+	switch format {
+	case "base64", "raw", "pem":
+	default:
+		return nil, errors.New("invalid key format: expected base64, raw, or pem")
+	}
+	if source == "" {
+		return nil, errors.New("key material must not be empty")
+	}
+	fromFile := strings.HasPrefix(source, "@")
+	if format != "base64" && !fromFile {
+		return nil, errors.New("raw and PEM key formats require @path notation")
+	}
+	material := []byte(source)
+	if fromFile {
+		var err error
+		material, err = os.ReadFile(source[1:])
+		if err != nil {
+			return nil, fmt.Errorf("error reading key material file: %w", err)
+		}
+	}
+	if len(material) == 0 {
+		return nil, errors.New("key material must not be empty")
+	}
+	switch format {
+	case "base64":
+		key, err := base64.StdEncoding.DecodeString(string(material))
+		if err != nil {
+			return nil, fmt.Errorf("error base64 decoding source key material: %w", err)
+		}
+		if len(key) == 0 {
+			return nil, errors.New("key material must not be empty")
+		}
+		return key, nil
+	case "raw":
+		return material, nil
+	default:
+		return parseTransitImportPEM(material)
+	}
+}
+
+func parseTransitImportPEM(material []byte) ([]byte, error) {
+	material = bytes.TrimSpace(material)
+	// pem.Decode can skip leading text and malformed blocks. Accept exactly one
+	// block instead, so that extra key material cannot be silently discarded.
+	if !bytes.HasPrefix(material, []byte("-----BEGIN ")) || bytes.Count(material, []byte("-----BEGIN ")) != 1 {
+		return nil, errors.New("expected exactly one private-key PEM block")
+	}
+	block, rest := pem.Decode(material)
+	if block == nil || len(bytes.TrimSpace(rest)) != 0 {
+		return nil, errors.New("expected exactly one private-key PEM block")
+	}
+	if len(block.Headers) != 0 || block.Type == "ENCRYPTED PRIVATE KEY" {
+		return nil, errors.New("encrypted PEM and PEM headers are not supported")
+	}
+
+	// Some x509 parsers accept trailing DER data. Check the complete object
+	// before parsing so that normalization cannot discard extra material.
+	var object asn1.RawValue
+	rest, err := asn1.Unmarshal(block.Bytes, &object)
+	if err != nil || len(rest) != 0 {
+		return nil, errors.New("invalid private-key DER in PEM block")
+	}
+	var key any
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+	case "RSA PRIVATE KEY":
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		key, err = x509.ParseECPrivateKey(block.Bytes)
+	default:
+		return nil, errors.New("unsupported PEM block: expected PRIVATE KEY, RSA PRIVATE KEY, or EC PRIVATE KEY")
+	}
+	if err != nil {
+		return nil, errors.New("invalid private key in PEM block")
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, errors.New("unable to encode private key as PKCS#8 DER")
+	}
+	return der, nil
+}

--- a/internal/command/transit_import_key_material_test.go
+++ b/internal/command/transit_import_key_material_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openbao/openbao/api/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func transitImportTestFile(t *testing.T, material []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "key")
+	require.NoError(t, os.WriteFile(path, material, 0o600))
+	return "@" + path
+}
+
+func TestReadTransitImportKey(t *testing.T) {
+	t.Parallel()
+	// Include NUL and whitespace-valued bytes at both ends of binary input.
+	raw := append([]byte{0, '\n', '\t', ' '}, bytes.Repeat([]byte{0xff}, 24)...)
+	raw = append(raw, ' ', '\t', '\r', '\n')
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	for _, format := range []string{"base64", "raw"} {
+		t.Run(format, func(t *testing.T) {
+			material := raw
+			if format == "base64" {
+				material = []byte(encoded + "\r\n")
+			}
+			key, err := readTransitImportKey(transitImportTestFile(t, material), format)
+			require.NoError(t, err)
+			require.Equal(t, raw, key)
+		})
+	}
+	key, err := readTransitImportKey(encoded, "base64")
+	require.NoError(t, err)
+	require.Equal(t, raw, key)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecDER, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name string
+		key  any
+		typ  string
+		der  []byte
+	}{
+		{"pkcs8-rsa", rsaKey, "PRIVATE KEY", nil},
+		{"pkcs1-rsa", rsaKey, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(rsaKey)},
+		{"pkcs8-ec", ecKey, "PRIVATE KEY", nil},
+		{"sec1-ec", ecKey, "EC PRIVATE KEY", ecDER},
+		{"pkcs8-ed25519", edKey, "PRIVATE KEY", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want, err := x509.MarshalPKCS8PrivateKey(tc.key)
+			require.NoError(t, err)
+			der := tc.der
+			if der == nil {
+				der = want
+			}
+			material := pem.EncodeToMemory(&pem.Block{Type: tc.typ, Bytes: der})
+			material = append([]byte(" \r\n"), material...)
+			material = append(material, '\t', '\n')
+			got, err := readTransitImportKey(transitImportTestFile(t, material), "pem")
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+			got, err = readTransitImportKey(transitImportTestFile(t, want), "raw")
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestTransitImportInvalidKeyMaterial(t *testing.T) {
+	t.Parallel()
+	const marker = "SYNTHETIC-SECRET-MARKER"
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	valid := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	pemBlock := func(typ string, data []byte, headers map[string]string) []byte {
+		return pem.EncodeToMemory(&pem.Block{Type: typ, Bytes: data, Headers: headers})
+	}
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	config := api.DefaultConfig()
+	config.Address = server.URL
+	client, err := api.NewClient(config)
+	require.NoError(t, err)
+	client.SetMaxRetries(0)
+
+	for _, tc := range []struct {
+		name, format string
+		material     []byte
+		inline       bool
+		want         string
+	}{
+		{"empty-argument", "base64", nil, true, "must not be empty"},
+		{"empty-file", "raw", nil, false, "must not be empty"},
+		{"empty-base64", "base64", []byte("\r\n"), false, "must not be empty"},
+		{"invalid-base64", "base64", []byte(marker), false, "base64 decoding"},
+		{"unknown-format", marker, []byte(marker), true, "invalid key format"},
+		{"inline-raw", "raw", []byte(marker), true, "require @path"},
+		{"inline-pem", "pem", []byte(marker), true, "require @path"},
+		{"not-pem", "pem", []byte(marker), false, "exactly one"},
+		{"leading-text", "pem", append([]byte(marker), valid...), false, "exactly one"},
+		{"trailing-text", "pem", append(bytes.Clone(valid), []byte(marker)...), false, "exactly one"},
+		{"multiple-blocks", "pem", append(bytes.Clone(valid), valid...), false, "exactly one"},
+		{"skipped-malformed-block", "pem", append([]byte("-----BEGIN PRIVATE KEY-----\ninvalid\n"), valid...), false, "exactly one"},
+		{"malformed-block", "pem", []byte("-----BEGIN PRIVATE KEY-----\n" + marker), false, "exactly one"},
+		{"encrypted-pkcs8", "pem", pemBlock("ENCRYPTED PRIVATE KEY", der, nil), false, "encrypted PEM"},
+		{"legacy-encrypted", "pem", pemBlock("RSA PRIVATE KEY", der, map[string]string{"Proc-Type": "4,ENCRYPTED", "DEK-Info": marker}), false, "encrypted PEM"},
+		{"headers", "pem", pemBlock("PRIVATE KEY", der, map[string]string{"Comment": marker}), false, "PEM headers"},
+		{"unsupported-type", "pem", pemBlock(marker, der, nil), false, "unsupported PEM block"},
+		{"invalid-der", "pem", pemBlock("PRIVATE KEY", []byte(marker), nil), false, "invalid private-key DER"},
+		{"trailing-der", "pem", pemBlock("PRIVATE KEY", append(bytes.Clone(der), 0), nil), false, "invalid private-key DER"},
+		{"wrong-key-type", "pem", pemBlock("RSA PRIVATE KEY", der, nil), false, "invalid private key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := string(tc.material)
+			if !tc.inline {
+				source = transitImportTestFile(t, tc.material)
+			}
+			for _, method := range []string{"import", "import-version"} {
+				stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+				code := RunCustom([]string{"transit", method, "-key-format=" + tc.format, "transit/keys/test", source}, &RunOptions{
+					Stdout: stdout, Stderr: stderr, Client: client,
+				})
+				require.Equal(t, 1, code, stderr.String())
+				require.Contains(t, stderr.String(), tc.want)
+				require.NotContains(t, stdout.String()+stderr.String(), marker)
+			}
+		})
+	}
+	require.Zero(t, requests.Load(), "invalid local input must not contact the server")
+	_, err = readTransitImportKey("@"+filepath.Join(t.TempDir(), "missing"), "raw")
+	require.ErrorContains(t, err, "error reading key material file")
+}
+
+func TestTransitImportKeyFormats(t *testing.T) {
+	t.Parallel()
+	client, closer := testVaultServer(t)
+	defer closer()
+	require.NoError(t, client.Sys().Mount("transit", &api.MountInput{Type: "transit"}))
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaDER, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecDER, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	ecPKCS8, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+	aesKey := bytes.Repeat([]byte{0x42}, 32)
+	copy(aesKey[28:], []byte(" \t\r\n"))
+
+	for _, tc := range []struct {
+		name, format, typ, exportType string
+		material, want                []byte
+	}{
+		{"base64-file", "base64", "aes256-gcm96", "encryption-key", []byte(base64.StdEncoding.EncodeToString(aesKey) + "\n"), aesKey},
+		{"raw-aes", "raw", "aes256-gcm96", "encryption-key", aesKey, aesKey},
+		{"raw-rsa-der", "raw", "rsa-2048", "encryption-key", rsaDER, rsaDER},
+		{"pem-pkcs8", "pem", "rsa-2048", "encryption-key", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: rsaDER}), rsaDER},
+		{"pem-pkcs1", "pem", "rsa-2048", "encryption-key", pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)}), rsaDER},
+		{"pem-sec1", "pem", "ecdsa-p256", "signing-key", pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecDER}), ecPKCS8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := transitImportTestFile(t, tc.material)
+			updatedSource, updatedWant := source, tc.want
+			if tc.typ == "aes256-gcm96" {
+				updatedWant = bytes.Clone(tc.want)
+				updatedWant[0] ^= 0xff
+				material := updatedWant
+				if tc.format == "base64" {
+					material = []byte(base64.StdEncoding.EncodeToString(updatedWant))
+				}
+				updatedSource = transitImportTestFile(t, material)
+			}
+			path := "transit/keys/" + tc.name
+			for i, method := range []string{"import", "import", "import-version"} {
+				if i > 0 {
+					source = updatedSource
+				}
+				stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+				args := []string{"transit", method}
+				if tc.format != "base64" {
+					args = append(args, "-key-format="+tc.format)
+				}
+				args = append(args, path, source, "type="+tc.typ, "exportable=true")
+				code := RunCustom(args, &RunOptions{Stdout: stdout, Stderr: stderr, Client: client})
+				if i == 1 {
+					require.Equal(t, 3, code, stderr.String())
+				} else {
+					require.Zero(t, code, stderr.String())
+				}
+				query := map[string][]string{}
+				if tc.typ != "aes256-gcm96" {
+					query["format"] = []string{"der"}
+				}
+				secret, err := client.Logical().ReadWithData("transit/export/"+tc.exportType+"/"+tc.name, query)
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				keys := secret.Data["keys"].(map[string]any)
+				versions := 1
+				if method == "import-version" {
+					versions = 2
+				}
+				require.Len(t, keys, versions)
+				for version := 1; version <= versions; version++ {
+					got, err := base64.StdEncoding.DecodeString(keys[fmt.Sprint(version)].(string))
+					require.NoError(t, err)
+					want := tc.want
+					if version == 2 {
+						want = updatedWant
+					}
+					require.Equal(t, want, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/command/transit_import_key_version.go
+++ b/internal/command/transit_import_key_version.go
@@ -17,6 +17,7 @@ var (
 
 type TransitImportVersionCommand struct {
 	*BaseCommand
+	keyFormat string
 }
 
 func (c *TransitImportVersionCommand) Synopsis() string {
@@ -25,13 +26,15 @@ func (c *TransitImportVersionCommand) Synopsis() string {
 
 func (c *TransitImportVersionCommand) Help() string {
 	helpText := `
-Usage: bao transit import-version PATH KEY [...]
+Usage: bao transit import-version [flags] PATH KEY [...]
 
   Using the Transit key wrapping system, imports key material from
   the base64 encoded KEY (either directly on the CLI or via @path notation),
-  into a new key whose API path is PATH.  To import a new Transit
-  key, use the import command instead.  The remaining options after KEY
-  (key=value style) are passed on to the Transit create key endpoint.
+  into a new version of the key whose API path is PATH. Use -key-format=raw
+  or -key-format=pem with @path to read binary key material or an unencrypted
+  private-key PEM file. To import a new Transit key, use the import command
+  instead. The remaining options after KEY (key=value style) are passed on to
+  the Transit import-version endpoint.
   If your system or device natively supports the RSA AES key wrap mechanism
   (such as the PKCS#11 mechanism CKM_RSA_AES_KEY_WRAP), you should use it
   directly rather than this command.
@@ -42,7 +45,7 @@ Usage: bao transit import-version PATH KEY [...]
 }
 
 func (c *TransitImportVersionCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP)
+	return transitImportFlags(c.BaseCommand, &c.keyFormat)
 }
 
 func (c *TransitImportVersionCommand) AutocompleteArgs() complete.Predictor {
@@ -54,5 +57,5 @@ func (c *TransitImportVersionCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *TransitImportVersionCommand) Run(args []string) int {
-	return ImportKey(c.BaseCommand, "import_version", transitImportKeyPath, c.Flags(), args)
+	return ImportKey(c.BaseCommand, "import_version", transitImportKeyPath, c.Flags(), &c.keyFormat, args)
 }

--- a/website/content/docs/commands/transit/import.mdx
+++ b/website/content/docs/commands/transit/import.mdx
@@ -43,10 +43,55 @@ Submitting wrapped key to OpenBao transit.
 Success!
 ```
 
+Imports a binary AES-256 key file without base64 conversion:
+
+```shell
+$ bao transit import -key-format=raw transit/keys/aes-key @aes-key.bin type=aes256-gcm96
+```
+
+Imports an unencrypted RSA private-key PEM file:
+
+```shell
+$ bao transit import -key-format=pem transit/keys/rsa-key @rsa-key.pem type=rsa-2048
+```
+
+Imports a PKCS#8 DER private-key file as a new version:
+
+```shell
+$ bao transit import-version -key-format=raw transit/keys/rsa-key @rsa-key-updated.der
+```
+
 ## Usage
 
-This command does not have any unique flags and respects core OpenBao CLI
-commands. See `bao transit import -help` for more information.
+Both commands respect the core OpenBao CLI flags. Place flags before the
+positional arguments. See `bao transit import -help` for more information.
+
+### Key format
+
+`-key-format` selects the source key representation:
+
+- `base64` (default): Standard Base64 input, either inline or through `@file`.
+  Existing input behavior is preserved; formats are not detected automatically.
+- `raw`: Binary key material read through `@file`, without trimming or decoding.
+  Use raw key bytes for symmetric keys or PKCS#8 DER for asymmetric keys.
+- `pem`: A single unencrypted private-key PEM block read through `@file`.
+  Supported labels are `PRIVATE KEY` (PKCS#8), `RSA PRIVATE KEY` (PKCS#1), and
+  `EC PRIVATE KEY` (SEC1), using the private-key formats supported by Go's
+  `crypto/x509` package. The key is converted to PKCS#8 DER before wrapping.
+  Encrypted keys, PEM headers, additional blocks, and non-whitespace text outside
+  the block are rejected. Malformed keys and extra DER data inside the block are
+  also rejected.
+
+Raw and PEM inputs require `@file`; key contents cannot be passed inline in
+these modes. Prefer files with restrictive permissions rather than putting
+base64 key contents in shell history or process arguments. Do not commit key
+files to source control.
+
+The input format does not select the Transit key type. For a new key, supply
+`type=<key-type>` matching the source material. Server-side restrictions on
+supported key types, key sizes, and version imports remain unchanged.
+
+### Arguments
 
 This command requires two positional arguments:
 
@@ -54,8 +99,7 @@ This command requires two positional arguments:
     `<mount>/keys/<key-name>`, where `<mount>` is the path to the mount
     (using `-namespace=<ns>` to specify any namespaces), and `<key-name>`
     is the desired name of the key.
- 2. `KEY`, the key material to import in Standard Base64 encoding (either
-    of a raw key in the case of symmetric keys such as AES, or of the DER
-    encoded format for asymmetric keys such as RSA). If the value for `KEY`
-    begins with an `@`, the CLI argument is assumed to be a path to a file
-    on disk to be read.
+ 2. `KEY`, the key material in the selected `-key-format` (Standard Base64 by
+    default). For symmetric keys such as AES, the decoded material is the raw
+    key; for asymmetric keys such as RSA, it is PKCS#8 DER. If `KEY` begins
+    with an `@`, the rest of the argument is a path to a file on disk to read.


### PR DESCRIPTION
## Description

Add `-key-format=base64|raw|pem` to `bao transit import` and `bao transit import-version`.

- Keep base64 as the default, including existing inline and `@file` inputs.
- Require `@file` for raw and PEM input. Raw preserves binary bytes exactly, including whitespace-valued bytes, and can read PKCS#8 DER directly.
- Normalize a single unencrypted PKCS#8, PKCS#1 RSA, or SEC1 EC PEM private key to PKCS#8 DER using Go's `crypto/x509` parsers.
- Reject empty input, malformed PEM, encrypted/header-bearing blocks, unsupported labels, extra blocks/text, and trailing DER within PEM before any server request. Parsing errors do not include source key contents.
- Share the input handling and flag across both commands; retain the existing AES-KWP/RSA-OAEP envelope and server-side key-type/version validation.
- Add command help, usage examples, parser regressions, and integration tests using the repository's in-process OpenBao server harness.

No new server endpoint, SDK API, cryptographic scheme, external dependency, standalone importer, or unrelated wrapping-response hardening is included.

### Verification

Passed locally with Go 1.27.0 on Linux/amd64:

```sh
BAO_ADDR= BAO_TOKEN= BAO_DEV_ROOT_TOKEN_ID= BAO_ACC= \
  go test -race ./internal/command \
  -run 'Test(ReadTransitImportKey|TransitImport)' -count=1 -timeout=10m
go build -o bin/bao .
go vet ./internal/command
bin/bao transit import -help
bin/bao transit import-version -help
```

The focused tests cover existing inline base64 behavior, base64 files, byte-exact raw AES and RSA DER imports, RSA PKCS#8/PKCS#1 and EC SEC1 PEM imports, duplicate rejection, preservation of original key material, and new version creation. Exporting disposable test keys verifies their actual imported bytes. Parser tests also cover PKCS#8 EC/Ed25519, malformed input, and synthetic secret markers. A request-counting HTTP server verifies that invalid local inputs make no server requests.

The full repository test suite and website build were not run. These results apply to this upstream patch, not a separate importer or a production deployment.

## Rationale

Resolves: #3970

The native CLI already performs BYOK wrapping and import. This change removes the need to convert existing binary or private-key PEM files into intermediate base64 files. Explicit selection avoids guessing binary formats and preserves the default interface.

This is a draft proposal pending community review of #3970 and the flag/format scope. No prior community approval is claimed.

## Acknowledgements

- [x] By contributing this change, I certify I have not used generative AI
      (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
      filling out the pull request description or associated issue.
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
