### PR TITLE
Remove unused symbols found by golangci-lint

### DIFF
--- a/internal/command/agentproxyshared/sink/file/file_sink_test.go
+++ b/internal/command/agentproxyshared/sink/file/file_sink_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/openbao/openbao/v2/internal/command/agentproxyshared/sink"
 )
 
-const (
-	fileServerTestDir = "vault-agent-file-test"
-)
-
 func testFileSink(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "token")

--- a/internal/command/proxy.go
+++ b/internal/command/proxy.go
@@ -80,8 +80,6 @@ type ProxyCommand struct {
 	// Telemetry object
 	metricsHelper *metricsutil.MetricsHelper
 
-	cleanupGuard sync.Once
-
 	startedCh  chan struct{} // for tests
 	reloadedCh chan struct{} // for tests
 

--- a/internal/helper/forwarding/util.go
+++ b/internal/helper/forwarding/util.go
@@ -14,15 +14,6 @@ import (
 	"github.com/openbao/openbao/v2/internal/helper/buffer"
 )
 
-type bufCloser struct {
-	*bytes.Buffer
-}
-
-func (b bufCloser) Close() error {
-	b.Reset()
-	return nil
-}
-
 func GenerateForwardedRequest(req *http.Request) (*Request, error) {
 	var reader io.Reader = req.Body
 	body, err := io.ReadAll(reader)

--- a/internal/http/util.go
+++ b/internal/http/util.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/openbao/openbao/v2/internal/helper/buffer"
 	"github.com/openbao/openbao/v2/internal/helper/namespace"
@@ -236,28 +235,6 @@ func parseRemoteIPAddress(r *http.Request) string {
 	}
 
 	return ip
-}
-
-type multiReaderCloser struct {
-	readers []io.Reader
-	io.Reader
-}
-
-func newMultiReaderCloser(readers ...io.Reader) *multiReaderCloser {
-	return &multiReaderCloser{
-		readers: readers,
-		Reader:  io.MultiReader(readers...),
-	}
-}
-
-func (m *multiReaderCloser) Close() error {
-	var err error
-	for _, r := range m.readers {
-		if c, ok := r.(io.Closer); ok {
-			err = multierror.Append(err, c.Close())
-		}
-	}
-	return err
 }
 
 // https://www.rfc-editor.org/rfc/rfc9440.html#name-encoding

--- a/internal/physical/raft/transaction.go
+++ b/internal/physical/raft/transaction.go
@@ -443,28 +443,6 @@ func (t *RaftTransaction) List(ctx context.Context, prefix string) ([]string, er
 	return t.ListPage(ctx, prefix, "", -1)
 }
 
-// returns (entryName, isFolder, shouldVisit)
-func listShouldIncludeEntry(prefix string, after string, key string) (string, bool, bool) {
-	subKey := strings.TrimPrefix(key, prefix)
-	i := strings.Index(subKey, "/")
-	if i == -1 {
-		// Not a folder; check if we can skip this entry by suffix.
-		if after != "" && subKey <= after {
-			return subKey, false, false
-		}
-
-		return subKey, false, true
-	}
-
-	// Check if we need to visit the truncated folder path.
-	folder := string(subKey[:i+1])
-	if after != "" && folder <= after {
-		return folder, true, false
-	}
-
-	return folder, true, true
-}
-
 func (t *RaftTransaction) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
 	t.l.Lock()
 	defer t.l.Unlock()


### PR DESCRIPTION
Resolves: #

lint findings: unused

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
