### PR TITLE
Add concurrency group to mirror job, do cleanup

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,7 +1,6 @@
-name: Mirror Repo
+name: Mirror Repository
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches:
       - main
@@ -11,26 +10,32 @@ permissions:
   contents: read
 
 jobs:
-  mirror:
-    runs-on: ubuntu-slim
+  codeberg:
+    name: Codeberg
     if: github.repository == 'openbao/openbao'
+    runs-on: ubuntu-slim
+    concurrency:
+      group: mirror-codeberg-${{ github.ref_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: configure ssh
+          persist-credentials: false
+
+      - name: Configure SSH
         run: |
           cat > known_hosts <<EOF
-          codeberg.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8hZi7K1/2E2uBX8gwPRJAHvRAob+3Sn+y2hxiEhN0buv1igjYFTgFO2qQD8vLfU/HT/P/rqvEeTvaDfY1y/vcvQ8+YuUYyTwE2UaVU5aJv89y6PEZBYycaJCPdGIfZlLMmjilh/Sk8IWSEK6dQr+g686lu5cSWrFW60ixWpHpEVB26eRWin3lKYWSQGMwwKv4LwmW3ouqqs4Z4vsqRFqXJ/eCi3yhpT+nOjljXvZKiYTpYajqUC48IHAxTWugrKe1vXWOPxVXXMQEPsaIRc2hpK+v1LmfB7GnEGvF1UAKnEZbUuiD9PBEeD5a1MZQIzcoPWCrTxipEpuXQ5Tni4mN
-          codeberg.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL2pDxWr18SoiDJCGZ5LmxPygTlPu+cCKSkpqkvCyQzl5xmIMeKNdfdBpfbCGDPoZQghePzFZkKJNR/v9Win3Sc=
           codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB
           EOF
 
-          echo "${{ secrets.CODEBERG_GIT_SSH_PRIVATE_KEY }}" > id_codeberg
+          echo "$CODEBERG_GIT_SSH_PRIVATE_KEY" > id_codeberg
           chmod 0600 id_codeberg
-      - name: mirror repo
+        env:
+          CODEBERG_GIT_SSH_PRIVATE_KEY: ${{ secrets.CODEBERG_GIT_SSH_PRIVATE_KEY }}
+
+      - name: Push to remote
         run: |
           git remote add codeberg git@codeberg.org:openbao/openbao.git
-          git push -u codeberg ${{ github.ref_name }}
+          git push -u codeberg "$GITHUB_REF_NAME"
         env:
           GIT_SSH_COMMAND: ssh -i id_codeberg -o UserKnownHostsFile=known_hosts


### PR DESCRIPTION
## Description

Add a concurrency group such that mirror jobs don't race and sometimes overtake each other, causing jobs trying to push older commits to fail since they weren't scheduled first.

See https://github.com/openbao/openbao/actions/runs/34632963359/job/103374000302 for an example.

Also do some general housekeeping. AFAICT there's no reason to add all of Codeberg's keys to `known_hosts`, so keep just the Ed25519 one since that is both the shortest and most modern.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.
