### PR TITLE
Wait for raft retry_join before self-initializing

### DIFF
--- a/internal/command/self_init_retry_join_test.go
+++ b/internal/command/self_init_retry_join_test.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/cli"
+	log "github.com/hashicorp/go-hclog"
+	testintf "github.com/mitchellh/go-testing-interface"
+	"github.com/openbao/openbao/v2/internal/command/server"
+	"github.com/openbao/openbao/v2/internal/helper/testhelpers/teststorage"
+	vaulthttp "github.com/openbao/openbao/v2/internal/http"
+	"github.com/openbao/openbao/v2/internal/vault"
+	"github.com/openbao/openbao/v2/internal/vault/seal"
+	"github.com/stretchr/testify/require"
+)
+
+// Waiting on anything but raft would add most of a minute to the first boot of
+// every other deployment. Core is nil on purpose: reaching for it here is the
+// bug we're guarding against.
+func TestWaitForRaftRetryJoinSkipsNonRaft(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		storage *server.Storage
+	}{
+		{name: "file_storage", storage: &server.Storage{Type: "file"}},
+		{name: "inmem_storage", storage: &server.Storage{Type: "inmem"}},
+		{name: "raft_ha_storage_only", storage: &server.Storage{Type: "postgresql"}},
+		{name: "no_storage", storage: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &ServerCommand{logger: log.NewInterceptLogger(&log.LoggerOptions{Output: io.Discard})}
+
+			start := time.Now()
+			joined, err := cmd.waitForRaftRetryJoin(context.Background(), nil, &server.Config{Storage: tc.storage})
+
+			require.NoError(t, err)
+			require.False(t, joined, "reported a join we never waited for")
+			require.Less(t, time.Since(start), time.Second,
+				"we waited, so the wait is being applied to non-raft storage")
+		})
+	}
+}
+
+// testRaftCore brings up a single-node raft-backed cluster, optionally with a
+// retry_join stanza, and hands back a command and its core.
+func testRaftCore(t *testing.T, retryJoin string) (*ServerCommand, *vault.Core, func()) {
+	t.Helper()
+
+	testSeal, _ := seal.NewTestSeal(nil)
+	autoSeal, err := vault.NewAutoSeal(testSeal)
+	require.NoError(t, err)
+
+	logger := log.NewInterceptLogger(&log.LoggerOptions{Output: io.Discard})
+	conf, opts := teststorage.ClusterSetup(&vault.CoreConfig{
+		Logger: logger,
+		Seal:   autoSeal,
+	}, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+		Logger:      logger,
+		NumCores:    1,
+	}, func(_ *vault.CoreConfig, opts *vault.TestClusterOptions) {
+		opts.PhysicalFactory = func(t testintf.T, coreIdx int, logger log.Logger, _ map[string]any) *vault.PhysicalBackendBundle {
+			extra := map[string]any{}
+			if retryJoin != "" {
+				extra["retry_join"] = retryJoin
+			}
+			return teststorage.MakeRaftBackend(t, coreIdx, logger, extra)
+		}
+	})
+
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+
+	cmd := &ServerCommand{
+		BaseCommand: &BaseCommand{UI: cli.NewMockUi()},
+		ShutdownCh:  MakeShutdownCh(),
+		SighupCh:    MakeSighupCh(),
+		SigUSR2Ch:   MakeSigUSR2Ch(),
+		logger:      logger,
+	}
+
+	return cmd, cluster.Cores[0].Core, cluster.Cleanup
+}
+
+func testRaftConfig() *server.Config {
+	return &server.Config{Storage: &server.Storage{Type: storageTypeRaft}}
+}
+
+// Raft on its own isn't enough: with no retry_join stanza there is no join
+// coming, so we mustn't hold up initialization waiting for one.
+func TestWaitForRaftRetryJoinWithoutJoinConfig(t *testing.T) {
+	cmd, core, cleanup := testRaftCore(t, "")
+	defer cleanup()
+
+	start := time.Now()
+	joined, err := cmd.waitForRaftRetryJoin(context.Background(), core, testRaftConfig())
+
+	require.NoError(t, err)
+	require.False(t, joined)
+	require.Less(t, time.Since(start), time.Second, "waited despite there being no retry_join")
+}
+
+// An initialized core is the state a follower reaches once its join lands, and
+// the one case we must not self-initialize over.
+func TestWaitForRaftRetryJoinAlreadyInitialized(t *testing.T) {
+	cmd, core, cleanup := testRaftCore(t, `[{"leader_api_addr":"https://127.0.0.1:8200"}]`)
+	defer cleanup()
+
+	start := time.Now()
+	joined, err := cmd.waitForRaftRetryJoin(context.Background(), core, testRaftConfig())
+
+	require.NoError(t, err)
+	require.True(t, joined, "an initialized node should count as joined")
+	require.Less(t, time.Since(start), time.Second, "waited despite the node already being up")
+}

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -1703,6 +1703,64 @@ func (c *ServerCommand) notifySystemd(status string) {
 	}
 }
 
+// selfInitRetryJoinSeconds is how long we wait for an outstanding raft
+// retry_join before deciding we're the first node of a new cluster. A first
+// node has no peer to reach, so it always waits the whole time; that only
+// happens once, on the very first boot.
+const selfInitRetryJoinSeconds = 35
+
+// waitForRaftRetryJoin waits for a backgrounded raft retry_join to initialize
+// this node, and reports whether it did. False means there was nothing to wait
+// for, or that nothing completed in time; either way the caller should go on
+// and self-initialize.
+func (c *ServerCommand) waitForRaftRetryJoin(ctx context.Context, core *vault.Core, config *server.Config) (bool, error) {
+	// Raft as HA storage only is left out on purpose: there we're unsealed
+	// before we join, so there can't be a join in flight this early. Storage
+	// is nil-checked because Initialize is also called directly, outside the
+	// startup path that guarantees a storage stanza.
+	if config.Storage == nil || config.Storage.Type != storageTypeRaft {
+		return false, nil
+	}
+
+	raftBackend := core.GetRaftBackend()
+	if raftBackend == nil {
+		return false, nil
+	}
+
+	// A bad retry_join stanza has already failed the server in
+	// InitiateRetryJoin, which runs before we get here, so treat an error as
+	// nothing to wait for rather than failing startup twice over.
+	joinInfos, err := raftBackend.JoinConfig()
+	if err != nil || len(joinInfos) == 0 {
+		return false, nil
+	}
+
+	c.logger.Info("waiting for raft retry join")
+
+	joinCount := selfInitRetryJoinSeconds
+	for {
+		// Initialized, unlike InitializedLocally, goes true as soon as a
+		// successful join has bootstrapped the raft backend, which is the
+		// transition we're waiting on.
+		inited, err := core.Initialized(ctx)
+		if err != nil {
+			return false, fmt.Errorf("unable to check core initialization status: %w", err)
+		}
+		if inited {
+			c.logger.Info("raft retry join completed, skipping self-initialization")
+			return true, nil
+		}
+
+		if joinCount == 0 {
+			c.logger.Info("raft retry join did not complete, self-initializing")
+			return false, nil
+		}
+
+		time.Sleep(1 * time.Second)
+		joinCount--
+	}
+}
+
 func (c *ServerCommand) waitForLeader(core *vault.Core) (bool, error) {
 	// By definition of self-initialization, we can't have added any follower
 	// nodes yet because key material was just created prior to this. We can
@@ -1768,6 +1826,21 @@ func (c *ServerCommand) Initialize(core *vault.Core, config *server.Config) (ret
 		// other authentication information but on subsequent startups
 		// presumably the admin has created an alternative mechanism we should
 		// defer to.
+		return nil
+	}
+
+	// The check above is one sample of a value a concurrent retry_join is
+	// racing to flip: InitiateRetryJoin backgrounds its retry loop, so on a
+	// follower we get here while the join is still in flight and would
+	// bootstrap a competing single-node cluster moments before it lands. We
+	// can't undo that either, since JoinRaftCluster gives up once the node is
+	// initialized locally. Wait for any outstanding join to finish before we
+	// decide we're the first node.
+	joined, err := c.waitForRaftRetryJoin(ctx, core, config)
+	if err != nil {
+		return err
+	}
+	if joined {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

A node with both an `initialize` stanza and `retry_join` can bootstrap its own single-node cluster while the join is still in flight: `InitiateRetryJoin` backgrounds the retry loop, so self-init runs alongside it rather than after. This waits for an outstanding join first, with a timeout so the first node of a new cluster still comes up.

I went with polling `core.Initialized` rather than the `raftJoinDoneCh` approach sketched in the issue - `joinInProgress` is only set under Shamir, and `Initialize` bails out without auto-unseal, so that signal never fires on this path.

It doesn't cover several nodes starting at once with no leader to find; they all time out and self-init.
## Rationale

Resolves: https://github.com/openbao/openbao/issues/3652

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the [DCO ownership](https://developercertificate.org/) statement and this change did not use post-BUSL-licensed code from HashiCorp. Existing MPL-licensed code is still allowed, subject to attribution. Code authored by yourself and submitted to HashiCorp for inclusion is also allowed.